### PR TITLE
feature: 优化模型与 Agent 市场工作台

### DIFF
--- a/client/src/components/ComingSoon.tsx
+++ b/client/src/components/ComingSoon.tsx
@@ -44,7 +44,7 @@ export default function ComingSoon({
               className="rounded-full border border-white/10 bg-white/[0.055] px-5 py-2.5 text-sm font-semibold text-slate-100 transition duration-200 hover:border-brand-300/35 hover:bg-brand-300/10 hover:text-brand-100 active:scale-[0.98]"
               to="/agents"
             >
-              去 AI 人才市场
+              去 Agent人才市场
             </Link>
           </div>
         </div>

--- a/client/src/components/ModelWorkbenchSidebar.test.tsx
+++ b/client/src/components/ModelWorkbenchSidebar.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import ModelWorkbenchSidebar from "./ModelWorkbenchSidebar";
+
+const expectedEntries = [
+  ["自定义工作流", "/workflow", "拖拽节点，编排并运行任务"],
+  ["RAG 知识库", "/rag", "上传资料，检索并用于问答"],
+  ["Coding", "/coding", "连接项目，完成代码任务"],
+  ["系统设置", "/settings", "管理连接、网关与功能开关"],
+] as const;
+
+function renderSidebar(compact = false) {
+  return render(
+    <MemoryRouter>
+      <ModelWorkbenchSidebar compact={compact} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ModelWorkbenchSidebar", () => {
+  it("shows the four real workbench destinations in the approved order", () => {
+    renderSidebar();
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(4);
+
+    expectedEntries.forEach(([name, href, description], index) => {
+      expect(links[index]).toHaveAttribute("href", href);
+      expect(links[index]).toHaveTextContent(name);
+      expect(links[index]).toHaveTextContent(description);
+    });
+
+    expect(screen.queryByText("已完成适配")).not.toBeInTheDocument();
+    expect(screen.queryByText("模镜服务台")).not.toBeInTheDocument();
+    expect(screen.queryByText("元智能体 Beta")).not.toBeInTheDocument();
+  });
+
+  it("keeps the mobile workbench entry collapsed by default", () => {
+    const { container } = renderSidebar(true);
+
+    const details = container.querySelector("details");
+    expect(details).not.toHaveAttribute("open");
+    expect(screen.getByText("4 个入口")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/ModelWorkbenchSidebar.tsx
+++ b/client/src/components/ModelWorkbenchSidebar.tsx
@@ -1,0 +1,141 @@
+import {
+  BookOpenText,
+  ChevronRight,
+  Code2,
+  Settings,
+  Workflow,
+  type LucideIcon,
+} from "lucide-react";
+import { Link } from "react-router-dom";
+
+interface WorkbenchEntry {
+  accent: "amber" | "cyan" | "neutral";
+  badge: string;
+  description: string;
+  href: string;
+  icon: LucideIcon;
+  title: string;
+}
+
+const workbenchEntries: WorkbenchEntry[] = [
+  {
+    accent: "amber",
+    badge: "构建",
+    description: "拖拽节点，编排并运行任务",
+    href: "/workflow",
+    icon: Workflow,
+    title: "自定义工作流",
+  },
+  {
+    accent: "cyan",
+    badge: "知识",
+    description: "上传资料，检索并用于问答",
+    href: "/rag",
+    icon: BookOpenText,
+    title: "RAG 知识库",
+  },
+  {
+    accent: "cyan",
+    badge: "开发",
+    description: "连接项目，完成代码任务",
+    href: "/coding",
+    icon: Code2,
+    title: "Coding",
+  },
+  {
+    accent: "neutral",
+    badge: "管理",
+    description: "管理连接、网关与功能开关",
+    href: "/settings",
+    icon: Settings,
+    title: "系统设置",
+  },
+];
+
+const entryTone: Record<WorkbenchEntry["accent"], string> = {
+  amber:
+    "border-hire-300/35 bg-[linear-gradient(105deg,rgba(251,146,60,0.18),rgba(15,23,42,0.72))] hover:border-hire-200/65 hover:bg-hire-300/20",
+  cyan:
+    "border-cyan-300/15 bg-white/[0.035] hover:border-cyan-300/35 hover:bg-cyan-300/[0.07]",
+  neutral:
+    "border-white/10 bg-white/[0.035] hover:border-white/25 hover:bg-white/[0.07]",
+};
+
+const iconTone: Record<WorkbenchEntry["accent"], string> = {
+  amber: "border-hire-300/30 bg-hire-300/10 text-hire-100",
+  cyan: "border-cyan-300/20 bg-cyan-300/[0.07] text-cyan-100",
+  neutral: "border-white/15 bg-white/[0.055] text-slate-200",
+};
+
+function WorkbenchLinks() {
+  return (
+    <div className="mt-4 space-y-2.5">
+      {workbenchEntries.map((entry) => {
+        const Icon = entry.icon;
+
+        return (
+          <Link
+            className={`group grid min-h-[88px] grid-cols-[36px_minmax(0,1fr)_auto] items-center gap-x-2 rounded-lg border px-2 py-3 transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hire-200/80 ${entryTone[entry.accent]}`}
+            key={entry.href}
+            to={entry.href}
+          >
+            <span
+              className={`flex h-9 w-9 items-center justify-center rounded-md border ${iconTone[entry.accent]}`}
+            >
+              <Icon aria-hidden="true" size={19} strokeWidth={1.8} />
+            </span>
+            <span className="min-w-0">
+              <span className="block whitespace-nowrap text-[13px] font-semibold text-white">
+                {entry.title}
+              </span>
+              <span className="mt-1 block text-[11px] leading-4 text-slate-400">
+                {entry.description}
+              </span>
+            </span>
+            <span className="flex items-center gap-0.5 text-hire-100">
+              <span className="rounded-full border border-white/10 bg-ink-950/35 px-1 py-0.5 text-[10px] font-medium text-slate-300">
+                {entry.badge}
+              </span>
+              <ChevronRight
+                aria-hidden="true"
+                className="transition-transform duration-200 group-hover:translate-x-0.5"
+                size={14}
+              />
+            </span>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function ModelWorkbenchSidebar({
+  compact = false,
+}: {
+  compact?: boolean;
+}) {
+  if (compact) {
+    return (
+      <details className="surface-panel rounded-lg p-4">
+        <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 text-sm font-semibold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hire-200/80">
+          <span>工作台入口</span>
+          <span className="text-xs font-medium text-slate-400">4 个入口</span>
+        </summary>
+        <p className="mt-2 text-xs leading-5 text-slate-400">
+          继续构建、检索与管理 AI 能力。
+        </p>
+        <WorkbenchLinks />
+      </details>
+    );
+  }
+
+  return (
+    <section aria-label="工作台入口">
+      <h2 className="text-base font-semibold text-white">工作台入口</h2>
+      <p className="mt-1.5 text-xs leading-5 text-slate-400">
+        继续构建、检索与管理 AI 能力。
+      </p>
+      <WorkbenchLinks />
+    </section>
+  );
+}

--- a/client/src/components/PageContainer.tsx
+++ b/client/src/components/PageContainer.tsx
@@ -10,7 +10,10 @@ interface PageContainerProps {
   contentClassName?: string;
   hideSidebar?: boolean;
   maxWidthClassName?: string;
+  mobileSidebar?: ReactNode;
   sidebar?: ReactNode;
+  sidebarGridClassName?: string;
+  showSystemCapabilityBar?: boolean;
 }
 
 export default function PageContainer({
@@ -20,17 +23,22 @@ export default function PageContainer({
   contentClassName = "",
   hideSidebar = false,
   maxWidthClassName = "max-w-[1480px]",
+  mobileSidebar,
   sidebar,
+  sidebarGridClassName = "xl:grid-cols-[260px_minmax(0,1fr)]",
+  showSystemCapabilityBar = true,
 }: PageContainerProps) {
   const sidebarContent = (
     <div className="space-y-5">
       {sidebar ? (
         <>
           {sidebar}
-          <div className="border-t border-white/10" />
+          {showSystemCapabilityBar ? (
+            <div className="border-t border-white/10" />
+          ) : null}
         </>
       ) : null}
-      <SystemCapabilityBar />
+      {showSystemCapabilityBar ? <SystemCapabilityBar /> : null}
     </div>
   );
 
@@ -43,16 +51,17 @@ export default function PageContainer({
       <div
         className={`relative mx-auto w-full ${maxWidthClassName} px-4 py-6 sm:px-6 lg:px-8 lg:py-8`}
       >
-        {!hideSidebar ? (
-          <div className="mb-5 xl:hidden">
-            <SystemCapabilityBar compact />
+        {!hideSidebar && (mobileSidebar || showSystemCapabilityBar) ? (
+          <div className="mb-5 space-y-3 xl:hidden">
+            {mobileSidebar}
+            {showSystemCapabilityBar ? <SystemCapabilityBar compact /> : null}
           </div>
         ) : null}
 
         {hideSidebar ? (
           <div className={`min-w-0 ${contentClassName}`}>{children}</div>
         ) : sidebar ? (
-          <div className="grid min-w-0 gap-6 xl:grid-cols-[260px_minmax(0,1fr)]">
+          <div className={`grid min-w-0 gap-6 ${sidebarGridClassName}`}>
             <aside className="hidden xl:block">
               <div className="surface-panel sticky top-28 rounded-lg p-4">
                 {sidebarContent}
@@ -63,7 +72,7 @@ export default function PageContainer({
             </div>
           </div>
         ) : (
-          <div className="grid min-w-0 gap-6 xl:grid-cols-[260px_minmax(0,1fr)]">
+          <div className={`grid min-w-0 gap-6 ${sidebarGridClassName}`}>
             <aside className="hidden xl:block">
               <div className="surface-panel sticky top-28 rounded-lg p-4">
                 {sidebarContent}

--- a/client/src/components/PlatformCapabilityCard.tsx
+++ b/client/src/components/PlatformCapabilityCard.tsx
@@ -1,3 +1,17 @@
+import {
+  AppWindow,
+  Bot,
+  CalendarClock,
+  ChartPie,
+  ChevronRight,
+  Layers3,
+  Rocket,
+  Settings2,
+  UsersRound,
+  Workflow,
+  type LucideIcon,
+} from "lucide-react";
+
 export interface PlatformCapability {
   id: string;
   icon: string;
@@ -6,51 +20,128 @@ export interface PlatformCapability {
   detail: string;
   tag: string;
   eta: string;
+  statusLabel?: string;
+  actionLabel?: string;
 }
 
 interface PlatformCapabilityCardProps {
   capability: PlatformCapability;
+  featured?: boolean;
   onOpen: (capability: PlatformCapability) => void;
+}
+
+const capabilityIcons: Record<string, LucideIcon> = {
+  "agent-workspace": AppWindow,
+  "conversation-goals": CalendarClock,
+  datax: ChartPie,
+  "expert-squad": UsersRound,
+  "meta-agent": Workflow,
+  "xpert-automations": Settings2,
+  "xpert-studio": Layers3,
+};
+
+function CapabilityIcon({
+  capability,
+  featured,
+}: {
+  capability: PlatformCapability;
+  featured: boolean;
+}) {
+  const Icon = capabilityIcons[capability.id] ?? Bot;
+
+  if (featured) {
+    return (
+      <span className="relative flex h-[76px] w-[76px] shrink-0 items-center justify-center rounded-2xl border border-hire-200/45 bg-[linear-gradient(145deg,rgba(251,146,60,0.22),rgba(8,17,36,0.86))] text-hire-100 shadow-[0_16px_38px_rgba(3,8,22,0.36)]">
+        <Layers3 aria-hidden="true" size={42} strokeWidth={1.7} />
+        <span className="absolute -bottom-1 -right-1 flex h-8 w-8 items-center justify-center rounded-lg border border-hire-100/35 bg-ink-950 text-hire-100 shadow-lg">
+          <Rocket aria-hidden="true" size={18} strokeWidth={1.8} />
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl border border-cyan-200/25 bg-[linear-gradient(145deg,rgba(34,211,238,0.14),rgba(9,21,43,0.98))] text-cyan-100 shadow-[0_10px_26px_rgba(2,8,23,0.34)]"
+    >
+      <Icon aria-hidden="true" size={30} strokeWidth={1.7} />
+    </span>
+  );
 }
 
 export default function PlatformCapabilityCard({
   capability,
+  featured = false,
   onOpen,
 }: PlatformCapabilityCardProps) {
-  return (
-    <article className="group relative isolate flex h-full min-h-[260px] flex-col overflow-hidden rounded-lg border border-hire-300/25 bg-[linear-gradient(145deg,rgba(67,20,7,0.62),rgba(6,9,22,0.9)_52%,rgba(17,24,39,0.84))] p-5 shadow-prism transition duration-300 hover:-translate-y-1 hover:border-hire-300/55 hover:bg-surface-900/95">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_15%,rgba(251,146,60,0.18),transparent_36%),radial-gradient(circle_at_80%_80%,rgba(196,181,253,0.12),transparent_34%)]" />
-      <div className="relative flex items-start justify-between gap-3">
-        <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border border-hire-300/35 bg-hire-300/10 text-lg font-bold text-hire-100 shadow-[0_0_24px_rgba(251,146,60,0.14)]">
-          {capability.icon}
-        </span>
-        <span className="rounded-full border border-white/10 bg-white/[0.055] px-2.5 py-1 text-xs font-semibold text-slate-200">
-          平台能力
-        </span>
-      </div>
+  if (featured) {
+    return (
+      <article className="group relative isolate flex h-full min-h-[316px] flex-col overflow-hidden rounded-xl border border-hire-300/45 bg-[linear-gradient(135deg,rgba(74,31,18,0.72),rgba(6,12,28,0.96)_58%)] p-6">
+        <div className="pointer-events-none absolute inset-y-0 right-0 w-2/5 opacity-35 [background-image:linear-gradient(rgba(251,146,60,0.25)_1px,transparent_1px),linear-gradient(90deg,rgba(251,146,60,0.25)_1px,transparent_1px)] [background-size:32px_32px] [mask-image:linear-gradient(to_left,black,transparent)]" />
+        <CapabilityIcon capability={capability} featured />
 
-      <h2 className="relative mt-5 text-lg font-semibold text-white">
-        {capability.title}
-      </h2>
-      <p className="relative mt-3 text-sm leading-6 text-slate-300">
-        {capability.summary}
-      </p>
+        <h3 className="relative mt-6 text-2xl font-semibold text-white">
+          {capability.title}
+        </h3>
+        <p className="relative mt-3 max-w-[34ch] text-sm leading-6 text-slate-300">
+          {capability.summary}
+        </p>
 
-      <div className="relative mt-5 flex flex-wrap gap-2">
-        <span className="rounded-full border border-hire-300/30 bg-hire-300/10 px-2.5 py-1 text-xs font-semibold text-hire-100">
+        <span className="relative mt-4 w-fit rounded-md border border-emerald-300/20 bg-emerald-300/10 px-2.5 py-1 text-xs font-semibold text-emerald-100">
           {capability.tag}
         </span>
-        <span className="rounded-full border border-emerald-300/25 bg-emerald-300/10 px-2.5 py-1 text-xs font-semibold text-emerald-100">
-          求职状态：排队入场
-        </span>
+
+        <button
+          className="relative mt-auto flex min-h-11 w-fit items-center gap-3 rounded-lg bg-hire-300 px-5 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hire-100 active:scale-[0.98]"
+          onClick={() => onOpen(capability)}
+          type="button"
+        >
+          {capability.actionLabel ?? "打开工作台"}
+          <ChevronRight aria-hidden="true" size={16} />
+        </button>
+      </article>
+    );
+  }
+
+  return (
+    <article className="group relative flex min-h-[104px] items-center gap-4 overflow-hidden rounded-xl border border-slate-400/15 bg-[linear-gradient(135deg,rgba(7,17,36,0.98),rgba(5,11,27,0.99))] px-4 py-3 shadow-[0_14px_30px_rgba(2,6,18,0.2)] transition duration-200 hover:border-cyan-300/30 hover:bg-[linear-gradient(135deg,rgba(9,25,48,0.99),rgba(6,13,30,1))]">
+      <span className="pointer-events-none absolute inset-y-0 left-0 w-28 bg-cyan-300/[0.025] [mask-image:linear-gradient(to_right,black,transparent)]" />
+      <CapabilityIcon capability={capability} featured={false} />
+
+      <div className="relative min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="text-sm font-semibold text-white sm:text-base">
+            {capability.title}
+          </h3>
+          <span
+            className={`rounded-md border px-2 py-0.5 text-[11px] font-semibold ${
+              capability.tag === "可用"
+                ? "border-emerald-300/20 bg-emerald-300/10 text-emerald-100"
+                : "border-violet-300/20 bg-violet-300/10 text-violet-200"
+            }`}
+          >
+            {capability.tag}
+          </span>
+        </div>
+        <p className="mt-1 line-clamp-2 text-xs leading-5 text-slate-300/80 sm:text-sm">
+          {capability.summary}
+        </p>
       </div>
 
       <button
-        className="relative mt-auto w-fit rounded-full border border-white/10 bg-white/[0.06] px-4 py-2 text-sm font-semibold text-slate-100 transition duration-200 hover:border-hire-300/40 hover:bg-hire-300/10 hover:text-hire-100 active:scale-[0.98]"
+        aria-label={`${capability.actionLabel ?? "打开"}${capability.title}`}
+        className="relative flex min-h-11 shrink-0 items-center gap-1 rounded-md px-2 text-xs font-semibold text-hire-100 transition hover:bg-hire-300/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hire-100 sm:px-3 sm:text-sm"
         onClick={() => onOpen(capability)}
         type="button"
       >
-        了解更多
+        <span className="hidden sm:inline">
+          {capability.actionLabel ?? "打开"}
+        </span>
+        <ChevronRight
+          aria-hidden="true"
+          className="transition-transform group-hover:translate-x-0.5"
+          size={16}
+        />
       </button>
     </article>
   );

--- a/client/src/pages/AgentsPage.platform-capabilities.test.tsx
+++ b/client/src/pages/AgentsPage.platform-capabilities.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ModelPreferenceProvider } from "../context/ModelPreferenceContext";
+import { resourceNavItems } from "../theme/resources";
+import AgentsPage, {
+  featuredPlatformCapability,
+  platformCapabilities,
+  platformCapabilityPath,
+} from "./AgentsPage";
+
+vi.mock("../components/AgentCard", () => ({
+  default: ({ agent }: { agent: { name: string } }) => (
+    <div data-testid="agent-card">{agent.name}</div>
+  ),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function renderPage(workbenchEnabled = false) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ enabled: workbenchEnabled }), {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        }),
+      ),
+    ),
+  );
+
+  return render(
+    <MemoryRouter>
+      <ModelPreferenceProvider>
+        <AgentsPage />
+      </ModelPreferenceProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("AgentsPage platform capabilities", () => {
+  it("uses the real Data X entry instead of the obsolete workflow showcase", () => {
+    const dataX = platformCapabilities.find((item) => item.id === "datax");
+
+    expect(dataX).toMatchObject({
+      title: "Data X 数据分析",
+      statusLabel: "服务状态：已开放",
+    });
+    expect(platformCapabilities.some((item) => item.id === "workflow-builder")).toBe(
+      false,
+    );
+    expect(platformCapabilityPath("datax")).toBe("/datax");
+    expect(platformCapabilities.map((item) => item.summary)).toEqual([
+      "一句话生成可编辑工作流。",
+      "定时运行已发布智能体。",
+      "规划可暂停、可恢复的长期目标。",
+      "导入数据，生成指标与分析。",
+      "组合多个专家协同完成任务。",
+    ]);
+    expect(resourceNavItems.find((item) => item.key === "agents")).toMatchObject({
+      shortTitle: "Agent",
+      title: "Agent人才市场",
+    });
+  });
+
+  it("promotes the publishing center and uses the approved Agent market hierarchy", () => {
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Agent人才市场" }),
+    ).toBeVisible();
+    expect(screen.getByText(/个部门 ·/)).toBeVisible();
+    expect(screen.getByRole("searchbox", { name: "搜索专家" })).toBeVisible();
+    expect(
+      screen.getByRole("heading", { name: featuredPlatformCapability.title }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "管理智能体" }),
+    ).toBeVisible();
+    expect(screen.getByRole("heading", { name: "部门招聘牌" })).toBeVisible();
+
+    expect(screen.queryByText("资源分区")).not.toBeInTheDocument();
+    expect(screen.queryByText("人才市场规模")).not.toBeInTheDocument();
+    expect(screen.queryByText(/位 AI 专家现场递简历/)).not.toBeInTheDocument();
+  });
+
+  it("reuses the workbench sidebar and only reveals the development workshop when enabled", async () => {
+    renderPage(true);
+
+    const workflowLinks = screen.getAllByRole("link", {
+      name: /自定义工作流/,
+    });
+    const ragLinks = screen.getAllByRole("link", { name: /RAG 知识库/ });
+    expect(workflowLinks).toHaveLength(2);
+    expect(ragLinks).toHaveLength(2);
+    workflowLinks.forEach((link) =>
+      expect(link).toHaveAttribute("href", "/workflow"),
+    );
+    ragLinks.forEach((link) => expect(link).toHaveAttribute("href", "/rag"));
+    expect(await screen.findByText("AI 应用开发工坊")).toBeVisible();
+  });
+});

--- a/client/src/pages/AgentsPage.tsx
+++ b/client/src/pages/AgentsPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
+import { Search } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import AgentCard from "../components/AgentCard";
+import ModelWorkbenchSidebar from "../components/ModelWorkbenchSidebar";
 import PageContainer from "../components/PageContainer";
 import PlatformCapabilityCard, {
   type PlatformCapability,
@@ -21,81 +23,93 @@ import {
   saveAgentInterview,
 } from "../utils/agentInterview";
 
-const platformCapabilities: PlatformCapability[] = [
+export const featuredPlatformCapability: PlatformCapability = {
+  id: "xpert-studio",
+  icon: "XP",
+  title: "智能体发布中心",
+  summary: "创建、发布并管理可组合的智能体应用。",
+  detail: "复用经典工作流内核，把模型、Toolset、知识、中间件与 Handoff 组合成不可变发布版本。",
+  tag: "可用",
+  eta: "已开放草稿、发布与聊天运行",
+  actionLabel: "管理智能体",
+};
+
+export const platformCapabilities: PlatformCapability[] = [
+  {
+    id: "meta-agent",
+    icon: "元",
+    title: "AI 工作流生成器",
+    summary: "一句话生成可编辑工作流。",
+    detail: "输入目标后生成原生 React Flow 工作流，并通过现有工作流运行接口执行。",
+    tag: "Beta",
+    eta: "已接入生成与运行工作台",
+    actionLabel: "生成工作流",
+  },
   {
     id: "xpert-automations",
     icon: "AT",
-    title: "智能体自动化",
-    summary: "按单次、间隔或 Cron 调度已发布智能体，并在失败后重试或进入死信。",
-    detail:
-      "每条自动化固定智能体发布版本，支持预算、并发与重叠策略；审批和客户端等待可以在后台恢复。",
-    tag: "后台执行 · Beta",
+    title: "自动化任务",
+    summary: "定时运行已发布智能体。",
+    detail: "支持预算、并发、失败重试与死信处理。",
+    tag: "Beta",
     eta: "已开放自动化工作台",
+    actionLabel: "管理任务",
   },
   {
     id: "conversation-goals",
     icon: "GL",
-    title: "长期 Goal",
-    summary: "把对话目标拆成可审核的依赖计划，并由已发布智能体持续协作执行。",
-    detail:
-      "选择规划智能体自动生成计划，人工确认步骤和依赖后启动。支持暂停、恢复、失败重试、改派与最终结果汇总。",
-    tag: "长期任务 · Beta",
+    title: "长期任务",
+    summary: "规划可暂停、可恢复的长期目标。",
+    detail: "把对话目标拆成可审核的依赖计划，并由已发布智能体持续协作执行。",
+    tag: "Beta",
     eta: "已开放规划、执行与恢复工作台",
+    actionLabel: "管理任务",
   },
   {
-    id: "xpert-studio",
-    icon: "XP",
-    title: "Agent Studio",
-    summary: "创建、版本化发布并直接运行可组合的智能体应用。",
-    detail:
-      "复用经典工作流内核，把模型、Toolset、知识、中间件与 Handoff 组合成不可变发布版本。",
-    tag: "可发布智能体 · Beta",
-    eta: "已开放草稿、发布与聊天运行",
-  },
-  {
-    id: "workflow-builder",
-    icon: "流",
-    title: "自定义工作流",
-    summary:
-      "像搭积木一样创建你的 AI 工作流，拖拽、连线、一键运行。",
-    detail:
-      "未来将支持定时触发、条件分支、多模型协作和人工确认节点。现在先作为招聘会里的低代码展位预告，不会影响现有智能体面试功能。",
-    tag: "低代码 · 即将开放",
-    eta: "预计 2025 年下半年开放内测",
-  },
-  {
-    id: "meta-agent",
-    icon: "元",
-    title: "元智能体",
-    summary:
-      "用自然语言生成可编辑 Agent 工作流，并直接接入模镜经典画布试运行。",
-    detail:
-      "输入目标后，元智能体会拆解子任务、推断变量依赖、生成原生 React Flow 工作流，并通过现有 /api/workflow/run 执行。",
-    tag: "自然语言驱动 · Beta",
-    eta: "已接入生成与运行工作台",
+    id: "datax",
+    icon: "DX",
+    title: "Data X 数据分析",
+    summary: "导入数据，生成指标与分析。",
+    detail: "支持 CSV、Parquet 与 Excel 数据的本地分析和可视化。",
+    tag: "可用",
+    eta: "已开放数据导入、建模、指标与分析",
+    statusLabel: "服务状态：已开放",
+    actionLabel: "分析数据",
   },
   {
     id: "expert-squad",
     icon: "团",
-    title: "专家团",
-    summary:
-      "多个 AI 专家角色组成部门，支持模型融合、自动派工和团队协作。",
-    detail:
-      "例如“产品发布专家组”可包含产品经理、设计师、开发、测试和运营。现在可以进入专家会诊室，体验 Fusion 模型融合、自动路由和 AI Team 接力。",
-    tag: "多智能体协作 · 已开放",
+    title: "多智能体协作",
+    summary: "组合多个专家协同完成任务。",
+    detail: "支持模型融合、自动派工和团队协作。",
+    tag: "可用",
     eta: "专家会诊室已上线",
+    actionLabel: "组建协作",
   },
 ];
 
-const agentWorkspaceCapability: PlatformCapability = {
+export const agentWorkspaceCapability: PlatformCapability = {
   id: "agent-workspace",
   icon: "GA",
-  title: "General Agent 工作区",
-  summary: "用文件可读的 Agent State 配置第二套原生 Agent，并管理提示词、运行参数、九个工具 Schema 与 Skill 快照。",
-  detail: "当前开放配置工作台；执行 Session、审批与一句话生成 Agent 将在后续轮次接入，不影响既有聊天和画布工作流。",
-  tag: "原生 Agent State · Round 1",
+  title: "AI 应用开发工坊",
+  summary: "配置模型、工具与 Agent State。",
+  detail: "当前开放配置工作台；执行 Session 与审批能力按实际服务状态提供。",
+  tag: "Beta",
   eta: "配置面已开放",
+  actionLabel: "开发应用",
 };
+
+export function platformCapabilityPath(capabilityId: string) {
+  return {
+    "agent-workspace": "/agents/workbench",
+    "conversation-goals": "/agents/goals",
+    datax: "/datax",
+    "meta-agent": "/agents/meta-agent",
+    "xpert-automations": "/agents/automations",
+    "xpert-studio": "/agents/studio",
+    "expert-squad": "/expert-team",
+  }[capabilityId];
+}
 
 export default function AgentsPage() {
   const navigate = useNavigate();
@@ -103,12 +117,10 @@ export default function AgentsPage() {
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedDepartment, setSelectedDepartment] = useState("全部");
   const [expandedAgentIds, setExpandedAgentIds] = useState<string[]>([]);
-  const [selectedCapability, setSelectedCapability] =
-    useState<PlatformCapability | null>(null);
   const [agentWorkspaceEnabled, setAgentWorkspaceEnabled] = useState(false);
 
   useEffect(() => {
-    document.title = "模镜 - AI 人才市场";
+    document.title = "模镜 - Agent人才市场";
     void fetch("/api/agent-workspace/status")
       .then((response) => (response.ok ? response.json() : null))
       .then((status: { enabled?: boolean } | null) =>
@@ -120,7 +132,11 @@ export default function AgentsPage() {
   const visiblePlatformCapabilities = useMemo(
     () =>
       agentWorkspaceEnabled
-        ? [agentWorkspaceCapability, ...platformCapabilities]
+        ? [
+            platformCapabilities[0],
+            agentWorkspaceCapability,
+            ...platformCapabilities.slice(1),
+          ]
         : platformCapabilities,
     [agentWorkspaceEnabled],
   );
@@ -174,141 +190,79 @@ export default function AgentsPage() {
   }
 
   function openPlatformCapability(capability: PlatformCapability) {
-    if (capability.id === "agent-workspace") {
-      navigate("/agents/workbench");
-      return;
-    }
-    if (capability.id === "xpert-automations") {
-      navigate("/agents/automations");
-      return;
-    }
-    if (capability.id === "conversation-goals") {
-      navigate("/agents/goals");
-      return;
-    }
-    if (capability.id === "xpert-studio") {
-      navigate("/agents/studio");
-      return;
-    }
-    if (capability.id === "workflow-builder") {
-      navigate("/workflow/new");
-      return;
-    }
-    if (capability.id === "meta-agent") {
-      navigate("/agents/meta-agent");
-      return;
-    }
-    if (capability.id === "expert-squad") {
-      navigate("/expert-team");
-      return;
-    }
-
-    setSelectedCapability(capability);
+    const path = platformCapabilityPath(capability.id);
+    if (path) navigate(path);
   }
 
   return (
     <PageContainer
       activeResource="agents"
-      sidebar={
-        <div>
-          <p className="text-sm font-semibold text-white">资源分区</p>
-          <p className="mt-2 text-sm leading-6 text-slate-400">
-            AI 人才市场收录 {agents.length} 位带完整岗位人设的智能体专家。
-          </p>
-          <div className="mt-4 rounded-lg border border-white/10 bg-white/[0.045] p-3">
-            <p className="text-xs text-slate-400">当前可面试</p>
-            <p className="mt-1 text-sm font-semibold text-hire-100">
-              {filteredAgents.length} / {agents.length}
-            </p>
-          </div>
-        </div>
-      }
+      maxWidthClassName="max-w-[1500px]"
+      mobileSidebar={<ModelWorkbenchSidebar compact />}
+      showSystemCapabilityBar={false}
+      sidebar={<ModelWorkbenchSidebar />}
+      sidebarGridClassName="xl:grid-cols-[230px_minmax(0,1fr)]"
     >
-        <header className="relative overflow-hidden border-y border-hire-300/20 py-8 sm:py-10 lg:py-12">
-          <div className="absolute inset-x-6 top-0 h-16 rounded-b-[50%] border-x border-b border-hire-300/30 bg-[linear-gradient(180deg,rgba(251,146,60,0.18),transparent)]" />
-          <div className="absolute left-0 top-0 h-px w-full animate-pulse-line bg-[linear-gradient(90deg,transparent,rgba(251,146,60,0.82),rgba(253,186,116,0.72),transparent)]" />
+      <header className="relative border-b border-white/10 pb-6 pt-2 sm:pt-4">
+        <div className="pointer-events-none absolute right-3 top-0 hidden h-20 w-40 opacity-40 lg:block">
+          <span className="absolute right-2 top-2 h-1.5 w-1.5 rounded-full bg-cyan-200" />
+          <span className="absolute right-14 top-10 h-1 w-1 rounded-full bg-hire-200" />
+          <span className="absolute right-28 top-5 h-1 w-1 rounded-full bg-cyan-300" />
+          <span className="absolute right-5 top-4 h-px w-28 -rotate-[12deg] bg-cyan-200/35" />
+          <span className="absolute right-12 top-9 h-px w-20 rotate-[18deg] bg-hire-200/25" />
+        </div>
 
-          <div className="grid min-w-0 gap-8 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-end">
-            <div className="min-w-0">
-              <div className="max-w-4xl">
-                <p className="text-sm font-semibold text-hire-200">
-                  {agents.length} 位 AI 专家现场递简历
-                </p>
-                <h1 className="mt-3 max-w-4xl text-4xl font-semibold tracking-normal text-white sm:text-6xl">
-                  AI 人才市场
-                  <span className="block text-hire-100">开源专家等你来招</span>
-                </h1>
-                <p className="mt-5 max-w-2xl text-base leading-7 text-slate-300">
-                  来源于 agency-agents-zh 的最新中文智能体快照，按部门、专长和任务场景筛选。看中哪位专家，就带进面试间直接开聊。
-                </p>
-              </div>
-            </div>
-
-            <div className="surface-card min-w-0 overflow-hidden rounded-lg p-4">
-              <div className="flex items-center justify-between border-b border-white/10 pb-4">
-                <span className="text-sm text-slate-400">人才市场规模</span>
-                <span className="text-2xl font-semibold text-white">
-                  {agents.length}
-                </span>
-              </div>
-              <div className="mt-4 grid grid-cols-[repeat(3,minmax(0,1fr))] gap-2 text-center text-xs">
-                <div className="rounded-lg bg-white/[0.055] px-2 py-3">
-                  <p className="text-lg font-semibold text-hire-100">
-                    {agentDepartments.length}
-                  </p>
-                  <p className="mt-1 truncate text-slate-400">部门</p>
-                </div>
-                <div className="rounded-lg bg-white/[0.055] px-2 py-3">
-                  <p className="text-lg font-semibold text-brand-100">
-                    {filteredAgents.length}
-                  </p>
-                  <p className="mt-1 truncate text-slate-400">可面试</p>
-                </div>
-                <div className="rounded-lg bg-white/[0.055] px-2 py-3">
-                  <p className="text-lg font-semibold text-emerald-100">0</p>
-                  <p className="mt-1 truncate text-slate-400">招聘费</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="mt-8 grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
-            <label className="group relative block">
-              <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-sm font-medium text-slate-400 transition group-focus-within:text-hire-100">
-                搜索
-              </span>
-              <input
-                className="h-14 w-full rounded-full border border-white/10 bg-ink-950/70 pl-20 pr-5 text-sm text-white outline-none shadow-dock backdrop-blur-xl transition duration-200 placeholder:text-slate-500 hover:border-white/20 focus:border-hire-300/70 focus:ring-4 focus:ring-hire-300/10"
-                onChange={(event) => setSearchTerm(event.target.value)}
-                placeholder="搜索专家姓名、部门、专长或适用场景"
-                type="search"
-                value={searchTerm}
-              />
-            </label>
-
-            <p className="rounded-full border border-white/10 bg-white/[0.055] px-4 py-3 text-sm text-slate-300">
-              当前{" "}
-              <span className="font-semibold text-white">
-                {filteredAgents.length}
-              </span>{" "}
-              位专家可约面试
+        <div className="relative flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+              Agent人才市场
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-300">
+              按部门、专长和任务场景筛选开源智能体专家，选择模型后即可开始对话。
             </p>
           </div>
-        </header>
+          <p className="relative shrink-0 text-sm text-slate-300">
+            <span className="font-semibold text-hire-100">
+              {agentDepartments.length}
+            </span>{" "}
+            个部门 ·{" "}
+            <span className="font-semibold text-hire-100">{agents.length}</span>{" "}
+            位专家
+          </p>
+        </div>
 
-        <section className="mt-6">
-          <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <h2 className="text-xl font-semibold text-white">特色能力专区</h2>
-              <p className="mt-1 text-sm text-slate-400">
-                这些不是单个专家，而是未来的人才编排和工作流展位。
-              </p>
-            </div>
-            <span className="w-fit rounded-full border border-hire-300/30 bg-hire-300/10 px-3 py-1.5 text-xs font-semibold text-hire-100">
-              {visiblePlatformCapabilities.length} 个平台能力
-            </span>
-          </div>
-          <div className="grid gap-4 md:grid-cols-2 2xl:grid-cols-4">
+        <label className="relative mt-5 block">
+          <Search
+            aria-hidden="true"
+            className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
+            size={19}
+          />
+          <span className="sr-only">搜索专家</span>
+          <input
+            className="h-14 w-full rounded-lg border border-white/10 bg-ink-950/65 pl-12 pr-4 text-sm text-white outline-none transition placeholder:text-slate-500 hover:border-white/20 focus:border-hire-300/60 focus:ring-4 focus:ring-hire-300/10"
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder="搜索专家姓名、部门、专长或适用场景"
+            type="search"
+            value={searchTerm}
+          />
+        </label>
+      </header>
+
+      <section className="border-b border-white/10 py-6">
+        <div className="mb-3">
+          <h2 className="text-xl font-semibold text-white">平台能力</h2>
+          <p className="mt-1 text-sm text-slate-400">
+            创建、发布与运行你的 AI 应用。
+          </p>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-[minmax(280px,0.95fr)_minmax(0,2fr)]">
+          <PlatformCapabilityCard
+            capability={featuredPlatformCapability}
+            featured
+            onOpen={openPlatformCapability}
+          />
+          <div className="grid gap-3 sm:grid-cols-2">
             {visiblePlatformCapabilities.map((capability) => (
               <PlatformCapabilityCard
                 capability={capability}
@@ -317,126 +271,89 @@ export default function AgentsPage() {
               />
             ))}
           </div>
-        </section>
+        </div>
+      </section>
 
-        <section className="mt-6">
-          <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <h2 className="text-xl font-semibold text-white">部门招聘牌</h2>
-              <p className="mt-1 text-sm text-slate-400">
-                按工程、设计、营销、产品等部门快速挑专家。
-              </p>
-            </div>
-            <button
-              className="w-fit rounded-full border border-white/10 bg-white/[0.06] px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-hire-300/40 hover:bg-hire-300/10 hover:text-hire-100"
-              onClick={() => {
-                setSelectedDepartment("全部");
-                setSearchTerm("");
-              }}
-              type="button"
-            >
-              清空岗位要求
-            </button>
+      <section className="pt-6">
+        <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-white">部门招聘牌</h2>
+            <p className="mt-1 text-sm text-slate-400">
+              按工程、设计、营销、产品等部门快速挑选专家。
+            </p>
           </div>
-
-          <div className="flex gap-2 overflow-x-auto pb-2">
-            {["全部", ...agentDepartments].map((department) => {
-              const isActive = selectedDepartment === department;
-              const count =
-                department === "全部"
-                  ? agents.length
-                  : agentDepartmentCounts[department] ?? 0;
-
-              return (
-                <button
-                  className={`shrink-0 rounded-full border px-4 py-2 text-sm font-semibold transition duration-200 ${
-                    isActive
-                      ? "border-hire-200/50 bg-hire-300 text-ink-950 shadow-[0_0_22px_rgba(251,146,60,0.18)]"
-                      : "border-white/10 bg-white/[0.055] text-slate-300 hover:border-hire-300/40 hover:bg-hire-300/10 hover:text-hire-100"
-                  }`}
-                  key={department}
-                  onClick={() => setSelectedDepartment(department)}
-                  type="button"
-                >
-                  {department}
-                  <span className="ml-2 opacity-70">{count}</span>
-                </button>
-              );
-            })}
-          </div>
-        </section>
-
-        <section className="mt-8">
-          {filteredAgents.length > 0 ? (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {filteredAgents.map((agent) => (
-                <AgentCard
-                  agent={agent}
-                  isExpanded={expandedAgentIds.includes(agent.id)}
-                  key={agent.id}
-                  onInterview={startInterview}
-                  onToggleDetails={toggleDetails}
-                />
-              ))}
-            </div>
-          ) : (
-            <div className="surface-panel rounded-lg px-6 py-16 text-center">
-              <img
-                alt="模镜 ModelMirror"
-                className="mx-auto h-16 w-16 rounded-lg object-cover shadow-neon"
-                src="/logo.png"
-              />
-              <p className="mt-5 text-lg font-semibold text-white">
-                人才市场暂时没有符合要求的候选人
-              </p>
-              <p className="mt-2 text-sm text-slate-400">
-                换个部门，或把搜索关键词放宽一点。
-              </p>
-            </div>
-          )}
-        </section>
-
-        <footer className="mt-10 border-t border-white/10 py-6 text-sm text-slate-500">
-          © 2026 模镜 ModelMirror
-        </footer>
-
-        {selectedCapability ? (
-          <div
-            aria-modal="true"
-            className="fixed inset-0 z-[80] flex items-center justify-center bg-slate-950/78 p-4 backdrop-blur-sm"
-            role="dialog"
+          <button
+            className="min-h-11 w-fit rounded-full border border-white/10 bg-white/[0.05] px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-hire-300/40 hover:bg-hire-300/10 hover:text-hire-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hire-100"
+            onClick={() => {
+              setSelectedDepartment("全部");
+              setSearchTerm("");
+            }}
+            type="button"
           >
-            <div className="surface-card w-full max-w-lg rounded-lg p-6">
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <span className="inline-flex h-12 w-12 items-center justify-center rounded-lg border border-hire-300/35 bg-hire-300/10 text-lg font-bold text-hire-100">
-                    {selectedCapability.icon}
-                  </span>
-                  <h2 className="mt-4 text-2xl font-semibold text-white">
-                    {selectedCapability.title}
-                  </h2>
-                </div>
-                <button
-                  aria-label="关闭"
-                  className="rounded-full border border-white/10 bg-white/[0.06] px-3 py-1.5 text-sm font-semibold text-slate-200 transition hover:bg-white/10"
-                  onClick={() => setSelectedCapability(null)}
-                  type="button"
-                >
-                  关闭
-                </button>
-              </div>
-              <p className="mt-4 text-sm leading-6 text-slate-300">
-                {selectedCapability.detail}
-              </p>
-              <div className="mt-5 rounded-lg border border-white/10 bg-white/[0.045] p-3">
-                <p className="text-xs text-slate-400">预计上线时间</p>
-                <p className="mt-1 text-sm font-semibold text-hire-100">
-                  {selectedCapability.eta}
-                </p>
-              </div>
-            </div>
+            清空岗位要求
+          </button>
+        </div>
+
+        <div className="flex gap-2 overflow-x-auto pb-2">
+          {["全部", ...agentDepartments].map((department) => {
+            const isActive = selectedDepartment === department;
+            const count =
+              department === "全部"
+                ? agents.length
+                : agentDepartmentCounts[department] ?? 0;
+
+            return (
+              <button
+                className={`min-h-11 shrink-0 rounded-full border px-4 py-2 text-sm font-semibold transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hire-100 ${
+                  isActive
+                    ? "border-hire-200/50 bg-hire-300 text-ink-950"
+                    : "border-white/10 bg-white/[0.05] text-slate-300 hover:border-hire-300/40 hover:bg-hire-300/10 hover:text-hire-100"
+                }`}
+                key={department}
+                onClick={() => setSelectedDepartment(department)}
+                type="button"
+              >
+                {department}
+                <span className="ml-2 opacity-70">{count}</span>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="mt-6">
+        {filteredAgents.length > 0 ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {filteredAgents.map((agent) => (
+              <AgentCard
+                agent={agent}
+                isExpanded={expandedAgentIds.includes(agent.id)}
+                key={agent.id}
+                onInterview={startInterview}
+                onToggleDetails={toggleDetails}
+              />
+            ))}
           </div>
-        ) : null}
+        ) : (
+          <div className="surface-panel rounded-lg px-6 py-16 text-center">
+            <img
+              alt="模镜 ModelMirror"
+              className="mx-auto h-16 w-16 rounded-lg object-cover shadow-neon"
+              src="/logo.png"
+            />
+            <p className="mt-5 text-lg font-semibold text-white">
+              人才市场暂时没有符合要求的候选人
+            </p>
+            <p className="mt-2 text-sm text-slate-400">
+              换个部门，或把搜索关键词放宽一点。
+            </p>
+          </div>
+        )}
+      </section>
+
+      <footer className="mt-10 border-t border-white/10 py-6 text-sm text-slate-500">
+        © 2026 模镜 ModelMirror
+      </footer>
     </PageContainer>
   );
 }

--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -1344,7 +1344,7 @@ function ChatConversationPage() {
     return {
       agentId: agentId ?? "url-agent",
       agentName: searchParams.get("agentName") ?? "AI 专家",
-      department: searchParams.get("agentDepartment") ?? "AI 人才市场",
+      department: searchParams.get("agentDepartment") ?? "Agent人才市场",
       expertise: searchParams.get("agentExpertise") ?? "按指定角色进入面试",
       prompt: agentPrompt,
       sourceUrl: "",

--- a/client/src/pages/ModelListPage.tsx
+++ b/client/src/pages/ModelListPage.tsx
@@ -6,6 +6,7 @@ import ModelCompareView from "../components/ModelCompareView";
 import ModelCard, {
   type AudioCapabilityStatus,
 } from "../components/ModelCard";
+import ModelWorkbenchSidebar from "../components/ModelWorkbenchSidebar";
 import PageContainer from "../components/PageContainer";
 import FilterPanel from "../components/filters/FilterPanel";
 import {
@@ -656,33 +657,6 @@ export default function ModelListPage() {
     (model) =>
       model.catalog_counted && model.catalog_status !== "expired",
   );
-  const adaptedFilteredCount = onsiteFilteredModels.filter(
-    (model) => {
-      const audioStatus = audioCapabilityStatuses.get(model.id);
-      const primaryAudioOperation =
-        model.primary_operation === "transcribe" ||
-        model.primary_operation === "synthesize_speech" ||
-        model.primary_operation === "generate_audio" ||
-        model.primary_operation === "realtime_voice";
-      if (primaryAudioOperation && audioStatus) {
-        return Boolean(adaptedAudioOperations.get(model.id)?.length);
-      }
-      return (
-        model.interaction_status === "ready" ||
-        Boolean(confirmedAudioOperations.get(model.id)?.length) ||
-        Boolean(confirmedImageOperations.get(model.id)?.length) ||
-        Boolean(
-          confirmedVideoOperations
-            .get(model.id)
-            ?.some(
-              (operation) =>
-                operation === "analyze_video" ||
-                operation === "generate_video",
-            ),
-        )
-      );
-    },
-  ).length;
   const usableFilteredCount = onsiteFilteredModels.filter(
     (model) =>
       invocableModelIds.has(model.id) ||
@@ -731,23 +705,10 @@ export default function ModelListPage() {
   return (
     <PageContainer
       activeResource="models"
-      sidebar={
-        <div>
-          <p className="text-sm font-semibold text-white">资源分区</p>
-          <p className="mt-2 text-sm leading-6 text-slate-400">
-            浏览模型能力，并进入当前已适配的对话或资料库入口。
-          </p>
-          <div className="mt-4 rounded-lg border border-white/10 bg-white/[0.045] p-3">
-            <p className="text-xs text-slate-400">已完成适配</p>
-            <p className="mt-1 text-sm font-semibold text-hire-100">
-              {adaptedFilteredCount} / {onsiteFilteredModels.length}
-            </p>
-            <p className="mt-1 text-xs leading-5 text-slate-500">
-              是否已启用，请以模型卡片状态为准。
-            </p>
-          </div>
-        </div>
-      }
+      mobileSidebar={<ModelWorkbenchSidebar compact />}
+      showSystemCapabilityBar={false}
+      sidebar={<ModelWorkbenchSidebar />}
+      sidebarGridClassName="xl:grid-cols-[230px_minmax(0,1fr)] xl:gap-x-[54px]"
     >
         <ModelMarketHero
           onsiteCount={onsiteModels.length}

--- a/client/src/theme/resources.ts
+++ b/client/src/theme/resources.ts
@@ -28,8 +28,8 @@ export const resourceNavItems: ResourceNavItem[] = [
   },
   {
     key: "agents",
-    title: "AI 人才市场",
-    shortTitle: "人才",
+    title: "Agent人才市场",
+    shortTitle: "Agent",
     english: "Agents",
     path: "/agents",
     icon: "才",
@@ -85,7 +85,7 @@ export const resourceComingSoonCopy: Record<
   skills: {
     title: "Skill 技能培训即将上线",
     description: "培训教室正在排课，未来会集中展示可复用的 Skill、工作流和操作手册。",
-    actionHint: "先逛 AI 人才市场，挑一位专家进面试间试试。",
+    actionHint: "先逛 Agent人才市场，挑一位专家进面试间试试。",
   },
   prompts: {
     title: "提示词市场即将上线",


### PR DESCRIPTION
## 范围
- 用紧凑工作台入口替换模型市场冗余资源分区
- 收紧模型市场侧栏宽度，保留模型卡片与筛选行为
- 将 AI 人才市场统一更名为 Agent人才市场
- 精简 Agent 市场首屏，突出智能体发布中心与真实平台能力入口
- 更新平台能力图标、短文案与层级，专家卡片保持不变

## 验证
- npm.cmd run test:run -- src/pages/AgentsPage.platform-capabilities.test.tsx src/components/ModelWorkbenchSidebar.test.tsx src/pages/AgentWorkbenchPage.test.tsx src/data/models.refresh.test.ts
  - 4 files / 24 tests passed
- npm.cmd run build
  - passed, 3104 modules
- git diff --check origin/main...HEAD
  - passed
- 独立预览 1440x900 与 390x844
  - 无横向溢出，部门招聘牌在桌面首屏可见

## 边界
- 不改后端 API、协议或专家卡片
- 不包含全局导航布局调整；仅统一 Agent人才市场名称
- 共享栈更新在 PR 建立后单独执行并保留现有环境与数据