### PR TITLE
feature: 完成 MCP Wave 26-27 受控适配

### DIFF
--- a/client/src/data/mcpCatalogExpansionV3.generated.ts
+++ b/client/src/data/mcpCatalogExpansionV3.generated.ts
@@ -183,7 +183,7 @@ export const mcpCatalogExpansionV3 = [
     "repoUrl": "https://github.com/githejie/mcp-server-calculator",
     "category": "通用工具",
     "description": "githejie/mcp-server-calculator 🐍 🏠 - This server enables LLMs to use calculator for precise numerical calculations",
-    "readmeSummary": "githejie/mcp-server-calculator 已通过 Wave 24 双源公开仓库、许可证和维护门禁；当前判定为 planned，原因码 planned-wave26-offline-file-or-deterministic-artifact。",
+    "readmeSummary": "githejie/mcp-server-calculator 已通过 Wave 24 双源公开仓库、许可证和维护门禁；当前判定为 ready，原因码 ready-wave26a-calculator。",
     "stars": 155,
     "language": "Python",
     "verifiedAt": "2026-08-12",
@@ -192,10 +192,7 @@ export const mcpCatalogExpansionV3 = [
       "Python",
       "MIT"
     ],
-    "requirements": [
-      "sealed-workspace",
-      "external-runtime"
-    ],
+    "requirements": [],
     "usageExamples": [
       "查看 Calculator 的上游用途和当前适配判定",
       "完成对应安全门槛后再进行隔离连接和代表调用验收"
@@ -206,18 +203,17 @@ export const mcpCatalogExpansionV3 = [
     ],
     "adaptation": {
       "wave": 26,
-      "availability": "planned",
+      "availability": "ready",
       "connectionKind": "sandboxed-stdio",
       "risk": "medium",
       "requiredCapabilities": [
-        "scoped-filesystem",
         "network-disabled",
-        "artifact-cleanup",
+        "bounded-runtime-surface",
+        "schema-drift-recovery",
         "resource-limits"
       ],
       "limitations": [
-        "可继续评估断网、封存输入、确定性处理与服务端复制产物的文件子集；在路径隔离、资源限额、超时、清理和真实镜像验收前保持 planned。",
-        "当前仅登记产品身份与适配判定；没有命令、端点、凭据槽、工具策略、运行镜像或默认 allowlist，任何功能开关都不能使该条目可执行。"
+        "已冻结单一 calculate 工具、断网数值 AST、复杂度与结果上限，并通过真实 UDS、超时回收、默认拒绝和用户验收。"
       ]
     }
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
     network_mode: none
     environment:
       MCP_FILES_MAX_SESSIONS: "4"
-      MCP_FILE_ALLOWED_ADAPTERS: basic-memory-mcp,excel-mcp-server,git-mcp,markitdown-mcp,office-parser-mcp,output-renderer-mcp,zcaceres-markdownify-mcp,vivekvells-mcp-pandoc,antvis-mcp-server-chart,cyberchitta-llm-context-py,haris-musa-excel-mcp-server,dataeval-dingo,ozgurcd-gograph
+      MCP_FILE_ALLOWED_ADAPTERS: basic-memory-mcp,excel-mcp-server,git-mcp,markitdown-mcp,office-parser-mcp,output-renderer-mcp,zcaceres-markdownify-mcp,vivekvells-mcp-pandoc,antvis-mcp-server-chart,cyberchitta-llm-context-py,haris-musa-excel-mcp-server,dataeval-dingo,ozgurcd-gograph,githejie-mcp-server-calculator
       MCP_FILES_SOCKET_PATH: /run/modelmirror-files-mcp/files-mcp.sock
       MCP_FILE_INPUT_ROOT: /inputs
       MCP_FILE_OUTPUT_ROOT: /outputs

--- a/docs/MCP_CATALOG_EXPANSION_WAVE24_REVIEW.md
+++ b/docs/MCP_CATALOG_EXPANSION_WAVE24_REVIEW.md
@@ -5,7 +5,7 @@
 ## 结论
 
 - 用户已批准本次固定 100 项清单进入静态产品目录。
-- 判定：`4 ready / 42 planned / 54 blocked`。
+- 判定：`5 ready / 41 planned / 54 blocked`。
 - Wave 24 首次导入不创建 ready；后续只有完成真实运行证据与用户验收的精确 ID 才能晋级。
 - Wave 25A 三项和 Wave 25B Fantasy PL 共四项已晋级；命令、工具策略与 allowlist 仍由服务端显式冻结，不由生成器产生。
 - 与原有 200 项合并后产品目录总数保持 300。
@@ -23,7 +23,7 @@
 | 2 | `ergut-mcp-bigquery-server` | 数据库 | planned | Wave 26 / `planned-wave26-token-readonly-preflight` |
 | 3 | `executeautomation-mcp-playwright` | 浏览器与网页 | blocked | Wave 24 / `blocked-superseded-existing-controlled-capability` |
 | 4 | `fradser-mcp-server-apple-reminders` | 效率与协作 | blocked | Wave 24 / `blocked-desktop-browser-or-device-control` |
-| 5 | `githejie-mcp-server-calculator` | 通用工具 | planned | Wave 26 / `planned-wave26-offline-file-or-deterministic-artifact` |
+| 5 | `githejie-mcp-server-calculator` | 通用工具 | ready | Wave 26 / `ready-wave26a-calculator` |
 | 6 | `modelscope-funasr` | 多媒体 | planned | Wave 26 / `planned-wave26-offline-file-or-deterministic-artifact` |
 | 7 | `muvon-octocode` | 开发与代码 | blocked | Wave 24 / `blocked-superseded-existing-controlled-capability` |
 | 8 | `narumiruna-yfinance-mcp` | 金融与市场 | planned | Wave 25 / `planned-wave25-anonymous-public-read-contract` |

--- a/docs/MCP_CATALOG_ROADMAP.md
+++ b/docs/MCP_CATALOG_ROADMAP.md
@@ -15,7 +15,7 @@
 - [Awesome-MCP-ZH](https://github.com/yzfly/Awesome-MCP-ZH)
 - [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers)
 
-截至 2026-08-12，产品目录为 300 个 MCP 条目、18 个分类。第一阶段原有 100 项保持不变：批次 8 的两个 Python 执行上游均未通过门槛；批次 9 仅 Terraform 公共 Registry 只读子集通过；批次 10 暂缓到多租户主体边界完善后；批次 11 的 13 个桌面/宿主条目因缺少可信本机桥接、实例所有权证明和逐应用授权而全部受阻。第二阶段新增 100 项经批次 13 逐项判定，批次 14—15 提升五项固定只读子集，批次 16A—17A 再提升八项公共研究能力，批次 18A—18B 再提升六项确定性文件产物/分析能力，批次 19A 再提升三项只读数据服务；批次 20 只晋级 GoGraph，并将另外两个代码索引实现收敛为 superseded blocked。Wave 23 将 Vectorize 因持续 MIT/ISC 元数据冲突转为 blocked，并在最新主线复验后晋级 Milvus、Neo4j 与 ArcadeDB。第三阶段 Wave 24 将用户批准的双源固定 100 项先以静态 `planned/blocked` 身份纳入目录；Wave 25A 将通过真实隔离与用户验收的 DexPaprika、Chess、AniList 三项精确晋级，Wave 25B 又晋级 Fantasy PL；MCP-NixOS 因固定匿名后端依赖嵌入凭据转为 blocked，Reddit Buddy 因真实提供方 429 保持 planned。该批现为 **4 ready / 42 planned / 54 blocked**，产品目录为 **75 ready / 69 planned / 156 blocked**。
+截至 2026-08-12，产品目录为 300 个 MCP 条目、18 个分类。第一阶段原有 100 项保持不变：批次 8 的两个 Python 执行上游均未通过门槛；批次 9 仅 Terraform 公共 Registry 只读子集通过；批次 10 暂缓到多租户主体边界完善后；批次 11 的 13 个桌面/宿主条目因缺少可信本机桥接、实例所有权证明和逐应用授权而全部受阻。第二阶段新增 100 项经批次 13 逐项判定，批次 14—15 提升五项固定只读子集，批次 16A—17A 再提升八项公共研究能力，批次 18A—18B 再提升六项确定性文件产物/分析能力，批次 19A 再提升三项只读数据服务；批次 20 只晋级 GoGraph，并将另外两个代码索引实现收敛为 superseded blocked。Wave 23 将 Vectorize 因持续 MIT/ISC 元数据冲突转为 blocked，并在最新主线复验后晋级 Milvus、Neo4j 与 ArcadeDB。第三阶段 Wave 24 将用户批准的双源固定 100 项先以静态 `planned/blocked` 身份纳入目录；Wave 25A 将通过真实隔离与用户验收的 DexPaprika、Chess、AniList 三项精确晋级，Wave 25B 又晋级 Fantasy PL；MCP-NixOS 因固定匿名后端依赖嵌入凭据转为 blocked，Reddit Buddy 因真实提供方 429 保持 planned。Wave 26A 进一步将断网 Calculator 契约晋级，ImageSorcery 暂不放行；Wave 26B 的 Google News 与 Naver 因尚无真实账号证据维持 staged planned。Wave 27 已完成 GreptimeDB 原生只读账号和隔离 sidecar 验收，但在用户批准晋级前仍保持默认关闭的 planned。该批现为 **5 ready / 41 planned / 54 blocked**，产品目录为 **76 ready / 68 planned / 156 blocked**。
 
 批次 0—11 的第一阶段交付边界、状态分布、阶段二准入条件和可复现验收命令统一记录在 [MCP 适配第一阶段收口](./MCP_ADAPTER_PHASE_ONE_CLOSEOUT.md)。
 
@@ -38,6 +38,8 @@
 Wave 25A 已为 DexPaprika、Chess 与 AniList 完成匿名公共读取兼容层、隔离双轮与用户验收，三项已晋级 ready 并进入精确 allowlist；MCP-NixOS 因固定匿名后端依赖嵌入凭据转为 blocked。详见 [Wave 25A 匿名公共读取](./MCP_WAVE25A_ANONYMOUS_PUBLIC_READ.md)。
 
 Wave 25B 已为 Reddit Buddy 与 Fantasy PL 落盘公共只读契约。Fantasy PL 已完成两轮隔离真实调用和用户验收，现已晋级 ready 并加入精确 allowlist；Reddit Buddy 因公共 Atom 端点返回 429 保持 planned。详见 [Wave 25B 公共研究读取](./MCP_WAVE25B_PUBLIC_RESEARCH_READ.md)。
+
+Wave 26A 仅晋级断网 Calculator，ImageSorcery 继续 planned；Wave 26B 为 Google News 与 Naver 冻结 Token 只读契约，但因缺少真实账号代表调用继续 staged planned。Wave 27 仅推进 GreptimeDB：官方 v1.1.4 服务的原生 `ro` 账号、两轮 UDS 代表调用、写拒绝、provider timeout 和精确清理已通过，当前等待用户验收后再决定是否晋级。详见 [Wave 26A 离线文件](./MCP_WAVE26A_OFFLINE_FILES.md)、[Wave 26B Token 只读](./MCP_WAVE26B_TOKEN_READONLY.md) 与 [Wave 27 原生只读数据服务](./MCP_WAVE27_NATIVE_READONLY.md)。
 
 第二阶段已完成独立的双源目录审计、人工批准和逐项适配判定，固定解析两个上游清单的服务器实现章节，并对仓库身份、重复项、归档状态、许可证和最近维护时间执行 fail-closed 筛选。[100 项适配判定](./MCP_CATALOG_EXPANSION_REVIEW.md) 已写入前端发现目录与后端 manifest。十三项固定只读子集已经进入 Token Sidecar 或匿名公共读取 sidecar，批次 18A—18B 的六项确定性文件能力进入文件 sidecar，批次 19A 的三项只读数据服务进入数据库 sidecar；批次 17B 的四项仍处于默认关闭 staging，其余条目没有新增执行配置，且 14 个首轮复审条目已从 planned 收敛为 blocked。
 

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -83,7 +83,7 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 目录适配器安全默认值：
 
 - 前端不能提交 `server_command`、MCP URL、Header、环境变量名或工作目录。
-- 当前目录状态为 **75 ready / 69 planned / 156 blocked**。第二阶段新增 100 项由批次 12 纳入目录，批次 14—20 共将其中 23 项提升为 ready；Wave 23 将 Vectorize 因 MIT/ISC 许可证元数据冲突转为 blocked，并晋级三个真实复验的图数据库适配器。Wave 24 再以非执行状态导入固定 100 项；Wave 25A 的三个匿名公共读取候选和 Wave 25B 的 Fantasy PL 已通过隔离与用户验收并进入精确 allowlist，MCP-NixOS 因匿名后端依赖嵌入凭据转为 blocked。planned 与 blocked 项没有默认执行命令或端点，设置环境功能开关也不能绕过状态门槛。
+- 当前目录状态为 **76 ready / 68 planned / 156 blocked**。第二阶段新增 100 项由批次 12 纳入目录，批次 14—20 共将其中 23 项提升为 ready；Wave 23 将 Vectorize 因 MIT/ISC 许可证元数据冲突转为 blocked，并晋级三个真实复验的图数据库适配器。Wave 24 再以非执行状态导入固定 100 项；Wave 25A 的三个匿名公共读取候选和 Wave 25B 的 Fantasy PL 已通过隔离与用户验收并进入精确 allowlist，MCP-NixOS 因匿名后端依赖嵌入凭据转为 blocked；Wave 26A 又将断网 Calculator 契约精确晋级，ImageSorcery 仍为 planned。Wave 26B 的两个 Token 只读契约尚无真实账号证据；Wave 27 的 GreptimeDB 已通过原生只读服务隔离验收，但在用户批准晋级前仍为默认关闭的 staged planned。planned 与 blocked 项没有默认执行命令或端点，设置环境功能开关也不能绕过状态门槛。
 - 批次 13 的官方 Brave Search MCP Server v2.1.0 只开放 `brave_web_search` 与 `brave_local_search`。批次 14 新增官方 Kagi v1.0.2 的 `kagi_search_fetch`、`kagi_extract`，以及 arxiv-mcp-server v0.6.2 的 `search_papers`、`get_abstract` 原生只读兼容契约。批次 15 新增 Search1API v0.5.3 的 `search`、`news`、`trending`，以及 Live Tennis v1.4.0 的 8 项 FREE 层比分/赛程/目录工具；全部固定出口、工具 Schema、输出上限和服务端加密凭据槽，不运行可扩张能力的上游进程。
 - 批次 16A 复用 `mcp-public`：DuckDuckGo 只开放严格安全搜索元数据，shadcn/ui 只读取固定提交的组件目录/Git 元数据，Docker Hub 只开放匿名仓库搜索、仓库与标签元数据；三项已经人工验收并进入精确默认 allowlist。
 - 批次 16B 继续复用 `mcp-public`：BioMCP 只开放 Europe PMC、ClinicalTrials.gov 和 MyVariant.info 的公共文章/试验/变异元数据；SafeDep Vet 只接受规范化 npm/PyPI PURL，读取社区漏洞/许可证/恶意软件报告与公共 Registry 版本元数据。诊断上传、包下载或执行、SQL、任意 URL/Header/Registry 和认证租户均关闭；两项已完成人工验收并进入精确默认 allowlist。

--- a/docs/MCP_WAVE25A_ANONYMOUS_PUBLIC_READ.md
+++ b/docs/MCP_WAVE25A_ANONYMOUS_PUBLIC_READ.md
@@ -10,7 +10,7 @@ Wave 25A 从 Wave 24 的候选中复核四项匿名公共读取能力：
 - `utensils-mcp-nixos` 转为 `blocked`：固定 v3.0.0 使用的 NixOS 搜索后端对匿名访问返回 401，且上游源码包含 Basic Auth 凭据。本项目不复制该凭据、不新增凭据槽，也不更换后端冒充原产品。
 - `public_proxy.py`、public sidecar 默认 allowlist、生产 Compose allowlist 和目录运行时 manifest 只增加这三个精确 ID；没有开放其他 Wave 24 项。
 
-Wave 25B 后续又验收并晋级 Fantasy PL，因此当前 Wave 24 新增目录为 **4 ready / 42 planned / 54 blocked**，全目录为 **75 ready / 69 planned / 156 blocked**。Wave 25A 本身的三个精确 ID 和回退边界保持不变。
+Wave 25B 后续又验收并晋级 Fantasy PL；在 Wave 25B 完成时，Wave 24 新增目录为 **4 ready / 42 planned / 54 blocked**，全目录为 **75 ready / 69 planned / 156 blocked**。Wave 25A 本身的三个精确 ID 和回退边界保持不变，后续批次的晋级不改写该历史快照。
 
 ## 2. 固定身份与公开工具
 

--- a/docs/MCP_WAVE25B_PUBLIC_RESEARCH_READ.md
+++ b/docs/MCP_WAVE25B_PUBLIC_RESEARCH_READ.md
@@ -7,7 +7,7 @@ Wave 25B 只选择了两项能够在固定公共域名、无凭据、纯读取�
 - `karanb192-reddit-mcp-buddy`：锁定 `v1.1.14` / commit `e2d3f3fa1ab281a1ef872eeaea86134bbad2c7ec` / MIT，只开放 `browse_subreddit`、`search_reddit`。实现只访问 `www.reddit.com` 的匿名 Atom feed，不开放任意 URL、帖子详情、用户画像、评论树或账号操作。
 - `rishijatia-fantasy-pl-mcp`：锁定 `v0.1.7` / commit `fdaef005143347455fc500cb1f934d451f95251a` / MIT，只开放 `search_fpl_players`、`get_player_information`、`list_fpl_fixtures`。实现只访问 `fantasy.premierleague.com` 官方公开 API，不开放登录、经理队伍、联赛、阵容、转会或建议工具。
 
-用户验收后，Fantasy PL 已晋级 `ready` 并加入 `public_proxy.py`、Compose 与 sidecar 三处精确默认 allowlist；Reddit Buddy 继续保持 `planned`，没有可执行 manifest 或 allowlist 入口。当前 Wave 24 新增目录为 **4 ready / 42 planned / 54 blocked**，全目录为 **75 ready / 69 planned / 156 blocked**。
+用户验收后，Fantasy PL 已晋级 `ready` 并加入 `public_proxy.py`、Compose 与 sidecar 三处精确默认 allowlist；Reddit Buddy 继续保持 `planned`，没有可执行 manifest 或 allowlist 入口。Wave 25B 完成时，Wave 24 新增目录为 **4 ready / 42 planned / 54 blocked**，全目录为 **75 ready / 69 planned / 156 blocked**；后续批次的晋级不改变本批验收结论。
 
 - Fantasy PL 已在 fresh 隔离镜像中完成两轮 initialize、tools/list、三个代表工具、拒绝未公开工具、取消超时、手动 sidecar 重启与工作目录/容器/卷精确清理，并通过用户验收。
 - Reddit Buddy 的直接匿名 Atom 调用曾成功返回三条结果，但正式烟测随后命中提供方 `HTTP 429`，再次诊断时首个 feed 调用仍受限。因此不宣称真实门槛通过，不加入 allowlist，保持 `planned` 等待上游限流窗口和代表调用重新验证。

--- a/docs/MCP_WAVE26A_OFFLINE_FILES.md
+++ b/docs/MCP_WAVE26A_OFFLINE_FILES.md
@@ -1,0 +1,108 @@
+# MCP Wave 26A：离线文件与确定性工具
+
+## 当前结论
+
+本单元在隔离分支中为两个候选建立了文件 sidecar 兼容契约；用户验收后仅 Calculator
+晋级，ImageSorcery 继续 **staged、默认拒绝**：
+
+| 目录 ID | 上游冻结 | staged 工具 | 状态 |
+| --- | --- | --- | --- |
+| `githejie-mcp-server-calculator` | 0.2.1 / `3dcaedcd58867206627d121092b401728db202da` / MIT | `calculate` | 用户验收通过，目录晋级 ready，并加入精确文件 sidecar allowlist |
+| `sunriseapps-imagesorcery-mcp` | 0.12.0 / `2f77957a0671a5cf30d90285c7024ae229d86917` / MIT | `get_metainfo`、`resize`、`crop`、`rotate` | staged 验收通过但暂不放行；目录继续 planned/default-deny |
+
+两项都进入 `mcp-files` 镜像内部 builder 集合，但只有 Calculator 进入生产
+`file_proxy.py`、Compose `MCP_FILE_ALLOWED_ADAPTERS`、目录可执行 manifest 与
+`FILE_PROJECTS` 空工作区配置。ImageSorcery 仍未进入上述任何生产入口，并保留在
+`STAGED_FILE_ADAPTERS` 中；普通目录连接会在子进程启动前拒绝它。
+
+## 固定边界
+
+### Calculator
+
+- 保留上游 0.2.1 的单一 `calculate(expression)` 产品身份。
+- 只允许常量、`+ - * / // % **`、正负号、`pi/e/tau` 与固定数学函数。
+- 表达式最多 256 字符、64 个 AST 节点、16 层；幂指数、底数和结果绝对值均
+  有界，NaN/Infinity fail closed。
+- 属性访问、import、任意函数、列表/字典/集合、推导式、变量、文件、网络与
+  子进程全部不可发现。
+- 工具为纯 `read`，不会创建工作区文件或产物。
+
+### ImageSorcery
+
+- 保留上游核心的图像元数据、缩放、裁剪和旋转身份；明确标注为独立兼容契约，
+  不宣称运行了上游包。
+- 客户端只提交 opaque `file_id` 和受限数值参数，不接受 `input_path`、
+  `output_path`、URL、Header、env、命令或动态配置。
+- 仅接收单帧 JPEG/PNG/WebP，输入不超过 16 MiB；宽高不超过 8192，输入/输出
+  不超过 2500 万像素，产物不超过 32 MiB。
+- 源文件只读；变换结果总是以服务端独占创建的 PNG 新文件写入受控产物目录，
+  绝不覆盖输入。
+- detect/find/OCR、模型下载、遥测、持久配置、prompt/resource、overlay、任意
+  绘制与路径工具全部不开放。
+- 三个变换工具均为 `artifact-create`，管理器不得自动重发；结果不明确时仍按
+  `unknown_outcome` 处理。
+
+## 本单元未晋级项
+
+- `nameetp-pdfmux`：GitHub v1.8.7 与 PyPI 最新 1.8.2 不一致，且产品身份依赖
+  有明确版本约束的多引擎 PyMuPDF 自愈链。当前不安装、不兼容模拟，继续 planned。
+- `aimino-tech-opendocswork-mcp`：无固定 release，GPL-3.0，Office 读写和技能面过宽；
+  在无法冻结窄工具与产物行为前继续 planned。
+- FunASR、Skill Seekers、APKTool、Apple Health 等分别涉及模型下载/执行、网络抓取
+  与向量库、逆向工程或健康敏感数据，不进入本低风险单元。
+
+## Schema 冻结
+
+- Calculator：`fd720b0ecc719751f3d7fcf5702a3d2c1f7e77073de249cd812c3753bed35a9f`
+- ImageSorcery：`cba6ba696a976b5815e66c31b8ab02b47cf48a6d5bf7604d64ad8bb86b4bbfae`
+
+所有工具顶层 Schema 均为 `additionalProperties=false`。
+
+## 验收与回退
+
+验收必须使用重新构建的独立 `mcp-files` 镜像，并验证：真实 UDS
+`initialize/tools/list`、Schema、两轮代表调用、确定性 PNG、输入哈希不变、危险
+参数/工具拒绝、客户端 timeout 后进程组回收、默认拒绝和精确清理。容器必须
+`network=none`、只读根、UID/GID 65532、`cap_drop=ALL`、NNP，并使用临时 volume；
+不得启动共享栈。
+
+回退不涉及数据迁移：Calculator 需要从目录 ready 判定、`file_proxy.py`、Compose 精确
+allowlist 和空工作区登记中移除，再恢复为 planned；ImageSorcery 只需删除 staged builder、
+contract smoke、测试与本说明。两者都没有持久状态，回退不会改变既有文件或数据库。
+
+## 隔离验收证据
+
+2026-08-12 从本工作树重新构建 `modelmirror-mcp-files:wave26a-staged`，镜像
+manifest 为
+`sha256:9a67f3b9994fe1f49401af85f0b7c465163663361e4ee3bb95796202c5254873`。
+构建期对 Wave 18A、18B、20 与 26A 的所有冻结 Schema 契约均重新校验通过。
+
+运行时使用 `network=none`、只读根、UID/GID 65532、`cap_drop=ALL`、NNP、
+128 PID、1 GiB、1.5 CPU 与 512 MiB `noexec` 临时目录。两个适配器各在两个
+全新 UDS/official SDK 会话完成 initialize、tools/list、Schema 与代表调用；
+ImageSorcery 三个 PNG 在两轮中逐字节一致，源 PNG 哈希不变。未公开工具、路径、
+URL、额外参数、代码执行表达式和资源越界均 fail closed；ImageSorcery 调用在
+1 ms 客户端 timeout 后，UDS 关闭触发整个子进程组回收。精确 smoke 容器已由
+`--rm` 删除且复核无同名残留。
+
+成功行：
+
+```text
+adapter=githejie-mcp-server-calculator rounds=2 artifacts=0
+adapter=sunriseapps-imagesorcery-mcp rounds=2 artifacts=3
+wave26_file_runtime_smoke=ok network=none source_immutable=true deterministic=true default_deny=true timeout=verified cleanup=verified
+```
+
+补充回归结果：
+
+- Wave 26A 定向测试：`8 passed`。
+- 受影响的 Wave 18A/18B/20、目录与文件工作区集合：`120 passed, 2 skipped`。
+- 按 CI 约束使用 Node 22 的完整后端命令：`2897 passed, 29 skipped`。
+- Agency Worker：7 个桥接测试与全部上游兼容测试通过。
+- 前端 `typecheck` 与生产构建通过；Vitest 为 `233 passed, 1 failed`，唯一失败是
+  本基线已有的 `NodePalette.test.ts` 过期断言（实现包含
+  `vision_understanding`，测试仍只接受两个知识节点），与本批文件 sidecar 变更无交集。
+- `docker compose config --quiet` 通过。
+
+以上证据与用户验收支持 Calculator 晋级 ready。ImageSorcery 当前是明确披露的窄
+兼容契约而非上游包运行时，继续 planned/default-deny；不得加入生产 allowlist。

--- a/docs/MCP_WAVE26B_TOKEN_READONLY.md
+++ b/docs/MCP_WAVE26B_TOKEN_READONLY.md
@@ -1,0 +1,50 @@
+# MCP Wave 26B：Token 只读数据适配
+
+## 结论
+
+Wave 26B 首个验收单元只实现两个默认关闭的 staged 兼容契约：
+
+- `chanmeng666-server-google-news`：固定 SerpAPI Google News 搜索；
+- `isnow890-naver-search-mcp`：固定 Naver Developer Center 的网页、新闻和博客搜索。
+
+两项仍为 `planned`，不进入生产 `MCP_TOKEN_ALLOWED_ADAPTERS`。在真实只读账号完成
+预检、代表调用、限流与超时验收之前，不得晋级 `ready`。
+
+## 冻结的上游身份
+
+| 目录 ID | 上游版本与提交 | 许可证 | 固定出口 |
+|---|---|---|---|
+| `chanmeng666-server-google-news` | 1.0.0 / `5ed14341ff6ef290e13bafa08abc12157bbe23a3` | MIT | `serpapi.com:443` |
+| `isnow890-naver-search-mcp` | 1.0.50 / `d7c7c58cab0de2692336b710727f1ee123270e6c` | MIT | `openapi.naver.com:443` |
+
+本地 sidecar 不安装或执行上述仓库包，只实现经审阅的产品身份子集。工具 Schema 摘要、
+凭据槽和固定 Host 保存在私有 sidecar 契约中，客户端不能提交 Host、Header、环境变量或
+动态 endpoint。
+
+## 允许与拒绝的能力
+
+Google News 仅开放 `google_news_search`，接受有长度限制的查询、国家、语言和结果数。
+上游的 topic、publication、story、section token 均不开放。SerpAPI Key 仅由加密槽映射
+到短生命周期环境变量，不出现在结果或日志中。
+
+Naver 仅开放 `search_webkr`、`search_news`、`search_blog`，分页最多 20 条、起点最多
+1000。只支持 classic Developer Center 凭据和 `openapi.naver.com`；Naver API Hub、
+DataLab、购物、图片、Local、知识社区、Cafe 和分类工具均不开放。
+
+两项输出都去除供应商 HTML 标记、限制字段和大小、拒绝包含 credential-like query 的
+结果链接。Provider 429 不自动重发。
+
+## 本批不实现的候选
+
+- BigQuery：真实查询会产生云资源读取和计费，等待项目/数据集 Scope 与费用上限；
+- Nutrient DWS：核心能力涉及云端上传、转换、签名或 OCR，不属于 Token 只读数据；
+- Massive/Polygon：当前产品身份依赖动态 endpoint 搜索、通用 `call_api` 和本地 SQL
+  控制面，无法在保持身份的同时收窄为固定小工具面。
+
+## 验收和回退
+
+当前可执行验收仅包括离线 initialize、tools/list、Schema、固定请求投影、429、Secret
+脱敏、额外参数/工具拒绝、默认 allowlist 拒绝、断开与清理。供应商代表调用尚未执行，
+这是保持 `planned` 的明确边界。
+
+回退只需移除这两个 staged 私有契约及测试；生产 allowlist、共享栈和持久数据均未变化。

--- a/docs/MCP_WAVE27_NATIVE_READONLY.md
+++ b/docs/MCP_WAVE27_NATIVE_READONLY.md
@@ -1,0 +1,64 @@
+# MCP Wave 27：原生只读数据服务
+
+## 当前结论
+
+Wave 27 首个验收单元仅推进 `greptimeteam-greptimedb-mcp-server`。它当前仍为
+`planned`，私有 sidecar 契约已编译但默认关闭，未加入生产
+`MCP_DATABASE_ALLOWED_ADAPTERS`。只有真实 GreptimeDB 原生只读账号、代表调用、
+限流/超时、断开、重启和清理全部通过，并经人工验收后，才能晋级 `ready`。
+
+VictoriaMetrics 与 Chroma 本轮不用于补足数量。VictoriaMetrics 的 bearer token
+出口与动态目标边界尚未形成可证明的最小契约；Chroma 尚未证明原生服务端只读主体。
+Snowflake、Confluent、dbt、Superset、OpenTelemetry 和 PlanetScale 等候选继续保持
+`planned`，等待真实只读账号、固定资源范围或更窄的产品身份。
+
+## 冻结的上游身份
+
+- 项目：`GreptimeTeam/greptimedb-mcp-server`
+- 版本：`v0.5.1`
+- 提交：`ba3b732fe2113378f41c391da880b9ab75f2d862`
+- 许可证：MIT
+- 工具 Schema SHA-256：
+  `86c8dbbfda387925e345fde14bdfdb3681c2b02e5072e5b84bfb7000e1aef65c`
+
+ModelMirror 不安装或运行上游 MCP 包，只实现经审阅的同产品只读子集。上游身份用于
+锁定产品语义、版本、许可和副作用边界；运行时通过 GreptimeDB 的固定 HTTP SQL
+接口访问项目绑定资源。
+
+## 暴露的工具
+
+- `describe_table()`：仅描述配置中绑定的一张表；
+- `query_range(start, end, limit=200)`：仅读取绑定的时间列和值列，时间范围最多
+  24 小时，返回最多 200 行；
+- `health_check()`：执行固定的 `SELECT 1` 只读预检。
+
+客户端不能提交 SQL、TQL、查询表达式、数据库名、表名、列名、Host、URL、DSN、
+Header、环境变量或命令。所有 SQL 均由 sidecar 从已验证配置生成；标识符只允许
+受限字符集，时间会规范化为 UTC RFC3339。
+
+## 配置与凭据边界
+
+配置字段固定为 `host`、`port`、`database`、`table`、`time_column`、
+`value_column`、`tls_mode` 和 `username`；凭据槽固定为 `password`。生产只允许
+`verify-full`，明文模式仅在隔离测试同时设置专用测试开关时有效。Host 必须通过
+数据库 sidecar 的 DNS 全答案与管理员私网 allowlist 检查。
+
+默认 allowlist 排除该 ID，因此目录虽能展示 `planned` 条目，但不能准备、连接或
+执行。测试显式 allowlist 只作用于随机命名的隔离容器，不改变共享栈。
+
+## 验收门槛与回退
+
+隔离验收已使用官方 `greptime/greptimedb:v1.1.4`（manifest
+`sha256:9726587eac95d0360755254cd59a528dbf48abfdf268478aea6a644f62afe44c`）完成：
+原生 `ro` 账号读取返回 `HTTP 200 / code 0`，建表写入由服务端拒绝为
+`HTTP 403 / code 7006`；两次独立 UDS 会话均通过 initialize、tools/list、Schema、
+三项代表调用和负向工具门禁；确定性延迟 fixture 证明 provider timeout 在
+`10.5–16.0s` 观测窗口内先于 gateway 硬期限返回。会话后 sidecar 仅剩 PID1，随机
+命名容器、卷和网络清理为零残留。
+
+429、503 与 403 的固定错误分类由定向自动化测试覆盖；真实 GreptimeDB 没有被人为
+配置为产生 429。日志和公开 smoke 结果不含密码、Authorization、SQL 或行值。目录
+计数仍保持 `76 ready / 68 planned / 156 blocked`，等待用户验收后再决定晋级。
+
+回退无需数据迁移：移除私有契约与测试，或在晋级后从精确 allowlist 删除该 ID，
+恢复 `planned` 清单并断开相关目录会话即可。

--- a/docs/mcp-catalog-expansion-wave24/review-candidates.json
+++ b/docs/mcp-catalog-expansion-wave24/review-candidates.json
@@ -408,11 +408,11 @@
         },
         "latestRelease": null
       },
-      "decision": "deferred-planned",
-      "proposed_availability": "planned",
-      "decision_reason": "可继续评估断网、封存输入、确定性处理与服务端复制产物的文件子集；在路径隔离、资源限额、超时、清理和真实镜像验收前保持 planned。",
+      "decision": "accepted-ready",
+      "proposed_availability": "ready",
+      "decision_reason": "已冻结单一 calculate 工具、断网数值 AST、复杂度与结果上限，并通过真实 UDS、超时回收、默认拒绝和用户验收。",
       "catalog_id": "githejie-mcp-server-calculator",
-      "decision_reason_code": "planned-wave26-offline-file-or-deterministic-artifact",
+      "decision_reason_code": "ready-wave26a-calculator",
       "adapter_version": "",
       "adaptation_wave": 26
     },
@@ -6924,11 +6924,11 @@
     "classified_at": "2026-08-12",
     "classified_count": 100,
     "availability": {
-      "ready": 4,
-      "planned": 42,
+      "ready": 5,
+      "planned": 41,
       "blocked": 54
     },
-    "ready_boundary": "wave25-runtime-evidence-and-user-acceptance",
+    "ready_boundary": "per-adapter-runtime-evidence-and-user-acceptance",
     "non_ready_boundary": "no-command-endpoint-credential-tool-policy-or-allowlist"
   }
 }

--- a/scripts/mcp_catalog_integrate_wave24.py
+++ b/scripts/mcp_catalog_integrate_wave24.py
@@ -146,6 +146,24 @@ DECISION_GROUPS: dict[str, dict[str, Any]] = {
             "isnow890-naver-search-mcp",
         ),
     ),
+    "ready-wave26a-calculator": _group(
+        availability="ready",
+        wave=26,
+        reason=(
+            "已冻结单一 calculate 工具、断网数值 AST、复杂度与结果上限，"
+            "并通过真实 UDS、超时回收、默认拒绝和用户验收。"
+        ),
+        connection_kind="sandboxed-stdio",
+        risk="medium",
+        requirements=(),
+        capabilities=(
+            "network-disabled",
+            "bounded-runtime-surface",
+            "schema-drift-recovery",
+            "resource-limits",
+        ),
+        ids=("githejie-mcp-server-calculator",),
+    ),
     "planned-wave26-offline-file-or-deterministic-artifact": _group(
         availability="planned",
         wave=26,
@@ -163,7 +181,6 @@ DECISION_GROUPS: dict[str, dict[str, Any]] = {
             "resource-limits",
         ),
         ids=(
-            "githejie-mcp-server-calculator",
             "modelscope-funasr",
             "mckinsey-vizro",
             "openfate-ai-bazi-mcp",
@@ -438,7 +455,7 @@ def build_approved_payload(source: dict[str, Any]) -> dict[str, Any]:
         status: sum(item["proposed_availability"] == status for item in candidates)
         for status in ("ready", "planned", "blocked")
     }
-    if availability != {"ready": 4, "planned": 42, "blocked": 54}:
+    if availability != {"ready": 5, "planned": 41, "blocked": 54}:
         raise ValueError(f"unexpected Wave 24 classification: {availability}")
     payload.update(
         {
@@ -454,7 +471,7 @@ def build_approved_payload(source: dict[str, Any]) -> dict[str, Any]:
                 "classified_at": SNAPSHOT_DATE,
                 "classified_count": 100,
                 "availability": availability,
-                "ready_boundary": "wave25-runtime-evidence-and-user-acceptance",
+                "ready_boundary": "per-adapter-runtime-evidence-and-user-acceptance",
                 "non_ready_boundary": "no-command-endpoint-credential-tool-policy-or-allowlist",
             },
         }

--- a/server/mcp/catalog.py
+++ b/server/mcp/catalog.py
@@ -1164,6 +1164,23 @@ WAVE_TWENTY_FILE_ADAPTERS: dict[
 }
 
 
+WAVE_TWENTYSIX_FILE_ADAPTERS: dict[
+    str,
+    tuple[str, dict[str, CatalogToolPolicy], tuple[str, ...]],
+] = {
+    "githejie-mcp-server-calculator": (
+        "0.2.1-reviewed-commit-3dcaedcd-compatible-native-v1",
+        {
+            "calculate": CatalogToolPolicy(read_only=True, effect="read"),
+        },
+        (
+            "仅开放上游单一 calculate 产品身份，并使用断网、有界数值 AST 执行；不接收命令、代码、变量、路径、URL 或环境变量。",
+            "表达式长度、AST 节点/深度、幂指数、底数与结果绝对值均有硬上限；NaN、Infinity、属性访问、导入和任意函数 fail closed。",
+        ),
+    ),
+}
+
+
 WAVE_THREE_ADAPTERS: dict[str, tuple[str, dict[str, CatalogToolPolicy]]] = {
     "basic-memory-mcp": (
         "0.22.1-local-contract-v1",
@@ -3513,6 +3530,41 @@ def build_catalog_manifests() -> dict[str, CatalogAdapterManifest]:
                 f"duplicate Wave 24 catalog expansion id: {adapter.project_id}"
             )
         if adapter.availability == "ready":
+            wave26_file_spec = WAVE_TWENTYSIX_FILE_ADAPTERS.get(adapter.project_id)
+            if wave26_file_spec is not None:
+                adapter_version, tool_policies, limitations = wave26_file_spec
+                manifests[adapter.project_id] = CatalogAdapterManifest(
+                    project_id=adapter.project_id,
+                    wave=adapter.adaptation_wave,
+                    availability="ready",
+                    connection_kind="sandboxed-stdio",
+                    risk="medium",
+                    required_capabilities=adapter.required_capabilities,
+                    limitations=limitations,
+                    adapter_version=adapter_version,
+                    runtime_image="modelmirror-mcp-files:wave3-v1",
+                    network_policy="disabled",
+                    filesystem_policy="read-only-empty-workspace",
+                    resource_limits=(
+                        ("cpu", "1.5 cores / 10 CPU seconds per call"),
+                        ("memory", "1 GiB sidecar cgroup"),
+                        ("processes", "maximum 4 sessions / 128 sidecar PIDs"),
+                        ("operation_timeout", "10 seconds"),
+                        ("tool_output", "64 KiB"),
+                    ),
+                    server_command=(*FILE_SANDBOX_PROXY, adapter.project_id),
+                    preparation_kind="bundled",
+                    tool_policies=tool_policies,
+                    workspace_policy=CatalogWorkspacePolicy(
+                        persistent=False,
+                        idle_ttl_seconds=24 * 60 * 60,
+                        accepted_extensions=(),
+                    ),
+                    enabled_by_default=True,
+                    operation_timeout=10.0,
+                    max_output_bytes=64 * 1024,
+                )
+                continue
             public_spec = WAVE_SIXTEEN_PUBLIC_ADAPTERS.get(adapter.project_id)
             if public_spec is None:
                 raise RuntimeError(
@@ -3552,7 +3604,9 @@ def build_catalog_manifests() -> dict[str, CatalogAdapterManifest]:
                 max_output_bytes=128 * 1024,
             )
             continue
-        if adapter.project_id in WAVE_SIXTEEN_PUBLIC_ADAPTERS:
+        if adapter.project_id in (
+            WAVE_SIXTEEN_PUBLIC_ADAPTERS | WAVE_TWENTYSIX_FILE_ADAPTERS
+        ):
             raise RuntimeError(
                 f"non-ready Wave 24 expansion has runtime contract: {adapter.project_id}"
             )

--- a/server/mcp/catalog_expansion_v3.py
+++ b/server/mcp/catalog_expansion_v3.py
@@ -60,13 +60,13 @@ CATALOG_EXPANSION_V3_ADAPTERS = (
     ),
     CatalogExpansionV3Adapter(
         project_id='githejie-mcp-server-calculator',
-        availability='planned',
-        decision_reason_code='planned-wave26-offline-file-or-deterministic-artifact',
+        availability='ready',
+        decision_reason_code='ready-wave26a-calculator',
         adaptation_wave=26,
         connection_kind='sandboxed-stdio',
         risk='medium',
-        required_capabilities=('scoped-filesystem', 'network-disabled', 'artifact-cleanup', 'resource-limits'),
-        limitations=('可继续评估断网、封存输入、确定性处理与服务端复制产物的文件子集；在路径隔离、资源限额、超时、清理和真实镜像验收前保持 planned。', '当前仅登记产品身份与适配判定；没有命令、端点、凭据槽、工具策略、运行镜像或默认 allowlist，任何功能开关都不能使该条目可执行。'),
+        required_capabilities=('network-disabled', 'bounded-runtime-surface', 'schema-drift-recovery', 'resource-limits'),
+        limitations=('已冻结单一 calculate 工具、断网数值 AST、复杂度与结果上限，并通过真实 UDS、超时回收、默认拒绝和用户验收。',),
     ),
     CatalogExpansionV3Adapter(
         project_id='modelscope-funasr',

--- a/server/mcp/database_proxy.py
+++ b/server/mcp/database_proxy.py
@@ -30,6 +30,7 @@ ALLOWED_ADAPTERS = {
     "zilliztech-mcp-server-milvus",
     "neo4j-contrib-mcp-neo4j",
     "arcadedata-arcadedb",
+    "greptimeteam-greptimedb-mcp-server",
 }
 REMOTE_SOCKET_PATH = Path(
     os.getenv(

--- a/server/mcp/file_proxy.py
+++ b/server/mcp/file_proxy.py
@@ -25,6 +25,7 @@ ALLOWED_ADAPTERS = {
     "haris-musa-excel-mcp-server",
     "dataeval-dingo",
     "ozgurcd-gograph",
+    "githejie-mcp-server-calculator",
 }
 WORKSPACE_PATTERN = re.compile(r"mcpws_[0-9a-f]{32}")
 SOCKET_PATH = Path(os.getenv("MCP_FILES_SOCKET_PATH", "/run/modelmirror-files-mcp/files-mcp.sock"))

--- a/server/mcp/smoke_database_adapters.py
+++ b/server/mcp/smoke_database_adapters.py
@@ -78,6 +78,9 @@ EXPECTED_TOOLS = {
     },
     "neo4j-contrib-mcp-neo4j": {"get_schema", "read_cypher"},
     "arcadedata-arcadedb": {"list_types", "describe_type", "read_query"},
+    "greptimeteam-greptimedb-mcp-server": {
+        "describe_table", "query_range", "health_check",
+    },
 }
 
 EXPECTED_SCHEMA_SHA256 = {
@@ -205,6 +208,19 @@ VALID_CONFIGURATIONS = {
         },
         "credentials": {"password": "dummy"},
     },
+    "greptimeteam-greptimedb-mcp-server": {
+        "settings": {
+            "host": "greptime.example.com",
+            "port": 443,
+            "database": "public",
+            "table": "project_metrics",
+            "time_column": "observed_at",
+            "value_column": "metric_value",
+            "tls_mode": "verify-full",
+            "username": "readonly",
+        },
+        "credentials": {"password": "dummy"},
+    },
 }
 
 
@@ -220,15 +236,18 @@ async def _schema_smoke() -> None:
     try:
         from server.sandbox_sidecar.database_mcp import BUILDERS
         from server.sandbox_sidecar.database_graph_services import WAVE19B_SCHEMA_SHA256
+        from server.sandbox_sidecar.database_wave27 import WAVE27_SCHEMA_SHA256
     except ModuleNotFoundError as error:
         if error.name != "server":
             raise
         from sandbox_sidecar.database_mcp import BUILDERS
         from sandbox_sidecar.database_graph_services import WAVE19B_SCHEMA_SHA256
+        from sandbox_sidecar.database_wave27 import WAVE27_SCHEMA_SHA256
 
     for adapter_id, builder in BUILDERS.items():
         tools = await builder(None).list_tools()
-        if adapter_id in WAVE19B_SCHEMA_SHA256:
+        reviewed_digests = WAVE19B_SCHEMA_SHA256 | WAVE27_SCHEMA_SHA256
+        if adapter_id in reviewed_digests:
             reviewed = [
                 {"name": tool.name, "inputSchema": tool.inputSchema}
                 for tool in sorted(tools, key=lambda item: item.name)
@@ -236,7 +255,7 @@ async def _schema_smoke() -> None:
             digest = hashlib.sha256(
                 json.dumps(reviewed, sort_keys=True, separators=(",", ":")).encode("utf-8")
             ).hexdigest()
-            expected_digest = WAVE19B_SCHEMA_SHA256[adapter_id]
+            expected_digest = reviewed_digests[adapter_id]
         else:
             schemas = {tool.name: tool.inputSchema for tool in tools}
             digest = hashlib.sha256(

--- a/server/mcp/smoke_database_wave27_fixture.py
+++ b/server/mcp/smoke_database_wave27_fixture.py
@@ -1,0 +1,63 @@
+"""Deterministic local HTTP fixture for the Wave-27 provider-timeout smoke."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class FixtureHandler(BaseHTTPRequestHandler):
+    request_count = 0
+    lock = threading.Lock()
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib callback name
+        if not self.path.startswith("/v1/sql"):
+            self.send_error(404)
+            return
+        length = int(self.headers.get("content-length", "0"))
+        if length > 64 * 1024:
+            self.send_error(413)
+            return
+        self.rfile.read(length)
+        with self.lock:
+            type(self).request_count += 1
+            request_number = type(self).request_count
+        if request_number > 1:
+            time.sleep(20)
+        payload = json.dumps(
+            {
+                "code": 0,
+                "output": [
+                    {
+                        "records": {
+                            "schema": {
+                                "column_schemas": [{"name": "modelmirror_readonly"}]
+                            },
+                            "rows": [[1]],
+                        }
+                    }
+                ],
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+        try:
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        except (BrokenPipeError, ConnectionError):
+            return
+
+
+def main() -> None:
+    ThreadingHTTPServer(("0.0.0.0", 4000), FixtureHandler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/server/mcp/smoke_database_wave27_live.py
+++ b/server/mcp/smoke_database_wave27_live.py
@@ -1,0 +1,239 @@
+"""Live UDS acceptance client for the staged Wave-27 GreptimeDB adapter.
+
+The host harness supplies one base64 configuration and mounts only the private
+database socket. This helper has no network access and never prints credentials,
+provider payloads, SQL text, hostnames, or row values.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import socket
+import time
+from pathlib import Path
+from typing import Any
+
+
+SOCKET_PATH = Path(
+    os.getenv("MCP_DATABASE_SOCKET_PATH", "/run/modelmirror-database-mcp/database-mcp.sock")
+)
+ADAPTER_ID = "greptimeteam-greptimedb-mcp-server"
+CONFIGURATION_B64 = os.environ.pop("MCP_DATABASE_WAVE27_CONFIGURATION_B64", "")
+EXPECT_TIMEOUT = os.environ.pop("MCP_DATABASE_WAVE27_EXPECT_TIMEOUT", "") == "true"
+EXPECTED_TOOLS = {"describe_table", "query_range", "health_check"}
+EXPECTED_SCHEMA_SHA256 = "86c8dbbfda387925e345fde14bdfdb3681c2b02e5072e5b84bfb7000e1aef65c"
+
+
+class RpcClient:
+    def __init__(self, configuration: dict[str, Any]) -> None:
+        self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.socket.settimeout(25)
+        self.socket.connect(str(SOCKET_PATH))
+        self.stream = self.socket.makefile("rwb", buffering=0)
+        self.stream.write(
+            json.dumps(
+                {
+                    "action": "mcp_stdio",
+                    "adapter_id": ADAPTER_ID,
+                    "configuration": configuration,
+                },
+                separators=(",", ":"),
+            ).encode("utf-8")
+            + b"\n"
+        )
+        handshake = self._read()
+        if handshake.get("ok") is not True or handshake.get("read_only") is not True:
+            raise RuntimeError("wave27_handshake_rejected")
+        if set(handshake.get("tools") or []) != EXPECTED_TOOLS:
+            raise RuntimeError("wave27_handshake_tool_drift")
+        self.next_id = 1
+
+    def _read(self) -> dict[str, Any]:
+        raw = self.stream.readline(512 * 1024 + 1)
+        if not raw or len(raw) > 512 * 1024:
+            raise RuntimeError("wave27_rpc_response_invalid")
+        value = json.loads(raw.decode("utf-8"))
+        if not isinstance(value, dict):
+            raise RuntimeError("wave27_rpc_response_invalid")
+        return value
+
+    def request(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        request_id = self.next_id
+        self.next_id += 1
+        payload: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
+        if params is not None:
+            payload["params"] = params
+        self.stream.write(json.dumps(payload, separators=(",", ":")).encode("utf-8") + b"\n")
+        response = self._read()
+        if response.get("id") != request_id:
+            raise RuntimeError("wave27_rpc_id_drift")
+        return response
+
+    def notify(self, method: str) -> None:
+        self.stream.write(
+            json.dumps({"jsonrpc": "2.0", "method": method}, separators=(",", ":")).encode(
+                "utf-8"
+            )
+            + b"\n"
+        )
+
+    def close(self) -> None:
+        try:
+            self.stream.close()
+        finally:
+            self.socket.close()
+
+
+def _result(response: dict[str, Any], label: str) -> dict[str, Any]:
+    if "error" in response:
+        raise RuntimeError(f"{label}_rpc_error")
+    result = response.get("result")
+    if not isinstance(result, dict) or result.get("isError") is True:
+        raise RuntimeError(f"{label}_tool_failed")
+    structured = result.get("structuredContent")
+    if isinstance(structured, dict):
+        value = structured.get("result", structured)
+        if isinstance(value, dict):
+            return value
+    content = result.get("content")
+    if isinstance(content, list):
+        for item in content:
+            if not isinstance(item, dict) or item.get("type") != "text":
+                continue
+            text = item.get("text")
+            if not isinstance(text, str):
+                continue
+            try:
+                value = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(value, dict):
+                return value
+    raise RuntimeError(f"{label}_result_invalid")
+
+
+def _call(client: RpcClient, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    return _result(
+        client.request("tools/call", {"name": name, "arguments": arguments}),
+        name,
+    )
+
+
+def main() -> None:
+    if not CONFIGURATION_B64:
+        raise RuntimeError("wave27_smoke_configuration_missing")
+    try:
+        configuration = json.loads(base64.urlsafe_b64decode(CONFIGURATION_B64.encode("ascii")))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("wave27_smoke_configuration_invalid") from exc
+    if not isinstance(configuration, dict):
+        raise RuntimeError("wave27_smoke_configuration_invalid")
+
+    client = RpcClient(configuration)
+    configuration = {}
+    try:
+        initialized = client.request(
+            "initialize",
+            {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "modelmirror-wave27-smoke", "version": "1"},
+            },
+        )
+        if "error" in initialized:
+            raise RuntimeError("wave27_initialize_failed")
+        client.notify("notifications/initialized")
+        listed = client.request("tools/list")
+        result = listed.get("result")
+        tools = result.get("tools") if isinstance(result, dict) else None
+        if not isinstance(tools, list):
+            raise RuntimeError("wave27_tools_list_invalid")
+        reviewed = [
+            {"name": item.get("name"), "inputSchema": item.get("inputSchema")}
+            for item in sorted(
+                (item for item in tools if isinstance(item, dict)),
+                key=lambda item: str(item.get("name")),
+            )
+        ]
+        if {item["name"] for item in reviewed} != EXPECTED_TOOLS:
+            raise RuntimeError("wave27_tools_list_drift")
+        digest = hashlib.sha256(
+            json.dumps(reviewed, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        if digest != EXPECTED_SCHEMA_SHA256:
+            raise RuntimeError("wave27_schema_drift")
+
+        if EXPECT_TIMEOUT:
+            started = time.monotonic()
+            timed_out = client.request("tools/call", {"name": "health_check", "arguments": {}})
+            elapsed = time.monotonic() - started
+            result = timed_out.get("result")
+            if not isinstance(result, dict) or result.get("isError") is not True:
+                raise RuntimeError("wave27_timeout_not_reported")
+            if not 10.5 <= elapsed <= 16.0:
+                raise RuntimeError("wave27_timeout_deadline_drift")
+            summary = {
+                "ok": True,
+                "adapter_id": ADAPTER_ID,
+                "tools": sorted(EXPECTED_TOOLS),
+                "schema_sha256": EXPECTED_SCHEMA_SHA256,
+                "provider_timeout": "bounded",
+                "elapsed_seconds_bucket": "10.5-16.0",
+            }
+        else:
+            health = _call(client, "health_check", {})
+            described = _call(client, "describe_table", {})
+            queried = _call(
+                client,
+                "query_range",
+                {
+                    "start": "2026-08-01T00:00:00Z",
+                    "end": "2026-08-01T02:00:00Z",
+                    "limit": 10,
+                },
+            )
+            if health.get("status") != "ok":
+                raise RuntimeError("wave27_health_result_invalid")
+            if not isinstance(described.get("returned_count"), int) or described["returned_count"] < 3:
+                raise RuntimeError("wave27_describe_result_invalid")
+            if queried.get("returned_count") != 2 or queried.get("truncated") is not False:
+                raise RuntimeError("wave27_query_result_invalid")
+
+            denied = client.request("tools/call", {"name": "execute_sql", "arguments": {}})
+            if denied.get("error", {}).get("code") != -32601:
+                raise RuntimeError("wave27_generic_sql_not_denied")
+            guarded = client.request(
+                "tools/call",
+                {
+                    "name": "query_range",
+                    "arguments": {
+                        "start": "2026-08-01T00:00:00Z",
+                        "end": "2026-08-01T02:00:00Z",
+                        "query": "SELECT secret FROM other_table",
+                    },
+                },
+            )
+            if guarded.get("error", {}).get("code") != -32602:
+                raise RuntimeError("wave27_open_query_surface_not_denied")
+            summary = {
+                "ok": True,
+                "adapter_id": ADAPTER_ID,
+                "tools": sorted(EXPECTED_TOOLS),
+                "schema_sha256": EXPECTED_SCHEMA_SHA256,
+                "health_status": "ok",
+                "described_columns_minimum": 3,
+                "query_returned_count": 2,
+                "generic_sql": "denied",
+                "open_query_surface": "denied",
+            }
+    finally:
+        client.close()
+
+    print(json.dumps(summary, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/server/mcp/token_proxy.py
+++ b/server/mcp/token_proxy.py
@@ -24,6 +24,7 @@ ALLOWED_ADAPTERS = {
     "pinecone-assistant-mcp", "shodan-mcp", "virustotal-mcp",
     "terraform-mcp", "livetennisapi-livetennisapi-mcp",
     "cablate-mcp-google-map", "comet-ml-opik-mcp", "keboola-keboola-mcp-server",
+    "chanmeng666-server-google-news", "isnow890-naver-search-mcp",
 }
 SOCKET_PATH = Path(
     os.getenv(

--- a/server/mcp/workspace.py
+++ b/server/mcp/workspace.py
@@ -43,6 +43,7 @@ FILE_PROJECTS = {
     "haris-musa-excel-mcp-server",
     "dataeval-dingo",
     "ozgurcd-gograph",
+    "githejie-mcp-server-calculator",
 }
 
 PROJECT_EXTENSIONS: dict[str, set[str] | None] = {
@@ -67,6 +68,7 @@ PROJECT_EXTENSIONS: dict[str, set[str] | None] = {
     "haris-musa-excel-mcp-server": {".xlsx"},
     "dataeval-dingo": {".jsonl", ".json", ".csv", ".txt"},
     "ozgurcd-gograph": {".go", ".mod", ".sum", ".work"},
+    "githejie-mcp-server-calculator": set(),
 }
 
 

--- a/server/sandbox_sidecar/Dockerfile.database
+++ b/server/sandbox_sidecar/Dockerfile.database
@@ -19,7 +19,7 @@ WORKDIR /opt/modelmirror
 COPY database-requirements.lock ./database-requirements.lock
 RUN pip install --no-cache-dir --retries 5 --timeout 120 -r database-requirements.lock
 
-COPY __init__.py engine.py landlock_exec.py database_contracts.py database_data_services.py database_graph_services.py database_landlock_exec.py database_mcp.py database_server.py ./sandbox_sidecar/
+COPY __init__.py engine.py landlock_exec.py database_contracts.py database_data_services.py database_graph_services.py database_wave27.py database_landlock_exec.py database_mcp.py database_server.py ./sandbox_sidecar/
 COPY THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-mcp-database/THIRD_PARTY_NOTICES.md
 
 USER 65532:65532

--- a/server/sandbox_sidecar/Dockerfile.files
+++ b/server/sandbox_sidecar/Dockerfile.files
@@ -77,12 +77,13 @@ RUN pip install --no-cache-dir --retries 5 --timeout 120 -r file-requirements.lo
 RUN test "$(pandoc --version | sed -n '1s/^pandoc //p')" = "3.10.1"
 RUN test "$(gograph version)" = "gograph version v1.5.6"
 RUN test "$(go env GOVERSION)" = "go1.26.5"
-COPY __init__.py engine.py landlock_exec.py file_landlock_exec.py file_artifacts.py file_analysis.py file_code_index.py file_mcp.py file_server.py smoke_file_artifacts.py smoke_file_analysis.py smoke_file_code_index.py ./sandbox_sidecar/
+COPY __init__.py engine.py landlock_exec.py file_landlock_exec.py file_artifacts.py file_analysis.py file_code_index.py file_wave26.py file_mcp.py file_server.py smoke_file_artifacts.py smoke_file_analysis.py smoke_file_code_index.py smoke_file_wave26.py ./sandbox_sidecar/
 COPY THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-mcp-files/THIRD_PARTY_NOTICES.md
 
 RUN python -m sandbox_sidecar.smoke_file_artifacts --contract-only
 RUN python -m sandbox_sidecar.smoke_file_analysis --contract-only
 RUN python -m sandbox_sidecar.smoke_file_code_index --contract-only
+RUN python -m sandbox_sidecar.smoke_file_wave26 --contract-only
 
 USER 65532:65532
 CMD ["python", "-m", "sandbox_sidecar.file_server"]

--- a/server/sandbox_sidecar/Dockerfile.token
+++ b/server/sandbox_sidecar/Dockerfile.token
@@ -32,7 +32,7 @@ RUN apt-get update \
 WORKDIR /opt/modelmirror
 COPY requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --retries 5 --timeout 120 -r requirements.txt
-COPY __init__.py engine.py landlock_exec.py network_guard.cjs safe_http.py smoke_token_adapters.py token_builtin.py token_contracts.py token_server.py ./sandbox_sidecar/
+COPY __init__.py engine.py landlock_exec.py network_guard.cjs safe_http.py smoke_token_adapters.py smoke_token_gateway.py token_builtin.py token_contracts.py token_server.py ./sandbox_sidecar/
 COPY THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-mcp-token/THIRD_PARTY_NOTICES.md
 
 USER 65532:65532

--- a/server/sandbox_sidecar/THIRD_PARTY_NOTICES.md
+++ b/server/sandbox_sidecar/THIRD_PARTY_NOTICES.md
@@ -160,6 +160,31 @@ IDs are present in the production allowlist:
   local rules are represented; LLM, Agent, cloud, SQL and registry inputs are
   absent.
 
+Wave 26A stages two more independently implemented, network-free compatibility
+contracts in the file image. Neither upstream MCP package is installed, copied,
+or executed, and both IDs remain outside the production proxy and Compose
+allowlists until isolated validation and user acceptance:
+
+- MCP Server Calculator 0.2.1 (`githejie/mcp-server-calculator`), commit
+  `3dcaedcd58867206627d121092b401728db202da`: MIT. The single upstream
+  `calculate` identity is retained, but the local parser permits only a bounded
+  numeric AST and a fixed subset of Python math functions. Attributes, imports,
+  collections, comprehensions and arbitrary callables are absent.
+- ImageSorcery MCP 0.12.0 (`sunriseapps/imagesorcery-mcp`), commit
+  `2f77957a0671a5cf30d90285c7024ae229d86917`: MIT. Only path-free versions of
+  `get_metainfo`, `resize`, `crop` and `rotate` are represented using the already
+  pinned Pillow 12.3.0 dependency. The upstream package, OpenCV, imutils,
+  Ultralytics, EasyOCR, Hugging Face downloads, telemetry, configuration writes,
+  prompts, resources, detection, OCR, object finding, overlays and arbitrary
+  input/output paths are absent.
+
+pdfmux 1.8.7 (`NameetP/pdfmux`), commit
+`891e34c2d32bcbf1796dc8307e13dea1076bc2cf`, was also reviewed under MIT but
+remains planned and is not included. The reviewed Git tag reports 1.8.7 while
+the latest published PyPI artifact is 1.8.2, and its self-healing product
+identity depends on a version-sensitive multi-engine PyMuPDF extraction stack.
+ModelMirror does not substitute a generic PDF parser for that product identity.
+
 The `modelmirror-mcp-token:wave4-v1` runtime bundles the following pinned MCP
 packages and their locked transitive npm dependencies. Runtime installation and
 update checks are disabled; package license metadata is retained under
@@ -238,6 +263,21 @@ real account read-only preflight is accepted:
   `653118bc42fab00fe0268b6feaf4c4ad032dbf7c` (MIT). Only project, bucket and
   table metadata on the fixed `connection.keboola.com` stack are represented.
 
+Wave 26B adds two further default-disabled, independently implemented read-only
+compatibility contracts. Their upstream packages and source are not copied or
+executed, and neither catalog ID is in the production allowlist without a real
+provider-account acceptance run:
+
+- Google News MCP Server 1.0.0 (`ChanMeng666/server-google-news`, commit
+  `5ed14341ff6ef290e13bafa08abc12157bbe23a3`, MIT). Only the
+  `google_news_search` identity is represented on the fixed `serpapi.com`
+  endpoint. Provider topic, publication, story and section tokens are absent.
+- Naver Search MCP 1.0.50 (`isnow890/naver-search-mcp`, commit
+  `d7c7c58cab0de2692336b710727f1ee123270e6c`, MIT). Only classic Developer
+  Center web, news and blog search on `openapi.naver.com` is represented.
+  Naver API Hub, local/image/community search, shopping, DataLab and category
+  tools are absent.
+
 The `modelmirror-mcp-database:wave5-v1` image implements independent, fixed
 read-only compatibility contracts after reviewing these upstream projects. It
 does not install their MCP server packages and never downloads runtime code:
@@ -293,6 +333,21 @@ The isolated acceptance services were Milvus 2.5.21, Neo4j Enterprise
 5.26.12 and ArcadeDB 26.8.1. Those provider images and Neo4j Enterprise are
 test-only dependencies and are not copied into or distributed with the
 ModelMirror database sidecar image.
+
+The same database image contains one default-disabled Wave 27 compatibility
+contract after review of GreptimeDB MCP Server v0.5.1
+(`GreptimeTeam/greptimedb-mcp-server`, commit
+`ba3b732fe2113378f41c391da880b9ab75f2d862`), licensed under MIT. The upstream
+package and source are not copied or executed. The facade binds one database,
+table, timestamp column and value column and exposes only table description,
+a server-generated bounded range query and a constant health query. Arbitrary
+SQL/TQL, resource selection, writes, administration and dynamic endpoints are
+absent. This contract remains staged and is excluded from the default runtime
+allowlist until isolated native read-only service acceptance is complete.
+The isolated acceptance service was the official GreptimeDB v1.1.4 image at
+manifest digest
+`sha256:9726587eac95d0360755254cd59a528dbf48abfdf268478aea6a644f62afe44c`;
+that provider image is not copied into or distributed with ModelMirror.
 
 The `modelmirror-mcp-files` image also bundles GoGraph v1.5.6
 (`ozgurcd/gograph`, commit

--- a/server/sandbox_sidecar/database_contracts.py
+++ b/server/sandbox_sidecar/database_contracts.py
@@ -50,15 +50,21 @@ GRAPH_DATA_SERVICE_ADAPTERS = frozenset(
         "arcadedata-arcadedb",
     }
 )
+WAVE_TWENTYSEVEN_DATA_SERVICE_ADAPTERS = frozenset(
+    {
+        "greptimeteam-greptimedb-mcp-server",
+    }
+)
 REMOTE_DATA_SERVICE_ADAPTERS = frozenset(
     {
         "pab1it0-prometheus-mcp-server",
         "qdrant-mcp-server-qdrant",
         "cr7258-elasticsearch-mcp-server",
         *GRAPH_DATA_SERVICE_ADAPTERS,
+        *WAVE_TWENTYSEVEN_DATA_SERVICE_ADAPTERS,
     }
 )
-STAGED_DATABASE_ADAPTERS = frozenset()
+STAGED_DATABASE_ADAPTERS = WAVE_TWENTYSEVEN_DATA_SERVICE_ADAPTERS
 FORBIDDEN_CONFIGURATION_KEYS = frozenset(
     {
         "command",
@@ -214,6 +220,24 @@ DATABASE_ADAPTERS: dict[str, DatabaseAdapterContract] = {
         "arcadedata-arcadedb",
         frozenset({"list_types", "describe_type", "read_query"}),
         frozenset({"host", "port", "tls_mode", "database", "username"}),
+        frozenset(),
+        frozenset({"password"}),
+    ),
+    "greptimeteam-greptimedb-mcp-server": DatabaseAdapterContract(
+        "greptimeteam-greptimedb-mcp-server",
+        frozenset({"describe_table", "query_range", "health_check"}),
+        frozenset(
+            {
+                "host",
+                "port",
+                "database",
+                "table",
+                "time_column",
+                "value_column",
+                "tls_mode",
+                "username",
+            }
+        ),
         frozenset(),
         frozenset({"password"}),
     ),
@@ -419,6 +443,22 @@ def validate_configuration(adapter_id: str, configuration: object) -> ValidatedC
         )
         settings["username"] = _safe_text(
             raw_settings.get("username"), pattern=SAFE_USERNAME, code="invalid_username"
+        )
+    elif adapter_id == "greptimeteam-greptimedb-mcp-server":
+        settings["database"] = _safe_text(
+            raw_settings.get("database"), pattern=DATA_SERVICE_RESOURCE, code="invalid_database"
+        )
+        settings["username"] = _safe_text(
+            raw_settings.get("username"), pattern=SAFE_USERNAME, code="invalid_username"
+        )
+        settings["table"] = _safe_text(
+            raw_settings.get("table"), pattern=SAFE_IDENTIFIER, code="invalid_table"
+        )
+        settings["time_column"] = _safe_text(
+            raw_settings.get("time_column"), pattern=SAFE_IDENTIFIER, code="invalid_time_column"
+        )
+        settings["value_column"] = _safe_text(
+            raw_settings.get("value_column"), pattern=SAFE_IDENTIFIER, code="invalid_value_column"
         )
 
     workspace_raw = str(configuration.get("workspace_id") or "").strip()

--- a/server/sandbox_sidecar/database_mcp.py
+++ b/server/sandbox_sidecar/database_mcp.py
@@ -54,6 +54,7 @@ from .database_graph_services import (
     preflight_milvus,
     preflight_neo4j,
 )
+from .database_wave27 import build_greptime, preflight_greptime
 
 
 READ_ONLY = ToolAnnotations(
@@ -1064,6 +1065,7 @@ BUILDERS = {
     "zilliztech-mcp-server-milvus": build_milvus,
     "neo4j-contrib-mcp-neo4j": build_neo4j,
     "arcadedata-arcadedb": build_arcadedb,
+    "greptimeteam-greptimedb-mcp-server": build_greptime,
 }
 
 PREFLIGHTS = {
@@ -1079,6 +1081,7 @@ PREFLIGHTS = {
     "zilliztech-mcp-server-milvus": preflight_milvus,
     "neo4j-contrib-mcp-neo4j": preflight_neo4j,
     "arcadedata-arcadedb": preflight_arcadedb,
+    "greptimeteam-greptimedb-mcp-server": preflight_greptime,
 }
 
 

--- a/server/sandbox_sidecar/database_server.py
+++ b/server/sandbox_sidecar/database_server.py
@@ -20,6 +20,7 @@ from .database_contracts import (
     MAX_OUTPUT_BYTES,
     REMOTE_DATA_SERVICE_ADAPTERS,
     STAGED_DATABASE_ADAPTERS,
+    WAVE_TWENTYSEVEN_DATA_SERVICE_ADAPTERS,
     WORKSPACE_PATTERN,
     resolve_allowed_addresses,
     validate_configuration,
@@ -28,6 +29,7 @@ from .database_contracts import (
 )
 from .database_data_services import validate_data_service_arguments
 from .database_graph_services import validate_graph_service_arguments
+from .database_wave27 import validate_wave27_arguments
 from .engine import SandboxEngineError
 
 
@@ -101,7 +103,9 @@ def _validate_tool_arguments(adapter_id: str, tool_name: str, arguments: object)
         for field in ("filter", "projection", "sort"):
             if field in arguments and arguments[field] is not None:
                 validate_document(arguments[field])
-    if adapter_id in GRAPH_DATA_SERVICE_ADAPTERS:
+    if adapter_id in WAVE_TWENTYSEVEN_DATA_SERVICE_ADAPTERS:
+        validate_wave27_arguments(adapter_id, tool_name, arguments)
+    elif adapter_id in GRAPH_DATA_SERVICE_ADAPTERS:
         validate_graph_service_arguments(adapter_id, tool_name, arguments)
     elif adapter_id in REMOTE_DATA_SERVICE_ADAPTERS:
         validate_data_service_arguments(adapter_id, tool_name, arguments)

--- a/server/sandbox_sidecar/database_wave27.py
+++ b/server/sandbox_sidecar/database_wave27.py
@@ -1,0 +1,285 @@
+"""Staged Wave-27 native read-only data-service contracts.
+
+The reviewed upstream projects define the product identity and tool intent.
+This module exposes only project-bound read operations: all provider paths,
+SQL text, PromQL selectors, headers, and credentials are constructed by the
+sidecar.  Catalog clients cannot submit a query language, endpoint, DSN,
+header, environment variable, or resource name.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import json
+import math
+import re
+from typing import Any, Mapping, Protocol
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+from .database_contracts import MAX_OUTPUT_BYTES
+from .database_data_services import PROVIDER_TIMEOUT_SECONDS, _integer
+
+
+GREPTIME_ADAPTER_ID = "greptimeteam-greptimedb-mcp-server"
+WAVE27_ADAPTERS = frozenset({GREPTIME_ADAPTER_ID})
+
+WAVE27_UPSTREAM_LOCKS = {
+    GREPTIME_ADAPTER_ID: {
+        "version": "v0.5.1",
+        "commit": "ba3b732fe2113378f41c391da880b9ab75f2d862",
+        "license": "MIT",
+        "repository": "GreptimeTeam/greptimedb-mcp-server",
+    },
+}
+
+WAVE27_SCHEMA_SHA256 = {
+    GREPTIME_ADAPTER_ID: "86c8dbbfda387925e345fde14bdfdb3681c2b02e5072e5b84bfb7000e1aef65c",
+}
+
+READ_ONLY = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+GREPTIME_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,127}")
+MAX_GREPTIME_ROWS = 200
+MAX_GREPTIME_COLUMNS = 128
+
+
+class Wave27Context(Protocol):
+    adapter_id: str
+    settings: Mapping[str, str | int]
+    credentials: Mapping[str, str]
+
+
+def _exact_keys(arguments: Mapping[str, Any], allowed: frozenset[str]) -> None:
+    if set(arguments) - allowed:
+        raise ValueError("wave27_argument_contract_mismatch")
+
+
+def _rfc3339(value: object) -> tuple[str, float]:
+    if not isinstance(value, str) or not value.strip() or len(value) > 64:
+        raise ValueError("invalid_time")
+    clean = value.strip()
+    try:
+        parsed = dt.datetime.fromisoformat(clean.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("invalid_time") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("invalid_time")
+    timestamp = parsed.timestamp()
+    if not math.isfinite(timestamp) or timestamp < 0:
+        raise ValueError("invalid_time")
+    normalized = parsed.astimezone(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    return normalized, timestamp
+
+
+def _greptime_range(start: object, end: object) -> tuple[str, str]:
+    start_text, start_value = _rfc3339(start)
+    end_text, end_value = _rfc3339(end)
+    if end_value <= start_value or end_value - start_value > 24 * 60 * 60:
+        raise ValueError("greptime_range_denied")
+    return start_text, end_text
+
+
+def validate_wave27_arguments(
+    adapter_id: str,
+    tool_name: str,
+    arguments: Mapping[str, Any],
+) -> None:
+    if adapter_id == GREPTIME_ADAPTER_ID:
+        if tool_name in {"describe_table", "health_check"}:
+            _exact_keys(arguments, frozenset())
+            return
+        if tool_name == "query_range":
+            _exact_keys(arguments, frozenset({"start", "end", "limit"}))
+            _greptime_range(arguments.get("start"), arguments.get("end"))
+            if "limit" in arguments:
+                _integer(
+                    arguments["limit"],
+                    minimum=1,
+                    maximum=MAX_GREPTIME_ROWS,
+                    code="invalid_limit",
+                )
+            return
+    raise ValueError("wave27_tool_denied")
+
+
+def _base_url(context: Wave27Context) -> str:
+    scheme = "http" if context.settings.get("tls_mode") == "test-only-plaintext" else "https"
+    return f"{scheme}://{context.settings['host']}:{int(context.settings['port'])}"
+
+
+def _bounded_json_response(response: httpx.Response) -> Any:
+    if 300 <= response.status_code < 400:
+        raise ValueError("database_redirect_denied")
+    if response.status_code == 429:
+        raise ValueError("database_rate_limited")
+    if response.status_code >= 500:
+        raise ValueError("database_upstream_unavailable")
+    if response.status_code >= 400:
+        raise ValueError("database_provider_rejected")
+    length = response.headers.get("content-length")
+    if length is not None:
+        try:
+            declared = int(length)
+        except ValueError as exc:
+            raise ValueError("database_response_invalid") from exc
+        if declared < 0 or declared > MAX_OUTPUT_BYTES:
+            raise ValueError("output_too_large")
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_bytes():
+        total += len(chunk)
+        if total > MAX_OUTPUT_BYTES:
+            raise ValueError("output_too_large")
+        chunks.append(chunk)
+    try:
+        return json.loads(b"".join(chunks).decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError("database_invalid_json") from exc
+
+
+def _greptime_sql(context: Wave27Context, sql: str) -> Any:
+    basic = base64.b64encode(
+        f"{context.settings['username']}:{context.credentials['password']}".encode("utf-8")
+    ).decode("ascii")
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f"Basic {basic}",
+        "User-Agent": "ModelMirror-GreptimeDB-ReadOnly/1",
+    }
+    verify = context.settings.get("tls_mode") != "test-only-plaintext"
+    try:
+        with httpx.Client(
+            base_url=_base_url(context),
+            headers=headers,
+            timeout=httpx.Timeout(PROVIDER_TIMEOUT_SECONDS, connect=10.0),
+            verify=verify,
+            follow_redirects=False,
+            trust_env=False,
+        ) as client:
+            with client.stream(
+                "POST",
+                "/v1/sql",
+                params={"db": str(context.settings["database"])},
+                data={"sql": sql},
+            ) as response:
+                return _bounded_json_response(response)
+    except httpx.TimeoutException as exc:
+        raise ValueError("database_upstream_timeout") from exc
+    except httpx.HTTPError as exc:
+        raise ValueError("database_upstream_unavailable") from exc
+
+
+def _greptime_records(value: object, *, limit: int) -> dict[str, Any]:
+    if not isinstance(value, dict) or value.get("code") not in {0, None}:
+        raise ValueError("greptime_response_invalid")
+    outputs = value.get("output")
+    if not isinstance(outputs, list) or len(outputs) != 1 or not isinstance(outputs[0], dict):
+        raise ValueError("greptime_response_invalid")
+    records = outputs[0].get("records")
+    if not isinstance(records, dict):
+        raise ValueError("greptime_response_invalid")
+    schema = records.get("schema")
+    columns_raw = schema.get("column_schemas") if isinstance(schema, dict) else None
+    rows = records.get("rows")
+    if not isinstance(columns_raw, list) or not isinstance(rows, list):
+        raise ValueError("greptime_response_invalid")
+    if len(columns_raw) > MAX_GREPTIME_COLUMNS:
+        raise ValueError("greptime_response_invalid")
+    columns: list[str] = []
+    for item in columns_raw:
+        if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+            raise ValueError("greptime_response_invalid")
+        columns.append(item["name"])
+    for row in rows:
+        if not isinstance(row, list) or len(row) != len(columns):
+            raise ValueError("greptime_response_invalid")
+    return {
+        "columns": columns,
+        "rows": rows[:limit],
+        "returned_count": min(len(rows), limit),
+        "truncated": len(rows) > limit,
+    }
+
+
+def _identifier(context: Wave27Context, setting: str) -> str:
+    value = str(context.settings[setting])
+    if not GREPTIME_IDENTIFIER.fullmatch(value):
+        raise ValueError("greptime_identifier_invalid")
+    return f"`{value}`"
+
+
+def _greptime_range_sql(context: Wave27Context, start: str, end: str, limit: int) -> str:
+    table = _identifier(context, "table")
+    time_column = _identifier(context, "time_column")
+    value_column = _identifier(context, "value_column")
+    # start/end are canonical RFC3339 values produced by _greptime_range and
+    # contain no quote characters. Every identifier is fixed by configuration.
+    return (
+        f"SELECT {time_column}, {value_column} FROM {table} "
+        f"WHERE {time_column} >= '{start}' AND {time_column} <= '{end}' "
+        f"ORDER BY {time_column} ASC LIMIT {limit + 1}"
+    )
+
+
+def build_greptime(context: Wave27Context) -> FastMCP:
+    mcp = FastMCP("ModelMirror GreptimeDB Read Only")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def describe_table() -> dict[str, Any]:
+        """Describe the one project-bound GreptimeDB table."""
+        table = str(context.settings["table"])
+        database = str(context.settings["database"])
+        sql = (
+            "SELECT column_name, data_type, semantic_type, is_nullable "
+            "FROM information_schema.columns "
+            f"WHERE table_schema = '{database}' AND table_name = '{table}' "
+            f"ORDER BY ordinal_position LIMIT {MAX_GREPTIME_COLUMNS + 1}"
+        )
+        return _greptime_records(
+            _greptime_sql(context, sql),
+            limit=MAX_GREPTIME_COLUMNS,
+        )
+
+    @mcp.tool(annotations=READ_ONLY)
+    def query_range(start: str, end: str, limit: int = 200) -> dict[str, Any]:
+        """Read fixed time/value columns for at most 24 hours and 200 rows."""
+        start_text, end_text = _greptime_range(start, end)
+        safe_limit = _integer(
+            limit,
+            minimum=1,
+            maximum=MAX_GREPTIME_ROWS,
+            code="invalid_limit",
+        )
+        sql = _greptime_range_sql(context, start_text, end_text, safe_limit)
+        return _greptime_records(_greptime_sql(context, sql), limit=safe_limit)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def health_check() -> dict[str, str]:
+        """Verify the bound read-only principal with a constant query."""
+        result = _greptime_records(
+            _greptime_sql(context, "SELECT 1 AS modelmirror_readonly LIMIT 1"),
+            limit=1,
+        )
+        if not result["rows"]:
+            raise ValueError("greptime_response_invalid")
+        return {"status": "ok"}
+
+    return mcp
+
+
+def preflight_greptime(context: Wave27Context) -> None:
+    result = _greptime_records(
+        _greptime_sql(context, "SELECT 1 AS modelmirror_readonly LIMIT 1"),
+        limit=1,
+    )
+    if not result["rows"]:
+        raise RuntimeError("database_preflight_failed")

--- a/server/sandbox_sidecar/file_mcp.py
+++ b/server/sandbox_sidecar/file_mcp.py
@@ -32,6 +32,7 @@ from pydantic import Field
 from .file_artifacts import WAVE18A_BUILDERS, WAVE18A_TOOL_NAMES
 from .file_analysis import WAVE18B_BUILDERS, WAVE18B_TOOL_NAMES
 from .file_code_index import WAVE20_BUILDERS, WAVE20_TOOL_NAMES
+from .file_wave26 import WAVE26_BUILDERS, WAVE26_TOOL_NAMES
 
 
 WORKSPACE_PATTERN = re.compile(r"mcpws_[0-9a-f]{32}")
@@ -2021,6 +2022,7 @@ BUILDERS = {
     **WAVE18A_BUILDERS,
     **WAVE18B_BUILDERS,
     **WAVE20_BUILDERS,
+    **WAVE26_BUILDERS,
 }
 
 ADAPTER_TOOL_NAMES = {
@@ -2044,6 +2046,7 @@ ADAPTER_TOOL_NAMES = {
     **WAVE18A_TOOL_NAMES,
     **WAVE18B_TOOL_NAMES,
     **WAVE20_TOOL_NAMES,
+    **WAVE26_TOOL_NAMES,
 }
 
 

--- a/server/sandbox_sidecar/file_server.py
+++ b/server/sandbox_sidecar/file_server.py
@@ -16,6 +16,7 @@ from .engine import SandboxEngineError
 from .file_artifacts import WAVE18A_BUILDERS
 from .file_analysis import WAVE18B_BUILDERS
 from .file_mcp import BUILDERS, WORKSPACE_PATTERN
+from .file_wave26 import STAGED_WAVE26_ADAPTERS
 
 
 SOCKET_PATH = Path(os.getenv("MCP_FILES_SOCKET_PATH", "/run/modelmirror-files-mcp/files-mcp.sock"))
@@ -27,8 +28,8 @@ MAX_MCP_MESSAGE_BYTES = 16 * 1024 * 1024
 MAX_SESSIONS = max(1, min(int(os.getenv("MCP_FILES_MAX_SESSIONS", "4")), 8))
 SEMAPHORE = asyncio.Semaphore(MAX_SESSIONS)
 OFFICE_PARSER_SEMAPHORE = asyncio.Semaphore(1)
-STAGED_FILE_ADAPTERS = frozenset()
-DEFAULT_ALLOWED_ADAPTERS = frozenset(BUILDERS)
+STAGED_FILE_ADAPTERS = STAGED_WAVE26_ADAPTERS
+DEFAULT_ALLOWED_ADAPTERS = frozenset(BUILDERS) - STAGED_FILE_ADAPTERS
 
 
 def _allowed_adapters() -> frozenset[str]:

--- a/server/sandbox_sidecar/file_wave26.py
+++ b/server/sandbox_sidecar/file_wave26.py
@@ -1,0 +1,404 @@
+"""Wave 26A offline deterministic compatibility contracts."""
+
+from __future__ import annotations
+
+import ast
+import math
+import os
+import warnings
+from pathlib import Path
+from typing import Annotated, Any, Literal
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+from pydantic import ConfigDict, Field
+
+
+FileId = Annotated[
+    str,
+    Field(
+        description=(
+            "Select an image from the current sealed workspace. Host paths and "
+            "URIs are not accepted."
+        ),
+        json_schema_extra={"x-modelmirror-input": "workspace-file"},
+    ),
+]
+ArtifactName = Annotated[
+    str,
+    Field(
+        description="PNG artifact name written only to the managed output directory.",
+        json_schema_extra={"x-modelmirror-input": "artifact-name"},
+    ),
+]
+
+READ_ONLY = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+ARTIFACT_CREATE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+
+CALCULATOR_ADAPTER_ID = "githejie-mcp-server-calculator"
+IMAGESORCERY_ADAPTER_ID = "sunriseapps-imagesorcery-mcp"
+STAGED_WAVE26_ADAPTERS = frozenset({IMAGESORCERY_ADAPTER_ID})
+
+MAX_EXPRESSION_CHARS = 256
+MAX_EXPRESSION_NODES = 64
+MAX_EXPRESSION_DEPTH = 16
+MAX_ABSOLUTE_RESULT = 1e100
+MAX_IMAGE_SOURCE_BYTES = 16 * 1024 * 1024
+MAX_IMAGE_DIMENSION = 8_192
+MAX_IMAGE_PIXELS = 25_000_000
+MAX_IMAGE_ARTIFACT_BYTES = 32 * 1024 * 1024
+ALLOWED_IMAGE_FORMATS = frozenset({"JPEG", "PNG", "WEBP"})
+
+
+def _freeze_strict_tool_contract(mcp: FastMCP) -> FastMCP:
+    for tool in mcp._tool_manager._tools.values():
+        argument_model = tool.fn_metadata.arg_model
+        argument_model.model_config = ConfigDict(
+            **dict(argument_model.model_config),
+            extra="forbid",
+            allow_inf_nan=False,
+        )
+        argument_model.model_rebuild(force=True)
+        tool.parameters = argument_model.model_json_schema(by_alias=True)
+    return mcp
+
+
+_CALCULATOR_FUNCTIONS: dict[str, Any] = {
+    "acos": math.acos,
+    "asin": math.asin,
+    "atan": math.atan,
+    "atan2": math.atan2,
+    "ceil": math.ceil,
+    "cos": math.cos,
+    "degrees": math.degrees,
+    "exp": math.exp,
+    "fabs": math.fabs,
+    "floor": math.floor,
+    "log": math.log,
+    "log10": math.log10,
+    "log2": math.log2,
+    "radians": math.radians,
+    "sin": math.sin,
+    "sqrt": math.sqrt,
+    "tan": math.tan,
+}
+_CALCULATOR_CONSTANTS = {"e": math.e, "pi": math.pi, "tau": math.tau}
+_BINARY_OPERATORS = {
+    ast.Add: lambda left, right: left + right,
+    ast.Sub: lambda left, right: left - right,
+    ast.Mult: lambda left, right: left * right,
+    ast.Div: lambda left, right: left / right,
+    ast.FloorDiv: lambda left, right: left // right,
+    ast.Mod: lambda left, right: left % right,
+    ast.Pow: lambda left, right: left**right,
+}
+
+
+def _bounded_number(value: Any) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("calculator_non_numeric_result")
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError("calculator_non_finite_result")
+    if abs(value) > MAX_ABSOLUTE_RESULT:
+        raise ValueError("calculator_result_limit_exceeded")
+    return value
+
+
+def _expression_depth(node: ast.AST) -> int:
+    children = list(ast.iter_child_nodes(node))
+    return 1 if not children else 1 + max(_expression_depth(child) for child in children)
+
+
+def evaluate_calculator_expression(expression: str) -> int | float:
+    clean = str(expression or "").strip().replace("^", "**").replace("×", "*").replace("÷", "/")
+    if not clean or len(clean) > MAX_EXPRESSION_CHARS:
+        raise ValueError("calculator_expression_length_invalid")
+    try:
+        root = ast.parse(clean, mode="eval")
+    except (SyntaxError, ValueError) as exc:
+        raise ValueError("calculator_expression_invalid") from exc
+    nodes = list(ast.walk(root))
+    if len(nodes) > MAX_EXPRESSION_NODES or _expression_depth(root) > MAX_EXPRESSION_DEPTH:
+        raise ValueError("calculator_expression_complexity_exceeded")
+
+    def evaluate(node: ast.AST) -> int | float | Any:
+        if isinstance(node, ast.Constant):
+            return _bounded_number(node.value)
+        if isinstance(node, ast.Name):
+            if node.id in _CALCULATOR_CONSTANTS:
+                return _CALCULATOR_CONSTANTS[node.id]
+            if node.id in _CALCULATOR_FUNCTIONS:
+                return _CALCULATOR_FUNCTIONS[node.id]
+            raise ValueError("calculator_identifier_denied")
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.USub, ast.UAdd)):
+            operand = _bounded_number(evaluate(node.operand))
+            return _bounded_number(-operand if isinstance(node.op, ast.USub) else operand)
+        if isinstance(node, ast.BinOp) and type(node.op) in _BINARY_OPERATORS:
+            left = _bounded_number(evaluate(node.left))
+            right = _bounded_number(evaluate(node.right))
+            if isinstance(node.op, ast.Pow):
+                if abs(right) > 100 or abs(left) > 1_000_000:
+                    raise ValueError("calculator_power_limit_exceeded")
+            try:
+                return _bounded_number(_BINARY_OPERATORS[type(node.op)](left, right))
+            except (ArithmeticError, OverflowError, ValueError) as exc:
+                raise ValueError("calculator_arithmetic_error") from exc
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            function = _CALCULATOR_FUNCTIONS.get(node.func.id)
+            if function is None or node.keywords or len(node.args) not in {1, 2}:
+                raise ValueError("calculator_function_call_denied")
+            arguments = [_bounded_number(evaluate(argument)) for argument in node.args]
+            try:
+                return _bounded_number(function(*arguments))
+            except (ArithmeticError, OverflowError, TypeError, ValueError) as exc:
+                raise ValueError("calculator_arithmetic_error") from exc
+        raise ValueError("calculator_operation_denied")
+
+    return _bounded_number(evaluate(root.body))
+
+
+def build_calculator(_context: Any) -> FastMCP:
+    """Expose the reviewed single-tool contract of calculator 0.2.1."""
+
+    mcp = FastMCP("ModelMirror MCP Server Calculator")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def calculate(
+        expression: Annotated[str, Field(min_length=1, max_length=MAX_EXPRESSION_CHARS)],
+    ) -> dict[str, Any]:
+        """Evaluate one bounded numeric expression without code execution."""
+
+        result = evaluate_calculator_expression(expression)
+        return {"result": str(result), "numeric_result": result}
+
+    return _freeze_strict_tool_contract(mcp)
+
+
+def _load_image(context: Any, file_id: str):
+    from PIL import Image
+
+    path = context.resolve_file(file_id)
+    if path.suffix.casefold() not in {".jpg", ".jpeg", ".png", ".webp"}:
+        raise ValueError("imagesorcery_input_format_denied")
+    size = path.stat().st_size
+    if size <= 0 or size > MAX_IMAGE_SOURCE_BYTES:
+        raise ValueError("imagesorcery_input_size_invalid")
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", Image.DecompressionBombWarning)
+            with Image.open(path) as probe:
+                if probe.format not in ALLOWED_IMAGE_FORMATS:
+                    raise ValueError("imagesorcery_input_format_denied")
+                if getattr(probe, "n_frames", 1) != 1:
+                    raise ValueError("imagesorcery_animated_input_denied")
+                width, height = probe.size
+                if (
+                    width <= 0
+                    or height <= 0
+                    or width > MAX_IMAGE_DIMENSION
+                    or height > MAX_IMAGE_DIMENSION
+                    or width * height > MAX_IMAGE_PIXELS
+                ):
+                    raise ValueError("imagesorcery_pixel_limit_exceeded")
+                source_format = str(probe.format)
+                source_mode = str(probe.mode)
+                probe.verify()
+            with Image.open(path) as image:
+                image.load()
+                use_alpha = image.mode in {"RGBA", "LA"} or "transparency" in image.info
+                normalized = image.convert("RGBA" if use_alpha else "RGB")
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError("imagesorcery_image_invalid") from exc
+    return path, normalized, source_format, source_mode
+
+
+def _validate_output_dimensions(width: int, height: int) -> None:
+    if (
+        width <= 0
+        or height <= 0
+        or width > MAX_IMAGE_DIMENSION
+        or height > MAX_IMAGE_DIMENSION
+        or width * height > MAX_IMAGE_PIXELS
+    ):
+        raise ValueError("imagesorcery_output_pixel_limit_exceeded")
+
+
+def _write_png_artifact(context: Any, artifact_name: str, image: Any) -> dict[str, Any]:
+    target = context.artifact_path(artifact_name, ".png")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(target, flags, 0o640)
+        with os.fdopen(descriptor, "wb", closefd=True) as stream:
+            descriptor = None
+            image.save(
+                stream,
+                format="PNG",
+                optimize=False,
+                compress_level=9,
+            )
+            stream.flush()
+            os.fsync(stream.fileno())
+        if target.is_symlink() or not target.is_file():
+            raise ValueError("imagesorcery_artifact_invalid")
+        if target.stat().st_size <= 0 or target.stat().st_size > MAX_IMAGE_ARTIFACT_BYTES:
+            raise ValueError("imagesorcery_artifact_size_exceeded")
+        return context.artifact_payload(target)
+    except Exception:
+        if descriptor is not None:
+            os.close(descriptor)
+        target.unlink(missing_ok=True)
+        raise
+
+
+def build_imagesorcery(context: Any) -> FastMCP:
+    """Expose a path-free deterministic subset of ImageSorcery MCP 0.12.0."""
+
+    from PIL import Image
+
+    mcp = FastMCP("ModelMirror ImageSorcery MCP")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_metainfo(file_id: FileId) -> dict[str, Any]:
+        """Return bounded image metadata without host paths or filesystem times."""
+
+        path, image, source_format, source_mode = _load_image(context, file_id)
+        width, height = image.size
+        image.close()
+        return {
+            "filename": path.name,
+            "size_bytes": path.stat().st_size,
+            "dimensions": {
+                "width": width,
+                "height": height,
+                "aspect_ratio": round(width / height, 6),
+            },
+            "format": source_format,
+            "color_mode": source_mode,
+        }
+
+    @mcp.tool(annotations=ARTIFACT_CREATE)
+    def resize(
+        file_id: FileId,
+        width: Annotated[int | None, Field(default=None, ge=1, le=MAX_IMAGE_DIMENSION)] = None,
+        height: Annotated[int | None, Field(default=None, ge=1, le=MAX_IMAGE_DIMENSION)] = None,
+        scale_factor: Annotated[float | None, Field(default=None, ge=0.05, le=8.0)] = None,
+        interpolation: Literal["nearest", "linear", "area", "cubic", "lanczos"] = "area",
+        artifact_name: ArtifactName = "resized.png",
+    ) -> dict[str, Any]:
+        """Resize one selected image and create a registered PNG artifact."""
+
+        _path, image, _source_format, _source_mode = _load_image(context, file_id)
+        original_width, original_height = image.size
+        if scale_factor is not None:
+            target_width = max(1, round(original_width * scale_factor))
+            target_height = max(1, round(original_height * scale_factor))
+        elif width is not None and height is not None:
+            target_width, target_height = width, height
+        elif width is not None:
+            target_width = width
+            target_height = max(1, round(original_height * width / original_width))
+        elif height is not None:
+            target_height = height
+            target_width = max(1, round(original_width * height / original_height))
+        else:
+            image.close()
+            raise ValueError("imagesorcery_resize_dimensions_required")
+        _validate_output_dimensions(target_width, target_height)
+        methods = {
+            "nearest": Image.Resampling.NEAREST,
+            "linear": Image.Resampling.BILINEAR,
+            "area": Image.Resampling.BOX,
+            "cubic": Image.Resampling.BICUBIC,
+            "lanczos": Image.Resampling.LANCZOS,
+        }
+        try:
+            transformed = image.resize((target_width, target_height), methods[interpolation])
+            return _write_png_artifact(context, artifact_name, transformed)
+        finally:
+            image.close()
+            if "transformed" in locals():
+                transformed.close()
+
+    @mcp.tool(annotations=ARTIFACT_CREATE)
+    def crop(
+        file_id: FileId,
+        x1: Annotated[int, Field(ge=0, le=MAX_IMAGE_DIMENSION)],
+        y1: Annotated[int, Field(ge=0, le=MAX_IMAGE_DIMENSION)],
+        x2: Annotated[int, Field(ge=1, le=MAX_IMAGE_DIMENSION)],
+        y2: Annotated[int, Field(ge=1, le=MAX_IMAGE_DIMENSION)],
+        artifact_name: ArtifactName = "cropped.png",
+    ) -> dict[str, Any]:
+        """Crop one selected image using a bounded rectangle."""
+
+        _path, image, _source_format, _source_mode = _load_image(context, file_id)
+        width, height = image.size
+        if x2 <= x1 or y2 <= y1 or x2 > width or y2 > height:
+            image.close()
+            raise ValueError("imagesorcery_crop_bounds_invalid")
+        try:
+            transformed = image.crop((x1, y1, x2, y2))
+            return _write_png_artifact(context, artifact_name, transformed)
+        finally:
+            image.close()
+            if "transformed" in locals():
+                transformed.close()
+
+    @mcp.tool(annotations=ARTIFACT_CREATE)
+    def rotate(
+        file_id: FileId,
+        angle: Annotated[float, Field(ge=-360.0, le=360.0)],
+        artifact_name: ArtifactName = "rotated.png",
+    ) -> dict[str, Any]:
+        """Rotate one selected image counterclockwise and keep the full result."""
+
+        _path, image, _source_format, _source_mode = _load_image(context, file_id)
+        try:
+            transformed = image.rotate(
+                angle,
+                resample=Image.Resampling.BICUBIC,
+                expand=True,
+            )
+            _validate_output_dimensions(*transformed.size)
+            return _write_png_artifact(context, artifact_name, transformed)
+        finally:
+            image.close()
+            if "transformed" in locals():
+                transformed.close()
+
+    return _freeze_strict_tool_contract(mcp)
+
+
+WAVE26_BUILDERS = {
+    CALCULATOR_ADAPTER_ID: build_calculator,
+    IMAGESORCERY_ADAPTER_ID: build_imagesorcery,
+}
+
+WAVE26_TOOL_NAMES = {
+    CALCULATOR_ADAPTER_ID: ("calculate",),
+    IMAGESORCERY_ADAPTER_ID: ("get_metainfo", "resize", "crop", "rotate"),
+}
+
+# Filled from the actual FastMCP tools/list response and enforced by tests/smoke.
+WAVE26_SCHEMA_SHA256 = {
+    CALCULATOR_ADAPTER_ID: (
+        "fd720b0ecc719751f3d7fcf5702a3d2c1f7e77073de249cd812c3753bed35a9f"
+    ),
+    IMAGESORCERY_ADAPTER_ID: (
+        "cba6ba696a976b5815e66c31b8ab02b47cf48a6d5bf7604d64ad8bb86b4bbfae"
+    ),
+}

--- a/server/sandbox_sidecar/smoke_file_wave26.py
+++ b/server/sandbox_sidecar/smoke_file_wave26.py
@@ -1,0 +1,507 @@
+"""Contract and real offline smoke for staged Wave 26A file adapters."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+import socket
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mcp.client.session import ClientSession
+
+from .file_mcp import opaque_file_id
+from .file_wave26 import (
+    CALCULATOR_ADAPTER_ID,
+    IMAGESORCERY_ADAPTER_ID,
+    WAVE26_BUILDERS,
+    WAVE26_SCHEMA_SHA256,
+    WAVE26_TOOL_NAMES,
+)
+
+
+def _load_mcp_stdio() -> tuple[Any, Any, Any]:
+    from mcp.client.session import ClientSession
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+
+    return ClientSession, StdioServerParameters, stdio_client
+
+
+def _digest(tools: list[Any]) -> str:
+    reviewed = [
+        {"name": tool.name, "inputSchema": tool.inputSchema}
+        for tool in sorted(tools, key=lambda item: item.name)
+    ]
+    return hashlib.sha256(
+        json.dumps(
+            reviewed,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+async def contract_only() -> None:
+    for adapter_id, builder in sorted(WAVE26_BUILDERS.items()):
+        tools = await builder(object()).list_tools()
+        names = {tool.name for tool in tools}
+        digest = _digest(tools)
+        if names != set(WAVE26_TOOL_NAMES[adapter_id]):
+            raise RuntimeError("wave26_tool_contract_drift")
+        if digest != WAVE26_SCHEMA_SHA256[adapter_id]:
+            raise RuntimeError("wave26_schema_contract_drift")
+        print(
+            f"adapter={adapter_id} tools={len(names)} schema_sha256={digest}",
+            flush=True,
+        )
+    print("wave26_file_contract_smoke=ok", flush=True)
+
+
+def _base_env(root: Path, workspace_id: str) -> dict[str, str]:
+    temp_root = root / "tmp"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    return {
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "PYTHONPATH": "/opt/modelmirror",
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONUNBUFFERED": "1",
+        "HOME": str(temp_root),
+        "TMPDIR": str(temp_root),
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "TZ": "UTC",
+        "NO_PROXY": "*",
+        "no_proxy": "*",
+        "MCP_FILE_WORKSPACE_ID": workspace_id,
+        "MCP_FILE_ADAPTER_ID": "",
+        "MCP_FILE_INPUT_ROOT": str(root / "inputs"),
+        "MCP_FILE_OUTPUT_ROOT": str(root / "outputs"),
+        "MCP_FILE_MEMORY_ROOT": str(root / "memory"),
+    }
+
+
+def _write_fixture(adapter_id: str, input_root: Path) -> tuple[str | None, str]:
+    if adapter_id == CALCULATOR_ADAPTER_ID:
+        return None, ""
+    from PIL import Image
+
+    path = input_root / "source.png"
+    image = Image.new("RGB", (96, 64), color=(20, 40, 80))
+    for x in range(16, 80):
+        for y in range(12, 52):
+            image.putpixel((x, y), (220, 140, 30))
+    image.save(path, format="PNG", optimize=False, compress_level=9)
+    image.close()
+    return opaque_file_id(input_root.name, path.name), path.name
+
+
+async def _call_ok(session: ClientSession, name: str, arguments: dict[str, Any]) -> Any:
+    result = await session.call_tool(name, arguments)
+    if result.isError:
+        raise RuntimeError(f"wave26_representative_call_failed:{name}")
+    return result
+
+
+async def _one_round(adapter_id: str, root: Path, round_number: int) -> dict[str, bytes]:
+    client_session_type, stdio_parameters_type, stdio_client_runtime = _load_mcp_stdio()
+    workspace_id = "mcpws_" + hashlib.sha256(
+        f"{adapter_id}:{round_number}".encode()
+    ).hexdigest()[:32]
+    input_root = root / "inputs" / workspace_id
+    output_root = root / "outputs" / workspace_id
+    memory_root = root / "memory" / workspace_id
+    input_root.mkdir(parents=True)
+    output_root.mkdir(parents=True)
+    memory_root.mkdir(parents=True)
+    file_id, source_name = _write_fixture(adapter_id, input_root)
+    source_hash = (
+        hashlib.sha256((input_root / source_name).read_bytes()).hexdigest()
+        if source_name
+        else ""
+    )
+    server, socket_path = await _start_file_server(
+        root,
+        allowed_adapters=adapter_id,
+    )
+    env = _base_env(root, workspace_id)
+    env["MCP_FILES_SOCKET_PATH"] = str(socket_path)
+    params = stdio_parameters_type(
+        command=sys.executable,
+        args=[
+            "-m",
+            "sandbox_sidecar.smoke_file_wave26",
+            "--proxy",
+            adapter_id,
+        ],
+        env=env,
+        cwd=Path(env["TMPDIR"]),
+    )
+    try:
+        async with stdio_client_runtime(params) as (read_stream, write_stream):
+            async with client_session_type(read_stream, write_stream) as session:
+                await session.initialize()
+                listed = await session.list_tools()
+                if {tool.name for tool in listed.tools} != set(WAVE26_TOOL_NAMES[adapter_id]):
+                    raise RuntimeError("wave26_runtime_tool_drift")
+                if _digest(listed.tools) != WAVE26_SCHEMA_SHA256[adapter_id]:
+                    raise RuntimeError("wave26_runtime_schema_drift")
+                if adapter_id == CALCULATOR_ADAPTER_ID:
+                    for expression, expected in (
+                        ("2 + 3 * 4", "14"),
+                        ("sqrt(81) + sin(pi / 2)", "10.0"),
+                    ):
+                        result = await _call_ok(
+                            session,
+                            "calculate",
+                            {"expression": expression},
+                        )
+                        structured = result.structuredContent or {}
+                        if structured.get("numeric_result") is None:
+                            raise RuntimeError("wave26_calculator_result_missing")
+                        if str(structured.get("result")) != expected:
+                            raise RuntimeError("wave26_calculator_result_drift")
+                    for expression in (
+                        "__import__('os').system('id')",
+                        "(1).__class__",
+                        "9**999999",
+                    ):
+                        denied = await session.call_tool(
+                            "calculate",
+                            {"expression": expression},
+                        )
+                        if not denied.isError:
+                            raise RuntimeError("wave26_calculator_code_execution_exposed")
+                else:
+                    assert file_id is not None
+                    await _call_ok(session, "get_metainfo", {"file_id": file_id})
+                    await _call_ok(
+                        session,
+                        "resize",
+                        {
+                            "file_id": file_id,
+                            "width": 48,
+                            "interpolation": "area",
+                            "artifact_name": "resized.png",
+                        },
+                    )
+                    await _call_ok(
+                        session,
+                        "crop",
+                        {
+                            "file_id": file_id,
+                            "x1": 8,
+                            "y1": 8,
+                            "x2": 72,
+                            "y2": 48,
+                            "artifact_name": "cropped.png",
+                        },
+                    )
+                    await _call_ok(
+                        session,
+                        "rotate",
+                        {
+                            "file_id": file_id,
+                            "angle": 90,
+                            "artifact_name": "rotated.png",
+                        },
+                    )
+                    for blocked_name, arguments in (
+                        ("detect", {"input_path": "/inputs/source.png"}),
+                        ("ocr", {"input_path": "https://example.com/a.png"}),
+                        ("resize", {"file_id": file_id, "width": 32, "output_path": "/tmp/out.png"}),
+                        ("resize", {"file_id": "file:///etc/passwd", "width": 32}),
+                    ):
+                        denied = await session.call_tool(blocked_name, arguments)
+                        if not denied.isError:
+                            raise RuntimeError("wave26_imagesorcery_unsafe_surface_exposed")
+    finally:
+        await _stop_process(server)
+    if source_name and hashlib.sha256((input_root / source_name).read_bytes()).hexdigest() != source_hash:
+        raise RuntimeError("wave26_source_mutated")
+    artifacts = {
+        path.name: path.read_bytes()
+        for path in sorted(output_root.iterdir())
+        if path.is_file() and not path.is_symlink()
+    }
+    if adapter_id == IMAGESORCERY_ADAPTER_ID:
+        if set(artifacts) != {"resized.png", "cropped.png", "rotated.png"}:
+            raise RuntimeError("wave26_artifact_set_drift")
+        for data in artifacts.values():
+            if not data.startswith(b"\x89PNG\r\n\x1a\n"):
+                raise RuntimeError("wave26_png_invalid")
+            if len(data) > 32 * 1024 * 1024:
+                raise RuntimeError("wave26_artifact_too_large")
+    elif artifacts:
+        raise RuntimeError("wave26_calculator_created_artifact")
+    return artifacts
+
+
+async def _wait_for_socket(socket_path: Path) -> None:
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if socket_path.is_socket():
+            return
+        await asyncio.sleep(0.05)
+    raise RuntimeError("wave26_file_server_start_timeout")
+
+
+async def _stop_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    process.terminate()
+    try:
+        await asyncio.wait_for(process.wait(), timeout=3)
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.wait()
+
+
+async def _start_file_server(
+    root: Path,
+    *,
+    allowed_adapters: str | None,
+) -> tuple[asyncio.subprocess.Process, Path]:
+    socket_path = root / "run" / "files-mcp.sock"
+    socket_path.parent.mkdir(parents=True, exist_ok=True)
+    socket_path.unlink(missing_ok=True)
+    env = _base_env(root, "mcpws_" + "f" * 32)
+    env.update(
+        {
+            "MCP_FILES_SOCKET_PATH": str(socket_path),
+            "MCP_FILES_MAX_SESSIONS": "1",
+        }
+    )
+    if allowed_adapters is not None:
+        env["MCP_FILE_ALLOWED_ADAPTERS"] = allowed_adapters
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "sandbox_sidecar.file_server",
+        cwd=Path(env["TMPDIR"]),
+        env=env,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    try:
+        await _wait_for_socket(socket_path)
+    except Exception:
+        await _stop_process(process)
+        raise
+    return process, socket_path
+
+
+async def _default_deny_probe(root: Path) -> None:
+    workspace_id = "mcpws_" + "d" * 32
+    (root / "inputs" / workspace_id).mkdir(parents=True, exist_ok=True)
+    process, socket_path = await _start_file_server(
+        root,
+        allowed_adapters=None,
+    )
+    try:
+        for adapter_id in sorted(WAVE26_BUILDERS):
+            reader, writer = await asyncio.open_unix_connection(str(socket_path))
+            writer.write(
+                json.dumps(
+                    {
+                        "action": "mcp_stdio",
+                        "adapter_id": adapter_id,
+                        "workspace_id": workspace_id,
+                    },
+                    separators=(",", ":"),
+                ).encode()
+                + b"\n"
+            )
+            await writer.drain()
+            response = json.loads(
+                (await asyncio.wait_for(reader.readline(), timeout=3)).decode()
+            )
+            writer.close()
+            await writer.wait_closed()
+            if response.get("ok") is not False or response.get("code") != "mcp_adapter_denied":
+                raise RuntimeError("wave26_default_deny_failed")
+    finally:
+        await _stop_process(process)
+
+
+def _wave26_child_count() -> int:
+    count = 0
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            command = (entry / "cmdline").read_bytes()
+        except OSError:
+            continue
+        if b"sandbox_sidecar.file_mcp\0" in command and IMAGESORCERY_ADAPTER_ID.encode() in command:
+            count += 1
+    return count
+
+
+async def _timeout_probe(root: Path) -> None:
+    from PIL import Image
+
+    client_session_type, stdio_parameters_type, stdio_client_runtime = _load_mcp_stdio()
+    workspace_id = "mcpws_" + "e" * 32
+    input_root = root / "inputs" / workspace_id
+    input_root.mkdir(parents=True, exist_ok=True)
+    source = input_root / "large.png"
+    image = Image.new("RGB", (3_000, 3_000), color=(24, 48, 96))
+    image.save(source, format="PNG", optimize=False, compress_level=9)
+    image.close()
+    file_id = opaque_file_id(workspace_id, source.name)
+    process, socket_path = await _start_file_server(
+        root,
+        allowed_adapters=IMAGESORCERY_ADAPTER_ID,
+    )
+    proxy_env = _base_env(root, workspace_id)
+    proxy_env["MCP_FILES_SOCKET_PATH"] = str(socket_path)
+    params = stdio_parameters_type(
+        command=sys.executable,
+        args=[
+            "-m",
+            "sandbox_sidecar.smoke_file_wave26",
+            "--proxy",
+            IMAGESORCERY_ADAPTER_ID,
+        ],
+        env=proxy_env,
+        cwd=Path(proxy_env["TMPDIR"]),
+    )
+    started = time.monotonic()
+    try:
+        async with stdio_client_runtime(params) as (read_stream, write_stream):
+            async with client_session_type(read_stream, write_stream) as session:
+                await session.initialize()
+                try:
+                    await asyncio.wait_for(
+                        session.call_tool(
+                            "rotate",
+                            {
+                                "file_id": file_id,
+                                "angle": 33,
+                                "artifact_name": "timeout.png",
+                            },
+                        ),
+                        timeout=0.001,
+                    )
+                except asyncio.TimeoutError:
+                    pass
+                else:
+                    raise RuntimeError("wave26_timeout_not_triggered")
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline and _wave26_child_count():
+            await asyncio.sleep(0.05)
+        if _wave26_child_count():
+            raise RuntimeError("wave26_timeout_process_leaked")
+        if time.monotonic() - started > 5:
+            raise RuntimeError("wave26_timeout_cleanup_slow")
+    finally:
+        await _stop_process(process)
+
+
+def _copy_proxy_stdin(sock: socket.socket) -> None:
+    try:
+        while True:
+            chunk = os.read(sys.stdin.fileno(), 64 * 1024)
+            if not chunk:
+                break
+            sock.sendall(chunk)
+    except (BrokenPipeError, ConnectionError, OSError):
+        pass
+    finally:
+        try:
+            sock.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def _proxy(adapter_id: str) -> int:
+    if adapter_id not in WAVE26_BUILDERS:
+        return 64
+    socket_path = Path(os.environ["MCP_FILES_SOCKET_PATH"])
+    workspace_id = os.environ["MCP_FILE_WORKSPACE_ID"]
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.settimeout(5)
+        sock.connect(str(socket_path))
+        sock.sendall(
+            json.dumps(
+                {
+                    "action": "mcp_stdio",
+                    "adapter_id": adapter_id,
+                    "workspace_id": workspace_id,
+                },
+                separators=(",", ":"),
+            ).encode()
+            + b"\n"
+        )
+        response = json.loads(sock.makefile("rb", buffering=0).readline(4097).decode())
+        if response.get("ok") is not True:
+            return 69
+        sock.settimeout(None)
+        threading.Thread(target=_copy_proxy_stdin, args=(sock,), daemon=True).start()
+        while True:
+            chunk = sock.recv(64 * 1024)
+            if not chunk:
+                break
+            sys.stdout.buffer.write(chunk)
+            sys.stdout.buffer.flush()
+        return 0
+    except (ConnectionError, OSError, ValueError, json.JSONDecodeError):
+        return 69
+    finally:
+        sock.close()
+
+
+async def runtime_smoke() -> None:
+    base = Path(tempfile.mkdtemp(prefix="wave26-file-smoke-"))
+    try:
+        await _default_deny_probe(base / "default-deny")
+        for adapter_id in sorted(WAVE26_BUILDERS):
+            first = await asyncio.wait_for(
+                _one_round(adapter_id, base / "round-1", 1), timeout=30
+            )
+            second = await asyncio.wait_for(
+                _one_round(adapter_id, base / "round-2", 2), timeout=30
+            )
+            if first != second:
+                raise RuntimeError("wave26_artifact_not_deterministic")
+            print(
+                f"adapter={adapter_id} rounds=2 artifacts={len(second)}",
+                flush=True,
+            )
+        await _timeout_probe(base / "timeout")
+    finally:
+        shutil.rmtree(base, ignore_errors=False)
+    if base.exists():
+        raise RuntimeError("wave26_cleanup_failed")
+    print(
+        "wave26_file_runtime_smoke=ok network=none source_immutable=true "
+        "deterministic=true default_deny=true timeout=verified cleanup=verified",
+        flush=True,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--contract-only", action="store_true")
+    parser.add_argument("--proxy", choices=tuple(sorted(WAVE26_BUILDERS)))
+    args = parser.parse_args()
+    if args.proxy:
+        raise SystemExit(_proxy(args.proxy))
+    asyncio.run(contract_only() if args.contract_only else runtime_smoke())
+
+
+if __name__ == "__main__":
+    main()

--- a/server/sandbox_sidecar/smoke_token_gateway.py
+++ b/server/sandbox_sidecar/smoke_token_gateway.py
@@ -1,0 +1,128 @@
+"""Manual JSON-RPC probe for the private Token sidecar Unix-socket gateway."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import socket
+from pathlib import Path
+
+from .token_contracts import TOKEN_ADAPTERS, TOKEN_SCHEMA_SHA256
+
+
+def _configuration(adapter_id: str) -> dict[str, dict[str, str]]:
+    contract = TOKEN_ADAPTERS[adapter_id]
+    return {
+        "credentials": {
+            key: f"offline-smoke-{key}"
+            for key, _ in contract.credential_environment
+        },
+        "settings": {
+            key: "offline-smoke"
+            for key, _ in contract.setting_environment
+        },
+    }
+
+
+def _read_response(stream: object, request_id: int) -> dict[str, object]:
+    for _ in range(64):
+        raw = stream.readline(256 * 1024 + 1)
+        if not raw or len(raw) > 256 * 1024:
+            raise RuntimeError("token_gateway_response_invalid")
+        payload = json.loads(raw.decode("utf-8"))
+        if isinstance(payload, dict) and payload.get("id") == request_id:
+            return payload
+    raise RuntimeError("token_gateway_response_missing")
+
+
+def probe(adapter_id: str, *, expect_denied: bool) -> None:
+    socket_path = Path(
+        os.getenv(
+            "MCP_TOKEN_SOCKET_PATH",
+            "/run/modelmirror-token-mcp/token-mcp.sock",
+        )
+    )
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(10)
+    client.connect(str(socket_path))
+    stream = client.makefile("rwb", buffering=0)
+    handshake = {
+        "action": "mcp_stdio",
+        "adapter_id": adapter_id,
+        "configuration": _configuration(adapter_id),
+    }
+    stream.write(json.dumps(handshake, separators=(",", ":")).encode() + b"\n")
+    raw = stream.readline(4097)
+    response = json.loads(raw.decode("utf-8")) if raw else {}
+    if expect_denied:
+        if not isinstance(response, dict) or response.get("code") != "mcp_adapter_denied":
+            raise RuntimeError("staged_adapter_was_not_denied")
+        print(f"adapter={adapter_id} gateway_default_deny=ok")
+        return
+    if not isinstance(response, dict) or response.get("ok") is not True:
+        raise RuntimeError("token_gateway_handshake_rejected")
+
+    initialize = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "modelmirror-token-gateway-smoke", "version": "1"},
+        },
+    }
+    stream.write(json.dumps(initialize, separators=(",", ":")).encode() + b"\n")
+    initialized = _read_response(stream, 1)
+    if "result" not in initialized:
+        raise RuntimeError("token_gateway_initialize_failed")
+    stream.write(
+        b'{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}\n'
+    )
+    stream.write(b'{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}\n')
+    listed = _read_response(stream, 2)
+    result = listed.get("result")
+    tools = result.get("tools") if isinstance(result, dict) else None
+    if not isinstance(tools, list):
+        raise RuntimeError("token_gateway_tools_invalid")
+    reviewed = [
+        {"name": item.get("name"), "inputSchema": item.get("inputSchema")}
+        for item in sorted(
+            (value for value in tools if isinstance(value, dict)),
+            key=lambda value: str(value.get("name")),
+        )
+    ]
+    names = {str(item["name"]) for item in reviewed}
+    if names != set(TOKEN_ADAPTERS[adapter_id].tools):
+        raise RuntimeError("token_gateway_tool_filter_drift")
+    digest = hashlib.sha256(
+        json.dumps(
+            reviewed,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    if digest != TOKEN_SCHEMA_SHA256[adapter_id]:
+        raise RuntimeError("token_gateway_schema_drift")
+    client.shutdown(socket.SHUT_RDWR)
+    client.close()
+    print(
+        f"adapter={adapter_id} gateway_initialize=ok tools={len(names)} "
+        f"schema_sha256={digest} disconnect=ok"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("adapter_id", choices=sorted(TOKEN_ADAPTERS))
+    parser.add_argument("--expect-denied", action="store_true")
+    args = parser.parse_args()
+    probe(args.adapter_id, expect_denied=args.expect_denied)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/sandbox_sidecar/token_builtin.py
+++ b/server/sandbox_sidecar/token_builtin.py
@@ -3,17 +3,19 @@
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import os
 import re
 import xml.etree.ElementTree as ET
-from typing import Any
+from typing import Annotated, Any, Literal
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
+from pydantic import ConfigDict, Field
 
-from .safe_http import SafeHttpClient
+from .safe_http import NetworkPolicyError, SafeHttpClient
 
 
 MAX_RESULT_BYTES = 256 * 1024
@@ -23,6 +25,20 @@ READ_ONLY = ToolAnnotations(
     idempotentHint=True,
     openWorldHint=True,
 )
+
+
+def _freeze_strict_tool_contract(mcp: FastMCP) -> FastMCP:
+    """Reject undeclared arguments and non-finite numbers for reviewed facades."""
+    for tool in mcp._tool_manager._tools.values():
+        argument_model = tool.fn_metadata.arg_model
+        argument_model.model_config = ConfigDict(
+            **dict(argument_model.model_config),
+            extra="forbid",
+            allow_inf_nan=False,
+        )
+        argument_model.model_rebuild(force=True)
+        tool.parameters = argument_model.model_json_schema(by_alias=True)
+    return mcp
 
 
 def _required_environment(name: str, maximum: int = 20_000) -> str:
@@ -86,6 +102,21 @@ def _bounded_text_response(response: object, provider: str) -> str:
     if len(text.encode("utf-8")) > MAX_RESULT_BYTES:
         raise ValueError("Tool output exceeds the 256 KiB limit.")
     return text
+
+
+def _plain_provider_text(value: object, maximum: int = 2_000) -> str:
+    """Return bounded plain text without preserving provider-owned markup."""
+    clean = html.unescape(str(value or ""))
+    clean = re.sub(r"<[^>]*>", "", clean)
+    clean = re.sub(r"\s+", " ", clean).strip()
+    return clean[:maximum]
+
+
+def _bounded_public_result_url(value: object) -> str:
+    try:
+        return _public_extract_url(value)
+    except (ValueError, NetworkPolicyError):
+        return ""
 
 
 _SENSITIVE_QUERY_KEYS = frozenset(
@@ -1471,6 +1502,183 @@ def build_keboola_metadata_readonly() -> FastMCP:
     return mcp
 
 
+def build_google_news_readonly() -> FastMCP:
+    """Expose the fixed search-only identity of server-google-news 1.0.0."""
+    api_key = _required_environment("SERP_API_KEY")
+    client = SafeHttpClient(
+        allowed_hosts=frozenset({"serpapi.com"}),
+        max_response_bytes=MAX_RESULT_BYTES,
+    )
+    mcp = FastMCP("ModelMirror Google News Read Only")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def google_news_search(
+        q: Annotated[str, Field(min_length=1, max_length=500)],
+        gl: Annotated[str, Field(pattern=r"^[a-z]{2}$")] = "us",
+        hl: Annotated[str, Field(pattern=r"^[a-z]{2}(?:-[A-Z]{2})?$")] = "en",
+        max_results: Annotated[int, Field(ge=1, le=20)] = 10,
+    ) -> Any:
+        """Search Google News through one fixed SerpAPI endpoint and return bounded article metadata."""
+        query = _text(q, "q", 500)
+        country = str(gl).strip()
+        language = str(hl).strip()
+        if not re.fullmatch(r"[a-z]{2}", country):
+            raise ValueError("gl must be a two-letter lowercase country code.")
+        if not re.fullmatch(r"[a-z]{2}(?:-[A-Z]{2})?", language):
+            raise ValueError("hl must be a reviewed language code.")
+        limit = int(max_results)
+        if not 1 <= limit <= 20:
+            raise ValueError("max_results must be between 1 and 20.")
+        url = "https://serpapi.com/search?" + urlencode(
+            {
+                "engine": "google_news",
+                "q": query,
+                "gl": country,
+                "hl": language,
+                "api_key": api_key,
+            }
+        )
+        payload = _json(client.request(url), "SerpAPI Google News")
+        if not isinstance(payload, dict):
+            raise ValueError("SerpAPI Google News returned an invalid response.")
+        raw_articles = payload.get("news_results")
+        articles: list[dict[str, object]] = []
+        for item in raw_articles if isinstance(raw_articles, list) else []:
+            if not isinstance(item, dict):
+                continue
+            source_value = item.get("source")
+            if isinstance(source_value, dict):
+                source_name = _plain_provider_text(source_value.get("name"), 240)
+                raw_authors = source_value.get("authors")
+            else:
+                source_name = _plain_provider_text(source_value, 240)
+                raw_authors = None
+            authors = [
+                _plain_provider_text(author, 120)
+                for author in (raw_authors if isinstance(raw_authors, list) else [])[:10]
+                if _plain_provider_text(author, 120)
+            ]
+            article = {
+                "title": _plain_provider_text(item.get("title"), 500),
+                "source": source_name,
+                "date": _plain_provider_text(item.get("date"), 120),
+                "snippet": _plain_provider_text(item.get("snippet"), 2_000),
+                "link": _bounded_public_result_url(item.get("link")),
+                "authors": authors,
+            }
+            if article["title"]:
+                articles.append(article)
+            if len(articles) >= limit:
+                break
+        return {"articles": articles, "count": len(articles)}
+
+    return _freeze_strict_tool_contract(mcp)
+
+
+def build_naver_search_readonly() -> FastMCP:
+    """Expose three classic Naver Search API read tools from version 1.0.50."""
+    client_id = _required_environment("NAVER_CLIENT_ID", 1_000)
+    client_secret = _required_environment("NAVER_CLIENT_SECRET", 2_000)
+    client = SafeHttpClient(
+        allowed_hosts=frozenset({"openapi.naver.com"}),
+        max_response_bytes=MAX_RESULT_BYTES,
+        additional_allowed_headers=frozenset(
+            {"x-naver-client-id", "x-naver-client-secret"}
+        ),
+    )
+    headers = {
+        "X-Naver-Client-Id": client_id,
+        "X-Naver-Client-Secret": client_secret,
+    }
+    mcp = FastMCP("ModelMirror Naver Search Read Only")
+
+    def search(
+        search_type: Literal["webkr", "news", "blog"],
+        query: str,
+        display: int,
+        start: int,
+        sort: Literal["sim", "date"],
+    ) -> Any:
+        clean_query = _text(query, "query", 500)
+        page_size = int(display)
+        page_start = int(start)
+        if not 1 <= page_size <= 20:
+            raise ValueError("display must be between 1 and 20.")
+        if not 1 <= page_start <= 1_000:
+            raise ValueError("start must be between 1 and 1000.")
+        if sort not in {"sim", "date"}:
+            raise ValueError("sort must be sim or date.")
+        url = f"https://openapi.naver.com/v1/search/{search_type}?" + urlencode(
+            {
+                "query": clean_query,
+                "display": page_size,
+                "start": page_start,
+                "sort": sort,
+            }
+        )
+        payload = _json(client.request(url, headers=headers), "Naver Search")
+        if not isinstance(payload, dict):
+            raise ValueError("Naver Search returned an invalid response.")
+        raw_items = payload.get("items")
+        items: list[dict[str, str]] = []
+        for item in raw_items if isinstance(raw_items, list) else []:
+            if not isinstance(item, dict):
+                continue
+            projected = {
+                "title": _plain_provider_text(item.get("title"), 500),
+                "description": _plain_provider_text(item.get("description"), 2_000),
+                "link": _bounded_public_result_url(item.get("link")),
+                "originallink": _bounded_public_result_url(item.get("originallink")),
+                "bloggername": _plain_provider_text(item.get("bloggername"), 240),
+                "postdate": _plain_provider_text(item.get("postdate"), 40),
+                "pubDate": _plain_provider_text(item.get("pubDate"), 120),
+            }
+            if projected["title"]:
+                items.append(projected)
+            if len(items) >= page_size:
+                break
+        total_value = payload.get("total")
+        total = int(total_value) if isinstance(total_value, int) and total_value >= 0 else 0
+        return {
+            "total": total,
+            "start": page_start,
+            "display": len(items),
+            "items": items,
+        }
+
+    @mcp.tool(annotations=READ_ONLY)
+    def search_webkr(
+        query: Annotated[str, Field(min_length=1, max_length=500)],
+        display: Annotated[int, Field(ge=1, le=20)] = 10,
+        start: Annotated[int, Field(ge=1, le=1_000)] = 1,
+        sort: Literal["sim", "date"] = "sim",
+    ) -> Any:
+        """Search Korean web documents with bounded pagination."""
+        return search("webkr", query, display, start, sort)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def search_news(
+        query: Annotated[str, Field(min_length=1, max_length=500)],
+        display: Annotated[int, Field(ge=1, le=20)] = 10,
+        start: Annotated[int, Field(ge=1, le=1_000)] = 1,
+        sort: Literal["sim", "date"] = "sim",
+    ) -> Any:
+        """Search Naver news metadata with bounded pagination."""
+        return search("news", query, display, start, sort)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def search_blog(
+        query: Annotated[str, Field(min_length=1, max_length=500)],
+        display: Annotated[int, Field(ge=1, le=20)] = 10,
+        start: Annotated[int, Field(ge=1, le=1_000)] = 1,
+        sort: Literal["sim", "date"] = "sim",
+    ) -> Any:
+        """Search Naver blog metadata with bounded pagination."""
+        return search("blog", query, display, start, sort)
+
+    return _freeze_strict_tool_contract(mcp)
+
+
 BUILDERS = {
     "axiom-mcp": build_axiom,
     "blazickjp-arxiv-mcp-server": build_arxiv_readonly,
@@ -1484,6 +1692,8 @@ BUILDERS = {
     "cablate-mcp-google-map": build_google_map_readonly,
     "comet-ml-opik-mcp": build_opik_readonly,
     "keboola-keboola-mcp-server": build_keboola_metadata_readonly,
+    "chanmeng666-server-google-news": build_google_news_readonly,
+    "isnow890-naver-search-mcp": build_naver_search_readonly,
 }
 
 

--- a/server/sandbox_sidecar/token_contracts.py
+++ b/server/sandbox_sidecar/token_contracts.py
@@ -242,13 +242,42 @@ TOKEN_ADAPTERS: dict[str, TokenAdapterContract] = {
         allowed_hosts=frozenset({"connection.keboola.com"}),
         builtin=True,
     ),
+    "chanmeng666-server-google-news": TokenAdapterContract(
+        (
+            "python",
+            "-m",
+            "sandbox_sidecar.token_builtin",
+            "chanmeng666-server-google-news",
+        ),
+        frozenset({"google_news_search"}),
+        (("api_key", "SERP_API_KEY"),),
+        allowed_hosts=frozenset({"serpapi.com"}),
+        builtin=True,
+    ),
+    "isnow890-naver-search-mcp": TokenAdapterContract(
+        (
+            "python",
+            "-m",
+            "sandbox_sidecar.token_builtin",
+            "isnow890-naver-search-mcp",
+        ),
+        frozenset({"search_webkr", "search_news", "search_blog"}),
+        (
+            ("client_id", "NAVER_CLIENT_ID"),
+            ("client_secret", "NAVER_CLIENT_SECRET"),
+        ),
+        allowed_hosts=frozenset({"openapi.naver.com"}),
+        builtin=True,
+    ),
 }
 
 
 STAGED_TOKEN_ADAPTERS = frozenset(
     {
         "cablate-mcp-google-map",
+        "chanmeng666-server-google-news",
         "comet-ml-opik-mcp",
+        "isnow890-naver-search-mcp",
         "keboola-keboola-mcp-server",
     }
 )
@@ -279,6 +308,8 @@ TOKEN_SCHEMA_SHA256: dict[str, str] = {
     "cablate-mcp-google-map": "186785bce37ec786aa86bfa2b3fdfeb6918633eb309e0000de8d291d7a7650a6",
     "comet-ml-opik-mcp": "084588762fe49f9cc6be8c82e4e1b6a4eb2fc361cbf9156b792465a49d7d50b9",
     "keboola-keboola-mcp-server": "fc72f9c337b51f7ae45c6bb566256e6a7e163f98635df6bc406f15d11f027f3c",
+    "chanmeng666-server-google-news": "4b91bf5c89cf1b30de554e6bb6394d6f8a0c3c2fa906bf162319f6309f6726ae",
+    "isnow890-naver-search-mcp": "6faa94b4caad3ce9431395971416f058ad68564a8781f664f979b55e823d52ba",
 }
 
 

--- a/server/tests/test_mcp_catalog.py
+++ b/server/tests/test_mcp_catalog.py
@@ -371,11 +371,11 @@ def test_catalog_freezes_300_projects_and_maps_all_waves_once() -> None:
     assert sum(
         manifest.availability == "ready"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 75
+    ) == 76
     assert sum(
         manifest.availability == "planned"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 69
+    ) == 68
     assert sum(
         manifest.availability == "blocked"
         for manifest in CATALOG_ADAPTERS.values()
@@ -436,7 +436,7 @@ def test_frontend_catalog_ids_match_backend_registry_and_never_submit_commands()
     assert "server_command" not in expansion_v2_source + expansion_v3_source
     assert '"endpoint"' not in expansion_v2_source + expansion_v3_source
     assert expansion_v2_source.count('"availability": "ready"') == 26
-    assert expansion_v3_source.count('"availability": "ready"') == 4
+    assert expansion_v3_source.count('"availability": "ready"') == 5
     assert 'fetch("/api/mcp/connect"' not in card_source
     assert 'fetch("/api/mcp/install"' not in card_source
     assert not re.search(
@@ -793,12 +793,13 @@ def test_wave24_catalog_expansion_only_executes_accepted_wave25_ids(
     assert {
         status: sum(item.availability == status for item in CATALOG_EXPANSION_V3_ADAPTERS)
         for status in ("ready", "planned", "blocked")
-    } == {"ready": 4, "planned": 42, "blocked": 54}
+    } == {"ready": 5, "planned": 41, "blocked": 54}
     ready_ids = {
         "coinpaprika-dexpaprika-mcp",
         "pab1it0-chess-mcp",
         "rishijatia-fantasy-pl-mcp",
         "yuna0x0-anilist-mcp",
+        "githejie-mcp-server-calculator",
     }
     assert {
         item.project_id
@@ -808,15 +809,22 @@ def test_wave24_catalog_expansion_only_executes_accepted_wave25_ids(
     for project_id in ready_ids:
         manifest = CATALOG_ADAPTERS[project_id]
         assert manifest.availability == "ready"
-        assert manifest.enabled_by_default is False
-        assert manifest.executable is False
+        assert manifest.enabled_by_default is (
+            project_id == "githejie-mcp-server-calculator"
+        )
+        assert manifest.executable is (
+            project_id == "githejie-mcp-server-calculator"
+        )
         assert manifest.server_command[-1] == project_id
-        assert manifest.public_policy is not None
+        assert (manifest.public_policy is not None) is (
+            project_id != "githejie-mcp-server-calculator"
+        )
         assert manifest.credential_slots == ()
         assert manifest.tool_policies
         assert all(policy.effect == "read" for policy in manifest.tool_policies.values())
-        monkeypatch.setenv(manifest.feature_flag, "true")
-        assert manifest.executable is True
+        if not manifest.enabled_by_default:
+            monkeypatch.setenv(manifest.feature_flag, "true")
+            assert manifest.executable is True
     for project_id in expansion_ids - ready_ids:
         manifest = CATALOG_ADAPTERS[project_id]
         monkeypatch.setenv(manifest.feature_flag, "true")
@@ -1944,8 +1952,8 @@ async def test_catalog_api_hides_execution_details_and_rejects_planned_connect()
             assert response.status_code == 200
             payload = response.json()
             assert payload["total"] == 300
-            assert payload["ready"] == 75
-            assert payload["planned"] == 69
+            assert payload["ready"] == 76
+            assert payload["planned"] == 68
             assert payload["blocked"] == 156
             serialized = response.text.lower()
             assert "server_command" not in serialized

--- a/server/tests/test_mcp_catalog_wave24_review.py
+++ b/server/tests/test_mcp_catalog_wave24_review.py
@@ -121,8 +121,8 @@ def test_wave24_review_has_no_prior_catalog_identity_or_runtime_surface() -> Non
         return set()
 
     assert Counter(item["proposed_availability"] for item in candidates) == {
-        "ready": 4,
-        "planned": 42,
+        "ready": 5,
+        "planned": 41,
         "blocked": 54,
     }
     assert all(

--- a/server/tests/test_mcp_database_sidecar.py
+++ b/server/tests/test_mcp_database_sidecar.py
@@ -74,6 +74,11 @@ EXPECTED_TOOLS = {
     },
     "neo4j-contrib-mcp-neo4j": {"get_schema", "read_cypher"},
     "arcadedata-arcadedb": {"list_types", "describe_type", "read_query"},
+    "greptimeteam-greptimedb-mcp-server": {
+        "describe_table",
+        "query_range",
+        "health_check",
+    },
 }
 
 
@@ -99,7 +104,7 @@ def test_database_contract_and_proxy_allowlists_are_exact() -> None:
         adapter_id: set(tool_names)
         for adapter_id, tool_names in ADAPTER_TOOL_NAMES.items()
     } == EXPECTED_TOOLS
-    assert STAGED_DATABASE_ADAPTERS == frozenset()
+    assert STAGED_DATABASE_ADAPTERS == {"greptimeteam-greptimedb-mcp-server"}
     assert GRAPH_DATA_SERVICE_ADAPTERS == {
         "zilliztech-mcp-server-milvus",
         "neo4j-contrib-mcp-neo4j",
@@ -110,8 +115,9 @@ def test_database_contract_and_proxy_allowlists_are_exact() -> None:
         "qdrant-mcp-server-qdrant",
         "cr7258-elasticsearch-mcp-server",
         *GRAPH_DATA_SERVICE_ADAPTERS,
+        *STAGED_DATABASE_ADAPTERS,
     }
-    assert REMOTE_DATA_SERVICE_ADAPTERS <= database_server.ALLOWED_ADAPTERS
+    assert database_server.ALLOWED_ADAPTERS == set(EXPECTED_TOOLS) - set(STAGED_DATABASE_ADAPTERS)
 
 
 def test_database_configuration_is_structured_and_tls_is_strict() -> None:

--- a/server/tests/test_mcp_token_sidecar.py
+++ b/server/tests/test_mcp_token_sidecar.py
@@ -136,7 +136,9 @@ def test_runtime_contracts_match_catalog_and_never_include_snyk() -> None:
 
     assert STAGED_TOKEN_ADAPTERS == {
         "cablate-mcp-google-map",
+        "chanmeng666-server-google-news",
         "comet-ml-opik-mcp",
+        "isnow890-naver-search-mcp",
         "keboola-keboola-mcp-server",
     }
     assert not (set(token_server.ALLOWED_ADAPTERS) & set(STAGED_TOKEN_ADAPTERS))
@@ -154,6 +156,19 @@ def test_runtime_contracts_match_catalog_and_never_include_snyk() -> None:
     keboola = TOKEN_ADAPTERS["keboola-keboola-mcp-server"]
     assert keboola.tools == frozenset({"get_project_info", "get_buckets", "get_tables"})
     assert keboola.allowed_hosts == frozenset({"connection.keboola.com"})
+
+    google_news = TOKEN_ADAPTERS["chanmeng666-server-google-news"]
+    assert google_news.tools == frozenset({"google_news_search"})
+    assert google_news.allowed_hosts == frozenset({"serpapi.com"})
+    assert google_news.credential_environment == (("api_key", "SERP_API_KEY"),)
+
+    naver = TOKEN_ADAPTERS["isnow890-naver-search-mcp"]
+    assert naver.tools == frozenset({"search_webkr", "search_news", "search_blog"})
+    assert naver.allowed_hosts == frozenset({"openapi.naver.com"})
+    assert naver.credential_environment == (
+        ("client_id", "NAVER_CLIENT_ID"),
+        ("client_secret", "NAVER_CLIENT_SECRET"),
+    )
 
 
 def test_compose_token_allowlist_contains_every_non_registry_contract() -> None:

--- a/server/tests/test_mcp_wave18a_file_artifacts.py
+++ b/server/tests/test_mcp_wave18a_file_artifacts.py
@@ -122,7 +122,8 @@ async def test_wave18a_tool_names_schema_digests_and_markers(
 def test_wave18a_is_default_allowed_and_file_workspaces_are_narrow(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    assert STAGED_FILE_ADAPTERS == frozenset()
+    assert WAVE18A_IDS.isdisjoint(STAGED_FILE_ADAPTERS)
+    assert WAVE20_READY_IDS.isdisjoint(STAGED_FILE_ADAPTERS)
     assert WAVE18A_IDS.issubset(DEFAULT_ALLOWED_ADAPTERS)
     assert WAVE20_READY_IDS.issubset(DEFAULT_ALLOWED_ADAPTERS)
     assert WAVE18A_IDS.issubset(FILE_PROJECTS)

--- a/server/tests/test_mcp_wave18b_file_analysis.py
+++ b/server/tests/test_mcp_wave18b_file_analysis.py
@@ -109,7 +109,8 @@ async def test_wave18b_tool_contracts_are_frozen_and_do_not_expose_open_surfaces
 def test_wave18b_is_default_allowed_after_acceptance_and_has_narrow_workspace_formats(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    assert STAGED_FILE_ADAPTERS == frozenset()
+    assert WAVE18B_IDS.isdisjoint(STAGED_FILE_ADAPTERS)
+    assert WAVE20_READY_IDS.isdisjoint(STAGED_FILE_ADAPTERS)
     assert WAVE18B_IDS.issubset(DEFAULT_ALLOWED_ADAPTERS)
     assert WAVE20_READY_IDS.issubset(DEFAULT_ALLOWED_ADAPTERS)
     assert WAVE18B_IDS.issubset(FILE_PROJECTS)

--- a/server/tests/test_mcp_wave19b_graph_services.py
+++ b/server/tests/test_mcp_wave19b_graph_services.py
@@ -68,7 +68,7 @@ def _context(adapter_id: str) -> SimpleNamespace:
 @pytest.mark.asyncio
 async def test_wave23_promotes_exact_wave19b_read_only_contracts() -> None:
     assert WAVE19B == GRAPH_DATA_SERVICE_ADAPTERS
-    assert STAGED_DATABASE_ADAPTERS == frozenset()
+    assert WAVE19B.isdisjoint(STAGED_DATABASE_ADAPTERS)
     assert WAVE19B <= set(DATABASE_ADAPTERS)
     assert WAVE19B <= database_proxy.ALLOWED_ADAPTERS
     assert WAVE19B <= set(BUILDERS) == set(PREFLIGHTS)

--- a/server/tests/test_mcp_wave20_code_index.py
+++ b/server/tests/test_mcp_wave20_code_index.py
@@ -120,7 +120,7 @@ async def test_wave20_tool_contract_is_exact_and_closes_open_surfaces(
 def test_wave20_is_ready_default_allowed_and_workspace_formats_are_go_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    assert STAGED_FILE_ADAPTERS == frozenset()
+    assert GOGRAPH_ADAPTER_ID not in STAGED_FILE_ADAPTERS
     assert GOGRAPH_ADAPTER_ID in DEFAULT_ALLOWED_ADAPTERS
     assert GOGRAPH_ADAPTER_ID in file_proxy.ALLOWED_ADAPTERS
     assert GOGRAPH_ADAPTER_ID in FILE_PROJECTS

--- a/server/tests/test_mcp_wave26a_files.py
+++ b/server/tests/test_mcp_wave26a_files.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from server.mcp.catalog import CATALOG_ADAPTERS
+from server.mcp.catalog_expansion_v3 import CATALOG_EXPANSION_V3_ADAPTERS
+from server.mcp.workspace import FILE_PROJECTS, PROJECT_EXTENSIONS
+from server.sandbox_sidecar.file_mcp import BUILDERS
+from server.sandbox_sidecar.file_server import (
+    DEFAULT_ALLOWED_ADAPTERS,
+    STAGED_FILE_ADAPTERS,
+)
+from server.sandbox_sidecar.file_wave26 import (
+    CALCULATOR_ADAPTER_ID,
+    IMAGESORCERY_ADAPTER_ID,
+    MAX_EXPRESSION_CHARS,
+    WAVE26_BUILDERS,
+    WAVE26_SCHEMA_SHA256,
+    WAVE26_TOOL_NAMES,
+    build_calculator,
+    build_imagesorcery,
+    evaluate_calculator_expression,
+)
+
+
+WAVE26_IDS = {CALCULATOR_ADAPTER_ID, IMAGESORCERY_ADAPTER_ID}
+
+
+def _digest(tools: list[object]) -> str:
+    reviewed = [
+        {"name": tool.name, "inputSchema": tool.inputSchema}
+        for tool in sorted(tools, key=lambda item: item.name)
+    ]
+    return hashlib.sha256(
+        json.dumps(
+            reviewed,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+class _Context:
+    def __init__(self, root: Path, files: dict[str, bytes]) -> None:
+        self.input_root = root / "inputs"
+        self.output_root = root / "outputs"
+        self.input_root.mkdir(parents=True)
+        self.output_root.mkdir(parents=True)
+        self._files: dict[str, Path] = {}
+        for index, (name, content) in enumerate(files.items()):
+            path = self.input_root / name
+            path.write_bytes(content)
+            self._files[f"mcpf_{index:024x}"] = path
+
+    def resolve_file(self, file_id: str) -> Path:
+        path = self._files.get(file_id)
+        if path is None:
+            raise ValueError("selected workspace file does not exist")
+        return path
+
+    def artifact_path(self, name: str, suffix: str) -> Path:
+        clean = Path(str(name)).name
+        if clean != str(name) or clean in {"", ".", ".."}:
+            raise ValueError("artifact path invalid")
+        if not clean.casefold().endswith(suffix):
+            clean += suffix
+        target = self.output_root / clean
+        if target.exists() or target.is_symlink():
+            raise ValueError("artifact already exists")
+        return target
+
+    @staticmethod
+    def artifact_payload(path: Path) -> dict[str, object]:
+        content = path.read_bytes()
+        return {
+            "artifact_name": path.name,
+            "relative_path": path.name,
+            "size_bytes": len(content),
+            "sha256": hashlib.sha256(content).hexdigest(),
+        }
+
+
+def _image_bytes(size: tuple[int, int] = (96, 64)) -> bytes:
+    pillow = pytest.importorskip("PIL.Image")
+    import io
+
+    stream = io.BytesIO()
+    image = pillow.new("RGB", size, color=(20, 40, 80))
+    image.save(stream, format="PNG", optimize=False, compress_level=9)
+    image.close()
+    return stream.getvalue()
+
+
+def test_wave26_runtime_is_staged_default_deny_and_not_catalog_executable() -> None:
+    assert set(WAVE26_BUILDERS) == WAVE26_IDS
+    assert WAVE26_IDS.issubset(BUILDERS)
+    assert STAGED_FILE_ADAPTERS == {IMAGESORCERY_ADAPTER_ID}
+    assert CALCULATOR_ADAPTER_ID in DEFAULT_ALLOWED_ADAPTERS
+    assert IMAGESORCERY_ADAPTER_ID not in DEFAULT_ALLOWED_ADAPTERS
+    assert CALCULATOR_ADAPTER_ID in FILE_PROJECTS
+    assert PROJECT_EXTENSIONS[CALCULATOR_ADAPTER_ID] == set()
+    assert IMAGESORCERY_ADAPTER_ID not in FILE_PROJECTS
+    assert IMAGESORCERY_ADAPTER_ID not in PROJECT_EXTENSIONS
+
+    expansion = {
+        item.project_id: item
+        for item in CATALOG_EXPANSION_V3_ADAPTERS
+        if item.project_id in WAVE26_IDS
+    }
+    assert set(expansion) == WAVE26_IDS
+    assert expansion[CALCULATOR_ADAPTER_ID].availability == "ready"
+    calculator = CATALOG_ADAPTERS[CALCULATOR_ADAPTER_ID]
+    assert calculator.availability == "ready"
+    assert calculator.executable is True
+    assert calculator.server_command[-1] == CALCULATOR_ADAPTER_ID
+    assert set(calculator.tool_policies) == {"calculate"}
+    assert calculator.network_policy == "disabled"
+    assert calculator.filesystem_policy == "read-only-empty-workspace"
+
+    assert expansion[IMAGESORCERY_ADAPTER_ID].availability == "planned"
+    imagesorcery = CATALOG_ADAPTERS[IMAGESORCERY_ADAPTER_ID]
+    assert imagesorcery.availability == "planned"
+    assert imagesorcery.server_command == ()
+    assert imagesorcery.tool_policies == {}
+    assert imagesorcery.network_policy == (
+        "planned:planned-wave26-offline-file-or-deterministic-artifact"
+    )
+    assert imagesorcery.filesystem_policy == "planned:no-runtime"
+
+
+def test_wave26_production_proxy_and_compose_allow_only_accepted_calculator() -> None:
+    root = Path(__file__).resolve().parents[2]
+    proxy = (root / "server/mcp/file_proxy.py").read_text(encoding="utf-8")
+    compose = (root / "docker-compose.yml").read_text(encoding="utf-8")
+    assert CALCULATOR_ADAPTER_ID in proxy
+    assert CALCULATOR_ADAPTER_ID in compose
+    assert IMAGESORCERY_ADAPTER_ID not in proxy
+    assert IMAGESORCERY_ADAPTER_ID not in compose
+
+
+@pytest.mark.asyncio
+async def test_wave26_tool_names_and_schema_digests_are_frozen() -> None:
+    for adapter_id, builder in WAVE26_BUILDERS.items():
+        tools = await builder(object()).list_tools()
+        assert {tool.name for tool in tools} == set(WAVE26_TOOL_NAMES[adapter_id])
+        assert _digest(tools) == WAVE26_SCHEMA_SHA256[adapter_id]
+        for tool in tools:
+            assert tool.inputSchema.get("additionalProperties") is False
+
+
+def test_calculator_evaluates_only_bounded_numeric_ast() -> None:
+    assert evaluate_calculator_expression("2 + 3 * 4") == 14
+    assert evaluate_calculator_expression("sqrt(81) + sin(pi / 2)") == 10.0
+    assert evaluate_calculator_expression("2^8") == 256
+    for expression in (
+        "__import__('os').system('id')",
+        "(1).__class__",
+        "[1, 2, 3]",
+        "sum([1, 2])",
+        "9**999999",
+        "x + 1",
+        "1e1000",
+        "1+" * (MAX_EXPRESSION_CHARS // 2) + "1",
+    ):
+        with pytest.raises(ValueError):
+            evaluate_calculator_expression(expression)
+
+
+@pytest.mark.asyncio
+async def test_calculator_tool_rejects_unknown_arguments() -> None:
+    mcp = build_calculator(object())
+    result = await mcp.call_tool("calculate", {"expression": "6 * 7"})
+    assert result
+    with pytest.raises(Exception, match="Extra inputs are not permitted"):
+        await mcp.call_tool(
+            "calculate",
+            {"expression": "6 * 7", "command": "id"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_imagesorcery_metadata_and_deterministic_artifacts(tmp_path: Path) -> None:
+    source = _image_bytes()
+    context = _Context(tmp_path, {"source.png": source})
+    file_id = next(iter(context._files))
+    mcp = build_imagesorcery(context)
+
+    metadata = await mcp.call_tool("get_metainfo", {"file_id": file_id})
+    assert metadata
+    content = "".join(getattr(item, "text", "") for item in metadata)
+    assert str(tmp_path) not in content
+    assert "created_at" not in content
+    assert "modified_at" not in content
+
+    await mcp.call_tool(
+        "resize",
+        {"file_id": file_id, "width": 48, "artifact_name": "resized.png"},
+    )
+    await mcp.call_tool(
+        "crop",
+        {
+            "file_id": file_id,
+            "x1": 8,
+            "y1": 8,
+            "x2": 72,
+            "y2": 48,
+            "artifact_name": "cropped.png",
+        },
+    )
+    await mcp.call_tool(
+        "rotate",
+        {"file_id": file_id, "angle": 90, "artifact_name": "rotated.png"},
+    )
+    assert (context.input_root / "source.png").read_bytes() == source
+    assert {path.name for path in context.output_root.iterdir()} == {
+        "resized.png",
+        "cropped.png",
+        "rotated.png",
+    }
+    for path in context.output_root.iterdir():
+        assert path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+
+    second = _Context(tmp_path / "second", {"source.png": source})
+    second_id = next(iter(second._files))
+    second_mcp = build_imagesorcery(second)
+    for name, arguments in (
+        ("resize", {"file_id": second_id, "width": 48, "artifact_name": "resized.png"}),
+        (
+            "crop",
+            {
+                "file_id": second_id,
+                "x1": 8,
+                "y1": 8,
+                "x2": 72,
+                "y2": 48,
+                "artifact_name": "cropped.png",
+            },
+        ),
+        ("rotate", {"file_id": second_id, "angle": 90, "artifact_name": "rotated.png"}),
+    ):
+        await second_mcp.call_tool(name, arguments)
+    for name in ("resized.png", "cropped.png", "rotated.png"):
+        assert (context.output_root / name).read_bytes() == (
+            second.output_root / name
+        ).read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_imagesorcery_rejects_paths_urls_unsafe_tools_and_limits(tmp_path: Path) -> None:
+    context = _Context(tmp_path, {"source.png": _image_bytes()})
+    file_id = next(iter(context._files))
+    mcp = build_imagesorcery(context)
+    with pytest.raises(Exception, match="Extra inputs are not permitted"):
+        await mcp.call_tool(
+            "resize",
+            {"file_id": file_id, "width": 32, "output_path": "/tmp/out.png"},
+        )
+    with pytest.raises(Exception):
+        await mcp.call_tool("resize", {"file_id": "file:///etc/passwd", "width": 32})
+    with pytest.raises(Exception):
+        await mcp.call_tool("resize", {"file_id": file_id, "width": 9000})
+    with pytest.raises(Exception):
+        await mcp.call_tool(
+            "crop",
+            {"file_id": file_id, "x1": 0, "y1": 0, "x2": 1000, "y2": 1000},
+        )
+    for name in ("detect", "find", "ocr", "overlay", "config"):
+        with pytest.raises(Exception):
+            await mcp.call_tool(name, {})
+
+
+def test_wave26_dockerfile_and_notices_pin_contract_without_upstream_packages() -> None:
+    root = Path(__file__).resolve().parents[2]
+    dockerfile = (root / "server/sandbox_sidecar/Dockerfile.files").read_text(
+        encoding="utf-8"
+    )
+    notices = (root / "server/sandbox_sidecar/THIRD_PARTY_NOTICES.md").read_text(
+        encoding="utf-8"
+    )
+    assert "file_wave26.py" in dockerfile
+    assert "smoke_file_wave26 --contract-only" in dockerfile
+    assert "mcp-server-calculator" not in dockerfile
+    assert "imagesorcery-mcp" not in dockerfile
+    assert "3dcaedcd58867206627d121092b401728db202da" in notices
+    assert "2f77957a0671a5cf30d90285c7024ae229d86917" in notices
+    assert "pdfmux" in notices
+    assert "remains planned" in notices

--- a/server/tests/test_mcp_wave26b_token_readonly.py
+++ b/server/tests/test_mcp_wave26b_token_readonly.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from server.mcp import token_proxy
+from server.mcp.catalog import CATALOG_ADAPTERS
+from server.mcp.catalog_expansion_v3 import CATALOG_EXPANSION_V3_ADAPTERS
+from server.sandbox_sidecar import token_builtin, token_server
+from server.sandbox_sidecar.token_contracts import (
+    STAGED_TOKEN_ADAPTERS,
+    TOKEN_ADAPTERS,
+    TOKEN_SCHEMA_SHA256,
+    validate_configuration,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GOOGLE_NEWS_ID = "chanmeng666-server-google-news"
+NAVER_ID = "isnow890-naver-search-mcp"
+WAVE26B_IDS = {GOOGLE_NEWS_ID, NAVER_ID}
+
+
+class FakeHttpResponse:
+    def __init__(self, payload: object, status: int = 200) -> None:
+        self.body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.status = status
+
+
+class RecordingHttpClient:
+    def __init__(self, responses: list[FakeHttpResponse]) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def request(self, url: str, **kwargs: object) -> FakeHttpResponse:
+        self.calls.append((url, dict(kwargs)))
+        return self.responses.pop(0)
+
+
+def _tool_text(result: object) -> str:
+    if isinstance(result, tuple):
+        result = result[0]
+    if isinstance(result, list):
+        return "".join(str(getattr(item, "text", "")) for item in result)
+    return str(result)
+
+
+def _digest(tools: list[object]) -> str:
+    reviewed = [
+        {"name": tool.name, "inputSchema": tool.inputSchema}
+        for tool in sorted(tools, key=lambda item: item.name)
+    ]
+    return hashlib.sha256(
+        json.dumps(
+            reviewed,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def test_wave26b_contracts_are_staged_default_deny_and_catalog_planned() -> None:
+    assert WAVE26B_IDS.issubset(STAGED_TOKEN_ADAPTERS)
+    assert WAVE26B_IDS.issubset(TOKEN_ADAPTERS)
+    assert WAVE26B_IDS.issubset(token_proxy.ALLOWED_ADAPTERS)
+    assert not (WAVE26B_IDS & set(token_server.ALLOWED_ADAPTERS))
+
+    expansion = {
+        item.project_id: item
+        for item in CATALOG_EXPANSION_V3_ADAPTERS
+        if item.project_id in WAVE26B_IDS
+    }
+    assert set(expansion) == WAVE26B_IDS
+    for adapter_id in WAVE26B_IDS:
+        assert expansion[adapter_id].availability == "planned"
+        assert expansion[adapter_id].decision_reason_code == (
+            "planned-wave26-token-readonly-preflight"
+        )
+        manifest = CATALOG_ADAPTERS[adapter_id]
+        assert manifest.availability == "planned"
+        assert manifest.server_command == ()
+        assert manifest.tool_policies == {}
+        assert manifest.filesystem_policy == "planned:no-runtime"
+
+
+def test_wave26b_production_compose_does_not_allow_staged_ids() -> None:
+    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    token_block = compose[
+        compose.index("  mcp-token:\n") : compose.index("  mcp-registry:\n")
+    ]
+    for adapter_id in WAVE26B_IDS:
+        assert adapter_id not in token_block
+
+
+@pytest.mark.asyncio
+async def test_wave26b_tool_names_and_strict_schema_digests_are_frozen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SERP_API_KEY", "schema-serp-key")
+    google = token_builtin.build_google_news_readonly()
+    google_tools = await google.list_tools()
+    assert {tool.name for tool in google_tools} == {"google_news_search"}
+    assert _digest(google_tools) == TOKEN_SCHEMA_SHA256[GOOGLE_NEWS_ID]
+
+    monkeypatch.setenv("NAVER_CLIENT_ID", "schema-client-id")
+    monkeypatch.setenv("NAVER_CLIENT_SECRET", "schema-client-secret")
+    naver = token_builtin.build_naver_search_readonly()
+    naver_tools = await naver.list_tools()
+    assert {tool.name for tool in naver_tools} == {
+        "search_webkr",
+        "search_news",
+        "search_blog",
+    }
+    assert _digest(naver_tools) == TOKEN_SCHEMA_SHA256[NAVER_ID]
+    for tool in [*google_tools, *naver_tools]:
+        assert tool.inputSchema.get("additionalProperties") is False
+
+
+def test_wave26b_configuration_requires_exact_credential_slots() -> None:
+    _, credentials, settings = validate_configuration(
+        GOOGLE_NEWS_ID,
+        {"credentials": {"api_key": "secret"}, "settings": {}},
+    )
+    assert credentials == {"api_key": "secret"}
+    assert settings == {}
+
+    _, credentials, settings = validate_configuration(
+        NAVER_ID,
+        {
+            "credentials": {
+                "client_id": "client-id",
+                "client_secret": "client-secret",
+            },
+            "settings": {},
+        },
+    )
+    assert credentials == {
+        "client_id": "client-id",
+        "client_secret": "client-secret",
+    }
+    assert settings == {}
+    with pytest.raises(ValueError, match="configuration_contract_mismatch"):
+        validate_configuration(
+            NAVER_ID,
+            {
+                "credentials": {
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                    "host": "attacker.invalid",
+                },
+                "settings": {},
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_google_news_facade_uses_fixed_serpapi_contract_and_redacts_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = RecordingHttpClient(
+        [
+            FakeHttpResponse(
+                {
+                    "news_results": [
+                        {
+                            "title": "<b>Safe headline</b>",
+                            "source": {"name": "Example", "authors": ["A"]},
+                            "date": "1 hour ago",
+                            "snippet": "&lt;em&gt;Public summary&lt;/em&gt;",
+                            "link": "https://example.com/story",
+                        },
+                        {
+                            "title": "Credential link is omitted",
+                            "source": {"name": "Example"},
+                            "link": "https://example.com/story?token=provider-secret",
+                        },
+                    ]
+                }
+            )
+        ]
+    )
+    monkeypatch.setattr(token_builtin, "SafeHttpClient", lambda **_: client)
+    monkeypatch.setenv("SERP_API_KEY", "private-serp-key")
+    mcp = token_builtin.build_google_news_readonly()
+
+    result = await mcp.call_tool(
+        "google_news_search",
+        {"q": "model context protocol", "gl": "us", "hl": "en", "max_results": 2},
+    )
+    request_url = client.calls[0][0]
+    assert urlsplit(request_url).hostname == "serpapi.com"
+    query = parse_qs(urlsplit(request_url).query)
+    assert query == {
+        "engine": ["google_news"],
+        "q": ["model context protocol"],
+        "gl": ["us"],
+        "hl": ["en"],
+        "api_key": ["private-serp-key"],
+    }
+    text = _tool_text(result)
+    assert "Safe headline" in text
+    assert "<b>" not in text
+    assert "<em>" not in text
+    assert "private-serp-key" not in text
+    assert "provider-secret" not in text
+    with pytest.raises(Exception, match="Extra inputs are not permitted"):
+        await mcp.call_tool(
+            "google_news_search",
+            {"q": "safe", "topic_token": "unreviewed"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_naver_facade_uses_classic_fixed_paths_and_never_returns_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "total": 1,
+        "items": [
+            {
+                "title": "<b>Safe result</b>",
+                "description": "<i>Public description</i>",
+                "link": "https://example.com/result",
+                "originallink": "https://example.org/original",
+                "bloggername": "Example blog",
+                "postdate": "20260812",
+                "pubDate": "Wed, 12 Aug 2026 00:00:00 +0900",
+            }
+        ],
+    }
+    client = RecordingHttpClient([FakeHttpResponse(payload) for _ in range(3)])
+    monkeypatch.setattr(token_builtin, "SafeHttpClient", lambda **_: client)
+    monkeypatch.setenv("NAVER_CLIENT_ID", "private-client-id")
+    monkeypatch.setenv("NAVER_CLIENT_SECRET", "private-client-secret")
+    mcp = token_builtin.build_naver_search_readonly()
+
+    results = []
+    for tool_name in ("search_webkr", "search_news", "search_blog"):
+        results.append(
+            await mcp.call_tool(
+                tool_name,
+                {"query": "safe query", "display": 5, "start": 1, "sort": "sim"},
+            )
+        )
+    assert [urlsplit(item[0]).path for item in client.calls] == [
+        "/v1/search/webkr",
+        "/v1/search/news",
+        "/v1/search/blog",
+    ]
+    for _, kwargs in client.calls:
+        headers = kwargs["headers"]
+        assert isinstance(headers, dict)
+        assert headers == {
+            "X-Naver-Client-Id": "private-client-id",
+            "X-Naver-Client-Secret": "private-client-secret",
+        }
+    text = "".join(_tool_text(result) for result in results)
+    assert "Safe result" in text
+    assert "<b>" not in text
+    assert "private-client-id" not in text
+    assert "private-client-secret" not in text
+    for denied_tool in ("search_image", "search_local", "datalab_search"):
+        with pytest.raises(Exception):
+            await mcp.call_tool(denied_tool, {"query": "safe"})
+
+
+@pytest.mark.asyncio
+async def test_wave26b_provider_429_is_explicit_and_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = RecordingHttpClient([FakeHttpResponse({"error": "rate limited"}, status=429)])
+    monkeypatch.setattr(token_builtin, "SafeHttpClient", lambda **_: client)
+    monkeypatch.setenv("SERP_API_KEY", "private-serp-key")
+    mcp = token_builtin.build_google_news_readonly()
+    with pytest.raises(Exception, match="HTTP 429"):
+        await mcp.call_tool("google_news_search", {"q": "safe"})
+    assert len(client.calls) == 1
+
+
+def test_wave26b_notices_freeze_upstream_commits_without_bundling_packages() -> None:
+    notices = (ROOT / "server/sandbox_sidecar/THIRD_PARTY_NOTICES.md").read_text(
+        encoding="utf-8"
+    )
+    dockerfile = (ROOT / "server/sandbox_sidecar/Dockerfile.token").read_text(
+        encoding="utf-8"
+    )
+    assert "5ed14341ff6ef290e13bafa08abc12157bbe23a3" in notices
+    assert "d7c7c58cab0de2692336b710727f1ee123270e6c" in notices
+    assert "server-google-news" not in dockerfile
+    assert "naver-search-mcp" not in dockerfile
+    assert "smoke_token_gateway.py" in dockerfile

--- a/server/tests/test_mcp_wave27_native_readonly.py
+++ b/server/tests/test_mcp_wave27_native_readonly.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from server.mcp import database_proxy
+from server.mcp.catalog import CATALOG_ADAPTERS
+from server.mcp.catalog_expansion_v3 import CATALOG_EXPANSION_V3_ADAPTERS
+from server.sandbox_sidecar import database_server
+from server.sandbox_sidecar import database_wave27 as services
+from server.sandbox_sidecar.database_contracts import (
+    DATABASE_ADAPTERS,
+    STAGED_DATABASE_ADAPTERS,
+    WAVE_TWENTYSEVEN_DATA_SERVICE_ADAPTERS,
+    validate_configuration,
+)
+from server.sandbox_sidecar.database_mcp import BUILDERS, PREFLIGHTS
+
+
+ADAPTER_ID = "greptimeteam-greptimedb-mcp-server"
+EXPECTED_TOOLS = {"describe_table", "query_range", "health_check"}
+
+
+def _configuration() -> dict[str, object]:
+    return {
+        "settings": {
+            "host": "greptime.example.com",
+            "port": 443,
+            "database": "public",
+            "table": "project_metrics",
+            "time_column": "observed_at",
+            "value_column": "metric_value",
+            "tls_mode": "verify-full",
+            "username": "modelmirror_ro",
+        },
+        "credentials": {"password": "read-password"},
+    }
+
+
+def _context() -> SimpleNamespace:
+    validated = validate_configuration(ADAPTER_ID, _configuration())
+    return SimpleNamespace(
+        adapter_id=ADAPTER_ID,
+        settings=validated.settings,
+        credentials=validated.credentials,
+    )
+
+
+@pytest.mark.asyncio
+async def test_wave27_is_compiled_but_staged_and_not_catalog_executable() -> None:
+    assert WAVE_TWENTYSEVEN_DATA_SERVICE_ADAPTERS == {ADAPTER_ID}
+    assert STAGED_DATABASE_ADAPTERS == {ADAPTER_ID}
+    assert ADAPTER_ID in DATABASE_ADAPTERS
+    assert ADAPTER_ID in database_proxy.ALLOWED_ADAPTERS
+    assert ADAPTER_ID in BUILDERS
+    assert ADAPTER_ID in PREFLIGHTS
+    assert ADAPTER_ID not in database_server.ALLOWED_ADAPTERS
+    manifest = CATALOG_ADAPTERS[ADAPTER_ID]
+    assert manifest.availability == "planned"
+    assert manifest.executable is False
+    assert manifest.server_command == ()
+    assert manifest.tool_policies == {}
+
+    catalog = {item.project_id: item for item in CATALOG_EXPANSION_V3_ADAPTERS}
+    assert catalog[ADAPTER_ID].availability == "planned"
+    assert catalog[ADAPTER_ID].decision_reason_code == "planned-wave27-native-readonly-data-service"
+
+    compose = Path("docker-compose.yml").read_text(encoding="utf-8")
+    assert f"MCP_DATABASE_ALLOWED_ADAPTERS: {ADAPTER_ID}" not in compose
+    allowlist_line = next(
+        line for line in compose.splitlines() if "MCP_DATABASE_ALLOWED_ADAPTERS:" in line
+    )
+    assert ADAPTER_ID not in allowlist_line
+
+
+@pytest.mark.asyncio
+async def test_wave27_tool_contract_is_exact_read_only_and_digest_locked() -> None:
+    tools = await BUILDERS[ADAPTER_ID](_context()).list_tools()
+    assert {tool.name for tool in tools} == EXPECTED_TOOLS
+    reviewed = [
+        {"name": tool.name, "inputSchema": tool.inputSchema}
+        for tool in sorted(tools, key=lambda item: item.name)
+    ]
+    digest = hashlib.sha256(
+        json.dumps(
+            reviewed,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    assert digest == services.WAVE27_SCHEMA_SHA256[ADAPTER_ID]
+
+    for tool in tools:
+        assert tool.annotations is not None
+        assert tool.annotations.readOnlyHint is True
+        assert tool.annotations.destructiveHint is False
+        schema = json.dumps(tool.inputSchema, sort_keys=True).lower()
+        for forbidden in (
+            "query",
+            "sql",
+            "tql",
+            "url",
+            "dsn",
+            "header",
+            "environment",
+            "command",
+            "table",
+            "database",
+            "host",
+            "path",
+        ):
+            assert f'"{forbidden}"' not in schema
+
+
+def test_wave27_upstream_identity_is_frozen() -> None:
+    assert services.WAVE27_UPSTREAM_LOCKS == {
+        ADAPTER_ID: {
+            "version": "v0.5.1",
+            "commit": "ba3b732fe2113378f41c391da880b9ab75f2d862",
+            "license": "MIT",
+            "repository": "GreptimeTeam/greptimedb-mcp-server",
+        }
+    }
+
+
+def test_wave27_configuration_binds_target_and_plaintext_is_test_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    validated = validate_configuration(ADAPTER_ID, _configuration())
+    assert validated.settings["table"] == "project_metrics"
+    assert validated.settings["time_column"] == "observed_at"
+    assert validated.settings["value_column"] == "metric_value"
+    assert validated.credentials == {"password": "read-password"}
+
+    for key in ("url", "dsn", "headers", "environment", "command", "cwd", "query"):
+        invalid = json.loads(json.dumps(_configuration()))
+        invalid["settings"][key] = "denied"  # type: ignore[index]
+        with pytest.raises(ValueError):
+            validate_configuration(ADAPTER_ID, invalid)
+
+    plaintext = json.loads(json.dumps(_configuration()))
+    plaintext["settings"]["tls_mode"] = "test-only-plaintext"  # type: ignore[index]
+    monkeypatch.delenv("MCP_DATABASE_TEST_ALLOW_PLAINTEXT", raising=False)
+    with pytest.raises(ValueError, match="invalid_tls_mode"):
+        validate_configuration(ADAPTER_ID, plaintext)
+    monkeypatch.setenv("MCP_DATABASE_TEST_ALLOW_PLAINTEXT", "true")
+    assert validate_configuration(ADAPTER_ID, plaintext).settings["tls_mode"] == "test-only-plaintext"
+
+
+def test_wave27_arguments_are_structured_and_bounded() -> None:
+    services.validate_wave27_arguments(ADAPTER_ID, "describe_table", {})
+    services.validate_wave27_arguments(ADAPTER_ID, "health_check", {})
+    services.validate_wave27_arguments(
+        ADAPTER_ID,
+        "query_range",
+        {"start": "2026-08-01T00:00:00Z", "end": "2026-08-01T01:00:00Z", "limit": 25},
+    )
+    for invalid in (
+        {"start": "2026-08-01T00:00:00Z", "end": "2026-08-02T00:00:01Z"},
+        {"start": "2026-08-01T01:00:00Z", "end": "2026-08-01T00:00:00Z"},
+        {"start": "now()", "end": "2026-08-01T01:00:00Z"},
+        {"start": "2026-08-01T00:00:00Z", "end": "2026-08-01T01:00:00Z", "limit": 201},
+        {"start": "2026-08-01T00:00:00Z", "end": "2026-08-01T01:00:00Z", "query": "DROP TABLE x"},
+    ):
+        with pytest.raises(ValueError):
+            services.validate_wave27_arguments(ADAPTER_ID, "query_range", invalid)
+
+
+def _greptime_payload(rows: list[list[Any]], columns: list[str]) -> dict[str, Any]:
+    return {
+        "code": 0,
+        "output": [
+            {
+                "records": {
+                    "schema": {"column_schemas": [{"name": name} for name in columns]},
+                    "rows": rows,
+                }
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_wave27_calls_only_server_generated_sql(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    statements: list[str] = []
+
+    def fake_sql(_context: Any, sql: str) -> dict[str, Any]:
+        statements.append(sql)
+        if "information_schema.columns" in sql:
+            return _greptime_payload(
+                [["observed_at", "TimestampMillisecond", "TIMESTAMP", "NO"]],
+                ["column_name", "data_type", "semantic_type", "is_nullable"],
+            )
+        if "modelmirror_readonly" in sql:
+            return _greptime_payload([[1]], ["modelmirror_readonly"])
+        return _greptime_payload(
+            [["2026-08-01T00:00:00Z", 1.5]],
+            ["observed_at", "metric_value"],
+        )
+
+    monkeypatch.setattr(services, "_greptime_sql", fake_sql)
+    mcp = BUILDERS[ADAPTER_ID](_context())
+    assert await mcp.call_tool("describe_table", {})
+    assert await mcp.call_tool(
+        "query_range",
+        {"start": "2026-08-01T00:00:00+00:00", "end": "2026-08-01T01:00:00Z", "limit": 10},
+    )
+    assert await mcp.call_tool("health_check", {})
+
+    assert len(statements) == 3
+    assert "`project_metrics`" in statements[1]
+    assert "`observed_at`" in statements[1]
+    assert "`metric_value`" in statements[1]
+    assert "2026-08-01T00:00:00Z" in statements[1]
+    assert statements[1].endswith("LIMIT 11")
+    assert all("DROP" not in sql and ";" not in sql for sql in statements)
+
+
+def test_wave27_record_parser_is_bounded_and_fail_closed() -> None:
+    payload = _greptime_payload([[1], [2], [3]], ["value"])
+    assert services._greptime_records(payload, limit=2) == {
+        "columns": ["value"],
+        "rows": [[1], [2]],
+        "returned_count": 2,
+        "truncated": True,
+    }
+    for invalid in (
+        {},
+        {"code": 1, "output": []},
+        {"code": 0, "output": []},
+        _greptime_payload([[1, 2]], ["value"]),
+    ):
+        with pytest.raises(ValueError, match="greptime_response_invalid"):
+            services._greptime_records(invalid, limit=10)
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (429, "database_rate_limited"),
+        (503, "database_upstream_unavailable"),
+        (403, "database_provider_rejected"),
+    ],
+)
+def test_wave27_provider_failures_map_to_fixed_codes(status: int, expected: str) -> None:
+    class Response:
+        status_code = status
+        headers: dict[str, str] = {}
+
+        def iter_bytes(self) -> list[bytes]:
+            return []
+
+    with pytest.raises(ValueError, match=expected):
+        services._bounded_json_response(Response())  # type: ignore[arg-type]


### PR DESCRIPTION
# 摘要

- 完成 Wave 26A 离线文件适配：Calculator 经隔离验收后晋级 ready 并加入精确文件 sidecar allowlist；ImageSorcery 保持 planned。
- 完成 Wave 26B Token 只读适配骨架：Google News、Naver Search 固定凭据槽、出口和工具契约；缺少真实账号代表调用，因此继续 planned、默认关闭且不加入 allowlist。
- 完成 Wave 27 原生只读数据服务适配：GreptimeDB 固定 `describe_table`、`query_range`、`health_check` 三个只读工具并提供真实服务验收 harness；本 PR 中继续 planned、默认关闭且不加入生产 allowlist。
- 同步目录、计数、供应链说明、Compose、回归测试和 Wave 26–27 操作文档。目录状态保持 `76 ready / 68 planned / 156 blocked`。

# 安全边界

- 不新增通用 MCP 执行器，也不接受任意命令、URL、Header、环境变量、DSN、宿主路径或用户 SQL/TQL。
- 公共读取只允许安全重试；产物与状态写入继续禁止管理器自动重发。
- Wave 26B/27 在真实凭据或用户晋级确认前保持 default-deny，可通过移除精确 ID/恢复 planned 清单直接回退。

# 验证

- 最新 `origin/main` 上 Wave 26A、26B、27 与目录/sidecar 联合回归：`137 passed`。
- `docker compose config --quiet`：通过。
- `git diff --check` 与暂存范围复核：通过，47 个预期文件。
- Wave 27 官方 `greptime/greptimedb:v1.1.4` 隔离验收：原生只读角色读取成功、CREATE 被拒，两个 UDS 会话完成 initialize/tools/list/Schema/代表调用，超时与进程清理通过。
- 前端 typecheck、生产构建：通过。较早完整前端单测为 `233 passed / 1 unrelated failed`，失败是既有 `NodePalette.test.ts` 对新增 `vision_understanding` 的期望漂移。
- 较早完整后端回归为 `2914 passed / 29 skipped / 1 unrelated failed`，失败是旧测试镜像 Node 20 下的 Skill Finder TypeScript 加载环境差异；本次同步最新 main 后重跑的 MCP 联合回归已全绿，完整结果交由本 PR CI 复核。

# 运维影响

- 未重建或修改共享栈，未迁移数据，未部署生产服务。
- 仅 Calculator 进入默认文件 sidecar allowlist；其他新增候选继续由功能开关和精确 allowlist 双重关闭。
