### PR TITLE
test: 修复主线质量检查回归

### DIFF
--- a/client/src/components/workflow/NodePalette.test.ts
+++ b/client/src/components/workflow/NodePalette.test.ts
@@ -17,7 +17,9 @@ describe("NodePalette disabled workflow nodes", () => {
     expect(knowledgePipelineItems.map((item) => item.kind)).toEqual([
       "knowledge_base",
       "knowledge_retrieval",
+      "vision_understanding",
     ]);
+    expect(knowledgePipelineItems.every((item) => item.enabled !== false)).toBe(true);
     expect(knowledgePipelinePlaceholders).toEqual([]);
   });
 

--- a/scripts/typescript-module-loader.mjs
+++ b/scripts/typescript-module-loader.mjs
@@ -1,7 +1,7 @@
 import { access, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
-import ts from "../client/node_modules/typescript/lib/typescript.js";
+import ts from "../server/orchestration_worker/node_modules/typescript/lib/typescript.js";
 
 const SOURCE_SUFFIXES = [".ts", ".tsx", ".json"];
 

--- a/scripts/typescript-module-register.mjs
+++ b/scripts/typescript-module-register.mjs
@@ -1,0 +1,3 @@
+import { register } from "node:module";
+
+register("./typescript-module-loader.mjs", import.meta.url);

--- a/server/tests/test_multimodal_chat_foundation.py
+++ b/server/tests/test_multimodal_chat_foundation.py
@@ -314,7 +314,7 @@ async def test_audio_catalog_only_marks_verified_interactions_ready(
 
     assert result.status == "online"
     assert result.catalog_version == (
-            "modelmirror-audio-contracts-2026-08-06-c1"
+        "modelmirror-audio-contracts-2026-08-13-c1"
     )
     assert by_id["openai/gpt-audio"].provider == "openrouter"
     assert by_id["openai/gpt-audio"].operations == ["analyze_audio"]
@@ -659,7 +659,7 @@ async def test_audio_catalog_endpoint_does_not_expose_credentials(
     assert response.status_code == 200
     assert response.json()["profiles"]
     assert response.json()["catalog_version"] == (
-            "modelmirror-audio-contracts-2026-08-06-c1"
+        "modelmirror-audio-contracts-2026-08-13-c1"
     )
     assert response.json()["microphone_enabled"] is True
     assert "audio-catalog-secret" not in response.text

--- a/server/tests/test_skill_finder.py
+++ b/server/tests/test_skill_finder.py
@@ -282,8 +282,8 @@ def test_python_and_typescript_matcher_keep_the_same_golden_order() -> None:
     completed = subprocess.run(
         [
             "node",
-            "--experimental-loader",
-            str(ROOT / "scripts" / "typescript-module-loader.mjs"),
+            "--import",
+            (ROOT / "scripts" / "typescript-module-register.mjs").as_uri(),
             "--input-type=module",
             "-e",
             script,

--- a/server/tests/test_skill_semantic_rerank.py
+++ b/server/tests/test_skill_semantic_rerank.py
@@ -164,8 +164,8 @@ def test_python_and_typescript_keep_the_same_market_recall_order() -> None:
     completed = subprocess.run(
         [
             "node",
-            "--experimental-loader",
-            str(ROOT / "scripts" / "typescript-module-loader.mjs"),
+            "--import",
+            (ROOT / "scripts" / "typescript-module-register.mjs").as_uri(),
             "--input-type=module",
             "-e",
             script,
@@ -210,8 +210,8 @@ def test_generated_search_index_is_reproducible() -> None:
     completed = subprocess.run(
         [
             "node",
-            "--experimental-loader",
-            str(ROOT / "scripts" / "typescript-module-loader.mjs"),
+            "--import",
+            (ROOT / "scripts" / "typescript-module-register.mjs").as_uri(),
             "--input-type=module",
             "-e",
             script,


### PR DESCRIPTION
## 摘要

- 将 TypeScript 测试加载链从已弃用的 `--experimental-loader` 迁移到 Node 官方 `register()` + `--import`。
- 使用 Backend CI 已安装并锁定的 Agency Worker TypeScript 依赖，不再依赖未安装的前端 node_modules。
- 同步音频目录契约版本断言与可执行视觉理解节点断言。
- 仅修改测试与测试加载入口，不改变生产行为。

## 本地验证

- 确认的后端回归：5 passed。
- client/node_modules 遮蔽回归：3 passed。
- Agency Worker：核心 7 passed；上游测试全部通过；Python bridge 33 passed。
- 前端：58 files / 274 tests passed。
- 前端构建：3107 modules transformed。
- Linux Node 22 register smoke：passed。
- `docker compose config --quiet`：passed。
- `git diff --check`：passed。

## GitHub CI

- Backend quality：passed（2959 passed / 32 skipped）。
- Frontend quality：passed。
- Windows Project Host：passed。

## 边界

- 未启动或重建共享栈。
- 无依赖、迁移、公共 API 或生产代码变更。