### PR TITLE
feature: 重构 V15 Worker Console

### DIFF
--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -67,7 +67,7 @@ beforeEach(() => {
   Object.values(api).forEach((mock) => "mockReset" in mock && mock.mockReset());
   Object.values(projectApi).forEach((mock) => "mockReset" in mock && mock.mockReset());
   api.codingWorkerArtifactUrl.mockImplementation((taskId: string, artifactId: string) => `/artifact/${taskId}/${artifactId}`);
-  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, acceptance_checks: ["python-pytest", "react-build"], reason: null, capabilities: { api_version: "v1", task_runtime: true, professional_file_tools: true, shell: true, operation_output: true, changesets: true, code_intelligence: true } });
+  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, acceptance_checks: ["python-pytest", "react-build"], model_routes: ["coding/default", "coding/quality"], reason: null, capabilities: { api_version: "v1", task_runtime: true, professional_file_tools: true, shell: true, operation_output: true, changesets: true, code_intelligence: true } });
   api.listCodingWorkerTasks.mockResolvedValue([task]);
   api.getCodingWorkerTask.mockResolvedValue(task);
   api.listCodingWorkerApprovals.mockResolvedValue([{ approval_id: "approval_1234567890abcdef1234567890abcdef", task_id: task.task_id, operation_id: "operation_1", capability: "command", status: "pending", request: { command: "pytest" }, lease: null, created_at: 1, decided_at: null }]);
@@ -125,12 +125,11 @@ describe("CodingWorkerConsole", () => {
     const user = userEvent.setup();
     render(<CodingWorkerConsole context="coding" />);
 
-    expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(2);
+    expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(3);
     expect(screen.getByText("宿主写回")).toBeInTheDocument();
     expect(await screen.findByText("src/app.py")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("tab", { name: "证据" }));
-    await user.click(await screen.findByRole("button", { name: "批准一次" }));
+    await user.click(await screen.findByRole("button", { name: "批准本次执行" }));
     await waitFor(() => expect(api.decideCodingWorkerApproval).toHaveBeenCalledWith(
       task.task_id,
       "approval_1234567890abcdef1234567890abcdef",
@@ -140,7 +139,7 @@ describe("CodingWorkerConsole", () => {
 
   it("keeps domain writeback controls out of the generic Agent context", async () => {
     render(<CodingWorkerConsole context="agent" />);
-    expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(2);
+    expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(3);
     expect(screen.queryByText("宿主写回")).not.toBeInTheDocument();
   });
 
@@ -198,6 +197,7 @@ describe("CodingWorkerConsole", () => {
       queueMicrotask(() => {
         handlers.onEvent({ sequence: 1, task_id: task.task_id, type: "provider_event", payload: { kind: "plan", data: { summary: "先复现失败，再修复并复测。" } }, created_at: 1 });
         handlers.onEvent({ sequence: 2, task_id: task.task_id, type: "tool_operation", payload: { operation_id: "operation_shell_1", state: "completed" }, created_at: 2 });
+        handlers.onEvent({ sequence: 3, task_id: task.task_id, type: "provider_event", payload: { kind: "internal_frame" }, created_at: 3 });
       });
       return () => undefined;
     });
@@ -205,10 +205,11 @@ describe("CodingWorkerConsole", () => {
     const user = userEvent.setup();
     render(<CodingWorkerConsole context="agent" />);
 
-    expect(await screen.findByText("先复现失败，再修复并复测。")).toBeInTheDocument();
-    await user.click(screen.getByRole("tab", { name: "证据" }));
+    expect((await screen.findAllByText("先复现失败，再修复并复测。")).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText("provider event")).not.toBeInTheDocument();
     expect(await screen.findByText("Shell 单次审批")).toBeInTheDocument();
-    expect(screen.getByText("c".repeat(64))).toBeInTheDocument();
+    await user.click(screen.getByText("查看操作绑定"));
+    expect(screen.getByText((content) => content.includes("c".repeat(64)))).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "本任务批准" })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "终端" }));
@@ -235,7 +236,7 @@ describe("CodingWorkerConsole", () => {
     const user = userEvent.setup();
     render(<CodingWorkerConsole context="coding" onCodingHandoff={onCodingHandoff} />);
 
-    await user.click(await screen.findByRole("button", { name: "进入 v13 写回确认" }));
+    await user.click(await screen.findByRole("button", { name: "进入写回确认" }));
 
     await waitFor(() => expect(api.handoffCodingWorkerTask).toHaveBeenCalledWith(task.task_id));
     expect(onCodingHandoff).toHaveBeenCalledWith(expect.objectContaining({ revision: 1 }));
@@ -282,15 +283,23 @@ describe("CodingWorkerConsole", () => {
         max_projects: 50,
         projects: [newProject],
       });
+    api.createCodingWorkerTask.mockResolvedValue(task);
 
     const user = userEvent.setup();
     render(<CodingWorkerConsole context="coding" />);
     await user.click(await screen.findByRole("button", { name: "创建任务" }));
     await user.click(screen.getByRole("button", { name: "添加本地项目" }));
 
-    await waitFor(() => expect(screen.getByLabelText("本地项目")).toHaveValue(newProject.id));
+    await waitFor(() => expect(screen.getByLabelText("项目")).toHaveValue(newProject.id));
     expect(screen.getByLabelText("基准 revision")).toHaveValue(newProject.head);
     expect(projectApi.createCodingProjectSelection).toHaveBeenCalledTimes(1);
+
+    await user.selectOptions(screen.getByLabelText("执行方式"), "coding/quality");
+    await user.type(screen.getByLabelText("任务目标"), "修复类型错误并完成复测");
+    await user.click(screen.getByRole("button", { name: "创建并开始" }));
+    await waitFor(() => expect(api.createCodingWorkerTask).toHaveBeenCalledWith(
+      expect.objectContaining({ model_route: "coding/quality" }),
+    ));
   });
 
   it("recovers a project registered after the selection request expires", async () => {
@@ -340,7 +349,7 @@ describe("CodingWorkerConsole", () => {
     await user.click(await screen.findByRole("button", { name: "创建任务" }));
     await user.click(screen.getByRole("button", { name: "添加本地项目" }));
 
-    await waitFor(() => expect(screen.getByLabelText("本地项目")).toHaveValue(lateProject.id));
+    await waitFor(() => expect(screen.getByLabelText("项目")).toHaveValue(lateProject.id));
     expect(screen.getByLabelText("基准 revision")).toHaveValue(lateProject.head);
     expect(screen.queryByText("选择请求已超时", { exact: false })).not.toBeInTheDocument();
   });

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -1,19 +1,30 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  Activity,
+  Archive,
+  ArrowRight,
   CheckCircle2,
   CircleAlert,
+  Clock3,
+  Code2,
+  Eye,
   FileCode2,
   FolderPlus,
   FolderTree,
   GitCompareArrows,
-  MessageSquareText,
+  History,
+  Menu,
   Pause,
   Pin,
   Play,
   Plus,
+  Search,
+  Send,
   ShieldCheck,
   Square,
+  TestTube2,
   TerminalSquare,
+  X,
 } from "lucide-react";
 import type {
   CodingWorkerApproval,
@@ -57,29 +68,26 @@ import {
   getCodingProjects,
   getCodingWorkerHostSource,
 } from "../utils/codingApi";
+import {
+  activitiesFromEvents,
+  currentProgressStage,
+  evidenceStatus,
+  formatRelativeTime,
+  groupTasks,
+  pendingApprovals,
+  routeLabel,
+  shortId,
+  taskStateCopy,
+  terminalTaskStates,
+  type WorkerProgressStage,
+  type WorkerTaskGroup,
+} from "./coding-worker/viewModel";
 
 type ConsoleContext = "coding" | "agent";
 type InspectorTab = "files" | "diff" | "changesets" | "diagnostics" | "evidence" | "terminal";
 
-const terminalStates = new Set([
-  "completed", "blocked", "failed", "cancelled", "budget_limited", "expired",
-]);
-
-const stateCopy: Record<string, string> = {
-  queued: "排队中", preparing: "准备工作区", running: "执行中",
-  waiting_approval: "等待批准", paused: "已暂停", testing: "运行验收",
-  interrupted: "已中断", completed: "已完成", blocked: "已阻塞",
-  failed: "失败", cancelled: "已取消", budget_limited: "预算已用完", expired: "已过期",
-};
-
 function errorMessage(error: unknown, fallback: string) {
   return error instanceof Error ? error.message : fallback;
-}
-
-function payloadText(event: CodingWorkerEvent) {
-  const candidates = [event.payload.message, event.payload.text, event.payload.summary, event.payload.output];
-  const value = candidates.find((item) => typeof item === "string");
-  return typeof value === "string" ? value : null;
 }
 
 function publicPlanText(event: CodingWorkerEvent) {
@@ -89,18 +97,54 @@ function publicPlanText(event: CodingWorkerEvent) {
   if (!data || typeof data !== "object") return null;
   const record = data as Record<string, unknown>;
   const value = [record.summary, record.message, record.text].find((item) => typeof item === "string");
-  return typeof value === "string" ? value : JSON.stringify(record);
+  return typeof value === "string" ? value : "计划已更新。";
 }
 
 function approvalField(request: Record<string, unknown>, key: string) {
   const value = request[key];
-  return typeof value === "string" || typeof value === "number" ? String(value) : "未请求";
+  return typeof value === "string" || typeof value === "number" ? String(value) : null;
 }
 
 function outputTone(stream: CodingWorkerOperationOutputChunk["stream"]) {
   if (stream === "stderr") return "text-rose-200";
   if (stream === "system") return "text-amber-200";
   return "text-slate-200";
+}
+
+const taskGroupCopy: Record<WorkerTaskGroup, { label: string; empty: string }> = {
+  attention: { label: "需要处理", empty: "没有待处理任务" },
+  active: { label: "运行中", empty: "没有运行中任务" },
+  queued: { label: "排队", empty: "队列为空" },
+  history: { label: "最近任务", empty: "暂无历史任务" },
+};
+
+const progressStages: Array<{ value: WorkerProgressStage; label: string }> = [
+  { value: "analyze", label: "分析" },
+  { value: "reproduce", label: "复现" },
+  { value: "change", label: "修改" },
+  { value: "verify", label: "验收" },
+];
+
+function taskStateTone(state: CodingWorkerTask["state"]) {
+  if (["completed"].includes(state)) return "text-emerald-200";
+  if (["waiting_approval", "interrupted", "blocked", "budget_limited"].includes(state)) return "text-amber-200";
+  if (["failed", "cancelled", "expired"].includes(state)) return "text-rose-200";
+  if (["running", "testing", "preparing"].includes(state)) return "text-cyan-200";
+  return "text-slate-300";
+}
+
+function approvalSummary(approval: CodingWorkerApproval) {
+  const command = approval.request.command ?? approval.request.script;
+  if (typeof command === "string" && command.trim()) return command;
+  return approval.capability === "shell"
+    ? `Shell ${approvalField(approval.request, "mode") ?? "受控执行"}`
+    : "执行一次受控命令";
+}
+
+function approvalCapabilityLabel(capability: string) {
+  if (capability === "shell") return "Shell 单次审批";
+  if (capability === "command") return "命令单次审批";
+  return `${capability} 单次审批`;
 }
 
 interface CodingWorkerConsoleProps {
@@ -127,10 +171,14 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   const [tab, setTab] = useState<InspectorTab>("files");
   const [message, setMessage] = useState("");
   const [showCreate, setShowCreate] = useState(false);
+  const [showMobileTasks, setShowMobileTasks] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+  const [taskQuery, setTaskQuery] = useState("");
   const [objective, setObjective] = useState("");
   const [sourceId, setSourceId] = useState("");
   const [revision, setRevision] = useState("");
-  const [checkId, setCheckId] = useState("");
+  const [checkIds, setCheckIds] = useState<string[]>([]);
+  const [modelRoute, setModelRoute] = useState("coding/default");
   const [codingProjects, setCodingProjects] = useState<CodingProjectSummary[]>([]);
   const [selection, setSelection] = useState<CodingProjectSelection | null>(null);
   const [busy, setBusy] = useState(false);
@@ -139,6 +187,7 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   const [error, setError] = useState("");
   const operationRef = useRef(false);
   const selectionProjectIdsRef = useRef<Set<string>>(new Set());
+  const refreshTimerRef = useRef<number | null>(null);
 
   const selectedTask = useMemo(
     () => tasks.find((task) => task.task_id === selectedTaskId) ?? null,
@@ -155,6 +204,23 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   const latestPlan = useMemo(
     () => events.map(publicPlanText).filter((item): item is string => Boolean(item)).at(-1) ?? null,
     [events],
+  );
+  const routeOptions = useMemo(
+    () => status?.model_routes?.length ? status.model_routes : ["coding/default"],
+    [status?.model_routes],
+  );
+  const filteredTasks = useMemo(() => {
+    const query = taskQuery.trim().toLocaleLowerCase();
+    return query
+      ? tasks.filter((task) => `${task.spec.objective} ${task.spec.origin.module} ${taskStateCopy[task.state]}`.toLocaleLowerCase().includes(query))
+      : tasks;
+  }, [taskQuery, tasks]);
+  const groupedTasks = useMemo(() => groupTasks(filteredTasks), [filteredTasks]);
+  const activities = useMemo(() => activitiesFromEvents(events), [events]);
+  const approvalsPending = useMemo(() => pendingApprovals(approvals), [approvals]);
+  const progressStage = useMemo(
+    () => selectedTask ? currentProgressStage(selectedTask, events) : "analyze",
+    [events, selectedTask],
   );
 
   const refreshCodingProjects = useCallback(async (preferredId?: string, selectNew = false) => {
@@ -226,9 +292,13 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
       .then(([nextStatus]) => {
         if (!active) return;
         setStatus(nextStatus);
-        setCheckId((current) => nextStatus.acceptance_checks.includes(current)
+        setCheckIds((current) => {
+          const retained = current.filter((item) => nextStatus.acceptance_checks.includes(item));
+          return retained.length ? retained : nextStatus.acceptance_checks.slice(0, 1);
+        });
+        setModelRoute((current) => nextStatus.model_routes?.includes(current)
           ? current
-          : nextStatus.acceptance_checks[0] ?? "");
+          : nextStatus.model_routes?.[0] ?? "coding/default");
       })
       .catch((caught) => { if (active) setError(errorMessage(caught, "Coding Worker 加载失败")); })
       .finally(() => { if (active) setLoading(false); });
@@ -301,11 +371,21 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
         cursor = event.sequence;
         setEvents((current) => [...current, event].slice(-400));
         setTransportWarning(false);
-        void refreshTaskPanels(selectedTaskId).catch(() => setTransportWarning(true));
+        if (refreshTimerRef.current !== null) window.clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = window.setTimeout(() => {
+          void refreshTaskPanels(selectedTaskId).catch(() => setTransportWarning(true));
+        }, 350);
       },
       onTransportError: () => { if (active) setTransportWarning(true); },
     });
-    return () => { active = false; disconnect(); };
+    return () => {
+      active = false;
+      disconnect();
+      if (refreshTimerRef.current !== null) {
+        window.clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+    };
   }, [refreshTaskPanels, selectedTaskId]);
 
   useEffect(() => {
@@ -348,8 +428,8 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   }, []);
 
   const createTask = () => run(async () => {
-    if (!objective.trim() || !sourceId.trim() || !revision.trim() || !checkId.trim()) {
-      setError("请填写目标、来源 ID、基准 revision 和必需检查 ID。");
+    if (!objective.trim() || !sourceId.trim() || !revision.trim() || checkIds.length === 0) {
+      setError("请填写任务目标、选择受控来源，并至少勾选一项必需检查。");
       return;
     }
     const suffix = crypto.randomUUID().replaceAll("-", "");
@@ -359,17 +439,17 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
       workspace_source: { kind: context === "coding" ? "host_snapshot" : "builtin", source_id: sourceId.trim(), revision: revision.trim() },
       acceptance: {
         contract_id: `contract_${suffix}`,
-        required_checks: [{ check_id: checkId.trim(), kind: "command", label: "必需检查", required: true }],
+        required_checks: checkIds.map((item) => ({ check_id: item, kind: "command", label: item, required: true })),
         required_artifacts: [],
       },
       policy_profile: "develop",
-      model_route: "coding/default",
+      model_route: modelRoute,
       budget: { max_seconds: 3600, max_turns: 64, max_tool_calls: 512, max_output_bytes: 8 * 1024 * 1024 },
       context_refs: [],
     };
     const task = await createCodingWorkerTask(spec);
     await refreshTasks(task.task_id);
-    setShowCreate(false); setObjective(""); setSourceId(""); setRevision(""); setCheckId("");
+    setShowCreate(false); setObjective(""); setSourceId(""); setRevision(""); setCheckIds([]);
   });
 
   const addCodingProject = () => run(async () => {
@@ -454,148 +534,177 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   }
 
   return (
-    <div className="mx-auto flex min-h-[calc(100vh-5rem)] max-w-[1800px] flex-col gap-3 px-3 py-4 lg:px-5">
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-3">
-        <div className="min-w-0">
-          <h1 className="text-xl font-semibold text-white">Coding Worker</h1>
-          <p className="mt-1 text-sm text-slate-300">两个隔离槽位，任务证据与 Diff 可在重启后继续读取。</p>
-          <div className="mt-2 flex flex-wrap gap-1.5" aria-label="Worker 通用能力">
-            {([
-              ["专业文件", status.capabilities.professional_file_tools],
-              ["Shell", status.capabilities.shell],
-              ["终端补发", status.capabilities.operation_output],
-              ["原子变更", status.capabilities.changesets],
-              ["代码诊断", status.capabilities.code_intelligence],
-            ] as const).map(([label, available]) => (
-              <span key={label} className={`rounded-full px-2.5 py-1 text-xs ${available ? "bg-cyan-300/10 text-cyan-100" : "bg-white/5 text-slate-500"}`}>
-                {label} · {available ? "可用" : "关闭"}
-              </span>
-            ))}
+    <div className="mx-auto flex min-h-[calc(100vh-5rem)] max-w-[1920px] flex-col px-3 py-3 lg:px-5">
+      <header className="flex flex-wrap items-center gap-x-5 gap-y-3 border-b border-white/10 pb-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-cyan-300/10 text-cyan-200">
+            <Code2 className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <h1 className="text-lg font-semibold text-white">Coding Worker</h1>
+            <p className="truncate text-xs text-slate-400">隔离执行 · 证据持久化 · Provider 中立</p>
           </div>
         </div>
-        <button type="button" onClick={() => setShowCreate((value) => !value)} className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-cyan-400 px-4 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50" disabled={busy}>
-          <Plus className="h-4 w-4" aria-hidden="true" />创建任务
-        </button>
+
+        {selectedTask && (
+          <div className="order-3 min-w-0 basis-full lg:order-none lg:basis-auto">
+            <p className="truncate text-sm font-medium text-slate-100">{selectedTask.spec.objective}</p>
+            <p className="mt-0.5 flex flex-wrap items-center gap-1.5 text-xs text-slate-400">
+              <span>{routeLabel(selectedTask.spec.model_route)}</span><span aria-hidden="true">·</span>
+              <span>{selectedTask.spec.workspace_source.kind === "host_snapshot" ? "Host Snapshot" : selectedTask.spec.workspace_source.kind}</span><span aria-hidden="true">·</span>
+              <code>{shortId(selectedTask.spec.workspace_source.revision, 6)}</code>
+            </p>
+          </div>
+        )}
+
+        <div className="ml-auto flex items-center gap-2">
+          <span className="hidden items-center gap-2 text-xs text-slate-400 sm:inline-flex">
+            <span className="h-2 w-2 rounded-full bg-emerald-300" aria-hidden="true" />
+            {Math.min(tasks.filter((task) => ["preparing", "running", "testing"].includes(task.state)).length, status.max_active_tasks)} / {status.max_active_tasks} 槽位活跃
+          </span>
+          <button
+            type="button"
+            className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-cyan-300 px-4 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200 disabled:opacity-50"
+            onClick={() => setShowCreate(true)}
+            disabled={busy}
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />创建任务
+          </button>
+        </div>
       </header>
 
       {showCreate && (
-        <form className="grid gap-3 border-b border-white/10 pb-4 md:grid-cols-2 xl:grid-cols-5" onSubmit={(event) => { event.preventDefault(); void createTask(); }}>
-          <label className="md:col-span-2 xl:col-span-2 text-sm text-slate-200">任务目标
-            <textarea value={objective} onChange={(event) => setObjective(event.target.value)} className="mt-1 min-h-24 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 py-2 text-white" maxLength={1_048_576} />
-          </label>
-          {context === "coding" ? (
-            <div className="text-sm text-slate-200">
-              <label htmlFor="worker-host-project">本地项目</label>
-              <select
-                id="worker-host-project"
-                value={sourceId}
-                onChange={(event) => void selectCodingProject(event.target.value)}
-                className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white outline-none focus:border-cyan-300/70 focus:ring-4 focus:ring-cyan-300/10"
-              >
-                <option value="">选择已授权项目</option>
-                {codingProjects.map((project) => (
-                  <option
-                    key={project.id}
-                    value={project.id}
-                    disabled={project.state !== "available" || !project.head}
-                  >
-                    {project.name}{project.branch ? ` · ${project.branch}` : ""}
-                    {project.head ? ` · ${project.head.slice(0, 12)}` : ""}
-                    {project.state !== "available" ? " · 当前不可用" : ""}
-                  </option>
-                ))}
-              </select>
-              <button
-                type="button"
-                onClick={() => void addCodingProject()}
-                disabled={busy || selection?.status === "pending" || selection?.status === "dispatched"}
-                className="mt-2 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg border border-cyan-300/35 px-3 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-300/10 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-cyan-300/20 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <FolderPlus className="h-4 w-4" aria-hidden="true" />
-                {selection?.status === "pending" || selection?.status === "dispatched"
-                  ? "等待 Helper 选择"
-                  : "添加本地项目"}
-              </button>
-              <p className="mt-2 text-xs leading-5 text-slate-400">
-                点击后在 Helper 弹出的窗口中选择干净的 Git 仓库，物理路径不会发送到 Server。
-              </p>
+        <section className="border-b border-white/10 py-5" aria-labelledby="worker-create-heading">
+          <div className="mx-auto max-w-6xl">
+            <div className="mb-5 flex items-start justify-between gap-4">
+              <div><h2 id="worker-create-heading" className="text-xl font-semibold text-white">新建开发任务</h2><p className="mt-1 text-sm text-slate-400">项目基准、执行方式与验收检查会在任务创建后冻结。</p></div>
+              <button type="button" onClick={() => setShowCreate(false)} className="grid min-h-11 min-w-11 place-items-center rounded-lg text-slate-300 hover:bg-white/5" aria-label="关闭创建任务"><X className="h-5 w-5" /></button>
             </div>
-          ) : (
-            <label className="text-sm text-slate-200">不透明来源 ID<input value={sourceId} onChange={(event) => setSourceId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
-          )}
-          <label className="text-sm text-slate-200">基准 revision<input value={revision} onChange={(event) => setRevision(event.target.value)} readOnly={context === "coding"} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white read-only:text-slate-300" /></label>
-          <label className="text-sm text-slate-200">冻结验收检查<select value={checkId} onChange={(event) => setCheckId(event.target.value)} disabled={!status.acceptance_checks.length} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white disabled:opacity-60">{status.acceptance_checks.map((item) => <option key={item} value={item}>{item}</option>)}</select></label>
-          <div className="flex items-end md:col-span-2 xl:col-span-5"><button type="submit" disabled={busy || !checkId} className="min-h-11 rounded-lg bg-cyan-400 px-5 text-sm font-semibold text-slate-950 disabled:opacity-50">提交到队列</button></div>
-        </form>
+            <form className="grid gap-x-6 gap-y-4 lg:grid-cols-[minmax(0,1fr)_20rem]" onSubmit={(event) => { event.preventDefault(); void createTask(); }}>
+              <div className="space-y-4">
+                <label className="block text-sm font-medium text-slate-200">任务目标
+                  <textarea value={objective} onChange={(event) => setObjective(event.target.value)} className="mt-1.5 min-h-32 w-full resize-y rounded-lg border border-white/15 bg-slate-950/70 px-3 py-2.5 text-white placeholder:text-slate-500" placeholder="说明要修复或实现的内容、不能改变的边界，以及期望的复现和复测方式。" maxLength={1_048_576} />
+                </label>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {context === "coding" ? (
+                    <div className="text-sm font-medium text-slate-200">
+                      <label htmlFor="worker-host-project">项目</label>
+                      <select id="worker-host-project" value={sourceId} onChange={(event) => void selectCodingProject(event.target.value)} className="mt-1.5 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white">
+                        <option value="">选择已授权项目</option>
+                        {codingProjects.map((project) => <option key={project.id} value={project.id} disabled={project.state !== "available" || !project.head}>{project.name}{project.branch ? ` · ${project.branch}` : ""}{project.state !== "available" ? " · 当前不可用" : ""}</option>)}
+                      </select>
+                      <button type="button" onClick={() => void addCodingProject()} disabled={busy || selection?.status === "pending" || selection?.status === "dispatched"} className="mt-2 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg border border-cyan-300/35 px-3 text-sm text-cyan-100 hover:bg-cyan-300/10 disabled:opacity-50">
+                        <FolderPlus className="h-4 w-4" />{selection?.status === "pending" || selection?.status === "dispatched" ? "等待 Helper 选择" : "添加本地项目"}
+                      </button>
+                    </div>
+                  ) : <label className="text-sm font-medium text-slate-200">不透明来源 ID<input value={sourceId} onChange={(event) => setSourceId(event.target.value)} className="mt-1.5 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>}
+                  <label className="text-sm font-medium text-slate-200">执行方式
+                    <select value={modelRoute} onChange={(event) => setModelRoute(event.target.value)} className="mt-1.5 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white">
+                      {routeOptions.map((route) => <option key={route} value={route}>{routeLabel(route)}{route === "coding/default" ? " · 常规修复" : route === "coding/quality" ? " · 复杂诊断" : ""}</option>)}
+                    </select>
+                  </label>
+                  <label className="text-sm font-medium text-slate-200">基准 revision<input value={revision} onChange={(event) => setRevision(event.target.value)} readOnly={context === "coding"} className="mt-1.5 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 font-mono text-xs text-white read-only:text-slate-300" /></label>
+                  <fieldset className="text-sm font-medium text-slate-200"><legend>必需检查</legend><div className="mt-1.5 space-y-1.5">{status.acceptance_checks.length === 0 ? <p className="min-h-11 rounded-lg border border-white/10 px-3 py-3 text-xs text-slate-500">当前没有可用检查</p> : status.acceptance_checks.map((item) => <label key={item} className="flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border border-white/10 px-3 text-sm text-slate-200 hover:bg-white/5"><input type="checkbox" checked={checkIds.includes(item)} onChange={(event) => setCheckIds((current) => event.target.checked ? [...current, item] : current.filter((value) => value !== item))} className="h-4 w-4 accent-cyan-300" /><span className="break-all">{item}</span></label>)}</div></fieldset>
+                </div>
+              </div>
+              <aside className="border-t border-white/10 pt-4 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0">
+                <h3 className="text-sm font-semibold text-white">任务边界</h3>
+                <ul className="mt-3 space-y-3 text-sm leading-5 text-slate-300">
+                  <li className="flex gap-2"><ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-cyan-200" /><span>Worker 只修改隔离 Workspace，宿主写回继续走 v13 确认链。</span></li>
+                  <li className="flex gap-2"><TerminalSquare className="mt-0.5 h-4 w-4 shrink-0 text-cyan-200" /><span>Shell 按操作审批，绑定脚本摘要、目录和超时。</span></li>
+                  <li className="flex gap-2"><GitCompareArrows className="mt-0.5 h-4 w-4 shrink-0 text-cyan-200" /><span>必需检查全部通过后，任务才会标记为完成。</span></li>
+                </ul>
+                <button type="submit" disabled={busy || checkIds.length === 0 || !modelRoute} className="mt-5 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg bg-cyan-300 px-4 text-sm font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-50"><Play className="h-4 w-4" />创建并开始</button>
+              </aside>
+            </form>
+          </div>
+        </section>
       )}
 
       {error && <div className="rounded-lg bg-rose-500/15 px-4 py-3 text-sm text-rose-100" role="alert">{error}</div>}
       {transportWarning && <div className="rounded-lg bg-amber-400/10 px-4 py-3 text-sm text-amber-100" role="status">事件连接已中断，任务状态仍可从持久存储恢复。</div>}
 
-      <div className="grid min-h-0 flex-1 gap-3 lg:grid-cols-[16rem_minmax(0,1fr)] xl:grid-cols-[16rem_minmax(0,1fr)_26rem]">
-        <aside className="min-h-0 border-r border-white/10 pr-3" aria-label="Worker 任务列表">
-          <div className="mb-2 flex items-center justify-between"><h2 className="text-sm font-semibold text-slate-200">任务</h2><span className="text-xs text-slate-400">{tasks.length}</span></div>
-          <div className="flex max-h-[38vh] flex-col gap-1 overflow-y-auto lg:max-h-[calc(100vh-11rem)]">
-            {tasks.length === 0 && <p className="rounded-lg bg-white/5 p-3 text-sm text-slate-300">还没有任务。先从受控来源创建一个任务。</p>}
-            {tasks.map((task) => (
-              <button key={task.task_id} type="button" onClick={() => setSelectedTaskId(task.task_id)} className={`min-h-14 rounded-lg px-3 py-2 text-left transition ${task.task_id === selectedTaskId ? "bg-cyan-400/15 text-white" : "text-slate-300 hover:bg-white/5"}`}>
-                <span className="block truncate text-sm font-medium">{task.spec.objective}</span>
-                <span className="mt-1 flex items-center justify-between gap-2 text-xs text-slate-400"><span>{stateCopy[task.state] ?? task.state}</span><span>{task.spec.origin.module}</span></span>
-              </button>
-            ))}
+      <div className="grid min-h-0 flex-1 gap-0 lg:grid-cols-[18rem_minmax(0,1fr)] xl:grid-cols-[18rem_minmax(0,1fr)_27rem]">
+        <div className="flex items-center justify-between border-b border-white/10 py-2 lg:hidden">
+          <button type="button" onClick={() => setShowMobileTasks((value) => !value)} className="inline-flex min-h-11 items-center gap-2 text-sm font-medium text-slate-200" aria-expanded={showMobileTasks}><Menu className="h-4 w-4" />{showMobileTasks ? "返回当前任务" : "查看任务列表"}</button>
+          <span className={selectedTask ? `text-xs ${taskStateTone(selectedTask.state)}` : "text-xs text-slate-400"}>{selectedTask ? taskStateCopy[selectedTask.state] : `${tasks.length} 个任务`}</span>
+        </div>
+
+        <aside className={`${showMobileTasks || !selectedTask ? "block" : "hidden"} min-h-0 border-b border-white/10 py-3 lg:block lg:border-b-0 lg:border-r lg:pr-3`} aria-label="Worker 任务列表">
+          <div className="flex items-center gap-2">
+            <label className="relative min-w-0 flex-1"><span className="sr-only">搜索任务</span><Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" /><input value={taskQuery} onChange={(event) => setTaskQuery(event.target.value)} placeholder="搜索任务" className="min-h-11 w-full rounded-lg border border-white/10 bg-slate-950/55 pl-9 pr-3 text-sm text-white placeholder:text-slate-500" /></label>
+          </div>
+          <div className="mt-3 max-h-[38rem] space-y-4 overflow-y-auto pr-1 lg:max-h-[calc(100vh-12rem)]">
+            {tasks.length === 0 && <p className="py-8 text-center text-sm text-slate-400">还没有任务。创建任务后会在这里跟踪执行状态。</p>}
+            {(["attention", "active", "queued", "history"] as WorkerTaskGroup[]).map((group) => {
+              const items = groupedTasks[group];
+              if (group === "history" && !showHistory) {
+                return items.length ? <button key={group} type="button" onClick={() => setShowHistory(true)} className="flex min-h-11 w-full items-center justify-between text-sm text-slate-400 hover:text-slate-200"><span className="inline-flex items-center gap-2"><History className="h-4 w-4" />查看最近任务</span><span>{items.length}</span></button> : null;
+              }
+              if (!items.length && (taskQuery || group === "history")) return null;
+              return <section key={group} aria-labelledby={`worker-group-${group}`}>
+                <div className="mb-1.5 flex items-center justify-between"><h2 id={`worker-group-${group}`} className="text-xs font-medium text-slate-400">{taskGroupCopy[group].label}</h2><span className="text-xs text-slate-600">{items.length}</span></div>
+                {items.length === 0 ? <p className="px-2 py-2 text-xs text-slate-600">{taskGroupCopy[group].empty}</p> : <div className="space-y-1">{items.slice(0, group === "history" ? 12 : undefined).map((task) => <button key={task.task_id} type="button" onClick={() => { setSelectedTaskId(task.task_id); setShowMobileTasks(false); }} className={`w-full rounded-lg px-3 py-2.5 text-left transition ${task.task_id === selectedTaskId ? "bg-cyan-300/10 text-white" : "text-slate-300 hover:bg-white/5"}`} aria-current={task.task_id === selectedTaskId ? "true" : undefined}>
+                  <span className="line-clamp-2 text-sm font-medium leading-5">{task.spec.objective}</span>
+                  <span className="mt-1.5 flex items-center justify-between gap-2 text-xs"><span className={taskStateTone(task.state)}>{taskStateCopy[task.state]}</span><span className="text-slate-500">{formatRelativeTime(task.updated_at)}</span></span>
+                </button>)}</div>}
+              </section>;
+            })}
+            {taskQuery && filteredTasks.length === 0 && <p className="py-8 text-center text-sm text-slate-400">没有匹配的任务。</p>}
           </div>
         </aside>
 
-        <main className="min-w-0">
-          {!selectedTask ? (
-            <div className="flex min-h-80 items-center justify-center text-sm text-slate-400">选择任务后查看目标、计划和运行事件。</div>
-          ) : (
-            <div className="flex h-full min-h-[32rem] flex-col">
-              <div className="flex flex-wrap items-start justify-between gap-3 border-b border-white/10 pb-3">
-                <div className="min-w-0"><p className="break-words text-lg font-semibold text-white">{selectedTask.spec.objective}</p><p className="mt-1 break-all text-xs text-slate-400">{selectedTask.task_id} · {stateCopy[selectedTask.state] ?? selectedTask.state}</p></div>
-                <div className="flex flex-wrap gap-2">
-                  {selectedTask.state === "running" || selectedTask.state === "testing" ? <button type="button" onClick={() => void taskAction("pause")} disabled={busy} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-white/15 px-3 text-sm text-slate-200"><Pause className="h-4 w-4" />暂停</button> : null}
-                  {selectedTask.state === "paused" || selectedTask.state === "interrupted" ? <button type="button" onClick={() => void taskAction("resume")} disabled={busy} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-cyan-300/40 px-3 text-sm text-cyan-100"><Play className="h-4 w-4" />继续</button> : null}
-                  {!terminalStates.has(selectedTask.state) && <button type="button" onClick={() => void taskAction("cancel")} disabled={busy} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-white/15 px-3 text-sm text-slate-200"><Square className="h-4 w-4" />取消</button>}
-                  <button type="button" onClick={() => void taskAction(selectedTask.pinned ? "unpin" : "pin")} disabled={busy} aria-pressed={selectedTask.pinned} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-white/15 px-3 text-sm text-slate-200"><Pin className="h-4 w-4" />{selectedTask.pinned ? "取消固定" : "固定"}</button>
+        <main className={`${showMobileTasks && selectedTask ? "hidden" : "block"} min-w-0 py-3 lg:block lg:px-5`}>
+          {!selectedTask ? <div className="flex min-h-96 flex-col items-center justify-center text-center"><Activity className="h-8 w-8 text-slate-600" /><p className="mt-3 text-sm text-slate-300">选择任务后查看目标、下一动作和执行证据。</p></div> : <div className="flex h-full min-h-[36rem] flex-col">
+            <section className="border-b border-white/10 pb-4" aria-labelledby="worker-task-heading">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0"><h2 id="worker-task-heading" className="max-w-[65ch] break-words text-xl font-semibold text-white">{selectedTask.spec.objective}</h2><p className="mt-1.5 flex flex-wrap items-center gap-2 text-xs text-slate-400"><span className={taskStateTone(selectedTask.state)}>{taskStateCopy[selectedTask.state]}</span><span>{selectedTask.spec.origin.module}</span><code>{shortId(selectedTask.task_id)}</code></p></div>
+                <div className="flex items-center gap-1">
+                  {selectedTask.state === "running" || selectedTask.state === "testing" ? <button type="button" onClick={() => void taskAction("pause")} disabled={busy} className="grid min-h-11 min-w-11 place-items-center rounded-lg text-slate-300 hover:bg-white/5" aria-label="暂停任务"><Pause className="h-4 w-4" /></button> : null}
+                  {selectedTask.state === "paused" || selectedTask.state === "interrupted" ? <button type="button" onClick={() => void taskAction("resume")} disabled={busy} className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-cyan-300/35 px-3 text-sm text-cyan-100"><Play className="h-4 w-4" />继续任务</button> : null}
+                  {!terminalTaskStates.has(selectedTask.state) && <button type="button" onClick={() => void taskAction("cancel")} disabled={busy} className="grid min-h-11 min-w-11 place-items-center rounded-lg text-slate-300 hover:bg-white/5" aria-label="取消任务"><Square className="h-4 w-4" /></button>}
+                  <button type="button" onClick={() => void taskAction(selectedTask.pinned ? "unpin" : "pin")} disabled={busy} aria-pressed={selectedTask.pinned} className="grid min-h-11 min-w-11 place-items-center rounded-lg text-slate-300 hover:bg-white/5" aria-label={selectedTask.pinned ? "取消固定" : "固定任务"}><Pin className="h-4 w-4" /></button>
                 </div>
               </div>
+              <ol className="mt-5 grid grid-cols-4 gap-1" aria-label="任务进度">{progressStages.map((stage, index) => { const currentIndex = progressStages.findIndex((item) => item.value === progressStage); const completed = index < currentIndex || selectedTask.state === "completed"; const current = index === currentIndex && selectedTask.state !== "completed"; return <li key={stage.value} className="min-w-0"><div className={`h-1 rounded-full ${completed ? "bg-emerald-300" : current ? "bg-cyan-300" : "bg-white/10"}`} /><span className={`mt-1.5 block text-xs ${completed ? "text-emerald-200" : current ? "text-cyan-100" : "text-slate-500"}`}>{stage.label}</span></li>; })}</ol>
+            </section>
 
-              <section className="mt-3 border-b border-white/10 pb-3" aria-labelledby="goal-heading">
-                <div className="flex items-center gap-2"><CheckCircle2 className="h-4 w-4 text-cyan-300" /><h2 id="goal-heading" className="text-sm font-semibold text-white">目标与验收</h2></div>
-                <ul className="mt-2 space-y-1 text-sm text-slate-300">{selectedTask.spec.acceptance.required_checks.map((check) => <li key={check.check_id}>• {check.label} <code className="break-all text-xs text-slate-400">{check.check_id}</code></li>)}</ul>
-              </section>
+            {approvalsPending.length > 0 && <section className="my-4 rounded-xl bg-amber-300/10 p-4" aria-labelledby="worker-actions-heading" aria-live="polite">
+              <div className="flex flex-wrap items-center justify-between gap-2"><h2 id="worker-actions-heading" className="inline-flex items-center gap-2 text-sm font-semibold text-amber-50"><ShieldCheck className="h-4 w-4 text-amber-200" />需要你的决定</h2><span className="text-xs text-amber-100/70">{approvalsPending.length} 项待处理</span></div>
+              {approvalsPending.map((approval) => <article key={approval.approval_id} className="mt-3 border-t border-amber-100/10 pt-3 first:border-t-0 first:pt-0">
+                <p className="mb-2 text-sm font-medium text-amber-50">{approvalCapabilityLabel(approval.capability)}</p>
+                <div className="rounded-lg bg-slate-950/60 px-3 py-2 font-mono text-sm text-slate-100">{approvalSummary(approval)}</div>
+                <dl className="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-xs">{approvalField(approval.request, "mode") && <div><dt className="inline text-slate-500">模式 </dt><dd className="inline text-slate-200">{approvalField(approval.request, "mode")}</dd></div>}{approvalField(approval.request, "cwd") && <div><dt className="inline text-slate-500">目录 </dt><dd className="inline text-slate-200">{approvalField(approval.request, "cwd")}</dd></div>}{approvalField(approval.request, "timeout_seconds") && <div><dt className="inline text-slate-500">超时 </dt><dd className="inline text-slate-200">{approvalField(approval.request, "timeout_seconds")} 秒</dd></div>}<div><dt className="inline text-slate-500">网络 </dt><dd className="inline text-slate-200">{approval.request.network_scope_sha256 ? "受限范围" : "关闭"}</dd></div></dl>
+                <details className="mt-2 text-xs text-slate-400"><summary className="min-h-11 cursor-pointer py-2">查看操作绑定</summary><code className="block break-all pb-2">operation {approval.operation_id}{approvalField(approval.request, "script_sha256") && <><br />script {approvalField(approval.request, "script_sha256")}</>}</code></details>
+                <div className="mt-3 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end"><button type="button" disabled={busy} onClick={() => void decide(approval.approval_id, "reject")} className="min-h-11 rounded-lg border border-white/15 px-4 text-sm text-slate-200">拒绝并反馈</button><button type="button" disabled={busy} onClick={() => void decide(approval.approval_id, "approve_once")} className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-amber-200 px-4 text-sm font-semibold text-slate-950"><CheckCircle2 className="h-4 w-4" />批准本次执行</button></div>
+              </article>)}
+            </section>}
 
-              {latestPlan && (
-                <section className="border-b border-white/10 py-3" aria-labelledby="worker-plan-heading">
-                  <div className="flex items-center justify-between gap-3">
-                    <h2 id="worker-plan-heading" className="text-sm font-semibold text-white">当前公开计划</h2>
-                    <span className="text-xs text-slate-500">Provider 中立</span>
-                  </div>
-                  <p className="mt-2 max-w-[72ch] whitespace-pre-wrap break-words text-sm leading-6 text-slate-300">{latestPlan}</p>
-                </section>
-              )}
+            <section className="border-b border-white/10 py-4" aria-labelledby="goal-heading">
+              <div className="flex items-center justify-between gap-3"><h2 id="goal-heading" className="text-sm font-semibold text-white">验收条件</h2><span className="text-xs text-slate-500">创建后不可降级</span></div>
+              <ul className="mt-2 flex flex-wrap gap-2">{selectedTask.spec.acceptance.required_checks.map((check) => { const state = evidenceStatus(check.check_id, evidence); return <li key={check.check_id} className="inline-flex min-h-9 items-center gap-2 rounded-lg bg-white/5 px-3 text-xs text-slate-200"><span className={state === "passed" ? "text-emerald-300" : state === "failed" ? "text-rose-300" : state === "invalidated" ? "text-amber-300" : "text-slate-500"}>{state === "passed" ? "通过" : state === "failed" ? "失败" : state === "invalidated" ? "已失效" : "待执行"}</span><span>{check.label}</span></li>; })}</ul>
+            </section>
 
-              <section className="min-h-0 flex-1 overflow-y-auto py-3" aria-label="任务事件" aria-live="polite">
-                {events.length === 0 ? <p className="text-sm text-slate-400">等待 Worker 事件。公开事件只包含计划、状态和工具摘要。</p> : events.map((event) => (
-                  <article key={event.sequence} className="mb-3 flex gap-3"><span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-cyan-300" aria-hidden="true" /><div className="min-w-0"><p className="text-xs font-medium text-slate-400">{event.type} · #{event.sequence}</p><p className="mt-1 whitespace-pre-wrap break-words text-sm text-slate-200">{payloadText(event) ?? JSON.stringify(event.payload)}</p></div></article>
-                ))}
-              </section>
+            {latestPlan && <section className="border-b border-white/10 py-4" aria-labelledby="worker-plan-heading"><div className="flex items-center justify-between gap-3"><h2 id="worker-plan-heading" className="text-sm font-semibold text-white">当前计划</h2><span className="text-xs text-slate-500">公开摘要</span></div><p className="mt-2 max-w-[72ch] whitespace-pre-wrap break-words text-sm leading-6 text-slate-300">{latestPlan}</p></section>}
 
-              <form className="border-t border-white/10 pt-3" onSubmit={(event) => { event.preventDefault(); void submitMessage(); }}>
-                <label className="sr-only" htmlFor="worker-message">追加指令</label>
-                <div className="flex gap-2"><textarea id="worker-message" value={message} onChange={(event) => setMessage(event.target.value)} disabled={busy || terminalStates.has(selectedTask.state)} placeholder="追加指令或运行中 steering" className="min-h-12 flex-1 resize-y rounded-lg border border-white/15 bg-slate-950/70 px-3 py-2 text-sm text-white placeholder:text-slate-400 disabled:opacity-60" /><button type="submit" disabled={busy || !message.trim() || terminalStates.has(selectedTask.state)} className="min-h-12 rounded-lg bg-cyan-400 px-4 text-sm font-semibold text-slate-950 disabled:opacity-50">发送指令</button></div>
-              </form>
-            </div>
-          )}
+            <section className="min-h-0 flex-1 py-4" aria-label="任务进展" aria-live="polite">
+              <h2 className="text-sm font-semibold text-white">任务进展</h2>
+              {activities.length === 0 ? <p className="mt-3 text-sm text-slate-400">等待 Worker 开始。状态、计划与工具摘要会显示在这里。</p> : <ol className="mt-4 space-y-5">{activities.slice(-80).map((activity) => <li key={activity.sequence} className="flex gap-3"><span className={`mt-1 grid h-7 w-7 shrink-0 place-items-center rounded-full ${activity.tone === "success" ? "bg-emerald-300/10 text-emerald-200" : activity.tone === "warning" ? "bg-amber-300/10 text-amber-200" : activity.tone === "danger" ? "bg-rose-300/10 text-rose-200" : "bg-cyan-300/10 text-cyan-200"}`}>{activity.tone === "success" ? <CheckCircle2 className="h-4 w-4" /> : activity.tone === "warning" ? <Clock3 className="h-4 w-4" /> : activity.tone === "danger" ? <CircleAlert className="h-4 w-4" /> : <Activity className="h-4 w-4" />}</span><div className="min-w-0 flex-1"><div className="flex flex-wrap items-baseline justify-between gap-2"><h3 className="text-sm font-medium text-slate-100">{activity.title}</h3><span className="text-xs text-slate-600">{activity.meta}</span></div><p className="mt-1 max-w-[72ch] whitespace-pre-wrap break-words text-sm leading-6 text-slate-300">{activity.detail}</p>{activity.operationId && <button type="button" onClick={() => setTab("terminal")} className="mt-1 min-h-11 text-xs text-cyan-200">查看操作 {shortId(activity.operationId)}</button>}</div></li>)}</ol>}
+            </section>
+
+            <form className="sticky bottom-0 border-t border-white/10 bg-[#060916]/95 py-3 backdrop-blur" onSubmit={(event) => { event.preventDefault(); void submitMessage(); }}>
+              <label className="sr-only" htmlFor="worker-message">追加指令</label><div className="flex gap-2"><textarea id="worker-message" value={message} onChange={(event) => setMessage(event.target.value)} disabled={busy || terminalTaskStates.has(selectedTask.state)} placeholder="追加约束或调整方向，当前工具结束后生效" className="min-h-12 flex-1 resize-y rounded-lg border border-white/15 bg-slate-950/80 px-3 py-2 text-sm text-white placeholder:text-slate-500 disabled:opacity-60" /><button type="submit" disabled={busy || !message.trim() || terminalTaskStates.has(selectedTask.state)} className="inline-flex min-h-12 min-w-12 items-center justify-center gap-2 rounded-lg bg-cyan-300 px-4 text-sm font-semibold text-slate-950 disabled:opacity-50"><Send className="h-4 w-4" /><span className="hidden sm:inline">发送</span></button></div>
+            </form>
+          </div>}
         </main>
 
-        <aside className="min-w-0 border-t border-white/10 pt-3 xl:border-l xl:border-t-0 xl:pl-3 xl:pt-0" aria-label="任务检查器">
-          <div className="flex overflow-x-auto border-b border-white/10" role="tablist">
-            {([ ["files", FolderTree, "文件"], ["diff", GitCompareArrows, "Diff"], ["changesets", GitCompareArrows, "变更"], ["diagnostics", CircleAlert, "诊断"], ["evidence", ShieldCheck, "证据"], ["terminal", TerminalSquare, "终端"] ] as const).map(([value, Icon, label]) => <button key={value} type="button" role="tab" aria-selected={tab === value} onClick={() => setTab(value)} className={`inline-flex min-h-11 items-center gap-1 px-3 text-sm ${tab === value ? "border-b-2 border-cyan-300 text-white" : "text-slate-400"}`}><Icon className="h-4 w-4" />{label}</button>)}
+        <aside className="min-w-0 border-t border-white/10 py-3 lg:col-span-2 xl:col-span-1 xl:border-l xl:border-t-0 xl:pl-4" aria-label="任务检查器">
+          {selectedTask?.state === "completed" && <section className="mb-4 rounded-xl bg-emerald-300/10 p-4" aria-labelledby="worker-result-heading"><div className="flex gap-3"><span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-emerald-300 text-slate-950"><CheckCircle2 className="h-5 w-5" /></span><div><h2 id="worker-result-heading" className="font-semibold text-emerald-50">任务完成</h2><p className="mt-1 text-xs leading-5 text-emerald-100/75">必需检查已通过，结果绑定当前 Workspace tree。</p></div></div><button type="button" onClick={() => setTab("diff")} className="mt-3 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg border border-emerald-200/25 text-sm text-emerald-50"><Eye className="h-4 w-4" />检查完整 Diff</button></section>}
+          <div className="flex overflow-x-auto border-b border-white/10" role="tablist" aria-label="任务检查器视图">
+            {([ ["files", FolderTree, "文件"], ["diff", GitCompareArrows, "Diff"], ["changesets", Archive, "变更"], ["diagnostics", CircleAlert, "诊断"], ["evidence", TestTube2, "测试"], ["terminal", TerminalSquare, "终端"] ] as const).map(([value, Icon, label]) => <button key={value} type="button" role="tab" aria-selected={tab === value} onClick={() => setTab(value)} className={`inline-flex min-h-11 shrink-0 items-center gap-1.5 px-3 text-sm ${tab === value ? "border-b-2 border-cyan-300 text-white" : "text-slate-400 hover:text-slate-200"}`}><Icon className="h-4 w-4" />{label}</button>)}
           </div>
-          <div className="max-h-[46rem] overflow-auto py-3 text-sm">
-            {tab === "files" && <div><p className="mb-2 break-all text-xs text-slate-400">tree {treeHash || "尚未创建"}</p>{preview ? <div><button type="button" className="mb-2 min-h-11 text-cyan-200" onClick={() => setPreview(null)}>返回文件树</button><p className="mb-2 break-all text-slate-300">{preview.path}</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{preview.content}</pre></div> : <ul className="space-y-1">{entries.map((entry) => <li key={entry.entry_id}><button type="button" disabled={entry.kind !== "file" || busy} onClick={() => void openEntry(entry)} className="flex min-h-10 w-full items-center gap-2 rounded-md px-2 text-left text-slate-300 hover:bg-white/5 disabled:cursor-default"><FileCode2 className="h-4 w-4 shrink-0" /><span className="min-w-0 break-all">{entry.display_path}</span></button></li>)}</ul>}</div>}
+          <div className="max-h-[34rem] overflow-auto py-3 text-sm xl:max-h-[calc(100vh-20rem)]">
+            {tab === "files" && <div><p className="mb-2 break-all text-xs text-slate-400">tree {treeHash || "尚未创建"}</p>{preview ? <div><button type="button" className="mb-2 min-h-11 text-cyan-200" onClick={() => setPreview(null)}>返回文件树</button><p className="mb-2 break-all text-slate-300">{preview.path}</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{preview.content}</pre></div> : <ul className="space-y-1">{entries.map((entry) => <li key={entry.entry_id}><button type="button" disabled={entry.kind !== "file" || busy} onClick={() => void openEntry(entry)} className="flex min-h-11 w-full items-center gap-2 rounded-md px-2 text-left text-slate-300 hover:bg-white/5 disabled:cursor-default"><FileCode2 className="h-4 w-4 shrink-0" /><span className="min-w-0 break-all">{entry.display_path}</span></button></li>)}</ul>}</div>}
             {tab === "diff" && <pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{diff || "工作区还没有变更。"}</pre>}
             {tab === "changesets" && (
               <div className="space-y-3" aria-busy={inspectorLoading}>
@@ -625,7 +734,7 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
                 ))}
               </div>
             )}
-            {tab === "evidence" && <div className="space-y-4"><section><h3 className="font-semibold text-white">审批</h3>{approvals.filter((item) => item.status === "pending").map((item) => <div key={item.approval_id} className="mt-2 rounded-lg bg-amber-300/10 p-3"><div className="flex flex-wrap items-center justify-between gap-2"><p className="text-amber-100">{item.capability === "shell" ? "Shell 单次审批" : item.capability}</p><code className="break-all text-xs text-slate-400">{item.operation_id}</code></div>{item.capability === "shell" ? <dl className="mt-3 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-2 text-xs"><dt className="text-slate-400">模式</dt><dd className="break-all text-slate-200">{approvalField(item.request, "mode")}</dd><dt className="text-slate-400">工作目录</dt><dd className="break-all text-slate-200">{approvalField(item.request, "cwd")}</dd><dt className="text-slate-400">超时</dt><dd className="break-all text-slate-200">{approvalField(item.request, "timeout_seconds")} 秒</dd><dt className="text-slate-400">脚本摘要</dt><dd className="break-all font-mono text-slate-200">{approvalField(item.request, "script_sha256")}</dd><dt className="text-slate-400">网络范围</dt><dd className="break-all font-mono text-slate-200">{approvalField(item.request, "network_scope_sha256")}</dd></dl> : <p className="mt-1 break-words text-xs text-slate-300">{JSON.stringify(item.request)}</p>}<div className="mt-3 flex flex-wrap gap-2"><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_once")} className="min-h-11 rounded-lg bg-cyan-400 px-3 font-semibold text-slate-950">批准一次</button>{item.capability !== "shell" ? <button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_task")} className="min-h-11 rounded-lg border border-cyan-300/40 px-3 text-cyan-100">本任务批准</button> : null}<button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "reject")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200">拒绝</button></div></div>)}</section><section><h3 className="font-semibold text-white">检查证据</h3><ul className="mt-2 space-y-2">{evidence.map((item) => <li key={item.evidence_id} className="rounded-lg bg-white/5 p-3"><span className={item.status === "passed" ? "text-emerald-300" : item.status === "failed" ? "text-rose-300" : "text-amber-300"}>{item.status}</span><span className="ml-2 break-all text-slate-200">{item.check_id}</span><span className="mt-1 block text-xs text-slate-400">exit {item.exit_code}</span></li>)}</ul></section><section><h3 className="font-semibold text-white">Artifacts</h3><ul className="mt-2 space-y-1">{artifacts.map((item) => <li key={item.artifact_id}><a className="block min-h-11 break-all rounded-md px-2 py-2.5 text-cyan-200 hover:bg-white/5" href={codingWorkerArtifactUrl(item.task_id, item.artifact_id)}>{item.artifact_id} · {item.media_type}</a></li>)}</ul></section></div>}
+            {tab === "evidence" && <div className="space-y-5"><section><div className="flex items-center justify-between"><h3 className="font-semibold text-white">必需检查</h3><span className="text-xs text-slate-500">{evidence.filter((item) => item.status === "passed").length}/{selectedTask?.spec.acceptance.required_checks.length ?? 0} 通过</span></div>{evidence.length === 0 ? <p className="mt-3 text-slate-400">尚未产生检查证据。</p> : <ul className="mt-3 space-y-2">{evidence.map((item) => <li key={item.evidence_id} className="rounded-lg bg-white/5 p-3"><div className="flex items-center justify-between gap-2"><span className="break-all text-slate-200">{item.check_id}</span><span className={item.status === "passed" ? "text-emerald-300" : item.status === "failed" ? "text-rose-300" : "text-amber-300"}>{item.status === "passed" ? "通过" : item.status === "failed" ? "失败" : "已失效"}</span></div><span className="mt-1 block text-xs text-slate-400">exit {item.exit_code} · tree {shortId(item.workspace_tree_hash, 6)}</span></li>)}</ul>}</section><section><h3 className="font-semibold text-white">归档内容</h3>{artifacts.length === 0 ? <p className="mt-3 text-slate-400">暂无可下载内容。</p> : <ul className="mt-2 space-y-1">{artifacts.map((item) => <li key={item.artifact_id}><a className="block min-h-11 break-all rounded-md px-2 py-2.5 text-cyan-200 hover:bg-white/5" href={codingWorkerArtifactUrl(item.task_id, item.artifact_id)}>{item.media_type} · {shortId(item.artifact_id)}</a></li>)}</ul>}</section></div>}
             {tab === "terminal" && (
               <div aria-busy={inspectorLoading}>
                 <p className="mb-2 text-xs text-slate-400">输出按 operation 归属并从持久事件补发；刷新页面不会丢失已归档片段。</p>
@@ -635,7 +744,7 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
               </div>
             )}
           </div>
-          {context === "coding" && selectedTask && <section className="mt-3 border-t border-white/10 pt-3"><div className="flex items-center gap-2"><GitCompareArrows className="h-4 w-4 text-cyan-300" /><h3 className="font-semibold text-white">宿主写回</h3></div><p className="mt-1 text-xs text-slate-400">完成后继续使用 v13 的应用、提交、撤销和发布确认链。Worker 不直接写用户仓库。</p>{selectedTask.state === "completed" && selectedTask.spec.workspace_source.kind === "host_snapshot" ? <button type="button" onClick={() => void handoffToWriteback()} disabled={busy} className="mt-3 min-h-11 w-full rounded-lg bg-cyan-400 px-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50">进入 v13 写回确认</button> : <p className="mt-3 text-xs text-slate-500">Host Snapshot 任务通过全部必需检查后，才会开放写回确认。</p>}<div className="mt-3 flex flex-wrap gap-2" aria-label="Coding 领域动作"><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">应用</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">提交</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">撤销</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">发布</span></div></section>}
+          {context === "coding" && selectedTask && <section className="mt-3 border-t border-white/10 pt-4"><div className="flex items-center gap-2"><GitCompareArrows className="h-4 w-4 text-cyan-300" /><h3 className="font-semibold text-white">宿主写回</h3></div><p className="mt-1 text-xs leading-5 text-slate-400">Worker 不直接修改用户仓库。完成后继续使用 v13 的应用、提交、撤销和发布确认链。</p>{selectedTask.state === "completed" && selectedTask.spec.workspace_source.kind === "host_snapshot" ? <button type="button" onClick={() => void handoffToWriteback()} disabled={busy} className="mt-3 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg bg-cyan-300 px-3 text-sm font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-50">进入写回确认<ArrowRight className="h-4 w-4" /></button> : <p className="mt-3 text-xs text-slate-500">Host Snapshot 任务通过全部必需检查后开放。</p>}</section>}
         </aside>
       </div>
     </div>

--- a/client/src/components/coding-worker/viewModel.ts
+++ b/client/src/components/coding-worker/viewModel.ts
@@ -1,0 +1,193 @@
+import type {
+  CodingWorkerApproval,
+  CodingWorkerEvent,
+  CodingWorkerEvidence,
+  CodingWorkerTask,
+  CodingWorkerTaskState,
+} from "../../types/codingWorker";
+
+export type WorkerTaskGroup = "attention" | "active" | "queued" | "history";
+export type WorkerProgressStage = "analyze" | "reproduce" | "change" | "verify";
+export type WorkerActivityTone = "neutral" | "running" | "success" | "warning" | "danger";
+
+export interface WorkerActivity {
+  sequence: number;
+  title: string;
+  detail: string;
+  meta: string;
+  tone: WorkerActivityTone;
+  operationId: string | null;
+}
+
+export const terminalTaskStates = new Set<CodingWorkerTaskState>([
+  "completed", "blocked", "failed", "cancelled", "budget_limited", "expired",
+]);
+
+export const taskStateCopy: Record<CodingWorkerTaskState, string> = {
+  queued: "排队中",
+  preparing: "准备工作区",
+  running: "执行中",
+  waiting_approval: "等待审批",
+  paused: "已暂停",
+  testing: "执行验收",
+  interrupted: "需要恢复",
+  completed: "已完成",
+  blocked: "已阻塞",
+  failed: "失败",
+  cancelled: "已取消",
+  budget_limited: "预算已用完",
+  expired: "已过期",
+};
+
+export function taskGroup(task: CodingWorkerTask): WorkerTaskGroup {
+  if (["waiting_approval", "interrupted", "blocked"].includes(task.state)) return "attention";
+  if (["preparing", "running", "testing", "paused"].includes(task.state)) return "active";
+  if (task.state === "queued") return "queued";
+  return "history";
+}
+
+export function groupTasks(tasks: CodingWorkerTask[]) {
+  const groups: Record<WorkerTaskGroup, CodingWorkerTask[]> = {
+    attention: [], active: [], queued: [], history: [],
+  };
+  tasks.forEach((task) => groups[taskGroup(task)].push(task));
+  return groups;
+}
+
+export function currentProgressStage(
+  task: CodingWorkerTask,
+  events: CodingWorkerEvent[],
+): WorkerProgressStage {
+  if (["testing", "completed"].includes(task.state)) return "verify";
+  if (events.some((event) => ["changeset", "workspace", "patch", "edit", "write_file"].some(
+    (term) => `${event.type} ${eventPayloadText(event) ?? ""}`.toLowerCase().includes(term),
+  ))) return "change";
+  if (events.some((event) => ["tool_operation", "operation_output", "approval_requested"].includes(event.type))) {
+    return "reproduce";
+  }
+  return "analyze";
+}
+
+export function eventPayloadText(event: CodingWorkerEvent) {
+  const candidates = [
+    event.payload.message,
+    event.payload.text,
+    event.payload.summary,
+    event.payload.output,
+  ];
+  const value = candidates.find((item) => typeof item === "string");
+  if (typeof value === "string") return value;
+  const data = event.payload.data;
+  if (typeof data === "string") return data;
+  if (data && typeof data === "object") {
+    const record = data as Record<string, unknown>;
+    const nested = [record.message, record.text, record.summary, record.output]
+      .find((item) => typeof item === "string");
+    if (typeof nested === "string") return nested;
+  }
+  return null;
+}
+
+function eventTitle(event: CodingWorkerEvent) {
+  if (event.type === "task_created") return "任务已进入队列";
+  if (event.type === "task_state") {
+    const next = event.payload.to;
+    return typeof next === "string" && next in taskStateCopy
+      ? `状态更新为${taskStateCopy[next as CodingWorkerTaskState]}`
+      : "任务状态已更新";
+  }
+  if (event.type === "approval_requested") return "需要批准一次工具操作";
+  if (event.type === "approval_decided") return "审批已处理";
+  if (event.type === "tool_operation") {
+    const state = event.payload.state;
+    if (state === "completed") return "工具操作已完成";
+    if (state === "failed") return "工具操作失败";
+    if (state === "unknown") return "工具结果需要核对";
+    return "工具操作已更新";
+  }
+  if (event.type === "operation_output") return "终端输出已更新";
+  if (event.type === "acceptance_evaluated") return "必需检查已执行";
+  if (event.type === "acceptance_retry") return "检查未通过，开始修复";
+  if (event.type === "steering_queued") return "追加指令已排队";
+  if (event.type === "provider_event") {
+    if (event.payload.kind === "plan") return "执行计划已更新";
+    if (event.payload.kind === "message") return "Worker 回复";
+    if (event.payload.kind === "tool_call") return "Worker 请求工具";
+    if (event.payload.kind === "turn_completed") return "本轮执行完成";
+  }
+  return event.type.replaceAll("_", " ");
+}
+
+function eventTone(event: CodingWorkerEvent): WorkerActivityTone {
+  const combined = `${event.type} ${String(event.payload.state ?? "")}`;
+  if (/failed|blocked|rejected/.test(combined)) return "danger";
+  if (/unknown|approval|interrupted|retry/.test(combined)) return "warning";
+  if (/completed|decided|evaluated/.test(combined)) return "success";
+  if (/running|provider|operation/.test(combined)) return "running";
+  return "neutral";
+}
+
+export function activitiesFromEvents(events: CodingWorkerEvent[]): WorkerActivity[] {
+  return events.filter((event) => {
+    if (event.type !== "provider_event") return event.type !== "artifact_created";
+    return event.payload.kind === "message" || event.payload.kind === "turn_completed";
+  }).map((event) => {
+    const operationId = typeof event.payload.operation_id === "string"
+      ? event.payload.operation_id
+      : null;
+    return {
+      sequence: event.sequence,
+      title: eventTitle(event),
+      detail: eventPayloadText(event) ?? eventDetail(event),
+      meta: `#${event.sequence}`,
+      tone: eventTone(event),
+      operationId,
+    };
+  });
+}
+
+function eventDetail(event: CodingWorkerEvent) {
+  if (event.type === "task_state") {
+    const reason = event.payload.reason;
+    return typeof reason === "string" && reason ? `原因：${reason}` : "状态已持久保存。";
+  }
+  if (event.type === "tool_operation") {
+    const operationId = event.payload.operation_id;
+    return typeof operationId === "string" ? `操作 ${shortId(operationId)}` : "工具执行状态已持久保存。";
+  }
+  if (event.type === "approval_requested") return "一次性审批已进入 Action Center。";
+  if (event.type === "approval_decided") return "审批决定已持久保存。";
+  if (event.type === "acceptance_evaluated") {
+    const evidence = event.payload.evidence;
+    if (Array.isArray(evidence)) return `已记录 ${evidence.length} 项检查结果。`;
+  }
+  return "详细数据已归档，可在检查器中查看。";
+}
+
+export function evidenceStatus(checkId: string, evidence: CodingWorkerEvidence[]) {
+  return evidence
+    .filter((item) => item.check_id === checkId)
+    .sort((a, b) => b.created_at - a.created_at)[0]?.status ?? "pending";
+}
+
+export function pendingApprovals(approvals: CodingWorkerApproval[]) {
+  return approvals.filter((approval) => approval.status === "pending");
+}
+
+export function routeLabel(route: string) {
+  if (route === "coding/default") return "标准执行";
+  if (route === "coding/quality") return "深度执行";
+  return route.startsWith("coding/") ? route.slice("coding/".length) : route;
+}
+
+export function shortId(value: string, visible = 8) {
+  return value.length > visible * 2 ? `${value.slice(0, visible)}…${value.slice(-visible)}` : value;
+}
+
+export function formatRelativeTime(timestamp: number) {
+  const delta = Math.max(0, Math.round(Date.now() / 1000 - timestamp));
+  if (delta < 60) return "刚刚";
+  if (delta < 3600) return `${Math.floor(delta / 60)} 分钟前`;
+  if (delta < 86400) return `${Math.floor(delta / 3600)} 小时前`;
+  return `${Math.floor(delta / 86400)} 天前`;
+}

--- a/client/src/types/codingWorker.ts
+++ b/client/src/types/codingWorker.ts
@@ -97,6 +97,7 @@ export interface CodingWorkerStatus {
   retention_seconds: number;
   network_enabled: boolean;
   acceptance_checks: string[];
+  model_routes?: string[];
   reason: string | null;
   capabilities: CodingWorkerCapabilities;
 }

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -188,6 +188,7 @@ async def coding_worker_status() -> dict[str, Any]:
             if _service is not None and _service.tool_broker is not None
             else []
         ),
+        "model_routes": _configured_model_routes(),
         "reason": _startup_error,
         "capabilities": capabilities.model_dump(mode="json"),
     }
@@ -770,12 +771,16 @@ def _task_workspace(task_id: str) -> tuple[CodingWorkerService, TaskRecord]:
     return service, task
 
 
-def _validate_model_route(model_route: str) -> None:
-    configured = {
+def _configured_model_routes() -> list[str]:
+    return sorted({
         value.strip()
         for value in os.getenv("CODING_WORKER_MODEL_ROUTES", "coding/default").split(",")
         if value.strip()
-    }
+    })
+
+
+def _validate_model_route(model_route: str) -> None:
+    configured = set(_configured_model_routes())
     if model_route not in configured:
         raise HTTPException(
             status_code=400,


### PR DESCRIPTION
## 变更摘要

- 将 Coding Worker Console 重构为桌面三栏专业工作台：任务队列、结构化执行流与文件/Diff/变更/诊断/测试/终端检查器。
- 新增独立 Action Center，Shell 与兼容命令审批只允许单次批准，并展示 operation、脚本摘要、目录、模式、超时和网络绑定。
- 新建任务改用供应商中立的“标准执行 / 深度执行”路由，并支持多项冻结验收检查。
- 对 Worker 原始事件进行视图建模和降噪，隐藏供应商内部帧，保留公开计划、回复、工具结果、终端输出及验收状态。
- 保留 Agent/Coding 双入口差异、v13 Host 写回确认链，并优化 SSE 高频刷新。
- 移动端采用监控、审批和结果优先布局；桌面保留完整开发工作台。

## 原因与影响

V15 后端已经具备专业文件工具、Shell、changeset、诊断和双引擎能力，但旧 Console 仍以原始事件和零散面板为中心，难以判断当前目标、下一动作、审批风险和完成证据。本 PR 只重构共享 Console 及其只读能力发现接口，不改变任务状态机、Provider 公共契约或 v13 写回执行面。

## 验证

- TypeScript app/node 两项目检查通过（禁用增量写入，避免当前预览占用 tsbuildinfo）。
- 前端全量：35 files / 170 tests passed。
- Console 专项：6 passed。
- Worker API：13 passed。
- Vite production build：通过（--configLoader runner，避免当前 4178 预览占用 .vite-temp）。
- 桌面 1280px 实机检查：无横向溢出，Action Center、创建流程和检查器正常。
- 移动端 390×844 实机检查：clientWidth=390、scrollWidth=390，任务切换、审批区正常，原始 provider_event 为 0。
- git diff --check：通过。

## 发布边界

Draft。目标分支为 V15 三组 PR 的顶层叠加分支 codex/coding-worker-v15-provider，不是 main。本 PR 未重建共享栈、未改密钥或环境配置、未重新执行真实双引擎任务，也未合并。