### PR TITLE
feature: 优化 MCP 工具市场与 Marble SPZ 预览

### DIFF
--- a/client/src/components/ModelCard.test.ts
+++ b/client/src/components/ModelCard.test.ts
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import { ModelPreferenceProvider } from "../context/ModelPreferenceContext";
-import { models } from "../data/models";
+import { models, type Model } from "../data/models";
 import ModelCard, { deriveDocumentInputPresentation } from "./ModelCard";
 import type { FileSurfaceSummary } from "../data/fileCapabilities";
 
@@ -142,5 +142,121 @@ describe("ModelCard decision-first layout", () => {
     expect(screen.getByText("文件")).toBeInTheDocument();
     expect(screen.queryByText(/当前地区|国内可用优先/)).not.toBeInTheDocument();
     expect(screen.queryByText(/人气值|已录用/)).not.toBeInTheDocument();
+  });
+
+  it("uses realtime audio readiness for previously static planned models", () => {
+    const baseModel = models.find((candidate) => candidate.id === "openai/gpt-5.6-sol");
+    expect(baseModel).toBeDefined();
+    const model: Model = {
+      ...baseModel!,
+      id: "openai/gpt-4o-mini-tts",
+      name: "OpenAI: GPT-4o Mini TTS",
+      primary_operation: "synthesize_speech",
+      operations: ["synthesize_speech"],
+      interaction_status: "planned",
+      ui_entrypoint: "planned",
+    };
+
+    render(
+      createElement(
+        MemoryRouter,
+        null,
+        createElement(
+          ModelPreferenceProvider,
+          null,
+          createElement(ModelCard, {
+            adaptedAudioOperations: ["synthesize_speech"],
+            audioCapabilityStatus: {
+              status: "ready",
+              operations: ["synthesize_speech"],
+              adaptedOperations: ["synthesize_speech"],
+              availabilityStatus: "available",
+              reason: null,
+              pricePerGenerationUsd: null,
+              fixedDurationSeconds: null,
+            },
+            confirmedAudioOperations: ["synthesize_speech"],
+            model,
+          }),
+        ),
+      ),
+    );
+
+    expect(screen.getByRole("link", { name: "生成语音" })).toBeInTheDocument();
+    expect(screen.queryByText("交互待适配")).not.toBeInTheDocument();
+  });
+
+  it("distinguishes a disabled feature switch from an unadapted model", () => {
+    const baseModel = models.find((candidate) => candidate.id === "openai/gpt-5.6-sol");
+    expect(baseModel).toBeDefined();
+    const model: Model = {
+      ...baseModel!,
+      id: "google/lyria-3-pro-preview",
+      name: "Google: Lyria 3 Pro Preview",
+      primary_operation: "generate_audio",
+      operations: ["generate_audio"],
+      interaction_status: "planned",
+      ui_entrypoint: "planned",
+    };
+
+    render(
+      createElement(
+        MemoryRouter,
+        null,
+        createElement(
+          ModelPreferenceProvider,
+          null,
+          createElement(ModelCard, {
+            adaptedAudioOperations: ["generate_audio"],
+            audioCapabilityStatus: {
+              status: "disabled",
+              operations: ["generate_audio"],
+              adaptedOperations: ["generate_audio"],
+              availabilityStatus: "disabled",
+              reason: "音频生成开关未开启",
+              pricePerGenerationUsd: null,
+              fixedDurationSeconds: null,
+            },
+            model,
+          }),
+        ),
+      ),
+    );
+
+    expect(screen.getAllByText("已适配 · 开关未开启").length).toBeGreaterThan(0);
+    expect(screen.queryByText("交互待适配")).not.toBeInTheDocument();
+  });
+
+  it("does not mislabel a static audio model while realtime status is loading", () => {
+    const baseModel = models.find((candidate) => candidate.id === "openai/gpt-5.6-sol");
+    expect(baseModel).toBeDefined();
+    const model: Model = {
+      ...baseModel!,
+      id: "fish-audio/s1",
+      name: "Fish Audio: S1",
+      primary_operation: "synthesize_speech",
+      operations: ["synthesize_speech"],
+      interaction_status: "planned",
+      ui_entrypoint: "planned",
+    };
+
+    render(
+      createElement(
+        MemoryRouter,
+        null,
+        createElement(
+          ModelPreferenceProvider,
+          null,
+          createElement(ModelCard, {
+            audioCatalogState: "loading",
+            model,
+          }),
+        ),
+      ),
+    );
+
+    expect(screen.getAllByText("文字转语音状态确认中").length).toBeGreaterThan(0);
+    expect(screen.getByText("正在读取实时能力目录。")).toBeInTheDocument();
+    expect(screen.queryByText(/待适配/)).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/ModelCard.tsx
+++ b/client/src/components/ModelCard.tsx
@@ -28,6 +28,7 @@ interface ModelCardProps {
   confirmedVideoOperations?: ModelOperation[];
   verificationVideoOperations?: ModelOperation[];
   audioCapabilityStatus?: AudioCapabilityStatus;
+  audioCatalogState?: "loading" | "available" | "unavailable";
   audioCatalogStale?: boolean;
   imageCatalogStale?: boolean;
   videoCatalogStale?: boolean;
@@ -138,6 +139,7 @@ const ModelCard = memo(function ModelCard({
   confirmedVideoOperations = [],
   verificationVideoOperations = [],
   audioCapabilityStatus,
+  audioCatalogState = "available",
   audioCatalogStale = false,
   imageCatalogStale = false,
   videoCatalogStale = false,
@@ -264,15 +266,23 @@ const ModelCard = memo(function ModelCard({
     (operation) => operationLabels[operation],
   );
   const pendingAudioStateLabel =
-    audioCapabilityStatus?.availabilityStatus === "needs_configuration"
+    !audioCapabilityStatus && audioCatalogState === "loading"
+      ? "状态确认中"
+      : !audioCapabilityStatus && audioCatalogState === "unavailable"
+        ? "状态待确认"
+    : audioCapabilityStatus?.availabilityStatus === "needs_configuration"
       ? "需要配置"
       : audioCapabilityStatus?.availabilityStatus === "upstream_unavailable"
         ? "上游暂不可用"
       : audioCapabilityStatus?.status === "disabled"
-      ? "当前未启用"
+      ? "开关未开启"
       : "待适配";
   const pendingAudioReason =
-    audioCapabilityStatus?.reason ??
+    (!audioCapabilityStatus && audioCatalogState === "loading"
+      ? "正在读取实时能力目录。"
+      : !audioCapabilityStatus && audioCatalogState === "unavailable"
+        ? "暂时无法读取实时能力目录，本卡不会宣称该能力可用。"
+        : audioCapabilityStatus?.reason) ??
     (
       pendingAudioLabels.length > 0
         ? isRealtimeVoiceModel
@@ -310,7 +320,7 @@ const ModelCard = memo(function ModelCard({
       ? "已适配 · 需配置"
       : audioCapabilityStatus?.availabilityStatus === "upstream_unavailable"
         ? "上游暂不可用"
-        : "已适配 · 当前未启用";
+        : "已适配 · 开关未开启";
   const showGeneralChatAction =
     canChat &&
     model.primary_operation !== "synthesize_speech" &&
@@ -337,7 +347,12 @@ const ModelCard = memo(function ModelCard({
             }
           : !isInteractionReady
             ? {
-                label: isRealtimeVoiceModel ? "需要配置" : "交互待适配",
+                label:
+                  pendingAudioLabels.length > 0
+                    ? `${pendingAudioLabels.join("、")}${pendingAudioStateLabel}`
+                    : isRealtimeVoiceModel
+                      ? "需要配置"
+                      : "交互待适配",
                 className: "border-hire-200/30 bg-hire-400/15 text-hire-100",
               }
             : null;
@@ -752,13 +767,15 @@ const ModelCard = memo(function ModelCard({
           {adaptedAudioUnavailable
             ? audioCapabilityStatus?.availabilityStatus === "needs_configuration"
               ? " · 需配置"
-              : " · 当前未启用"
+              : " · 开关未开启"
             : !isInteractionReady
             ? canManuallyVerifyVideo
               ? " · 人工核验"
               : isRealtimeVoiceModel
               ? " · 需要连接"
-              : " · 待适配"
+              : pendingAudioLabels.length > 0
+                ? ` · ${pendingAudioStateLabel}`
+                : " · 待适配"
             : ""}
         </span>
         {confirmedVideoLabels.map((label) => (
@@ -812,7 +829,7 @@ const ModelCard = memo(function ModelCard({
               {audioCapabilityStatus?.availabilityStatus ===
               "needs_configuration"
                 ? " · 需配置"
-                : " · 当前未启用"}
+                : " · 开关未开启"}
             </span>
           ))}
         {batchVariant ? (

--- a/client/src/components/world/SplatViewer.test.tsx
+++ b/client/src/components/world/SplatViewer.test.tsx
@@ -1,0 +1,162 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Vector3 } from "three";
+import { SplatViewer } from "./SplatViewer";
+
+const addSplatScene = vi.fn(async () => undefined);
+const start = vi.fn();
+const dispose = vi.fn(async () => undefined);
+const ViewerConstructor = vi.fn();
+const cameraPositionCopy = vi.fn();
+const cameraUpSet = vi.fn();
+const cameraLookAt = vi.fn();
+const cameraPosition = new Vector3();
+const updateProjectionMatrix = vi.fn();
+const controlsTargetCopy = vi.fn();
+const controlsUpdate = vi.fn();
+const forceRenderNextFrame = vi.fn();
+const stopListenToKeyEvents = vi.fn();
+const controls = {
+  target: new Vector3(),
+  screenSpacePanning: true,
+  enableRotate: true,
+  enablePan: true,
+  enableZoom: true,
+  enableDamping: true,
+  stopListenToKeyEvents,
+  update: controlsUpdate,
+};
+
+const sampledCenters = [
+  [-1.5, -0.8, -3.2],
+  [1.6, 0.6, 2.8],
+  [-1.2, 0.4, 2.5],
+  [1.3, -0.6, -3],
+];
+
+vi.mock("@mkkellogg/gaussian-splats-3d", () => ({
+  Viewer: class {
+    camera = {
+      position: cameraPosition,
+      up: { set: cameraUpSet },
+      near: 0.1,
+      far: 500,
+      lookAt: cameraLookAt,
+      updateProjectionMatrix,
+    };
+    controls = controls;
+    constructor(options: unknown) {
+      ViewerConstructor(options);
+    }
+    addSplatScene = addSplatScene;
+    getSplatScene = () => ({
+      splatBuffer: {
+        sceneCenter: new Vector3(0, 0, 0),
+        getSplatCount: () => sampledCenters.length,
+        getSplatCenter: (index: number, point: { set: (x: number, y: number, z: number) => void }) => {
+          const [x, y, z] = sampledCenters[index];
+          point.set(x, y, z);
+          return point;
+        },
+      },
+    });
+    forceRenderNextFrame = forceRenderNextFrame;
+    start = start;
+    dispose = dispose;
+  },
+  SceneFormat: { Spz: 3 },
+  SceneRevealMode: { Default: 0, Gradual: 1, Instant: 2 },
+  SplatRenderMode: { ThreeD: 0, TwoD: 1 },
+}));
+
+beforeEach(() => {
+  addSplatScene.mockClear();
+  start.mockClear();
+  dispose.mockClear();
+  ViewerConstructor.mockClear();
+  cameraPositionCopy.mockClear();
+  cameraUpSet.mockClear();
+  updateProjectionMatrix.mockClear();
+  controlsTargetCopy.mockClear();
+  controlsUpdate.mockClear();
+  forceRenderNextFrame.mockClear();
+  cameraLookAt.mockClear();
+  stopListenToKeyEvents.mockClear();
+  cameraPosition.set(0, 0, 0);
+  vi.spyOn(cameraPosition, "copy").mockImplementation((value) => {
+    cameraPositionCopy(value);
+    return cameraPosition.set(value.x, value.y, value.z);
+  });
+  vi.spyOn(controls.target, "copy").mockImplementation((value) => {
+    controlsTargetCopy(value);
+    return controls.target.set(value.x, value.y, value.z);
+  });
+  controls.enableRotate = true;
+  controls.enablePan = true;
+  controls.enableZoom = true;
+  controls.enableDamping = true;
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(new Uint8Array([1, 2, 3]))));
+  vi.stubGlobal("URL", {
+    createObjectURL: vi.fn(() => "blob:http://localhost/scene"),
+    revokeObjectURL: vi.fn(),
+  });
+});
+
+describe("SplatViewer", () => {
+  it("uses the self-driven 2D viewer and explicit SPZ format", async () => {
+    const rendered = render(<SplatViewer source="https://assets.example/world.spz" />);
+
+    await waitFor(() => expect(start).toHaveBeenCalledOnce());
+    expect(ViewerConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gpuAcceleratedSort: false,
+        sceneRevealMode: 2,
+        splatRenderMode: 1,
+      }),
+    );
+    expect(addSplatScene).toHaveBeenCalledWith(
+      "blob:http://localhost/scene",
+      expect.objectContaining({
+        format: 3,
+        rotation: [-Math.SQRT1_2, 0, 0, Math.SQRT1_2],
+      }),
+    );
+    expect(ViewerConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialCameraPosition: [0, 0, 0],
+        initialCameraLookAt: [0, 1, 0],
+        cameraUp: [0, 0, 1],
+      }),
+    );
+    expect(cameraPositionCopy).toHaveBeenCalledOnce();
+    expect(controlsTargetCopy).toHaveBeenCalledOnce();
+    expect(controlsUpdate).toHaveBeenCalledOnce();
+    expect(forceRenderNextFrame).toHaveBeenCalledOnce();
+
+    const position = cameraPositionCopy.mock.calls[0][0];
+    const target = controlsTargetCopy.mock.calls[0][0];
+    expect(position.x).toBeGreaterThan(-1.5);
+    expect(position.x).toBeLessThan(1.6);
+    expect(position.z).toBeGreaterThan(-3.2);
+    expect(position.z).toBeLessThan(2.8);
+    expect(target.y).toBeGreaterThan(position.y);
+    expect(cameraUpSet).toHaveBeenCalledWith(0, 0, 1);
+
+    const viewport = rendered.getByLabelText("3D 场景预览：拖动旋转视角，WASD 或方向键移动");
+    const positionBeforeRotate = cameraPosition.clone();
+    fireEvent.pointerDown(viewport, { button: 0, pointerId: 1, clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(viewport, { pointerId: 1, clientX: 140, clientY: 80 });
+    fireEvent.pointerUp(viewport, { pointerId: 1 });
+    expect(cameraLookAt).toHaveBeenCalled();
+    expect(cameraPosition.toArray()).toEqual(positionBeforeRotate.toArray());
+
+    const zBeforeMove = cameraPosition.z;
+    fireEvent.keyDown(viewport, { code: "KeyW" });
+    expect(cameraPosition.y).not.toBe(positionBeforeRotate.y);
+    expect(cameraPosition.z).toBe(zBeforeMove);
+    expect(stopListenToKeyEvents).toHaveBeenCalledOnce();
+    expect(controls.enableRotate).toBe(false);
+    expect(controls.enablePan).toBe(false);
+    expect(controls.enableZoom).toBe(false);
+  });
+});

--- a/client/src/components/world/SplatViewer.tsx
+++ b/client/src/components/world/SplatViewer.tsx
@@ -1,20 +1,223 @@
 import { useEffect, useRef, useState } from "react";
-import * as THREE from "three";
-import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
-import { DropInViewer } from "@mkkellogg/gaussian-splats-3d";
+import { Vector3 } from "three";
+import {
+  SceneFormat,
+  SceneRevealMode,
+  SplatRenderMode,
+  Viewer,
+} from "@mkkellogg/gaussian-splats-3d";
 
 interface SplatViewerProps {
   source: string;
   onError?: (message: string) => void;
 }
 
+const CAMERA_SAMPLE_LIMIT = 4096;
+const MIN_LOOK_DISTANCE = 0.5;
+const MARBLE_Z_UP_ROTATION: [number, number, number, number] = [
+  -Math.SQRT1_2,
+  0,
+  0,
+  Math.SQRT1_2,
+];
+
+interface InteriorFrame {
+  min: Vector3;
+  max: Vector3;
+  position: Vector3;
+  target: Vector3;
+  moveStep: number;
+}
+
+function rotateMarblePointToZUp(point: Vector3) {
+  return point.set(point.x, point.z, -point.y);
+}
+
+/**
+ * Marble SPZ files describe a navigable scene around their capture origin.
+ * Frame that origin from inside the sampled bounds instead of using a distant
+ * object-viewer camera, which makes room captures look like tiny exterior
+ * models.
+ */
+function frameSpzInterior(viewer: Viewer): InteriorFrame | null {
+  const splatBuffer = viewer.getSplatScene(0).splatBuffer;
+  const splatCount = splatBuffer.getSplatCount();
+  if (splatCount <= 0) return null;
+
+  const min = new Vector3(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY);
+  const max = new Vector3(Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY);
+  const point = new Vector3();
+  const sampleStep = Math.max(1, Math.floor(splatCount / CAMERA_SAMPLE_LIMIT));
+  let sampled = 0;
+
+  for (let index = 0; index < splatCount && sampled < CAMERA_SAMPLE_LIMIT; index += sampleStep) {
+    splatBuffer.getSplatCenter(index, point);
+    rotateMarblePointToZUp(point);
+    if (Number.isFinite(point.x) && Number.isFinite(point.y) && Number.isFinite(point.z)) {
+      min.min(point);
+      max.max(point);
+      sampled += 1;
+    }
+  }
+  if (sampled === 0) return null;
+
+  const size = max.clone().sub(min);
+  const diagonal = size.length();
+  if (!Number.isFinite(diagonal) || diagonal <= 0) return null;
+
+  const sceneCenter = rotateMarblePointToZUp(splatBuffer.sceneCenter.clone());
+  const inset = size.clone().multiplyScalar(0.04);
+  const clampInside = (value: number, low: number, high: number, padding: number) => {
+    const paddedLow = low + padding;
+    const paddedHigh = high - padding;
+    if (paddedLow > paddedHigh) return (low + high) / 2;
+    return Math.min(paddedHigh, Math.max(paddedLow, value));
+  };
+  const position = new Vector3(
+    clampInside(sceneCenter.x, min.x, max.x, inset.x),
+    clampInside(sceneCenter.y, min.y, max.y, inset.y),
+    clampInside(sceneCenter.z, min.z, max.z, inset.z),
+  );
+
+  // Marble exports use +Z as the capture-forward direction. Picking the
+  // longest side of the room can select -Z by a small margin and turn the
+  // initial view around by 180 degrees even though the camera is inside.
+  const forwardClearance = max.y - position.y;
+  const lookDistance = Math.max(MIN_LOOK_DISTANCE, forwardClearance * 0.65);
+  const target = position.clone().add(new Vector3(0, lookDistance, 0));
+
+  viewer.camera.position.copy(position);
+  viewer.camera.up.set(0, 0, 1);
+  viewer.camera.near = Math.max(0.001, diagonal / 10_000);
+  viewer.camera.far = Math.max(50, diagonal * 4);
+  viewer.camera.updateProjectionMatrix();
+  viewer.controls.target.copy(target);
+  viewer.controls.screenSpacePanning = false;
+  viewer.controls.update();
+  viewer.forceRenderNextFrame();
+
+  return {
+    min,
+    max,
+    position,
+    target,
+    moveStep: Math.min(0.25, Math.max(0.03, diagonal * 0.025)),
+  };
+}
+
+/**
+ * OrbitControls rotates the camera around a target and therefore changes the
+ * camera coordinates while looking around. Marble worlds need first-person
+ * navigation: pointer drag changes only local yaw/pitch, while keyboard
+ * movement remains on the Z-up X-Y ground plane.
+ */
+function setupFirstPersonControls(
+  viewer: Viewer,
+  rootElement: HTMLDivElement,
+  frame: InteriorFrame,
+) {
+  viewer.controls.enableRotate = false;
+  viewer.controls.enablePan = false;
+  viewer.controls.enableZoom = false;
+  viewer.controls.enableDamping = false;
+  viewer.controls.stopListenToKeyEvents();
+
+  const forward = frame.target.clone().sub(frame.position).normalize();
+  let yaw = Math.atan2(forward.x, forward.y);
+  let pitch = Math.asin(Math.max(-1, Math.min(1, forward.z)));
+  let draggingPointer: number | null = null;
+  let lastPointerX = 0;
+  let lastPointerY = 0;
+
+  const applyOrientation = () => {
+    const cosPitch = Math.cos(pitch);
+    const direction = new Vector3(
+      Math.sin(yaw) * cosPitch,
+      Math.cos(yaw) * cosPitch,
+      Math.sin(pitch),
+    );
+    const target = viewer.camera.position.clone().add(direction);
+    viewer.camera.up.set(0, 0, 1);
+    viewer.camera.lookAt(target);
+    viewer.controls.target.copy(target);
+    viewer.forceRenderNextFrame();
+  };
+
+  const onPointerDown = (event: PointerEvent) => {
+    if (event.button !== 0) return;
+    draggingPointer = event.pointerId;
+    lastPointerX = event.clientX;
+    lastPointerY = event.clientY;
+    rootElement.focus();
+    rootElement.setPointerCapture?.(event.pointerId);
+    rootElement.style.cursor = "grabbing";
+    event.preventDefault();
+  };
+  const onPointerMove = (event: PointerEvent) => {
+    if (draggingPointer !== event.pointerId) return;
+    const deltaX = event.clientX - lastPointerX;
+    const deltaY = event.clientY - lastPointerY;
+    lastPointerX = event.clientX;
+    lastPointerY = event.clientY;
+    yaw += deltaX * 0.003;
+    pitch = Math.max(-Math.PI * 0.47, Math.min(Math.PI * 0.47, pitch - deltaY * 0.003));
+    applyOrientation();
+    event.preventDefault();
+  };
+  const stopDragging = (event: PointerEvent) => {
+    if (draggingPointer !== event.pointerId) return;
+    rootElement.releasePointerCapture?.(event.pointerId);
+    draggingPointer = null;
+    rootElement.style.cursor = "grab";
+  };
+  const onKeyDown = (event: KeyboardEvent) => {
+    const forwardFlat = new Vector3(Math.sin(yaw), Math.cos(yaw), 0);
+    const rightFlat = new Vector3(Math.cos(yaw), -Math.sin(yaw), 0);
+    const movement = new Vector3();
+    if (event.code === "KeyW" || event.code === "ArrowUp") movement.copy(forwardFlat);
+    else if (event.code === "KeyS" || event.code === "ArrowDown") movement.copy(forwardFlat).negate();
+    else if (event.code === "KeyA" || event.code === "ArrowLeft") movement.copy(rightFlat).negate();
+    else if (event.code === "KeyD" || event.code === "ArrowRight") movement.copy(rightFlat);
+    else return;
+
+    const insetX = (frame.max.x - frame.min.x) * 0.04;
+    const insetY = (frame.max.y - frame.min.y) * 0.04;
+    const next = viewer.camera.position.clone().addScaledVector(movement, frame.moveStep);
+    next.x = Math.min(frame.max.x - insetX, Math.max(frame.min.x + insetX, next.x));
+    next.y = Math.min(frame.max.y - insetY, Math.max(frame.min.y + insetY, next.y));
+    next.z = frame.position.z;
+    viewer.camera.position.copy(next);
+    applyOrientation();
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  rootElement.tabIndex = 0;
+  rootElement.setAttribute("aria-label", "3D 场景预览：拖动旋转视角，WASD 或方向键移动");
+  rootElement.style.cursor = "grab";
+  rootElement.style.touchAction = "none";
+  rootElement.addEventListener("pointerdown", onPointerDown);
+  rootElement.addEventListener("pointermove", onPointerMove);
+  rootElement.addEventListener("pointerup", stopDragging);
+  rootElement.addEventListener("pointercancel", stopDragging);
+  rootElement.addEventListener("keydown", onKeyDown);
+
+  return () => {
+    rootElement.removeEventListener("pointerdown", onPointerDown);
+    rootElement.removeEventListener("pointermove", onPointerMove);
+    rootElement.removeEventListener("pointerup", stopDragging);
+    rootElement.removeEventListener("pointercancel", stopDragging);
+    rootElement.removeEventListener("keydown", onKeyDown);
+    rootElement.removeAttribute("aria-label");
+    rootElement.removeAttribute("tabindex");
+    rootElement.style.removeProperty("cursor");
+    rootElement.style.removeProperty("touch-action");
+  };
+}
+
 /**
  * Downloads the SPZ/PLY file with a real progress bar (fetch + stream),
  * then renders it with gaussian-splats-3d.
- *
- * DropInViewer extends THREE.Group (an Object3D, NOT a DOM node), so it
- * must be added to our own Three.js scene and rendered by our own
- * WebGLRenderer — never appendChild'd directly.
  */
 export function SplatViewer({ source, onError }: SplatViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -24,37 +227,12 @@ export function SplatViewer({ source, onError }: SplatViewerProps) {
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
+    const rootElement = container;
 
     let disposed = false;
     let objectUrl: string | null = null;
-    let viewer: DropInViewer | null = null;
-    let renderer: THREE.WebGLRenderer | null = null;
-
-    // Render loop (recursive requestAnimationFrame so the scene keeps painting).
-    let raf = 0;
-    const render = () => {
-      if (disposed) return;
-      controls.update();
-      if (renderer) renderer.render(scene, camera);
-      raf = requestAnimationFrame(render);
-    };
-
-    // Scene setup
-    const scene = new THREE.Scene();
-    scene.background = new THREE.Color(0x0e1524);
-    const camera = new THREE.PerspectiveCamera(
-      60,
-      container.clientWidth / container.clientHeight,
-      0.1,
-      1000,
-    );
-    camera.position.set(1, 1, 2);
-    const controls = new OrbitControls(camera, container);
-
-    renderer = new THREE.WebGLRenderer({ antialias: true });
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-    renderer.setSize(container.clientWidth, container.clientHeight);
-    container.appendChild(renderer.domElement);
+    let viewer: Viewer | null = null;
+    let cleanupFirstPersonControls: (() => void) | null = null;
 
     async function load() {
       try {
@@ -84,31 +262,34 @@ export function SplatViewer({ source, onError }: SplatViewerProps) {
         const blob = new Blob(chunks, { type: "application/octet-stream" });
         objectUrl = URL.createObjectURL(blob);
 
-        // 2) Parse + add DropInViewer to OUR scene.
+        // 2) Parse and render with the library's self-driven Viewer. Its own
+        // renderer/controls lifecycle is required for the first SPZ sort.
         setStage("parse");
         setProgress(null);
-        viewer = new DropInViewer({
-          gpuAcceleratedSort: true,
+        viewer = new Viewer({
+          rootElement,
+          cameraUp: [0, 0, 1],
+          initialCameraPosition: [0, 0, 0],
+          initialCameraLookAt: [0, 1, 0],
+          gpuAcceleratedSort: false,
           sharedMemoryForWorkers: false,
+          // Marble's current SPZ exports are 2D Gaussian surfels (the third
+          // scale axis is quantized to zero for most splats). Rendering them
+          // with the library's traditional 3D covariance path produces an
+          // apparently successful but empty frame.
+          splatRenderMode: SplatRenderMode.TwoD,
+          sceneRevealMode: SceneRevealMode.Instant,
         });
         await viewer.addSplatScene(objectUrl, {
+          format: SceneFormat.Spz,
+          rotation: MARBLE_Z_UP_ROTATION,
           showLoadingUI: true,
           progressiveLoad: true,
         });
-        scene.add(viewer);
         if (!disposed) {
-          // Center the splat on the scene.
-          viewer.position.set(0, 0, 0);
-          viewer.updateMatrixWorld(true);
-          const box = new THREE.Box3().setFromObject(viewer);
-          const size = box.getSize(new THREE.Vector3());
-          const maxDim = Math.max(size.x, size.y, size.z) || 1;
-          camera.near = maxDim * 0.001;
-          camera.far = maxDim * 20;
-          camera.position.set(maxDim * 0.8, maxDim * 0.6, maxDim * 0.8);
-          camera.updateProjectionMatrix();
-          controls.target.set(0, 0, 0);
-          controls.update();
+          const frame = frameSpzInterior(viewer);
+          if (frame) cleanupFirstPersonControls = setupFirstPersonControls(viewer, rootElement, frame);
+          viewer.start();
           setStage("ready");
           setProgress(null);
         }
@@ -122,35 +303,18 @@ export function SplatViewer({ source, onError }: SplatViewerProps) {
       }
     }
 
-    raf = requestAnimationFrame(render);
     void load();
 
     return () => {
       disposed = true;
-      cancelAnimationFrame(raf);
-      controls.dispose();
+      cleanupFirstPersonControls?.();
       if (viewer) {
         try {
-          scene.remove(viewer);
-          viewer.dispose();
+          void viewer.dispose();
         } catch {
           /* ignore dispose errors */
         }
       }
-      if (renderer) {
-        renderer.dispose();
-        if (renderer.domElement.parentElement === container) {
-          container.removeChild(renderer.domElement);
-        }
-      }
-      scene.traverse((obj) => {
-        if (obj instanceof THREE.Mesh) {
-          obj.geometry.dispose();
-          const mat = obj.material;
-          if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
-          else if (mat) mat.dispose();
-        }
-      });
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
   }, [source, onError]);

--- a/client/src/pages/McpBrowserPage.test.tsx
+++ b/client/src/pages/McpBrowserPage.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mcpProjects } from "../data/mcpProjects";
+import McpBrowserPage from "./McpBrowserPage";
+
+vi.mock("../components/McpServerCard", () => ({
+  default: ({ project }: { project: { name: string } }) => (
+    <article data-testid="mcp-server-card">{project.name}</article>
+  ),
+}));
+
+function response(payload: unknown) {
+  return Promise.resolve(
+    new Response(JSON.stringify(payload), {
+      headers: { "Content-Type": "application/json" },
+      status: 200,
+    }),
+  );
+}
+
+function renderPage(
+  adapters: Array<Record<string, unknown>> = [],
+  sessions: Array<Record<string, unknown>> = [],
+) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/mcp/sessions")) return response({ sessions });
+      if (url.endsWith("/api/registry/tools")) return response({ tools: [] });
+      if (url.endsWith("/api/mcp/catalog/adapters")) {
+        return response({ adapters });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    }),
+  );
+
+  return render(
+    <MemoryRouter>
+      <McpBrowserPage />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("McpBrowserPage first-screen shell", () => {
+  it("keeps only the approved compact procurement information", async () => {
+    renderPage([], [{ session_id: "session-1" }]);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "MCP 工具采购" }),
+    ).toBeVisible();
+    expect(
+      screen.getByText("安装 MCP 服务，为 AI 扩展更多工具能力"),
+    ).toBeVisible();
+    expect(screen.getByText("个工具")).toBeVisible();
+    expect(screen.getByText("可用")).toBeVisible();
+    expect(screen.getByText("分类")).toBeVisible();
+    expect(screen.getByText("已连接")).toBeVisible();
+    expect(screen.getByRole("tab", { name: "工具货架" })).toBeVisible();
+    expect(screen.getByRole("tab", { name: "已连接注册表" })).toBeVisible();
+    expect(
+      screen.getByRole("searchbox", { name: "搜索 MCP 工具" }),
+    ).toHaveAttribute("placeholder", "搜索名称、用途或标签");
+    expect(
+      screen.getByRole("heading", { name: "已上架工具箱" }),
+    ).toBeVisible();
+
+    expect(screen.queryByText("中文 MCP 工具目录")).not.toBeInTheDocument();
+    expect(screen.queryByText("采购台状态")).not.toBeInTheDocument();
+    expect(screen.queryByText("全局工具数")).not.toBeInTheDocument();
+    expect(screen.queryByText("运行态")).not.toBeInTheDocument();
+    expect(screen.queryByText("搜索工具")).not.toBeInTheDocument();
+    expect(screen.queryByText(/待适配.*不代表/)).not.toBeInTheDocument();
+
+    await waitFor(() => expect(screen.getByText("1")).toBeVisible());
+  });
+
+  it("reuses the approved workbench sidebar", () => {
+    renderPage();
+
+    expect(screen.getAllByText("工作台入口").length).toBeGreaterThan(0);
+    ["自定义工作流", "RAG 知识库", "Coding", "系统设置"].forEach(
+      (entry) => expect(screen.getAllByText(entry).length).toBeGreaterThan(0),
+    );
+    expect(screen.queryByText("工具采购清单")).not.toBeInTheDocument();
+  });
+
+  it("keeps the all filter visible and toggles wrapped secondary categories", () => {
+    renderPage();
+
+    expect(screen.getByRole("button", { name: "全部 · 300" })).toBeVisible();
+    const primaryGroup = screen.getByRole("group", { name: "按工具类别筛选" });
+    expect(within(primaryGroup).getAllByRole("button")).toHaveLength(4);
+    expect(primaryGroup.parentElement).not.toHaveClass("overflow-x-auto");
+    expect(
+      screen.queryByRole("group", { name: "更多 MCP 工具类别" }),
+    ).not.toBeInTheDocument();
+
+    const toggle = within(primaryGroup).getByRole("button", {
+      name: "更多分类",
+    });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(toggle);
+
+    const expandedGroup = screen.getByRole("group", {
+      name: "更多 MCP 工具类别",
+    });
+    expect(expandedGroup).toBeVisible();
+    expect(expandedGroup).not.toHaveClass("overflow-x-auto");
+    expect(
+      within(primaryGroup).getByRole("button", { name: "收起分类" }),
+    ).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(
+      within(primaryGroup).getByRole("button", { name: "收起分类" }),
+    );
+    expect(
+      screen.queryByRole("group", { name: "更多 MCP 工具类别" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("aggregates planned and adapting projects under the single 适配中 filter", async () => {
+    const adapters = [
+      ...mcpProjects.map((project) => ({
+        project_id: project.id,
+        availability: "blocked",
+      })),
+      { project_id: "playwright-mcp", availability: "planned" },
+      { project_id: "github-mcp-server", availability: "adapting" },
+    ];
+    renderPage(adapters);
+
+    const statusGroup = screen.getByRole("group", {
+      name: "按 MCP 适配状态筛选",
+    });
+    const inProgress = await within(statusGroup).findByRole("button", {
+      name: /适配中 · 2/,
+    });
+    fireEvent.click(inProgress);
+
+    expect(inProgress).toHaveAttribute("aria-pressed", "true");
+    await waitFor(() => expect(screen.getByText("匹配 2")).toBeVisible());
+    expect(screen.queryByText("已排期、待适配")).not.toBeInTheDocument();
+    expect(screen.queryByText("适配受阻")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/pages/McpBrowserPage.tsx
+++ b/client/src/pages/McpBrowserPage.tsx
@@ -1,16 +1,24 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Boxes,
+  CheckCircle2,
+  ChevronDown,
+  Grid2X2,
+  Plug,
+  RefreshCw,
+  Search,
+} from "lucide-react";
 import McpServerCard, {
   type McpSessionSummary,
 } from "../components/McpServerCard";
+import ModelWorkbenchSidebar from "../components/ModelWorkbenchSidebar";
 import PageContainer from "../components/PageContainer";
 import {
-  mcpCatalogSources,
   mcpCategories,
   mcpProjects,
   type McpCategory,
 } from "../data/mcpProjects";
 import {
-  mcpAvailabilityLabels,
   type McpAvailability,
   type McpCatalogAdapterStatus,
 } from "../data/mcpAdaptationPlan";
@@ -24,10 +32,22 @@ interface RegistryTool {
   registered_at: number;
 }
 
-type CatalogCategory = "全部" | McpCategory;
-type AvailabilityFilter = "all" | McpAvailability;
+type CatalogCategory = "全部类别" | McpCategory;
+type AvailabilityFilter = "all" | "ready" | "in_progress" | "blocked";
 
 const INITIAL_VISIBLE_COUNT = 18;
+const PRIMARY_CATEGORY_COUNT = 3;
+
+function matchesAvailability(
+  availability: McpAvailability,
+  filter: AvailabilityFilter,
+) {
+  if (filter === "all") return true;
+  if (filter === "in_progress") {
+    return availability === "planned" || availability === "adapting";
+  }
+  return availability === filter;
+}
 
 export default function McpBrowserPage() {
   const [sessions, setSessions] = useState<McpSessionSummary[]>([]);
@@ -35,9 +55,10 @@ export default function McpBrowserPage() {
   const [activeView, setActiveView] = useState<"servers" | "registry">("servers");
   const [query, setQuery] = useState("");
   const [selectedCategory, setSelectedCategory] =
-    useState<CatalogCategory>("全部");
+    useState<CatalogCategory>("全部类别");
   const [availabilityFilter, setAvailabilityFilter] =
     useState<AvailabilityFilter>("all");
+  const [categoriesExpanded, setCategoriesExpanded] = useState(false);
   const [adapterStatuses, setAdapterStatuses] = useState<
     McpCatalogAdapterStatus[]
   >([]);
@@ -117,15 +138,43 @@ export default function McpBrowserPage() {
     }
     return counts;
   }, []);
+  const rankedCategories = useMemo(
+    () =>
+      [...mcpCategories].sort((left, right) => {
+        const countDelta =
+          (categoryCounts.get(right) ?? 0) - (categoryCounts.get(left) ?? 0);
+        return countDelta || mcpCategories.indexOf(left) - mcpCategories.indexOf(right);
+      }),
+    [categoryCounts],
+  );
+  const primaryCategories = useMemo(() => {
+    const primary = rankedCategories.slice(0, PRIMARY_CATEGORY_COUNT);
+    if (
+      selectedCategory !== "全部类别" &&
+      !primary.includes(selectedCategory)
+    ) {
+      return [...primary.slice(0, PRIMARY_CATEGORY_COUNT - 1), selectedCategory];
+    }
+    return primary;
+  }, [rankedCategories, selectedCategory]);
+  const remainingCategories = useMemo(
+    () => rankedCategories.filter((category) => !primaryCategories.includes(category)),
+    [primaryCategories, rankedCategories],
+  );
   const filteredProjects = useMemo(() => {
     const normalizedQuery = query.trim().toLocaleLowerCase("zh-CN");
     return mcpProjects.filter((project) => {
-      if (selectedCategory !== "全部" && project.category !== selectedCategory) {
+      if (
+        selectedCategory !== "全部类别" &&
+        project.category !== selectedCategory
+      ) {
         return false;
       }
       if (
-        availabilityFilter !== "all" &&
-        effectiveAvailability(project.id) !== availabilityFilter
+        !matchesAvailability(
+          effectiveAvailability(project.id),
+          availabilityFilter,
+        )
       ) {
         return false;
       }
@@ -157,252 +206,185 @@ export default function McpBrowserPage() {
   return (
     <PageContainer
       activeResource="mcps"
-      sidebar={
-        <div>
-          <p className="text-sm font-semibold text-white">工具采购清单</p>
-          <p className="mt-2 text-sm leading-6 text-slate-400">
-            汇集两个社区清单，并按生产验收状态、适配批次和风险等级展示。
-          </p>
-          <div className="mt-4 rounded-lg border border-white/10 bg-white/[0.045] p-3">
-            <p className="text-xs text-slate-400">已上架工具</p>
-            <p className="mt-1 text-sm font-semibold text-hire-100">
-              {mcpProjects.length} 个
-            </p>
-          </div>
-          <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.045] p-3">
-            <p className="text-xs text-slate-400">覆盖分类</p>
-            <p className="mt-1 text-sm font-semibold text-brand-100">
-              {mcpCategories.length} 类
-            </p>
-          </div>
-          <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.045] p-3">
-            <p className="text-xs text-slate-400">生产级可用</p>
-            <p className="mt-1 text-sm font-semibold text-emerald-100">
-              {readyCount} 个
-            </p>
-          </div>
-          <button
-            className="mt-4 min-h-11 w-full rounded-full border border-brand-300/25 bg-brand-300/10 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:bg-brand-300/15"
-            onClick={() => void refreshRuntime()}
-            type="button"
-          >
-            刷新连接状态
-          </button>
-        </div>
-      }
+      maxWidthClassName="max-w-[1500px]"
+      mobileSidebar={<ModelWorkbenchSidebar compact />}
+      showSystemCapabilityBar={false}
+      sidebar={<ModelWorkbenchSidebar />}
+      sidebarGridClassName="xl:grid-cols-[230px_minmax(0,1fr)] xl:gap-x-[54px]"
     >
-      <header className="relative overflow-hidden border-y border-hire-300/20 py-8 sm:py-10 lg:py-12">
-        <div className="absolute inset-x-6 top-0 h-16 rounded-b-[50%] border-x border-b border-hire-300/30 bg-[linear-gradient(180deg,rgba(251,146,60,0.18),transparent)]" />
-        <div className="absolute left-0 top-0 h-px w-full bg-[linear-gradient(90deg,transparent,rgba(251,146,60,0.82),rgba(253,186,116,0.72),transparent)]" />
-        <div className="relative grid min-w-0 gap-8 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-end">
-          <div>
-            <p className="text-sm font-semibold text-hire-200">
-              中文 MCP 工具目录
-            </p>
-            <h1 className="mt-3 max-w-4xl text-4xl font-semibold tracking-normal text-white sm:text-6xl">
+      <header className="relative overflow-hidden rounded-xl border border-hire-300/25 bg-ink-900/65 px-4 py-5 sm:px-6">
+        <div className="pointer-events-none absolute right-4 top-3 hidden h-16 w-44 opacity-55 lg:block">
+          <span className="absolute right-1 top-2 h-1.5 w-1.5 rounded-full bg-hire-200" />
+          <span className="absolute right-14 top-9 h-1 w-1 rounded-full bg-cyan-200" />
+          <span className="absolute right-28 top-4 h-1 w-1 rounded-full bg-hire-300" />
+          <span className="absolute right-3 top-4 h-px w-28 -rotate-[14deg] bg-hire-200/40" />
+          <span className="absolute right-10 top-8 h-px w-24 rotate-[16deg] bg-cyan-200/30" />
+        </div>
+        <div className="relative grid gap-5 lg:grid-cols-[minmax(250px,0.8fr)_minmax(560px,1.2fr)] lg:items-center">
+          <div className="min-w-0">
+            <h1 className="text-3xl font-semibold tracking-[-0.025em] text-white sm:text-4xl">
               MCP 工具采购
             </h1>
-            <p className="mt-5 max-w-2xl text-base leading-7 text-slate-300">
-              从 {mcpProjects.length} 个中文化条目中按场景、批次与生产验收状态筛选。当前已有 {readyCount} 个项目通过验收，其余 {plannedCount + adaptingCount + blockedCount} 个仍需逐批通过安全门槛。
+            <p className="mt-2 text-sm leading-6 text-slate-300 sm:text-base">
+              安装 MCP 服务，为 AI 扩展更多工具能力
             </p>
           </div>
-
-          <div className="surface-card rounded-lg p-4">
-            <div className="flex items-center justify-between border-b border-white/10 pb-4">
-              <span className="text-sm text-slate-400">采购台状态</span>
-              <span className="text-2xl font-semibold text-white">
-                {mcpProjects.length}
-              </span>
-            </div>
-            <div className="mt-4 grid grid-cols-3 gap-2 text-center text-xs">
-              <div className="rounded-lg bg-white/[0.055] px-2 py-3">
-                <p className="text-lg font-semibold text-hire-100">
-                  {mcpCategories.length}
-                </p>
-                <p className="mt-1 truncate text-slate-400">工具分类</p>
+          <dl className="grid grid-cols-2 gap-x-3 gap-y-3 sm:grid-cols-4 lg:pr-32">
+            {([
+              [Boxes, mcpProjects.length, "个工具", "text-hire-100"],
+              [CheckCircle2, readyCount, "可用", "text-emerald-100"],
+              [Grid2X2, mcpCategories.length, "分类", "text-hire-100"],
+              [Plug, sessions.length, "已连接", "text-cyan-100"],
+            ] as const).map(([Icon, value, label, tone]) => (
+              <div className="flex min-w-0 items-center gap-2.5" key={label}>
+                <Icon aria-hidden="true" className={tone} size={20} strokeWidth={1.8} />
+                <div className="min-w-0">
+                  <dt className="text-xs text-slate-400">{label}</dt>
+                  <dd className={`text-xl font-semibold tabular-nums ${tone}`}>{value}</dd>
+                </div>
               </div>
-              <div className="rounded-lg bg-white/[0.055] px-2 py-3">
-                <p className="text-lg font-semibold text-brand-100">
-                  {plannedCount}
-                </p>
-                <p className="mt-1 truncate text-slate-400">待适配</p>
-              </div>
-              <div className="rounded-lg bg-white/[0.055] px-2 py-3">
-                <p className="text-lg font-semibold text-emerald-100">
-                  {readyCount}
-                </p>
-                <p className="mt-1 truncate text-slate-400">可连接</p>
-              </div>
-            </div>
-          </div>
+            ))}
+          </dl>
         </div>
       </header>
 
-      <section className="mt-8">
-        <div className="mb-5 grid gap-3 md:grid-cols-3">
-          <div className="rounded-lg border border-white/10 bg-white/[0.045] p-4">
-            <p className="text-xs text-slate-400">已连接 Server</p>
-            <p className="mt-2 text-2xl font-semibold text-white">
-              {sessions.length}
-            </p>
-          </div>
-          <div className="rounded-lg border border-white/10 bg-white/[0.045] p-4">
-            <p className="text-xs text-slate-400">全局工具数</p>
-            <p className="mt-2 text-2xl font-semibold text-brand-100">
-              {registryTools.length}
-            </p>
-          </div>
-          <div className="rounded-lg border border-white/10 bg-white/[0.045] p-4">
-            <p className="text-xs text-slate-400">运行态</p>
-            <p className="mt-2 text-sm font-semibold text-emerald-100">
-              {isLoadingRuntime ? "同步中..." : "已同步"}
-            </p>
-          </div>
-        </div>
+      <section className="mt-4">
 
         {runtimeError ? (
-          <div className="mb-5 rounded-lg border border-rose-300/25 bg-rose-300/10 p-4 text-sm text-rose-100">
+          <div className="mb-3 rounded-lg border border-rose-300/25 bg-rose-300/10 px-4 py-3 text-sm text-rose-100" role="status">
             {runtimeError}
           </div>
         ) : null}
 
-        <div className="mb-5 flex flex-wrap gap-2">
-          <button
-            className={`min-h-11 rounded-full px-4 py-2 text-sm font-semibold transition ${
-              activeView === "servers"
-                ? "bg-hire-300 text-ink-950"
-                : "border border-white/10 bg-white/[0.055] text-slate-200 hover:border-hire-300/30"
-            }`}
-            onClick={() => setActiveView("servers")}
-            type="button"
-          >
-            工具货架
-          </button>
-          <button
-            className={`min-h-11 rounded-full px-4 py-2 text-sm font-semibold transition ${
-              activeView === "registry"
-                ? "bg-brand-300 text-ink-950"
-                : "border border-white/10 bg-white/[0.055] text-slate-200 hover:border-brand-300/30"
-            }`}
-            onClick={() => {
-              setActiveView("registry");
-              void refreshRuntime();
-            }}
-            type="button"
-          >
-            全局工具注册表
-          </button>
+        <div className="rounded-xl border border-white/10 bg-ink-900/55 p-3 sm:p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex min-w-0 rounded-lg border border-white/10 bg-ink-950/55 p-1" role="tablist" aria-label="MCP 工具视图">
+              <button
+                aria-selected={activeView === "servers"}
+                className={`min-h-10 rounded-md px-4 py-2 text-sm font-semibold transition ${
+                  activeView === "servers"
+                    ? "bg-hire-300 text-ink-950"
+                    : "text-slate-300 hover:bg-white/[0.055] hover:text-white"
+                }`}
+                onClick={() => setActiveView("servers")}
+                role="tab"
+                type="button"
+              >
+                工具货架
+              </button>
+              <button
+                aria-selected={activeView === "registry"}
+                className={`min-h-10 rounded-md px-4 py-2 text-sm font-semibold transition ${
+                  activeView === "registry"
+                    ? "bg-hire-300 text-ink-950"
+                    : "text-slate-300 hover:bg-white/[0.055] hover:text-white"
+                }`}
+                onClick={() => {
+                  setActiveView("registry");
+                  void refreshRuntime();
+                }}
+                role="tab"
+                type="button"
+              >
+                已连接注册表
+              </button>
+            </div>
+            <button
+              className="flex min-h-10 items-center gap-2 rounded-lg border border-white/10 bg-white/[0.035] px-3 py-2 text-sm font-semibold text-slate-200 transition hover:border-hire-300/35 hover:text-hire-100 disabled:cursor-wait disabled:opacity-60"
+              disabled={isLoadingRuntime}
+              onClick={() => void refreshRuntime()}
+              type="button"
+            >
+              <RefreshCw aria-hidden="true" className={isLoadingRuntime ? "motion-safe:animate-spin" : ""} size={16} />
+              {isLoadingRuntime ? "正在刷新" : "刷新连接状态"}
+            </button>
+          </div>
+
+          {activeView === "servers" ? (
+            <div className="relative mt-3">
+              <Search aria-hidden="true" className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" size={18} />
+              <label className="sr-only" htmlFor="mcp-search">搜索 MCP 工具</label>
+              <input
+                className="min-h-11 w-full rounded-lg border border-white/10 bg-ink-950/70 py-2.5 pl-10 pr-28 text-sm text-white outline-none placeholder:text-slate-400 focus:border-hire-300/55 focus:ring-2 focus:ring-hire-300/15"
+                id="mcp-search"
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="搜索名称、用途或标签"
+                type="search"
+                value={query}
+              />
+              {query || selectedCategory !== "全部类别" || availabilityFilter !== "all" ? (
+                <button
+                  className="absolute right-2 top-1/2 min-h-9 -translate-y-1/2 rounded-md px-3 text-xs font-semibold text-slate-300 transition hover:bg-white/[0.06] hover:text-white"
+                  onClick={() => {
+                    setQuery("");
+                    setSelectedCategory("全部类别");
+                    setAvailabilityFilter("all");
+                  }}
+                  type="button"
+                >
+                  清除筛选
+                </button>
+              ) : null}
+            </div>
+          ) : null}
         </div>
 
         {activeView === "servers" ? (
-          <div className="mb-5 space-y-4">
-            <div className="rounded-lg border border-brand-300/20 bg-brand-300/[0.07] p-4 text-sm">
-              <p className="max-w-4xl leading-6 text-slate-300">
-                条目整理自{" "}
-                {mcpCatalogSources.map((source, index) => (
-                  <span key={source.id}>
-                    {index > 0 ? " 与 " : null}
-                    <a
-                      className="font-semibold text-brand-100 underline-offset-4 hover:underline"
-                      href={source.url}
-                      rel="noreferrer"
-                      target="_blank"
-                    >
-                      {source.name}
-                    </a>
-                  </span>
-                ))}
-                ，并按模镜的受控适配器边界重新分类、翻译和核验。
-              </p>
-              <p className="mt-2 text-xs leading-5 text-slate-400">
-                第 1 批核验日期 2026-08-05 · 目录数量冻结 · 当前不提供自定义连接、MCP Builder 或外站认证入口
-              </p>
-            </div>
-
-            <div className="rounded-lg border border-amber-300/25 bg-amber-300/[0.08] p-4 text-sm leading-6 text-amber-50">
-              “待适配”不代表上游项目不可用，而是尚未通过模镜的安装、权限、Smoke 与回退验收。每个条目已归入固定批次；服务端未放行前，按钮始终不可连接。
-            </div>
-
-            <div className="rounded-lg border border-white/10 bg-white/[0.035] p-4">
-              <label className="block text-sm font-semibold text-slate-200" htmlFor="mcp-search">
-                搜索工具
-              </label>
-              <div className="mt-2 flex flex-col gap-2 sm:flex-row">
-                <input
-                  className="min-h-11 min-w-0 flex-1 rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2.5 text-sm text-white outline-none placeholder:text-slate-400 focus:border-brand-300/60"
-                  id="mcp-search"
-                  onChange={(event) => setQuery(event.target.value)}
-                  placeholder="搜索名称、仓库、用途或标签"
-                  type="search"
-                  value={query}
-                />
-                {query || selectedCategory !== "全部" || availabilityFilter !== "all" ? (
-                  <button
-                    className="min-h-11 rounded-lg border border-white/10 bg-white/[0.055] px-4 py-2.5 text-sm font-semibold text-slate-200 transition hover:border-brand-300/35 hover:text-brand-100"
-                    onClick={() => {
-                      setQuery("");
-                      setSelectedCategory("全部");
-                      setAvailabilityFilter("all");
-                    }}
-                    type="button"
-                  >
-                    清除筛选
-                  </button>
-                ) : null}
-              </div>
-              <div className="mt-4 border-t border-white/10 pt-4">
-                <p className="text-xs font-semibold text-slate-300">按当前适配状态</p>
-                <div
-                  aria-label="按 MCP 适配状态筛选"
-                  className="mt-2 flex flex-wrap gap-2"
-                  role="group"
-                >
-                  {([
-                    ["all", "全部状态", mcpProjects.length],
-                    ["ready", mcpAvailabilityLabels.ready, readyCount],
-                    ["planned", mcpAvailabilityLabels.planned, plannedCount],
-                    ["adapting", mcpAvailabilityLabels.adapting, adaptingCount],
-                    ["blocked", mcpAvailabilityLabels.blocked, blockedCount],
-                  ] as const).map(([value, label, count]) => {
-                    const isSelected = availabilityFilter === value;
-                    return (
-                      <button
-                        aria-pressed={isSelected}
-                        className={`min-h-11 rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
-                          isSelected
-                            ? value === "planned" || value === "blocked"
-                              ? "border-amber-300/60 bg-amber-300 text-ink-950"
-                              : "border-emerald-300/60 bg-emerald-300 text-ink-950"
-                            : "border-white/10 bg-white/[0.045] text-slate-300 hover:border-brand-300/35 hover:text-brand-100"
-                        }`}
-                        key={value}
-                        onClick={() => setAvailabilityFilter(value)}
-                        type="button"
-                      >
-                        {label} · {count}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-              <div
-                aria-label="按 MCP 场景筛选"
-                className="mt-3 flex flex-wrap gap-2"
-                role="group"
+          <div className="mt-3 rounded-xl border border-white/10 bg-white/[0.025] px-3 py-2.5 sm:px-4">
+            <div className="flex min-w-0 flex-wrap items-center gap-2.5">
+              <button
+                aria-pressed={availabilityFilter === "all" && selectedCategory === "全部类别"}
+                className={`min-h-9 whitespace-nowrap rounded-md border px-3 py-1.5 text-xs font-semibold transition ${
+                  availabilityFilter === "all" && selectedCategory === "全部类别"
+                    ? "border-hire-300/55 bg-hire-300 text-ink-950"
+                    : "border-white/10 bg-white/[0.035] text-slate-300 hover:border-hire-300/30 hover:text-white"
+                }`}
+                onClick={() => {
+                  setAvailabilityFilter("all");
+                  setSelectedCategory("全部类别");
+                }}
+                type="button"
               >
-                {(["全部", ...mcpCategories] as const).map((category) => {
-                  const isSelected = selectedCategory === category;
-                  const count =
-                    category === "全部"
-                      ? mcpProjects.length
-                      : (categoryCounts.get(category) ?? 0);
+                全部 · {mcpProjects.length}
+              </button>
+              <div className="flex flex-wrap items-center gap-2" role="group" aria-label="按 MCP 适配状态筛选">
+                <span className="whitespace-nowrap text-xs font-semibold text-slate-300">按适配状态</span>
+                {([
+                  ["ready", "可用", readyCount],
+                  ["in_progress", "适配中", plannedCount + adaptingCount],
+                  ["blocked", "未适配", blockedCount],
+                ] as const).map(([value, label, count]) => {
+                  const isSelected = availabilityFilter === value;
                   return (
                     <button
                       aria-pressed={isSelected}
-                      className={`min-h-11 rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                      className={`min-h-9 whitespace-nowrap rounded-md border px-3 py-1.5 text-xs font-semibold transition ${
                         isSelected
-                          ? "border-hire-300/60 bg-hire-300 text-ink-950"
-                          : "border-white/10 bg-white/[0.045] text-slate-300 hover:border-hire-300/35 hover:text-hire-100"
+                          ? "border-hire-300/55 bg-hire-300 text-ink-950"
+                          : "border-white/10 bg-white/[0.035] text-slate-300 hover:border-hire-300/30 hover:text-white"
+                      }`}
+                      key={value}
+                      onClick={() => setAvailabilityFilter(value)}
+                      type="button"
+                    >
+                      {label} · {count}
+                    </button>
+                  );
+                })}
+              </div>
+              <span aria-hidden="true" className="hidden h-7 w-px shrink-0 bg-white/10 sm:block" />
+              <div className="flex flex-wrap items-center gap-2" role="group" aria-label="按工具类别筛选">
+                <span className="whitespace-nowrap text-xs font-semibold text-slate-300">按工具类别</span>
+                {primaryCategories.map((category) => {
+                  const isSelected = selectedCategory === category;
+                  const count = categoryCounts.get(category) ?? 0;
+                  return (
+                    <button
+                      aria-pressed={isSelected}
+                      className={`min-h-9 whitespace-nowrap rounded-md border px-3 py-1.5 text-xs font-semibold transition ${
+                        isSelected
+                          ? "border-hire-300/55 bg-hire-300 text-ink-950"
+                          : "border-white/10 bg-white/[0.035] text-slate-300 hover:border-hire-300/30 hover:text-white"
                       }`}
                       key={category}
                       onClick={() => setSelectedCategory(category)}
@@ -412,26 +394,50 @@ export default function McpBrowserPage() {
                     </button>
                   );
                 })}
+                <button
+                  aria-expanded={categoriesExpanded}
+                  className="flex min-h-9 items-center gap-1 whitespace-nowrap rounded-md border border-hire-300/30 bg-hire-300/[0.07] px-3 py-1.5 text-xs font-semibold text-hire-100 transition hover:bg-hire-300/[0.12]"
+                  onClick={() => setCategoriesExpanded((expanded) => !expanded)}
+                  type="button"
+                >
+                  {categoriesExpanded ? "收起分类" : "更多分类"}
+                  <ChevronDown aria-hidden="true" className={`transition-transform ${categoriesExpanded ? "rotate-180" : ""}`} size={14} />
+                </button>
               </div>
             </div>
+            {categoriesExpanded ? (
+              <div className="mt-2 flex flex-wrap items-center gap-2 border-t border-white/10 pt-2" role="group" aria-label="更多 MCP 工具类别">
+                {remainingCategories.map((category) => {
+                  const isSelected = selectedCategory === category;
+                  return (
+                    <button
+                      aria-pressed={isSelected}
+                      className={`min-h-9 whitespace-nowrap rounded-md border px-3 py-1.5 text-xs font-semibold transition ${
+                        isSelected
+                          ? "border-hire-300/55 bg-hire-300 text-ink-950"
+                          : "border-white/10 bg-white/[0.035] text-slate-300 hover:border-hire-300/30 hover:text-white"
+                      }`}
+                      key={category}
+                      onClick={() => setSelectedCategory(category)}
+                      type="button"
+                    >
+                      {category} · {categoryCounts.get(category) ?? 0}
+                    </button>
+                  );
+                })}
+              </div>
+            ) : null}
           </div>
         ) : null}
 
-        <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <h2 className="text-xl font-semibold text-white">
-              {activeView === "servers" ? "已上架工具箱" : "全局工具注册表"}
-            </h2>
-            <p className="mt-1 text-sm text-slate-400">
-              {activeView === "servers"
-                ? "可用项由后端固定适配器启动；第 3 批文件工具使用断网受控工作区、只读输入、一次性写入确认和可清理产物。"
-                : "这里聚合所有已连接 MCP Server 的工具；重名工具按首次出现保留。"}
-            </p>
-          </div>
-          <span className="w-fit rounded-full border border-emerald-300/25 bg-emerald-300/10 px-3 py-1.5 text-xs font-semibold text-emerald-100">
+        <div className="mb-3 mt-4 flex items-center justify-between gap-3">
+          <h2 className="text-xl font-semibold text-white sm:text-2xl">
+            {activeView === "servers" ? "已上架工具箱" : "已连接注册表"}
+          </h2>
+          <span className="w-fit shrink-0 rounded-md border border-white/10 bg-white/[0.035] px-3 py-1.5 text-xs font-semibold text-slate-300">
             {activeView === "servers"
-              ? `显示 ${visibleProjects.length} / 匹配 ${filteredProjects.length}`
-              : `${registryTools.length} 个已发现工具`}
+              ? `匹配 ${filteredProjects.length}`
+              : `${registryTools.length} 个工具`}
           </span>
         </div>
 
@@ -478,7 +484,7 @@ export default function McpBrowserPage() {
                 className="mt-4 min-h-11 rounded-full bg-brand-300 px-4 py-2 text-sm font-semibold text-ink-950 transition hover:bg-brand-200"
                 onClick={() => {
                   setQuery("");
-                  setSelectedCategory("全部");
+                  setSelectedCategory("全部类别");
                   setAvailabilityFilter("all");
                 }}
                 type="button"

--- a/client/src/pages/ModelListPage.layout.test.tsx
+++ b/client/src/pages/ModelListPage.layout.test.tsx
@@ -66,6 +66,12 @@ describe("model market recommendation layout", () => {
       ),
     ).toBe(false);
     expect(
+      shouldShowFeaturedRecommendations(
+        { ...defaultFilterState, providers: ["OpenAI"] },
+        "",
+      ),
+    ).toBe(false);
+    expect(
       shouldShowFeaturedRecommendations(defaultFilterState, "Lyria 3"),
     ).toBe(false);
   });

--- a/client/src/pages/ModelListPage.layout.test.tsx
+++ b/client/src/pages/ModelListPage.layout.test.tsx
@@ -1,6 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { ModelMarketHero } from "./ModelListPage";
+import { defaultFilterState } from "../data/filterState";
+import {
+  ModelMarketHero,
+  shouldShowFeaturedRecommendations,
+} from "./ModelListPage";
 
 describe("ModelMarketHero", () => {
   it("keeps the brand, concise status, and search as the first-screen hierarchy", () => {
@@ -49,5 +53,20 @@ describe("ModelMarketHero", () => {
     const status = screen.getByLabelText("模型市场状态");
     expect(status).toHaveTextContent("可调用数待确认");
     expect(status).not.toHaveTextContent("0 可直接调用");
+  });
+});
+
+describe("model market recommendation layout", () => {
+  it("reserves router and flagship cards for the unfiltered landing view", () => {
+    expect(shouldShowFeaturedRecommendations(defaultFilterState, "")).toBe(true);
+    expect(
+      shouldShowFeaturedRecommendations(
+        { ...defaultFilterState, jobCapabilities: ["video_generation"] },
+        "",
+      ),
+    ).toBe(false);
+    expect(
+      shouldShowFeaturedRecommendations(defaultFilterState, "Lyria 3"),
+    ).toBe(false);
   });
 });

--- a/client/src/pages/ModelListPage.tsx
+++ b/client/src/pages/ModelListPage.tsx
@@ -117,24 +117,56 @@ export function shouldShowFeaturedRecommendations(
   filters: ModelFilterState,
   searchTerm: string,
 ) {
+  const isDefaultRange = (
+    selected: { min: number; max: number },
+    baseline: { min: number; max: number },
+  ) => selected.min === baseline.min && selected.max === baseline.max;
+  const hasDefaultMetricRanges = <T extends string>(
+    selected: Record<T, { min: number; max: number }>,
+    baseline: Record<T, { min: number; max: number }>,
+  ) =>
+    Object.entries(baseline).every(([metric, range]) => {
+      const selectedRange = selected[metric as T];
+      const baselineRange = range as { min: number; max: number };
+      return selectedRange && isDefaultRange(selectedRange, baselineRange);
+    });
+
   return (
     searchTerm.trim() === "" &&
     filters.inputModalities.length === 0 &&
     filters.series.length === 0 &&
     filters.jobCapabilities.length === 0 &&
+    filters.openRouterCategories.length === 0 &&
     filters.supportedParameters.length === 0 &&
+    filters.providers.length === 0 &&
     filters.modelAuthors.length === 0 &&
-    !filters.distillable &&
-    !filters.zeroDataRetention &&
-    !filters.inRegionRouting &&
-    filters.provider === defaultFilterState.provider &&
+    filters.regions.length === 0 &&
+    filters.discounted === defaultFilterState.discounted &&
+    filters.distillable === defaultFilterState.distillable &&
+    filters.zeroDataRetention === defaultFilterState.zeroDataRetention &&
+    filters.minContextLength === defaultFilterState.minContextLength &&
+    filters.minToolSuccessRate === defaultFilterState.minToolSuccessRate &&
     filters.showInactive === defaultFilterState.showInactive &&
-    filters.contextRange.min === defaultFilterState.contextRange.min &&
-    filters.contextRange.max === defaultFilterState.contextRange.max &&
-    filters.promptPriceCnyRange.min ===
-      defaultFilterState.promptPriceCnyRange.min &&
-    filters.promptPriceCnyRange.max ===
-      defaultFilterState.promptPriceCnyRange.max
+    isDefaultRange(
+      filters.promptPriceUsdRange,
+      defaultFilterState.promptPriceUsdRange,
+    ) &&
+    isDefaultRange(
+      filters.outputPriceUsdRange,
+      defaultFilterState.outputPriceUsdRange,
+    ) &&
+    isDefaultRange(
+      filters.modelAgeDaysRange,
+      defaultFilterState.modelAgeDaysRange,
+    ) &&
+    hasDefaultMetricRanges(
+      filters.artificialAnalysisRanges,
+      defaultFilterState.artificialAnalysisRanges,
+    ) &&
+    hasDefaultMetricRanges(
+      filters.designArenaRanges,
+      defaultFilterState.designArenaRanges,
+    )
   );
 }
 

--- a/client/src/pages/ModelListPage.tsx
+++ b/client/src/pages/ModelListPage.tsx
@@ -113,6 +113,31 @@ function createDefaultFilters(): ModelFilterState {
   };
 }
 
+export function shouldShowFeaturedRecommendations(
+  filters: ModelFilterState,
+  searchTerm: string,
+) {
+  return (
+    searchTerm.trim() === "" &&
+    filters.inputModalities.length === 0 &&
+    filters.series.length === 0 &&
+    filters.jobCapabilities.length === 0 &&
+    filters.supportedParameters.length === 0 &&
+    filters.modelAuthors.length === 0 &&
+    !filters.distillable &&
+    !filters.zeroDataRetention &&
+    !filters.inRegionRouting &&
+    filters.provider === defaultFilterState.provider &&
+    filters.showInactive === defaultFilterState.showInactive &&
+    filters.contextRange.min === defaultFilterState.contextRange.min &&
+    filters.contextRange.max === defaultFilterState.contextRange.max &&
+    filters.promptPriceCnyRange.min ===
+      defaultFilterState.promptPriceCnyRange.min &&
+    filters.promptPriceCnyRange.max ===
+      defaultFilterState.promptPriceCnyRange.max
+  );
+}
+
 interface VideoModelProfile {
   model_id: string;
   operation: "analyze_video" | "generate_video";
@@ -276,6 +301,7 @@ export default function ModelListPage() {
     useState<VideoCatalogPayload | null>(null);
   const [audioCatalog, setAudioCatalog] =
     useState<AudioCatalogPayload | null>(null);
+  const [audioCatalogLoading, setAudioCatalogLoading] = useState(true);
   const [imageCatalog, setImageCatalog] =
     useState<ImageCatalogPayload | null>(null);
   const [generalCatalog, setGeneralCatalog] =
@@ -324,11 +350,13 @@ export default function ModelListPage() {
       .then((payload) => {
         if (!controller.signal.aborted) {
           setAudioCatalog(payload);
+          setAudioCatalogLoading(false);
         }
       })
       .catch(() => {
         if (!controller.signal.aborted) {
           setAudioCatalog(null);
+          setAudioCatalogLoading(false);
         }
       });
 
@@ -769,8 +797,16 @@ export default function ModelListPage() {
     videoCatalog !== null ||
     audioCatalog !== null ||
     imageCatalog !== null;
-  const featuredModels = filteredModels.slice(0, 2);
-  const galleryModels = filteredModels.slice(featuredModels.length);
+  const showFeaturedRecommendations = shouldShowFeaturedRecommendations(
+    filters,
+    searchTerm,
+  );
+  const featuredModels = showFeaturedRecommendations
+    ? filteredModels.slice(0, 2)
+    : [];
+  const galleryModels = showFeaturedRecommendations
+    ? filteredModels.slice(featuredModels.length)
+    : filteredModels;
   const compareState = useMemo(
     () => parseModelCompareState(searchParams),
     [searchParams],
@@ -829,16 +865,24 @@ export default function ModelListPage() {
             />
           ) : (
           <>
-          <div className="mb-6 grid gap-4 lg:grid-cols-3">
-            <FederationRouterCard />
-            {featuredModels.length > 0
-              ? featuredModels.map((model) => (
+          {showFeaturedRecommendations ? (
+            <div className="mb-6 grid gap-4 lg:grid-cols-3">
+              <FederationRouterCard />
+              {featuredModels.length > 0
+                ? featuredModels.map((model) => (
                   <div
                     className="animate-soft-rise"
                     key={`featured-${model.id}`}
                   >
                     <ModelCard
                       audioCatalogStale={audioCatalog?.stale ?? false}
+                      audioCatalogState={
+                        audioCatalogLoading
+                          ? "loading"
+                          : audioCatalog
+                            ? "available"
+                            : "unavailable"
+                      }
                       audioCapabilityStatus={
                         audioCapabilityStatuses.get(model.id)
                       }
@@ -868,15 +912,23 @@ export default function ModelListPage() {
                       videoCatalogStale={videoCatalog?.stale ?? false}
                     />
                   </div>
-                ))
-              : null}
-          </div>
+                  ))
+                : null}
+            </div>
+          ) : null}
 
           {filteredModels.length > 0 ? (
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
               {galleryModels.map((model) => (
                 <ModelCard
                   audioCatalogStale={audioCatalog?.stale ?? false}
+                  audioCatalogState={
+                    audioCatalogLoading
+                      ? "loading"
+                      : audioCatalog
+                        ? "available"
+                        : "unavailable"
+                  }
                   audioCapabilityStatus={
                     audioCapabilityStatuses.get(model.id)
                   }

--- a/client/src/types/gaussian-splats-3d.d.ts
+++ b/client/src/types/gaussian-splats-3d.d.ts
@@ -3,21 +3,89 @@
  * The library ships no types; this covers only what the project uses.
  */
 declare module "@mkkellogg/gaussian-splats-3d" {
-  import type { Object3D } from "three";
+  import type { Object3D, PerspectiveCamera, Vector3 } from "three";
+
+  export const SceneFormat: {
+    Splat: number;
+    KSplat: number;
+    Ply: number;
+    Spz: number;
+  };
+
+  export const SplatRenderMode: {
+    ThreeD: number;
+    TwoD: number;
+  };
+
+  export const SceneRevealMode: {
+    Default: number;
+    Gradual: number;
+    Instant: number;
+  };
+
+  interface ViewerOptions {
+    rootElement?: HTMLElement;
+    cameraUp?: [number, number, number];
+    initialCameraPosition?: [number, number, number];
+    initialCameraLookAt?: [number, number, number];
+    gpuAcceleratedSort?: boolean;
+    sharedMemoryForWorkers?: boolean;
+    splatRenderMode?: number;
+    sceneRevealMode?: number;
+  }
+
+  interface AddSplatSceneOptions {
+    format?: number;
+    rotation?: [number, number, number, number];
+    showLoadingUI?: boolean;
+    progressiveLoad?: boolean;
+    splatAlphaRemovalThreshold?: number;
+  }
+
+  export class Viewer {
+    constructor(options?: ViewerOptions);
+    camera: PerspectiveCamera;
+    controls: {
+      target: Vector3;
+      screenSpacePanning: boolean;
+      enableRotate: boolean;
+      enablePan: boolean;
+      enableZoom: boolean;
+      enableDamping: boolean;
+      stopListenToKeyEvents(): void;
+      update(): void;
+    };
+    addSplatScene(path: string, options?: AddSplatSceneOptions): Promise<void>;
+    getSplatScene(sceneIndex: number): Object3D & {
+      splatBuffer: {
+        sceneCenter: Vector3;
+        getSplatCount(): number;
+        getSplatCenter(
+          splatIndex: number,
+          outCenter: Vector3,
+          transform?: unknown,
+        ): Vector3;
+      };
+    };
+    forceRenderNextFrame(): void;
+    start(): void;
+    dispose(): Promise<void>;
+  }
 
   export class DropInViewer extends Object3D {
-    constructor(options?: {
-      gpuAcceleratedSort?: boolean;
-      sharedMemoryForWorkers?: boolean;
-    });
-    addSplatScene(
-      path: string,
-      options?: {
-        showLoadingUI?: boolean;
-        progressiveLoad?: boolean;
-        splatAlphaRemovalThreshold?: number;
-      },
-    ): Promise<void>;
+    constructor(options?: ViewerOptions);
+    addSplatScene(path: string, options?: AddSplatSceneOptions): Promise<void>;
+    getSplatScene(sceneIndex: number): Object3D & {
+      splatBuffer: {
+        sceneCenter: Vector3;
+        getSplatCount(): number;
+        getSplatCenter(
+          splatIndex: number,
+          outCenter: Vector3,
+          transform?: unknown,
+        ): Vector3;
+      };
+    };
     start(): void;
     dispose(): void;
   }


### PR DESCRIPTION
﻿## 改动

- 精简 MCP 工具采购首屏，保留关键统计、连接状态、搜索和无横向滚动的适配/类别筛选。
- 统一模型分类结果为普通卡片，分类筛选时移除 ModelMirror Router 占位；修复已启用能力被误标为待适配的问题。
- 修复 Marble SPZ 的显式格式加载、2D Gaussian 渲染、室内取景、Z-up 朝向与第一人称控制；拖动原地转向，WASD/方向键在 X-Y 平面移动。
- 对齐 PR #187 刷新后的模型筛选契约，确保仅未筛选首页显示精选推荐。

## 根因

- MCP 分类选项使用横向滚动容器，导致常用入口和展开控制在窄屏不可见。
- 模型分类页复用了首页精选卡片/路由占位逻辑。
- SPZ 原实现把 DropInViewer 当普通 Three.js 对象渲染，未触发正确的 SPZ 排序与 2D Gaussian 路径；OrbitControls 又造成绕目标旋转而非第一人称原地观察。

## 验证

- `npm.cmd run test:run -- src/components/ModelCard.test.ts src/components/world/SplatViewer.test.tsx src/pages/McpBrowserPage.test.tsx src/pages/ModelListPage.layout.test.tsx` — 4 files / 17 tests passed。
- `npm.cmd run build` — passed（3107 modules；仅既有大 chunk warning）。
- `git diff --check origin/main...HEAD` — passed。
- 隔离预览 `15185` 人工验收通过；未触碰共享 `5173/8000`。
