### PR TITLE
feature: 整合 V15 专业级 Coding Worker

### DIFF
--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -7,9 +7,12 @@ const api = vi.hoisted(() => ({
   getCodingWorkerStatus: vi.fn(),
   listCodingWorkerTasks: vi.fn(),
   getCodingWorkerTask: vi.fn(),
+  getCodingWorkerChangeset: vi.fn(),
+  getCodingWorkerDiagnostics: vi.fn(),
   handoffCodingWorkerTask: vi.fn(),
   listCodingWorkerApprovals: vi.fn(),
   listCodingWorkerEvidence: vi.fn(),
+  listCodingWorkerOperationOutput: vi.fn(),
   listCodingWorkerArtifacts: vi.fn(),
   listCodingWorkerTree: vi.fn(),
   readCodingWorkerDiff: vi.fn(),
@@ -64,7 +67,7 @@ beforeEach(() => {
   Object.values(api).forEach((mock) => "mockReset" in mock && mock.mockReset());
   Object.values(projectApi).forEach((mock) => "mockReset" in mock && mock.mockReset());
   api.codingWorkerArtifactUrl.mockImplementation((taskId: string, artifactId: string) => `/artifact/${taskId}/${artifactId}`);
-  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, acceptance_checks: ["python-pytest", "react-build"], reason: null });
+  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, acceptance_checks: ["python-pytest", "react-build"], reason: null, capabilities: { api_version: "v1", task_runtime: true, professional_file_tools: true, shell: true, operation_output: true, changesets: true, code_intelligence: true } });
   api.listCodingWorkerTasks.mockResolvedValue([task]);
   api.getCodingWorkerTask.mockResolvedValue(task);
   api.listCodingWorkerApprovals.mockResolvedValue([{ approval_id: "approval_1234567890abcdef1234567890abcdef", task_id: task.task_id, operation_id: "operation_1", capability: "command", status: "pending", request: { command: "pytest" }, lease: null, created_at: 1, decided_at: null }]);
@@ -72,6 +75,9 @@ beforeEach(() => {
   api.listCodingWorkerArtifacts.mockResolvedValue([]);
   api.listCodingWorkerTree.mockResolvedValue({ workspace_id: task.workspace_id, tree_hash: "a".repeat(64), entries: [{ entry_id: "entry_1", name: "app.py", display_path: "src/app.py", kind: "file", size: 12, sha256: "b".repeat(64) }] });
   api.readCodingWorkerDiff.mockResolvedValue("diff --git a/src/app.py b/src/app.py");
+  api.listCodingWorkerOperationOutput.mockResolvedValue([]);
+  api.getCodingWorkerChangeset.mockRejectedValue(new Error("not a changeset"));
+  api.getCodingWorkerDiagnostics.mockRejectedValue(new Error("not diagnostics"));
   api.connectCodingWorkerEvents.mockReturnValue(() => undefined);
   api.decideCodingWorkerApproval.mockResolvedValue({});
   projectApi.getCodingProjects.mockResolvedValue({
@@ -136,6 +142,82 @@ describe("CodingWorkerConsole", () => {
     render(<CodingWorkerConsole context="agent" />);
     expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(2);
     expect(screen.queryByText("宿主写回")).not.toBeInTheDocument();
+  });
+
+  it("shows public plans, exact shell approval, replayed output, changesets and diagnostics", async () => {
+    api.listCodingWorkerApprovals.mockResolvedValue([{
+      approval_id: "approval_1234567890abcdef1234567890abcdef",
+      task_id: task.task_id,
+      operation_id: "operation_shell_1",
+      capability: "shell",
+      status: "pending",
+      request: {
+        operation_id: "operation_shell_1",
+        script_sha256: "c".repeat(64),
+        cwd: "src",
+        mode: "mutate",
+        timeout_seconds: 120,
+        network_scope_sha256: null,
+      },
+      lease: null,
+      created_at: 1,
+      decided_at: null,
+    }]);
+    api.listCodingWorkerOperationOutput.mockResolvedValue([{
+      task_id: task.task_id,
+      operation_id: "operation_shell_1",
+      sequence: 3,
+      stream: "stderr",
+      text: "pytest failed\n",
+      created_at: 2,
+      truncated: false,
+    }]);
+    api.getCodingWorkerChangeset.mockResolvedValue({
+      changeset_id: "changeset_1234567890abcdef1234567890abcdef",
+      task_id: task.task_id,
+      operation_id: "operation_shell_1",
+      base_tree_hash: "a".repeat(64),
+      result_tree_hash: "d".repeat(64),
+      state: "applied",
+      entries: [{ entry_id: "entry_1", kind: "modify", display_path: "src/app.py", destination_display_path: null, preimage_sha256: "b".repeat(64), postimage_sha256: "d".repeat(64), binary: false }],
+      artifact_id: null,
+      created_at: 2,
+      updated_at: 3,
+    });
+    api.getCodingWorkerDiagnostics.mockResolvedValue({
+      task_id: task.task_id,
+      operation_id: "operation_shell_1",
+      entry_id: "entry_1",
+      language: "python",
+      workspace_tree_hash: "d".repeat(64),
+      current_tree_hash: "d".repeat(64),
+      stale: false,
+      diagnostics: [{ diagnostic_id: "diagnostic_1", task_id: task.task_id, entry_id: "entry_1", workspace_tree_hash: "d".repeat(64), range: { start: { line: 4, character: 2 }, end: { line: 4, character: 8 } }, severity: "error", code: "reportGeneralTypeIssues", message: "返回类型不匹配", created_at: 3 }],
+    });
+    api.connectCodingWorkerEvents.mockImplementation((_taskId, _after, handlers) => {
+      queueMicrotask(() => {
+        handlers.onEvent({ sequence: 1, task_id: task.task_id, type: "provider_event", payload: { kind: "plan", data: { summary: "先复现失败，再修复并复测。" } }, created_at: 1 });
+        handlers.onEvent({ sequence: 2, task_id: task.task_id, type: "tool_operation", payload: { operation_id: "operation_shell_1", state: "completed" }, created_at: 2 });
+      });
+      return () => undefined;
+    });
+
+    const user = userEvent.setup();
+    render(<CodingWorkerConsole context="agent" />);
+
+    expect(await screen.findByText("先复现失败，再修复并复测。")).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "证据" }));
+    expect(await screen.findByText("Shell 单次审批")).toBeInTheDocument();
+    expect(screen.getByText("c".repeat(64))).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "本任务批准" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "终端" }));
+    expect(await screen.findByText("pytest failed", { exact: false })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "变更" }));
+    expect(await screen.findByText("src/app.py")).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "诊断" }));
+    expect(await screen.findByText("返回类型不匹配")).toBeInTheDocument();
+    expect(screen.getByText("5:3 · reportGeneralTypeIssues")).toBeInTheDocument();
   });
 
   it("hands a completed Host Snapshot task to the v13 confirmation chain", async () => {

--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -67,7 +67,7 @@ beforeEach(() => {
   Object.values(api).forEach((mock) => "mockReset" in mock && mock.mockReset());
   Object.values(projectApi).forEach((mock) => "mockReset" in mock && mock.mockReset());
   api.codingWorkerArtifactUrl.mockImplementation((taskId: string, artifactId: string) => `/artifact/${taskId}/${artifactId}`);
-  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, acceptance_checks: ["python-pytest", "react-build"], reason: null, capabilities: { api_version: "v1", task_runtime: true, professional_file_tools: true, shell: true, operation_output: true, changesets: true, code_intelligence: true } });
+  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, acceptance_checks: ["python-pytest", "react-build"], model_routes: ["coding/default", "coding/quality"], reason: null, capabilities: { api_version: "v1", task_runtime: true, professional_file_tools: true, shell: true, operation_output: true, changesets: true, code_intelligence: true } });
   api.listCodingWorkerTasks.mockResolvedValue([task]);
   api.getCodingWorkerTask.mockResolvedValue(task);
   api.listCodingWorkerApprovals.mockResolvedValue([{ approval_id: "approval_1234567890abcdef1234567890abcdef", task_id: task.task_id, operation_id: "operation_1", capability: "command", status: "pending", request: { command: "pytest" }, lease: null, created_at: 1, decided_at: null }]);
@@ -125,12 +125,11 @@ describe("CodingWorkerConsole", () => {
     const user = userEvent.setup();
     render(<CodingWorkerConsole context="coding" />);
 
-    expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(2);
+    expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(3);
     expect(screen.getByText("宿主写回")).toBeInTheDocument();
     expect(await screen.findByText("src/app.py")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("tab", { name: "证据" }));
-    await user.click(await screen.findByRole("button", { name: "批准一次" }));
+    await user.click(await screen.findByRole("button", { name: "批准本次执行" }));
     await waitFor(() => expect(api.decideCodingWorkerApproval).toHaveBeenCalledWith(
       task.task_id,
       "approval_1234567890abcdef1234567890abcdef",
@@ -140,7 +139,7 @@ describe("CodingWorkerConsole", () => {
 
   it("keeps domain writeback controls out of the generic Agent context", async () => {
     render(<CodingWorkerConsole context="agent" />);
-    expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(2);
+    expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(3);
     expect(screen.queryByText("宿主写回")).not.toBeInTheDocument();
   });
 
@@ -198,6 +197,7 @@ describe("CodingWorkerConsole", () => {
       queueMicrotask(() => {
         handlers.onEvent({ sequence: 1, task_id: task.task_id, type: "provider_event", payload: { kind: "plan", data: { summary: "先复现失败，再修复并复测。" } }, created_at: 1 });
         handlers.onEvent({ sequence: 2, task_id: task.task_id, type: "tool_operation", payload: { operation_id: "operation_shell_1", state: "completed" }, created_at: 2 });
+        handlers.onEvent({ sequence: 3, task_id: task.task_id, type: "provider_event", payload: { kind: "internal_frame" }, created_at: 3 });
       });
       return () => undefined;
     });
@@ -205,10 +205,11 @@ describe("CodingWorkerConsole", () => {
     const user = userEvent.setup();
     render(<CodingWorkerConsole context="agent" />);
 
-    expect(await screen.findByText("先复现失败，再修复并复测。")).toBeInTheDocument();
-    await user.click(screen.getByRole("tab", { name: "证据" }));
+    expect((await screen.findAllByText("先复现失败，再修复并复测。")).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText("provider event")).not.toBeInTheDocument();
     expect(await screen.findByText("Shell 单次审批")).toBeInTheDocument();
-    expect(screen.getByText("c".repeat(64))).toBeInTheDocument();
+    await user.click(screen.getByText("查看操作绑定"));
+    expect(screen.getByText((content) => content.includes("c".repeat(64)))).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "本任务批准" })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "终端" }));
@@ -235,7 +236,7 @@ describe("CodingWorkerConsole", () => {
     const user = userEvent.setup();
     render(<CodingWorkerConsole context="coding" onCodingHandoff={onCodingHandoff} />);
 
-    await user.click(await screen.findByRole("button", { name: "进入 v13 写回确认" }));
+    await user.click(await screen.findByRole("button", { name: "进入写回确认" }));
 
     await waitFor(() => expect(api.handoffCodingWorkerTask).toHaveBeenCalledWith(task.task_id));
     expect(onCodingHandoff).toHaveBeenCalledWith(expect.objectContaining({ revision: 1 }));
@@ -282,15 +283,23 @@ describe("CodingWorkerConsole", () => {
         max_projects: 50,
         projects: [newProject],
       });
+    api.createCodingWorkerTask.mockResolvedValue(task);
 
     const user = userEvent.setup();
     render(<CodingWorkerConsole context="coding" />);
     await user.click(await screen.findByRole("button", { name: "创建任务" }));
     await user.click(screen.getByRole("button", { name: "添加本地项目" }));
 
-    await waitFor(() => expect(screen.getByLabelText("本地项目")).toHaveValue(newProject.id));
+    await waitFor(() => expect(screen.getByLabelText("项目")).toHaveValue(newProject.id));
     expect(screen.getByLabelText("基准 revision")).toHaveValue(newProject.head);
     expect(projectApi.createCodingProjectSelection).toHaveBeenCalledTimes(1);
+
+    await user.selectOptions(screen.getByLabelText("执行方式"), "coding/quality");
+    await user.type(screen.getByLabelText("任务目标"), "修复类型错误并完成复测");
+    await user.click(screen.getByRole("button", { name: "创建并开始" }));
+    await waitFor(() => expect(api.createCodingWorkerTask).toHaveBeenCalledWith(
+      expect.objectContaining({ model_route: "coding/quality" }),
+    ));
   });
 
   it("recovers a project registered after the selection request expires", async () => {
@@ -340,7 +349,7 @@ describe("CodingWorkerConsole", () => {
     await user.click(await screen.findByRole("button", { name: "创建任务" }));
     await user.click(screen.getByRole("button", { name: "添加本地项目" }));
 
-    await waitFor(() => expect(screen.getByLabelText("本地项目")).toHaveValue(lateProject.id));
+    await waitFor(() => expect(screen.getByLabelText("项目")).toHaveValue(lateProject.id));
     expect(screen.getByLabelText("基准 revision")).toHaveValue(lateProject.head);
     expect(screen.queryByText("选择请求已超时", { exact: false })).not.toBeInTheDocument();
   });

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -1,19 +1,30 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  Activity,
+  Archive,
+  ArrowRight,
   CheckCircle2,
   CircleAlert,
+  Clock3,
+  Code2,
+  Eye,
   FileCode2,
   FolderPlus,
   FolderTree,
   GitCompareArrows,
-  MessageSquareText,
+  History,
+  Menu,
   Pause,
   Pin,
   Play,
   Plus,
+  Search,
+  Send,
   ShieldCheck,
   Square,
+  TestTube2,
   TerminalSquare,
+  X,
 } from "lucide-react";
 import type {
   CodingWorkerApproval,
@@ -57,29 +68,26 @@ import {
   getCodingProjects,
   getCodingWorkerHostSource,
 } from "../utils/codingApi";
+import {
+  activitiesFromEvents,
+  currentProgressStage,
+  evidenceStatus,
+  formatRelativeTime,
+  groupTasks,
+  pendingApprovals,
+  routeLabel,
+  shortId,
+  taskStateCopy,
+  terminalTaskStates,
+  type WorkerProgressStage,
+  type WorkerTaskGroup,
+} from "./coding-worker/viewModel";
 
 type ConsoleContext = "coding" | "agent";
 type InspectorTab = "files" | "diff" | "changesets" | "diagnostics" | "evidence" | "terminal";
 
-const terminalStates = new Set([
-  "completed", "blocked", "failed", "cancelled", "budget_limited", "expired",
-]);
-
-const stateCopy: Record<string, string> = {
-  queued: "排队中", preparing: "准备工作区", running: "执行中",
-  waiting_approval: "等待批准", paused: "已暂停", testing: "运行验收",
-  interrupted: "已中断", completed: "已完成", blocked: "已阻塞",
-  failed: "失败", cancelled: "已取消", budget_limited: "预算已用完", expired: "已过期",
-};
-
 function errorMessage(error: unknown, fallback: string) {
   return error instanceof Error ? error.message : fallback;
-}
-
-function payloadText(event: CodingWorkerEvent) {
-  const candidates = [event.payload.message, event.payload.text, event.payload.summary, event.payload.output];
-  const value = candidates.find((item) => typeof item === "string");
-  return typeof value === "string" ? value : null;
 }
 
 function publicPlanText(event: CodingWorkerEvent) {
@@ -89,18 +97,54 @@ function publicPlanText(event: CodingWorkerEvent) {
   if (!data || typeof data !== "object") return null;
   const record = data as Record<string, unknown>;
   const value = [record.summary, record.message, record.text].find((item) => typeof item === "string");
-  return typeof value === "string" ? value : JSON.stringify(record);
+  return typeof value === "string" ? value : "计划已更新。";
 }
 
 function approvalField(request: Record<string, unknown>, key: string) {
   const value = request[key];
-  return typeof value === "string" || typeof value === "number" ? String(value) : "未请求";
+  return typeof value === "string" || typeof value === "number" ? String(value) : null;
 }
 
 function outputTone(stream: CodingWorkerOperationOutputChunk["stream"]) {
   if (stream === "stderr") return "text-rose-200";
   if (stream === "system") return "text-amber-200";
   return "text-slate-200";
+}
+
+const taskGroupCopy: Record<WorkerTaskGroup, { label: string; empty: string }> = {
+  attention: { label: "需要处理", empty: "没有待处理任务" },
+  active: { label: "运行中", empty: "没有运行中任务" },
+  queued: { label: "排队", empty: "队列为空" },
+  history: { label: "最近任务", empty: "暂无历史任务" },
+};
+
+const progressStages: Array<{ value: WorkerProgressStage; label: string }> = [
+  { value: "analyze", label: "分析" },
+  { value: "reproduce", label: "复现" },
+  { value: "change", label: "修改" },
+  { value: "verify", label: "验收" },
+];
+
+function taskStateTone(state: CodingWorkerTask["state"]) {
+  if (["completed"].includes(state)) return "text-emerald-200";
+  if (["waiting_approval", "interrupted", "blocked", "budget_limited"].includes(state)) return "text-amber-200";
+  if (["failed", "cancelled", "expired"].includes(state)) return "text-rose-200";
+  if (["running", "testing", "preparing"].includes(state)) return "text-cyan-200";
+  return "text-slate-300";
+}
+
+function approvalSummary(approval: CodingWorkerApproval) {
+  const command = approval.request.command ?? approval.request.script;
+  if (typeof command === "string" && command.trim()) return command;
+  return approval.capability === "shell"
+    ? `Shell ${approvalField(approval.request, "mode") ?? "受控执行"}`
+    : "执行一次受控命令";
+}
+
+function approvalCapabilityLabel(capability: string) {
+  if (capability === "shell") return "Shell 单次审批";
+  if (capability === "command") return "命令单次审批";
+  return `${capability} 单次审批`;
 }
 
 interface CodingWorkerConsoleProps {
@@ -127,10 +171,14 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   const [tab, setTab] = useState<InspectorTab>("files");
   const [message, setMessage] = useState("");
   const [showCreate, setShowCreate] = useState(false);
+  const [showMobileTasks, setShowMobileTasks] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+  const [taskQuery, setTaskQuery] = useState("");
   const [objective, setObjective] = useState("");
   const [sourceId, setSourceId] = useState("");
   const [revision, setRevision] = useState("");
-  const [checkId, setCheckId] = useState("");
+  const [checkIds, setCheckIds] = useState<string[]>([]);
+  const [modelRoute, setModelRoute] = useState("coding/default");
   const [codingProjects, setCodingProjects] = useState<CodingProjectSummary[]>([]);
   const [selection, setSelection] = useState<CodingProjectSelection | null>(null);
   const [busy, setBusy] = useState(false);
@@ -139,6 +187,7 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   const [error, setError] = useState("");
   const operationRef = useRef(false);
   const selectionProjectIdsRef = useRef<Set<string>>(new Set());
+  const refreshTimerRef = useRef<number | null>(null);
 
   const selectedTask = useMemo(
     () => tasks.find((task) => task.task_id === selectedTaskId) ?? null,
@@ -155,6 +204,23 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   const latestPlan = useMemo(
     () => events.map(publicPlanText).filter((item): item is string => Boolean(item)).at(-1) ?? null,
     [events],
+  );
+  const routeOptions = useMemo(
+    () => status?.model_routes?.length ? status.model_routes : ["coding/default"],
+    [status?.model_routes],
+  );
+  const filteredTasks = useMemo(() => {
+    const query = taskQuery.trim().toLocaleLowerCase();
+    return query
+      ? tasks.filter((task) => `${task.spec.objective} ${task.spec.origin.module} ${taskStateCopy[task.state]}`.toLocaleLowerCase().includes(query))
+      : tasks;
+  }, [taskQuery, tasks]);
+  const groupedTasks = useMemo(() => groupTasks(filteredTasks), [filteredTasks]);
+  const activities = useMemo(() => activitiesFromEvents(events), [events]);
+  const approvalsPending = useMemo(() => pendingApprovals(approvals), [approvals]);
+  const progressStage = useMemo(
+    () => selectedTask ? currentProgressStage(selectedTask, events) : "analyze",
+    [events, selectedTask],
   );
 
   const refreshCodingProjects = useCallback(async (preferredId?: string, selectNew = false) => {
@@ -226,9 +292,13 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
       .then(([nextStatus]) => {
         if (!active) return;
         setStatus(nextStatus);
-        setCheckId((current) => nextStatus.acceptance_checks.includes(current)
+        setCheckIds((current) => {
+          const retained = current.filter((item) => nextStatus.acceptance_checks.includes(item));
+          return retained.length ? retained : nextStatus.acceptance_checks.slice(0, 1);
+        });
+        setModelRoute((current) => nextStatus.model_routes?.includes(current)
           ? current
-          : nextStatus.acceptance_checks[0] ?? "");
+          : nextStatus.model_routes?.[0] ?? "coding/default");
       })
       .catch((caught) => { if (active) setError(errorMessage(caught, "Coding Worker 加载失败")); })
       .finally(() => { if (active) setLoading(false); });
@@ -301,11 +371,21 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
         cursor = event.sequence;
         setEvents((current) => [...current, event].slice(-400));
         setTransportWarning(false);
-        void refreshTaskPanels(selectedTaskId).catch(() => setTransportWarning(true));
+        if (refreshTimerRef.current !== null) window.clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = window.setTimeout(() => {
+          void refreshTaskPanels(selectedTaskId).catch(() => setTransportWarning(true));
+        }, 350);
       },
       onTransportError: () => { if (active) setTransportWarning(true); },
     });
-    return () => { active = false; disconnect(); };
+    return () => {
+      active = false;
+      disconnect();
+      if (refreshTimerRef.current !== null) {
+        window.clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+    };
   }, [refreshTaskPanels, selectedTaskId]);
 
   useEffect(() => {
@@ -348,8 +428,8 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   }, []);
 
   const createTask = () => run(async () => {
-    if (!objective.trim() || !sourceId.trim() || !revision.trim() || !checkId.trim()) {
-      setError("请填写目标、来源 ID、基准 revision 和必需检查 ID。");
+    if (!objective.trim() || !sourceId.trim() || !revision.trim() || checkIds.length === 0) {
+      setError("请填写任务目标、选择受控来源，并至少勾选一项必需检查。");
       return;
     }
     const suffix = crypto.randomUUID().replaceAll("-", "");
@@ -359,17 +439,17 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
       workspace_source: { kind: context === "coding" ? "host_snapshot" : "builtin", source_id: sourceId.trim(), revision: revision.trim() },
       acceptance: {
         contract_id: `contract_${suffix}`,
-        required_checks: [{ check_id: checkId.trim(), kind: "command", label: "必需检查", required: true }],
+        required_checks: checkIds.map((item) => ({ check_id: item, kind: "command", label: item, required: true })),
         required_artifacts: [],
       },
       policy_profile: "develop",
-      model_route: "coding/default",
+      model_route: modelRoute,
       budget: { max_seconds: 3600, max_turns: 64, max_tool_calls: 512, max_output_bytes: 8 * 1024 * 1024 },
       context_refs: [],
     };
     const task = await createCodingWorkerTask(spec);
     await refreshTasks(task.task_id);
-    setShowCreate(false); setObjective(""); setSourceId(""); setRevision(""); setCheckId("");
+    setShowCreate(false); setObjective(""); setSourceId(""); setRevision(""); setCheckIds([]);
   });
 
   const addCodingProject = () => run(async () => {
@@ -454,148 +534,177 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   }
 
   return (
-    <div className="mx-auto flex min-h-[calc(100vh-5rem)] max-w-[1800px] flex-col gap-3 px-3 py-4 lg:px-5">
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-3">
-        <div className="min-w-0">
-          <h1 className="text-xl font-semibold text-white">Coding Worker</h1>
-          <p className="mt-1 text-sm text-slate-300">两个隔离槽位，任务证据与 Diff 可在重启后继续读取。</p>
-          <div className="mt-2 flex flex-wrap gap-1.5" aria-label="Worker 通用能力">
-            {([
-              ["专业文件", status.capabilities.professional_file_tools],
-              ["Shell", status.capabilities.shell],
-              ["终端补发", status.capabilities.operation_output],
-              ["原子变更", status.capabilities.changesets],
-              ["代码诊断", status.capabilities.code_intelligence],
-            ] as const).map(([label, available]) => (
-              <span key={label} className={`rounded-full px-2.5 py-1 text-xs ${available ? "bg-cyan-300/10 text-cyan-100" : "bg-white/5 text-slate-500"}`}>
-                {label} · {available ? "可用" : "关闭"}
-              </span>
-            ))}
+    <div className="mx-auto flex min-h-[calc(100vh-5rem)] max-w-[1920px] flex-col px-3 py-3 lg:px-5">
+      <header className="flex flex-wrap items-center gap-x-5 gap-y-3 border-b border-white/10 pb-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-cyan-300/10 text-cyan-200">
+            <Code2 className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <h1 className="text-lg font-semibold text-white">Coding Worker</h1>
+            <p className="truncate text-xs text-slate-400">隔离执行 · 证据持久化 · Provider 中立</p>
           </div>
         </div>
-        <button type="button" onClick={() => setShowCreate((value) => !value)} className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-cyan-400 px-4 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50" disabled={busy}>
-          <Plus className="h-4 w-4" aria-hidden="true" />创建任务
-        </button>
+
+        {selectedTask && (
+          <div className="order-3 min-w-0 basis-full lg:order-none lg:basis-auto">
+            <p className="truncate text-sm font-medium text-slate-100">{selectedTask.spec.objective}</p>
+            <p className="mt-0.5 flex flex-wrap items-center gap-1.5 text-xs text-slate-400">
+              <span>{routeLabel(selectedTask.spec.model_route)}</span><span aria-hidden="true">·</span>
+              <span>{selectedTask.spec.workspace_source.kind === "host_snapshot" ? "Host Snapshot" : selectedTask.spec.workspace_source.kind}</span><span aria-hidden="true">·</span>
+              <code>{shortId(selectedTask.spec.workspace_source.revision, 6)}</code>
+            </p>
+          </div>
+        )}
+
+        <div className="ml-auto flex items-center gap-2">
+          <span className="hidden items-center gap-2 text-xs text-slate-400 sm:inline-flex">
+            <span className="h-2 w-2 rounded-full bg-emerald-300" aria-hidden="true" />
+            {Math.min(tasks.filter((task) => ["preparing", "running", "testing"].includes(task.state)).length, status.max_active_tasks)} / {status.max_active_tasks} 槽位活跃
+          </span>
+          <button
+            type="button"
+            className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-cyan-300 px-4 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200 disabled:opacity-50"
+            onClick={() => setShowCreate(true)}
+            disabled={busy}
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />创建任务
+          </button>
+        </div>
       </header>
 
       {showCreate && (
-        <form className="grid gap-3 border-b border-white/10 pb-4 md:grid-cols-2 xl:grid-cols-5" onSubmit={(event) => { event.preventDefault(); void createTask(); }}>
-          <label className="md:col-span-2 xl:col-span-2 text-sm text-slate-200">任务目标
-            <textarea value={objective} onChange={(event) => setObjective(event.target.value)} className="mt-1 min-h-24 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 py-2 text-white" maxLength={1_048_576} />
-          </label>
-          {context === "coding" ? (
-            <div className="text-sm text-slate-200">
-              <label htmlFor="worker-host-project">本地项目</label>
-              <select
-                id="worker-host-project"
-                value={sourceId}
-                onChange={(event) => void selectCodingProject(event.target.value)}
-                className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white outline-none focus:border-cyan-300/70 focus:ring-4 focus:ring-cyan-300/10"
-              >
-                <option value="">选择已授权项目</option>
-                {codingProjects.map((project) => (
-                  <option
-                    key={project.id}
-                    value={project.id}
-                    disabled={project.state !== "available" || !project.head}
-                  >
-                    {project.name}{project.branch ? ` · ${project.branch}` : ""}
-                    {project.head ? ` · ${project.head.slice(0, 12)}` : ""}
-                    {project.state !== "available" ? " · 当前不可用" : ""}
-                  </option>
-                ))}
-              </select>
-              <button
-                type="button"
-                onClick={() => void addCodingProject()}
-                disabled={busy || selection?.status === "pending" || selection?.status === "dispatched"}
-                className="mt-2 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg border border-cyan-300/35 px-3 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-300/10 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-cyan-300/20 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <FolderPlus className="h-4 w-4" aria-hidden="true" />
-                {selection?.status === "pending" || selection?.status === "dispatched"
-                  ? "等待 Helper 选择"
-                  : "添加本地项目"}
-              </button>
-              <p className="mt-2 text-xs leading-5 text-slate-400">
-                点击后在 Helper 弹出的窗口中选择干净的 Git 仓库，物理路径不会发送到 Server。
-              </p>
+        <section className="border-b border-white/10 py-5" aria-labelledby="worker-create-heading">
+          <div className="mx-auto max-w-6xl">
+            <div className="mb-5 flex items-start justify-between gap-4">
+              <div><h2 id="worker-create-heading" className="text-xl font-semibold text-white">新建开发任务</h2><p className="mt-1 text-sm text-slate-400">项目基准、执行方式与验收检查会在任务创建后冻结。</p></div>
+              <button type="button" onClick={() => setShowCreate(false)} className="grid min-h-11 min-w-11 place-items-center rounded-lg text-slate-300 hover:bg-white/5" aria-label="关闭创建任务"><X className="h-5 w-5" /></button>
             </div>
-          ) : (
-            <label className="text-sm text-slate-200">不透明来源 ID<input value={sourceId} onChange={(event) => setSourceId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
-          )}
-          <label className="text-sm text-slate-200">基准 revision<input value={revision} onChange={(event) => setRevision(event.target.value)} readOnly={context === "coding"} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white read-only:text-slate-300" /></label>
-          <label className="text-sm text-slate-200">冻结验收检查<select value={checkId} onChange={(event) => setCheckId(event.target.value)} disabled={!status.acceptance_checks.length} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white disabled:opacity-60">{status.acceptance_checks.map((item) => <option key={item} value={item}>{item}</option>)}</select></label>
-          <div className="flex items-end md:col-span-2 xl:col-span-5"><button type="submit" disabled={busy || !checkId} className="min-h-11 rounded-lg bg-cyan-400 px-5 text-sm font-semibold text-slate-950 disabled:opacity-50">提交到队列</button></div>
-        </form>
+            <form className="grid gap-x-6 gap-y-4 lg:grid-cols-[minmax(0,1fr)_20rem]" onSubmit={(event) => { event.preventDefault(); void createTask(); }}>
+              <div className="space-y-4">
+                <label className="block text-sm font-medium text-slate-200">任务目标
+                  <textarea value={objective} onChange={(event) => setObjective(event.target.value)} className="mt-1.5 min-h-32 w-full resize-y rounded-lg border border-white/15 bg-slate-950/70 px-3 py-2.5 text-white placeholder:text-slate-500" placeholder="说明要修复或实现的内容、不能改变的边界，以及期望的复现和复测方式。" maxLength={1_048_576} />
+                </label>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {context === "coding" ? (
+                    <div className="text-sm font-medium text-slate-200">
+                      <label htmlFor="worker-host-project">项目</label>
+                      <select id="worker-host-project" value={sourceId} onChange={(event) => void selectCodingProject(event.target.value)} className="mt-1.5 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white">
+                        <option value="">选择已授权项目</option>
+                        {codingProjects.map((project) => <option key={project.id} value={project.id} disabled={project.state !== "available" || !project.head}>{project.name}{project.branch ? ` · ${project.branch}` : ""}{project.state !== "available" ? " · 当前不可用" : ""}</option>)}
+                      </select>
+                      <button type="button" onClick={() => void addCodingProject()} disabled={busy || selection?.status === "pending" || selection?.status === "dispatched"} className="mt-2 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg border border-cyan-300/35 px-3 text-sm text-cyan-100 hover:bg-cyan-300/10 disabled:opacity-50">
+                        <FolderPlus className="h-4 w-4" />{selection?.status === "pending" || selection?.status === "dispatched" ? "等待 Helper 选择" : "添加本地项目"}
+                      </button>
+                    </div>
+                  ) : <label className="text-sm font-medium text-slate-200">不透明来源 ID<input value={sourceId} onChange={(event) => setSourceId(event.target.value)} className="mt-1.5 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>}
+                  <label className="text-sm font-medium text-slate-200">执行方式
+                    <select value={modelRoute} onChange={(event) => setModelRoute(event.target.value)} className="mt-1.5 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white">
+                      {routeOptions.map((route) => <option key={route} value={route}>{routeLabel(route)}{route === "coding/default" ? " · 常规修复" : route === "coding/quality" ? " · 复杂诊断" : ""}</option>)}
+                    </select>
+                  </label>
+                  <label className="text-sm font-medium text-slate-200">基准 revision<input value={revision} onChange={(event) => setRevision(event.target.value)} readOnly={context === "coding"} className="mt-1.5 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 font-mono text-xs text-white read-only:text-slate-300" /></label>
+                  <fieldset className="text-sm font-medium text-slate-200"><legend>必需检查</legend><div className="mt-1.5 space-y-1.5">{status.acceptance_checks.length === 0 ? <p className="min-h-11 rounded-lg border border-white/10 px-3 py-3 text-xs text-slate-500">当前没有可用检查</p> : status.acceptance_checks.map((item) => <label key={item} className="flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border border-white/10 px-3 text-sm text-slate-200 hover:bg-white/5"><input type="checkbox" checked={checkIds.includes(item)} onChange={(event) => setCheckIds((current) => event.target.checked ? [...current, item] : current.filter((value) => value !== item))} className="h-4 w-4 accent-cyan-300" /><span className="break-all">{item}</span></label>)}</div></fieldset>
+                </div>
+              </div>
+              <aside className="border-t border-white/10 pt-4 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0">
+                <h3 className="text-sm font-semibold text-white">任务边界</h3>
+                <ul className="mt-3 space-y-3 text-sm leading-5 text-slate-300">
+                  <li className="flex gap-2"><ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-cyan-200" /><span>Worker 只修改隔离 Workspace，宿主写回继续走 v13 确认链。</span></li>
+                  <li className="flex gap-2"><TerminalSquare className="mt-0.5 h-4 w-4 shrink-0 text-cyan-200" /><span>Shell 按操作审批，绑定脚本摘要、目录和超时。</span></li>
+                  <li className="flex gap-2"><GitCompareArrows className="mt-0.5 h-4 w-4 shrink-0 text-cyan-200" /><span>必需检查全部通过后，任务才会标记为完成。</span></li>
+                </ul>
+                <button type="submit" disabled={busy || checkIds.length === 0 || !modelRoute} className="mt-5 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg bg-cyan-300 px-4 text-sm font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-50"><Play className="h-4 w-4" />创建并开始</button>
+              </aside>
+            </form>
+          </div>
+        </section>
       )}
 
       {error && <div className="rounded-lg bg-rose-500/15 px-4 py-3 text-sm text-rose-100" role="alert">{error}</div>}
       {transportWarning && <div className="rounded-lg bg-amber-400/10 px-4 py-3 text-sm text-amber-100" role="status">事件连接已中断，任务状态仍可从持久存储恢复。</div>}
 
-      <div className="grid min-h-0 flex-1 gap-3 lg:grid-cols-[16rem_minmax(0,1fr)] xl:grid-cols-[16rem_minmax(0,1fr)_26rem]">
-        <aside className="min-h-0 border-r border-white/10 pr-3" aria-label="Worker 任务列表">
-          <div className="mb-2 flex items-center justify-between"><h2 className="text-sm font-semibold text-slate-200">任务</h2><span className="text-xs text-slate-400">{tasks.length}</span></div>
-          <div className="flex max-h-[38vh] flex-col gap-1 overflow-y-auto lg:max-h-[calc(100vh-11rem)]">
-            {tasks.length === 0 && <p className="rounded-lg bg-white/5 p-3 text-sm text-slate-300">还没有任务。先从受控来源创建一个任务。</p>}
-            {tasks.map((task) => (
-              <button key={task.task_id} type="button" onClick={() => setSelectedTaskId(task.task_id)} className={`min-h-14 rounded-lg px-3 py-2 text-left transition ${task.task_id === selectedTaskId ? "bg-cyan-400/15 text-white" : "text-slate-300 hover:bg-white/5"}`}>
-                <span className="block truncate text-sm font-medium">{task.spec.objective}</span>
-                <span className="mt-1 flex items-center justify-between gap-2 text-xs text-slate-400"><span>{stateCopy[task.state] ?? task.state}</span><span>{task.spec.origin.module}</span></span>
-              </button>
-            ))}
+      <div className="grid min-h-0 flex-1 gap-0 lg:grid-cols-[18rem_minmax(0,1fr)] xl:grid-cols-[18rem_minmax(0,1fr)_27rem]">
+        <div className="flex items-center justify-between border-b border-white/10 py-2 lg:hidden">
+          <button type="button" onClick={() => setShowMobileTasks((value) => !value)} className="inline-flex min-h-11 items-center gap-2 text-sm font-medium text-slate-200" aria-expanded={showMobileTasks}><Menu className="h-4 w-4" />{showMobileTasks ? "返回当前任务" : "查看任务列表"}</button>
+          <span className={selectedTask ? `text-xs ${taskStateTone(selectedTask.state)}` : "text-xs text-slate-400"}>{selectedTask ? taskStateCopy[selectedTask.state] : `${tasks.length} 个任务`}</span>
+        </div>
+
+        <aside className={`${showMobileTasks || !selectedTask ? "block" : "hidden"} min-h-0 border-b border-white/10 py-3 lg:block lg:border-b-0 lg:border-r lg:pr-3`} aria-label="Worker 任务列表">
+          <div className="flex items-center gap-2">
+            <label className="relative min-w-0 flex-1"><span className="sr-only">搜索任务</span><Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" /><input value={taskQuery} onChange={(event) => setTaskQuery(event.target.value)} placeholder="搜索任务" className="min-h-11 w-full rounded-lg border border-white/10 bg-slate-950/55 pl-9 pr-3 text-sm text-white placeholder:text-slate-500" /></label>
+          </div>
+          <div className="mt-3 max-h-[38rem] space-y-4 overflow-y-auto pr-1 lg:max-h-[calc(100vh-12rem)]">
+            {tasks.length === 0 && <p className="py-8 text-center text-sm text-slate-400">还没有任务。创建任务后会在这里跟踪执行状态。</p>}
+            {(["attention", "active", "queued", "history"] as WorkerTaskGroup[]).map((group) => {
+              const items = groupedTasks[group];
+              if (group === "history" && !showHistory) {
+                return items.length ? <button key={group} type="button" onClick={() => setShowHistory(true)} className="flex min-h-11 w-full items-center justify-between text-sm text-slate-400 hover:text-slate-200"><span className="inline-flex items-center gap-2"><History className="h-4 w-4" />查看最近任务</span><span>{items.length}</span></button> : null;
+              }
+              if (!items.length && (taskQuery || group === "history")) return null;
+              return <section key={group} aria-labelledby={`worker-group-${group}`}>
+                <div className="mb-1.5 flex items-center justify-between"><h2 id={`worker-group-${group}`} className="text-xs font-medium text-slate-400">{taskGroupCopy[group].label}</h2><span className="text-xs text-slate-600">{items.length}</span></div>
+                {items.length === 0 ? <p className="px-2 py-2 text-xs text-slate-600">{taskGroupCopy[group].empty}</p> : <div className="space-y-1">{items.slice(0, group === "history" ? 12 : undefined).map((task) => <button key={task.task_id} type="button" onClick={() => { setSelectedTaskId(task.task_id); setShowMobileTasks(false); }} className={`w-full rounded-lg px-3 py-2.5 text-left transition ${task.task_id === selectedTaskId ? "bg-cyan-300/10 text-white" : "text-slate-300 hover:bg-white/5"}`} aria-current={task.task_id === selectedTaskId ? "true" : undefined}>
+                  <span className="line-clamp-2 text-sm font-medium leading-5">{task.spec.objective}</span>
+                  <span className="mt-1.5 flex items-center justify-between gap-2 text-xs"><span className={taskStateTone(task.state)}>{taskStateCopy[task.state]}</span><span className="text-slate-500">{formatRelativeTime(task.updated_at)}</span></span>
+                </button>)}</div>}
+              </section>;
+            })}
+            {taskQuery && filteredTasks.length === 0 && <p className="py-8 text-center text-sm text-slate-400">没有匹配的任务。</p>}
           </div>
         </aside>
 
-        <main className="min-w-0">
-          {!selectedTask ? (
-            <div className="flex min-h-80 items-center justify-center text-sm text-slate-400">选择任务后查看目标、计划和运行事件。</div>
-          ) : (
-            <div className="flex h-full min-h-[32rem] flex-col">
-              <div className="flex flex-wrap items-start justify-between gap-3 border-b border-white/10 pb-3">
-                <div className="min-w-0"><p className="break-words text-lg font-semibold text-white">{selectedTask.spec.objective}</p><p className="mt-1 break-all text-xs text-slate-400">{selectedTask.task_id} · {stateCopy[selectedTask.state] ?? selectedTask.state}</p></div>
-                <div className="flex flex-wrap gap-2">
-                  {selectedTask.state === "running" || selectedTask.state === "testing" ? <button type="button" onClick={() => void taskAction("pause")} disabled={busy} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-white/15 px-3 text-sm text-slate-200"><Pause className="h-4 w-4" />暂停</button> : null}
-                  {selectedTask.state === "paused" || selectedTask.state === "interrupted" ? <button type="button" onClick={() => void taskAction("resume")} disabled={busy} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-cyan-300/40 px-3 text-sm text-cyan-100"><Play className="h-4 w-4" />继续</button> : null}
-                  {!terminalStates.has(selectedTask.state) && <button type="button" onClick={() => void taskAction("cancel")} disabled={busy} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-white/15 px-3 text-sm text-slate-200"><Square className="h-4 w-4" />取消</button>}
-                  <button type="button" onClick={() => void taskAction(selectedTask.pinned ? "unpin" : "pin")} disabled={busy} aria-pressed={selectedTask.pinned} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-white/15 px-3 text-sm text-slate-200"><Pin className="h-4 w-4" />{selectedTask.pinned ? "取消固定" : "固定"}</button>
+        <main className={`${showMobileTasks && selectedTask ? "hidden" : "block"} min-w-0 py-3 lg:block lg:px-5`}>
+          {!selectedTask ? <div className="flex min-h-96 flex-col items-center justify-center text-center"><Activity className="h-8 w-8 text-slate-600" /><p className="mt-3 text-sm text-slate-300">选择任务后查看目标、下一动作和执行证据。</p></div> : <div className="flex h-full min-h-[36rem] flex-col">
+            <section className="border-b border-white/10 pb-4" aria-labelledby="worker-task-heading">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0"><h2 id="worker-task-heading" className="max-w-[65ch] break-words text-xl font-semibold text-white">{selectedTask.spec.objective}</h2><p className="mt-1.5 flex flex-wrap items-center gap-2 text-xs text-slate-400"><span className={taskStateTone(selectedTask.state)}>{taskStateCopy[selectedTask.state]}</span><span>{selectedTask.spec.origin.module}</span><code>{shortId(selectedTask.task_id)}</code></p></div>
+                <div className="flex items-center gap-1">
+                  {selectedTask.state === "running" || selectedTask.state === "testing" ? <button type="button" onClick={() => void taskAction("pause")} disabled={busy} className="grid min-h-11 min-w-11 place-items-center rounded-lg text-slate-300 hover:bg-white/5" aria-label="暂停任务"><Pause className="h-4 w-4" /></button> : null}
+                  {selectedTask.state === "paused" || selectedTask.state === "interrupted" ? <button type="button" onClick={() => void taskAction("resume")} disabled={busy} className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-cyan-300/35 px-3 text-sm text-cyan-100"><Play className="h-4 w-4" />继续任务</button> : null}
+                  {!terminalTaskStates.has(selectedTask.state) && <button type="button" onClick={() => void taskAction("cancel")} disabled={busy} className="grid min-h-11 min-w-11 place-items-center rounded-lg text-slate-300 hover:bg-white/5" aria-label="取消任务"><Square className="h-4 w-4" /></button>}
+                  <button type="button" onClick={() => void taskAction(selectedTask.pinned ? "unpin" : "pin")} disabled={busy} aria-pressed={selectedTask.pinned} className="grid min-h-11 min-w-11 place-items-center rounded-lg text-slate-300 hover:bg-white/5" aria-label={selectedTask.pinned ? "取消固定" : "固定任务"}><Pin className="h-4 w-4" /></button>
                 </div>
               </div>
+              <ol className="mt-5 grid grid-cols-4 gap-1" aria-label="任务进度">{progressStages.map((stage, index) => { const currentIndex = progressStages.findIndex((item) => item.value === progressStage); const completed = index < currentIndex || selectedTask.state === "completed"; const current = index === currentIndex && selectedTask.state !== "completed"; return <li key={stage.value} className="min-w-0"><div className={`h-1 rounded-full ${completed ? "bg-emerald-300" : current ? "bg-cyan-300" : "bg-white/10"}`} /><span className={`mt-1.5 block text-xs ${completed ? "text-emerald-200" : current ? "text-cyan-100" : "text-slate-500"}`}>{stage.label}</span></li>; })}</ol>
+            </section>
 
-              <section className="mt-3 border-b border-white/10 pb-3" aria-labelledby="goal-heading">
-                <div className="flex items-center gap-2"><CheckCircle2 className="h-4 w-4 text-cyan-300" /><h2 id="goal-heading" className="text-sm font-semibold text-white">目标与验收</h2></div>
-                <ul className="mt-2 space-y-1 text-sm text-slate-300">{selectedTask.spec.acceptance.required_checks.map((check) => <li key={check.check_id}>• {check.label} <code className="break-all text-xs text-slate-400">{check.check_id}</code></li>)}</ul>
-              </section>
+            {approvalsPending.length > 0 && <section className="my-4 rounded-xl bg-amber-300/10 p-4" aria-labelledby="worker-actions-heading" aria-live="polite">
+              <div className="flex flex-wrap items-center justify-between gap-2"><h2 id="worker-actions-heading" className="inline-flex items-center gap-2 text-sm font-semibold text-amber-50"><ShieldCheck className="h-4 w-4 text-amber-200" />需要你的决定</h2><span className="text-xs text-amber-100/70">{approvalsPending.length} 项待处理</span></div>
+              {approvalsPending.map((approval) => <article key={approval.approval_id} className="mt-3 border-t border-amber-100/10 pt-3 first:border-t-0 first:pt-0">
+                <p className="mb-2 text-sm font-medium text-amber-50">{approvalCapabilityLabel(approval.capability)}</p>
+                <div className="rounded-lg bg-slate-950/60 px-3 py-2 font-mono text-sm text-slate-100">{approvalSummary(approval)}</div>
+                <dl className="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-xs">{approvalField(approval.request, "mode") && <div><dt className="inline text-slate-500">模式 </dt><dd className="inline text-slate-200">{approvalField(approval.request, "mode")}</dd></div>}{approvalField(approval.request, "cwd") && <div><dt className="inline text-slate-500">目录 </dt><dd className="inline text-slate-200">{approvalField(approval.request, "cwd")}</dd></div>}{approvalField(approval.request, "timeout_seconds") && <div><dt className="inline text-slate-500">超时 </dt><dd className="inline text-slate-200">{approvalField(approval.request, "timeout_seconds")} 秒</dd></div>}<div><dt className="inline text-slate-500">网络 </dt><dd className="inline text-slate-200">{approval.request.network_scope_sha256 ? "受限范围" : "关闭"}</dd></div></dl>
+                <details className="mt-2 text-xs text-slate-400"><summary className="min-h-11 cursor-pointer py-2">查看操作绑定</summary><code className="block break-all pb-2">operation {approval.operation_id}{approvalField(approval.request, "script_sha256") && <><br />script {approvalField(approval.request, "script_sha256")}</>}</code></details>
+                <div className="mt-3 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end"><button type="button" disabled={busy} onClick={() => void decide(approval.approval_id, "reject")} className="min-h-11 rounded-lg border border-white/15 px-4 text-sm text-slate-200">拒绝并反馈</button><button type="button" disabled={busy} onClick={() => void decide(approval.approval_id, "approve_once")} className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-amber-200 px-4 text-sm font-semibold text-slate-950"><CheckCircle2 className="h-4 w-4" />批准本次执行</button></div>
+              </article>)}
+            </section>}
 
-              {latestPlan && (
-                <section className="border-b border-white/10 py-3" aria-labelledby="worker-plan-heading">
-                  <div className="flex items-center justify-between gap-3">
-                    <h2 id="worker-plan-heading" className="text-sm font-semibold text-white">当前公开计划</h2>
-                    <span className="text-xs text-slate-500">Provider 中立</span>
-                  </div>
-                  <p className="mt-2 max-w-[72ch] whitespace-pre-wrap break-words text-sm leading-6 text-slate-300">{latestPlan}</p>
-                </section>
-              )}
+            <section className="border-b border-white/10 py-4" aria-labelledby="goal-heading">
+              <div className="flex items-center justify-between gap-3"><h2 id="goal-heading" className="text-sm font-semibold text-white">验收条件</h2><span className="text-xs text-slate-500">创建后不可降级</span></div>
+              <ul className="mt-2 flex flex-wrap gap-2">{selectedTask.spec.acceptance.required_checks.map((check) => { const state = evidenceStatus(check.check_id, evidence); return <li key={check.check_id} className="inline-flex min-h-9 items-center gap-2 rounded-lg bg-white/5 px-3 text-xs text-slate-200"><span className={state === "passed" ? "text-emerald-300" : state === "failed" ? "text-rose-300" : state === "invalidated" ? "text-amber-300" : "text-slate-500"}>{state === "passed" ? "通过" : state === "failed" ? "失败" : state === "invalidated" ? "已失效" : "待执行"}</span><span>{check.label}</span></li>; })}</ul>
+            </section>
 
-              <section className="min-h-0 flex-1 overflow-y-auto py-3" aria-label="任务事件" aria-live="polite">
-                {events.length === 0 ? <p className="text-sm text-slate-400">等待 Worker 事件。公开事件只包含计划、状态和工具摘要。</p> : events.map((event) => (
-                  <article key={event.sequence} className="mb-3 flex gap-3"><span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-cyan-300" aria-hidden="true" /><div className="min-w-0"><p className="text-xs font-medium text-slate-400">{event.type} · #{event.sequence}</p><p className="mt-1 whitespace-pre-wrap break-words text-sm text-slate-200">{payloadText(event) ?? JSON.stringify(event.payload)}</p></div></article>
-                ))}
-              </section>
+            {latestPlan && <section className="border-b border-white/10 py-4" aria-labelledby="worker-plan-heading"><div className="flex items-center justify-between gap-3"><h2 id="worker-plan-heading" className="text-sm font-semibold text-white">当前计划</h2><span className="text-xs text-slate-500">公开摘要</span></div><p className="mt-2 max-w-[72ch] whitespace-pre-wrap break-words text-sm leading-6 text-slate-300">{latestPlan}</p></section>}
 
-              <form className="border-t border-white/10 pt-3" onSubmit={(event) => { event.preventDefault(); void submitMessage(); }}>
-                <label className="sr-only" htmlFor="worker-message">追加指令</label>
-                <div className="flex gap-2"><textarea id="worker-message" value={message} onChange={(event) => setMessage(event.target.value)} disabled={busy || terminalStates.has(selectedTask.state)} placeholder="追加指令或运行中 steering" className="min-h-12 flex-1 resize-y rounded-lg border border-white/15 bg-slate-950/70 px-3 py-2 text-sm text-white placeholder:text-slate-400 disabled:opacity-60" /><button type="submit" disabled={busy || !message.trim() || terminalStates.has(selectedTask.state)} className="min-h-12 rounded-lg bg-cyan-400 px-4 text-sm font-semibold text-slate-950 disabled:opacity-50">发送指令</button></div>
-              </form>
-            </div>
-          )}
+            <section className="min-h-0 flex-1 py-4" aria-label="任务进展" aria-live="polite">
+              <h2 className="text-sm font-semibold text-white">任务进展</h2>
+              {activities.length === 0 ? <p className="mt-3 text-sm text-slate-400">等待 Worker 开始。状态、计划与工具摘要会显示在这里。</p> : <ol className="mt-4 space-y-5">{activities.slice(-80).map((activity) => <li key={activity.sequence} className="flex gap-3"><span className={`mt-1 grid h-7 w-7 shrink-0 place-items-center rounded-full ${activity.tone === "success" ? "bg-emerald-300/10 text-emerald-200" : activity.tone === "warning" ? "bg-amber-300/10 text-amber-200" : activity.tone === "danger" ? "bg-rose-300/10 text-rose-200" : "bg-cyan-300/10 text-cyan-200"}`}>{activity.tone === "success" ? <CheckCircle2 className="h-4 w-4" /> : activity.tone === "warning" ? <Clock3 className="h-4 w-4" /> : activity.tone === "danger" ? <CircleAlert className="h-4 w-4" /> : <Activity className="h-4 w-4" />}</span><div className="min-w-0 flex-1"><div className="flex flex-wrap items-baseline justify-between gap-2"><h3 className="text-sm font-medium text-slate-100">{activity.title}</h3><span className="text-xs text-slate-600">{activity.meta}</span></div><p className="mt-1 max-w-[72ch] whitespace-pre-wrap break-words text-sm leading-6 text-slate-300">{activity.detail}</p>{activity.operationId && <button type="button" onClick={() => setTab("terminal")} className="mt-1 min-h-11 text-xs text-cyan-200">查看操作 {shortId(activity.operationId)}</button>}</div></li>)}</ol>}
+            </section>
+
+            <form className="sticky bottom-0 border-t border-white/10 bg-[#060916]/95 py-3 backdrop-blur" onSubmit={(event) => { event.preventDefault(); void submitMessage(); }}>
+              <label className="sr-only" htmlFor="worker-message">追加指令</label><div className="flex gap-2"><textarea id="worker-message" value={message} onChange={(event) => setMessage(event.target.value)} disabled={busy || terminalTaskStates.has(selectedTask.state)} placeholder="追加约束或调整方向，当前工具结束后生效" className="min-h-12 flex-1 resize-y rounded-lg border border-white/15 bg-slate-950/80 px-3 py-2 text-sm text-white placeholder:text-slate-500 disabled:opacity-60" /><button type="submit" disabled={busy || !message.trim() || terminalTaskStates.has(selectedTask.state)} className="inline-flex min-h-12 min-w-12 items-center justify-center gap-2 rounded-lg bg-cyan-300 px-4 text-sm font-semibold text-slate-950 disabled:opacity-50"><Send className="h-4 w-4" /><span className="hidden sm:inline">发送</span></button></div>
+            </form>
+          </div>}
         </main>
 
-        <aside className="min-w-0 border-t border-white/10 pt-3 xl:border-l xl:border-t-0 xl:pl-3 xl:pt-0" aria-label="任务检查器">
-          <div className="flex overflow-x-auto border-b border-white/10" role="tablist">
-            {([ ["files", FolderTree, "文件"], ["diff", GitCompareArrows, "Diff"], ["changesets", GitCompareArrows, "变更"], ["diagnostics", CircleAlert, "诊断"], ["evidence", ShieldCheck, "证据"], ["terminal", TerminalSquare, "终端"] ] as const).map(([value, Icon, label]) => <button key={value} type="button" role="tab" aria-selected={tab === value} onClick={() => setTab(value)} className={`inline-flex min-h-11 items-center gap-1 px-3 text-sm ${tab === value ? "border-b-2 border-cyan-300 text-white" : "text-slate-400"}`}><Icon className="h-4 w-4" />{label}</button>)}
+        <aside className="min-w-0 border-t border-white/10 py-3 lg:col-span-2 xl:col-span-1 xl:border-l xl:border-t-0 xl:pl-4" aria-label="任务检查器">
+          {selectedTask?.state === "completed" && <section className="mb-4 rounded-xl bg-emerald-300/10 p-4" aria-labelledby="worker-result-heading"><div className="flex gap-3"><span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-emerald-300 text-slate-950"><CheckCircle2 className="h-5 w-5" /></span><div><h2 id="worker-result-heading" className="font-semibold text-emerald-50">任务完成</h2><p className="mt-1 text-xs leading-5 text-emerald-100/75">必需检查已通过，结果绑定当前 Workspace tree。</p></div></div><button type="button" onClick={() => setTab("diff")} className="mt-3 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg border border-emerald-200/25 text-sm text-emerald-50"><Eye className="h-4 w-4" />检查完整 Diff</button></section>}
+          <div className="flex overflow-x-auto border-b border-white/10" role="tablist" aria-label="任务检查器视图">
+            {([ ["files", FolderTree, "文件"], ["diff", GitCompareArrows, "Diff"], ["changesets", Archive, "变更"], ["diagnostics", CircleAlert, "诊断"], ["evidence", TestTube2, "测试"], ["terminal", TerminalSquare, "终端"] ] as const).map(([value, Icon, label]) => <button key={value} type="button" role="tab" aria-selected={tab === value} onClick={() => setTab(value)} className={`inline-flex min-h-11 shrink-0 items-center gap-1.5 px-3 text-sm ${tab === value ? "border-b-2 border-cyan-300 text-white" : "text-slate-400 hover:text-slate-200"}`}><Icon className="h-4 w-4" />{label}</button>)}
           </div>
-          <div className="max-h-[46rem] overflow-auto py-3 text-sm">
-            {tab === "files" && <div><p className="mb-2 break-all text-xs text-slate-400">tree {treeHash || "尚未创建"}</p>{preview ? <div><button type="button" className="mb-2 min-h-11 text-cyan-200" onClick={() => setPreview(null)}>返回文件树</button><p className="mb-2 break-all text-slate-300">{preview.path}</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{preview.content}</pre></div> : <ul className="space-y-1">{entries.map((entry) => <li key={entry.entry_id}><button type="button" disabled={entry.kind !== "file" || busy} onClick={() => void openEntry(entry)} className="flex min-h-10 w-full items-center gap-2 rounded-md px-2 text-left text-slate-300 hover:bg-white/5 disabled:cursor-default"><FileCode2 className="h-4 w-4 shrink-0" /><span className="min-w-0 break-all">{entry.display_path}</span></button></li>)}</ul>}</div>}
+          <div className="max-h-[34rem] overflow-auto py-3 text-sm xl:max-h-[calc(100vh-20rem)]">
+            {tab === "files" && <div><p className="mb-2 break-all text-xs text-slate-400">tree {treeHash || "尚未创建"}</p>{preview ? <div><button type="button" className="mb-2 min-h-11 text-cyan-200" onClick={() => setPreview(null)}>返回文件树</button><p className="mb-2 break-all text-slate-300">{preview.path}</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{preview.content}</pre></div> : <ul className="space-y-1">{entries.map((entry) => <li key={entry.entry_id}><button type="button" disabled={entry.kind !== "file" || busy} onClick={() => void openEntry(entry)} className="flex min-h-11 w-full items-center gap-2 rounded-md px-2 text-left text-slate-300 hover:bg-white/5 disabled:cursor-default"><FileCode2 className="h-4 w-4 shrink-0" /><span className="min-w-0 break-all">{entry.display_path}</span></button></li>)}</ul>}</div>}
             {tab === "diff" && <pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{diff || "工作区还没有变更。"}</pre>}
             {tab === "changesets" && (
               <div className="space-y-3" aria-busy={inspectorLoading}>
@@ -625,7 +734,7 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
                 ))}
               </div>
             )}
-            {tab === "evidence" && <div className="space-y-4"><section><h3 className="font-semibold text-white">审批</h3>{approvals.filter((item) => item.status === "pending").map((item) => <div key={item.approval_id} className="mt-2 rounded-lg bg-amber-300/10 p-3"><div className="flex flex-wrap items-center justify-between gap-2"><p className="text-amber-100">{item.capability === "shell" ? "Shell 单次审批" : item.capability}</p><code className="break-all text-xs text-slate-400">{item.operation_id}</code></div>{item.capability === "shell" ? <dl className="mt-3 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-2 text-xs"><dt className="text-slate-400">模式</dt><dd className="break-all text-slate-200">{approvalField(item.request, "mode")}</dd><dt className="text-slate-400">工作目录</dt><dd className="break-all text-slate-200">{approvalField(item.request, "cwd")}</dd><dt className="text-slate-400">超时</dt><dd className="break-all text-slate-200">{approvalField(item.request, "timeout_seconds")} 秒</dd><dt className="text-slate-400">脚本摘要</dt><dd className="break-all font-mono text-slate-200">{approvalField(item.request, "script_sha256")}</dd><dt className="text-slate-400">网络范围</dt><dd className="break-all font-mono text-slate-200">{approvalField(item.request, "network_scope_sha256")}</dd></dl> : <p className="mt-1 break-words text-xs text-slate-300">{JSON.stringify(item.request)}</p>}<div className="mt-3 flex flex-wrap gap-2"><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_once")} className="min-h-11 rounded-lg bg-cyan-400 px-3 font-semibold text-slate-950">批准一次</button>{item.capability !== "shell" ? <button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_task")} className="min-h-11 rounded-lg border border-cyan-300/40 px-3 text-cyan-100">本任务批准</button> : null}<button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "reject")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200">拒绝</button></div></div>)}</section><section><h3 className="font-semibold text-white">检查证据</h3><ul className="mt-2 space-y-2">{evidence.map((item) => <li key={item.evidence_id} className="rounded-lg bg-white/5 p-3"><span className={item.status === "passed" ? "text-emerald-300" : item.status === "failed" ? "text-rose-300" : "text-amber-300"}>{item.status}</span><span className="ml-2 break-all text-slate-200">{item.check_id}</span><span className="mt-1 block text-xs text-slate-400">exit {item.exit_code}</span></li>)}</ul></section><section><h3 className="font-semibold text-white">Artifacts</h3><ul className="mt-2 space-y-1">{artifacts.map((item) => <li key={item.artifact_id}><a className="block min-h-11 break-all rounded-md px-2 py-2.5 text-cyan-200 hover:bg-white/5" href={codingWorkerArtifactUrl(item.task_id, item.artifact_id)}>{item.artifact_id} · {item.media_type}</a></li>)}</ul></section></div>}
+            {tab === "evidence" && <div className="space-y-5"><section><div className="flex items-center justify-between"><h3 className="font-semibold text-white">必需检查</h3><span className="text-xs text-slate-500">{evidence.filter((item) => item.status === "passed").length}/{selectedTask?.spec.acceptance.required_checks.length ?? 0} 通过</span></div>{evidence.length === 0 ? <p className="mt-3 text-slate-400">尚未产生检查证据。</p> : <ul className="mt-3 space-y-2">{evidence.map((item) => <li key={item.evidence_id} className="rounded-lg bg-white/5 p-3"><div className="flex items-center justify-between gap-2"><span className="break-all text-slate-200">{item.check_id}</span><span className={item.status === "passed" ? "text-emerald-300" : item.status === "failed" ? "text-rose-300" : "text-amber-300"}>{item.status === "passed" ? "通过" : item.status === "failed" ? "失败" : "已失效"}</span></div><span className="mt-1 block text-xs text-slate-400">exit {item.exit_code} · tree {shortId(item.workspace_tree_hash, 6)}</span></li>)}</ul>}</section><section><h3 className="font-semibold text-white">归档内容</h3>{artifacts.length === 0 ? <p className="mt-3 text-slate-400">暂无可下载内容。</p> : <ul className="mt-2 space-y-1">{artifacts.map((item) => <li key={item.artifact_id}><a className="block min-h-11 break-all rounded-md px-2 py-2.5 text-cyan-200 hover:bg-white/5" href={codingWorkerArtifactUrl(item.task_id, item.artifact_id)}>{item.media_type} · {shortId(item.artifact_id)}</a></li>)}</ul>}</section></div>}
             {tab === "terminal" && (
               <div aria-busy={inspectorLoading}>
                 <p className="mb-2 text-xs text-slate-400">输出按 operation 归属并从持久事件补发；刷新页面不会丢失已归档片段。</p>
@@ -635,7 +744,7 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
               </div>
             )}
           </div>
-          {context === "coding" && selectedTask && <section className="mt-3 border-t border-white/10 pt-3"><div className="flex items-center gap-2"><GitCompareArrows className="h-4 w-4 text-cyan-300" /><h3 className="font-semibold text-white">宿主写回</h3></div><p className="mt-1 text-xs text-slate-400">完成后继续使用 v13 的应用、提交、撤销和发布确认链。Worker 不直接写用户仓库。</p>{selectedTask.state === "completed" && selectedTask.spec.workspace_source.kind === "host_snapshot" ? <button type="button" onClick={() => void handoffToWriteback()} disabled={busy} className="mt-3 min-h-11 w-full rounded-lg bg-cyan-400 px-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50">进入 v13 写回确认</button> : <p className="mt-3 text-xs text-slate-500">Host Snapshot 任务通过全部必需检查后，才会开放写回确认。</p>}<div className="mt-3 flex flex-wrap gap-2" aria-label="Coding 领域动作"><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">应用</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">提交</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">撤销</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">发布</span></div></section>}
+          {context === "coding" && selectedTask && <section className="mt-3 border-t border-white/10 pt-4"><div className="flex items-center gap-2"><GitCompareArrows className="h-4 w-4 text-cyan-300" /><h3 className="font-semibold text-white">宿主写回</h3></div><p className="mt-1 text-xs leading-5 text-slate-400">Worker 不直接修改用户仓库。完成后继续使用 v13 的应用、提交、撤销和发布确认链。</p>{selectedTask.state === "completed" && selectedTask.spec.workspace_source.kind === "host_snapshot" ? <button type="button" onClick={() => void handoffToWriteback()} disabled={busy} className="mt-3 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg bg-cyan-300 px-3 text-sm font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-50">进入写回确认<ArrowRight className="h-4 w-4" /></button> : <p className="mt-3 text-xs text-slate-500">Host Snapshot 任务通过全部必需检查后开放。</p>}</section>}
         </aside>
       </div>
     </div>

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -18,9 +18,12 @@ import {
 import type {
   CodingWorkerApproval,
   CodingWorkerArtifact,
+  CodingWorkerChangeset,
+  CodingWorkerDiagnosticsSnapshot,
   CodingWorkerEntry,
   CodingWorkerEvent,
   CodingWorkerEvidence,
+  CodingWorkerOperationOutputChunk,
   CodingWorkerStatus,
   CodingWorkerTask,
   CodingWorkerTaskSpec,
@@ -31,12 +34,15 @@ import {
   connectCodingWorkerEvents,
   createCodingWorkerTask,
   decideCodingWorkerApproval,
+  getCodingWorkerChangeset,
+  getCodingWorkerDiagnostics,
   getCodingWorkerTask,
   getCodingWorkerStatus,
   handoffCodingWorkerTask,
   listCodingWorkerApprovals,
   listCodingWorkerArtifacts,
   listCodingWorkerEvidence,
+  listCodingWorkerOperationOutput,
   listCodingWorkerTasks,
   listCodingWorkerTree,
   readCodingWorkerDiff,
@@ -53,7 +59,7 @@ import {
 } from "../utils/codingApi";
 
 type ConsoleContext = "coding" | "agent";
-type InspectorTab = "files" | "diff" | "evidence" | "terminal";
+type InspectorTab = "files" | "diff" | "changesets" | "diagnostics" | "evidence" | "terminal";
 
 const terminalStates = new Set([
   "completed", "blocked", "failed", "cancelled", "budget_limited", "expired",
@@ -76,6 +82,27 @@ function payloadText(event: CodingWorkerEvent) {
   return typeof value === "string" ? value : null;
 }
 
+function publicPlanText(event: CodingWorkerEvent) {
+  if (event.type !== "provider_event" || event.payload.kind !== "plan") return null;
+  const data = event.payload.data;
+  if (typeof data === "string") return data;
+  if (!data || typeof data !== "object") return null;
+  const record = data as Record<string, unknown>;
+  const value = [record.summary, record.message, record.text].find((item) => typeof item === "string");
+  return typeof value === "string" ? value : JSON.stringify(record);
+}
+
+function approvalField(request: Record<string, unknown>, key: string) {
+  const value = request[key];
+  return typeof value === "string" || typeof value === "number" ? String(value) : "未请求";
+}
+
+function outputTone(stream: CodingWorkerOperationOutputChunk["stream"]) {
+  if (stream === "stderr") return "text-rose-200";
+  if (stream === "system") return "text-amber-200";
+  return "text-slate-200";
+}
+
 interface CodingWorkerConsoleProps {
   context: ConsoleContext;
   onCodingHandoff?: (result: CodingWorkerHandoffResult) => void;
@@ -91,6 +118,10 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   const [artifacts, setArtifacts] = useState<CodingWorkerArtifact[]>([]);
   const [entries, setEntries] = useState<CodingWorkerEntry[]>([]);
   const [treeHash, setTreeHash] = useState("");
+  const [operationOutputs, setOperationOutputs] = useState<Record<string, CodingWorkerOperationOutputChunk[]>>({});
+  const [changesets, setChangesets] = useState<CodingWorkerChangeset[]>([]);
+  const [diagnostics, setDiagnostics] = useState<CodingWorkerDiagnosticsSnapshot[]>([]);
+  const [inspectorLoading, setInspectorLoading] = useState(false);
   const [preview, setPreview] = useState<{ path: string; content: string } | null>(null);
   const [diff, setDiff] = useState("");
   const [tab, setTab] = useState<InspectorTab>("files");
@@ -112,6 +143,18 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   const selectedTask = useMemo(
     () => tasks.find((task) => task.task_id === selectedTaskId) ?? null,
     [selectedTaskId, tasks],
+  );
+  const operationIds = useMemo(() => {
+    const ids = new Set<string>();
+    events.forEach((event) => {
+      const operationId = event.payload.operation_id;
+      if (typeof operationId === "string" && operationId.length <= 128) ids.add(operationId);
+    });
+    return [...ids].slice(-32);
+  }, [events]);
+  const latestPlan = useMemo(
+    () => events.map(publicPlanText).filter((item): item is string => Boolean(item)).at(-1) ?? null,
+    [events],
   );
 
   const refreshCodingProjects = useCallback(async (preferredId?: string, selectNew = false) => {
@@ -238,12 +281,16 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     if (!selectedTaskId) {
       setEvents([]); setApprovals([]); setEvidence([]); setArtifacts([]);
       setEntries([]); setPreview(null); setDiff(""); setTreeHash("");
+      setOperationOutputs({}); setChangesets([]); setDiagnostics([]);
       return;
     }
     let active = true;
     let cursor = 0;
     setEvents([]);
     setPreview(null);
+    setOperationOutputs({});
+    setChangesets([]);
+    setDiagnostics([]);
     setTransportWarning(false);
     void refreshTaskPanels(selectedTaskId).catch((caught) => {
       if (active) setError(errorMessage(caught, "任务详情加载失败"));
@@ -260,6 +307,35 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     });
     return () => { active = false; disconnect(); };
   }, [refreshTaskPanels, selectedTaskId]);
+
+  useEffect(() => {
+    if (!selectedTaskId || operationIds.length === 0) return;
+    let active = true;
+    const loadStructuredInspector = async () => {
+      setInspectorLoading(true);
+      try {
+        if (tab === "terminal" && status?.capabilities.operation_output) {
+          const values = await Promise.all(operationIds.map(async (operationId) => [
+            operationId,
+            await listCodingWorkerOperationOutput(selectedTaskId, operationId).catch(() => []),
+          ] as const));
+          if (active) setOperationOutputs(Object.fromEntries(values));
+        } else if (tab === "changesets" && status?.capabilities.changesets) {
+          const values = await Promise.all(operationIds.map((operationId) =>
+            getCodingWorkerChangeset(selectedTaskId, operationId).catch(() => null)));
+          if (active) setChangesets(values.filter((item): item is CodingWorkerChangeset => item !== null));
+        } else if (tab === "diagnostics" && status?.capabilities.code_intelligence) {
+          const values = await Promise.all(operationIds.map((operationId) =>
+            getCodingWorkerDiagnostics(selectedTaskId, operationId).catch(() => null)));
+          if (active) setDiagnostics(values.filter((item): item is CodingWorkerDiagnosticsSnapshot => item !== null));
+        }
+      } finally {
+        if (active) setInspectorLoading(false);
+      }
+    };
+    void loadStructuredInspector();
+    return () => { active = false; };
+  }, [operationIds, selectedTaskId, status?.capabilities, tab]);
 
   const run = useCallback(async (operation: () => Promise<unknown>) => {
     if (operationRef.current) return;
@@ -383,6 +459,19 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
         <div className="min-w-0">
           <h1 className="text-xl font-semibold text-white">Coding Worker</h1>
           <p className="mt-1 text-sm text-slate-300">两个隔离槽位，任务证据与 Diff 可在重启后继续读取。</p>
+          <div className="mt-2 flex flex-wrap gap-1.5" aria-label="Worker 通用能力">
+            {([
+              ["专业文件", status.capabilities.professional_file_tools],
+              ["Shell", status.capabilities.shell],
+              ["终端补发", status.capabilities.operation_output],
+              ["原子变更", status.capabilities.changesets],
+              ["代码诊断", status.capabilities.code_intelligence],
+            ] as const).map(([label, available]) => (
+              <span key={label} className={`rounded-full px-2.5 py-1 text-xs ${available ? "bg-cyan-300/10 text-cyan-100" : "bg-white/5 text-slate-500"}`}>
+                {label} · {available ? "可用" : "关闭"}
+              </span>
+            ))}
+          </div>
         </div>
         <button type="button" onClick={() => setShowCreate((value) => !value)} className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-cyan-400 px-4 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50" disabled={busy}>
           <Plus className="h-4 w-4" aria-hidden="true" />创建任务
@@ -477,6 +566,16 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
                 <ul className="mt-2 space-y-1 text-sm text-slate-300">{selectedTask.spec.acceptance.required_checks.map((check) => <li key={check.check_id}>• {check.label} <code className="break-all text-xs text-slate-400">{check.check_id}</code></li>)}</ul>
               </section>
 
+              {latestPlan && (
+                <section className="border-b border-white/10 py-3" aria-labelledby="worker-plan-heading">
+                  <div className="flex items-center justify-between gap-3">
+                    <h2 id="worker-plan-heading" className="text-sm font-semibold text-white">当前公开计划</h2>
+                    <span className="text-xs text-slate-500">Provider 中立</span>
+                  </div>
+                  <p className="mt-2 max-w-[72ch] whitespace-pre-wrap break-words text-sm leading-6 text-slate-300">{latestPlan}</p>
+                </section>
+              )}
+
               <section className="min-h-0 flex-1 overflow-y-auto py-3" aria-label="任务事件" aria-live="polite">
                 {events.length === 0 ? <p className="text-sm text-slate-400">等待 Worker 事件。公开事件只包含计划、状态和工具摘要。</p> : events.map((event) => (
                   <article key={event.sequence} className="mb-3 flex gap-3"><span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-cyan-300" aria-hidden="true" /><div className="min-w-0"><p className="text-xs font-medium text-slate-400">{event.type} · #{event.sequence}</p><p className="mt-1 whitespace-pre-wrap break-words text-sm text-slate-200">{payloadText(event) ?? JSON.stringify(event.payload)}</p></div></article>
@@ -493,13 +592,48 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
 
         <aside className="min-w-0 border-t border-white/10 pt-3 xl:border-l xl:border-t-0 xl:pl-3 xl:pt-0" aria-label="任务检查器">
           <div className="flex overflow-x-auto border-b border-white/10" role="tablist">
-            {([ ["files", FolderTree, "文件"], ["diff", GitCompareArrows, "Diff"], ["evidence", ShieldCheck, "证据"], ["terminal", TerminalSquare, "终端"] ] as const).map(([value, Icon, label]) => <button key={value} type="button" role="tab" aria-selected={tab === value} onClick={() => setTab(value)} className={`inline-flex min-h-11 items-center gap-1 px-3 text-sm ${tab === value ? "border-b-2 border-cyan-300 text-white" : "text-slate-400"}`}><Icon className="h-4 w-4" />{label}</button>)}
+            {([ ["files", FolderTree, "文件"], ["diff", GitCompareArrows, "Diff"], ["changesets", GitCompareArrows, "变更"], ["diagnostics", CircleAlert, "诊断"], ["evidence", ShieldCheck, "证据"], ["terminal", TerminalSquare, "终端"] ] as const).map(([value, Icon, label]) => <button key={value} type="button" role="tab" aria-selected={tab === value} onClick={() => setTab(value)} className={`inline-flex min-h-11 items-center gap-1 px-3 text-sm ${tab === value ? "border-b-2 border-cyan-300 text-white" : "text-slate-400"}`}><Icon className="h-4 w-4" />{label}</button>)}
           </div>
           <div className="max-h-[46rem] overflow-auto py-3 text-sm">
             {tab === "files" && <div><p className="mb-2 break-all text-xs text-slate-400">tree {treeHash || "尚未创建"}</p>{preview ? <div><button type="button" className="mb-2 min-h-11 text-cyan-200" onClick={() => setPreview(null)}>返回文件树</button><p className="mb-2 break-all text-slate-300">{preview.path}</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{preview.content}</pre></div> : <ul className="space-y-1">{entries.map((entry) => <li key={entry.entry_id}><button type="button" disabled={entry.kind !== "file" || busy} onClick={() => void openEntry(entry)} className="flex min-h-10 w-full items-center gap-2 rounded-md px-2 text-left text-slate-300 hover:bg-white/5 disabled:cursor-default"><FileCode2 className="h-4 w-4 shrink-0" /><span className="min-w-0 break-all">{entry.display_path}</span></button></li>)}</ul>}</div>}
             {tab === "diff" && <pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{diff || "工作区还没有变更。"}</pre>}
-            {tab === "evidence" && <div className="space-y-4"><section><h3 className="font-semibold text-white">审批</h3>{approvals.filter((item) => item.status === "pending").map((item) => <div key={item.approval_id} className="mt-2 rounded-lg bg-amber-300/10 p-3"><p className="text-amber-100">{item.capability}</p><p className="mt-1 break-words text-xs text-slate-300">{JSON.stringify(item.request)}</p><div className="mt-3 flex flex-wrap gap-2"><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_once")} className="min-h-11 rounded-lg bg-cyan-400 px-3 font-semibold text-slate-950">批准一次</button><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_task")} className="min-h-11 rounded-lg border border-cyan-300/40 px-3 text-cyan-100">本任务批准</button><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "reject")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200">拒绝</button></div></div>)}</section><section><h3 className="font-semibold text-white">检查证据</h3><ul className="mt-2 space-y-2">{evidence.map((item) => <li key={item.evidence_id} className="rounded-lg bg-white/5 p-3"><span className={item.status === "passed" ? "text-emerald-300" : item.status === "failed" ? "text-rose-300" : "text-amber-300"}>{item.status}</span><span className="ml-2 break-all text-slate-200">{item.check_id}</span><span className="mt-1 block text-xs text-slate-400">exit {item.exit_code}</span></li>)}</ul></section><section><h3 className="font-semibold text-white">Artifacts</h3><ul className="mt-2 space-y-1">{artifacts.map((item) => <li key={item.artifact_id}><a className="block min-h-10 break-all rounded-md px-2 py-2 text-cyan-200 hover:bg-white/5" href={codingWorkerArtifactUrl(item.task_id, item.artifact_id)}>{item.artifact_id} · {item.media_type}</a></li>)}</ul></section></div>}
-            {tab === "terminal" && <div><p className="mb-2 text-xs text-slate-400">命令归属和输出只来自 Tool Broker 公开事件。</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{events.filter((event) => event.type === "tool_operation" || event.type === "provider_event").map((event) => `#${event.sequence} ${event.type}\n${payloadText(event) ?? JSON.stringify(event.payload)}`).join("\n\n") || "尚无工具输出。"}</pre></div>}
+            {tab === "changesets" && (
+              <div className="space-y-3" aria-busy={inspectorLoading}>
+                {!status.capabilities.changesets ? <p className="text-slate-400">原子 changeset 当前关闭。</p> : null}
+                {status.capabilities.changesets && changesets.length === 0 ? <p className="text-slate-400">{inspectorLoading ? "正在读取变更记录。" : "尚无 changeset。"}</p> : null}
+                {changesets.map((changeset) => (
+                  <section key={changeset.changeset_id} className="rounded-lg bg-white/5 p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="break-all font-semibold text-white">{changeset.changeset_id}</h3><span className={changeset.state === "applied" ? "text-emerald-300" : "text-amber-200"}>{changeset.state}</span></div>
+                    <p className="mt-1 break-all text-xs text-slate-400">operation {changeset.operation_id}</p>
+                    <p className="mt-1 break-all text-xs text-slate-500">tree {changeset.base_tree_hash.slice(0, 12)} → {changeset.result_tree_hash?.slice(0, 12) ?? "未发布"}</p>
+                    <ul className="mt-3 space-y-2">{changeset.entries.map((entry) => <li key={`${changeset.changeset_id}-${entry.entry_id}`} className="break-all text-slate-200"><span className="mr-2 rounded bg-slate-800 px-1.5 py-0.5 text-xs text-cyan-100">{entry.kind}</span>{entry.display_path}{entry.destination_display_path ? ` → ${entry.destination_display_path}` : ""}{entry.binary ? <span className="ml-2 text-xs text-amber-200">二进制</span> : null}</li>)}</ul>
+                    {changeset.artifact_id ? <a className="mt-3 block min-h-11 break-all py-2 text-cyan-200" href={codingWorkerArtifactUrl(changeset.task_id, changeset.artifact_id)}>下载 changeset Artifact</a> : null}
+                  </section>
+                ))}
+              </div>
+            )}
+            {tab === "diagnostics" && (
+              <div className="space-y-3" aria-busy={inspectorLoading}>
+                {!status.capabilities.code_intelligence ? <p className="text-slate-400">代码诊断当前关闭。</p> : null}
+                {status.capabilities.code_intelligence && diagnostics.length === 0 ? <p className="text-slate-400">{inspectorLoading ? "正在读取诊断。" : "尚无诊断结果。"}</p> : null}
+                {diagnostics.map((snapshot) => (
+                  <section key={snapshot.operation_id} className="rounded-lg bg-white/5 p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="break-all font-semibold text-white">{entries.find((entry) => entry.entry_id === snapshot.entry_id)?.display_path ?? snapshot.entry_id}</h3><span className="text-xs text-slate-400">{snapshot.language}</span></div>
+                    {snapshot.stale ? <p className="mt-2 rounded-md bg-amber-300/10 px-2 py-1.5 text-xs text-amber-100" role="status">工作区已改变，此诊断仅作历史证据。</p> : null}
+                    <ul className="mt-3 space-y-2">{snapshot.diagnostics.map((item) => <li key={item.diagnostic_id} className="break-words text-slate-200"><span className={item.severity === "error" ? "text-rose-300" : item.severity === "warning" ? "text-amber-200" : "text-cyan-200"}>{item.severity}</span><span className="ml-2 text-xs text-slate-500">{item.range.start.line + 1}:{item.range.start.character + 1}{item.code ? ` · ${item.code}` : ""}</span><p className="mt-1 leading-5">{item.message}</p></li>)}</ul>
+                  </section>
+                ))}
+              </div>
+            )}
+            {tab === "evidence" && <div className="space-y-4"><section><h3 className="font-semibold text-white">审批</h3>{approvals.filter((item) => item.status === "pending").map((item) => <div key={item.approval_id} className="mt-2 rounded-lg bg-amber-300/10 p-3"><div className="flex flex-wrap items-center justify-between gap-2"><p className="text-amber-100">{item.capability === "shell" ? "Shell 单次审批" : item.capability}</p><code className="break-all text-xs text-slate-400">{item.operation_id}</code></div>{item.capability === "shell" ? <dl className="mt-3 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-2 text-xs"><dt className="text-slate-400">模式</dt><dd className="break-all text-slate-200">{approvalField(item.request, "mode")}</dd><dt className="text-slate-400">工作目录</dt><dd className="break-all text-slate-200">{approvalField(item.request, "cwd")}</dd><dt className="text-slate-400">超时</dt><dd className="break-all text-slate-200">{approvalField(item.request, "timeout_seconds")} 秒</dd><dt className="text-slate-400">脚本摘要</dt><dd className="break-all font-mono text-slate-200">{approvalField(item.request, "script_sha256")}</dd><dt className="text-slate-400">网络范围</dt><dd className="break-all font-mono text-slate-200">{approvalField(item.request, "network_scope_sha256")}</dd></dl> : <p className="mt-1 break-words text-xs text-slate-300">{JSON.stringify(item.request)}</p>}<div className="mt-3 flex flex-wrap gap-2"><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_once")} className="min-h-11 rounded-lg bg-cyan-400 px-3 font-semibold text-slate-950">批准一次</button>{item.capability !== "shell" ? <button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_task")} className="min-h-11 rounded-lg border border-cyan-300/40 px-3 text-cyan-100">本任务批准</button> : null}<button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "reject")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200">拒绝</button></div></div>)}</section><section><h3 className="font-semibold text-white">检查证据</h3><ul className="mt-2 space-y-2">{evidence.map((item) => <li key={item.evidence_id} className="rounded-lg bg-white/5 p-3"><span className={item.status === "passed" ? "text-emerald-300" : item.status === "failed" ? "text-rose-300" : "text-amber-300"}>{item.status}</span><span className="ml-2 break-all text-slate-200">{item.check_id}</span><span className="mt-1 block text-xs text-slate-400">exit {item.exit_code}</span></li>)}</ul></section><section><h3 className="font-semibold text-white">Artifacts</h3><ul className="mt-2 space-y-1">{artifacts.map((item) => <li key={item.artifact_id}><a className="block min-h-11 break-all rounded-md px-2 py-2.5 text-cyan-200 hover:bg-white/5" href={codingWorkerArtifactUrl(item.task_id, item.artifact_id)}>{item.artifact_id} · {item.media_type}</a></li>)}</ul></section></div>}
+            {tab === "terminal" && (
+              <div aria-busy={inspectorLoading}>
+                <p className="mb-2 text-xs text-slate-400">输出按 operation 归属并从持久事件补发；刷新页面不会丢失已归档片段。</p>
+                {!status.capabilities.operation_output ? <p className="text-slate-400">终端补发当前关闭。</p> : null}
+                {status.capabilities.operation_output && Object.values(operationOutputs).every((items) => items.length === 0) ? <p className="text-slate-400">{inspectorLoading ? "正在补发终端输出。" : "尚无命令输出。"}</p> : null}
+                <div className="space-y-3">{Object.entries(operationOutputs).filter(([, chunks]) => chunks.length > 0).map(([operationId, chunks]) => <section key={operationId} className="overflow-hidden rounded-lg bg-slate-950/80"><h3 className="border-b border-white/10 px-3 py-2 break-all text-xs font-semibold text-cyan-100">{operationId}</h3><pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words p-3 text-xs">{chunks.map((chunk) => <span key={chunk.sequence} className={outputTone(chunk.stream)}>{chunk.text}{chunk.truncated ? "\n[输出已截断]\n" : ""}</span>)}</pre></section>)}</div>
+              </div>
+            )}
           </div>
           {context === "coding" && selectedTask && <section className="mt-3 border-t border-white/10 pt-3"><div className="flex items-center gap-2"><GitCompareArrows className="h-4 w-4 text-cyan-300" /><h3 className="font-semibold text-white">宿主写回</h3></div><p className="mt-1 text-xs text-slate-400">完成后继续使用 v13 的应用、提交、撤销和发布确认链。Worker 不直接写用户仓库。</p>{selectedTask.state === "completed" && selectedTask.spec.workspace_source.kind === "host_snapshot" ? <button type="button" onClick={() => void handoffToWriteback()} disabled={busy} className="mt-3 min-h-11 w-full rounded-lg bg-cyan-400 px-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50">进入 v13 写回确认</button> : <p className="mt-3 text-xs text-slate-500">Host Snapshot 任务通过全部必需检查后，才会开放写回确认。</p>}<div className="mt-3 flex flex-wrap gap-2" aria-label="Coding 领域动作"><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">应用</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">提交</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">撤销</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">发布</span></div></section>}
         </aside>

--- a/client/src/components/coding-worker/viewModel.ts
+++ b/client/src/components/coding-worker/viewModel.ts
@@ -1,0 +1,193 @@
+import type {
+  CodingWorkerApproval,
+  CodingWorkerEvent,
+  CodingWorkerEvidence,
+  CodingWorkerTask,
+  CodingWorkerTaskState,
+} from "../../types/codingWorker";
+
+export type WorkerTaskGroup = "attention" | "active" | "queued" | "history";
+export type WorkerProgressStage = "analyze" | "reproduce" | "change" | "verify";
+export type WorkerActivityTone = "neutral" | "running" | "success" | "warning" | "danger";
+
+export interface WorkerActivity {
+  sequence: number;
+  title: string;
+  detail: string;
+  meta: string;
+  tone: WorkerActivityTone;
+  operationId: string | null;
+}
+
+export const terminalTaskStates = new Set<CodingWorkerTaskState>([
+  "completed", "blocked", "failed", "cancelled", "budget_limited", "expired",
+]);
+
+export const taskStateCopy: Record<CodingWorkerTaskState, string> = {
+  queued: "排队中",
+  preparing: "准备工作区",
+  running: "执行中",
+  waiting_approval: "等待审批",
+  paused: "已暂停",
+  testing: "执行验收",
+  interrupted: "需要恢复",
+  completed: "已完成",
+  blocked: "已阻塞",
+  failed: "失败",
+  cancelled: "已取消",
+  budget_limited: "预算已用完",
+  expired: "已过期",
+};
+
+export function taskGroup(task: CodingWorkerTask): WorkerTaskGroup {
+  if (["waiting_approval", "interrupted", "blocked"].includes(task.state)) return "attention";
+  if (["preparing", "running", "testing", "paused"].includes(task.state)) return "active";
+  if (task.state === "queued") return "queued";
+  return "history";
+}
+
+export function groupTasks(tasks: CodingWorkerTask[]) {
+  const groups: Record<WorkerTaskGroup, CodingWorkerTask[]> = {
+    attention: [], active: [], queued: [], history: [],
+  };
+  tasks.forEach((task) => groups[taskGroup(task)].push(task));
+  return groups;
+}
+
+export function currentProgressStage(
+  task: CodingWorkerTask,
+  events: CodingWorkerEvent[],
+): WorkerProgressStage {
+  if (["testing", "completed"].includes(task.state)) return "verify";
+  if (events.some((event) => ["changeset", "workspace", "patch", "edit", "write_file"].some(
+    (term) => `${event.type} ${eventPayloadText(event) ?? ""}`.toLowerCase().includes(term),
+  ))) return "change";
+  if (events.some((event) => ["tool_operation", "operation_output", "approval_requested"].includes(event.type))) {
+    return "reproduce";
+  }
+  return "analyze";
+}
+
+export function eventPayloadText(event: CodingWorkerEvent) {
+  const candidates = [
+    event.payload.message,
+    event.payload.text,
+    event.payload.summary,
+    event.payload.output,
+  ];
+  const value = candidates.find((item) => typeof item === "string");
+  if (typeof value === "string") return value;
+  const data = event.payload.data;
+  if (typeof data === "string") return data;
+  if (data && typeof data === "object") {
+    const record = data as Record<string, unknown>;
+    const nested = [record.message, record.text, record.summary, record.output]
+      .find((item) => typeof item === "string");
+    if (typeof nested === "string") return nested;
+  }
+  return null;
+}
+
+function eventTitle(event: CodingWorkerEvent) {
+  if (event.type === "task_created") return "任务已进入队列";
+  if (event.type === "task_state") {
+    const next = event.payload.to;
+    return typeof next === "string" && next in taskStateCopy
+      ? `状态更新为${taskStateCopy[next as CodingWorkerTaskState]}`
+      : "任务状态已更新";
+  }
+  if (event.type === "approval_requested") return "需要批准一次工具操作";
+  if (event.type === "approval_decided") return "审批已处理";
+  if (event.type === "tool_operation") {
+    const state = event.payload.state;
+    if (state === "completed") return "工具操作已完成";
+    if (state === "failed") return "工具操作失败";
+    if (state === "unknown") return "工具结果需要核对";
+    return "工具操作已更新";
+  }
+  if (event.type === "operation_output") return "终端输出已更新";
+  if (event.type === "acceptance_evaluated") return "必需检查已执行";
+  if (event.type === "acceptance_retry") return "检查未通过，开始修复";
+  if (event.type === "steering_queued") return "追加指令已排队";
+  if (event.type === "provider_event") {
+    if (event.payload.kind === "plan") return "执行计划已更新";
+    if (event.payload.kind === "message") return "Worker 回复";
+    if (event.payload.kind === "tool_call") return "Worker 请求工具";
+    if (event.payload.kind === "turn_completed") return "本轮执行完成";
+  }
+  return event.type.replaceAll("_", " ");
+}
+
+function eventTone(event: CodingWorkerEvent): WorkerActivityTone {
+  const combined = `${event.type} ${String(event.payload.state ?? "")}`;
+  if (/failed|blocked|rejected/.test(combined)) return "danger";
+  if (/unknown|approval|interrupted|retry/.test(combined)) return "warning";
+  if (/completed|decided|evaluated/.test(combined)) return "success";
+  if (/running|provider|operation/.test(combined)) return "running";
+  return "neutral";
+}
+
+export function activitiesFromEvents(events: CodingWorkerEvent[]): WorkerActivity[] {
+  return events.filter((event) => {
+    if (event.type !== "provider_event") return event.type !== "artifact_created";
+    return event.payload.kind === "message" || event.payload.kind === "turn_completed";
+  }).map((event) => {
+    const operationId = typeof event.payload.operation_id === "string"
+      ? event.payload.operation_id
+      : null;
+    return {
+      sequence: event.sequence,
+      title: eventTitle(event),
+      detail: eventPayloadText(event) ?? eventDetail(event),
+      meta: `#${event.sequence}`,
+      tone: eventTone(event),
+      operationId,
+    };
+  });
+}
+
+function eventDetail(event: CodingWorkerEvent) {
+  if (event.type === "task_state") {
+    const reason = event.payload.reason;
+    return typeof reason === "string" && reason ? `原因：${reason}` : "状态已持久保存。";
+  }
+  if (event.type === "tool_operation") {
+    const operationId = event.payload.operation_id;
+    return typeof operationId === "string" ? `操作 ${shortId(operationId)}` : "工具执行状态已持久保存。";
+  }
+  if (event.type === "approval_requested") return "一次性审批已进入 Action Center。";
+  if (event.type === "approval_decided") return "审批决定已持久保存。";
+  if (event.type === "acceptance_evaluated") {
+    const evidence = event.payload.evidence;
+    if (Array.isArray(evidence)) return `已记录 ${evidence.length} 项检查结果。`;
+  }
+  return "详细数据已归档，可在检查器中查看。";
+}
+
+export function evidenceStatus(checkId: string, evidence: CodingWorkerEvidence[]) {
+  return evidence
+    .filter((item) => item.check_id === checkId)
+    .sort((a, b) => b.created_at - a.created_at)[0]?.status ?? "pending";
+}
+
+export function pendingApprovals(approvals: CodingWorkerApproval[]) {
+  return approvals.filter((approval) => approval.status === "pending");
+}
+
+export function routeLabel(route: string) {
+  if (route === "coding/default") return "标准执行";
+  if (route === "coding/quality") return "深度执行";
+  return route.startsWith("coding/") ? route.slice("coding/".length) : route;
+}
+
+export function shortId(value: string, visible = 8) {
+  return value.length > visible * 2 ? `${value.slice(0, visible)}…${value.slice(-visible)}` : value;
+}
+
+export function formatRelativeTime(timestamp: number) {
+  const delta = Math.max(0, Math.round(Date.now() / 1000 - timestamp));
+  if (delta < 60) return "刚刚";
+  if (delta < 3600) return `${Math.floor(delta / 60)} 分钟前`;
+  if (delta < 86400) return `${Math.floor(delta / 3600)} 小时前`;
+  return `${Math.floor(delta / 86400)} 天前`;
+}

--- a/client/src/types/codingWorker.ts
+++ b/client/src/types/codingWorker.ts
@@ -97,6 +97,7 @@ export interface CodingWorkerStatus {
   retention_seconds: number;
   network_enabled: boolean;
   acceptance_checks: string[];
+  model_routes?: string[];
   reason: string | null;
   capabilities: CodingWorkerCapabilities;
 }

--- a/client/src/types/codingWorker.ts
+++ b/client/src/types/codingWorker.ts
@@ -79,6 +79,16 @@ export interface CodingWorkerEvent {
   created_at: number;
 }
 
+export interface CodingWorkerCapabilities {
+  api_version: "v1";
+  task_runtime: boolean;
+  professional_file_tools: boolean;
+  shell: boolean;
+  operation_output: boolean;
+  changesets: boolean;
+  code_intelligence: boolean;
+}
+
 export interface CodingWorkerStatus {
   enabled: boolean;
   available: boolean;
@@ -88,6 +98,7 @@ export interface CodingWorkerStatus {
   network_enabled: boolean;
   acceptance_checks: string[];
   reason: string | null;
+  capabilities: CodingWorkerCapabilities;
 }
 
 export interface CodingWorkerApproval {
@@ -135,4 +146,70 @@ export interface CodingWorkerEntry {
   kind: string;
   size: number;
   sha256: string | null;
+}
+
+export interface CodingWorkerOperationOutputChunk {
+  task_id: string;
+  operation_id: string;
+  sequence: number;
+  stream: "stdout" | "stderr" | "system";
+  text: string;
+  created_at: number;
+  truncated: boolean;
+}
+
+export interface CodingWorkerChangesetEntry {
+  entry_id: string;
+  kind: "add" | "modify" | "delete" | "move";
+  display_path: string;
+  destination_display_path: string | null;
+  preimage_sha256: string | null;
+  postimage_sha256: string | null;
+  binary: boolean;
+}
+
+export interface CodingWorkerChangeset {
+  changeset_id: string;
+  task_id: string;
+  operation_id: string;
+  base_tree_hash: string;
+  result_tree_hash: string | null;
+  state: "prepared" | "applied" | "conflict" | "rejected" | "unknown";
+  entries: CodingWorkerChangesetEntry[];
+  artifact_id: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface CodingWorkerCodePosition {
+  line: number;
+  character: number;
+}
+
+export interface CodingWorkerCodeRange {
+  start: CodingWorkerCodePosition;
+  end: CodingWorkerCodePosition;
+}
+
+export interface CodingWorkerDiagnostic {
+  diagnostic_id: string;
+  task_id: string;
+  entry_id: string;
+  workspace_tree_hash: string;
+  range: CodingWorkerCodeRange;
+  severity: "error" | "warning" | "information" | "hint";
+  code: string | null;
+  message: string;
+  created_at: number;
+}
+
+export interface CodingWorkerDiagnosticsSnapshot {
+  task_id: string;
+  operation_id: string;
+  entry_id: string;
+  language: "python" | "typescript" | "typescriptreact" | "javascript" | "javascriptreact";
+  workspace_tree_hash: string;
+  current_tree_hash: string;
+  stale: boolean;
+  diagnostics: CodingWorkerDiagnostic[];
 }

--- a/client/src/utils/codingWorkerApi.ts
+++ b/client/src/utils/codingWorkerApi.ts
@@ -1,9 +1,12 @@
 import type {
   CodingWorkerApproval,
   CodingWorkerArtifact,
+  CodingWorkerChangeset,
+  CodingWorkerDiagnosticsSnapshot,
   CodingWorkerEntry,
   CodingWorkerEvent,
   CodingWorkerEvidence,
+  CodingWorkerOperationOutputChunk,
   CodingWorkerStatus,
   CodingWorkerTask,
   CodingWorkerTaskSpec,
@@ -59,7 +62,7 @@ const taskEventTypes = [
   "approval_requested", "approval_decided", "tool_operation",
   "artifact_created", "evidence_recorded", "evidence_invalidated",
   "checkpoint_created", "acceptance_evaluated", "acceptance_retry",
-  "task_pinned", "task_unpinned",
+  "task_pinned", "task_unpinned", "operation_output",
 ] as const;
 
 export const getCodingWorkerStatus = () => request<CodingWorkerStatus>(API_ROOT);
@@ -129,6 +132,26 @@ export async function listCodingWorkerArtifacts(taskId: string) {
     `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/artifacts`,
   )).artifacts;
 }
+
+export async function listCodingWorkerOperationOutput(
+  taskId: string,
+  operationId: string,
+  after = 0,
+) {
+  return (await request<{ chunks: CodingWorkerOperationOutputChunk[] }>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/operations/${encodeURIComponent(operationId)}/output?after=${Math.max(0, after)}`,
+  )).chunks;
+}
+
+export const getCodingWorkerChangeset = (taskId: string, operationId: string) =>
+  request<CodingWorkerChangeset>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/changesets/${encodeURIComponent(operationId)}`,
+  );
+
+export const getCodingWorkerDiagnostics = (taskId: string, operationId: string) =>
+  request<CodingWorkerDiagnosticsSnapshot>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/diagnostics/${encodeURIComponent(operationId)}`,
+  );
 
 export async function listCodingWorkerTree(taskId: string) {
   return request<{ workspace_id: string; tree_hash: string; entries: CodingWorkerEntry[] }>(

--- a/docker-compose.coding-worker-v14.yml
+++ b/docker-compose.coding-worker-v14.yml
@@ -135,7 +135,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 10s
     healthcheck:
-      test: ["CMD", "python", "-c", "import json,os,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-coding/executor.sock'); s.sendall((json.dumps({'token':os.environ['CODING_WORKER_EXECUTOR_TOKEN'],'action':'bind_task','payload':{'task_id':'healthcheck','workspace_id':'healthcheck'}})+'\\n').encode()); assert json.loads(s.recv(65536))['error']['code']=='executor_failed'"]
+      test: ["CMD", "python", "-c", "import json,os,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-coding/executor.sock'); s.sendall((json.dumps({'token':os.environ['CODING_WORKER_EXECUTOR_TOKEN'],'action':'health','payload':{}})+'\\n').encode()); assert json.loads(s.recv(65536))['result']=={'healthy':True}"]
       interval: 10s
       timeout: 5s
       retries: 8

--- a/docker-compose.coding-worker-v15-claude.yml
+++ b/docker-compose.coding-worker-v15-claude.yml
@@ -1,0 +1,40 @@
+services:
+  server:
+    environment:
+      CODING_WORKER_CLAUDE_ENABLED: ${CODING_WORKER_CLAUDE_ENABLED:-false}
+      CODING_WORKER_MODEL_ROUTES: coding/default,coding/quality
+      CODING_WORKER_ROUTE_SLOTS_JSON: '{"coding/default":["slot-a"],"coding/quality":["slot-b"]}'
+
+  coding-worker-provider-b:
+    image: modelmirror-coding-worker-claude-v15:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.claude
+    depends_on: !reset {}
+    networks: !override
+      - coding_worker_claude
+    environment: !override
+      CODING_WORKER_PROVIDER_SOCKET: /run/modelmirror-coding/provider.sock
+      CODING_WORKER_SIDECAR_TOKEN: ${CODING_WORKER_SLOT_B_TOKEN:?set a random V15 slot B token}
+      CODING_WORKER_PROVIDER_KIND: claude-code
+      CODING_WORKER_ROUTE_ID: coding/quality
+      CODING_WORKER_MODEL_ID: ${CODING_WORKER_CLAUDE_MODEL_ID:?set the controlled Claude model id}
+      CODING_WORKER_CLAUDE_SECRET_PATH: /run/secrets/modelmirror_claude_api_key
+    volumes: !override
+      - coding_worker_provider_b:/run/modelmirror-coding
+      - coding_worker_broker:/run/modelmirror-coding-broker:ro
+    secrets: !override
+      - source: coding_worker_claude_api_key
+        target: modelmirror_claude_api_key
+        uid: "65532"
+        gid: "65532"
+        mode: 0400
+
+secrets:
+  coding_worker_claude_api_key:
+    file: ${CODING_WORKER_CLAUDE_SECRET_FILE:?set an absolute Claude API key secret file}
+
+networks:
+  coding_worker_claude:
+    driver: bridge
+    internal: true

--- a/docker-compose.coding-worker-v15-claude.yml
+++ b/docker-compose.coding-worker-v15-claude.yml
@@ -20,6 +20,7 @@ services:
       CODING_WORKER_ROUTE_ID: coding/quality
       CODING_WORKER_MODEL_ID: ${CODING_WORKER_CLAUDE_MODEL_ID:?set the controlled Claude model id}
       CODING_WORKER_CLAUDE_SECRET_PATH: /run/secrets/modelmirror_claude_api_key
+      CODING_WORKER_PROVIDER_PROXY_URL: http://provider:${CODING_WORKER_CLAUDE_PROXY_TOKEN:?set a random URL-safe Claude proxy token}@coding-worker-claude-egress:8081
     volumes: !override
       - coding_worker_provider_b:/run/modelmirror-coding
       - coding_worker_broker:/run/modelmirror-coding-broker:ro
@@ -30,6 +31,32 @@ services:
         gid: "65532"
         mode: 0400
 
+  coding-worker-claude-egress:
+    image: modelmirror-coding-worker-claude-v15:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.claude
+    container_name: modelmirror-coding-worker-claude-egress
+    command: ["python", "-m", "coding_worker.egress_proxy"]
+    networks:
+      - coding_worker_claude
+      - coding_worker_claude_egress
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 64
+    mem_limit: 128m
+    cpus: 0.5
+    tmpfs:
+      - /tmp:rw,nosuid,noexec,size=8m,uid=65532,gid=65532,mode=0700
+    environment:
+      CODING_WORKER_PROVIDER_EGRESS_TOKEN: ${CODING_WORKER_CLAUDE_PROXY_TOKEN:?set a random URL-safe Claude proxy token}
+      CODING_WORKER_PROVIDER_NETWORK_DOMAINS: api.anthropic.com
+    restart: unless-stopped
+
 secrets:
   coding_worker_claude_api_key:
     file: ${CODING_WORKER_CLAUDE_SECRET_FILE:?set an absolute Claude API key secret file}
@@ -38,3 +65,5 @@ networks:
   coding_worker_claude:
     driver: bridge
     internal: true
+  coding_worker_claude_egress:
+    driver: bridge

--- a/docker-compose.coding-worker-v15-claude.yml
+++ b/docker-compose.coding-worker-v15-claude.yml
@@ -55,6 +55,7 @@ services:
     environment:
       CODING_WORKER_PROVIDER_EGRESS_TOKEN: ${CODING_WORKER_CLAUDE_PROXY_TOKEN:?set a random URL-safe Claude proxy token}
       CODING_WORKER_PROVIDER_NETWORK_DOMAINS: api.anthropic.com
+      CODING_WORKER_PROVIDER_ALLOW_DOCKER_DESKTOP_DNS_PROXY: ${CODING_WORKER_PROVIDER_ALLOW_DOCKER_DESKTOP_DNS_PROXY:-false}
     restart: unless-stopped
 
 secrets:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -331,3 +331,31 @@ flowchart LR
 - `host_snapshot` 在任务真正出队时才向 Windows Helper 请求一次性快照并导入 Project Source；Server 始终不获得宿主物理路径。完成后仅能显式交给现有 v13 写回链，Worker 本身不写用户仓库。
 
 `/coding` 和 `/agents/workbench` 使用同一个 Worker Console。前者保留 v13 apply/commit/undo/publish 领域动作；后者只显示通用任务、文件、Diff、审批、Evidence、Artifact 与终端语义。下游 Skill/MCP 创建、AI 应用、3D 引擎和用户开发模块只注册来源、上下文和验收适配器，不向 Worker 内核加入领域逻辑。
+
+## V15 专业执行与双引擎边界
+
+V15 保持 `/api/coding-worker/v1`、`TaskSpec` 和 V14 Workspace/Store 不变，在 Tool Broker 与
+Provider 私有层补充专业执行能力：
+
+- 文件修改使用带 preimage hash 的统一 changeset；多文件 Patch、移动或删除任一项冲突时整批
+  失败。Shell `mutate` 只在退出码为零且真实 Workspace tree CAS 未变化时发布，`inspect` 的
+  任何文件变化均丢弃。完整输出进入 Artifact，公共事件只保存有界、可补发的顺序片段。
+- Shell 批准只绑定一个 operation ID、脚本摘要、相对 cwd、模式、超时和网络范围，不存在
+  “本任务全部批准”。后台服务、冻结检查和 Shell 共享任务进程归属，但不共享批准租约。
+- Pyright 与 TypeScript Language Server 固定在 Executor 镜像内。symbols、definition、
+  references、hover 与 diagnostics 均绑定 task、entry ID 和 tree hash；树变化后旧诊断失效，
+  重启只重建 LSP，不恢复旧进程。
+- Provider 私有契约 v2 统一 Fake、OpenCode 与 Claude 的 capability、工具 allowlist、usage、
+  checkpoint compatibility 和错误分类。任务创建时固定内部 Provider；不可用时进入
+  `interrupted`，不跨引擎迁移 checkpoint，也不自动换供应商。
+- Claude Code 固定为 `2.1.89`，运行在独立、无 Workspace 挂载的 Provider sidecar。内建
+  Bash、文件、Web、Skill、插件、hooks、marketplace 与更新检查关闭；仅能调用
+  ModelMirror MCP Broker。凭据只以只读 secret 文件进入 Claude sidecar，并仅在启动子进程
+  时注入；Executor、Store、日志、Artifact 和公共 API 不接收它。
+- 平台内部 route catalog 把 `coding/default`、`coding/quality` 等通用路由固定到执行槽和
+  Provider。浏览器、模块与公共 SSE 仍看不到供应商名、端口、原始帧、session ID 或凭据状态。
+
+共享 Console 只查询公共 capability、公开计划、operation output、changeset 与 diagnostics，
+并展示精确 Shell 批准字段；它不获得 Provider 控制权。模块 SDK 对每次读取、steering、暂停、
+恢复和取消都复核服务端 `origin(module, business_object)`，跨模块任务 ID 在副作用前拒绝。
+模块仍不能注册 Provider、工具进程、密钥或任意 MCP Server；领域适配继续位于调用模块。

--- a/docs/CODING_AGENT_INTEGRATION.md
+++ b/docs/CODING_AGENT_INTEGRATION.md
@@ -742,3 +742,28 @@ V14 的公共入口是版本化 `/api/coding-worker/v1`。OpenCode、ACP、sidec
 `/coding` 与 `/agents/workbench` 的新会话可渐进使用同一 `CodingWorkerConsole`；已有活动会话仍走 legacy。Coding 场景中的 completed `host_snapshot` 任务可调用 `POST /api/coding/worker-tasks/{task_id}/handoff`，把严格 UTF-8 文本 Diff 交给 v13 Recovery，然后由用户确认 apply/commit/undo/publish。二进制变更、未通过验收、Workspace 变化或 Host 身份变化均不得进入写回。
 
 模型停止输出不代表完成。服务端先进入 `testing`，Harness Runner 运行冻结检查并写 Evidence Ledger；只有全部必需检查对当前 tree hash 为 passed，任务才进入 `completed`。运行中命令在重启时停止，任务标记 `interrupted`；resume 只恢复确定 checkpoint，不恢复旧进程或盲重放未知 operation ID。
+
+## V15 专业工具与模块控制
+
+V15 不改变 TaskSpec，也不允许调用方选择供应商。它在同一版本化 API 上增加只读查询：
+
+| 接口 | 用途 |
+| --- | --- |
+| `GET /tasks/{task_id}/operations/{operation_id}/output?after=` | 按序补发有界 Shell/检查输出；完整输出从绑定 Artifact 下载 |
+| `GET /tasks/{task_id}/changesets/{operation_id}` | 读取原子发布结果、preimage/tree CAS 与文件摘要 |
+| `GET /tasks/{task_id}/diagnostics/{operation_id}` | 读取绑定 entry ID 与 tree hash 的代码诊断；旧树结果标记失效 |
+
+公共 capability 只说明 `shell`、`changesets`、`code_intelligence` 等中立能力。内部 route catalog
+在任务创建时固定 Provider 与兼容版本；公共 API、SSE 和 Console 不返回 Claude/OpenCode 名称、
+原始帧、端口、session ID、secret 或真实端点。Provider 完成但回执丢失时先按 checkpoint/operation
+对账，不重新执行工具副作用。
+
+共享 `CodingWorkerConsole` 展示公开计划、实时终端、changeset、diagnostics、Evidence 与精确
+Shell 批准。Shell 批准包含 operation ID、脚本摘要、相对 cwd、模式、timeout 和网络范围；Shell
+不允许 task-scope lease。Coding 场景仍可在任务 completed 后进入 v13 handoff；通用 Agent 场景不
+显示 apply、commit、undo 或 publish。
+
+模块侧 `CodingWorkerClient` 的所有任务读取和生命周期操作都需要服务端 origin。跨模块或业务对象
+任务 ID 在读取事件或产生副作用前拒绝。模块可以注册 source、context、acceptance 和通用 route
+allowlist，不能控制 Provider、Tool Broker、Shell/LSP 进程、secret 或任意 MCP Server。旧 V14 任务
+继续按兼容默认值读取与恢复，不迁移 Provider checkpoint。

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -592,3 +592,46 @@ docker compose -f docker-compose.yml -f docker-compose.coding-project-host.yml -
 验收至少包括：两个任务并行、第三个排队；失败检查后的自动修复与复测；审批拒绝/过期；SSE 断线补发；Server、两个 Provider/Executor 逐个重启；Host Snapshot 经过 v13 写回。真实 OpenCode、Windows Helper 和用户项目写回必须单列人工结果，不能用 Fake Provider 或 Compose `config` 代替。
 
 回退只需设置 `CODING_WORKER_V14_ENABLED=false` 并重建 Server，使新会话回到 legacy。不要删除 `coding_worker_state`、slot Workspace 卷、v13 Recovery 或 Agent Workspace 数据；已有任务保持可审计，已有宿主副作用不会自动撤销。
+
+## Coding Worker V15 部署
+
+V15 在 V14 overlay 之后可选加载 `docker-compose.coding-worker-v15-claude.yml`。以下开关默认
+全部关闭；前三项写入绝对 `MODELMIRROR_DATA_ROOT` 对应的 `server/.env`，单独设置浏览器参数
+或 TaskSpec 不能开启能力：
+
+```dotenv
+CODING_WORKER_V15_ENABLED=false
+CODING_WORKER_SHELL_ENABLED=false
+CODING_WORKER_CODE_INTELLIGENCE_ENABLED=false
+```
+
+Claude overlay 的值用于 Compose 插值，必须由部署脚本/宿主环境或 Compose project `.env`
+显式提供；Server 的 `env_file` 不会替代这些插值：
+
+```dotenv
+CODING_WORKER_CLAUDE_ENABLED=false
+CODING_WORKER_CLAUDE_MODEL_ID=<controlled-model-id>
+CODING_WORKER_CLAUDE_SECRET_FILE=C:\\absolute\\path\\claude-api-key.secret
+CODING_WORKER_CLAUDE_PROXY_TOKEN=<random-url-safe-token>
+```
+
+Claude secret 文件不得放入仓库或数据导出；sidecar 只接受普通、非链接、单硬链接的只读文件。
+缺少或不安全的 secret 只禁用相应内部路由，不影响 OpenCode、Fake、legacy 或已有 V14 任务。
+Claude Provider 不挂载 Workspace、Docker socket、宿主目录或 Server 密钥；独立出口代理只允许
+`api.anthropic.com:443`，Executor 仍无模型网络。`CODING_WORKER_CLAUDE_MODEL_ID` 是部署者控制
+的内部映射，不进入公共 TaskSpec。
+
+只展开最终配置而不启动服务：
+
+```powershell
+docker compose -f docker-compose.yml `
+  -f docker-compose.coding-worker-v14.yml `
+  -f docker-compose.coding-worker-v15-claude.yml `
+  -p modelmirror --profile coding config --quiet
+```
+
+重建、真实 secret、真实双引擎任务和逐组件重启必须在用户确认的共享栈窗口执行。自动测试、
+镜像版本探针或 Compose 展开不等同于真实 Claude/OpenCode 验收。回退时先关闭
+`CODING_WORKER_CLAUDE_ENABLED`，再按需关闭 code intelligence、Shell 与 V15 总开关并停止接收
+新 V15 任务；不要删除 V14 Store、Workspace、Evidence、v13 Recovery 或 Agent Workspace 数据。
+已开始的任务必须进入明确的 `interrupted`/终态，未知 operation 只能对账，不能重放。

--- a/docs/HARNESS_ENGINEERING.md
+++ b/docs/HARNESS_ENGINEERING.md
@@ -405,3 +405,24 @@ curl http://localhost:5173/models
 49. **共享 Console 必须区分展示与能力。** `/coding` 和 `/agents/workbench` 可复用任务、对话、文件、
     Diff、审批、Evidence、Artifact 与终端组件；只有 Coding 上下文展示 v13 领域动作。开关关闭、Provider
     不可用或 legacy 活动会话存在时必须清晰降级，不能把 Mock/静态状态误报为真实引擎就绪。
+50. **专业文件修改必须以 preimage 与 tree CAS 整批发布。** unified patch、移动、删除和批量修改的每个
+    输入都要绑定旧内容；任一冲突时全部保持旧状态。Shell `mutate` 还必须满足 exit 0 与真实 Workspace
+    tree 未变化，`inspect` 永不发布文件变化；超限或策略外产物只进入 Artifact。
+51. **Shell 没有任务级永久批准。** 每次批准必须精确绑定 operation ID、脚本摘要、相对 cwd、模式、
+    timeout 和网络范围。修改脚本、重复批准、过期批准或把服务/检查租约复用于 Shell 都必须拒绝；未知
+    结果按原 operation ID 对账，不能换 ID 重跑。
+52. **代码智能结果是树版本证据，不是长期事实。** symbols、definition、references、hover 和 diagnostics
+    必须绑定 task、entry ID 与 tree hash。任何 Workspace 变化立即使旧结果失效；LSP 重启只能重新索引，
+    不能恢复旧进程、旧诊断或读取另一个任务的 Workspace。
+53. **Provider 可移植不等于 Provider 可见。** 公共 route 只表达平台质量档；供应商、版本、端口、原始帧、
+    session ID 与凭据只存在于加密私有绑定。任务只允许原 Provider、兼容版本和相同 tree 恢复；不得自动
+    跨引擎迁移或把缺少 Claude secret 扩大为 OpenCode/legacy 故障。
+54. **真实 Provider 内建工具必须保持关闭。** OpenCode 与 Claude 都只能经 ModelMirror Tool Broker 读写、
+    执行或联网。Claude secret 只进入独立 Provider 子进程，Provider 不挂 Workspace，Executor 不接收模型
+    凭据；conformance Mock 或 CLI `--version` 不能替代真实双引擎任务验收。
+55. **模块控制必须持续复核 origin。** SDK 的查询、事件、message、pause、resume 与 cancel 都要匹配
+    `origin(module, business_object)`，不能只在创建时校验。模块可登记来源、上下文和验收适配器，但不能
+    注册 Provider、Shell/LSP 进程、secret 或任意 MCP Server。
+56. **Console 展示的输出必须可补发且有界。** operation output 按序号重连，完整内容从受限 Artifact 获取；
+    大输出、长路径和 diagnostics 不得阻塞主线程或破坏移动端。精确 Shell 批准要可键盘操作、带明确焦点
+    与状态反馈，Coding 领域动作仍只在 Coding 上下文出现。

--- a/docs/tasks/CODING_WORKER_V15.md
+++ b/docs/tasks/CODING_WORKER_V15.md
@@ -41,7 +41,8 @@
 
 ## 当前进度（2026-08-11）
 
-PR A 已作为 Draft PR #151 发布；PR B 的实现与自动门禁已完成，尚未进行真实 Provider/人工验收，也未开始 PR C：
+PR A 已作为 Draft PR #151 发布，PR B 已作为 Draft PR #155 发布；PR C 的实现与自动门禁也已完成，
+尚未进行真实 Provider、共享栈或 v13 写回人工验收：
 
 - 契约与文件工具：`d0e955b`、`50d933e`、`29c135b`。
 - Shell 执行、审批、changeset 与查询：`ad831ac`、`0a56605`、`45df707`。
@@ -79,6 +80,30 @@ PR B 实际自动验证：
 - 有效 Compose 配置确认 Claude Provider 不继承 route key、gateway base URL 或 Workspace 挂载；Provider 只接内部网络和受控 socket/secret，独立代理只允许 `api.anthropic.com:443`。
 
 上述 PR B 证据证明契约、隔离、恢复对账和镜像构造，不等同于使用真实 Anthropic 凭据完成任务。真实 OpenCode/Claude 双任务、逐组件重启和 v13 Host 写回仍属于 PR C 后的人工验收，完成前 V15 保持非 Ready。
+
+PR C 实现提交：
+
+- 共享 Console 的中立 capability、公开计划、operation output、changeset、diagnostics 与精确 Shell
+  批准：`d553877`。
+- 持续复核 `origin(module, business_object)` 的模块任务查询、事件、steering 与生命周期控制：
+  `201602d`。
+- 两个实现提交分别修改 4 个和 2 个文件，均未扩大公共 TaskSpec，也未新增依赖。
+
+PR C 实际自动验证：
+
+- Linux 无网络只读源码环境全部 Worker：145 passed、5 skipped、1 条既有框架告警。
+- Agent Workspace：44 passed；全部 Coding：768 passed、14 skipped、1 条既有框架告警。
+- 后端全量：2617 passed、27 skipped、7 failed、6 warnings。5 项仍为 Agency Worker 测试镜像缺少
+  构建产物，1 项仍为 Node 20 无法直接导入 `.ts`；二者已在 PR B 基线复现。另 1 项 Host Apply
+  同内容替换身份测试在本次全量中波动失败，但同一 PR C 的 Coding 全量已通过，随后在 PR C 与
+  PR B 基线分别精确复跑均为 1 passed；未把该波动写成全绿或跨范围修改。
+- 前端 TypeScript 检查通过；35 个测试文件、170 项测试全部通过；production build 成功，仅有
+  既有大 chunk 告警。
+- 变更 Python 文件 `py_compile` 通过；V14 与 V15 Claude overlay 合并后的 Compose
+  `config --quiet` 通过；`git diff --check` 通过。
+
+上述 PR C 证据证明公共 Console、模块 origin 隔离和受影响回归，不等同于真实双引擎任务、
+逐组件重启、网络/依赖 lease 或 v13 Host 写回。PR C 必须保持 Draft，人工验收通过前 V15 非 Ready。
 
 ## 开关与回退
 

--- a/docs/tasks/CODING_WORKER_V15.md
+++ b/docs/tasks/CODING_WORKER_V15.md
@@ -41,7 +41,7 @@
 
 ## 当前进度（2026-08-11）
 
-PR A 的实现与自动门禁已完成，尚未进行真实 Provider/人工验收，也未开始 PR B、PR C：
+PR A 已作为 Draft PR #151 发布；PR B 的实现与自动门禁已完成，尚未进行真实 Provider/人工验收，也未开始 PR C：
 
 - 契约与文件工具：`d0e955b`、`50d933e`、`29c135b`。
 - Shell 执行、审批、changeset 与查询：`ad831ac`、`0a56605`、`45df707`。
@@ -58,6 +58,27 @@ PR A 实际自动验证：
 - `git diff --check` 通过；提交文件数门禁通过。
 
 上述结果只证明 PR A 的自动化边界，不等同于 OpenCode/Claude 双引擎真实任务、逐组件重启或 v13 Host 写回人工验收。PR A 发布后仍须按顺序完成 PR B、PR C，并在人工验收通过前保持 V15 非 Ready。
+
+PR B 实现提交：
+
+- Provider 私有契约 v2 与 route 固定：`59b4bf9`、`ae337ee`。
+- Claude Code Provider 与 Sidecar：`01512d0`、`6544878`。
+- Claude secret、网络和部署隔离：`f6bf8a5`、`23b9fc1`。
+- 完成回执对账与 Fake/OpenCode/Claude conformance：`b70d0e4`、`c040d60`。
+- 以上 8 个实现提交均不超过五个文件；PR B 以 PR A 的 `cdad6da` 为基线。
+
+PR B 实际自动验证：
+
+- Linux 无网络只读源码环境全部 Worker：142 passed、5 skipped、1 条框架告警。
+- Windows 全部 Worker：132 passed、12 skipped、3 项 V14 snapshot reader 的 `mtime_ns` 漂移失败；同样 3 项已在 PR A 工作树精确复现。
+- Agent Workspace：44 passed；Coding：765 passed、14 skipped。
+- 后端全量：2615 passed、27 skipped、6 failed、6 warnings。5 项为 PR A 已记录的 Agency Worker 测试镜像缺少构建产物；另 1 项为当前 `modelmirror-server` 镜像 Node 20 无法直接导入 `.ts`，已在 PR A 基线用相同镜像精确复现。该结果不是全绿，两个基线问题均未在 PR B 跨范围修复。
+- 前端 TypeScript 检查通过；35 个测试文件、169 项测试全部通过；production build 成功，仅有既有大 chunk 告警。
+- 变更 Python 文件 `py_compile` 通过；合并 V14/V15 overlay 的 Compose `config --quiet` 通过。
+- Claude 镜像使用固定包 `@anthropic-ai/claude-code@2.1.89` 及 SHA512 完整性门禁；最终镜像无网络只读探针返回 `2.1.89 (Claude Code)`，运行用户为 `65532`。
+- 有效 Compose 配置确认 Claude Provider 不继承 route key、gateway base URL 或 Workspace 挂载；Provider 只接内部网络和受控 socket/secret，独立代理只允许 `api.anthropic.com:443`。
+
+上述 PR B 证据证明契约、隔离、恢复对账和镜像构造，不等同于使用真实 Anthropic 凭据完成任务。真实 OpenCode/Claude 双任务、逐组件重启和 v13 Host 写回仍属于 PR C 后的人工验收，完成前 V15 保持非 Ready。
 
 ## 开关与回退
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -36,6 +36,15 @@ CODING_WORKER_MAX_ACTIVE_TASKS=2
 CODING_WORKER_RETENTION_SECONDS=604800
 CODING_WORKER_NETWORK_ENABLED=false
 CODING_WORKER_MODEL_ROUTES=coding/default
+# V15 Provider portability remains opt-in. The Claude secret is a host-side
+# regular file referenced by the dedicated Compose overlay; never put its value
+# in this env file or mount it into the Server/Executor containers.
+CODING_WORKER_V15_ENABLED=false
+CODING_WORKER_SHELL_ENABLED=false
+CODING_WORKER_CODE_INTELLIGENCE_ENABLED=false
+CODING_WORKER_CLAUDE_ENABLED=false
+CODING_WORKER_CLAUDE_MODEL_ID=
+CODING_WORKER_CLAUDE_SECRET_FILE=
 
 # 图片识别与生成使用实时能力目录；关闭后保留静态条目但隐藏交互入口。
 MULTIMODAL_IMAGE_ANALYSIS_ENABLED=true

--- a/server/THIRD_PARTY_NOTICES.md
+++ b/server/THIRD_PARTY_NOTICES.md
@@ -240,3 +240,17 @@ the immutable vendor directory.
 This image does not include the PenguinHarness Server/Hono API, database,
 Vault, cost center, desktop application, CLI, installer, MinGit, release
 tooling, or Penguin branding.
+## Claude Code command-line runtime
+
+The optional V15 Claude Provider image contains the unmodified
+`@anthropic-ai/claude-code` npm package, pinned to version `2.1.89` and verified
+against its npm registry SHA-512 integrity value during the image build.
+
+- Copyright: Copyright Anthropic PBC. All rights reserved.
+- Package: <https://www.npmjs.com/package/@anthropic-ai/claude-code/v/2.1.89>
+- Legal terms: <https://code.claude.com/docs/en/legal-and-compliance>
+- Packaged notice: `/usr/local/lib/node_modules/@anthropic-ai/claude-code/LICENSE.md`
+
+Use of Claude Code and Anthropic services remains subject to Anthropic's legal
+agreements. The package is isolated in the optional Provider sidecar and is not
+linked into ModelMirror application code.

--- a/server/coding_worker/Dockerfile.claude
+++ b/server/coding_worker/Dockerfile.claude
@@ -1,0 +1,38 @@
+FROM node:22-bookworm-slim AS claude_runtime
+
+ARG CLAUDE_CODE_VERSION=2.1.89
+ARG CLAUDE_CODE_INTEGRITY=sha512-etjihHqVxj1RjS5Zu/o+rv3ojn1N7AWzfgIOCSSSncfyb4qJn9J677scj0LHIxtwzjgU7j1qAedXlXKxgkFG2w==
+
+RUN npm pack "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" --pack-destination /tmp \
+    && node -e "const fs=require('fs');const crypto=require('crypto');const p='/tmp/anthropic-ai-claude-code-${CLAUDE_CODE_VERSION}.tgz';const actual='sha512-'+crypto.createHash('sha512').update(fs.readFileSync(p)).digest('base64');if(actual!=='${CLAUDE_CODE_INTEGRITY}'){throw new Error('Claude Code package integrity mismatch')}" \
+    && npm install --global "/tmp/anthropic-ai-claude-code-${CLAUDE_CODE_VERSION}.tgz" \
+    && test "$(claude --version | awk '{print $1}')" = "${CLAUDE_CODE_VERSION}"
+
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    CODING_WORKER_RUNTIME_ROOT=/worker-runtime
+
+COPY --from=claude_runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=claude_runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s ../lib/node_modules/@anthropic-ai/claude-code/cli.js /usr/local/bin/claude \
+    && groupadd --gid 65532 coding \
+    && useradd --uid 65532 --gid 65532 --home-dir /home/coding --no-create-home coding \
+    && mkdir -p /opt/modelmirror /home/coding /worker-runtime /run/modelmirror-coding \
+    && chown -R 65532:65532 /home/coding /worker-runtime /run/modelmirror-coding
+
+WORKDIR /opt/modelmirror
+COPY server/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --retries 5 --timeout 120 -r /tmp/requirements.txt
+
+COPY server/coding_worker ./coding_worker
+COPY server/THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-coding/THIRD_PARTY_NOTICES.md
+
+USER 65532:65532
+
+CMD ["python", "-m", "coding_worker.sidecar"]

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -188,6 +188,7 @@ async def coding_worker_status() -> dict[str, Any]:
             if _service is not None and _service.tool_broker is not None
             else []
         ),
+        "model_routes": _configured_model_routes(),
         "reason": _startup_error,
         "capabilities": capabilities.model_dump(mode="json"),
     }
@@ -770,12 +771,16 @@ def _task_workspace(task_id: str) -> tuple[CodingWorkerService, TaskRecord]:
     return service, task
 
 
-def _validate_model_route(model_route: str) -> None:
-    configured = {
+def _configured_model_routes() -> list[str]:
+    return sorted({
         value.strip()
         for value in os.getenv("CODING_WORKER_MODEL_ROUTES", "coding/default").split(",")
         if value.strip()
-    }
+    })
+
+
+def _validate_model_route(model_route: str) -> None:
+    configured = set(_configured_model_routes())
     if model_route not in configured:
         raise HTTPException(
             status_code=400,

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -21,7 +21,6 @@ from .contracts import (
     StrictModel,
     TaskCreateRequest,
     TaskRecord,
-    TaskState,
     TERMINAL_STATES,
     WorkerCapabilities,
     WorkerApproval,
@@ -293,13 +292,7 @@ async def decide_task_approval(
             task_scope=payload.decision == "approve_task",
             ttl_seconds=payload.ttl_seconds,
         )
-        task = service.store.get_task(task_id)
-        if task.state is TaskState.WAITING_APPROVAL:
-            service.store.transition(
-                task_id,
-                TaskState.RUNNING,
-                expected_state=TaskState.WAITING_APPROVAL,
-            )
+        service.settle_approval_state(task_id)
         return decided
     except Exception as exc:
         _raise_worker_error(exc)

--- a/server/coding_worker/claude_provider.py
+++ b/server/coding_worker/claude_provider.py
@@ -565,9 +565,17 @@ class ClaudeCodeProvider(CodingAgentProvider):
                     code="provider_credential_unavailable",
                     failure_kind=ProviderFailureKind.AUTHENTICATION,
                 )
-            value = os.read(descriptor, MAX_SECRET_BYTES + 1).decode("utf-8").strip()
+            encoded = os.read(descriptor, MAX_SECRET_BYTES + 1)
         finally:
             os.close(descriptor)
+        try:
+            value = encoded.decode("utf-8").strip()
+        except UnicodeError as exc:
+            raise ClaudeCodeProviderError(
+                "Claude credential is invalid.",
+                code="provider_credential_unavailable",
+                failure_kind=ProviderFailureKind.AUTHENTICATION,
+            ) from exc
         if not value or len(value.encode("utf-8")) > MAX_SECRET_BYTES:
             raise ClaudeCodeProviderError(
                 "Claude credential is invalid.",

--- a/server/coding_worker/claude_provider.py
+++ b/server/coding_worker/claude_provider.py
@@ -1,0 +1,640 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import secrets
+import signal
+import stat
+import uuid
+from collections.abc import AsyncIterator, Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pydantic import Field
+
+from .contracts import StrictModel
+from .provider import (
+    CodingAgentProvider,
+    ProviderCapabilities,
+    ProviderCheckpoint,
+    ProviderCheckpointCompatibility,
+    ProviderEvent,
+    ProviderEventKind,
+    ProviderFailureKind,
+    ProviderOpenRequest,
+    ProviderSession,
+    ProviderUsage,
+)
+
+
+CLAUDE_CODE_VERSION = "2.1.89"
+CLAUDE_MCP_NAME = "modelmirror-tool-broker"
+MAX_SECRET_BYTES = 16 * 1024
+MAX_STDERR_BYTES = 16 * 1024
+CLAUDE_BUILTIN_TOOLS = (
+    "Bash",
+    "Edit",
+    "Write",
+    "Read",
+    "Glob",
+    "Grep",
+    "WebFetch",
+    "WebSearch",
+    "Skill",
+    "Task",
+    "NotebookEdit",
+)
+
+
+class ClaudeCodeProviderError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        failure_kind: ProviderFailureKind = ProviderFailureKind.UNAVAILABLE,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.failure_kind = failure_kind
+
+
+class ClaudeCodeRoute(StrictModel):
+    route_id: str
+    model_id: str = Field(min_length=1, max_length=128)
+    max_budget_usd: float = Field(default=20.0, gt=0, le=1_000)
+
+
+@dataclass(slots=True)
+class ClaudeSessionHandle:
+    request: ProviderOpenRequest
+    route: ClaudeCodeRoute
+    state_root: Path
+    home: Path
+    settings_path: Path
+    mcp_path: Path
+    session_id: str
+    revoke_broker: Callable[[], None]
+    resumed_once: bool = False
+    active_process: asyncio.subprocess.Process | None = None
+    public_context: list[str] = field(default_factory=list)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+class ClaudeCodeProvider(CodingAgentProvider):
+    """Claude Code 2.1.89 adapter with no Workspace mount or public frames."""
+
+    def __init__(
+        self,
+        *,
+        runtime_root: Path,
+        routes: Mapping[str, ClaudeCodeRoute],
+        secret_path: Path,
+        command_prefix: tuple[str, ...] = ("/usr/local/bin/claude",),
+        tool_broker_command: tuple[str, ...] = (
+            "python",
+            "-m",
+            "coding_worker.broker_mcp",
+        ),
+        provider_proxy_url: str | None = None,
+    ) -> None:
+        if not command_prefix or not tool_broker_command:
+            raise ValueError("Claude provider commands cannot be empty")
+        self._runtime_root = Path(runtime_root)
+        self._routes = dict(routes)
+        self._secret_path = Path(secret_path)
+        self._command_prefix = command_prefix
+        self._tool_broker_command = tool_broker_command
+        self._provider_proxy_url = provider_proxy_url
+        self._broker_bindings: dict[str, tuple[str, str]] = {}
+        self._handles: dict[str, ClaudeSessionHandle] = {}
+        self._lock = asyncio.Lock()
+
+    def bind_broker(self, task_id: str, endpoint: str, token: str) -> None:
+        if not (
+            endpoint.startswith("unix:") or endpoint.startswith("tcp:127.0.0.1:")
+        ) or len(token) < 32:
+            raise ClaudeCodeProviderError(
+                "Tool Broker binding is invalid.", code="tool_broker_unavailable"
+            )
+        existing = self._broker_bindings.get(task_id)
+        if existing is not None and existing != (endpoint, token):
+            raise ClaudeCodeProviderError(
+                "Tool Broker binding changed.", code="tool_broker_binding_changed"
+            )
+        self._broker_bindings[task_id] = (endpoint, token)
+
+    def unbind_broker(self, task_id: str) -> None:
+        self._broker_bindings.pop(task_id, None)
+
+    async def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            supports_streaming=True,
+            supports_cancel=True,
+            supports_checkpoint=True,
+            supports_restore=True,
+            supports_steering=True,
+            supports_usage=True,
+        )
+
+    async def open(self, request: ProviderOpenRequest) -> ProviderSession:
+        route = self._require_route(request.model_route)
+        binding = self._broker_bindings.get(request.task_id)
+        if binding is None:
+            raise ClaudeCodeProviderError(
+                "Tool Broker binding is missing.", code="tool_broker_unavailable"
+            )
+        self._validate_secret_file()
+        session_id = str(uuid.uuid4())
+        state_root = self._runtime_root / request.task_id / session_id
+        state_root.mkdir(parents=True, exist_ok=False, mode=0o700)
+        home = state_root / "home"
+        home.mkdir(mode=0o700)
+        settings_path = state_root / "settings.json"
+        mcp_path = state_root / "mcp.json"
+        endpoint, token = binding
+        self._write_private_json(
+            settings_path, self.build_settings(request.tool_allowlist)
+        )
+        self._write_private_json(
+            mcp_path,
+            self.build_mcp_config(
+                task_id=request.task_id,
+                endpoint=endpoint,
+                token=token,
+            ),
+        )
+        handle = ClaudeSessionHandle(
+            request=request,
+            route=route,
+            state_root=state_root,
+            home=home,
+            settings_path=settings_path,
+            mcp_path=mcp_path,
+            session_id=session_id,
+            revoke_broker=lambda: self.unbind_broker(request.task_id),
+        )
+        async with self._lock:
+            if session_id in self._handles:
+                raise ClaudeCodeProviderError(
+                    "Claude session collision.", code="provider_invalid_response"
+                )
+            self._handles[session_id] = handle
+        return ProviderSession(
+            session_id=session_id,
+            task_id=request.task_id,
+            provider_capabilities=await self.capabilities(),
+        )
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        if not text.strip():
+            raise ValueError("provider message cannot be blank")
+        handle = self._require_session(session)
+        async with handle.lock:
+            if handle.active_process is not None:
+                raise ClaudeCodeProviderError(
+                    "Claude session is busy.", code="provider_session_busy"
+                )
+            api_key = self._read_secret()
+            command = self.build_command(handle)
+            environment = self.build_environment(handle, api_key=api_key)
+            process: asyncio.subprocess.Process | None = None
+            output_bytes = 0
+            saw_terminal = False
+            try:
+                process = await asyncio.create_subprocess_exec(
+                    *command,
+                    cwd=handle.state_root,
+                    env=environment,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    start_new_session=True,
+                )
+                handle.active_process = process
+                if process.stdin is None or process.stdout is None:
+                    raise ClaudeCodeProviderError(
+                        "Claude stream is unavailable.",
+                        code="provider_unavailable",
+                    )
+                frame = self.build_input_frame(session.session_id, text)
+                process.stdin.write(
+                    json.dumps(frame, ensure_ascii=False, separators=(",", ":")).encode(
+                        "utf-8"
+                    )
+                    + b"\n"
+                )
+                await process.stdin.drain()
+                process.stdin.close()
+                with contextlib.suppress(Exception):
+                    await process.stdin.wait_closed()
+                async with asyncio.timeout(handle.request.budget.max_seconds):
+                    while line := await process.stdout.readline():
+                        output_bytes += len(line)
+                        if output_bytes > handle.request.budget.max_output_bytes:
+                            await _stop_process(process)
+                            yield self._failure_event(ProviderFailureKind.BUDGET)
+                            return
+                        events = self.map_stream_frame(line, session.session_id)
+                        for event in events:
+                            if event.kind is ProviderEventKind.MESSAGE:
+                                value = event.data.get("text")
+                                if isinstance(value, str) and value:
+                                    handle.public_context.append(value[:16_384])
+                                    if len(handle.public_context) > 64:
+                                        del handle.public_context[:-64]
+                            yield event
+                            if event.kind in {
+                                ProviderEventKind.TURN_COMPLETED,
+                                ProviderEventKind.CANCELLED,
+                                ProviderEventKind.FAILED,
+                            }:
+                                saw_terminal = True
+                    return_code = await process.wait()
+                if not saw_terminal:
+                    yield self._failure_event(
+                        ProviderFailureKind.INTERRUPTED
+                        if return_code == 0
+                        else ProviderFailureKind.UNAVAILABLE
+                    )
+            except TimeoutError:
+                if process is not None:
+                    await _stop_process(process)
+                yield self._failure_event(ProviderFailureKind.BUDGET)
+            except OSError as exc:
+                raise ClaudeCodeProviderError(
+                    "Claude process failed to start.", code="provider_unavailable"
+                ) from exc
+            finally:
+                if process is not None and process.returncode is None:
+                    await _stop_process(process)
+                if process is not None and process.stderr is not None:
+                    with contextlib.suppress(Exception):
+                        await asyncio.wait_for(
+                            process.stderr.read(MAX_STDERR_BYTES), timeout=0.2
+                        )
+                handle.active_process = None
+                handle.resumed_once = True
+
+    async def cancel(self, session: ProviderSession) -> bool:
+        handle = self._require_session(session)
+        process = handle.active_process
+        if process is None or process.returncode is not None:
+            return False
+        await _stop_process(process)
+        return True
+
+    async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
+        handle = self._require_session(session)
+        public_text = "".join(handle.public_context)
+        return ProviderCheckpoint(
+            checkpoint_id=f"checkpoint_{secrets.token_hex(16)}",
+            compatibility=ProviderCheckpointCompatibility(
+                provider_family="claude-code",
+                provider_version=CLAUDE_CODE_VERSION,
+                task_id=session.task_id,
+                workspace_tree_hash=handle.request.workspace_tree_hash,
+            ),
+            payload={
+                "task_id": session.task_id,
+                "public_output": public_text[-32_768:],
+            },
+        )
+
+    async def restore(
+        self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
+    ) -> ProviderSession:
+        compatibility = checkpoint.compatibility
+        if (
+            compatibility is None
+            or compatibility.provider_family != "claude-code"
+            or compatibility.provider_version != CLAUDE_CODE_VERSION
+            or compatibility.task_id != request.task_id
+            or compatibility.workspace_tree_hash != request.workspace_tree_hash
+            or checkpoint.payload.get("task_id") != request.task_id
+            or not isinstance(checkpoint.payload.get("public_output", ""), str)
+        ):
+            raise ClaudeCodeProviderError(
+                "Claude checkpoint binding is invalid.", code="checkpoint_invalid"
+            )
+        return await self.open(request)
+
+    async def close(self, session: ProviderSession) -> None:
+        async with self._lock:
+            handle = self._handles.pop(session.session_id, None)
+        if handle is None:
+            return
+        if handle.active_process is not None:
+            await _stop_process(handle.active_process)
+        handle.revoke_broker()
+
+    def build_settings(self, tool_allowlist: tuple[str, ...]) -> dict[str, Any]:
+        allowed = [self._claude_tool_name(name) for name in tool_allowlist]
+        return {
+            "permissions": {
+                "allow": allowed,
+                "deny": list(CLAUDE_BUILTIN_TOOLS),
+                "defaultMode": "dontAsk",
+                "disableBypassPermissionsMode": "disable",
+            },
+            "disableAllHooks": True,
+            "enabledPlugins": {},
+            "strictKnownMarketplaces": [],
+            "allowManagedPermissionRulesOnly": True,
+            "allowManagedHooksOnly": True,
+        }
+
+    def build_mcp_config(
+        self, *, task_id: str, endpoint: str, token: str
+    ) -> dict[str, Any]:
+        return {
+            "mcpServers": {
+                CLAUDE_MCP_NAME: {
+                    "type": "stdio",
+                    "command": self._tool_broker_command[0],
+                    "args": list(self._tool_broker_command[1:]),
+                    "env": {
+                        "CODING_WORKER_BROKER_ENDPOINT": endpoint,
+                        "CODING_WORKER_BROKER_TOKEN": token,
+                        "CODING_WORKER_TASK_ID": task_id,
+                        "PYTHONPATH": str(Path(__file__).resolve().parent.parent),
+                    },
+                }
+            }
+        }
+
+    def build_command(self, handle: ClaudeSessionHandle) -> tuple[str, ...]:
+        allowed = ",".join(
+            self._claude_tool_name(name)
+            for name in handle.request.tool_allowlist
+        )
+        command = [
+            *self._command_prefix,
+            "--print",
+            "--input-format",
+            "stream-json",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--bare",
+            "--strict-mcp-config",
+            "--mcp-config",
+            str(handle.mcp_path),
+            "--settings",
+            str(handle.settings_path),
+            "--tools",
+            "",
+            "--allowedTools",
+            allowed,
+            "--disallowedTools",
+            ",".join(CLAUDE_BUILTIN_TOOLS),
+            "--disable-slash-commands",
+            "--no-chrome",
+            "--permission-mode",
+            "dontAsk",
+            "--model",
+            handle.route.model_id,
+            "--max-budget-usd",
+            f"{handle.route.max_budget_usd:.6f}",
+        ]
+        if handle.resumed_once:
+            command.extend(("--resume", handle.session_id))
+        else:
+            command.extend(("--session-id", handle.session_id))
+        return tuple(command)
+
+    def build_environment(
+        self, handle: ClaudeSessionHandle, *, api_key: str
+    ) -> dict[str, str]:
+        environment = {
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "HOME": str(handle.home),
+            "TMPDIR": str(handle.state_root),
+            "ANTHROPIC_API_KEY": api_key,
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL": "1",
+            "CLAUDE_CODE_DONT_INHERIT_ENV": "1",
+            "DISABLE_AUTOUPDATER": "1",
+            "DISABLE_ERROR_REPORTING": "1",
+            "DISABLE_PLUGIN_AUTOLOAD": "1",
+            "DISABLE_TELEMETRY": "1",
+        }
+        if self._provider_proxy_url is not None:
+            environment["HTTPS_PROXY"] = self._provider_proxy_url
+            environment["HTTP_PROXY"] = self._provider_proxy_url
+        return environment
+
+    @staticmethod
+    def build_input_frame(session_id: str, text: str) -> dict[str, Any]:
+        return {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": text}],
+            },
+            "parent_tool_use_id": None,
+            "session_id": session_id,
+        }
+
+    @staticmethod
+    def map_stream_frame(
+        encoded: bytes, session_id: str
+    ) -> tuple[ProviderEvent, ...]:
+        if len(encoded) > 1_048_576:
+            return ()
+        try:
+            value = json.loads(encoded)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return ()
+        if not isinstance(value, dict):
+            return ()
+        frame_session = value.get("session_id")
+        if frame_session is not None and frame_session != session_id:
+            return ()
+        frame_type = value.get("type")
+        if frame_type == "assistant":
+            message = value.get("message")
+            content = message.get("content") if isinstance(message, dict) else None
+            text = "".join(
+                item.get("text", "")
+                for item in content
+                if isinstance(item, dict)
+                and item.get("type") == "text"
+                and isinstance(item.get("text"), str)
+            ) if isinstance(content, list) else ""
+            events: list[ProviderEvent] = []
+            if text:
+                events.append(
+                    ProviderEvent(
+                        kind=ProviderEventKind.MESSAGE,
+                        data={"text": text[:1_048_576]},
+                    )
+                )
+            usage = _usage_from_mapping(
+                message.get("usage") if isinstance(message, dict) else None,
+                cost=None,
+            )
+            if usage is not None:
+                events.append(_usage_event(usage))
+            return tuple(events)
+        if frame_type == "result":
+            usage = _usage_from_mapping(
+                value.get("usage"), cost=value.get("total_cost_usd")
+            )
+            events = [_usage_event(usage)] if usage is not None else []
+            if value.get("is_error") is True:
+                subtype = value.get("subtype")
+                failure = (
+                    ProviderFailureKind.BUDGET
+                    if subtype in {"error_max_budget_usd", "error_max_turns"}
+                    else ProviderFailureKind.UNAVAILABLE
+                )
+                events.append(ClaudeCodeProvider._failure_event(failure))
+            else:
+                events.append(ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED))
+            return tuple(events)
+        return ()
+
+    @staticmethod
+    def _failure_event(kind: ProviderFailureKind) -> ProviderEvent:
+        return ProviderEvent(
+            kind=ProviderEventKind.FAILED,
+            data={"failure_kind": kind.value},
+        )
+
+    @staticmethod
+    def _claude_tool_name(tool_name: str) -> str:
+        return f"mcp__{CLAUDE_MCP_NAME}__{tool_name}"
+
+    def _require_route(self, route_id: str) -> ClaudeCodeRoute:
+        route = self._routes.get(route_id)
+        if route is None or route.route_id != route_id:
+            raise ClaudeCodeProviderError(
+                "Model route is unavailable.", code="model_route_unavailable"
+            )
+        return route
+
+    def _require_session(self, session: ProviderSession) -> ClaudeSessionHandle:
+        handle = self._handles.get(session.session_id)
+        if handle is None or handle.request.task_id != session.task_id:
+            raise ClaudeCodeProviderError(
+                "Provider session was not found.", code="session_not_found"
+            )
+        return handle
+
+    def _validate_secret_file(self) -> os.stat_result:
+        try:
+            metadata = self._secret_path.lstat()
+        except OSError as exc:
+            raise ClaudeCodeProviderError(
+                "Claude credential is unavailable.",
+                code="provider_credential_unavailable",
+                failure_kind=ProviderFailureKind.AUTHENTICATION,
+            ) from exc
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or self._secret_path.is_symlink()
+            or metadata.st_nlink != 1
+            or metadata.st_size <= 0
+            or metadata.st_size > MAX_SECRET_BYTES
+        ):
+            raise ClaudeCodeProviderError(
+                "Claude credential is unsafe.",
+                code="provider_credential_unavailable",
+                failure_kind=ProviderFailureKind.AUTHENTICATION,
+            )
+        return metadata
+
+    def _read_secret(self) -> str:
+        expected = self._validate_secret_file()
+        descriptor = os.open(self._secret_path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        try:
+            actual = os.fstat(descriptor)
+            if (actual.st_dev, actual.st_ino, actual.st_size) != (
+                expected.st_dev,
+                expected.st_ino,
+                expected.st_size,
+            ):
+                raise ClaudeCodeProviderError(
+                    "Claude credential changed.",
+                    code="provider_credential_unavailable",
+                    failure_kind=ProviderFailureKind.AUTHENTICATION,
+                )
+            value = os.read(descriptor, MAX_SECRET_BYTES + 1).decode("utf-8").strip()
+        finally:
+            os.close(descriptor)
+        if not value or len(value.encode("utf-8")) > MAX_SECRET_BYTES:
+            raise ClaudeCodeProviderError(
+                "Claude credential is invalid.",
+                code="provider_credential_unavailable",
+                failure_kind=ProviderFailureKind.AUTHENTICATION,
+            )
+        return value
+
+    @staticmethod
+    def _write_private_json(path: Path, value: dict[str, Any]) -> None:
+        encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            os.write(descriptor, encoded)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+
+def _usage_from_mapping(value: Any, *, cost: Any) -> ProviderUsage | None:
+    if not isinstance(value, dict):
+        return None
+    return ProviderUsage(
+        input_tokens=_nonnegative_int(value.get("input_tokens")),
+        output_tokens=_nonnegative_int(value.get("output_tokens")),
+        cache_read_tokens=_nonnegative_int(value.get("cache_read_input_tokens")),
+        cache_write_tokens=_nonnegative_int(value.get("cache_creation_input_tokens")),
+        cost_microusd=(
+            round(float(cost) * 1_000_000)
+            if isinstance(cost, (int, float)) and cost >= 0
+            else None
+        ),
+    )
+
+
+def _usage_event(usage: ProviderUsage) -> ProviderEvent:
+    return ProviderEvent(
+        kind=ProviderEventKind.USAGE,
+        data={"usage": usage.model_dump(mode="json")},
+    )
+
+
+def _nonnegative_int(value: Any) -> int:
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0
+        else 0
+    )
+
+
+async def _stop_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    with contextlib.suppress(ProcessLookupError):
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGTERM)
+        else:
+            process.terminate()
+    try:
+        await asyncio.wait_for(process.wait(), timeout=3.0)
+    except TimeoutError:
+        with contextlib.suppress(ProcessLookupError):
+            if os.name == "posix":
+                os.killpg(process.pid, signal.SIGKILL)
+            else:
+                process.kill()
+        with contextlib.suppress(Exception):
+            await process.wait()

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -41,6 +41,11 @@ class TaskState(StrEnum):
     EXPIRED = "expired"
 
 
+BUDGET_ACTIVE_STATES = frozenset(
+    {TaskState.PREPARING, TaskState.RUNNING, TaskState.TESTING}
+)
+
+
 TERMINAL_STATES = frozenset(
     {
         TaskState.COMPLETED,

--- a/server/coding_worker/egress_proxy.py
+++ b/server/coding_worker/egress_proxy.py
@@ -14,12 +14,19 @@ from .network_policy import EgressPolicy, NetworkPolicyError
 
 MAX_HEADER_BYTES = 16 * 1024
 PROVIDER_TOKEN = re.compile(r"^[A-Za-z0-9._~-]{32,256}$")
+DOCKER_DESKTOP_DNS_PROXY_NETWORK = ipaddress.ip_network("198.18.0.0/15")
 
 
 class ProviderEgressPolicy:
     """Authenticates one Provider sidecar to an exact API domain set."""
 
-    def __init__(self, *, token: str, allowed_domains: tuple[str, ...]) -> None:
+    def __init__(
+        self,
+        *,
+        token: str,
+        allowed_domains: tuple[str, ...],
+        allow_docker_desktop_dns_proxy: bool = False,
+    ) -> None:
         if PROVIDER_TOKEN.fullmatch(token) is None:
             raise NetworkPolicyError(
                 "Provider proxy token is invalid.", code="network_grant_key_invalid"
@@ -32,6 +39,7 @@ class ProviderEgressPolicy:
             raise NetworkPolicyError(
                 "Provider domains are unavailable.", code="network_domain_not_allowed"
             )
+        self.allow_docker_desktop_dns_proxy = allow_docker_desktop_dns_proxy
 
     def validate(self, token: str, *, domain: str) -> None:
         normalized = EgressPolicy._normalize_domain(domain)
@@ -45,6 +53,20 @@ class ProviderEgressPolicy:
                 "Provider destination is not allowed.",
                 code="network_domain_not_allowed",
             )
+
+    def validate_resolved_address(self, address: str) -> None:
+        candidate = ipaddress.ip_address(address)
+        if candidate.is_global:
+            return
+        if (
+            self.allow_docker_desktop_dns_proxy
+            and candidate.version == 4
+            and candidate in DOCKER_DESKTOP_DNS_PROXY_NETWORK
+        ):
+            return
+        raise NetworkPolicyError(
+            "Private destination is denied.", code="network_private_address_denied"
+        )
 
 
 class EgressProxy:
@@ -104,8 +126,13 @@ class EgressProxy:
             selected: str | None = None
             for _family, _type, _protocol, _name, address in addresses:
                 candidate = str(address[0])
-                if not ipaddress.ip_address(candidate).is_global:
-                    raise NetworkPolicyError("Private destination is denied.", code="network_private_address_denied")
+                if self.provider_policy is not None:
+                    self.provider_policy.validate_resolved_address(candidate)
+                elif not ipaddress.ip_address(candidate).is_global:
+                    raise NetworkPolicyError(
+                        "Private destination is denied.",
+                        code="network_private_address_denied",
+                    )
                 selected = selected or candidate
             if selected is None:
                 raise NetworkPolicyError("Destination could not be resolved.", code="network_resolution_required")
@@ -142,6 +169,14 @@ class EgressProxy:
 async def run() -> None:
     provider_token = os.environ.get("CODING_WORKER_PROVIDER_EGRESS_TOKEN", "")
     if provider_token:
+        allow_dns_proxy = os.environ.get(
+            "CODING_WORKER_PROVIDER_ALLOW_DOCKER_DESKTOP_DNS_PROXY", "false"
+        ).strip().lower()
+        if allow_dns_proxy not in {"true", "false"}:
+            raise NetworkPolicyError(
+                "Provider DNS proxy setting is invalid.",
+                code="network_policy_invalid",
+            )
         domains = tuple(
             item.strip().lower()
             for item in os.environ.get(
@@ -151,7 +186,9 @@ async def run() -> None:
         )
         proxy = EgressProxy(
             provider_policy=ProviderEgressPolicy(
-                token=provider_token, allowed_domains=domains
+                token=provider_token,
+                allowed_domains=domains,
+                allow_docker_desktop_dns_proxy=allow_dns_proxy == "true",
             )
         )
         port = 8081

--- a/server/coding_worker/egress_proxy.py
+++ b/server/coding_worker/egress_proxy.py
@@ -3,19 +3,61 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import hmac
 import ipaddress
 import os
+import re
 import socket
 
 from .network_policy import EgressPolicy, NetworkPolicyError
 
 
 MAX_HEADER_BYTES = 16 * 1024
+PROVIDER_TOKEN = re.compile(r"^[A-Za-z0-9._~-]{32,256}$")
+
+
+class ProviderEgressPolicy:
+    """Authenticates one Provider sidecar to an exact API domain set."""
+
+    def __init__(self, *, token: str, allowed_domains: tuple[str, ...]) -> None:
+        if PROVIDER_TOKEN.fullmatch(token) is None:
+            raise NetworkPolicyError(
+                "Provider proxy token is invalid.", code="network_grant_key_invalid"
+            )
+        self._token = token
+        self.allowed_domains = frozenset(
+            EgressPolicy._normalize_domain(domain) for domain in allowed_domains
+        )
+        if not self.allowed_domains:
+            raise NetworkPolicyError(
+                "Provider domains are unavailable.", code="network_domain_not_allowed"
+            )
+
+    def validate(self, token: str, *, domain: str) -> None:
+        normalized = EgressPolicy._normalize_domain(domain)
+        if not hmac.compare_digest(token, self._token):
+            raise NetworkPolicyError(
+                "Provider proxy authorization is invalid.",
+                code="network_grant_invalid",
+            )
+        if normalized not in self.allowed_domains:
+            raise NetworkPolicyError(
+                "Provider destination is not allowed.",
+                code="network_domain_not_allowed",
+            )
 
 
 class EgressProxy:
-    def __init__(self, policy: EgressPolicy) -> None:
+    def __init__(
+        self,
+        policy: EgressPolicy | None = None,
+        *,
+        provider_policy: ProviderEgressPolicy | None = None,
+    ) -> None:
+        if (policy is None) == (provider_policy is None):
+            raise ValueError("exactly one proxy policy is required")
         self.policy = policy
+        self.provider_policy = provider_policy
 
     async def handle(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
@@ -38,10 +80,24 @@ class EgressProxy:
             )
             if not authorization.startswith("Basic "):
                 raise NetworkPolicyError("Proxy authorization is required.", code="network_grant_invalid")
-            username, token = base64.b64decode(authorization[6:]).decode("utf-8").split(":", 1)
-            if username != "grant":
-                raise NetworkPolicyError("Proxy authorization is invalid.", code="network_grant_invalid")
-            self.policy.validate_grant(token, domain=domain)
+            try:
+                username, token = (
+                    base64.b64decode(authorization[6:], validate=True)
+                    .decode("utf-8")
+                    .split(":", 1)
+                )
+            except (ValueError, UnicodeError) as exc:
+                raise NetworkPolicyError(
+                    "Proxy authorization is invalid.", code="network_grant_invalid"
+                ) from exc
+            if username == "grant" and self.policy is not None:
+                self.policy.validate_grant(token, domain=domain)
+            elif username == "provider" and self.provider_policy is not None:
+                self.provider_policy.validate(token, domain=domain)
+            else:
+                raise NetworkPolicyError(
+                    "Proxy authorization is invalid.", code="network_grant_invalid"
+                )
             addresses = await asyncio.get_running_loop().getaddrinfo(
                 domain, 443, type=socket.SOCK_STREAM
             )
@@ -84,15 +140,34 @@ class EgressProxy:
 
 
 async def run() -> None:
-    key = os.environ.get("CODING_WORKER_EGRESS_GRANT_KEY", "")
-    domains = tuple(
-        item.strip().lower()
-        for item in os.environ.get("CODING_WORKER_NETWORK_DOMAINS", "").split(",")
-        if item.strip()
+    provider_token = os.environ.get("CODING_WORKER_PROVIDER_EGRESS_TOKEN", "")
+    if provider_token:
+        domains = tuple(
+            item.strip().lower()
+            for item in os.environ.get(
+                "CODING_WORKER_PROVIDER_NETWORK_DOMAINS", ""
+            ).split(",")
+            if item.strip()
+        )
+        proxy = EgressProxy(
+            provider_policy=ProviderEgressPolicy(
+                token=provider_token, allowed_domains=domains
+            )
+        )
+        port = 8081
+    else:
+        key = os.environ.get("CODING_WORKER_EGRESS_GRANT_KEY", "")
+        domains = tuple(
+            item.strip().lower()
+            for item in os.environ.get("CODING_WORKER_NETWORK_DOMAINS", "").split(",")
+            if item.strip()
+        )
+        policy = EgressPolicy(enabled=True, allowed_domains=domains, grant_key=key)
+        proxy = EgressProxy(policy)
+        port = 8080
+    server = await asyncio.start_server(
+        proxy.handle, "0.0.0.0", port, limit=MAX_HEADER_BYTES
     )
-    policy = EgressPolicy(enabled=True, allowed_domains=domains, grant_key=key)
-    proxy = EgressProxy(policy)
-    server = await asyncio.start_server(proxy.handle, "0.0.0.0", 8080, limit=MAX_HEADER_BYTES)
     async with server:
         await server.serve_forever()
 

--- a/server/coding_worker/executor.py
+++ b/server/coding_worker/executor.py
@@ -914,6 +914,13 @@ class ExecutorRPCServer:
         *,
         output_callback: Callable[[str, bytes], Awaitable[None]] | None = None,
     ) -> dict[str, Any]:
+        if action == "health":
+            if payload:
+                raise ExecutorRPCError(
+                    "Executor health request is invalid.",
+                    code="executor_request_invalid",
+                )
+            return {"healthy": True}
         task_id = str(payload.get("task_id", ""))
         workspace_id = str(payload.get("workspace_id", ""))
         if action == "bind_task":
@@ -1005,12 +1012,14 @@ class ExecutorSidecarClientPool:
         endpoints: Mapping[str, str],
         tokens: Mapping[str, str],
         workspace_slot_resolver: Callable[[str], str],
+        auto_rebind: bool = False,
     ) -> None:
         if set(endpoints) != set(tokens) or not endpoints:
             raise ValueError("executor sidecar bindings are incomplete")
         self._endpoints = dict(endpoints)
         self._tokens = dict(tokens)
         self._workspace_slot_resolver = workspace_slot_resolver
+        self._auto_rebind = auto_rebind
 
     async def bind_task(self, task_id: str, workspace_id: str) -> None:
         await self._workspace_call(workspace_id, "bind_task", {"task_id": task_id, "workspace_id": workspace_id})
@@ -1091,6 +1100,46 @@ class ExecutorSidecarClientPool:
         )
 
     async def _workspace_stream_call(
+        self,
+        workspace_id: str,
+        action: str,
+        payload: dict[str, Any],
+        *,
+        output_callback: Callable[[str, bytes], Awaitable[None]] | None,
+    ) -> dict[str, Any]:
+        try:
+            return await self._workspace_stream_call_once(
+                workspace_id,
+                action,
+                payload,
+                output_callback=output_callback,
+            )
+        except ExecutorRPCError as exc:
+            task_id = payload.get("task_id")
+            payload_workspace_id = payload.get("workspace_id")
+            if (
+                not self._auto_rebind
+                or exc.code != "executor_binding_invalid"
+                or action in {"bind_task", "close_task", "health"}
+                or not isinstance(task_id, str)
+                or SAFE_ID.fullmatch(task_id) is None
+                or payload_workspace_id != workspace_id
+            ):
+                raise
+            await self._workspace_stream_call_once(
+                workspace_id,
+                "bind_task",
+                {"task_id": task_id, "workspace_id": workspace_id},
+                output_callback=None,
+            )
+            return await self._workspace_stream_call_once(
+                workspace_id,
+                action,
+                payload,
+                output_callback=output_callback,
+            )
+
+    async def _workspace_stream_call_once(
         self,
         workspace_id: str,
         action: str,

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -22,10 +22,13 @@ from .provider import (
     CodingAgentProvider,
     ProviderCapabilities,
     ProviderCheckpoint,
+    ProviderCheckpointCompatibility,
     ProviderEvent,
     ProviderEventKind,
     ProviderOpenRequest,
     ProviderSession,
+    PROVIDER_TOOL_NAMES,
+    ProviderUsage,
 )
 
 
@@ -203,7 +206,7 @@ class OpenCodeProvider(CodingAgentProvider):
                         "modelID": route.model_id,
                     },
                     "agent": "modelmirror-worker",
-                    "tools": self._prompt_tools(),
+                    "tools": self._prompt_tools(request.tool_allowlist),
                     "parts": [{"type": "text", "text": text}],
                 },
             )
@@ -257,6 +260,12 @@ class OpenCodeProvider(CodingAgentProvider):
         public_text = "".join(self._public_context.get(session.session_id, ()))
         return ProviderCheckpoint(
             checkpoint_id=f"checkpoint_{secrets.token_hex(16)}",
+            compatibility=ProviderCheckpointCompatibility(
+                provider_family="opencode",
+                provider_version=OPENCODE_VERSION,
+                task_id=request.task_id,
+                workspace_tree_hash=request.workspace_tree_hash,
+            ),
             payload={
                 "engine": "opencode-1.18.9",
                 "task_id": request.task_id,
@@ -267,10 +276,21 @@ class OpenCodeProvider(CodingAgentProvider):
     async def restore(
         self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
     ) -> ProviderSession:
+        compatibility = checkpoint.compatibility
         if (
             checkpoint.payload.get("engine") != "opencode-1.18.9"
             or checkpoint.payload.get("task_id") != request.task_id
             or not isinstance(checkpoint.payload.get("public_output", ""), str)
+            or (
+                compatibility is not None
+                and (
+                    compatibility.provider_family != "opencode"
+                    or compatibility.provider_version != OPENCODE_VERSION
+                    or compatibility.task_id != request.task_id
+                    or compatibility.workspace_tree_hash
+                    != request.workspace_tree_hash
+                )
+            )
         ):
             raise OpenCodeProviderError(
                 "OpenCode checkpoint binding is invalid.", code="checkpoint_invalid"
@@ -289,7 +309,11 @@ class OpenCodeProvider(CodingAgentProvider):
         if handle is not None:
             await handle.close()
 
-    def build_config(self, route: OpenCodeRoute) -> dict[str, Any]:
+    def build_config(
+        self,
+        route: OpenCodeRoute,
+        tool_allowlist: tuple[str, ...] = PROVIDER_TOOL_NAMES,
+    ) -> dict[str, Any]:
         permission: dict[str, str] = {
             "*": "deny",
             "external_directory": "deny",
@@ -298,7 +322,8 @@ class OpenCodeProvider(CodingAgentProvider):
         }
         mcp: dict[str, Any] = {}
         if self._tool_broker_command is not None:
-            permission[f"{TOOL_BROKER_MCP_NAME}_*"] = "allow"
+            for tool_name in tool_allowlist:
+                permission[f"{TOOL_BROKER_MCP_NAME}_{tool_name}"] = "allow"
             mcp[TOOL_BROKER_MCP_NAME] = {
                 "type": "local",
                 "command": list(self._tool_broker_command),
@@ -364,7 +389,9 @@ class OpenCodeProvider(CodingAgentProvider):
             "XDG_STATE_HOME": str(home / ".local/state"),
             "XDG_CACHE_HOME": str(home / ".cache"),
             "OPENCODE_CONFIG_CONTENT": json.dumps(
-                self.build_config(route), ensure_ascii=False, separators=(",", ":")
+                self.build_config(route, request.tool_allowlist),
+                ensure_ascii=False,
+                separators=(",", ":"),
             ),
             "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
             "OPENCODE_PURE": "1",
@@ -475,10 +502,17 @@ class OpenCodeProvider(CodingAgentProvider):
             raise OpenCodeProviderError("Provider session was not found.", code="session_not_found")
         return handle, request
 
-    def _prompt_tools(self) -> dict[str, bool]:
+    def _prompt_tools(
+        self, tool_allowlist: tuple[str, ...] = PROVIDER_TOOL_NAMES
+    ) -> dict[str, bool]:
         tools = {name: False for name in DIRECT_TOOL_NAMES}
         if self._tool_broker_command is not None:
-            tools[f"{TOOL_BROKER_MCP_NAME}_*"] = True
+            tools.update(
+                {
+                    f"{TOOL_BROKER_MCP_NAME}_{tool_name}": True
+                    for tool_name in tool_allowlist
+                }
+            )
         return tools
 
     async def _wait_for_tool_broker(self, handle: OpenCodeServerHandle) -> None:
@@ -531,6 +565,31 @@ class OpenCodeProvider(CodingAgentProvider):
                 text = delta if isinstance(delta, str) else part.get("text")
             if isinstance(text, str) and text:
                 return ProviderEvent(kind=ProviderEventKind.MESSAGE, data={"text": text})
+        if event_type == "message.updated":
+            info = properties.get("info")
+            tokens = info.get("tokens") if isinstance(info, dict) else None
+            if isinstance(tokens, dict):
+                cache = tokens.get("cache")
+                cost = info.get("cost")
+                usage = ProviderUsage(
+                    input_tokens=_nonnegative_int(tokens.get("input")),
+                    output_tokens=_nonnegative_int(tokens.get("output")),
+                    cache_read_tokens=_nonnegative_int(
+                        cache.get("read") if isinstance(cache, dict) else None
+                    ),
+                    cache_write_tokens=_nonnegative_int(
+                        cache.get("write") if isinstance(cache, dict) else None
+                    ),
+                    cost_microusd=(
+                        round(float(cost) * 1_000_000)
+                        if isinstance(cost, (int, float)) and cost >= 0
+                        else None
+                    ),
+                )
+                return ProviderEvent(
+                    kind=ProviderEventKind.USAGE,
+                    data={"usage": usage.model_dump(mode="json")},
+                )
         if event_type in {"permission.asked", "permission.updated"}:
             return ProviderEvent(
                 kind=ProviderEventKind.APPROVAL_REQUIRED,
@@ -543,6 +602,14 @@ class OpenCodeProvider(CodingAgentProvider):
         if event_type in {"session.error", "message.error"}:
             return ProviderEvent(kind=ProviderEventKind.FAILED, data={"error": "provider_failed"})
         return None
+
+
+def _nonnegative_int(value: Any) -> int:
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0
+        else 0
+    )
 
 
 async def _iter_sse_json(response: httpx.Response) -> AsyncIterator[dict[str, Any]]:

--- a/server/coding_worker/provider.py
+++ b/server/coding_worker/provider.py
@@ -183,16 +183,19 @@ class FakeCodingAgentProvider:
         self._block = block
         self._cancelled: set[str] = set()
         self._closed: set[str] = set()
+        self._requests: dict[str, ProviderOpenRequest] = {}
 
     async def capabilities(self) -> ProviderCapabilities:
         return ProviderCapabilities(supports_checkpoint=True, supports_restore=True)
 
     async def open(self, request: ProviderOpenRequest) -> ProviderSession:
-        return ProviderSession(
+        session = ProviderSession(
             session_id=f"fake_{uuid.uuid4().hex}",
             task_id=request.task_id,
             provider_capabilities=await self.capabilities(),
         )
+        self._requests[session.session_id] = request
+        return session
 
     async def message(
         self, session: ProviderSession, text: str
@@ -215,12 +218,16 @@ class FakeCodingAgentProvider:
         return True
 
     async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
+        request = self._requests.get(session.session_id)
+        if request is None or request.task_id != session.task_id:
+            raise ValueError("invalid session")
         return ProviderCheckpoint(
             checkpoint_id=f"checkpoint_{uuid.uuid4().hex}",
             compatibility=ProviderCheckpointCompatibility(
                 provider_family="fake",
                 provider_version="1",
                 task_id=session.task_id,
+                workspace_tree_hash=request.workspace_tree_hash,
             ),
             payload={"fake_session": session.session_id},
         )
@@ -235,8 +242,7 @@ class FakeCodingAgentProvider:
             compatibility.provider_family != "fake"
             or compatibility.provider_version != "1"
             or compatibility.task_id != request.task_id
-            or compatibility.workspace_tree_hash
-            not in {None, request.workspace_tree_hash}
+            or compatibility.workspace_tree_hash != request.workspace_tree_hash
         ):
             raise ValueError("incompatible checkpoint")
         return await self.open(request)
@@ -244,3 +250,4 @@ class FakeCodingAgentProvider:
     async def close(self, session: ProviderSession) -> None:
         self._closed.add(session.session_id)
         self._cancelled.discard(session.session_id)
+        self._requests.pop(session.session_id, None)

--- a/server/coding_worker/provider.py
+++ b/server/coding_worker/provider.py
@@ -4,11 +4,44 @@ import asyncio
 import uuid
 from collections.abc import AsyncIterator, Sequence
 from enum import StrEnum
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, ClassVar, Protocol, runtime_checkable
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from .contracts import PolicyProfile, SAFE_ID, StrictModel, TaskBudget
+
+
+PROVIDER_CONTRACT_VERSION = 2
+PROVIDER_CHECKPOINT_FORMAT_VERSION = 2
+PROVIDER_TOOL_NAMES = (
+    "list_files",
+    "read_file",
+    "read_file_range",
+    "glob_files",
+    "search_text",
+    "search_regex",
+    "workspace_diff",
+    "code_symbols",
+    "code_definition",
+    "code_references",
+    "code_hover",
+    "code_diagnostics",
+    "write_file",
+    "delete_file",
+    "apply_changeset",
+    "list_acceptance_checks",
+    "run_check",
+    "run_command",
+    "run_shell",
+    "install_dependencies",
+    "start_service",
+    "service_status",
+    "service_input",
+    "stop_service",
+)
+INSPECT_PROVIDER_TOOLS = PROVIDER_TOOL_NAMES[:12] + (
+    "list_acceptance_checks",
+)
 
 
 class ProviderEventKind(StrEnum):
@@ -22,23 +55,71 @@ class ProviderEventKind(StrEnum):
     TURN_COMPLETED = "turn_completed"
     CANCELLED = "cancelled"
     FAILED = "failed"
+    USAGE = "usage"
+
+
+class ProviderFailureKind(StrEnum):
+    UNAVAILABLE = "unavailable"
+    AUTHENTICATION = "authentication"
+    RATE_LIMITED = "rate_limited"
+    INVALID_RESPONSE = "invalid_response"
+    POLICY = "policy"
+    BUDGET = "budget"
+    INTERRUPTED = "interrupted"
+
+
+class ProviderUsage(StrictModel):
+    input_tokens: int = Field(default=0, ge=0)
+    output_tokens: int = Field(default=0, ge=0)
+    cache_read_tokens: int = Field(default=0, ge=0)
+    cache_write_tokens: int = Field(default=0, ge=0)
+    cost_microusd: int | None = Field(default=None, ge=0)
+
+
+class ProviderCheckpointCompatibility(StrictModel):
+    contract_version: int = PROVIDER_CONTRACT_VERSION
+    format_version: int = PROVIDER_CHECKPOINT_FORMAT_VERSION
+    provider_family: str = Field(pattern=r"^[a-z][a-z0-9-]{1,31}$")
+    provider_version: str = Field(min_length=1, max_length=64)
+    task_id: str
+    workspace_tree_hash: str | None = Field(
+        default=None, pattern=r"^[0-9a-f]{64}$"
+    )
 
 
 class ProviderCapabilities(StrictModel):
+    contract_version: int = PROVIDER_CONTRACT_VERSION
     supports_streaming: bool = True
     supports_cancel: bool = True
     supports_checkpoint: bool = False
     supports_restore: bool = False
     supports_steering: bool = True
+    supports_usage: bool = True
+    tool_names: tuple[str, ...] = PROVIDER_TOOL_NAMES
 
 
 class ProviderOpenRequest(StrictModel):
+    _VALID_TOOLS: ClassVar[frozenset[str]] = frozenset(PROVIDER_TOOL_NAMES)
+
     task_id: str
     workspace_id: str
     objective: str = Field(min_length=1, max_length=1_048_576)
     model_route: str
     policy_profile: PolicyProfile
     budget: TaskBudget
+    workspace_tree_hash: str | None = Field(
+        default=None, pattern=r"^[0-9a-f]{64}$"
+    )
+    tool_allowlist: tuple[str, ...] = PROVIDER_TOOL_NAMES
+
+    @field_validator("tool_allowlist")
+    @classmethod
+    def _validate_tool_allowlist(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(value) != len(set(value)) or any(
+            tool not in cls._VALID_TOOLS for tool in value
+        ):
+            raise ValueError("provider tool allowlist is invalid")
+        return value
 
 
 class ProviderSession(StrictModel):
@@ -54,7 +135,14 @@ class ProviderEvent(StrictModel):
 
 class ProviderCheckpoint(StrictModel):
     checkpoint_id: str
+    compatibility: ProviderCheckpointCompatibility | None = None
     payload: dict[str, Any] = Field(default_factory=dict)
+
+
+def provider_tools_for_policy(policy: PolicyProfile) -> tuple[str, ...]:
+    if policy is PolicyProfile.INSPECT:
+        return INSPECT_PROVIDER_TOOLS
+    return PROVIDER_TOOL_NAMES
 
 
 @runtime_checkable
@@ -129,6 +217,11 @@ class FakeCodingAgentProvider:
     async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
         return ProviderCheckpoint(
             checkpoint_id=f"checkpoint_{uuid.uuid4().hex}",
+            compatibility=ProviderCheckpointCompatibility(
+                provider_family="fake",
+                provider_version="1",
+                task_id=session.task_id,
+            ),
             payload={"fake_session": session.session_id},
         )
 
@@ -137,6 +230,15 @@ class FakeCodingAgentProvider:
     ) -> ProviderSession:
         if SAFE_ID.fullmatch(checkpoint.checkpoint_id) is None:
             raise ValueError("invalid checkpoint")
+        compatibility = checkpoint.compatibility
+        if compatibility is not None and (
+            compatibility.provider_family != "fake"
+            or compatibility.provider_version != "1"
+            or compatibility.task_id != request.task_id
+            or compatibility.workspace_tree_hash
+            not in {None, request.workspace_tree_hash}
+        ):
+            raise ValueError("incompatible checkpoint")
         return await self.open(request)
 
     async def close(self, session: ProviderSession) -> None:

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -99,6 +99,7 @@ class CodingWorkerRuntime:
                 endpoints=executor_endpoints,
                 tokens=executor_tokens,
                 workspace_slot_resolver=self.workspace_broker.workspace_slot,
+                auto_rebind=True,
             )
         self.provider = ProviderSidecarClientPool(
             endpoints=provider_endpoints,
@@ -107,7 +108,7 @@ class CodingWorkerRuntime:
             broker_rpc=self.broker_rpc,
             executor_pool=executor_pool,
         )
-        self.tool_broker.executor = self.provider
+        self.tool_broker.executor = executor_pool or self.provider
         self.harness = HarnessRunner(
             store=self.store,
             workspace_broker=self.workspace_broker,

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import json
 import os
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 from .broker_rpc import BrokerRPCServer
@@ -49,6 +50,7 @@ class CodingWorkerRuntime:
         network_grant_key: bytes | str | None = None,
         sidecar_uid: int = 65532,
         sidecar_gid: int = 65532,
+        route_slots: Mapping[str, Sequence[str]] | None = None,
     ) -> None:
         if (
             set(slot_roots) != set(provider_endpoints)
@@ -118,6 +120,7 @@ class CodingWorkerRuntime:
             harness_runner=self.harness,
             max_active_tasks=max_active_tasks,
             tool_broker=self.tool_broker,
+            route_slots=route_slots,
         )
         self.broker_socket_path = broker_socket_path
         self.sidecar_gid = sidecar_gid
@@ -237,6 +240,7 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         "slot-a": os.getenv("CODING_WORKER_SLOT_A_TOKEN", ""),
         "slot-b": os.getenv("CODING_WORKER_SLOT_B_TOKEN", ""),
     }
+    route_slots = _route_slots_from_environment(tuple(slot_roots))
     executor_endpoints = {
         "slot-a": os.getenv(
             "CODING_WORKER_EXECUTOR_A_ENDPOINT",
@@ -339,4 +343,45 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         network_domains=domains,
         egress_proxy_url=os.getenv("CODING_WORKER_EGRESS_PROXY_URL") or None,
         network_grant_key=os.getenv("CODING_WORKER_EGRESS_GRANT_KEY") or None,
+        route_slots=route_slots,
     )
+
+
+def _route_slots_from_environment(
+    slot_ids: tuple[str, ...]
+) -> dict[str, tuple[str, ...]] | None:
+    encoded = os.getenv("CODING_WORKER_ROUTE_SLOTS_JSON", "").strip()
+    if not encoded:
+        return None
+    try:
+        value = json.loads(encoded)
+    except json.JSONDecodeError as exc:
+        raise CodingWorkerRuntimeError(
+            "Worker route catalog is invalid.", code="coding_worker_config_invalid"
+        ) from exc
+    if not isinstance(value, dict):
+        raise CodingWorkerRuntimeError(
+            "Worker route catalog is invalid.", code="coding_worker_config_invalid"
+        )
+    allowed_slots = set(slot_ids)
+    result: dict[str, tuple[str, ...]] = {}
+    for route_id, raw_slots in value.items():
+        if (
+            not isinstance(route_id, str)
+            or not route_id
+            or not isinstance(raw_slots, list)
+            or not raw_slots
+            or any(not isinstance(slot, str) for slot in raw_slots)
+        ):
+            raise CodingWorkerRuntimeError(
+                "Worker route catalog is invalid.",
+                code="coding_worker_config_invalid",
+            )
+        slots = tuple(dict.fromkeys(raw_slots))
+        if not set(slots).issubset(allowed_slots):
+            raise CodingWorkerRuntimeError(
+                "Worker route catalog is invalid.",
+                code="coding_worker_config_invalid",
+            )
+        result[route_id] = slots
+    return result

--- a/server/coding_worker/sdk.py
+++ b/server/coding_worker/sdk.py
@@ -7,6 +7,7 @@ from .contracts import (
     Origin,
     TaskCreateRequest,
     TaskRecord,
+    WorkerEvent,
 )
 from .runtime import register_frozen_check, register_workspace_source_adapter
 from .service import CodingWorkerService
@@ -75,6 +76,68 @@ class CodingWorkerModuleClient:
         return await self.service.create_task(
             Origin(module=self.module, object_id=business_object_id), request
         )
+
+    def get_task(self, *, business_object_id: str, task_id: str) -> TaskRecord:
+        """Return one task only when its immutable origin belongs to this module."""
+
+        return self._require_owned_task(business_object_id, task_id)
+
+    def list_events(
+        self,
+        *,
+        business_object_id: str,
+        task_id: str,
+        after: int = 0,
+        limit: int = 500,
+    ) -> tuple[WorkerEvent, ...]:
+        """Read provider-neutral public events without exposing provider sessions."""
+
+        self._require_owned_task(business_object_id, task_id)
+        if after < 0 or limit < 1 or limit > 1000:
+            raise CodingWorkerSDKError(
+                "Event cursor is invalid.", code="worker_event_cursor_invalid"
+            )
+        return tuple(self.service.store.list_events(task_id, after=after, limit=limit))
+
+    async def append_message(
+        self, *, business_object_id: str, task_id: str, message: str
+    ) -> TaskRecord:
+        self._require_owned_task(business_object_id, task_id)
+        if not message.strip() or len(message) > 1_048_576:
+            raise CodingWorkerSDKError(
+                "Worker message is invalid.", code="worker_message_invalid"
+            )
+        return await self.service.append_message(task_id, message)
+
+    async def pause_task(
+        self, *, business_object_id: str, task_id: str
+    ) -> TaskRecord:
+        self._require_owned_task(business_object_id, task_id)
+        return await self.service.pause(task_id)
+
+    async def resume_task(
+        self, *, business_object_id: str, task_id: str
+    ) -> TaskRecord:
+        self._require_owned_task(business_object_id, task_id)
+        return await self.service.resume(task_id)
+
+    async def cancel_task(
+        self, *, business_object_id: str, task_id: str
+    ) -> TaskRecord:
+        self._require_owned_task(business_object_id, task_id)
+        return await self.service.cancel(task_id)
+
+    def _require_owned_task(
+        self, business_object_id: str, task_id: str
+    ) -> TaskRecord:
+        task = self.service.store.get_task(task_id)
+        expected = Origin(module=self.module, object_id=business_object_id)
+        if task.spec.origin != expected:
+            raise CodingWorkerSDKError(
+                "Worker task is not available to this module.",
+                code="worker_task_not_owned",
+            )
+        return task
 
     def _validate_context(self, references: tuple[ContextReference, ...]) -> None:
         for reference in references:

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -367,6 +367,7 @@ class CodingWorkerService:
             resume_phase: str | None = None
             resume_context: dict[str, object] | None = None
             completed_turns = 0
+            message_cursor = 0
             checkpoint = self.store.latest_checkpoint(task_id)
             uncheckpointed_turns = self._uncheckpointed_completed_turns(task_id)
             if uncheckpointed_turns:
@@ -397,6 +398,9 @@ class CodingWorkerService:
                     )
                     resume_phase = str(checkpoint.payload["phase"])
                     completed_turns = int(checkpoint.payload["completed_turns"])
+                    message_cursor = int(checkpoint.payload.get("message_cursor", 0))
+                    if message_cursor < 0:
+                        raise ValueError("message cursor is invalid")
                     raw_context = checkpoint.payload.get("context_summary")
                     if raw_context is not None:
                         if not isinstance(raw_context, dict):
@@ -414,6 +418,23 @@ class CodingWorkerService:
             else:
                 session = await self.provider.open(request)
             self._sessions[task_id] = session
+            messages = self.store.list_messages(task_id)
+            if not messages:
+                objective_message = self.store.append_message(
+                    task_id, role="user", content=task.spec.objective
+                )
+                messages = [objective_message]
+            if message_cursor == 0:
+                objective_message = next(
+                    (
+                        item
+                        for item in messages
+                        if item.role == "user" and item.content == task.spec.objective
+                    ),
+                    None,
+                )
+                if objective_message is not None:
+                    message_cursor = objective_message.sequence
             self.store.transition(
                 task_id,
                 TaskState.RUNNING,
@@ -421,14 +442,13 @@ class CodingWorkerService:
                 provider_session_id=session.session_id,
                 expected_state=TaskState.PREPARING,
             )
-            if not self.store.list_messages(task_id):
-                self.store.append_message(task_id, role="user", content=task.spec.objective)
             await self._drive_session(
                 task,
                 session,
                 resume_phase=resume_phase,
                 resume_context=resume_context,
                 completed_turns=completed_turns,
+                message_cursor=message_cursor,
             )
         except TimeoutError:
             current = self.store.get_task(task_id)
@@ -496,6 +516,7 @@ class CodingWorkerService:
         resume_phase: str | None,
         resume_context: dict[str, object] | None,
         completed_turns: int,
+        message_cursor: int,
     ) -> None:
         driver = asyncio.create_task(
             self._drive_session_steps(
@@ -504,6 +525,7 @@ class CodingWorkerService:
                 resume_phase=resume_phase,
                 resume_context=resume_context,
                 completed_turns=completed_turns,
+                message_cursor=message_cursor,
             ),
             name=f"coding-worker-drive-{task.task_id}",
         )
@@ -534,15 +556,24 @@ class CodingWorkerService:
         resume_phase: str | None,
         resume_context: dict[str, object] | None,
         completed_turns: int,
+        message_cursor: int,
     ) -> None:
         task_id = task.task_id
         message = task.spec.objective
         turns = completed_turns
         if resume_phase == "testing":
-            feedback = await self._evaluate_acceptance(task, turns)
-            if feedback is None:
-                return
-            message = self._restored_context_message(resume_context, feedback)
+            steering, message_cursor = self._next_steering(
+                task_id, after_sequence=message_cursor
+            )
+            if steering is not None:
+                message = steering
+            else:
+                feedback, message_cursor = await self._evaluate_acceptance(
+                    task, turns, message_cursor=message_cursor
+                )
+                if feedback is None:
+                    return
+                message = self._restored_context_message(resume_context, feedback)
         while True:
             turns += 1
             turn_completed = False
@@ -581,6 +612,7 @@ class CodingWorkerService:
                     payload={
                         "phase": "testing",
                         "completed_turns": turns,
+                        "message_cursor": message_cursor,
                         "provider": provider_checkpoint.model_dump(mode="json"),
                         "context_summary": self._context_summary(
                             task_id,
@@ -599,10 +631,42 @@ class CodingWorkerService:
                     expected_state=TaskState.RUNNING,
                 )
                 return
-            feedback = await self._evaluate_acceptance(task, turns)
+            steering, message_cursor = self._next_steering(
+                task_id, after_sequence=message_cursor
+            )
+            if steering is not None:
+                message = steering
+                continue
+            feedback, message_cursor = await self._evaluate_acceptance(
+                task, turns, message_cursor=message_cursor
+            )
             if feedback is None:
                 return
             message = feedback
+
+    def _next_steering(
+        self, task_id: str, *, after_sequence: int
+    ) -> tuple[str | None, int]:
+        pending = next(
+            (
+                item
+                for item in self.store.list_messages(task_id)
+                if item.role == "user" and item.sequence > after_sequence
+            ),
+            None,
+        )
+        if pending is None:
+            return None, after_sequence
+        self.store.append_event(
+            task_id,
+            "steering_scheduled",
+            {"message_id": pending.message_id, "sequence": pending.sequence},
+        )
+        return (
+            "User steering received at a safe tool boundary. Follow it without "
+            "weakening the immutable acceptance contract.\n\n" + pending.content,
+            pending.sequence,
+        )
 
     def _context_summary(
         self, task_id: str, *, tree_hash: str, public_output: str
@@ -663,7 +727,9 @@ class CodingWorkerService:
             text += f"Last public provider output:\n{prior}\n"
         return (text + feedback)[:32_768]
 
-    async def _evaluate_acceptance(self, task: TaskRecord, turns: int) -> str | None:
+    async def _evaluate_acceptance(
+        self, task: TaskRecord, turns: int, *, message_cursor: int
+    ) -> tuple[str | None, int]:
         task_id = task.task_id
         self.store.transition(
             task_id, TaskState.TESTING, expected_state=TaskState.RUNNING
@@ -675,7 +741,7 @@ class CodingWorkerService:
                 reason="acceptance_runner_pending",
                 expected_state=TaskState.TESTING,
             )
-            return None
+            return None, message_cursor
         try:
             evidence = await self.harness_runner.run_required_checks(task_id)
         except ToolBrokerError as exc:
@@ -685,7 +751,7 @@ class CodingWorkerService:
                 reason=exc.code,
                 expected_state=TaskState.TESTING,
             )
-            return None
+            return None, message_cursor
         self.store.append_event(
             task_id,
             "acceptance_evaluated",
@@ -701,13 +767,25 @@ class CodingWorkerService:
                 ],
             },
         )
+        steering, message_cursor = self._next_steering(
+            task_id, after_sequence=message_cursor
+        )
         if self.harness_runner.acceptance_satisfied(task_id):
-            self.store.transition(
-                task_id,
-                TaskState.COMPLETED,
-                expected_state=TaskState.TESTING,
-            )
-            return None
+            if steering is None:
+                self.store.transition(
+                    task_id,
+                    TaskState.COMPLETED,
+                    expected_state=TaskState.TESTING,
+                )
+                return None, message_cursor
+            if turns < task.spec.budget.max_turns:
+                self.store.transition(
+                    task_id,
+                    TaskState.RUNNING,
+                    reason="steering_pending",
+                    expected_state=TaskState.TESTING,
+                )
+                return steering, message_cursor
         if turns >= task.spec.budget.max_turns:
             self.store.transition(
                 task_id,
@@ -715,7 +793,7 @@ class CodingWorkerService:
                 reason="turn_budget_exhausted",
                 expected_state=TaskState.TESTING,
             )
-            return None
+            return None, message_cursor
         message = self._acceptance_feedback(task_id, evidence)
         self.store.append_message(task_id, role="system", content=message)
         self.store.append_event(task_id, "acceptance_retry", {"turn": turns + 1})
@@ -725,7 +803,9 @@ class CodingWorkerService:
             reason="acceptance_failed",
             expected_state=TaskState.TESTING,
         )
-        return message
+        if steering is not None:
+            message = steering + "\n\nFrozen acceptance feedback:\n" + message
+        return message, message_cursor
 
     def _acceptance_feedback(
         self, task_id: str, evidence: tuple[WorkerEvidence, ...]

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 
 from .contracts import (
     EvidenceStatus,
@@ -40,6 +40,7 @@ class CodingWorkerService:
         harness_runner: HarnessRunner | None = None,
         max_active_tasks: int = 2,
         tool_broker: ToolBroker | None = None,
+        route_slots: Mapping[str, Sequence[str]] | None = None,
     ) -> None:
         if not 1 <= max_active_tasks <= 16:
             raise ValueError("active task capacity is outside the allowed range")
@@ -49,6 +50,23 @@ class CodingWorkerService:
         self.harness_runner = harness_runner
         self.max_active_tasks = max_active_tasks
         self.tool_broker = tool_broker
+        self._route_slots = (
+            {
+                route_id: tuple(dict.fromkeys(slot_ids))
+                for route_id, slot_ids in route_slots.items()
+            }
+            if route_slots is not None
+            else None
+        )
+        if self._route_slots is not None:
+            known_slots = set(self.workspace_broker.slot_ids)
+            if any(
+                not route_id
+                or not slot_ids
+                or not set(slot_ids).issubset(known_slots)
+                for route_id, slot_ids in self._route_slots.items()
+            ):
+                raise ValueError("provider route slot configuration is invalid")
         self._active: dict[str, asyncio.Task[None]] = {}
         self._task_slots: dict[str, str] = {}
         self._sessions: dict[str, ProviderSession] = {}
@@ -97,6 +115,10 @@ class CodingWorkerService:
         self._started = False
 
     async def create_task(self, origin: Origin, request: TaskCreateRequest) -> TaskRecord:
+        if self._route_slots is not None and request.model_route not in self._route_slots:
+            raise WorkerConflictError(
+                "Model route is unavailable.", code="model_route_unavailable"
+            )
         frozen_checks = getattr(self.tool_broker, "frozen_checks", None)
         if isinstance(frozen_checks, Mapping):
             unknown = [
@@ -241,6 +263,16 @@ class CodingWorkerService:
         if not available:
             return None
         for record in queued:
+            route_slots = self._allowed_slots(record.spec.model_route)
+            if route_slots is None:
+                with contextlib.suppress(WorkerConflictError):
+                    self.store.transition(
+                        record.task_id,
+                        TaskState.BLOCKED,
+                        reason="model_route_unavailable",
+                        expected_state=TaskState.QUEUED,
+                    )
+                continue
             required_slot: str | None = None
             if record.workspace_id is not None:
                 try:
@@ -249,12 +281,35 @@ class CodingWorkerService:
                     )
                 except WorkspaceError:
                     # Let the runner persist the precise workspace failure.
-                    required_slot = available[0]
+                    required_slot = next(
+                        (slot for slot in route_slots if slot in available), None
+                    )
+                if required_slot is None:
+                    continue
+                if required_slot not in route_slots:
+                    with contextlib.suppress(WorkerConflictError):
+                        self.store.transition(
+                            record.task_id,
+                            TaskState.BLOCKED,
+                            reason="provider_binding_changed",
+                            expected_state=TaskState.QUEUED,
+                        )
+                    continue
             if required_slot is None:
-                return record, available[0]
+                selected = next(
+                    (slot for slot in route_slots if slot in available), None
+                )
+                if selected is not None:
+                    return record, selected
+                continue
             if required_slot in available:
                 return record, required_slot
         return None
+
+    def _allowed_slots(self, model_route: str) -> tuple[str, ...] | None:
+        if self._route_slots is None:
+            return self.workspace_broker.slot_ids
+        return self._route_slots.get(model_route)
 
     def _task_finished(self, task_id: str, _task: asyncio.Task[None]) -> None:
         self._active.pop(task_id, None)

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -196,6 +196,25 @@ class CodingWorkerService:
         self.store.append_event(task_id, "steering_queued", {})
         return self.store.get_task(task_id)
 
+    def settle_approval_state(self, task_id: str) -> TaskRecord:
+        """Leave a decided approval runnable only while its original runner exists."""
+        task = self.store.get_task(task_id)
+        if task.state is not TaskState.WAITING_APPROVAL:
+            return task
+        runner = self._active.get(task_id)
+        if runner is not None and not runner.done():
+            return self.store.transition(
+                task_id,
+                TaskState.RUNNING,
+                expected_state=TaskState.WAITING_APPROVAL,
+            )
+        return self.store.transition(
+            task_id,
+            TaskState.INTERRUPTED,
+            reason="approval_resume_required",
+            expected_state=TaskState.WAITING_APPROVAL,
+        )
+
     async def wait_for(
         self,
         task_id: str,

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -349,7 +349,18 @@ class CodingWorkerService:
             resume_context: dict[str, object] | None = None
             completed_turns = 0
             checkpoint = self.store.latest_checkpoint(task_id)
-            if checkpoint is not None:
+            uncheckpointed_turns = self._uncheckpointed_completed_turns(task_id)
+            if uncheckpointed_turns:
+                current_tree_hash = self.workspace_broker.current_tree_hash(
+                    workspace.workspace_id
+                )
+                resume_phase = "testing"
+                completed_turns = uncheckpointed_turns
+                resume_context = self._context_summary(
+                    task_id, tree_hash=current_tree_hash, public_output=""
+                )
+                session = await self.provider.open(request)
+            elif checkpoint is not None:
                 current_tree_hash = self.workspace_broker.current_tree_hash(
                     workspace.workspace_id
                 )
@@ -429,6 +440,34 @@ class CodingWorkerService:
             if session is not None:
                 with contextlib.suppress(Exception):
                     await self.provider.close(session)
+
+    def _uncheckpointed_completed_turns(self, task_id: str) -> int:
+        cursor = 0
+        completed_turns = 0
+        last_completed_sequence = 0
+        last_checkpoint_sequence = 0
+        while True:
+            events = self.store.list_events(task_id, after=cursor, limit=1000)
+            if not events:
+                break
+            for event in events:
+                if (
+                    event.type == "provider_event"
+                    and event.payload.get("kind")
+                    == ProviderEventKind.TURN_COMPLETED.value
+                ):
+                    completed_turns += 1
+                    last_completed_sequence = event.sequence
+                elif event.type == "checkpoint_created":
+                    last_checkpoint_sequence = event.sequence
+            cursor = events[-1].sequence
+            if len(events) < 1000:
+                break
+        return (
+            completed_turns
+            if last_completed_sequence > last_checkpoint_sequence
+            else 0
+        )
 
     async def _drive_session(
         self,

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -21,6 +21,7 @@ from .provider import (
     ProviderEventKind,
     ProviderOpenRequest,
     ProviderSession,
+    provider_tools_for_policy,
 )
 from .store import CodingWorkerStore, WorkerConflictError
 from .tool_broker import ToolBroker, ToolBrokerError
@@ -284,6 +285,10 @@ class CodingWorkerService:
                 model_route=task.spec.model_route,
                 policy_profile=task.spec.policy_profile,
                 budget=task.spec.budget,
+                workspace_tree_hash=self.workspace_broker.current_tree_hash(
+                    workspace.workspace_id
+                ),
+                tool_allowlist=provider_tools_for_policy(task.spec.policy_profile),
             )
             resume_phase: str | None = None
             resume_context: dict[str, object] | None = None

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -497,75 +497,112 @@ class CodingWorkerService:
         resume_context: dict[str, object] | None,
         completed_turns: int,
     ) -> None:
+        driver = asyncio.create_task(
+            self._drive_session_steps(
+                task,
+                session,
+                resume_phase=resume_phase,
+                resume_context=resume_context,
+                completed_turns=completed_turns,
+            ),
+            name=f"coding-worker-drive-{task.task_id}",
+        )
+        try:
+            while not driver.done():
+                remaining = (
+                    task.spec.budget.max_seconds
+                    - self.store.active_runtime_seconds(task.task_id)
+                )
+                if remaining <= 0:
+                    driver.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await driver
+                    raise TimeoutError
+                await asyncio.wait({driver}, timeout=min(remaining, 0.25))
+            await driver
+        finally:
+            if not driver.done():
+                driver.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await driver
+
+    async def _drive_session_steps(
+        self,
+        task: TaskRecord,
+        session: ProviderSession,
+        *,
+        resume_phase: str | None,
+        resume_context: dict[str, object] | None,
+        completed_turns: int,
+    ) -> None:
         task_id = task.task_id
         message = task.spec.objective
         turns = completed_turns
-        async with asyncio.timeout(task.spec.budget.max_seconds):
-            if resume_phase == "testing":
-                feedback = await self._evaluate_acceptance(task, turns)
-                if feedback is None:
-                    return
-                message = self._restored_context_message(resume_context, feedback)
-            while True:
-                turns += 1
-                turn_completed = False
-                async for event in self.provider.message(session, message):
-                    self.store.append_event(
-                        task_id,
-                        "provider_event",
-                        {"kind": event.kind.value, "data": event.data},
-                    )
-                    if event.kind is ProviderEventKind.TURN_COMPLETED:
-                        turn_completed = True
-                        break
-                    if event.kind is ProviderEventKind.CANCELLED:
-                        self.store.transition(
-                            task_id, TaskState.CANCELLED, reason="provider_cancelled"
-                        )
-                        return
-                    if event.kind is ProviderEventKind.FAILED:
-                        self.store.transition(task_id, TaskState.FAILED, reason="provider_failed")
-                        return
-                if not turn_completed:
-                    current = self.store.get_task(task_id)
-                    if current.state not in TERMINAL_STATES:
-                        self.store.transition(
-                            task_id, TaskState.INTERRUPTED, reason="provider_stream_ended"
-                        )
-                    return
-                try:
-                    provider_checkpoint = await self.provider.checkpoint(session)
-                    tree_hash = self.workspace_broker.current_tree_hash(
-                        self.store.get_task(task_id).workspace_id or ""
-                    )
-                    self.store.create_checkpoint(
-                        task_id=task_id,
-                        workspace_tree_hash=tree_hash,
-                        payload={
-                            "phase": "testing",
-                            "completed_turns": turns,
-                            "provider": provider_checkpoint.model_dump(mode="json"),
-                            "context_summary": self._context_summary(
-                                task_id,
-                                tree_hash=tree_hash,
-                                public_output=str(
-                                    provider_checkpoint.payload.get("public_output", "")
-                                ),
-                            ),
-                        },
-                    )
-                except Exception:
+        if resume_phase == "testing":
+            feedback = await self._evaluate_acceptance(task, turns)
+            if feedback is None:
+                return
+            message = self._restored_context_message(resume_context, feedback)
+        while True:
+            turns += 1
+            turn_completed = False
+            async for event in self.provider.message(session, message):
+                self.store.append_event(
+                    task_id,
+                    "provider_event",
+                    {"kind": event.kind.value, "data": event.data},
+                )
+                if event.kind is ProviderEventKind.TURN_COMPLETED:
+                    turn_completed = True
+                    break
+                if event.kind is ProviderEventKind.CANCELLED:
                     self.store.transition(
-                        task_id,
-                        TaskState.BLOCKED,
-                        reason="checkpoint_failed",
-                        expected_state=TaskState.RUNNING,
+                        task_id, TaskState.CANCELLED, reason="provider_cancelled"
                     )
                     return
-                feedback = await self._evaluate_acceptance(task, turns)
-                if feedback is None:
+                if event.kind is ProviderEventKind.FAILED:
+                    self.store.transition(task_id, TaskState.FAILED, reason="provider_failed")
                     return
-                message = feedback
+            if not turn_completed:
+                current = self.store.get_task(task_id)
+                if current.state not in TERMINAL_STATES:
+                    self.store.transition(
+                        task_id, TaskState.INTERRUPTED, reason="provider_stream_ended"
+                    )
+                return
+            try:
+                provider_checkpoint = await self.provider.checkpoint(session)
+                tree_hash = self.workspace_broker.current_tree_hash(
+                    self.store.get_task(task_id).workspace_id or ""
+                )
+                self.store.create_checkpoint(
+                    task_id=task_id,
+                    workspace_tree_hash=tree_hash,
+                    payload={
+                        "phase": "testing",
+                        "completed_turns": turns,
+                        "provider": provider_checkpoint.model_dump(mode="json"),
+                        "context_summary": self._context_summary(
+                            task_id,
+                            tree_hash=tree_hash,
+                            public_output=str(
+                                provider_checkpoint.payload.get("public_output", "")
+                            ),
+                        ),
+                    },
+                )
+            except Exception:
+                self.store.transition(
+                    task_id,
+                    TaskState.BLOCKED,
+                    reason="checkpoint_failed",
+                    expected_state=TaskState.RUNNING,
+                )
+                return
+            feedback = await self._evaluate_acceptance(task, turns)
+            if feedback is None:
+                return
+            message = feedback
 
     def _context_summary(
         self, task_id: str, *, tree_hash: str, public_output: str

--- a/server/coding_worker/sidecar.py
+++ b/server/coding_worker/sidecar.py
@@ -8,6 +8,7 @@ from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 from .contracts import SAFE_ID
+from .claude_provider import ClaudeCodeProvider, ClaudeCodeRoute
 from .opencode_provider import OpenCodeProvider, OpenCodeRoute
 from .provider_rpc import ProviderRPCServer
 from .executor import ExecutorRPCServer, SidecarExecutor
@@ -61,19 +62,7 @@ async def run() -> None:
         await executor_server.start_unix(socket_path)
         await _wait_for_stop(executor_server.close)
         return
-    route_id = os.getenv("CODING_WORKER_ROUTE_ID", "coding/default").strip()
-    route = OpenCodeRoute(
-        route_id=route_id,
-        model_id=_required_environment("CODING_WORKER_MODEL_ID"),
-        base_url=_required_environment("CODING_WORKER_MODEL_BASE_URL"),
-        api_key=_required_environment("CODING_WORKER_ROUTE_KEY"),
-    )
-    provider = OpenCodeProvider(
-        workspace_resolver=_workspace_resolver(workspace_root),
-        runtime_root=runtime_root,
-        routes={route_id: route},
-        tool_broker_command=("python", "-m", "coding_worker.broker_mcp"),
-    )
+    provider = _provider_from_environment(workspace_root, runtime_root)
     server = ProviderRPCServer(
         provider,
         token=_required_environment("CODING_WORKER_SIDECAR_TOKEN"),
@@ -82,6 +71,38 @@ async def run() -> None:
     )
     await server.start_unix(socket_path)
     await _wait_for_stop(server.close)
+
+
+def _provider_from_environment(
+    workspace_root: Path, runtime_root: Path
+) -> OpenCodeProvider | ClaudeCodeProvider:
+    provider_kind = os.getenv("CODING_WORKER_PROVIDER_KIND", "opencode").strip()
+    route_id = os.getenv("CODING_WORKER_ROUTE_ID", "coding/default").strip()
+    model_id = _required_environment("CODING_WORKER_MODEL_ID")
+    command = ("python", "-m", "coding_worker.broker_mcp")
+    if provider_kind == "claude-code":
+        route = ClaudeCodeRoute(route_id=route_id, model_id=model_id)
+        return ClaudeCodeProvider(
+            runtime_root=runtime_root,
+            routes={route_id: route},
+            secret_path=Path(_required_environment("CODING_WORKER_CLAUDE_SECRET_PATH")),
+            tool_broker_command=command,
+            provider_proxy_url=os.getenv("CODING_WORKER_PROVIDER_PROXY_URL") or None,
+        )
+    if provider_kind != "opencode":
+        raise RuntimeError("CODING_WORKER_PROVIDER_KIND is invalid")
+    route = OpenCodeRoute(
+        route_id=route_id,
+        model_id=model_id,
+        base_url=_required_environment("CODING_WORKER_MODEL_BASE_URL"),
+        api_key=_required_environment("CODING_WORKER_ROUTE_KEY"),
+    )
+    return OpenCodeProvider(
+        workspace_resolver=_workspace_resolver(workspace_root),
+        runtime_root=runtime_root,
+        routes={route_id: route},
+        tool_broker_command=command,
+    )
 
 
 async def _wait_for_stop(close: Callable[[], Awaitable[None]]) -> None:

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from .contracts import (
     ApprovalStatus,
+    BUDGET_ACTIVE_STATES,
     CapabilityName,
     EvidenceStatus,
     CapabilityLease,
@@ -265,6 +266,54 @@ class CodingWorkerStore:
             )
             for row in rows
         ]
+
+    def active_runtime_seconds(self, task_id: str) -> float:
+        """Return durable active time, excluding queue and human wait intervals."""
+        with self._lock:
+            task = self.get_task(task_id)
+            total = 0.0
+            state = TaskState.QUEUED
+            last_at = task.created_at
+            cursor = 0
+            while True:
+                events = self.list_events(task_id, after=cursor, limit=1000)
+                if not events:
+                    break
+                for event in events:
+                    if event.type != "task_state":
+                        continue
+                    try:
+                        source = TaskState(str(event.payload["from"]))
+                        target = TaskState(str(event.payload["to"]))
+                    except (KeyError, ValueError) as exc:
+                        raise WorkerStoreError(
+                            "Worker state history is corrupt.", code="worker_data_corrupt"
+                        ) from exc
+                    if source is not state or event.created_at < last_at:
+                        raise WorkerStoreError(
+                            "Worker state history is inconsistent.",
+                            code="worker_data_corrupt",
+                        )
+                    if state in BUDGET_ACTIVE_STATES:
+                        total += event.created_at - last_at
+                    state = target
+                    last_at = event.created_at
+                cursor = events[-1].sequence
+                if len(events) < 1000:
+                    break
+            if state is not task.state:
+                raise WorkerStoreError(
+                    "Worker state history does not match the task.",
+                    code="worker_data_corrupt",
+                )
+            now = self._now()
+            if now < last_at:
+                raise WorkerStoreError(
+                    "Worker state clock moved backwards.", code="worker_data_corrupt"
+                )
+            if state in BUDGET_ACTIVE_STATES:
+                total += now - last_at
+            return total
 
     def append_message(self, task_id: str, *, role: str, content: str) -> WorkerMessage:
         if role not in {"user", "assistant", "tool", "system"} or not content.strip():

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -14,7 +14,13 @@ from fastapi.testclient import TestClient
 from server.coding_worker.api import configure_coding_worker_for_tests, router
 import server.coding_worker.api as worker_api
 from server.coding_worker.provider import FakeCodingAgentProvider
-from server.coding_worker.contracts import OperationState
+from server.coding_worker.contracts import (
+    OperationState,
+    Origin,
+    TaskCreateRequest,
+    TaskSpec,
+    TaskState,
+)
 from server.coding_worker.service import CodingWorkerService
 from server.coding_worker.store import CodingWorkerStore
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
@@ -225,6 +231,39 @@ def test_approval_endpoints_are_task_bound_and_single_decision(tmp_path: Path) -
             json={"approval_id": approval.approval_id, "decision": "reject"},
         )
         assert replay.status_code == 409
+
+
+def test_decided_approval_never_leaves_an_orphaned_task_running(
+    tmp_path: Path,
+) -> None:
+    client, service = _client(tmp_path, blocked=True)
+    request = TaskCreateRequest.model_validate(_payload("orphaned-approval"))
+    task = service.store.create_task(
+        TaskSpec(
+            **request.model_dump(),
+            origin=Origin(module="test", object_id="orphaned-approval"),
+        )
+    )
+    service.store.transition(task.task_id, TaskState.PREPARING)
+    service.store.transition(task.task_id, TaskState.RUNNING)
+    service.store.transition(task.task_id, TaskState.WAITING_APPROVAL)
+    approval = service.store.create_approval(
+        task_id=task.task_id,
+        operation_id="orphaned-approval-operation",
+        capability="command",
+        request={"argv": ["python", "-m", "pytest"]},
+    )
+
+    with client:
+        decided = client.post(
+            f"/api/coding-worker/v1/tasks/{task.task_id}/approvals",
+            json={"approval_id": approval.approval_id, "decision": "approve_once"},
+        )
+
+    assert decided.status_code == 200
+    interrupted = service.store.get_task(task.task_id)
+    assert interrupted.state is TaskState.INTERRUPTED
+    assert interrupted.reason == "approval_resume_required"
 
 
 def test_shell_approval_cannot_be_promoted_to_task_scope(tmp_path: Path) -> None:

--- a/server/tests/test_coding_worker_claude.py
+++ b/server/tests/test_coding_worker_claude.py
@@ -20,6 +20,7 @@ from server.coding_worker.provider import (
     ProviderEventKind,
     ProviderOpenRequest,
 )
+from server.coding_worker.sidecar import _provider_from_environment
 
 
 def _request() -> ProviderOpenRequest:
@@ -70,6 +71,25 @@ def test_managed_settings_and_command_disable_builtin_surfaces(tmp_path: Path) -
         "mcp__modelmirror-tool-broker__apply_changeset",
         "mcp__modelmirror-tool-broker__run_shell",
     ]
+
+
+def test_sidecar_selects_claude_without_gateway_key_or_workspace_resolver(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret = tmp_path / "secret"
+    secret.write_text("secret", encoding="utf-8")
+    monkeypatch.setenv("CODING_WORKER_PROVIDER_KIND", "claude-code")
+    monkeypatch.setenv("CODING_WORKER_ROUTE_ID", "coding/quality")
+    monkeypatch.setenv("CODING_WORKER_MODEL_ID", "claude-test-model")
+    monkeypatch.setenv("CODING_WORKER_CLAUDE_SECRET_PATH", str(secret))
+    monkeypatch.delenv("CODING_WORKER_MODEL_BASE_URL", raising=False)
+    monkeypatch.delenv("CODING_WORKER_ROUTE_KEY", raising=False)
+
+    provider = _provider_from_environment(
+        tmp_path / "unused-workspace", tmp_path / "runtime"
+    )
+    assert isinstance(provider, ClaudeCodeProvider)
+    assert "secret" not in repr(provider)
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_claude.py
+++ b/server/tests/test_coding_worker_claude.py
@@ -215,3 +215,22 @@ async def test_secret_symlink_is_rejected_before_process_start(tmp_path: Path) -
     with pytest.raises(ClaudeCodeProviderError) as caught:
         await provider.open(_request())
     assert caught.value.code == "provider_credential_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_non_utf8_secret_is_an_authentication_failure(tmp_path: Path) -> None:
+    secret = tmp_path / "invalid-secret"
+    secret.write_bytes(b"\xff\xfe")
+    provider = ClaudeCodeProvider(
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/quality": _route()},
+        secret_path=secret,
+        command_prefix=("must-not-start",),
+    )
+    provider.bind_broker("task-claude", "unix:/run/broker.sock", "b" * 48)
+    session = await provider.open(_request())
+    with pytest.raises(ClaudeCodeProviderError) as caught:
+        _ = [event async for event in provider.message(session, "continue")]
+    assert caught.value.code == "provider_credential_unavailable"
+    assert caught.value.failure_kind.value == "authentication"
+    await provider.close(session)

--- a/server/tests/test_coding_worker_claude.py
+++ b/server/tests/test_coding_worker_claude.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from server.coding_worker.claude_provider import (
+    CLAUDE_BUILTIN_TOOLS,
+    CLAUDE_CODE_VERSION,
+    ClaudeCodeProvider,
+    ClaudeCodeProviderError,
+    ClaudeCodeRoute,
+)
+from server.coding_worker.contracts import PolicyProfile, TaskBudget
+from server.coding_worker.provider import (
+    ProviderCheckpointCompatibility,
+    ProviderEventKind,
+    ProviderOpenRequest,
+)
+
+
+def _request() -> ProviderOpenRequest:
+    return ProviderOpenRequest(
+        task_id="task-claude",
+        workspace_id="workspace-claude",
+        objective="Inspect and fix the project.",
+        model_route="coding/quality",
+        policy_profile=PolicyProfile.DEVELOP,
+        budget=TaskBudget(max_seconds=60, max_output_bytes=1024 * 1024),
+        workspace_tree_hash="a" * 64,
+        tool_allowlist=("read_file", "apply_changeset", "run_shell"),
+    )
+
+
+def _route() -> ClaudeCodeRoute:
+    return ClaudeCodeRoute(
+        route_id="coding/quality",
+        model_id="claude-test-model",
+        max_budget_usd=3.5,
+    )
+
+
+def _provider(tmp_path: Path, *, command_prefix: tuple[str, ...]) -> ClaudeCodeProvider:
+    secret = tmp_path / "claude-api-key"
+    secret.write_text("test-secret-value\n", encoding="utf-8")
+    secret.chmod(0o600)
+    provider = ClaudeCodeProvider(
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/quality": _route()},
+        secret_path=secret,
+        command_prefix=command_prefix,
+        tool_broker_command=(sys.executable, "-m", "coding_worker.broker_mcp"),
+    )
+    provider.bind_broker("task-claude", "unix:/run/broker.sock", "b" * 48)
+    return provider
+
+
+def test_managed_settings_and_command_disable_builtin_surfaces(tmp_path: Path) -> None:
+    provider = _provider(tmp_path, command_prefix=("claude",))
+    settings = provider.build_settings(_request().tool_allowlist)
+    assert settings["disableAllHooks"] is True
+    assert settings["enabledPlugins"] == {}
+    assert settings["strictKnownMarketplaces"] == []
+    assert settings["permissions"]["deny"] == list(CLAUDE_BUILTIN_TOOLS)
+    assert settings["permissions"]["allow"] == [
+        "mcp__modelmirror-tool-broker__read_file",
+        "mcp__modelmirror-tool-broker__apply_changeset",
+        "mcp__modelmirror-tool-broker__run_shell",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_headless_stream_maps_only_neutral_events_and_private_checkpoint(
+    tmp_path: Path,
+) -> None:
+    script = tmp_path / "fake_claude.py"
+    script.write_text(
+        """
+import json
+import os
+import sys
+
+args = sys.argv[1:]
+assert '--print' in args
+assert args[args.index('--input-format') + 1] == 'stream-json'
+assert args[args.index('--output-format') + 1] == 'stream-json'
+assert args[args.index('--tools') + 1] == ''
+assert '--strict-mcp-config' in args and '--bare' in args
+assert os.environ['ANTHROPIC_API_KEY'] == 'test-secret-value'
+frame = json.loads(sys.stdin.readline())
+session = frame['session_id']
+assert frame['type'] == 'user'
+assert ('--session-id' in args) != ('--resume' in args)
+text = 'resumed' if '--resume' in args else 'done'
+print(json.dumps({
+    'type': 'assistant',
+    'session_id': session,
+    'message': {
+        'content': [{'type': 'text', 'text': text}],
+        'usage': {'input_tokens': 10, 'output_tokens': 4},
+    },
+}))
+print(json.dumps({
+    'type': 'result',
+    'session_id': session,
+    'is_error': False,
+    'usage': {
+        'input_tokens': 10,
+        'output_tokens': 4,
+        'cache_read_input_tokens': 2,
+        'cache_creation_input_tokens': 1,
+    },
+    'total_cost_usd': 0.002,
+    'supplier_frame': 'must-not-leak',
+}))
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    provider = _provider(
+        tmp_path, command_prefix=(sys.executable, str(script))
+    )
+    session = await provider.open(_request())
+
+    events = [event async for event in provider.message(session, "continue")]
+    assert [event.kind for event in events] == [
+        ProviderEventKind.MESSAGE,
+        ProviderEventKind.USAGE,
+        ProviderEventKind.USAGE,
+        ProviderEventKind.TURN_COMPLETED,
+    ]
+    assert events[0].data == {"text": "done"}
+    assert all("supplier" not in json.dumps(event.data) for event in events)
+    resumed_events = [
+        event async for event in provider.message(session, "continue again")
+    ]
+    assert resumed_events[0].data == {"text": "resumed"}
+    assert resumed_events[-1].kind is ProviderEventKind.TURN_COMPLETED
+    checkpoint = await provider.checkpoint(session)
+    assert checkpoint.compatibility is not None
+    assert checkpoint.compatibility.provider_family == "claude-code"
+    assert checkpoint.compatibility.provider_version == CLAUDE_CODE_VERSION
+    assert checkpoint.compatibility.workspace_tree_hash == "a" * 64
+    assert checkpoint.payload == {
+        "task_id": "task-claude",
+        "public_output": "doneresumed",
+    }
+    assert "session" not in checkpoint.payload
+
+    await provider.close(session)
+    provider.bind_broker("task-claude", "unix:/run/broker.sock", "b" * 48)
+    restored = await provider.restore(_request(), checkpoint)
+    await provider.close(restored)
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_provider_version_or_tree_change(tmp_path: Path) -> None:
+    provider = _provider(tmp_path, command_prefix=("claude",))
+    session = await provider.open(_request())
+    checkpoint = await provider.checkpoint(session)
+    assert checkpoint.compatibility is not None
+    incompatible = checkpoint.model_copy(
+        update={
+            "compatibility": ProviderCheckpointCompatibility(
+                provider_family="claude-code",
+                provider_version="2.1.90",
+                task_id="task-claude",
+                workspace_tree_hash="a" * 64,
+            )
+        }
+    )
+    with pytest.raises(ClaudeCodeProviderError) as caught:
+        await provider.restore(_request(), incompatible)
+    assert caught.value.code == "checkpoint_invalid"
+    await provider.close(session)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires POSIX symlink semantics")
+@pytest.mark.asyncio
+async def test_secret_symlink_is_rejected_before_process_start(tmp_path: Path) -> None:
+    target = tmp_path / "target-secret"
+    target.write_text("outside-secret", encoding="utf-8")
+    link = tmp_path / "secret-link"
+    link.symlink_to(target)
+    provider = ClaudeCodeProvider(
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/quality": _route()},
+        secret_path=link,
+        command_prefix=("claude",),
+    )
+    provider.bind_broker("task-claude", "unix:/run/broker.sock", "b" * 48)
+    with pytest.raises(ClaudeCodeProviderError) as caught:
+        await provider.open(_request())
+    assert caught.value.code == "provider_credential_unavailable"

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -83,6 +83,10 @@ def test_v15_claude_provider_has_a_pinned_private_image_and_secret_only_mount() 
     assert "coding-worker-claude-egress:" in compose
     assert "CODING_WORKER_PROVIDER_NETWORK_DOMAINS: api.anthropic.com" in compose
     assert "CODING_WORKER_PROVIDER_EGRESS_TOKEN" in compose
+    assert (
+        "CODING_WORKER_PROVIDER_ALLOW_DOCKER_DESKTOP_DNS_PROXY: "
+        "${CODING_WORKER_PROVIDER_ALLOW_DOCKER_DESKTOP_DNS_PROXY:-false}"
+    ) in compose
     assert "CODING_WORKER_PROVIDER_PROXY_URL: http://provider:" in provider
     proxy = compose.split("\n  coding-worker-claude-egress:", 1)[1].split(
         "secrets:", 1

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -78,3 +78,12 @@ def test_v15_claude_provider_has_a_pinned_private_image_and_secret_only_mount() 
     assert ".ssh" not in provider
     assert "internal: true" in compose
     assert "CODING_WORKER_ROUTE_SLOTS_JSON" in compose
+    assert "coding-worker-claude-egress:" in compose
+    assert "CODING_WORKER_PROVIDER_NETWORK_DOMAINS: api.anthropic.com" in compose
+    assert "CODING_WORKER_PROVIDER_EGRESS_TOKEN" in compose
+    assert "CODING_WORKER_PROVIDER_PROXY_URL: http://provider:" in provider
+    proxy = compose.split("\n  coding-worker-claude-egress:", 1)[1].split(
+        "secrets:", 1
+    )[0]
+    assert "modelmirror_claude_api_key" not in proxy
+    assert "coding_worker_provider_b" not in proxy

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -47,3 +47,34 @@ def test_v14_sidecar_is_non_root_and_has_no_host_control_mounts() -> None:
     assert "coding-worker-network" in compose
     assert 'command: ["python", "-m", "coding_worker.egress_proxy"]' in compose
     assert "CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}" in compose
+
+
+def test_v15_claude_provider_has_a_pinned_private_image_and_secret_only_mount() -> None:
+    root = Path(__file__).parents[2]
+    dockerfile = (root / "server/coding_worker/Dockerfile.claude").read_text()
+    compose = (root / "docker-compose.coding-worker-v15-claude.yml").read_text()
+
+    assert "CLAUDE_CODE_VERSION=2.1.89" in dockerfile
+    assert "CLAUDE_CODE_INTEGRITY=sha512-" in dockerfile
+    assert "Claude Code package integrity mismatch" in dockerfile
+    assert 'test "$(claude --version | awk' in dockerfile
+    assert "USER 65532:65532" in dockerfile
+    assert 'CMD ["python", "-m", "coding_worker.sidecar"]' in dockerfile
+    assert "git " not in dockerfile
+    assert "ripgrep" not in dockerfile
+
+    provider = compose.split("coding-worker-provider-b:", 1)[1].split(
+        "secrets:", 1
+    )[0]
+    assert "CODING_WORKER_PROVIDER_KIND: claude-code" in provider
+    assert "CODING_WORKER_ROUTE_ID: coding/quality" in provider
+    assert "CODING_WORKER_CLAUDE_SECRET_PATH: /run/secrets/" in provider
+    assert "coding_worker_provider_b:/run/modelmirror-coding" in provider
+    assert "coding_worker_broker:/run/modelmirror-coding-broker:ro" in provider
+    assert "coding_worker_slot_b:/worker-data" not in provider
+    assert "CODING_WORKER_ROUTE_KEY" not in provider
+    assert "CODING_WORKER_MODEL_BASE_URL" not in provider
+    assert "docker.sock" not in provider
+    assert ".ssh" not in provider
+    assert "internal: true" in compose
+    assert "CODING_WORKER_ROUTE_SLOTS_JSON" in compose

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -47,6 +47,8 @@ def test_v14_sidecar_is_non_root_and_has_no_host_control_mounts() -> None:
     assert "coding-worker-network" in compose
     assert 'command: ["python", "-m", "coding_worker.egress_proxy"]' in compose
     assert "CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}" in compose
+    assert "'action':'health','payload':{}" in compose
+    assert "'task_id':'healthcheck'" not in compose
 
 
 def test_v15_claude_provider_has_a_pinned_private_image_and_secret_only_mount() -> None:

--- a/server/tests/test_coding_worker_network.py
+++ b/server/tests/test_coding_worker_network.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from server.coding_worker.contracts import CapabilityLease
+from server.coding_worker.egress_proxy import ProviderEgressPolicy
 from server.coding_worker.network_policy import EgressPolicy, NetworkPolicyError
 
 
@@ -149,3 +150,27 @@ def test_signed_proxy_grant_is_exact_task_domain_purpose_and_ttl() -> None:
     tampered = token[:-1] + ("a" if token[-1] != "a" else "b")
     with pytest.raises(NetworkPolicyError):
         policy.validate_grant(tampered, domain="registry.npmjs.org")
+
+
+def test_provider_proxy_is_exact_token_and_anthropic_api_domain() -> None:
+    policy = ProviderEgressPolicy(
+        token="p" * 48, allowed_domains=("api.anthropic.com",)
+    )
+    policy.validate("p" * 48, domain="API.ANTHROPIC.COM.")
+
+    with pytest.raises(NetworkPolicyError) as wrong_token:
+        policy.validate("q" * 48, domain="api.anthropic.com")
+    assert wrong_token.value.code == "network_grant_invalid"
+    with pytest.raises(NetworkPolicyError) as wrong_domain:
+        policy.validate("p" * 48, domain="console.anthropic.com")
+    assert wrong_domain.value.code == "network_domain_not_allowed"
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["short", "p" * 31 + ":" + "p" * 16, "p" * 31 + " " + "p" * 16],
+)
+def test_provider_proxy_token_is_url_safe_and_bounded(token: str) -> None:
+    with pytest.raises(NetworkPolicyError) as invalid:
+        ProviderEgressPolicy(token=token, allowed_domains=("api.anthropic.com",))
+    assert invalid.value.code == "network_grant_key_invalid"

--- a/server/tests/test_coding_worker_network.py
+++ b/server/tests/test_coding_worker_network.py
@@ -166,6 +166,27 @@ def test_provider_proxy_is_exact_token_and_anthropic_api_domain() -> None:
     assert wrong_domain.value.code == "network_domain_not_allowed"
 
 
+def test_provider_proxy_dns_exception_is_explicit_and_narrow() -> None:
+    strict = ProviderEgressPolicy(
+        token="p" * 48, allowed_domains=("api.anthropic.com",)
+    )
+    with pytest.raises(NetworkPolicyError) as synthetic:
+        strict.validate_resolved_address("198.18.0.250")
+    assert synthetic.value.code == "network_private_address_denied"
+
+    docker_desktop = ProviderEgressPolicy(
+        token="p" * 48,
+        allowed_domains=("api.anthropic.com",),
+        allow_docker_desktop_dns_proxy=True,
+    )
+    docker_desktop.validate_resolved_address("198.18.0.250")
+    docker_desktop.validate_resolved_address("93.184.216.34")
+    for address in ("10.0.0.8", "127.0.0.1", "169.254.169.254", "::1"):
+        with pytest.raises(NetworkPolicyError) as denied:
+            docker_desktop.validate_resolved_address(address)
+        assert denied.value.code == "network_private_address_denied"
+
+
 @pytest.mark.parametrize(
     "token",
     ["short", "p" * 31 + ":" + "p" * 16, "p" * 31 + " " + "p" * 16],

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -60,7 +60,8 @@ def test_config_disables_direct_tools_plugins_sharing_and_supplier_surface(tmp_p
     config = provider.build_config(_route())
     permission = config["permission"]
     assert permission["*"] == "deny"
-    assert permission["modelmirror-tool-broker_*"] == "allow"
+    assert "modelmirror-tool-broker_*" not in permission
+    assert permission["modelmirror-tool-broker_read_file"] == "allow"
     assert Path(
         config["mcp"][TOOL_BROKER_MCP_NAME]["environment"]["PYTHONPATH"]
     ).name == "server"
@@ -70,6 +71,7 @@ def test_config_disables_direct_tools_plugins_sharing_and_supplier_surface(tmp_p
         "{env:CODING_WORKER_ROUTE_KEY}"
     )
     assert all(provider._prompt_tools()[name] is False for name in DIRECT_TOOL_NAMES)
+    assert provider._prompt_tools()["modelmirror-tool-broker_read_file"] is True
 
 
 @pytest.mark.asyncio
@@ -199,6 +201,9 @@ async def test_headless_adapter_maps_events_cancel_and_checkpoint_without_public
         "task_id": "task-01",
         "public_output": "done",
     }
+    assert checkpoint.compatibility is not None
+    assert checkpoint.compatibility.provider_family == "opencode"
+    assert checkpoint.compatibility.provider_version == "1.18.9"
     assert "http" not in checkpoint.payload and "port" not in checkpoint.payload
     assert "session" not in checkpoint.payload and "messages" not in checkpoint.payload
     await provider.close(session)
@@ -262,6 +267,37 @@ def test_raw_permission_frame_never_enters_provider_neutral_event() -> None:
     assert event is not None
     assert event.kind is ProviderEventKind.APPROVAL_REQUIRED
     assert event.data == {"capability": "provider_permission"}
+
+
+def test_raw_usage_frame_maps_to_provider_neutral_usage() -> None:
+    event = OpenCodeProvider._map_event(
+        {
+            "type": "message.updated",
+            "properties": {
+                "sessionID": "ses_test",
+                "info": {
+                    "tokens": {
+                        "input": 12,
+                        "output": 7,
+                        "cache": {"read": 4, "write": 2},
+                    },
+                    "cost": 0.00125,
+                    "supplier": "must-not-leak",
+                },
+            },
+        },
+        "ses_test",
+    )
+    assert event is not None and event.kind is ProviderEventKind.USAGE
+    assert event.data == {
+        "usage": {
+            "input_tokens": 12,
+            "output_tokens": 7,
+            "cache_read_tokens": 4,
+            "cache_write_tokens": 2,
+            "cost_microusd": 1250,
+        }
+    }
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_provider_conformance.py
+++ b/server/tests/test_coding_worker_provider_conformance.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from server.coding_worker.claude_provider import (
+    ClaudeCodeProvider,
+    ClaudeCodeProviderError,
+    ClaudeCodeRoute,
+)
+from server.coding_worker.contracts import PolicyProfile, TaskBudget
+from server.coding_worker.opencode_provider import (
+    OpenCodeProvider,
+    OpenCodeProviderError,
+    OpenCodeRoute,
+    OpenCodeServerHandle,
+)
+from server.coding_worker.provider import (
+    CodingAgentProvider,
+    FakeCodingAgentProvider,
+    PROVIDER_CHECKPOINT_FORMAT_VERSION,
+    PROVIDER_CONTRACT_VERSION,
+    ProviderEventKind,
+    ProviderOpenRequest,
+)
+
+
+def _request(route_id: str) -> ProviderOpenRequest:
+    return ProviderOpenRequest(
+        task_id="task-conformance",
+        workspace_id="workspace-conformance",
+        objective="Inspect and fix the project.",
+        model_route=route_id,
+        policy_profile=PolicyProfile.DEVELOP,
+        budget=TaskBudget(max_seconds=60, max_output_bytes=1024 * 1024),
+        workspace_tree_hash="a" * 64,
+        tool_allowlist=("read_file",),
+    )
+
+
+def _fake_provider(_tmp_path: Path) -> tuple[CodingAgentProvider, ProviderOpenRequest]:
+    return FakeCodingAgentProvider(), _request("coding/default")
+
+
+def _opencode_provider(
+    tmp_path: Path,
+) -> tuple[CodingAgentProvider, ProviderOpenRequest]:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    state: dict[str, Any] = {"counter": 0, "session_id": ""}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/session" and request.method == "POST":
+            state["counter"] += 1
+            state["session_id"] = f"ses_conformance_{state['counter']}"
+            return httpx.Response(200, json={"id": state["session_id"]})
+        if request.url.path == "/event":
+            body = (
+                "data: "
+                + json.dumps(
+                    {
+                        "type": "session.idle",
+                        "properties": {"sessionID": state["session_id"]},
+                    }
+                )
+                + "\n\n"
+            )
+            return httpx.Response(
+                200, text=body, headers={"content-type": "text/event-stream"}
+            )
+        if request.url.path.endswith("/prompt_async"):
+            return httpx.Response(204)
+        if request.url.path == "/mcp":
+            return httpx.Response(200, json={})
+        return httpx.Response(404)
+
+    async def factory(
+        request: ProviderOpenRequest, resolved: Path, route: OpenCodeRoute
+    ) -> OpenCodeServerHandle:
+        assert request.task_id == "task-conformance"
+        assert resolved == workspace.resolve()
+        assert route.route_id == "coding/default"
+        client = httpx.AsyncClient(
+            base_url="http://127.0.0.1:4096",
+            transport=httpx.MockTransport(handler),
+        )
+
+        async def close() -> None:
+            await client.aclose()
+
+        return OpenCodeServerHandle(
+            task_id=request.task_id,
+            workspace=resolved,
+            state_root=tmp_path / "opencode-state",
+            client=client,
+            close_callback=close,
+        )
+
+    route = OpenCodeRoute(
+        route_id="coding/default",
+        model_id="test-model",
+        base_url="http://new-api:3000/v1",
+        api_key="test-route-key",
+    )
+    return (
+        OpenCodeProvider(
+            workspace_resolver=lambda _workspace_id: workspace,
+            runtime_root=tmp_path / "runtime",
+            routes={route.route_id: route},
+            server_factory=factory,
+        ),
+        _request(route.route_id),
+    )
+
+
+def _claude_provider(
+    tmp_path: Path,
+) -> tuple[CodingAgentProvider, ProviderOpenRequest]:
+    script = tmp_path / "fake_claude.py"
+    script.write_text(
+        """
+import json
+import sys
+frame = json.loads(sys.stdin.readline())
+print(json.dumps({
+    'type': 'result',
+    'session_id': frame['session_id'],
+    'is_error': False,
+    'usage': {'input_tokens': 1, 'output_tokens': 1},
+}))
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    secret = tmp_path / "claude-secret"
+    secret.write_text("test-secret", encoding="utf-8")
+    route = ClaudeCodeRoute(
+        route_id="coding/quality", model_id="claude-test-model"
+    )
+    provider = ClaudeCodeProvider(
+        runtime_root=tmp_path / "claude-runtime",
+        routes={route.route_id: route},
+        secret_path=secret,
+        command_prefix=(sys.executable, str(script)),
+    )
+    provider.bind_broker(
+        "task-conformance", "unix:/run/broker.sock", "b" * 48
+    )
+    return provider, _request(route.route_id)
+
+
+ProviderFactory = Callable[
+    [Path], tuple[CodingAgentProvider, ProviderOpenRequest]
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "factory", [_fake_provider, _opencode_provider, _claude_provider]
+)
+async def test_provider_v2_conformance(
+    factory: ProviderFactory, tmp_path: Path
+) -> None:
+    provider, request = factory(tmp_path)
+    capabilities = await provider.capabilities()
+    assert capabilities.contract_version == PROVIDER_CONTRACT_VERSION
+    assert capabilities.supports_streaming is True
+    assert capabilities.supports_checkpoint is True
+    assert capabilities.supports_restore is True
+
+    session = await provider.open(request)
+    events = [event async for event in provider.message(session, "continue")]
+    assert events[-1].kind is ProviderEventKind.TURN_COMPLETED
+    assert all("supplier" not in json.dumps(event.data) for event in events)
+    checkpoint = await provider.checkpoint(session)
+    compatibility = checkpoint.compatibility
+    assert compatibility is not None
+    assert compatibility.contract_version == PROVIDER_CONTRACT_VERSION
+    assert compatibility.format_version == PROVIDER_CHECKPOINT_FORMAT_VERSION
+    assert compatibility.task_id == request.task_id
+    assert compatibility.workspace_tree_hash == request.workspace_tree_hash
+    await provider.close(session)
+
+    if isinstance(provider, ClaudeCodeProvider):
+        provider.bind_broker(
+            "task-conformance", "unix:/run/broker.sock", "b" * 48
+        )
+    restored = await provider.restore(request, checkpoint)
+    await provider.close(restored)
+
+    changed = request.model_copy(update={"workspace_tree_hash": "b" * 64})
+    if isinstance(provider, ClaudeCodeProvider):
+        provider.bind_broker(
+            "task-conformance", "unix:/run/broker.sock", "b" * 48
+        )
+    with pytest.raises(
+        (ValueError, OpenCodeProviderError, ClaudeCodeProviderError)
+    ):
+        await provider.restore(changed, checkpoint)

--- a/server/tests/test_coding_worker_provider_rpc.py
+++ b/server/tests/test_coding_worker_provider_rpc.py
@@ -176,6 +176,53 @@ async def test_credential_free_executor_requires_exact_task_workspace_binding(
 
 
 @pytest.mark.asyncio
+async def test_runtime_executor_pool_rebinds_exact_task_after_executor_restart(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "slots" / "workspaces" / "workspace_one" / "repo"
+    repository.mkdir(parents=True)
+    (repository / "main.py").write_text("print('isolated')\n")
+    server = ExecutorRPCServer(
+        SidecarExecutor(
+            lambda workspace_id: (
+                repository if workspace_id == "workspace_one" else tmp_path / "missing"
+            ),
+            runtime_root=tmp_path / "runtime",
+        ),
+        token="e" * 48,
+    )
+    endpoint = await server.start_tcp_for_tests()
+    pool = ExecutorSidecarClientPool(
+        endpoints={"slot-a": endpoint},
+        tokens={"slot-a": "e" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+        auto_rebind=True,
+    )
+
+    result = await pool.run_process(
+        task_id="task_one",
+        workspace_id="workspace_one",
+        argv=("python", "main.py"),
+        timeout_seconds=10,
+        isolated=False,
+    )
+    assert result["exit_code"] == 0
+    assert str(result["output"]).splitlines() == ["isolated"]
+
+    with pytest.raises(ExecutorRPCError) as foreign:
+        await pool.run_process(
+            task_id="task_two",
+            workspace_id="workspace_one",
+            argv=("python", "main.py"),
+            timeout_seconds=10,
+            isolated=False,
+        )
+    assert foreign.value.code == "executor_slot_busy"
+    await pool.close_task("task_one", "workspace_one")
+    await server.close()
+
+
+@pytest.mark.asyncio
 async def test_provider_pool_binds_and_closes_separate_executor(tmp_path: Path) -> None:
     store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
     workspace = WorkspaceBroker(tmp_path / "workspace", {}, id_key=b"z" * 32)

--- a/server/tests/test_coding_worker_runtime.py
+++ b/server/tests/test_coding_worker_runtime.py
@@ -15,7 +15,11 @@ from server.coding_worker.contracts import (
 )
 from server.coding_worker.provider import FakeCodingAgentProvider
 from server.coding_worker.provider_rpc import ProviderRPCServer
-from server.coding_worker.runtime import CodingWorkerRuntime
+from server.coding_worker.runtime import (
+    CodingWorkerRuntime,
+    CodingWorkerRuntimeError,
+    _route_slots_from_environment,
+)
 from server.coding_worker.tool_broker import FrozenCheck
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter
 
@@ -92,3 +96,24 @@ async def test_runtime_connects_two_dedicated_provider_slots(tmp_path: Path) -> 
     await runtime.close()
     for server in servers.values():
         await server.close()
+
+
+def test_route_slot_catalog_is_strict_and_provider_neutral(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "CODING_WORKER_ROUTE_SLOTS_JSON",
+        '{"coding/default":["slot-a"],"coding/quality":["slot-b"]}',
+    )
+    assert _route_slots_from_environment(("slot-a", "slot-b")) == {
+        "coding/default": ("slot-a",),
+        "coding/quality": ("slot-b",),
+    }
+
+    monkeypatch.setenv(
+        "CODING_WORKER_ROUTE_SLOTS_JSON",
+        '{"coding/quality":["missing-slot"]}',
+    )
+    with pytest.raises(CodingWorkerRuntimeError) as caught:
+        _route_slots_from_environment(("slot-a", "slot-b"))
+    assert caught.value.code == "coding_worker_config_invalid"

--- a/server/tests/test_coding_worker_runtime.py
+++ b/server/tests/test_coding_worker_runtime.py
@@ -13,6 +13,7 @@ from server.coding_worker.contracts import (
     TaskState,
     WorkspaceSource,
 )
+from server.coding_worker.executor import ExecutorSidecarClientPool
 from server.coding_worker.provider import FakeCodingAgentProvider
 from server.coding_worker.provider_rpc import ProviderRPCServer
 from server.coding_worker.runtime import (
@@ -58,6 +59,7 @@ async def test_runtime_connects_two_dedicated_provider_slots(tmp_path: Path) -> 
         sidecar_uid=-1,
         sidecar_gid=-1,
     )
+    assert runtime.tool_broker.executor is runtime.provider
     await runtime.start()
     source = WorkspaceSource(kind="manifest", source_id="source", revision="h0")
     tasks = [
@@ -96,6 +98,26 @@ async def test_runtime_connects_two_dedicated_provider_slots(tmp_path: Path) -> 
     await runtime.close()
     for server in servers.values():
         await server.close()
+
+
+def test_runtime_routes_v15_tools_to_dedicated_executor_pool(
+    tmp_path: Path,
+) -> None:
+    runtime = CodingWorkerRuntime(
+        storage_root=tmp_path / "control",
+        slot_roots={"slot-a": tmp_path / "slot-a"},
+        source_adapters={},
+        frozen_checks={},
+        provider_endpoints={"slot-a": "tcp:127.0.0.1:18001"},
+        provider_tokens={"slot-a": "p" * 48},
+        executor_endpoints={"slot-a": "tcp:127.0.0.1:18002"},
+        executor_tokens={"slot-a": "x" * 48},
+        broker_socket_path=None,
+        sidecar_uid=-1,
+        sidecar_gid=-1,
+    )
+
+    assert isinstance(runtime.tool_broker.executor, ExecutorSidecarClientPool)
 
 
 def test_route_slot_catalog_is_strict_and_provider_neutral(

--- a/server/tests/test_coding_worker_sdk.py
+++ b/server/tests/test_coding_worker_sdk.py
@@ -54,6 +54,17 @@ def _request() -> TaskCreateRequest:
     )
 
 
+def _other_client(client: CodingWorkerModuleClient) -> CodingWorkerModuleClient:
+    return CodingWorkerModuleClient(
+        module="mcp-creator",
+        service=client.service,
+        source_kinds=client.source_kinds,
+        check_ids=client.check_ids,
+        model_routes=client.model_routes,
+        context_validators=client.context_validators,
+    )
+
+
 @pytest.mark.asyncio
 async def test_module_client_owns_origin_and_preserves_idempotency(tmp_path: Path) -> None:
     client = _client(tmp_path)
@@ -85,3 +96,65 @@ async def test_module_client_rejects_unregistered_execution_inputs(
     with pytest.raises(CodingWorkerSDKError) as raised:
         await client.create_task(business_object_id="skill_01", request=request)
     assert raised.value.code == expected
+
+
+@pytest.mark.asyncio
+async def test_module_client_reads_and_controls_only_its_own_origin(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    task = await client.create_task(business_object_id="skill_01", request=_request())
+    client.service.store.append_event(task.task_id, "plan", {"summary": "public"})
+
+    assert client.get_task(
+        business_object_id="skill_01", task_id=task.task_id
+    ).task_id == task.task_id
+    assert [event.type for event in client.list_events(
+        business_object_id="skill_01", task_id=task.task_id
+    )][-1] == "plan"
+
+    foreign = _other_client(client)
+    for action in (
+        lambda: foreign.get_task(
+            business_object_id="mcp_01", task_id=task.task_id
+        ),
+        lambda: foreign.list_events(
+            business_object_id="mcp_01", task_id=task.task_id
+        ),
+    ):
+        with pytest.raises(CodingWorkerSDKError) as raised:
+            action()
+        assert raised.value.code == "worker_task_not_owned"
+
+    with pytest.raises(CodingWorkerSDKError) as raised:
+        await foreign.cancel_task(
+            business_object_id="mcp_01", task_id=task.task_id
+        )
+    assert raised.value.code == "worker_task_not_owned"
+
+
+@pytest.mark.asyncio
+async def test_module_client_bounds_public_event_and_message_inputs(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    task = await client.create_task(business_object_id="skill_01", request=_request())
+
+    with pytest.raises(CodingWorkerSDKError) as cursor:
+        client.list_events(
+            business_object_id="skill_01", task_id=task.task_id, limit=1001
+        )
+    assert cursor.value.code == "worker_event_cursor_invalid"
+
+    with pytest.raises(CodingWorkerSDKError) as message:
+        await client.append_message(
+            business_object_id="skill_01", task_id=task.task_id, message="   "
+        )
+    assert message.value.code == "worker_message_invalid"
+
+
+def test_module_sdk_has_no_provider_tool_or_secret_registration_surface() -> None:
+    forbidden = {
+        "register_provider",
+        "register_tool",
+        "register_process",
+        "register_secret",
+        "register_mcp_server",
+    }
+    assert forbidden.isdisjoint(vars(CodingWorkerModuleClient))

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -25,6 +25,7 @@ from server.coding_worker.evidence import HarnessRunner
 from server.coding_worker.provider import (
     FakeCodingAgentProvider,
     ProviderEvent,
+    ProviderEventKind,
     ProviderCheckpoint,
     ProviderOpenRequest,
     ProviderSession,
@@ -132,6 +133,23 @@ class _LostTurnReceiptProvider(FakeCodingAgentProvider):
         return await super().checkpoint(session)
 
 
+class _SteeringProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: list[str] = []
+        self.first_turn_started = asyncio.Event()
+        self.release_first_turn = asyncio.Event()
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        self.messages.append(text)
+        if len(self.messages) == 1:
+            self.first_turn_started.set()
+            await self.release_first_turn.wait()
+        yield ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)
+
+
 def _service_with_harness(
     tmp_path: Path, provider: FakeCodingAgentProvider
 ) -> tuple[CodingWorkerService, ToolBroker]:
@@ -236,6 +254,42 @@ async def test_model_stop_cannot_complete_without_acceptance_runner(tmp_path: Pa
     terminal = await service.wait_for(task.task_id, lambda item: item.state is TaskState.BLOCKED)
     assert terminal.state is not TaskState.COMPLETED
     assert [event.type for event in service.store.list_events(task.task_id)].count("task_state") >= 3
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_running_steering_is_delivered_once_at_next_safe_turn_boundary(
+    tmp_path: Path,
+) -> None:
+    provider = _SteeringProvider()
+    service = _service(tmp_path, provider)
+    task = await service.create_task(
+        Origin(module="test", object_id="steering"), _request("steering")
+    )
+    await asyncio.wait_for(provider.first_turn_started.wait(), timeout=2)
+
+    await service.append_message(task.task_id, "Read calculator.py before retesting.")
+    assert provider.messages == ["Complete steering"]
+    provider.release_first_turn.set()
+
+    terminal = await service.wait_for(
+        task.task_id, lambda item: item.state is TaskState.BLOCKED
+    )
+    assert terminal.reason == "acceptance_runner_pending"
+    assert provider.messages == [
+        "Complete steering",
+        (
+            "User steering received at a safe tool boundary. Follow it without "
+            "weakening the immutable acceptance contract.\n\n"
+            "Read calculator.py before retesting."
+        ),
+    ]
+    assert [
+        item.content for item in service.store.list_messages(task.task_id)
+    ] == ["Complete steering", "Read calculator.py before retesting."]
+    assert [
+        event.type for event in service.store.list_events(task.task_id)
+    ].count("steering_scheduled") == 1
     await service.shutdown()
 
 
@@ -536,6 +590,7 @@ async def test_active_time_budget_survives_restart_and_excludes_waiting(
                 resume_phase=None,
                 resume_context=None,
                 completed_turns=0,
+                message_cursor=0,
             ),
             timeout=2,
         )

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -98,6 +98,16 @@ class _RestoreTrackingProvider(FakeCodingAgentProvider):
         return await super().restore(request, checkpoint)
 
 
+class _OpenTrackingProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.open_request: ProviderOpenRequest | None = None
+
+    async def open(self, request: ProviderOpenRequest) -> ProviderSession:
+        self.open_request = request
+        return await super().open(request)
+
+
 def _service_with_harness(
     tmp_path: Path, provider: FakeCodingAgentProvider
 ) -> tuple[CodingWorkerService, ToolBroker]:
@@ -202,6 +212,26 @@ async def test_model_stop_cannot_complete_without_acceptance_runner(tmp_path: Pa
     terminal = await service.wait_for(task.task_id, lambda item: item.state is TaskState.BLOCKED)
     assert terminal.state is not TaskState.COMPLETED
     assert [event.type for event in service.store.list_events(task.task_id)].count("task_state") >= 3
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_provider_request_binds_tree_and_policy_tool_allowlist(
+    tmp_path: Path,
+) -> None:
+    provider = _OpenTrackingProvider()
+    service = _service(tmp_path, provider)
+    task = await service.create_task(
+        Origin(module="test", object_id="provider-contract"),
+        _request("provider-contract"),
+    )
+    await service.wait_for(task.task_id, lambda item: item.state is TaskState.BLOCKED)
+
+    request = provider.open_request
+    assert request is not None and len(request.workspace_tree_hash or "") == 64
+    assert "read_file" in request.tool_allowlist
+    assert "write_file" not in request.tool_allowlist
+    assert "run_shell" not in request.tool_allowlist
     await service.shutdown()
 
 

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -312,6 +312,78 @@ async def test_dedicated_slots_queue_third_task_and_resume_on_original_slot(
 
 
 @pytest.mark.asyncio
+async def test_route_catalog_pins_tasks_to_provider_slots(tmp_path: Path) -> None:
+    blocker = asyncio.Event()
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    broker = WorkspaceBroker(
+        tmp_path / "control",
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {("source-01", "revision-01"): {"main.py": b"print('ok')\n"}}
+            )
+        },
+        id_key=b"r" * 32,
+        slot_roots={
+            "slot-a": tmp_path / "slot-a",
+            "slot-b": tmp_path / "slot-b",
+        },
+    )
+    service = CodingWorkerService(
+        store=store,
+        workspace_broker=broker,
+        provider=FakeCodingAgentProvider(block=blocker),
+        max_active_tasks=2,
+        route_slots={
+            "coding/default": ("slot-a",),
+            "coding/quality": ("slot-b",),
+        },
+    )
+    origin = Origin(module="test", object_id="route-slots")
+    default_task = await service.create_task(origin, _request("route-default"))
+    quality_task = await service.create_task(
+        origin,
+        _request("route-quality").model_copy(
+            update={"model_route": "coding/quality"}
+        ),
+    )
+    queued_default = await service.create_task(
+        origin, _request("route-default-queued")
+    )
+
+    for task in (default_task, quality_task):
+        await service.wait_for(task.task_id, lambda item: item.state is TaskState.RUNNING)
+    assert broker.workspace_slot(
+        store.get_task(default_task.task_id).workspace_id or ""
+    ) == "slot-a"
+    assert broker.workspace_slot(
+        store.get_task(quality_task.task_id).workspace_id or ""
+    ) == "slot-b"
+    assert store.get_task(queued_default.task_id).state is TaskState.QUEUED
+
+    await service.pause(quality_task.task_id)
+    await asyncio.sleep(0.05)
+    assert store.get_task(queued_default.task_id).state is TaskState.QUEUED
+    await service.cancel(default_task.task_id)
+    await service.wait_for(
+        queued_default.task_id, lambda item: item.state is TaskState.RUNNING
+    )
+    assert broker.workspace_slot(
+        store.get_task(queued_default.task_id).workspace_id or ""
+    ) == "slot-a"
+
+    with pytest.raises(WorkerConflictError) as unavailable:
+        await service.create_task(
+            origin,
+            _request("route-unknown").model_copy(
+                update={"model_route": "coding/unknown"}
+            ),
+        )
+    assert unavailable.value.code == "model_route_unavailable"
+    await service.cancel(queued_default.task_id)
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_failed_acceptance_is_repaired_and_retested_before_completion(
     tmp_path: Path,
 ) -> None:

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import sys
+import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 
@@ -468,6 +469,77 @@ async def test_required_check_failure_exhausts_turn_budget_without_completion(
     assert limited.state is not TaskState.COMPLETED
     assert len(service.store.list_evidence(task.task_id)) == 2
     await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_active_time_budget_survives_restart_and_excludes_waiting(
+    tmp_path: Path,
+) -> None:
+    key = Fernet.generate_key()
+    root = tmp_path / "worker"
+    now = [0.0]
+    first_store = CodingWorkerStore(root, master_key=key, clock=lambda: now[0])
+    request = _request("active-time-budget").model_copy(
+        update={"budget": TaskBudget(max_seconds=30)}
+    )
+    task = first_store.create_task(
+        TaskSpec(
+            **request.model_dump(),
+            origin=Origin(module="test", object_id="active-time-budget"),
+        )
+    )
+    first_store.transition(task.task_id, TaskState.PREPARING)
+    now[0] = 10.0
+    first_store.transition(task.task_id, TaskState.RUNNING)
+    now[0] = 20.0
+    first_store.transition(task.task_id, TaskState.WAITING_APPROVAL)
+    now[0] = 80.0
+    first_store.transition(task.task_id, TaskState.RUNNING)
+    now[0] = 89.95
+
+    restarted = CodingWorkerStore(root, master_key=key, clock=lambda: now[0])
+    assert restarted.get_task(task.task_id).state is TaskState.INTERRUPTED
+    assert restarted.active_runtime_seconds(task.task_id) == pytest.approx(29.95)
+    now[0] = 150.0
+    assert restarted.active_runtime_seconds(task.task_id) == pytest.approx(29.95)
+
+    started = time.monotonic()
+    restarted._clock = lambda: 150.0 + (time.monotonic() - started)
+    workspace = WorkspaceBroker(
+        root,
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {("source-01", "revision-01"): {"main.py": b"print('ok')\n"}}
+            )
+        },
+        id_key=b"r" * 32,
+    )
+    provider = FakeCodingAgentProvider(block=asyncio.Event())
+    service = CodingWorkerService(
+        store=restarted,
+        workspace_broker=workspace,
+        provider=provider,
+    )
+    restarted.transition(task.task_id, TaskState.QUEUED)
+    restarted.transition(task.task_id, TaskState.PREPARING)
+    running = restarted.transition(task.task_id, TaskState.RUNNING)
+    session = ProviderSession(
+        session_id="active-time-budget-session",
+        task_id=task.task_id,
+        provider_capabilities=await provider.capabilities(),
+    )
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(
+            service._drive_session(
+                running,
+                session,
+                resume_phase=None,
+                resume_context=None,
+                completed_turns=0,
+            ),
+            timeout=2,
+        )
+    assert restarted.active_runtime_seconds(task.task_id) >= 30
 
 
 async def _checkpointed_task(

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -108,6 +108,29 @@ class _OpenTrackingProvider(FakeCodingAgentProvider):
         return await super().open(request)
 
 
+class _LostTurnReceiptProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.message_count = 0
+        self.checkpoint_count = 0
+        self.repair: Callable[[], Awaitable[None]] | None = None
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        self.message_count += 1
+        if self.message_count == 1 and self.repair is not None:
+            await self.repair()
+        async for event in super().message(session, text):
+            yield event
+
+    async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
+        self.checkpoint_count += 1
+        if self.checkpoint_count == 1:
+            raise OSError("simulated provider receipt loss")
+        return await super().checkpoint(session)
+
+
 def _service_with_harness(
     tmp_path: Path, provider: FakeCodingAgentProvider
 ) -> tuple[CodingWorkerService, ToolBroker]:
@@ -535,4 +558,50 @@ async def test_resume_rejects_workspace_changed_after_checkpoint(tmp_path: Path)
     )
     assert blocked.reason == "checkpoint_workspace_changed"
     assert provider.restore_count == 0
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_completed_provider_turn_is_reconciled_before_any_replay(
+    tmp_path: Path,
+) -> None:
+    provider = _LostTurnReceiptProvider()
+    service, broker = _service_with_harness(tmp_path, provider)
+    request = _request("lost-turn-receipt").model_copy(
+        update={"policy_profile": PolicyProfile.DEVELOP}
+    )
+    task = await service.create_task(
+        Origin(module="test", object_id="lost-turn-receipt"), request
+    )
+
+    async def repair() -> None:
+        content = "print('reconciled')\n"
+        await broker.execute(
+            task_id=task.task_id,
+            operation_id="lost-turn-write",
+            tool_name="write_file",
+            arguments={
+                "path": "main.py",
+                "content": content,
+                "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+            },
+        )
+
+    provider.repair = repair
+    blocked = await service.wait_for(
+        task.task_id,
+        lambda item: item.state is TaskState.BLOCKED,
+    )
+    assert blocked.reason == "checkpoint_failed"
+    assert service.store.latest_checkpoint(task.task_id) is None
+    assert provider.message_count == 1
+
+    await service.resume(task.task_id)
+    completed = await service.wait_for(
+        task.task_id,
+        lambda item: item.state is TaskState.COMPLETED,
+    )
+    assert completed.reason is None
+    assert provider.message_count == 1
+    assert service.store.get_operation("lost-turn-write").state.value == "completed"
     await service.shutdown()

--- a/server/tests/test_coding_worker_shell_executor.py
+++ b/server/tests/test_coding_worker_shell_executor.py
@@ -168,6 +168,24 @@ async def test_shell_rpc_replays_stream_frames_before_terminal_result(
 
 
 @pytest.mark.asyncio
+async def test_executor_health_probe_is_stateless_while_slot_is_bound(
+    tmp_path: Path,
+) -> None:
+    executor, _, _ = _executor(tmp_path)
+    server = ExecutorRPCServer(executor, token="x" * 48)
+
+    await server._dispatch(
+        "bind_task", {"task_id": "task_one", "workspace_id": "workspace_one"}
+    )
+    assert await server._dispatch("health", {}) == {"healthy": True}
+    assert server._task_id == "task_one"
+    assert server._workspace_id == "workspace_one"
+    await server._dispatch(
+        "close_task", {"task_id": "task_one", "workspace_id": "workspace_one"}
+    )
+
+
+@pytest.mark.asyncio
 async def test_stopping_one_task_interrupts_only_its_shell_process_group(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## 结果

将尚未进入主线的 V15 顶层分支定向重放到最新 main，并补齐 Gate 0 审计发现的恢复与执行缺口。本 PR 仍为 Draft；真实双 Provider、逐组件重启、冻结 AcceptanceContract 与 v13 Host 写回人工验收完成前不得转 Ready 或合并。

## 范围

- 纳入原 V15 顶层 13 个逻辑提交；range-diff 其中 12 个 patch 完全等价，唯一上下文差异为 THIRD_PARTY_NOTICES 同时保留主线 PenguinHarness 与 V15 Claude notice。
- 修复延迟审批后的确定恢复：原 runner 存在则回到 running；跨重启无 runner 则进入 interrupted，必须显式 resume。
- 活动时间预算改为持久累计，排队、等待批准和中断时间不计入，跨重启不重置。
- 修复 Executor 精确任务重绑定、无状态健康探针、Docker Desktop Provider DNS 代理显式开关，以及工具边界一次性结算 steering。

## 自动验证

- Coding Worker Linux/no-network：152 passed, 5 skipped。
- Agent Workspace + Coding Linux/no-network：819 passed, 14 skipped。
- 最新 main (#172) Agent Workspace：44 passed。
- 全后端：2861 passed, 29 skipped；唯一 	est_skill_finder 红项为现有 modelmirror-server Node 20 无法直接导入 .ts，同测试在宿主 Node 24 为 1 passed。
- Agency Worker 前置 build 后原 10 个环境红项：32 passed。
- 前端：230 passed；生产 build 通过。首轮一个 5 秒并行超时已单文件 9 passed 并在第二轮全量通过。
- V14 + V15 Claude Compose config --quiet 通过，未启动容器。
- git diff --check、逐提交 <=5 文件、敏感模式与禁止产物扫描通过。

## 人工 Gate 0（未执行）

- [ ] 用后端冻结的完整 Python AcceptanceContract 跑真实 OpenCode。
- [ ] 用后端冻结的完整 React AcceptanceContract 跑真实 OpenCode。
- [ ] 同任务跑真实 Claude Provider，验证凭据/Provider/Executor 隔离。
- [ ] 等待审批时逐个重启 Server、Provider、Executor，确认显式恢复且副作用唯一。
- [ ] 验证跨重启累计 active-time 预算，批准等待时间不计入。
- [ ] Host Snapshot 经 v13 apply/commit/undo 完整闭环。
- [ ] Console 无 P0/P1，任务目标与 AcceptanceContract 一致。

## 回退

关闭 CODING_WORKER_V15_ENABLED、Shell、代码智能及 Claude 开关并停止接收新 V15 任务；保留 V14 Store、Workspace、Evidence 与 v13 Recovery，不自动重放或删除已有数据。

## V16 边界

本 PR 只收口 V15 Gate 0。V16 的 Parity Harness、单 Agent 补齐和 Subagent 尚未开工；必须等本 PR 人工验收并合入最新 main 后，从新基线创建三个顺序 PR。