### PR TITLE
feature: 更新八个最新模型快照

### DIFF
--- a/client/src/components/ImageGenerationWorkspace.tsx
+++ b/client/src/components/ImageGenerationWorkspace.tsx
@@ -10,6 +10,7 @@ import type { Model } from "../data/models";
 import {
   estimateImageCost,
   GROK_IMAGINE_IMAGE_2_PRICING,
+  SEEDREAM_5_PRO_PRICING,
   type ImagePricingItem,
 } from "../utils/imageCostEstimate";
 import BrandLogo from "./BrandLogo";
@@ -133,6 +134,8 @@ export default function ImageGenerationWorkspace({
         ? profile.pricing
         : model.id === "x-ai/grok-imagine-image-2.0"
           ? GROK_IMAGINE_IMAGE_2_PRICING
+          : model.id === "bytedance-seed/seedream-5-0-pro"
+            ? SEEDREAM_5_PRO_PRICING
           : [];
       return estimateImageCost(pricing, {
         outputCount: Number(parameters.n || 1),
@@ -279,6 +282,20 @@ export default function ImageGenerationWorkspace({
                     onChange={(event) => selectValue("n", event.target.value)}
                     type="number"
                     value={parameters.n ?? "1"}
+                  />
+                </label>
+              ) : null}
+              {supported.seed ? (
+                <label className="block">
+                  <span className="text-xs font-semibold text-slate-300">随机种子</span>
+                  <input
+                    className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2.5 text-sm"
+                    min={0}
+                    onChange={(event) => selectValue("seed", event.target.value)}
+                    placeholder="模型默认"
+                    step={1}
+                    type="number"
+                    value={parameters.seed ?? ""}
                   />
                 </label>
               ) : null}

--- a/client/src/components/VideoGenerationWorkspace.tsx
+++ b/client/src/components/VideoGenerationWorkspace.tsx
@@ -8,7 +8,10 @@ import {
 } from "react";
 import { Link } from "react-router-dom";
 import type { Model } from "../data/models";
-import { estimateVideoCost } from "../utils/videoCostEstimate";
+import {
+  estimateVideoCost,
+  supportedAspectRatiosForResolution,
+} from "../utils/videoCostEstimate";
 import BrandLogo from "./BrandLogo";
 import ResourceNav from "./ResourceNav";
 
@@ -796,6 +799,9 @@ export default function VideoGenerationWorkspace({
     providerOptionCount > 0;
   const capabilityRefreshRequired =
     catalogStale && enhancedInputsSelected;
+  const selectableAspectRatios = profile
+    ? supportedAspectRatiosForResolution(profile, resolution)
+    : [];
 
   const estimate = profile
     ? estimateVideoCost(profile, {
@@ -1080,7 +1086,20 @@ export default function VideoGenerationWorkspace({
                       className="mt-2 w-full rounded-lg border border-white/15 bg-ink-950 px-3 py-2.5 text-sm text-white outline-none transition focus:border-brand-300/60 focus:ring-4 focus:ring-brand-300/10"
                       disabled={submitting}
                       onChange={(event) => {
-                        setResolution(event.target.value);
+                        const nextResolution = event.target.value;
+                        setResolution(nextResolution);
+                        const nextAspectRatios =
+                          supportedAspectRatiosForResolution(
+                            profile,
+                            nextResolution,
+                          );
+                        if (!nextAspectRatios.includes(aspectRatio)) {
+                          setAspectRatio(
+                            nextAspectRatios.includes("16:9")
+                              ? "16:9"
+                              : (nextAspectRatios[0] ?? ""),
+                          );
+                        }
                         markFormChanged();
                       }}
                       value={resolution}
@@ -1098,7 +1117,7 @@ export default function VideoGenerationWorkspace({
                       className="mt-2 w-full rounded-lg border border-white/15 bg-ink-950 px-3 py-2.5 text-sm text-white outline-none transition focus:border-brand-300/60 focus:ring-4 focus:ring-brand-300/10 disabled:cursor-not-allowed disabled:opacity-55"
                       disabled={
                         submitting ||
-                        profile.supported_aspect_ratios.length === 0
+                        selectableAspectRatios.length === 0
                       }
                       onChange={(event) => {
                         setAspectRatio(event.target.value);
@@ -1106,10 +1125,10 @@ export default function VideoGenerationWorkspace({
                       }}
                       value={aspectRatio}
                     >
-                      {profile.supported_aspect_ratios.length === 0 ? (
+                      {selectableAspectRatios.length === 0 ? (
                         <option value="">由模型决定</option>
                       ) : (
-                        profile.supported_aspect_ratios.map((value) => (
+                        selectableAspectRatios.map((value) => (
                           <option key={value} value={value}>
                             {value}
                           </option>

--- a/client/src/components/agent-workspace/EngineShadowPanel.test.tsx
+++ b/client/src/components/agent-workspace/EngineShadowPanel.test.tsx
@@ -31,8 +31,8 @@ const candidate: EngineShadowRun = {
   session_id: "upstream-session-1",
   status: "candidate_ready",
   objective: "构建离线单文件应用",
-  model_base_id: "deepseek-v4-flash-0731",
-  resolved_model_id: "deepseek/deepseek-v4-flash-0731",
+  model_base_id: "deepseek-v4-pro-0813",
+  resolved_model_id: "deepseek/deepseek-v4-pro-0813",
   thinking_level: "medium",
   token_budget: 750_000,
   max_goal_rounds: 12,
@@ -105,7 +105,7 @@ describe("EngineShadowPanel", () => {
     await waitFor(() => {
       expect(api.create).toHaveBeenCalledWith({
         objective: "构建一个记忆卡片游戏",
-        model_base_id: "deepseek-v4-flash-0731",
+        model_base_id: "deepseek-v4-pro-0813",
         thinking_level: "medium",
         token_budget: 750_000,
       });

--- a/client/src/components/agent-workspace/EngineShadowPanel.tsx
+++ b/client/src/components/agent-workspace/EngineShadowPanel.tsx
@@ -33,7 +33,7 @@ function publicStatus(run: EngineShadowRun): string {
 
 export default function EngineShadowPanel() {
   const [objective, setObjective] = useState("");
-  const [modelBaseId, setModelBaseId] = useState("deepseek-v4-flash-0731");
+  const [modelBaseId, setModelBaseId] = useState("deepseek-v4-pro-0813");
   const [thinkingLevel, setThinkingLevel] =
     useState<AgentThinkingLevel>("medium");
   const [tokenBudget, setTokenBudget] = useState(750_000);

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -18,7 +18,6 @@ import "@xyflow/react/dist/style.css";
 import { Upload } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { DEFAULT_CHAT_MODEL_ID } from "../../context/ModelPreferenceContext";
 import { DEFAULT_WORKFLOW_AGENT_MODEL_ID } from "../../data/modelOptions";
 import { models } from "../../data/models";
 import {
@@ -178,7 +177,7 @@ function createNodeData(
       kind,
       title: "模型工位",
       description: "调用模型，把上游变量加工成新结果。",
-      modelId: DEFAULT_CHAT_MODEL_ID,
+      modelId: DEFAULT_WORKFLOW_AGENT_MODEL_ID,
       prompt: "请基于以下输入给出清晰回答：\n\n{{user_input}}",
       outputVariable: "llm_output",
     };
@@ -248,7 +247,7 @@ function createNodeData(
       description: "调用模型从文本中抽取字段，返回 JSON 字符串。",
       inputVariable: "user_input",
       schema: "name: 姓名\nemail_address: 邮箱地址",
-      modelId: DEFAULT_CHAT_MODEL_ID,
+      modelId: DEFAULT_WORKFLOW_AGENT_MODEL_ID,
       outputVariable: "parameters_json",
     };
   }
@@ -2404,7 +2403,7 @@ function NodeConfig({
             <select
               className={textInputClass()}
               onChange={(event) => update({ modelId: event.target.value })}
-              value={data.modelId ?? DEFAULT_CHAT_MODEL_ID}
+              value={data.modelId ?? DEFAULT_WORKFLOW_AGENT_MODEL_ID}
             >
               {models.map((model) => (
                 <option
@@ -2641,7 +2640,7 @@ function NodeConfig({
             <select
               className={textInputClass()}
               onChange={(event) => update({ modelId: event.target.value })}
-              value={data.modelId ?? DEFAULT_CHAT_MODEL_ID}
+              value={data.modelId ?? DEFAULT_WORKFLOW_AGENT_MODEL_ID}
             >
               {models.map((model) => (
                 <option

--- a/client/src/data/modelOptions.ts
+++ b/client/src/data/modelOptions.ts
@@ -2,9 +2,9 @@ import { models } from "./models";
 
 export const DEFAULT_CHAT_MODEL_ID = "openai/gpt-5.6-sol";
 export const DEFAULT_AGENT_BUILDER_MODEL_ID =
-  "deepseek/deepseek-v4-flash-0731";
+  "deepseek/deepseek-v4-pro-0813";
 export const DEFAULT_WORKFLOW_AGENT_MODEL_ID =
-  "deepseek/deepseek-v4-flash-0731";
+  "deepseek/deepseek-v4-pro-0813";
 export const DEFAULT_EMBEDDING_MODEL_ID = "text-embedding-3-small";
 
 export const chatModelOptions = models.filter(

--- a/client/src/data/models.refresh.test.ts
+++ b/client/src/data/models.refresh.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_AGENT_BUILDER_MODEL_ID,
+  DEFAULT_WORKFLOW_AGENT_MODEL_ID,
+} from "./modelOptions";
 import { models } from "./models";
 
 const middleModelIds = [
@@ -8,7 +12,24 @@ const middleModelIds = [
   "inclusionai/ling-3.0-tiny:free",
 ];
 
-describe("OpenRouter 2026-08-11 model refresh", () => {
+const august13ModelIds = [
+  "x-ai/grok-4.6",
+  "bytedance-seed/seedream-5-0-pro",
+  "deepgram/flux-tts:free",
+  "qwen/qwen3.8-2.4t-a95b",
+  "bytedance-seed/seed-2-1-turbo",
+  "bytedance-seed/seed-2.0-code",
+  "deepseek/deepseek-v4-pro-0813",
+  "bytedance/seedance-2.0-mini",
+];
+
+describe("OpenRouter 2026-08-13 model refresh", () => {
+  it("places V4 Pro, the former Flash default, and Seedream in their requested rows", () => {
+    expect(models[2]?.id).toBe("deepseek/deepseek-v4-pro-0813");
+    expect(models[5]?.id).toBe("deepseek/deepseek-v4-flash-0731");
+    expect(models[8]?.id).toBe("bytedance-seed/seedream-5-0-pro");
+  });
+
   it("places Seedance 2.5 at the former GPT-4o Mini TTS slot", () => {
     expect(models[11]?.id).toBe("bytedance/seedance-2.5");
     expect(models[12]?.id).toBe("gpt-4o-mini-tts");
@@ -28,16 +49,59 @@ describe("OpenRouter 2026-08-11 model refresh", () => {
     }
   });
 
-  it("adds Seed 2.0 Code as a counted live model below the sixth row", () => {
-    const index = models.findIndex(
-      (model) => model.id === "bytedance-seed/seed-2.0-code",
-    );
-    const model = models[index];
+  it("adds all eight live counted snapshots exactly once", () => {
+    for (const modelId of august13ModelIds) {
+      const matches = models.filter((model) => model.id === modelId);
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        catalog_status: "live",
+        catalog_counted: true,
+        active: true,
+      });
+    }
+  });
 
-    expect(index).toBeGreaterThanOrEqual(2 + 6 * 3);
-    expect(model?.catalog_status).toBe("live");
-    expect(model?.catalog_counted).toBe(true);
-    expect(model?.active).toBe(true);
+  it("scatters non-positioned refresh cards below the sixth row", () => {
+    for (const modelId of [
+      "x-ai/grok-4.6",
+      "deepgram/flux-tts:free",
+      "qwen/qwen3.8-2.4t-a95b",
+      "bytedance-seed/seed-2-1-turbo",
+      "bytedance-seed/seed-2.0-code",
+      "bytedance/seedance-2.0-mini",
+    ]) {
+      expect(models.findIndex((model) => model.id === modelId)).toBeGreaterThanOrEqual(
+        2 + 6 * 3,
+      );
+    }
+  });
+
+  it("routes the three media snapshots to their dedicated workspaces", () => {
+    expect(
+      models.find((model) => model.id === "bytedance-seed/seedream-5-0-pro"),
+    ).toMatchObject({
+      primary_operation: "generate_image",
+      output_modalities: ["image"],
+    });
+    expect(
+      models.find((model) => model.id === "deepgram/flux-tts:free"),
+    ).toMatchObject({
+      primary_operation: "synthesize_speech",
+      interaction_status: "ready",
+      output_modalities: ["speech"],
+    });
+    expect(
+      models.find((model) => model.id === "bytedance/seedance-2.0-mini"),
+    ).toMatchObject({
+      primary_operation: "generate_video",
+      interaction_status: "ready",
+      output_modalities: ["video"],
+    });
+  });
+
+  it("uses V4 Pro for agent builder and workflow-agent defaults", () => {
+    expect(DEFAULT_AGENT_BUILDER_MODEL_ID).toBe("deepseek/deepseek-v4-pro-0813");
+    expect(DEFAULT_WORKFLOW_AGENT_MODEL_ID).toBe("deepseek/deepseek-v4-pro-0813");
   });
 
   it("restores GPT-5.2 Chat as live", () => {

--- a/client/src/data/models.ts
+++ b/client/src/data/models.ts
@@ -1,10 +1,14 @@
 ﻿// Merged with OpenRouter model catalog on 2026-08-12T06:32:56.587Z.
-// Refreshed with entries published through 2026-08-11T22:07:24.000Z.
+// Current OpenRouter refresh verified on 2026-08-13 against the live all-modalities catalog.
+// Refreshed with entries published through 2026-08-13.
 // Source: https://openrouter.ai/api/v1/models?output_modalities=all&sort=newest&offset=0&limit=1000
-// Full OpenRouter catalog audit refresh: 2026-08-12. Batch catalog entries are
+// Full OpenRouter catalog audit refresh: 2026-08-13. Batch catalog entries are
 // attached to their canonical models as serving variants and excluded from
-// snapshot totals; the xAI image profile keeps the dedicated image-model contract.
+// snapshot totals; media-only records are cross-checked against their dedicated
+// Images, Speech, and Video API catalogs instead of the text-only model list.
 // Image source: https://openrouter.ai/api/v1/images/models
+// Speech source: https://openrouter.ai/api/v1/models?output_modalities=speech
+// Video source: https://openrouter.ai/api/v1/videos/models
 // Prices are stored as USD per 1M tokens and CNY per 1M tokens.
 export const USD_TO_CNY = 6.77;
 
@@ -162,6 +166,203 @@ interface RawCatalogModel {
 }
 
 const rawCatalogModels: RawCatalogModel[] = [
+  {
+    "id": "bytedance-seed/seedream-5-0-pro",
+    "canonical_slug": "bytedance-seed/seedream-5-0-pro-20260812",
+    "name": "ByteDance Seed: Seedream 5.0 Pro",
+    "raw_description": "Seedream 5.0 Pro is ByteDance Seed's professional image generation and editing model for natural, lifelike commercial visuals and precise edits. It accepts text and up to 14 image references and returns one image per request.",
+    "context_length": 0,
+    "pricing": { "input": -1, "output": -1 },
+    "input_modalities": ["text", "image"],
+    "output_modalities": ["image"],
+    "tokenizer": "Other",
+    "supported_parameters": [
+      "resolution",
+      "aspect_ratio",
+      "n",
+      "input_references",
+      "seed"
+    ],
+    "created": 1786578139,
+    "expiration_date": null,
+    "model_author": "ByteDance Seed",
+    "note": "OpenRouter 专用 Images API：支持 1K/2K、18 种宽高比、单次 1 张输出、最多 14 张参考图和 seed；参考图 $0.003/张，输出约 $0.045/张，高分辨率约 $0.09/张。"
+  },
+  {
+    "id": "deepgram/flux-tts:free",
+    "canonical_slug": "deepgram/flux-tts-20260812",
+    "name": "Deepgram: Flux TTS (free)",
+    "raw_description": "Flux TTS is Deepgram's free text-to-speech model for English voice synthesis. It exposes 36 Flux voices through OpenRouter's dedicated speech endpoint and returns binary audio rather than chat-completion text.",
+    "context_length": 0,
+    "pricing": { "input": 0, "output": 0 },
+    "input_modalities": ["text"],
+    "output_modalities": ["speech"],
+    "tokenizer": "Other",
+    "supported_parameters": ["voice", "response_format", "speed"],
+    "created": 1786574888,
+    "expiration_date": null,
+    "model_author": "Deepgram",
+    "note": "通过 OpenRouter /api/v1/audio/speech 调用；当前目录价格为免费，提供 36 个英文 Flux 音色，响应为原始音频字节。"
+  },
+  {
+    "id": "bytedance/seedance-2.0-mini",
+    "canonical_slug": "bytedance/seedance-2.0-mini-20260811",
+    "name": "ByteDance: Seedance 2.0 Mini",
+    "raw_description": "Seedance 2.0 Mini is a compact ByteDance video generation model supporting text, image, video, and audio guidance. It supports first- and last-frame control, optional generated audio, and 4–15 second video jobs at 480p or 720p.",
+    "context_length": 0,
+    "pricing": { "input": -1, "output": -1 },
+    "input_modalities": ["text", "image", "video", "audio"],
+    "output_modalities": ["video"],
+    "tokenizer": "Media",
+    "supported_parameters": [
+      "resolution",
+      "aspect_ratio",
+      "duration",
+      "frame_images",
+      "input_references",
+      "generate_audio",
+      "seed"
+    ],
+    "created": 1786552600,
+    "expiration_date": null,
+    "model_author": "ByteDance",
+    "note": "通过 OpenRouter 异步 Video API 提交并轮询；支持 480p/720p、4–15 秒、首尾帧与生成音频。价格按视频 token 与输入类型动态结算。"
+  },
+  {
+    "id": "bytedance-seed/seed-2-1-turbo",
+    "canonical_slug": "bytedance-seed/seed-2-1-turbo-20260810",
+    "name": "ByteDance Seed: Seed 2.1 Turbo",
+    "raw_description": "Seed 2.1 Turbo is ByteDance Seed's fast multimodal reasoning model for coding, long-horizon agent workflows, and visual or video understanding. It accepts text, image, and video input and supports tool calling and structured output.",
+    "context_length": 262144,
+    "pricing": { "input": 0.5, "output": 2.5 },
+    "input_modalities": ["text", "image", "video"],
+    "output_modalities": ["text"],
+    "tokenizer": "Other",
+    "supported_parameters": [
+      "frequency_penalty",
+      "include_reasoning",
+      "max_tokens",
+      "presence_penalty",
+      "reasoning",
+      "reasoning_effort",
+      "response_format",
+      "seed",
+      "stop",
+      "structured_outputs",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_p"
+    ],
+    "created": 1786552176,
+    "expiration_date": null,
+    "model_author": "ByteDance Seed"
+  },
+  {
+    "id": "qwen/qwen3.8-2.4t-a95b",
+    "canonical_slug": "qwen/qwen3.8-2.4t-a95b-20260812",
+    "name": "Qwen: Qwen3.8 2.4T A95B",
+    "raw_description": "Qwen3.8 2.4T A95B is Qwen's open-weight sparse mixture-of-experts flagship, with 2.4 trillion total parameters and 95 billion active parameters. It is designed for advanced reasoning, coding, and agentic tool use.",
+    "context_length": 262144,
+    "pricing": { "input": 2, "output": 6 },
+    "input_modalities": ["text"],
+    "output_modalities": ["text"],
+    "tokenizer": "Qwen",
+    "supported_parameters": [
+      "frequency_penalty",
+      "include_reasoning",
+      "logit_bias",
+      "logprobs",
+      "max_tokens",
+      "min_p",
+      "presence_penalty",
+      "reasoning",
+      "reasoning_effort",
+      "repetition_penalty",
+      "response_format",
+      "seed",
+      "stop",
+      "structured_outputs",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_k",
+      "top_logprobs",
+      "top_p"
+    ],
+    "created": 1786551702,
+    "expiration_date": null,
+    "model_author": "Qwen"
+  },
+  {
+    "id": "deepseek/deepseek-v4-pro-0813",
+    "canonical_slug": "deepseek/deepseek-v4-pro-20260813",
+    "name": "DeepSeek: DeepSeek V4 Pro 0813",
+    "raw_description": "DeepSeek V4 Pro 0813 is the generally available DeepSeek V4 Pro release. It provides a 1M-token context window and up to 384K output tokens for complex reasoning, coding, and long-horizon agent workflows.",
+    "context_length": 1048576,
+    "pricing": { "input": 0.435, "output": 0.87 },
+    "input_modalities": ["text"],
+    "output_modalities": ["text"],
+    "tokenizer": "DeepSeek",
+    "supported_parameters": [
+      "frequency_penalty",
+      "include_reasoning",
+      "logit_bias",
+      "logprobs",
+      "max_tokens",
+      "min_p",
+      "presence_penalty",
+      "reasoning",
+      "reasoning_effort",
+      "repetition_penalty",
+      "response_format",
+      "seed",
+      "stop",
+      "structured_outputs",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_k",
+      "top_logprobs",
+      "top_p"
+    ],
+    "created": 1786549364,
+    "expiration_date": null,
+    "model_author": "DeepSeek"
+  },
+  {
+    "id": "x-ai/grok-4.6",
+    "canonical_slug": "x-ai/grok-4.6-20260810",
+    "name": "SpaceXAI: Grok 4.6",
+    "raw_description": "Grok 4.6 is SpaceXAI's frontier reasoning model for coding, knowledge, and STEM workloads. It accepts text, images, and files, provides a 500K-token context window, and supports tool use and structured output.",
+    "context_length": 500000,
+    "pricing": { "input": 2, "output": 6 },
+    "input_modalities": ["text", "image", "file"],
+    "output_modalities": ["text"],
+    "tokenizer": "Grok",
+    "supported_parameters": [
+      "frequency_penalty",
+      "include_reasoning",
+      "logprobs",
+      "max_tokens",
+      "presence_penalty",
+      "reasoning",
+      "reasoning_effort",
+      "response_format",
+      "seed",
+      "stop",
+      "structured_outputs",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_logprobs",
+      "top_p"
+    ],
+    "created": 1786548957,
+    "expiration_date": null,
+    "model_author": "SpaceXAI",
+    "note": "基础价格为输入 $2、输出 $6 / 百万 token；上下文达到 200K tokens 后进入长上下文阶梯价，输入 $4、输出 $12 / 百万 token。"
+  },
   {
     "id": "x-ai/grok-imagine-image-2.0",
     "canonical_slug": "x-ai/grok-imagine-image-2.0",
@@ -803,7 +1004,7 @@ const rawCatalogModels: RawCatalogModel[] = [
       "tools",
       "top_p"
     ],
-    "created": 1785451719,
+    "created": 1786550701,
     "expiration_date": null,
     "model_author": "ByteDance Seed"
   },
@@ -20731,6 +20932,7 @@ function describeCategories(categories: Category[]) {
 }
 
 const VERIFIED_SPEECH_MODEL_IDS = new Set([
+  "deepgram/flux-tts:free",
   "fish-audio/s1",
   "fish-audio/s2-pro",
   "fish-audio/s2.1-pro-free:free",
@@ -20740,6 +20942,7 @@ const VERIFIED_SPEECH_MODEL_IDS = new Set([
 
 const VERIFIED_VIDEO_MODEL_IDS = new Set([
   "bytedance/seedance-2.0",
+  "bytedance/seedance-2.0-mini",
   "bytedance/seedance-2.5",
   "runway/aleph-2",
   "runway/gen-4.5",
@@ -21007,7 +21210,7 @@ const worldModelEntry: Model = {
 const FEATURED_MODEL_IDS = [
   "openai/gpt-5.6-sol",
   "anthropic/claude-opus-5",
-  "deepseek/deepseek-v4-flash-0731",
+  "deepseek/deepseek-v4-pro-0813",
   "anthropic/claude-fable-5",
   "moonshotai/kimi-k3",
   "anthropic/claude-opus-5-fast",
@@ -21197,6 +21400,9 @@ const sortedCatalogModels = [...rawCatalogModels]
   }));
 
 const SEEDANCE_2_5_MODEL_ID = "bytedance/seedance-2.5";
+const DEEPSEEK_V4_PRO_MODEL_ID = "deepseek/deepseek-v4-pro-0813";
+const DEEPSEEK_V4_FLASH_MODEL_ID = "deepseek/deepseek-v4-flash-0731";
+const SEEDREAM_5_PRO_MODEL_ID = "bytedance-seed/seedream-5-0-pro";
 const MID_CATALOG_MODEL_IDS = [
   "sakana/sakana-namazu",
   "upstage/solar-pro4",
@@ -21208,15 +21414,32 @@ const LATEST_REFRESH_MODEL_IDS = [
   "liquid/lfm-2.5-2.6b:free",
   "nvidia/nemotron-3.5-lightning",
   "nvidia/nemotron-3.5-lightning:free",
+  "x-ai/grok-4.6",
+  "deepgram/flux-tts:free",
+  "qwen/qwen3.8-2.4t-a95b",
+  "bytedance-seed/seed-2-1-turbo",
   "bytedance-seed/seed-2.0-code",
+  "bytedance/seedance-2.0-mini",
 ];
 const reservedCatalogModelIds = new Set([
   SEEDANCE_2_5_MODEL_ID,
+  DEEPSEEK_V4_PRO_MODEL_ID,
+  DEEPSEEK_V4_FLASH_MODEL_ID,
+  SEEDREAM_5_PRO_MODEL_ID,
   ...MID_CATALOG_MODEL_IDS,
   ...LATEST_REFRESH_MODEL_IDS,
 ]);
 const seedance25Model = sortedCatalogModels.find(
   (model) => model.id === SEEDANCE_2_5_MODEL_ID,
+);
+const deepseekV4ProModel = sortedCatalogModels.find(
+  (model) => model.id === DEEPSEEK_V4_PRO_MODEL_ID,
+);
+const deepseekV4FlashModel = sortedCatalogModels.find(
+  (model) => model.id === DEEPSEEK_V4_FLASH_MODEL_ID,
+);
+const seedream5ProModel = sortedCatalogModels.find(
+  (model) => model.id === SEEDREAM_5_PRO_MODEL_ID,
 );
 const midCatalogModels = MID_CATALOG_MODEL_IDS.map((modelId) =>
   sortedCatalogModels.find((model) => model.id === modelId),
@@ -21228,15 +21451,20 @@ const normallyOrderedCatalogModels = sortedCatalogModels.filter(
   (model) => !reservedCatalogModelIds.has(model.id),
 );
 
-// The homepage reserves two spotlight cards plus three desktop gallery rows for
-// broadly useful catalog models before showing direct OpenAI audio models.
-const REALTIME_MODEL_INSERT_INDEX = 11;
-
+// The list has one router card followed by two model cards in its first row.
+// Keep V4 Pro at row 2 column 1, move the former Flash default back exactly one
+// row, and reserve row 4 column 1 for Seedream 5 Pro.
 const primaryCatalogModels: Model[] = [
-  ...normallyOrderedCatalogModels.slice(0, REALTIME_MODEL_INSERT_INDEX),
+  ...normallyOrderedCatalogModels.slice(0, 2),
+  ...(deepseekV4ProModel ? [deepseekV4ProModel] : []),
+  ...normallyOrderedCatalogModels.slice(2, 4),
+  ...(deepseekV4FlashModel ? [deepseekV4FlashModel] : []),
+  ...normallyOrderedCatalogModels.slice(4, 6),
+  ...(seedream5ProModel ? [seedream5ProModel] : []),
+  ...normallyOrderedCatalogModels.slice(6, 8),
   ...(seedance25Model ? [seedance25Model] : []),
   ...DIRECT_OPENAI_AUDIO_MODELS,
-  ...normallyOrderedCatalogModels.slice(REALTIME_MODEL_INSERT_INDEX),
+  ...normallyOrderedCatalogModels.slice(8),
 ];
 const catalogMidpoint = Math.floor(primaryCatalogModels.length / 2);
 

--- a/client/src/pages/AgentWorkbenchPage.test.tsx
+++ b/client/src/pages/AgentWorkbenchPage.test.tsx
@@ -365,7 +365,7 @@ describe("AgentWorkbenchPage", () => {
     await screen.findByRole("heading", { name: "准备执行任务" });
     await userEvent.click(screen.getByRole("button", { name: "一句话创建 Agent" }));
     expect(screen.getByLabelText("Builder 模型")).toHaveValue(
-      "deepseek/deepseek-v4-flash-0731",
+      "deepseek/deepseek-v4-pro-0813",
     );
     const request = "创建一个负责审查 Python API 安全性的 Agent";
     await userEvent.type(screen.getByLabelText("Agent 需求"), request);
@@ -378,7 +378,7 @@ describe("AgentWorkbenchPage", () => {
       expect(call).toBeTruthy();
       expect(JSON.parse(String((call?.[1] as RequestInit).body))).toMatchObject({
         prompt: request,
-        model_id: "deepseek/deepseek-v4-flash-0731",
+        model_id: "deepseek/deepseek-v4-pro-0813",
         approval_mode: "always-ask",
       });
     });

--- a/client/src/utils/imageCostEstimate.test.ts
+++ b/client/src/utils/imageCostEstimate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   estimateImageCost,
   GROK_IMAGINE_IMAGE_2_PRICING,
+  SEEDREAM_5_PRO_PRICING,
 } from "./imageCostEstimate";
 
 describe("estimateImageCost", () => {
@@ -44,5 +45,20 @@ describe("estimateImageCost", () => {
         quality: "low",
       }),
     ).toBeNull();
+  });
+
+  it("uses Seedream's high-resolution output rate at 2K", () => {
+    expect(
+      estimateImageCost(SEEDREAM_5_PRO_PRICING, {
+        outputCount: 1,
+        referenceCount: 2,
+        resolution: "2K",
+      }),
+    ).toEqual({
+      minUsd: 0.096,
+      maxUsd: 0.096,
+      inputUsd: 0.006,
+      exact: true,
+    });
   });
 });

--- a/client/src/utils/imageCostEstimate.ts
+++ b/client/src/utils/imageCostEstimate.ts
@@ -30,6 +30,19 @@ export const GROK_IMAGINE_IMAGE_2_PRICING: ImagePricingItem[] = [
   { billable: "output_image", unit: "image", cost_usd: 0.08, variant: "medium_2k" },
 ];
 
+// Verified against the dedicated Seedream endpoint on 2026-08-13. The live
+// endpoint profile still takes precedence when OpenRouter updates its pricing.
+export const SEEDREAM_5_PRO_PRICING: ImagePricingItem[] = [
+  { billable: "input_image", unit: "image", cost_usd: 0.003 },
+  { billable: "output_image", unit: "image", cost_usd: 0.045 },
+  {
+    billable: "output_image",
+    unit: "image",
+    cost_usd: 0.09,
+    variant: "high_resolution",
+  },
+];
+
 function normalized(value?: string) {
   return value?.trim().toLowerCase() ?? "";
 }
@@ -42,6 +55,9 @@ export function estimateImageCost(
   const referenceCount = Math.max(0, Math.floor(input.referenceCount));
   const resolution = normalized(input.resolution);
   const quality = normalized(input.quality);
+  const hasHighResolutionVariant = pricing.some(
+    (item) => normalized(item.variant ?? undefined) === "high_resolution",
+  );
   const inputRates = pricing
     .filter((item) => item.billable === "input_image")
     .map((item) => item.cost_usd)
@@ -50,7 +66,12 @@ export function estimateImageCost(
     .filter((item) => item.billable === "output_image")
     .filter((item) => {
       const variant = normalized(item.variant ?? undefined);
-      if (!variant) return true;
+      if (!variant) {
+        return !(resolution === "2k" && hasHighResolutionVariant);
+      }
+      if (variant === "high_resolution") {
+        return !resolution || resolution === "2k";
+      }
       if (quality && !variant.startsWith(`${quality}_`)) return false;
       if (resolution && !variant.endsWith(`_${resolution}`)) return false;
       return true;

--- a/client/src/utils/videoCostEstimate.test.ts
+++ b/client/src/utils/videoCostEstimate.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { estimateVideoCost } from "./videoCostEstimate";
+import {
+  estimateVideoCost,
+  supportedAspectRatiosForResolution,
+} from "./videoCostEstimate";
 
 const seedance25Profile = {
   supported_resolutions: ["480p", "720p"],
@@ -71,5 +74,31 @@ describe("estimateVideoCost", () => {
     });
 
     expect(estimate).toBeNull();
+  });
+
+  it("maps Seedance Mini sizes by dimensions when a resolution omits one aspect ratio", () => {
+    const miniProfile = {
+        supported_resolutions: ["480p", "720p"],
+        supported_aspect_ratios: ["1:1", "3:4", "9:16", "4:3", "16:9", "21:9", "9:21"],
+        supported_sizes: [
+          "480x480", "480x640", "480x854", "640x480", "854x480", "1120x480",
+          "720x720", "720x960", "720x1280", "720x1680", "960x720", "1280x720", "1680x720",
+        ],
+        pricing_skus: { video_tokens: "0.0000035" },
+      };
+    const estimate = estimateVideoCost(
+      miniProfile,
+      {
+        duration: 4,
+        resolution: "720p",
+        aspectRatio: "16:9",
+        generateAudio: true,
+        imageInputCount: 0,
+      },
+    );
+
+    expect(estimate).toBeCloseTo(0.3024, 6);
+    expect(supportedAspectRatiosForResolution(miniProfile, "480p")).not.toContain("9:21");
+    expect(supportedAspectRatiosForResolution(miniProfile, "720p")).toContain("9:21");
   });
 });

--- a/client/src/utils/videoCostEstimate.ts
+++ b/client/src/utils/videoCostEstimate.ts
@@ -25,21 +25,40 @@ function selectedDimensions(
   resolution: string,
   aspectRatio: string,
 ) {
-  const resolutionIndex = profile.supported_resolutions.indexOf(resolution);
-  const aspectRatioIndex = profile.supported_aspect_ratios.indexOf(aspectRatio);
-  if (resolutionIndex < 0 || aspectRatioIndex < 0) return null;
+  const resolutionMatch = resolution.trim().toLowerCase().match(/^(\d+)p$/);
+  const ratioMatch = aspectRatio.trim().match(/^(\d+(?:\.\d+)?):(\d+(?:\.\d+)?)$/);
+  if (!resolutionMatch || !ratioMatch) return null;
+  const shortEdge = Number(resolutionMatch[1]);
+  const selectedRatio = Number(ratioMatch[1]) / Number(ratioMatch[2]);
 
-  // OpenRouter returns sizes in resolution-major, aspect-ratio-minor order.
-  const size =
-    profile.supported_sizes[
-      resolutionIndex * profile.supported_aspect_ratios.length +
-        aspectRatioIndex
-    ];
-  const match = size?.trim().toLowerCase().match(/^(\d+)x(\d+)$/);
-  if (!match) return null;
-  const width = Number(match[1]);
-  const height = Number(match[2]);
-  return width > 0 && height > 0 ? { width, height } : null;
+  for (const size of profile.supported_sizes) {
+    const match = size.trim().toLowerCase().match(/^(\d+)x(\d+)$/);
+    if (!match) continue;
+    const width = Number(match[1]);
+    const height = Number(match[2]);
+    if (
+      width > 0 &&
+      height > 0 &&
+      Math.min(width, height) === shortEdge &&
+      Math.abs(width / height - selectedRatio) <= 0.02
+    ) {
+      return { width, height };
+    }
+  }
+  return null;
+}
+
+export function supportedAspectRatiosForResolution(
+  profile: VideoPricingProfile,
+  resolution: string,
+) {
+  if (!resolution || profile.supported_sizes.length === 0) {
+    return profile.supported_aspect_ratios;
+  }
+  const matched = profile.supported_aspect_ratios.filter((aspectRatio) =>
+    Boolean(selectedDimensions(profile, resolution, aspectRatio)),
+  );
+  return matched.length > 0 ? matched : profile.supported_aspect_ratios;
 }
 
 export function estimateVideoCost(

--- a/docs/agent-workspace.md
+++ b/docs/agent-workspace.md
@@ -110,7 +110,7 @@ General Agent 快照中。现有外部 Skill 安装 API 保持不变。
   `system_config.yaml`、`AGENTS.md` 和 `manifest.json`。单次写文件或普通聊天不能
   触发提升。
 - 一句话创建的 Builder 默认模型独立固定为
-  `deepseek/deepseek-v4-flash-0731`，不跟随普通会话的全局模型偏好；界面允许用户
+  `deepseek/deepseek-v4-pro-0813`，不跟随普通会话的全局模型偏好；界面允许用户
   显式改选。服务端请求模型字段缺省时也采用同一默认值。
 - 初稿通过结构校验后必须进入第二次工具化领域复审：重新读取生成上下文、AGENTS.md
   与 manifest，重写并回读 AGENTS.md，随后才允许提升。后端质量契约验证语言一致性、

--- a/docs/multimodal-readiness.json
+++ b/docs/multimodal-readiness.json
@@ -1,23 +1,23 @@
 {
   "schema_version": 1,
-  "reviewed_at": "2026-08-12",
+  "reviewed_at": "2026-08-13",
   "catalog": {
-    "snapshot_total": 527,
+    "snapshot_total": 534,
     "serving_variant_total": 62,
     "serving_variants_by_type": {
       "batch": 62
     },
     "serving_variants_counted_in_snapshot": false,
-    "live": 470,
+    "live": 477,
     "uncertain": 53,
     "expired": 4,
-    "onsite_openrouter": 523,
-    "adaptation_denominator": 523,
+    "onsite_openrouter": 530,
+    "adaptation_denominator": 530,
     "uncertain_included_in_onsite": true,
     "expired_excluded_from_onsite": true
   },
   "video_generation": {
-    "dedicated_profiles": 22,
+    "dedicated_profiles": 23,
     "verified": [
       { "model_id": "bytedance/seedance-2.0", "verified_at": "2026-07-28", "evidence": ["manual_submission", "polling", "playback", "download"] },
       { "model_id": "runway/aleph-2", "verified_at": "2026-07-28", "evidence": ["manual_submission", "polling", "playback", "download"] },
@@ -36,6 +36,7 @@
       { "model_id": "bytedance/seedance-1-5-pro", "verified_at": "2026-08-06", "evidence": ["manual_submission", "frame_controls", "playback", "download"] },
       { "model_id": "bytedance/seedance-2.0-fast", "verified_at": "2026-08-06", "evidence": ["manual_submission", "reference_images", "playback", "download"] },
       { "model_id": "bytedance/seedance-2.5", "verified_at": "2026-08-11", "verification_status": "adapted_contract", "evidence": ["catalog_contract", "async_submission", "reference_images", "cost_estimate"] },
+      { "model_id": "bytedance/seedance-2.0-mini", "verified_at": "2026-08-13", "verification_status": "adapted_contract", "evidence": ["catalog_contract", "async_submission", "size_matrix", "cost_estimate"] },
       { "model_id": "google/veo-3.1-lite", "verified_at": "2026-08-06", "evidence": ["manual_submission", "audited_provider_options", "playback", "download"] },
       { "model_id": "google/veo-3.1-fast", "verified_at": "2026-08-06", "evidence": ["manual_submission", "minimum_spec", "playback", "download"] },
       { "model_id": "google/veo-3.1", "verified_at": "2026-08-06", "evidence": ["manual_submission", "minimum_spec", "playback", "download"] },

--- a/docs/task-cards/agent-workspace-r2.md
+++ b/docs/task-cards/agent-workspace-r2.md
@@ -46,7 +46,7 @@
 
 - Given：用户提交一句中文 Agent 需求。
 - When：General Agent 在隔离 staging Workspace 生成候选描述。
-- Then：默认使用 `deepseek/deepseek-v4-flash-0731` Builder，初稿必须经过第二次
+- Then：默认使用 `deepseek/deepseek-v4-pro-0813` Builder，初稿必须经过第二次
   工具化领域复审，并通过语言、领域章节、可操作项、知识边界和高风险证据门禁后才
   原子创建完整 Agent State；中文“工作流”等常见标题不会被词法误拒；初稿与二审
   各自使用独立的有界修复预算；冲突或无效候选不覆盖现有 Agent。

--- a/server/agent_upstream/models.py
+++ b/server/agent_upstream/models.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 UPSTREAM_REVISION = "047505dccc0cc16ad92be11011347d635f33ceb0"
 ENGINE_PROTOCOL = "modelmirror.upstream-workbench/1"
-DEFAULT_MODEL_BASE_ID = "deepseek-v4-flash-0731"
+DEFAULT_MODEL_BASE_ID = "deepseek-v4-pro-0813"
 
 ThinkingLevel = Literal["low", "medium", "high", "xhigh"]
 EngineShadowStatus = Literal[

--- a/server/agent_workspace/runtime_models.py
+++ b/server/agent_workspace/runtime_models.py
@@ -9,7 +9,7 @@ from .models import AGENT_ID_PATTERN, SKILL_ID_PATTERN, StrictModel
 
 ApprovalMode = Literal["always-ask", "read-only", "allow-all", "deny-all"]
 ThinkingLevel = Literal["low", "medium", "high", "xhigh"]
-DEFAULT_AGENT_BUILDER_MODEL_ID = "deepseek/deepseek-v4-flash-0731"
+DEFAULT_AGENT_BUILDER_MODEL_ID = "deepseek/deepseek-v4-pro-0813"
 SessionStatus = Literal["idle", "running", "waiting_approval", "failed"]
 TaskStatus = Literal[
     "pending",

--- a/server/multimodal/audio_catalog.py
+++ b/server/multimodal/audio_catalog.py
@@ -41,7 +41,7 @@ from .readiness import (
 
 AUDIO_CATALOG_TTL_SECONDS = 300.0
 AUDIO_CATALOG_STALE_SECONDS = 1_800.0
-AUDIO_PROFILE_REGISTRY_VERSION = "modelmirror-audio-contracts-2026-08-06-c1"
+AUDIO_PROFILE_REGISTRY_VERSION = "modelmirror-audio-contracts-2026-08-13-c1"
 
 NATIVE_AUDIO_VOICES = (
     "alloy",

--- a/server/multimodal/image_catalog.py
+++ b/server/multimodal/image_catalog.py
@@ -22,7 +22,10 @@ from .readiness import OperationReadiness
 IMAGE_CATALOG_TTL_SECONDS = 300.0
 IMAGE_CATALOG_STALE_SECONDS = 1_800.0
 IMAGE_PRICING_DETAIL_MODEL_IDS = frozenset(
-    {"x-ai/grok-imagine-image-2.0"}
+    {
+        "bytedance-seed/seedream-5-0-pro",
+        "x-ai/grok-imagine-image-2.0",
+    }
 )
 
 

--- a/server/multimodal/tts.py
+++ b/server/multimodal/tts.py
@@ -23,8 +23,9 @@ logger = logging.getLogger("modelmirror.multimodal")
 MAX_SPEECH_INPUT_CHARS = 4_000
 MAX_SPEECH_BYTES = 20 * 1024 * 1024
 CATALOG_CACHE_SECONDS = 300.0
-SPEECH_PROFILE_VERSION = "tts-contracts-2026-08-06-c1"
+SPEECH_PROFILE_VERSION = "tts-contracts-2026-08-13-c1"
 GEMINI_PCM_TTS_MODEL_ID = "google/gemini-3.1-flash-tts-preview"
+DEEPGRAM_FLUX_TTS_MODEL_ID = "deepgram/flux-tts:free"
 FISH_AUDIO_PUBLIC_VOICES = (
     "8ef4a238714b45718ce04243307c57a7",
     "802e3bc2b27e49c2995d23ef70e6ac89",
@@ -39,10 +40,49 @@ MINIMAX_SYSTEM_SPEECH_VOICES = (
     "English_magnetic_voiced_man",
     "English_Graceful_Lady",
 )
+DEEPGRAM_FLUX_TTS_VOICES = (
+    "flux-alexis-en",
+    "flux-bree-en",
+    "flux-brittany-en",
+    "flux-brooke-en",
+    "flux-bruce-en",
+    "flux-cliff-en",
+    "flux-cole-en",
+    "flux-colin-en",
+    "flux-conor-en",
+    "flux-donovan-en",
+    "flux-drew-en",
+    "flux-elise-en",
+    "flux-gemma-en",
+    "flux-haley-en",
+    "flux-hannah-en",
+    "flux-heather-en",
+    "flux-jack-en",
+    "flux-kai-en",
+    "flux-kelsey-en",
+    "flux-kit-en",
+    "flux-maeve-en",
+    "flux-marcelo-en",
+    "flux-marcus-en",
+    "flux-meena-en",
+    "flux-meghan-en",
+    "flux-miles-en",
+    "flux-naveen-en",
+    "flux-paige-en",
+    "flux-priya-en",
+    "flux-rufus-en",
+    "flux-sean-en",
+    "flux-sharon-en",
+    "flux-sienna-en",
+    "flux-tanner-en",
+    "flux-wade-en",
+    "flux-wes-en",
+)
 SPEECH_OUTPUT_FORMATS: dict[str, str] = {
     GEMINI_PCM_TTS_MODEL_ID: "wav",
 }
 ALLOWED_SPEECH_PROFILES: dict[str, tuple[str, ...]] = {
+    DEEPGRAM_FLUX_TTS_MODEL_ID: DEEPGRAM_FLUX_TTS_VOICES,
     "fish-audio/s1": FISH_AUDIO_PUBLIC_VOICES,
     "fish-audio/s2-pro": FISH_AUDIO_PUBLIC_VOICES,
     "fish-audio/s2.1-pro-free:free": FISH_AUDIO_PUBLIC_VOICES,

--- a/server/multimodal/video_catalog.py
+++ b/server/multimodal/video_catalog.py
@@ -49,6 +49,9 @@ VERIFIED_VIDEO_GENERATION_MODELS = frozenset(
         "bytedance/seedance-2.0-fast",
         # 2026-08-11：复用统一异步视频链路，首尾帧、本地参考图与费用估算已适配。
         "bytedance/seedance-2.5",
+        # 2026-08-13：实时目录确认 480p/720p、4–15 秒、首尾帧、
+        # 生成音频、seed 与 video-token 价格契约；复用同一异步链路。
+        "bytedance/seedance-2.0-mini",
         # 2026-08-06 人工验收：最低规格生成、轮询、播放与下载闭环通过。
         # Veo Lite 的受控高级参数也已完成验收。
         "google/veo-3.1-lite",

--- a/server/multimodal/video_jobs.py
+++ b/server/multimodal/video_jobs.py
@@ -740,6 +740,21 @@ class VideoJobService:
                 "所选模型不支持这个画面比例，请使用模型提供的比例选项。",
                 status_code=422,
             )
+        if (
+            resolution
+            and aspect_ratio
+            and profile.supported_sizes
+            and not VideoJobService._supports_size_combination(
+                profile,
+                resolution=resolution,
+                aspect_ratio=aspect_ratio,
+            )
+        ):
+            raise MultimodalServiceError(
+                "unsupported_video_size",
+                "所选模型不支持这个分辨率与画面比例组合，请使用目录提供的尺寸。",
+                status_code=422,
+            )
         if has_first_frame and (
             "first_frame" not in profile.supported_frame_types
             and not profile.supports_first_frame
@@ -783,6 +798,39 @@ class VideoJobService:
                 "所选模型不支持随机种子，请清空该参数。",
                 status_code=422,
             )
+
+    @staticmethod
+    def _supports_size_combination(
+        profile: VideoModelProfile,
+        *,
+        resolution: str,
+        aspect_ratio: str,
+    ) -> bool:
+        resolution_match = re.fullmatch(r"(\d+)p", resolution.strip().lower())
+        ratio_match = re.fullmatch(
+            r"(\d+(?:\.\d+)?):(\d+(?:\.\d+)?)",
+            aspect_ratio.strip(),
+        )
+        if not resolution_match or not ratio_match:
+            return True
+        short_edge = int(resolution_match.group(1))
+        ratio = float(ratio_match.group(1)) / float(ratio_match.group(2))
+        for supported_size in profile.supported_sizes:
+            size_match = re.fullmatch(
+                r"(\d+)x(\d+)",
+                supported_size.strip().lower(),
+            )
+            if not size_match:
+                continue
+            width, height = map(int, size_match.groups())
+            if (
+                width > 0
+                and height > 0
+                and min(width, height) == short_edge
+                and abs(width / height - ratio) <= 0.02
+            ):
+                return True
+        return False
 
     @staticmethod
     def _estimated_cost_usd(

--- a/server/tests/test_agent_upstream_api.py
+++ b/server/tests/test_agent_upstream_api.py
@@ -22,7 +22,7 @@ class _ApiShadowService:
     async def create_run(self, payload: EngineShadowRunCreate):
         model = ResolvedShadowModel(
             requested_base_id=payload.model_base_id,
-            invocation_id="deepseek/deepseek-v4-flash-0731",
+            invocation_id="deepseek/deepseek-v4-pro-0813",
             context_window=1_048_576,
             max_output_tokens=32_000,
         )
@@ -105,7 +105,7 @@ async def test_shadow_api_exposes_only_control_plane_and_read_only_workspace(
         "/api/agent-workspace/apps/engine-shadow-runs",
         json={
             "objective": "Build an offline single-file interaction",
-            "model_base_id": "deepseek-v4-flash-0731",
+            "model_base_id": "deepseek-v4-pro-0813",
             "thinking_level": "medium",
             "token_budget": 750_000,
             "max_goal_rounds": 12,

--- a/server/tests/test_agent_upstream_service.py
+++ b/server/tests/test_agent_upstream_service.py
@@ -23,10 +23,10 @@ def _catalog(*, available: bool = True) -> SimpleNamespace:
     return SimpleNamespace(
         models=[
             SimpleNamespace(
-                invocation_id="deepseek/deepseek-v4-flash-0731",
-                profile_id="deepseek-v4-flash-0731",
-                root="deepseek-v4-flash-0731",
-                name="DeepSeek V4 Flash 0731",
+                invocation_id="deepseek/deepseek-v4-pro-0813",
+                profile_id="deepseek-v4-pro-0813",
+                root="deepseek-v4-pro-0813",
+                name="DeepSeek V4 Pro 0813",
                 invocable=available,
                 availability="live" if available else "offline",
                 operations=("chat",),
@@ -48,7 +48,7 @@ class _FakeGateway:
             content="private-model-output-that-must-stay-in-memory",
             tool_calls=(),
             finish_reason="stop",
-            model_id="deepseek/deepseek-v4-flash-0731",
+            model_id="deepseek/deepseek-v4-pro-0813",
         )
 
 

--- a/server/tests/test_multimodal_image.py
+++ b/server/tests/test_multimodal_image.py
@@ -239,6 +239,115 @@ async def test_image_generation_validates_capabilities_and_complete_output(
 
 
 @pytest.mark.asyncio
+async def test_seedream_5_pro_uses_the_dedicated_images_contract(
+    tmp_path: Path,
+) -> None:
+    model_id = "bytedance-seed/seedream-5-0-pro"
+
+    def handler(request: Request) -> Response:
+        if request.url.path.endswith(f"/images/models/{model_id}/endpoints"):
+            return Response(
+                200,
+                json={
+                    "id": model_id,
+                    "endpoints": [
+                        {
+                            "pricing": [
+                                {
+                                    "billable": "output_image",
+                                    "unit": "image",
+                                    "cost_usd": 0.045,
+                                },
+                                {
+                                    "billable": "output_image",
+                                    "unit": "image",
+                                    "cost_usd": 0.09,
+                                    "variant": "high_resolution",
+                                },
+                                {
+                                    "billable": "input_image",
+                                    "unit": "image",
+                                    "cost_usd": 0.003,
+                                },
+                            ]
+                        }
+                    ],
+                },
+            )
+        if request.url.path.endswith("/images/models"):
+            return Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": model_id,
+                            "name": "ByteDance Seed: Seedream 5.0 Pro",
+                            "architecture": {
+                                "input_modalities": ["text", "image"],
+                                "output_modalities": ["image"],
+                            },
+                            "supported_parameters": {
+                                "resolution": {
+                                    "type": "enum",
+                                    "values": ["1K", "2K"],
+                                },
+                                "aspect_ratio": {
+                                    "type": "enum",
+                                    "values": ["1:1", "16:9", "auto"],
+                                },
+                                "n": {"type": "range", "min": 1, "max": 1},
+                                "input_references": {
+                                    "type": "range",
+                                    "min": 0,
+                                    "max": 14,
+                                },
+                                "seed": {"type": "boolean"},
+                            },
+                            "supports_streaming": False,
+                        }
+                    ]
+                },
+            )
+        return Response(200, json={"data": []})
+
+    catalog = ImageCatalogService(
+        openrouter_service(tmp_path),
+        client_factory=lambda: httpx.AsyncClient(
+            transport=MockTransport(handler)
+        ),
+    )
+    result = await catalog.get_catalog()
+    profile = next(item for item in result.profiles if item.model_id == model_id)
+
+    assert profile.operation == "generate_image"
+    assert profile.interaction_status == "ready"
+    assert profile.supports_streaming is False
+    assert profile.supported_parameters["resolution"].values == ["1K", "2K"]
+    assert profile.supported_parameters["n"].max == 1
+    assert profile.supported_parameters["input_references"].max == 14
+    assert [item.model_dump() for item in profile.pricing] == [
+        {
+            "billable": "output_image",
+            "unit": "image",
+            "cost_usd": 0.045,
+            "variant": None,
+        },
+        {
+            "billable": "output_image",
+            "unit": "image",
+            "cost_usd": 0.09,
+            "variant": "high_resolution",
+        },
+        {
+            "billable": "input_image",
+            "unit": "image",
+            "cost_usd": 0.003,
+            "variant": None,
+        },
+    ]
+
+
+@pytest.mark.asyncio
 async def test_grok_imagine_image_2_uses_dedicated_openrouter_contract(
     tmp_path: Path,
 ) -> None:

--- a/server/tests/test_multimodal_tts.py
+++ b/server/tests/test_multimodal_tts.py
@@ -16,6 +16,8 @@ from server.multimodal.audio_catalog import AudioCatalogService
 from server.multimodal.stt import MultimodalServiceError, OpenRouterTarget
 from server.multimodal.tts import (
     ALLOWED_SPEECH_PROFILES,
+    DEEPGRAM_FLUX_TTS_MODEL_ID,
+    DEEPGRAM_FLUX_TTS_VOICES,
     FISH_AUDIO_PUBLIC_VOICES,
     GEMINI_PCM_TTS_MODEL_ID,
     MAX_SPEECH_INPUT_CHARS,
@@ -46,6 +48,7 @@ def test_verified_speech_profiles_cover_multiple_providers() -> None:
         "qwen/qwen-audio-3.0-tts-flash",
         "x-ai/grok-voice-tts-1.0",
         "deepgram/aura-2",
+        DEEPGRAM_FLUX_TTS_MODEL_ID,
         "zyphra/zonos-v0.1-transformer",
         "zyphra/zonos-v0.1-hybrid",
         "canopylabs/orpheus-3b-0.1-ft",
@@ -57,6 +60,21 @@ def test_verified_speech_profiles_cover_multiple_providers() -> None:
     assert speech_output_format(MODEL_ID) == "mp3"
     assert speech_output_format(GEMINI_PCM_TTS_MODEL_ID) == "wav"
     assert "marin" in OPENAI_SPEECH_PROFILES["gpt-4o-mini-tts"]
+
+
+def test_deepgram_flux_tts_uses_the_live_openrouter_voice_contract() -> None:
+    assert len(DEEPGRAM_FLUX_TTS_VOICES) == 36
+    assert DEEPGRAM_FLUX_TTS_VOICES[0] == "flux-alexis-en"
+    assert DEEPGRAM_FLUX_TTS_VOICES[-1] == "flux-wes-en"
+    assert (
+        ALLOWED_SPEECH_PROFILES[DEEPGRAM_FLUX_TTS_MODEL_ID]
+        == DEEPGRAM_FLUX_TTS_VOICES
+    )
+    assert speech_output_format(DEEPGRAM_FLUX_TTS_MODEL_ID) == "mp3"
+    assert SpeechService._voice(
+        DEEPGRAM_FLUX_TTS_MODEL_ID,
+        "flux-alexis-en",
+    ) == "flux-alexis-en"
 
 
 def test_fish_audio_profiles_use_documented_public_voice_ids() -> None:
@@ -142,6 +160,7 @@ def test_fish_audio_catalog_profiles_are_ready(
         ("qwen/qwen-audio-3.0-tts-flash", "longanhuan_v3.6"),
         ("x-ai/grok-voice-tts-1.0", "ara"),
         ("deepgram/aura-2", "aura-2-amalthea-en"),
+        (DEEPGRAM_FLUX_TTS_MODEL_ID, "flux-alexis-en"),
         ("zyphra/zonos-v0.1-transformer", "american_female"),
         ("zyphra/zonos-v0.1-hybrid", "american_female"),
         ("canopylabs/orpheus-3b-0.1-ft", "dan"),

--- a/server/tests/test_multimodal_video_catalog.py
+++ b/server/tests/test_multimodal_video_catalog.py
@@ -148,6 +148,51 @@ async def test_video_catalog_normalizes_analysis_and_generation_models(
                             "supported_durations": [5],
                         },
                         {
+                            "id": "bytedance/seedance-2.0-mini",
+                            "supported_resolutions": ["480p", "720p"],
+                            "supported_aspect_ratios": [
+                                "1:1",
+                                "3:4",
+                                "9:16",
+                                "4:3",
+                                "16:9",
+                                "21:9",
+                                "9:21",
+                            ],
+                            "supported_sizes": [
+                                "480x480",
+                                "480x640",
+                                "480x854",
+                                "640x480",
+                                "854x480",
+                                "1120x480",
+                                "720x720",
+                                "720x960",
+                                "720x1280",
+                                "720x1680",
+                                "960x720",
+                                "1280x720",
+                                "1680x720",
+                            ],
+                            "supported_durations": list(range(4, 16)),
+                            "supported_frame_images": [
+                                "first_frame",
+                                "last_frame",
+                            ],
+                            "generate_audio": True,
+                            "seed": True,
+                            "pricing_skus": {
+                                "video_tokens": "0.0000035",
+                                "video_tokens_without_audio": "0.0000035",
+                                "video_tokens_with_video_input": "0.0000021",
+                            },
+                            "allowed_passthrough_parameters": [
+                                "watermark",
+                                "req_key",
+                                "return_last_frame",
+                            ],
+                        },
+                        {
                             "id": "runway/aleph-2",
                             "supported_resolutions": None,
                             "supported_aspect_ratios": [
@@ -216,7 +261,7 @@ async def test_video_catalog_normalizes_analysis_and_generation_models(
 
     assert result.status == "online"
     assert result.stale is False
-    assert len(result.profiles) == 5
+    assert len(result.profiles) == 6
     analysis = next(
         item for item in result.profiles if item.operation == "analyze_video"
     )
@@ -229,6 +274,11 @@ async def test_video_catalog_normalizes_analysis_and_generation_models(
         item
         for item in result.profiles
         if item.model_id == "bytedance/seedance-2.0-fast"
+    )
+    seedance_mini = next(
+        item
+        for item in result.profiles
+        if item.model_id == "bytedance/seedance-2.0-mini"
     )
     runway_aleph = next(
         item for item in result.profiles if item.model_id == "runway/aleph-2"
@@ -271,6 +321,23 @@ async def test_video_catalog_normalizes_analysis_and_generation_models(
     assert reference_model.supports_reference_images is True
     assert reference_model.max_reference_images == 3
     assert reference_model.verification_entry_enabled is False
+    assert seedance_mini.interaction_status == "ready"
+    assert seedance_mini.supported_resolutions == ["480p", "720p"]
+    assert seedance_mini.supported_durations == list(range(4, 16))
+    assert seedance_mini.supported_frame_types == [
+        "first_frame",
+        "last_frame",
+    ]
+    assert seedance_mini.supports_generated_audio is True
+    assert seedance_mini.supports_seed is True
+    assert seedance_mini.pricing_skus == {
+        "video_tokens": "0.0000035",
+        "video_tokens_without_audio": "0.0000035",
+        "video_tokens_with_video_input": "0.0000021",
+    }
+    assert seedance_mini.operation_readiness[0].verification_status == (
+        "verified"
+    )
     assert runway_aleph.interaction_status == "ready"
     assert runway_aleph.verification_entry_enabled is False
     assert runway_aleph.operation_readiness[0].verification_status == (

--- a/server/tests/test_multimodal_video_jobs.py
+++ b/server/tests/test_multimodal_video_jobs.py
@@ -684,6 +684,23 @@ async def test_parameters_are_cross_checked_before_submit(
     assert caught.value.code == "unsupported_duration"
     assert adapter.submit_calls == []
 
+    service.catalog_service.profile.supported_sizes = [
+        "854x480",
+        "1280x720",
+    ]
+    service.catalog_service.profile.supported_aspect_ratios.append("9:21")
+    with pytest.raises(MultimodalServiceError) as caught:
+        await service.create(
+            model_id="google/veo-test",
+            prompt="A test",
+            duration=5,
+            resolution="720p",
+            aspect_ratio="9:21",
+            idempotency_key="bad-size-combination-0001",
+        )
+    assert caught.value.code == "unsupported_video_size"
+    assert adapter.submit_calls == []
+
     no_frame_router = router_service(tmp_path / "no-frame")
     no_frame = VideoJobService(
         no_frame_router,

--- a/server/tests/test_xpert_publish.py
+++ b/server/tests/test_xpert_publish.py
@@ -66,7 +66,7 @@ def test_xpert_store_persists_unique_slugs_and_immutable_versions(
     assert validate_xpert_definition(created).valid is True
     assert (
         _workflow_agent_data(created.draft.workflow)["modelId"]
-        == "deepseek/deepseek-v4-flash-0731"
+        == "deepseek/deepseek-v4-pro-0813"
     )
 
     reloaded = XpertStore(xpert_store.storage_dir).get_xpert(created.id)

--- a/server/xperts/store.py
+++ b/server/xperts/store.py
@@ -70,7 +70,7 @@ def default_xpert_workflow(xpert_id: str, name: str) -> NativeWorkflowDefinition
                         "title": "主智能体",
                         "description": "执行已发布 Xpert 的主要推理步骤。",
                         "agentName": "primary-agent",
-                        "modelId": "deepseek/deepseek-v4-flash-0731",
+                        "modelId": "deepseek/deepseek-v4-pro-0813",
                         "rolePrompt": "你是一个可靠的任务智能体。请结合对话上下文，直接完成用户请求。",
                         "taskInput": "历史对话：\n{{conversation_history}}\n\n当前请求：\n{{user_input}}",
                         "toolMode": "none",


### PR DESCRIPTION
## 改动摘要
- 基于已合并 PR #184 更新八个 OpenRouter 快照，其中七个为新增模型，Seed 2.0 Code 为既有模型元数据修复
- DeepSeek V4 Pro 0813 替换 Flash 作为首页与 Agent、工作流、Agent Upstream、General Xpert 默认模型；Flash 保留并后置一排
- Seedream 5 Pro 固定在第四排第一个，其余刷新模型在第六排以后确定性分散
- 接入 Seedream 专用 Images API、Flux TTS 专用 Speech API 与 Seedance Mini 异步 Video API 契约
- 为 Seedance 分辨率和画面比例增加联动及服务端尺寸组合校验

## 验证
- client: npm.cmd run test:run -- 5 个相关测试文件，30 passed
- client: npm.cmd run build，成功；仅保留既有大 chunk 警告
- server: 8 个相关测试文件，115 passed；仅有 4 条 FastAPI on_event 弃用警告
- git diff --cached --check，成功
- 独立预览浏览器验收：首页八个入口、Seedream 图片页、Flux TTS 页、Seedance 视频页和工作流默认模型均通过，控制台无错误
- 独立后端实时目录：image/audio/video 均 online

## 验收边界
- 未发起会产生费用的真实图片、语音或视频生成请求；已完成实时目录、请求契约、UI 与适配器回归
- 共享栈 #183 未修改，验收环境使用 #184 隔离工作树与独立端口