### PR TITLE
refactor: 建立 Meta Planner NodeContract V3 契约内核

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,17 @@ cd client
 npm.cmd run build
 ```
 
+### 8.1.1 NodeContract V3 护栏
+
+- 所有 `NativeNodeKind` 必须在 `NodeContractRegistry` 中唯一登记；未知或缺失契约必须 fail-closed。
+- `contract_status=complete` 不等于 Planner、Evaluator、Evolution 或 App 可用。入口许可必须由契约显式声明。
+- Capability Snapshot 只允许完整契约、真实 Adapter、Adapter 版本和 compiler checksum 一致的节点；当前范围仍严格为既有七类。
+- NodeContract 版本与 Typed IR 版本独立。V3 Snapshot 必须继续声明 `ir_version=2`，直到独立 IR 升级轮次完成。
+- `checksum` 覆盖完整契约，`compiler_checksum` 仅覆盖编译关键事实；标题、图标和分类不得使 Adapter 失效。
+- 前端 fallback 只能保存展示信息，不得伪造 Planner 状态、端口、安全策略或 checksum。
+- 发布、Evaluator、App 和 Evolution 的静态节点策略必须查询 `NodePolicyService`；资源、Toolset、循环和中间件领域检查不得被删除。
+- 修改节点契约至少运行 `test_workflow_node_contracts.py`、Workflow Registry/Validator、Meta Planner、Xpert Publish、Evaluator、App、Evolution 和前端构建。
+
 ### 8.2 EvoAgentX Evaluator 护栏
 
 - Dataset 草稿必须使用 revision，Evaluation Run 只能引用不可变 DatasetVersion。

--- a/client/src/components/workflow/workflowNodeRegistry.test.ts
+++ b/client/src/components/workflow/workflowNodeRegistry.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasNodeContractV3,
+  workflowNodeRegistryFallback,
+} from "./workflowNodeRegistry";
+
+describe("workflowNodeRegistry NodeContract V3 guard", () => {
+  it("keeps fallback presentation-only and planner-neutral", () => {
+    expect(hasNodeContractV3(workflowNodeRegistryFallback)).toBe(false);
+
+    const items = [
+      ...workflowNodeRegistryFallback.sections.flatMap((section) => section.items),
+      ...workflowNodeRegistryFallback.knowledge_pipeline.items,
+    ];
+    const kinds = items.map((item) => item.kind);
+
+    expect(new Set(kinds).size).toBe(kinds.length);
+    expect(kinds).toEqual(expect.arrayContaining([
+      "json_serialize",
+      "json_deserialize",
+      "data_table_query",
+      "data_table_insert",
+      "data_table_update",
+      "data_table_delete",
+      "annotation",
+      "knowledge_base",
+      "knowledge_retrieval",
+      "vision_understanding",
+    ]));
+    expect(items.every((item) => item.contract === undefined)).toBe(true);
+    expect(items.every((item) => item.planner === undefined)).toBe(true);
+  });
+
+  it("rejects a nominal V3 registry without per-node contracts", () => {
+    expect(hasNodeContractV3({
+      ...workflowNodeRegistryFallback,
+      version: "xpert-workflow-node-registry-v3",
+      contract_version: 3,
+      contract_checksum: "registry-checksum",
+    })).toBe(false);
+  });
+
+  it("rejects an empty registry even with V3 metadata", () => {
+    expect(hasNodeContractV3({
+      version: "xpert-workflow-node-registry-v3",
+      contract_version: 3,
+      contract_checksum: "registry-checksum",
+      tabs: [],
+      sections: [],
+      knowledge_pipeline: { items: [], placeholders: [] },
+    })).toBe(false);
+  });
+});

--- a/client/src/components/workflow/workflowNodeRegistry.ts
+++ b/client/src/components/workflow/workflowNodeRegistry.ts
@@ -17,6 +17,41 @@ export interface WorkflowRegistryTab {
   label: string;
 }
 
+export interface WorkflowValueSchemaProjection {
+  type: "any" | "null" | "string" | "number" | "integer" | "boolean" | "object" | "array";
+  nullable?: boolean;
+  items?: WorkflowValueSchemaProjection | null;
+  properties?: Record<string, WorkflowValueSchemaProjection>;
+  required?: string[];
+  any_of?: WorkflowValueSchemaProjection[];
+}
+
+export interface WorkflowNodePortProjection {
+  name: string;
+  direction: "input" | "output";
+  value_schema: WorkflowValueSchemaProjection;
+  required: boolean;
+  cardinality: "one" | "many";
+  binding: "variable" | "literal" | "resource" | "none";
+}
+
+export interface WorkflowNodeContractProjection {
+  kind: WorkflowPaletteNodeKind | "runtime_middleware";
+  contract_status: "complete" | "compatibility";
+  config_schema: Record<string, unknown>;
+  ports: WorkflowNodePortProjection[];
+  edge: Record<string, unknown>;
+  execution: Record<string, unknown>;
+  availability: Record<string, unknown>;
+  resources: Array<Record<string, unknown>>;
+  planner: Record<string, unknown>;
+  contract_version: number;
+  checksum: string;
+  compiler_checksum: string;
+  deprecated?: boolean;
+  replacement_kind?: string | null;
+}
+
 export interface WorkflowPaletteItem {
   kind: WorkflowPaletteNodeKind;
   icon: string;
@@ -26,6 +61,9 @@ export interface WorkflowPaletteItem {
   tags?: string[];
   enabled?: boolean;
   metadata?: Record<string, unknown>;
+  contract?: WorkflowNodeContractProjection;
+  planner?: Record<string, unknown>;
+  contracts?: Record<string, unknown>;
 }
 
 export interface WorkflowPalettePlaceholder {
@@ -56,6 +94,8 @@ export interface WorkflowKnowledgePipelinePalette {
 
 export interface WorkflowNodeRegistryResponse {
   version: string;
+  contract_version: number;
+  contract_checksum: string;
   tabs: WorkflowRegistryTab[];
   sections: WorkflowPaletteSection[];
   knowledge_pipeline: WorkflowKnowledgePipelinePalette;
@@ -145,6 +185,20 @@ export const workflowPaletteSections: WorkflowPaletteSection[] = [
         tags: ["json", "extract"],
       },
       {
+        kind: "json_serialize",
+        icon: "JSON",
+        title: "JSON 序列化",
+        description: "把类型化变量序列化为 JSON 字符串。",
+        tags: ["json", "serialize", "typed-value"],
+      },
+      {
+        kind: "json_deserialize",
+        icon: "JSON",
+        title: "JSON 反序列化",
+        description: "把 JSON 字符串解析为类型化变量。",
+        tags: ["json", "deserialize", "typed-value"],
+      },
+      {
         kind: "document_extractor",
         icon: "□",
         title: "文档提取器",
@@ -170,24 +224,7 @@ export const workflowPaletteSections: WorkflowPaletteSection[] = [
         tags: ["output", "answer"],
       },
     ],
-    placeholders: [
-      {
-        id: "json_serialize",
-        icon: "JSON",
-        title: "JSON 序列化",
-        description: "待接入：把变量对象序列化为 JSON。",
-        statusLabel: "待接入",
-        tags: ["json", "serialize"],
-      },
-      {
-        id: "json_deserialize",
-        icon: "JSON",
-        title: "JSON 反序列化",
-        description: "待接入：把 JSON 字符串解析为结构化变量。",
-        statusLabel: "待接入",
-        tags: ["json", "deserialize"],
-      },
-    ],
+    placeholders: [],
   },
   {
     id: "resource",
@@ -291,33 +328,52 @@ export const workflowPaletteSections: WorkflowPaletteSection[] = [
     id: "memory",
     label: "记忆",
     description: "数据库、长期记忆和写入能力。",
-    items: [],
-    placeholders: [
+    items: [
       {
-        id: "database_memory",
-        icon: "DB",
-        title: "数据库",
-        description: "待接入：读写结构化数据和长期记忆。",
-        statusLabel: "待接入",
-        tags: ["database", "memory"],
+        kind: "data_table_query",
+        icon: "DB?",
+        title: "查询数据表",
+        description: "读取固定 Schema 的 Agent Table 记录。",
+        tags: ["database", "agent-table", "query"],
+      },
+      {
+        kind: "data_table_insert",
+        icon: "DB+",
+        title: "新增数据",
+        description: "向 Agent Table 插入一条类型化记录。",
+        tags: ["database", "agent-table", "insert"],
+      },
+      {
+        kind: "data_table_update",
+        icon: "DB~",
+        title: "更新数据",
+        description: "按非空条件更新 Agent Table 记录。",
+        tags: ["database", "agent-table", "update"],
+      },
+      {
+        kind: "data_table_delete",
+        icon: "DB-",
+        title: "删除数据",
+        description: "按非空条件删除 Agent Table 记录。",
+        tags: ["database", "agent-table", "delete"],
       },
     ],
+    placeholders: [],
   },
   {
     id: "other",
     label: "其他",
     description: "画布辅助节点。",
-    items: [],
-    placeholders: [
+    items: [
       {
-        id: "annotation",
+        kind: "annotation",
         icon: "※",
         title: "注释",
-        description: "待接入：仅用于画布说明，不参与运行。",
-        statusLabel: "待接入",
+        description: "仅用于画布说明，不参与拓扑或运行。",
         tags: ["note", "annotation"],
       },
     ],
+    placeholders: [],
   },
 ];
 
@@ -368,6 +424,8 @@ export function matchesWorkflowPaletteQuery(
 
 export const workflowNodeRegistryFallback: WorkflowNodeRegistryResponse = {
   version: "local-workflow-node-registry-fallback",
+  contract_version: 0,
+  contract_checksum: "",
   tabs: [
     { id: "workflow", label: "工作流" },
     { id: "knowledge", label: "知识流水线" },
@@ -379,10 +437,40 @@ export const workflowNodeRegistryFallback: WorkflowNodeRegistryResponse = {
   },
 };
 
+export function hasNodeContractV3(
+  registry: WorkflowNodeRegistryResponse,
+): boolean {
+  if (
+    registry.version !== "xpert-workflow-node-registry-v3" ||
+    registry.contract_version !== 3 ||
+    !registry.contract_checksum
+  ) {
+    return false;
+  }
+  const items = [
+    ...registry.sections.flatMap((section) => section.items),
+    ...registry.knowledge_pipeline.items,
+  ].filter((item) => item.enabled !== false);
+  if (items.length === 0) {
+    return false;
+  }
+  return items.every(
+    (item) =>
+      item.contract?.contract_version === 3 &&
+      item.contract.kind === item.kind &&
+      Boolean(item.contract.checksum) &&
+      Boolean(item.contract.compiler_checksum),
+  );
+}
+
 export async function fetchWorkflowNodeRegistry(): Promise<WorkflowNodeRegistryResponse> {
   const response = await fetch("/api/workflow/node-registry");
   if (!response.ok) {
     throw new Error(`Failed to fetch workflow node registry: ${response.status}`);
   }
-  return response.json();
+  const payload = (await response.json()) as WorkflowNodeRegistryResponse;
+  if (!hasNodeContractV3(payload)) {
+    throw new Error("Workflow node registry does not provide NodeContract V3.");
+  }
+  return payload;
 }

--- a/docs/EVOAGENTX_ALIGNMENT.md
+++ b/docs/EVOAGENTX_ALIGNMENT.md
@@ -115,6 +115,19 @@ Meta Planner V2 必须：
 - 迁移 EvoAgentX Provider、RAG、Memory、HITL、Storage 或 Tool Runtime。
 - GraphRAG、企业权限、多租户、远程插件市场和 Xpert UI 像素对齐。
 
+## NodeContract V3 收口
+
+ModelMirror 已将节点配置、端口、边、资源、执行安全和入口可用性统一到
+`NodeContractRegistry`。该契约内核是 ModelMirror 自有实现，只适配 EvoAgentX
+参数 Schema 与分层验证思想，不复制或引入 EvoAgentX Runtime。
+
+Capability Snapshot 已升级为 V3，但 Typed IR 继续保持 V2。Structure Evolution
+必须消费生产 Registry 生成的 Snapshot，不能在测试或运行时伪造可生成节点集合。
+完整契约不自动授予 Planner 权限；只有拥有有效 Adapter 且 checksum 一致的能力才能
+进入 Snapshot。当前可生成节点仍为既有七类，其他完整契约用于后续轮次的安全准备。
+
+详细契约、迁移边界和策略矩阵见 [NODE_CONTRACT_V3.md](./NODE_CONTRACT_V3.md)。
+
 ## 验收标准
 
 - 所有移植文件都有官方 commit、相对路径、SHA-256、许可证和本地测试映射。

--- a/docs/EVOAGENTX_AUDIT_V014.md
+++ b/docs/EVOAGENTX_AUDIT_V014.md
@@ -257,3 +257,20 @@ selection 与 early-stop 的分层概念，判定为 `adapt`。
 
 对应实现位于 `server/evolutions/mutations.py`、`service.py` 和 `executor.py`；
 测试位于 `server/tests/test_xpert_structure_evolutions.py`。逐文件源码复用数量仍为零。
+
+## 15. NodeContract V3 契约适配记录
+
+本轮只参考 EvoAgentX `v0.1.4@aad19b9` 中参数 JSON Schema 与分层验证的
+概念，判定为 `adapt/rewrite`：
+
+- ModelMirror 使用自有 `NodeContractRegistry` 描述类型、端口、边、执行策略、
+  入口许可、资源和 Planner Adapter 状态。
+- Workflow Registry、Capability Snapshot、发布预检、Evaluator、App 与 Evolution
+  消费同一安全投影或 `NodePolicyService` 决策。
+- Typed IR 继续保持 V2；NodeContract V3 不引入 EvoAgentX Workflow、Agent、
+  Provider、Storage 或 Runtime。
+- 现有逐节点 Validator 与 classic runner 在迁移期保持行为权威，V3 只增加通用
+  fail-closed 契约检查。
+
+对应实现位于 `server/workflow_native/node_contracts.py`，测试位于
+`server/tests/test_workflow_node_contracts.py`。逐文件源码复用数量仍为零。

--- a/docs/META_AGENT.md
+++ b/docs/META_AGENT.md
@@ -123,13 +123,26 @@ curl http://localhost:5173/agents/meta-agent
 2. 能力编译：从实时 Capability Snapshot 中选择真实节点、资源和中间件。
 3. 定向修复：本地确定性门禁失败时，最多调用模型修复一次。
 
+### NodeContract V3 能力门禁
+
+Meta Planner 的节点事实统一来自 `NodeContractRegistry`。Capability Snapshot V3
+只暴露满足以下全部条件的节点：契约状态完整、Planner 显式启用、编译模式真实存在、
+Adapter 版本一致，并且契约与 Adapter 的 compiler checksum 匹配。UI Registry 中出现
+节点不等于 Planner 可以生成该节点。
+
+当前开放范围仍严格保持为 `input`、`output`、`workflow_agent`、
+`external_xpert`、`knowledge_base`、`toolset_resource` 和 `plugin_resource`。
+NodeContract V3 与 Typed IR 独立演进，本轮 Capability Snapshot 升级为 V3，
+`ir_version` 仍为 2。旧 V2 Snapshot 保持可读，详见
+[NODE_CONTRACT_V3.md](./NODE_CONTRACT_V3.md)。
+
 ### Typed IR V2 编译边界
 
 能力编译阶段现在输出 `MetaPlannerTypedBlueprintV2`，显式声明节点引用、任务覆盖、
 类型化输入/输出变量、控制边、资源/中间件目标和唯一最终输出。任务和 Agent 不再
 强制一一对应：一个 Agent 可以覆盖多个任务，一个任务也可以由多个节点共同完成。
 
-Capability Snapshot v2 只暴露当前存在编译适配器的能力。首轮可执行 IR 节点只有
+Capability Snapshot V3 只暴露当前存在且与 NodeContract 校验一致的编译能力。首轮可执行 IR 节点只有
 `workflow_agent`；`input/output` 由编译器管理，外部 Xpert、知识库、Toolset 和
 Plugin 通过绑定记录编译。JSON、Agent Table、知识检索和视觉理解尚无 Planner
 适配器，因此不会进入授权快照，也不会被模型生成。

--- a/docs/NODE_CONTRACT_V3.md
+++ b/docs/NODE_CONTRACT_V3.md
@@ -1,0 +1,125 @@
+# NodeContract V3
+
+## Purpose
+
+NodeContract V3 is the single source of truth for the static contract of every
+classic workflow node. It removes planner, type, resource, and entrypoint policy
+facts from the UI palette and from independent allow/deny lists.
+
+NodeContract V3 does not replace the classic runner or the existing per-node
+validator. It does not add a node to Meta Planner. The contract layer describes
+the current behavior and lets each entrypoint fail closed when a contract or
+compiler adapter is incomplete.
+
+## Contract model
+
+Every `NativeNodeKind` has exactly one `NodeContract` with:
+
+- a bounded configuration JSON Schema;
+- typed input and output ports using `WorkflowValueSchema`;
+- control, binding, or metadata edge semantics and declared handles;
+- side-effect, determinism, idempotency, external-I/O, waiting, and error policy;
+- Workflow, Xpert, Goal, Handoff, App, Evaluator, and Evolution availability;
+- resource IDs, pinning fields, authorization needs, and dynamic-schema flags;
+- Planner support, compilation mode, adapter version, and IR configuration schema.
+
+Edge contracts declare every supported edge mode separately from the modes
+that participate in topology. This preserves compatibility nodes such as
+`runtime_middleware`, which supports both legacy linear control-flow edges and
+Agent binding edges, without adding Validator-specific exceptions.
+
+`contract_status=complete` means these facts are explicit. It does not mean that
+Planner, App, Evaluator, or Evolution may use the node. Those decisions remain
+explicit fields in the same contract. `contract_status=compatibility` keeps the
+existing validator and runner behavior while disabling Planner by default.
+
+Unknown node kinds are rejected. Registry construction also fails when a
+`NativeNodeKind` is missing or duplicated.
+
+## Checksums
+
+Each contract has two deterministic SHA-256 values:
+
+- `checksum` covers the full behavior and availability contract.
+- `compiler_checksum` covers only compiler-critical configuration, ports,
+  edges, resources, and Planner adapter facts.
+
+Display names, descriptions, icons, and palette categories are not compiler
+facts. A presentation-only change therefore does not invalidate an adapter.
+Capability Snapshot exposes a node only when its complete contract, adapter
+version, IR schema checksum, and compiler checksum agree.
+
+## Current migration boundary
+
+The first complete-contract group is:
+
+| Group | Node kinds | Planner state |
+| --- | --- | --- |
+| Compiler managed | `input`, `output` | enabled in IR V2 |
+| Adapter | `workflow_agent` | enabled in IR V2 |
+| Resource bindings | `external_xpert`, `knowledge_base`, `toolset_resource`, `plugin_resource` | binding only |
+| Pure-data targets | `json_serialize`, `json_deserialize` | unsupported |
+| Read targets | `knowledge_retrieval`, `data_table_query`, `vision_understanding` | unsupported |
+| Write targets | `data_table_insert`, `data_table_update`, `data_table_delete` | unsupported |
+| Metadata and middleware | `annotation`, `runtime_middleware` | metadata or binding contract only |
+
+All other nodes have compatibility contracts and remain executable through the
+existing classic validator and runner. Capability Snapshot still exposes only
+the existing seven node kinds. Typed IR remains version 2.
+
+JSON nodes retain their current inline-error behavior until the separate pure
+node round. Agent Table Query remains disabled in Evaluator. Vision remains
+disabled in Evaluator until evaluation datasets can carry explicit file assets.
+Condition, loop, and list contracts may describe current handles, but Planner
+cannot compile them yet.
+
+## Policy service
+
+`NodePolicyService` is the common static policy query for Xpert publication,
+Evaluator, public App deployment, and Structure Evolution. Resource existence,
+fixed Toolset safety, middleware configuration, collaboration cycles, and other
+domain checks continue to run in their existing services.
+
+The V3 migration preserves the current policy boundary:
+
+- Evaluator rejects Handoff, Human Intervention, every Agent Table node, and
+  Vision Understanding.
+- public App rejects External Xpert, Plugin, Human Intervention, every Agent
+  Table node, and Vision Understanding.
+- Structure Evolution can currently add only adapter-backed
+  `workflow_agent` control nodes. Resource bindings remain separately scoped.
+
+Conditional entries are not unconditional approval. Their domain preflight
+must still pass.
+
+## API and frontend
+
+`GET /api/workflow/node-registry` returns registry version
+`xpert-workflow-node-registry-v3`, `contract_version=3`, the registry checksum,
+and a safe contract projection for each palette node.
+
+The frontend fallback contains presentation facts only. It has no contract or
+Planner claims. If the server response is absent, incomplete, or has a checksum
+shape other than V3, contract-dependent operations stay disabled while the
+classic palette may continue to render.
+
+Meta Planner Capability Snapshot version is V3 while `ir_version` remains 2.
+Persisted V2 snapshots without contract metadata remain readable. Contract
+drift is a warning for an existing proposal; missing or invalid resources still
+block approval.
+
+## Change procedure
+
+When adding or changing a node:
+
+1. update `NativeNodeKind` and its unique NodeContract together;
+2. keep presentation metadata in the workflow palette only;
+3. add or update per-node runtime validation;
+4. add a versioned Planner adapter before enabling Planner;
+5. verify adapter schema and compiler checksum parity;
+6. state every entrypoint policy explicitly;
+7. add behavior-equivalence tests for any migrated policy;
+8. run Registry, Validator, Planner, Publish, Evaluator, App, and Evolution tests.
+
+Rollback requires restoring the previous Registry and policy call sites. V3
+does not migrate Workflow, Proposal, or XpertVersion data.

--- a/docs/XPERT_RUNTIME.md
+++ b/docs/XPERT_RUNTIME.md
@@ -334,6 +334,20 @@ Queries do not accept SQL. `DataXService` compiles a bounded DSL of published in
 
 The `datax_indicators` Agent middleware compiles explicit project/model scopes into `datax_tools`. Workflow, Xpert Chat, Goal, Handoff, and Automation share this provider. Agent writes are proposal-only; approval creates a draft and explicit publication remains a separate operation. Public Apps require `allow_datax_read`, an active tool policy, and valid project/model scope, and never receive proposal tools. See `docs/XPERT_DATAX.md`.
 
+## Workflow NodeContract V3
+
+Workflow node static facts are centralized in `NodeContractRegistry`. The
+workflow Registry API, Meta Planner Capability Snapshot, Xpert publish
+preflight, Evaluator, public App deployment, and Structure Evolution consume
+the same safe projection or `NodePolicyService` decision. Resource pinning,
+Toolset safety, middleware validation, and cycle checks remain in their domain
+services.
+
+A complete contract does not enable a node in Planner or a public entrypoint.
+Compatibility contracts preserve classic runner behavior and default Planner
+to disabled. See `docs/NODE_CONTRACT_V3.md` for the checksum and migration
+contract.
+
 ## Versioned MCP And API Toolset Runtime
 
 `ToolsetStore` persists editable MCP, OpenAPI, OData, and builtin Provider Toolset definitions plus immutable published versions. A version fixes the transport, API, or Provider profile, credential references, enabled tools, aliases, default arguments, JSON Schema hashes, tool semantics, prefix, and release metadata. Xpert publication resolves `latest` to a concrete Toolset version; later discovery, import, or draft edits cannot expand an already published Xpert.

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -849,8 +849,22 @@ These nodes must not regress to title/description-only cards or require hand
 editing workflow JSON.
 
 These nodes remain private-only and are excluded from Evaluator and Xpert App
-execution. They are also marked `planner_enabled=false`: the former
+execution. They are also marked `planner_enabled=false`. The former
 `EVOAGENTX-META-PLANNER-DATA-04` round was removed from this delivery route and
 must return as a standalone Planner closed loop. Knowledge pipeline stages
 remain owned by `/rag`; workflows continue to consume them through knowledge
-bindings and retrieval/citation nodes.
+resource bindings and deterministic retrieval nodes.
+
+## NodeContract V3 compatibility layer
+
+Classic workflow now has one exhaustive `NodeContractRegistry` for every
+`NativeNodeKind`. Contracts describe JSON-safe values, ports, edge modes,
+execution and side-effect semantics, entrypoint availability, resources, and
+Planner adapter state. Existing node-specific validation and classic execution
+remain authoritative during migration; V3 adds common fail-closed checks and
+does not rewrite scheduling or SSE.
+
+The Workflow Registry is a safe UI projection of these contracts. Resource
+bindings remain non-control edges. Annotation remains metadata-only. Nodes with
+`contract_status=compatibility` continue existing runtime behavior but cannot
+enter Meta Planner by default. See `docs/NODE_CONTRACT_V3.md`.

--- a/server/evaluations/service.py
+++ b/server/evaluations/service.py
@@ -7,6 +7,7 @@ import time
 from typing import Any, Callable
 
 try:
+    from server.workflow_native.node_contracts import node_policy_service
     from server.workflow_native.schemas import NativeWorkflowDefinition
     from server.xperts.models import (
         XpertDefinition,
@@ -15,6 +16,7 @@ try:
     )
     from server.xperts.validation import validate_xpert_workflow_graph
 except ModuleNotFoundError:
+    from workflow_native.node_contracts import node_policy_service
     from workflow_native.schemas import NativeWorkflowDefinition
     from xperts.models import XpertDefinition, XpertDraft, XpertVersion
     from xperts.validation import validate_xpert_workflow_graph
@@ -26,15 +28,6 @@ from .store import (
 )
 
 
-UNSAFE_NODE_KINDS = {
-    "agent_handoff",
-    "handoff_router",
-    "human_intervention",
-    "data_table_query",
-    "data_table_insert",
-    "data_table_update",
-    "data_table_delete",
-}
 UNSAFE_MIDDLEWARE_IDS = {
     "human_in_the_loop",
     "todo_planner",
@@ -571,11 +564,13 @@ class XpertEvaluationService:
         for node in workflow.nodes:
             data = node.data if isinstance(node.data, dict) else {}
             kind = str(data.get("kind") or node.type or "")
-            if kind in UNSAFE_NODE_KINDS:
+            policy = node_policy_service.decision(kind, "evaluation")
+            if not policy.allowed:
                 issues.append(
                     {
-                        "code": "evaluation_unsafe_node",
-                        "message": f"Evaluation does not allow node kind: {kind}.",
+                        "code": policy.code or "evaluation_unsafe_node",
+                        "message": policy.message
+                        or f"Evaluation does not allow node kind: {kind}.",
                         "node_id": node.id,
                     }
                 )

--- a/server/evolutions/mutations.py
+++ b/server/evolutions/mutations.py
@@ -9,6 +9,7 @@ from typing import Any
 
 try:
     from server.meta_agent.schemas import MetaPlannerCapabilitySnapshot
+    from server.workflow_native.node_contracts import node_policy_service
     from server.workflow_native.schemas import (
         NativeWorkflowDefinition,
         NativeWorkflowEdge,
@@ -23,6 +24,7 @@ try:
     from server.xperts.models import XpertDefinition
 except ModuleNotFoundError:
     from meta_agent.schemas import MetaPlannerCapabilitySnapshot
+    from workflow_native.node_contracts import node_policy_service
     from workflow_native.schemas import (
         NativeWorkflowDefinition,
         NativeWorkflowEdge,
@@ -44,18 +46,7 @@ from .models import (
 from .store import EvolutionStateError
 
 
-SAFE_CONTROL_NODE_KINDS = {
-    "condition",
-    "iteration",
-    "list_operation",
-    "llm",
-    "parameter_extractor",
-    "question_classifier",
-    "template_transform",
-    "variable_aggregator",
-    "variable_assign",
-    "workflow_agent",
-}
+SAFE_CONTROL_NODE_KINDS = frozenset(node_policy_service.evolution_control_kinds())
 RESOURCE_KINDS = {
     "external_xpert",
     "knowledge_base",

--- a/server/meta_agent/NOTICE.md
+++ b/server/meta_agent/NOTICE.md
@@ -53,6 +53,11 @@ implementation uses its own Pydantic contracts, Workflow Node Registry,
 Runtime Middleware Registry, AuthoringProposalStore, XpertStore, workflow
 validator, and publish preflight.
 
+NodeContract V3 independently applies the audited parameter-schema and layered
+validation concepts to ModelMirror's own node, entrypoint-policy, and compiler
+adapter contracts. No EvoAgentX schema or runtime object is copied. Typed IR
+remains a ModelMirror contract and EvoAgentX is not used to execute workflows.
+
 No EvoAgentX source file is copied into this package and EvoAgentX is not a
 runtime dependency. Provider, RAG, storage, HITL, memory, tool, workflow, and
 publication runtimes remain ModelMirror implementations.

--- a/server/meta_agent/capabilities.py
+++ b/server/meta_agent/capabilities.py
@@ -81,11 +81,16 @@ def build_capability_snapshot(
     for section in node_payload.get("sections", []):
         for item in section.get("items", []):
             planner = dict(item.get("planner") or {})
+            contract = dict(item.get("contract") or {})
             compiler = planner_capability_metadata(str(item.get("kind") or ""))
             if (
                 not item.get("enabled")
                 or not planner.get("enabled")
                 or compiler is None
+                or contract.get("contract_status") != "complete"
+                or contract.get("checksum") != compiler["contract_checksum"]
+                or contract.get("compiler_checksum")
+                != compiler["compiler_checksum"]
             ):
                 continue
             nodes.append(
@@ -101,18 +106,31 @@ def build_capability_snapshot(
                         "compilable": True,
                         "ir_version": compiler["ir_version"],
                         "adapter_version": compiler["adapter_version"],
+                        "contract_version": compiler["contract_version"],
+                        "contract_checksum": compiler["contract_checksum"],
+                        "compiler_checksum": compiler["compiler_checksum"],
                         "default_data": dict(planner.get("default_data") or {}),
                         "config_constraints": dict(
                             planner.get("config_constraints") or {}
                         ),
                     },
                     "contracts": dict(item.get("contracts") or {}),
+                    "contract": contract,
                 }
             )
     for item in node_payload.get("knowledge_pipeline", {}).get("items", []):
         planner = dict(item.get("planner") or {})
+        contract = dict(item.get("contract") or {})
         compiler = planner_capability_metadata(str(item.get("kind") or ""))
-        if item.get("enabled") and planner.get("enabled") and compiler is not None:
+        if (
+            item.get("enabled")
+            and planner.get("enabled")
+            and compiler is not None
+            and contract.get("contract_status") == "complete"
+            and contract.get("checksum") == compiler["contract_checksum"]
+            and contract.get("compiler_checksum")
+            == compiler["compiler_checksum"]
+        ):
             nodes.append(
                 {
                     "kind": item["kind"],
@@ -126,12 +144,16 @@ def build_capability_snapshot(
                         "compilable": True,
                         "ir_version": compiler["ir_version"],
                         "adapter_version": compiler["adapter_version"],
+                        "contract_version": compiler["contract_version"],
+                        "contract_checksum": compiler["contract_checksum"],
+                        "compiler_checksum": compiler["compiler_checksum"],
                         "default_data": dict(planner.get("default_data") or {}),
                         "config_constraints": dict(
                             planner.get("config_constraints") or {}
                         ),
                     },
                     "contracts": dict(item.get("contracts") or {}),
+                    "contract": contract,
                 }
             )
     nodes.sort(key=lambda item: item["kind"])
@@ -291,7 +313,10 @@ def build_capability_snapshot(
         agent_ids=[item["id"] for item in expert_summaries],
     )
     payload = {
-        "version": "evoagentx-meta-planner-capabilities-v2",
+        "version": "evoagentx-meta-planner-capabilities-v3",
+        "ir_version": 2,
+        "contract_version": int(node_payload.get("contract_version") or 0),
+        "contract_checksum": str(node_payload.get("contract_checksum") or ""),
         "node_registry_version": workflow_registry.version,
         "nodes": nodes,
         "middleware": middleware,

--- a/server/meta_agent/node_adapters.py
+++ b/server/meta_agent/node_adapters.py
@@ -11,13 +11,23 @@ from .schemas import (
 )
 
 try:
+    from server.workflow_native.node_contracts import (
+        NODE_CONTRACT_VERSION,
+        canonical_checksum,
+        workflow_node_contract_registry,
+    )
     from server.workflow_native.schemas import NativeWorkflowNode, WorkflowPosition
 except ModuleNotFoundError:
+    from workflow_native.node_contracts import (
+        NODE_CONTRACT_VERSION,
+        canonical_checksum,
+        workflow_node_contract_registry,
+    )
     from workflow_native.schemas import NativeWorkflowNode, WorkflowPosition
 
 
 META_PLANNER_IR_VERSION = 2
-META_PLANNER_ADAPTER_VERSION = "typed-ir-v2"
+META_PLANNER_ADAPTER_VERSION = "node-contract-v3"
 META_PLANNER_COMPILER_MANAGED_KINDS = frozenset({"input", "output"})
 META_PLANNER_BINDING_KINDS = frozenset(
     {
@@ -48,9 +58,15 @@ class PlannerNodeAdapter:
         [MetaPlannerIRNode, BaseModel, PlannerNodeCompileContext],
         NativeWorkflowNode,
     ]
+    decompile_node: Callable[[NativeWorkflowNode], MetaPlannerIRNode]
+    contract_version: int = NODE_CONTRACT_VERSION
 
     def validate_config(self, node: MetaPlannerIRNode) -> BaseModel:
         return self.config_model.model_validate(node.config)
+
+    @property
+    def config_schema_checksum(self) -> str:
+        return canonical_checksum(self.config_model.model_json_schema())
 
 
 def _compile_workflow_agent(
@@ -59,6 +75,7 @@ def _compile_workflow_agent(
     context: PlannerNodeCompileContext,
 ) -> NativeWorkflowNode:
     config = MetaPlannerWorkflowAgentConfig.model_validate(parsed)
+    contract = workflow_node_contract_registry.require("workflow_agent")
     return NativeWorkflowNode(
         id=context.node_id,
         type="workflow_agent",
@@ -84,6 +101,12 @@ def _compile_workflow_agent(
             "maxToolDepth": "4",
             "outputVariable": context.output_variable,
             "exceptionHandling": "fail",
+            "plannerContractVersion": NODE_CONTRACT_VERSION,
+            "plannerCompilerChecksum": contract.compiler_checksum,
+            "plannerRef": node.ref,
+            "plannerTaskIds": list(node.task_ids),
+            "plannerInputs": [item.model_dump(mode="json") for item in node.inputs],
+            "plannerOutputs": [item.model_dump(mode="json") for item in node.outputs],
             **(
                 {"sourceAgentId": config.source_agent_id}
                 if config.source_agent_id
@@ -98,11 +121,44 @@ def _compile_workflow_agent(
     )
 
 
+def _decompile_workflow_agent(node: NativeWorkflowNode) -> MetaPlannerIRNode:
+    data = node.data if isinstance(node.data, dict) else {}
+    contract = workflow_node_contract_registry.require("workflow_agent")
+    if int(data.get("plannerContractVersion") or 0) != NODE_CONTRACT_VERSION:
+        raise ValueError("Workflow Agent does not carry a NodeContract V3 marker.")
+    if str(data.get("plannerCompilerChecksum") or "") != contract.compiler_checksum:
+        raise ValueError("Workflow Agent compiler contract has drifted.")
+    node_ref = str(data.get("plannerRef") or "").strip()
+    task_ids = data.get("plannerTaskIds")
+    inputs = data.get("plannerInputs")
+    outputs = data.get("plannerOutputs")
+    if not node_ref or not isinstance(task_ids, list) or not task_ids:
+        raise ValueError("Workflow Agent is missing planner round-trip metadata.")
+    return MetaPlannerIRNode.model_validate(
+        {
+            "ref": node_ref,
+            "kind": "workflow_agent",
+            "title": str(data.get("title") or data.get("agentName") or node_ref),
+            "description": str(data.get("description") or ""),
+            "task_ids": task_ids,
+            "inputs": inputs if isinstance(inputs, list) else [],
+            "outputs": outputs if isinstance(outputs, list) else [],
+            "config": {
+                "role_prompt": str(data.get("rolePrompt") or ""),
+                "task_input": str(data.get("taskInput") or ""),
+                "model_id": str(data.get("modelId") or "") or None,
+                "source_agent_id": str(data.get("sourceAgentId") or "") or None,
+            },
+        }
+    )
+
+
 PLANNER_NODE_ADAPTERS: dict[str, PlannerNodeAdapter] = {
     "workflow_agent": PlannerNodeAdapter(
         kind="workflow_agent",
         config_model=MetaPlannerWorkflowAgentConfig,
         compile_node=_compile_workflow_agent,
+        decompile_node=_decompile_workflow_agent,
     )
 }
 
@@ -118,18 +174,43 @@ def get_planner_node_adapter(kind: str) -> PlannerNodeAdapter | None:
     return PLANNER_NODE_ADAPTERS.get(kind)
 
 
+def decompile_planner_node(node: NativeWorkflowNode) -> MetaPlannerIRNode:
+    kind = str((node.data or {}).get("kind") or node.type or "")
+    adapter = get_planner_node_adapter(kind)
+    if adapter is None:
+        raise ValueError(f"Node kind {kind} has no compiler adapter.")
+    return adapter.decompile_node(node)
+
+
 def planner_capability_metadata(kind: str) -> dict[str, Any] | None:
-    if kind not in META_PLANNER_COMPILABLE_NODE_KINDS:
+    contract = workflow_node_contract_registry.get(kind)
+    if (
+        kind not in META_PLANNER_COMPILABLE_NODE_KINDS
+        or contract is None
+        or contract.contract_status != "complete"
+        or not contract.planner.enabled
+    ):
         return None
     if kind in META_PLANNER_COMPILER_MANAGED_KINDS:
         support = "compiler_managed"
     elif kind in META_PLANNER_BINDING_KINDS:
         support = "binding_only"
     else:
+        adapter = get_planner_node_adapter(kind)
+        if adapter is None or adapter.contract_version != NODE_CONTRACT_VERSION:
+            return None
+        contract_schema_checksum = canonical_checksum(
+            contract.planner.ir_config_schema
+        )
+        if adapter.config_schema_checksum != contract_schema_checksum:
+            return None
         support = "full"
     return {
         "compilable": True,
         "support": support,
         "ir_version": META_PLANNER_IR_VERSION,
         "adapter_version": META_PLANNER_ADAPTER_VERSION,
+        "contract_version": NODE_CONTRACT_VERSION,
+        "contract_checksum": contract.checksum,
+        "compiler_checksum": contract.compiler_checksum,
     }

--- a/server/meta_agent/schemas.py
+++ b/server/meta_agent/schemas.py
@@ -4,6 +4,11 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+try:
+    from server.workflow_native.node_contracts import WorkflowAgentPlannerConfig
+except ModuleNotFoundError:
+    from workflow_native.node_contracts import WorkflowAgentPlannerConfig
+
 
 class MetaAgentGenerateRequest(BaseModel):
     goal: str = Field(min_length=10, max_length=20_000)
@@ -203,11 +208,7 @@ class MetaPlannerIRFinalOutput(BaseModel):
     variable: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
 
 
-class MetaPlannerWorkflowAgentConfig(BaseModel):
-    role_prompt: str = Field(min_length=1, max_length=20_000)
-    task_input: str = Field(min_length=1, max_length=8_000)
-    model_id: str | None = Field(default=None, max_length=300)
-    source_agent_id: str | None = Field(default=None, min_length=1, max_length=160)
+MetaPlannerWorkflowAgentConfig = WorkflowAgentPlannerConfig
 
 
 class MetaPlannerTypedBlueprintV2(BaseModel):
@@ -232,6 +233,11 @@ class MetaPlannerTypedBlueprintV2(BaseModel):
 
 class MetaPlannerCapabilitySnapshot(BaseModel):
     version: str
+    ir_version: Literal[2] = 2
+    # Persisted V2 proposals did not carry NodeContract metadata. Keep them
+    # readable; newly built snapshots always set the V3 values explicitly.
+    contract_version: int = 2
+    contract_checksum: str = ""
     snapshot_hash: str
     generated_at: float
     node_registry_version: str

--- a/server/tests/test_meta_planner_v2.py
+++ b/server/tests/test_meta_planner_v2.py
@@ -323,7 +323,10 @@ def test_capability_api_returns_stable_safe_contract():
     response = client.get("/api/meta-agent/capabilities")
     assert response.status_code == 200
     payload = response.json()
-    assert payload["version"] == "evoagentx-meta-planner-capabilities-v2"
+    assert payload["version"] == "evoagentx-meta-planner-capabilities-v3"
+    assert payload["ir_version"] == 2
+    assert payload["contract_version"] == 3
+    assert len(payload["contract_checksum"]) == 64
     assert payload["snapshot_hash"]
     assert isinstance(payload["nodes"], list)
     assert isinstance(payload["middleware"], list)
@@ -345,6 +348,11 @@ def test_capability_snapshot_only_exposes_compilable_node_kinds():
     }
     assert all(item["planner"]["compilable"] for item in snapshot.nodes)
     assert all(item["planner"]["ir_version"] == 2 for item in snapshot.nodes)
+    assert all(item["contract"]["contract_status"] == "complete" for item in snapshot.nodes)
+    assert all(
+        item["planner"]["contract_checksum"] == item["contract"]["checksum"]
+        for item in snapshot.nodes
+    )
 
 
 def test_compiler_creates_control_and_five_binding_edge_shapes():

--- a/server/tests/test_workflow_data_table_nodes.py
+++ b/server/tests/test_workflow_data_table_nodes.py
@@ -246,7 +246,11 @@ def test_data_table_nodes_are_runtime_enabled_but_planner_deferred() -> None:
         "data_table_delete",
     }
     assert all(item.enabled is True for item in items.values())
-    assert all(item.planner_enabled is False for item in items.values())
+    assert all(item.to_payload()["planner"]["enabled"] is False for item in items.values())
+    assert all(
+        item.to_payload()["contract"]["contract_status"] == "complete"
+        for item in items.values()
+    )
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_workflow_node_contracts.py
+++ b/server/tests/test_workflow_node_contracts.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from typing import get_args
+
+import pytest
+
+from server.meta_agent.node_adapters import (
+    META_PLANNER_COMPILABLE_NODE_KINDS,
+    PlannerNodeCompileContext,
+    decompile_planner_node,
+    get_planner_node_adapter,
+    planner_capability_metadata,
+)
+from server.meta_agent.schemas import (
+    MetaPlannerCapabilitySnapshot,
+    MetaPlannerIRInputBinding,
+    MetaPlannerIRNode,
+    MetaPlannerIROutputBinding,
+    MetaPlannerWorkflowAgentConfig,
+)
+from server.workflow_native.node_contracts import (
+    NODE_CONTRACT_VERSION,
+    canonical_checksum,
+    node_policy_service,
+    workflow_node_contract_registry,
+)
+from server.workflow_native.schemas import NativeNodeKind, WorkflowPosition
+from server.xpert_runtime.workflow_node_registry import workflow_node_registry
+
+
+EXPECTED_PLANNER_KINDS = {
+    "input",
+    "output",
+    "workflow_agent",
+    "external_xpert",
+    "knowledge_base",
+    "toolset_resource",
+    "plugin_resource",
+}
+
+
+def test_contract_registry_covers_every_native_kind_once() -> None:
+    expected = set(get_args(NativeNodeKind))
+
+    assert workflow_node_contract_registry.kinds() == expected
+    assert len(workflow_node_contract_registry.list()) == len(expected)
+    assert workflow_node_contract_registry.get("not-a-node") is None
+    with pytest.raises(KeyError, match="unknown workflow node kind"):
+        workflow_node_contract_registry.require("not-a-node")
+
+
+def test_contract_projection_and_checksums_are_deterministic() -> None:
+    first = workflow_node_contract_registry.to_safe_payload()
+    second = workflow_node_contract_registry.to_safe_payload()
+
+    assert first == second
+    assert first["contract_version"] == NODE_CONTRACT_VERSION
+    assert len(first["contract_checksum"]) == 64
+    assert canonical_checksum(first["items"]) == canonical_checksum(second["items"])
+    for item in first["items"]:
+        assert item["config_schema"]["type"] == "object"
+        assert item["kind"]
+        assert len(item["checksum"]) == 64
+        assert len(item["compiler_checksum"]) == 64
+        assert item["execution"]
+        assert item["availability"]
+        assert item["planner"]
+
+
+def test_only_current_seven_nodes_have_valid_planner_contracts() -> None:
+    available = {
+        kind
+        for kind in workflow_node_contract_registry.kinds()
+        if planner_capability_metadata(kind) is not None
+    }
+
+    assert available == EXPECTED_PLANNER_KINDS
+    assert available == set(META_PLANNER_COMPILABLE_NODE_KINDS)
+    for kind in available:
+        contract = workflow_node_contract_registry.require(kind)
+        metadata = planner_capability_metadata(kind)
+        assert metadata is not None
+        assert contract.contract_status == "complete"
+        assert metadata["contract_checksum"] == contract.checksum
+        assert metadata["compiler_checksum"] == contract.compiler_checksum
+
+
+def test_workflow_agent_adapter_round_trip_is_stable() -> None:
+    adapter = get_planner_node_adapter("workflow_agent")
+    assert adapter is not None
+    contract = workflow_node_contract_registry.require("workflow_agent")
+    assert adapter.config_schema_checksum == canonical_checksum(
+        contract.planner.ir_config_schema
+    )
+    ir_node = MetaPlannerIRNode(
+        ref="researcher",
+        kind="workflow_agent",
+        title="Researcher",
+        description="Find grounded evidence.",
+        task_ids=["research"],
+        inputs=[
+            MetaPlannerIRInputBinding(
+                port="request", variable="user_input", value_type="string"
+            )
+        ],
+        outputs=[
+            MetaPlannerIROutputBinding(
+                port="result", variable="research_output", value_type="string"
+            )
+        ],
+        config=MetaPlannerWorkflowAgentConfig(
+            role_prompt="Find grounded evidence.",
+            task_input="{{user_input}}",
+            model_id="model/agent",
+        ).model_dump(mode="json"),
+    )
+    context = PlannerNodeCompileContext(
+        node_id="planner-researcher",
+        position=WorkflowPosition(x=320, y=180),
+        default_agent_model_id="model/default",
+        output_variable="research_output",
+        acceptance_criteria="Cite the evidence.",
+        has_runtime_resources=True,
+        requires_runtime_mode=False,
+    )
+
+    compiled = adapter.compile_node(ir_node, adapter.validate_config(ir_node), context)
+    recovered = decompile_planner_node(compiled)
+    recompiled = adapter.compile_node(
+        recovered, adapter.validate_config(recovered), context
+    )
+
+    assert recovered == ir_node
+    assert recompiled.model_dump(mode="json") == compiled.model_dump(mode="json")
+
+
+def test_policy_service_preserves_current_entrypoint_boundaries() -> None:
+    evaluation_denied = {
+        "agent_handoff",
+        "handoff_router",
+        "human_intervention",
+        "vision_understanding",
+        "data_table_query",
+        "data_table_insert",
+        "data_table_update",
+        "data_table_delete",
+    }
+    app_denied = {
+        "external_xpert",
+        "plugin_resource",
+        "human_intervention",
+        "vision_understanding",
+        "data_table_query",
+        "data_table_insert",
+        "data_table_update",
+        "data_table_delete",
+    }
+
+    assert {
+        kind
+        for kind in workflow_node_contract_registry.kinds()
+        if not node_policy_service.decision(kind, "evaluation").allowed
+    } == evaluation_denied
+    assert {
+        kind
+        for kind in workflow_node_contract_registry.kinds()
+        if not node_policy_service.decision(kind, "app").allowed
+    } == app_denied
+    assert node_policy_service.evolution_control_kinds() == {"workflow_agent"}
+    assert not node_policy_service.decision("not-a-node", "app").allowed
+
+
+def test_runtime_middleware_contract_preserves_linear_and_binding_edges() -> None:
+    edge = workflow_node_contract_registry.require("runtime_middleware").edge
+
+    assert edge.modes == ("control", "binding")
+    assert edge.topology_modes == ("control",)
+    assert edge.supports("control")
+    assert edge.supports("binding")
+    assert not edge.supports("metadata")
+
+
+def test_old_capability_snapshot_remains_readable() -> None:
+    snapshot = MetaPlannerCapabilitySnapshot.model_validate(
+        {
+            "version": "evoagentx-meta-planner-capabilities-v2",
+            "snapshot_hash": "legacy-hash",
+            "generated_at": 1,
+            "node_registry_version": "xpert-workflow-node-registry-v2",
+            "nodes": [],
+            "middleware": [],
+            "external_xperts": [],
+            "knowledge_bases": [],
+            "toolsets": [],
+            "plugins": [],
+            "prompt_profiles": [],
+            "models": [],
+            "default_scope": {},
+        }
+    )
+
+    assert snapshot.ir_version == 2
+    assert snapshot.contract_version == 2
+    assert snapshot.contract_checksum == ""
+
+
+def test_registry_ui_projection_is_v3_and_contains_no_runtime_payloads() -> None:
+    payload = workflow_node_registry.to_payload()
+    serialized = str(payload).lower()
+    items = [
+        item
+        for section in payload["sections"]
+        for item in section["items"]
+    ] + list(payload["knowledge_pipeline"]["items"])
+
+    assert payload["version"] == "xpert-workflow-node-registry-v3"
+    assert payload["contract_version"] == 3
+    assert payload["contract_checksum"] == workflow_node_contract_registry.checksum
+    assert all(item["contract"]["kind"] == item["kind"] for item in items)
+    assert all(item["planner"]["contract_checksum"] for item in items)
+    assert "credential" not in serialized
+    assert "api_key" not in serialized
+    assert "embedding" not in serialized

--- a/server/tests/test_xpert_runtime_workflow_node_registry.py
+++ b/server/tests/test_xpert_runtime_workflow_node_registry.py
@@ -31,7 +31,9 @@ def _registry() -> WorkflowNodeRegistry:
 def test_workflow_node_registry_returns_workflow_and_knowledge_tabs() -> None:
     payload = _registry().to_payload()
 
-    assert payload["version"] == "xpert-workflow-node-registry-v2"
+    assert payload["version"] == "xpert-workflow-node-registry-v3"
+    assert payload["contract_version"] == 3
+    assert len(payload["contract_checksum"]) == 64
     assert {tab["id"] for tab in payload["tabs"]} == {"workflow", "knowledge"}
     assert payload["sections"]
     knowledge_items = payload["knowledge_pipeline"]["items"]
@@ -44,15 +46,14 @@ def test_workflow_node_registry_returns_workflow_and_knowledge_tabs() -> None:
 
     knowledge_base, retrieval, vision = knowledge_items
     assert knowledge_base["planner"]["support"] == "binding_only"
-    assert knowledge_base["contracts"]["resources"] == ["knowledge_base"]
+    assert knowledge_base["contracts"]["resources"][0]["kind"] == "knowledge_base"
     assert retrieval["planner"]["enabled"] is False
     assert retrieval["planner"]["support"] == "unsupported"
-    assert retrieval["contracts"]["outputs"] == {
-        "context": "string",
-        "result": "object",
-    }
+    assert retrieval["contracts"]["outputs"][0]["name"] == "result"
+    assert retrieval["contracts"]["outputs"][0]["value_schema"]["type"] == "any"
+    assert len(retrieval["contracts"]["outputs"][0]["value_schema"]["any_of"]) == 2
     assert vision["planner"]["support"] == "unsupported"
-    assert vision["contracts"]["outputs"] == {"outputVariable": "object"}
+    assert vision["contracts"]["outputs"][0]["value_schema"]["type"] == "object"
     assert vision["metadata"]["private_only"] is True
 
 
@@ -97,7 +98,9 @@ def test_document_extractor_palette_follows_file_asset_gate(monkeypatch) -> None
     )
     assert item.enabled is True
     assert item.metadata == {}
-    assert item.planner_default_data["assetIdVariable"] == "document_asset_id"
+    projection = item.to_payload()
+    assert projection["contract"]["contract_status"] == "compatibility"
+    assert projection["planner"]["enabled"] is False
 
 
 def test_placeholders_are_disabled_and_do_not_declare_kind() -> None:
@@ -121,7 +124,9 @@ async def test_workflow_node_registry_api_returns_stable_shape(
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["version"] == "xpert-workflow-node-registry-v2"
+    assert payload["version"] == "xpert-workflow-node-registry-v3"
+    assert payload["contract_version"] == 3
+    assert len(payload["contract_checksum"]) == 64
     assert isinstance(payload["tabs"], list)
     assert isinstance(payload["sections"], list)
     assert isinstance(payload["knowledge_pipeline"], dict)

--- a/server/tests/test_xpert_structure_evolutions.py
+++ b/server/tests/test_xpert_structure_evolutions.py
@@ -19,6 +19,7 @@ from server.evolutions.store import EvolutionStateError, XpertEvolutionStore
 from server.meta_agent.schemas import MetaPlannerCapabilitySnapshot, MetaPlannerScope
 from server.prompts.store import PromptProfileStore
 from server.xpert_runtime.authoring_store import AuthoringProposalStore
+from server.xpert_runtime.workflow_node_registry import workflow_node_registry
 from server.xperts import XpertStore
 
 
@@ -73,46 +74,23 @@ class _EvaluationService:
 
 
 def _snapshot() -> MetaPlannerCapabilitySnapshot:
+    registry_payload = workflow_node_registry.to_payload()
     nodes = [
-        {
-            "kind": "workflow_agent",
-            "title": "Workflow Agent",
-            "description": "Agent",
-            "planner": {"enabled": True, "default_data": {}},
-        },
-        {
-            "kind": "condition",
-            "title": "Condition",
-            "description": "Branch",
-            "planner": {"enabled": True, "default_data": {}},
-        },
-        {
-            "kind": "template_transform",
-            "title": "Template",
-            "description": "Transform",
-            "planner": {"enabled": True, "default_data": {}},
-        },
-        {
-            "kind": "list_operation",
-            "title": "List Operation",
-            "description": "List",
-            "planner": {"enabled": True, "default_data": {}},
-        },
-        {
-            "kind": "input",
-            "title": "Input",
-            "description": "Input",
-            "planner": {"enabled": True, "default_data": {}},
-        },
-        {
-            "kind": "output",
-            "title": "Output",
-            "description": "Output",
-            "planner": {"enabled": True, "default_data": {}},
-        },
+        copy.deepcopy(item)
+        for section in registry_payload["sections"]
+        for item in section["items"]
+        if item.get("enabled") and item.get("planner", {}).get("enabled")
     ]
+    nodes.extend(
+        copy.deepcopy(item)
+        for item in registry_payload["knowledge_pipeline"]["items"]
+        if item.get("enabled") and item.get("planner", {}).get("enabled")
+    )
     return MetaPlannerCapabilitySnapshot(
-        version="snapshot-v1",
+        version="evoagentx-meta-planner-capabilities-v3",
+        ir_version=2,
+        contract_version=registry_payload["contract_version"],
+        contract_checksum=registry_payload["contract_checksum"],
         snapshot_hash="snapshot-hash",
         generated_at=1,
         node_registry_version="registry-v1",
@@ -181,12 +159,7 @@ def _compiler(seed: str = "seed") -> StructureMutationCompiler:
     return StructureMutationCompiler(
         snapshot=_snapshot(),
         scope=EvolutionStructureScope(
-            allowed_node_kinds=[
-                "workflow_agent",
-                "condition",
-                "template_transform",
-                "list_operation",
-            ],
+            allowed_node_kinds=["workflow_agent"],
             external_xpert_ids=["specialist"],
             knowledge_base_ids=["kb-one"],
             toolset_ids=["toolset-one"],
@@ -285,7 +258,7 @@ def test_invalid_control_cycle_is_rejected_before_evaluation(tmp_path: Path) -> 
         )
 
 
-def test_control_add_replace_remove_and_edge_mutations(tmp_path: Path) -> None:
+def test_control_add_remove_edges_and_reject_agent_replacement(tmp_path: Path) -> None:
     baseline = _xpert(tmp_path)
     added, added_diff = _compiler("add").apply(
         baseline,
@@ -294,7 +267,7 @@ def test_control_add_replace_remove_and_edge_mutations(tmp_path: Path) -> None:
             StructureMutation(
                 op="add_control_node",
                 ref="format",
-                kind="template_transform",
+                kind="workflow_agent",
             ),
             StructureMutation(
                 op="add_control_edge",
@@ -309,30 +282,30 @@ def test_control_add_replace_remove_and_edge_mutations(tmp_path: Path) -> None:
         ],
     )
     added_node_id = added_diff["added_nodes"][0]["node_id"]
-    replaced, replaced_diff = _compiler("replace").apply(
-        added,
-        [
-            StructureMutation(
-                op="replace_control_node",
-                node_id=added_node_id,
-                kind="list_operation",
-            )
-        ],
-    )
-    assert replaced_diff["replaced_nodes"][0]["to_kind"] == "list_operation"
+    with pytest.raises(EvolutionStateError, match="cannot be replaced"):
+        _compiler("replace").apply(
+            added,
+            [
+                StructureMutation(
+                    op="replace_control_node",
+                    node_id=added_node_id,
+                    kind="workflow_agent",
+                )
+            ],
+        )
 
     incoming = next(
         edge
-        for edge in replaced.draft.workflow.edges
+        for edge in added.draft.workflow.edges
         if edge.target == added_node_id
     )
     outgoing = next(
         edge
-        for edge in replaced.draft.workflow.edges
+        for edge in added.draft.workflow.edges
         if edge.source == added_node_id
     )
     removed, removed_diff = _compiler("remove").apply(
-        replaced,
+        added,
         [
             StructureMutation(op="remove_control_edge", edge_id=incoming.id),
             StructureMutation(op="remove_control_edge", edge_id=outgoing.id),

--- a/server/workflow_native/node_contracts.py
+++ b/server/workflow_native/node_contracts.py
@@ -1,0 +1,1082 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Literal, get_args
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from .schemas import NativeNodeKind
+
+
+NODE_CONTRACT_VERSION = 3
+
+WorkflowValueType = Literal[
+    "any",
+    "null",
+    "string",
+    "number",
+    "integer",
+    "boolean",
+    "object",
+    "array",
+]
+NodeContractStatus = Literal["complete", "compatibility"]
+NodePortDirection = Literal["input", "output"]
+NodePortCardinality = Literal["one", "many"]
+NodePortBinding = Literal["variable", "literal", "resource", "none"]
+NodeEdgeMode = Literal["control", "binding", "metadata"]
+NodeSideEffect = Literal[
+    "none",
+    "read",
+    "write",
+    "external_read",
+    "external_write",
+    "code_execution",
+    "unknown",
+]
+NodeErrorSemantics = Literal[
+    "exception_strategy",
+    "fail_closed",
+    "ignored",
+    "legacy_inline_error",
+    "unknown",
+]
+NodeAvailabilityState = Literal["allow", "deny", "conditional"]
+NodePlannerSupport = Literal[
+    "full",
+    "binding_only",
+    "metadata_only",
+    "unsupported",
+]
+NodePlannerCompilationMode = Literal[
+    "adapter",
+    "binding",
+    "compiler_managed",
+    "none",
+]
+
+
+def canonical_checksum(value: Any) -> str:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json", exclude_none=True)
+    encoded = json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class WorkflowValueSchema(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    type: WorkflowValueType = "any"
+    nullable: bool = False
+    items: "WorkflowValueSchema | None" = None
+    properties: dict[str, "WorkflowValueSchema"] = Field(default_factory=dict)
+    required: tuple[str, ...] = ()
+    any_of: tuple["WorkflowValueSchema", ...] = ()
+
+    @model_validator(mode="after")
+    def validate_shape(self) -> "WorkflowValueSchema":
+        if self.items is not None and self.type != "array":
+            raise ValueError("items is only valid for array schemas")
+        if (self.properties or self.required) and self.type != "object":
+            raise ValueError("properties and required are only valid for object schemas")
+        if any(name not in self.properties for name in self.required):
+            raise ValueError("required properties must be declared")
+        if len(self.any_of) > 4:
+            raise ValueError("any_of supports at most four alternatives")
+        return self
+
+
+class NodePortContract(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_-]{0,63}$")
+    direction: NodePortDirection
+    value_schema: WorkflowValueSchema = Field(default_factory=WorkflowValueSchema)
+    required: bool = False
+    cardinality: NodePortCardinality = "one"
+    binding: NodePortBinding = "variable"
+
+
+class NodeEdgeContract(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    modes: tuple[NodeEdgeMode, ...] = ("control",)
+    topology_modes: tuple[NodeEdgeMode, ...] = ("control",)
+    allowed_source_handles: tuple[str, ...] = ()
+    allowed_target_handles: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_modes(self) -> "NodeEdgeContract":
+        if len(set(self.modes)) != len(self.modes):
+            raise ValueError("edge modes must be unique")
+        if len(set(self.topology_modes)) != len(self.topology_modes):
+            raise ValueError("topology modes must be unique")
+        if any(mode not in self.modes for mode in self.topology_modes):
+            raise ValueError("topology modes must be supported edge modes")
+        return self
+
+    def supports(self, mode: NodeEdgeMode) -> bool:
+        return mode in self.modes
+
+
+class NodeExecutionPolicy(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    side_effect: NodeSideEffect = "unknown"
+    deterministic: bool = False
+    idempotent: bool = False
+    external_io: bool = False
+    can_wait: bool = False
+    error_semantics: NodeErrorSemantics = "unknown"
+    security_category: str = "legacy"
+
+
+class NodeAvailabilityRule(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    state: NodeAvailabilityState = "conditional"
+    code: str = ""
+    message: str = ""
+
+
+class NodeAvailabilityPolicy(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    workflow: NodeAvailabilityRule = Field(
+        default_factory=lambda: NodeAvailabilityRule(state="allow")
+    )
+    xpert: NodeAvailabilityRule = Field(
+        default_factory=lambda: NodeAvailabilityRule(state="allow")
+    )
+    goal: NodeAvailabilityRule = Field(
+        default_factory=lambda: NodeAvailabilityRule(state="allow")
+    )
+    handoff: NodeAvailabilityRule = Field(
+        default_factory=lambda: NodeAvailabilityRule(state="allow")
+    )
+    app: NodeAvailabilityRule = Field(default_factory=NodeAvailabilityRule)
+    evaluation: NodeAvailabilityRule = Field(default_factory=NodeAvailabilityRule)
+    evolution: NodeAvailabilityRule = Field(
+        default_factory=lambda: NodeAvailabilityRule(state="deny")
+    )
+
+
+class NodeResourceContract(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    kind: str
+    id_field: str
+    required: bool = True
+    version_policy_field: str | None = None
+    pinned_version_field: str | None = None
+    dynamic_schema: bool = False
+
+
+class NodePlannerContract(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    enabled: bool = False
+    support: NodePlannerSupport = "unsupported"
+    compilation_mode: NodePlannerCompilationMode = "none"
+    ir_version: int = 2
+    adapter_version: str = ""
+    default_data: dict[str, Any] = Field(default_factory=dict)
+    config_constraints: dict[str, Any] = Field(default_factory=dict)
+    ir_config_schema: dict[str, Any] = Field(default_factory=dict)
+
+
+class NodeContract(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    kind: str
+    contract_status: NodeContractStatus = "compatibility"
+    config_schema: dict[str, Any] = Field(default_factory=dict)
+    ports: tuple[NodePortContract, ...] = ()
+    edge: NodeEdgeContract = Field(default_factory=NodeEdgeContract)
+    execution: NodeExecutionPolicy = Field(default_factory=NodeExecutionPolicy)
+    availability: NodeAvailabilityPolicy = Field(default_factory=NodeAvailabilityPolicy)
+    resources: tuple[NodeResourceContract, ...] = ()
+    planner: NodePlannerContract = Field(default_factory=NodePlannerContract)
+    deprecated: bool = False
+    replacement_kind: str | None = None
+
+    @model_validator(mode="after")
+    def validate_complete_contract(self) -> "NodeContract":
+        if self.contract_status == "complete" and not self.config_schema:
+            raise ValueError(f"complete node contract {self.kind} needs config_schema")
+        if self.planner.enabled and self.contract_status != "complete":
+            raise ValueError("planner-enabled nodes need complete contracts")
+        if self.planner.enabled and self.planner.support == "unsupported":
+            raise ValueError("planner-enabled nodes cannot be unsupported")
+        return self
+
+    def compiler_payload(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "contract_version": NODE_CONTRACT_VERSION,
+            "config_schema": self.config_schema,
+            "ports": [port.model_dump(mode="json") for port in self.ports],
+            "edge": self.edge.model_dump(mode="json"),
+            "resources": [resource.model_dump(mode="json") for resource in self.resources],
+            "planner": {
+                "support": self.planner.support,
+                "compilation_mode": self.planner.compilation_mode,
+                "ir_version": self.planner.ir_version,
+                "adapter_version": self.planner.adapter_version,
+                "ir_config_schema": self.planner.ir_config_schema,
+            },
+        }
+
+    @property
+    def compiler_checksum(self) -> str:
+        return canonical_checksum(self.compiler_payload())
+
+    @property
+    def checksum(self) -> str:
+        return canonical_checksum(self.model_dump(mode="json", exclude_none=True))
+
+    def to_safe_payload(self) -> dict[str, Any]:
+        payload = self.model_dump(mode="json", exclude_none=True)
+        payload.update(
+            {
+                "contract_version": NODE_CONTRACT_VERSION,
+                "checksum": self.checksum,
+                "compiler_checksum": self.compiler_checksum,
+            }
+        )
+        return payload
+
+
+class WorkflowAgentPlannerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    role_prompt: str = Field(min_length=1, max_length=20_000)
+    task_input: str = Field(min_length=1, max_length=8_000)
+    model_id: str | None = Field(default=None, max_length=300)
+    source_agent_id: str | None = Field(default=None, min_length=1, max_length=160)
+
+
+@dataclass(frozen=True, slots=True)
+class NodePolicyDecision:
+    allowed: bool
+    conditional: bool
+    code: str = ""
+    message: str = ""
+
+
+class NodeContractRegistry:
+    def __init__(self, contracts: list[NodeContract]) -> None:
+        self._contracts: dict[str, NodeContract] = {}
+        for contract in contracts:
+            if contract.kind in self._contracts:
+                raise ValueError(f"duplicate node contract: {contract.kind}")
+            self._contracts[contract.kind] = contract
+        expected = set(get_args(NativeNodeKind))
+        missing = expected - set(self._contracts)
+        extra = set(self._contracts) - expected
+        if missing or extra:
+            raise ValueError(
+                "node contract coverage mismatch; "
+                f"missing={sorted(missing)}, extra={sorted(extra)}"
+            )
+
+    def kinds(self) -> set[str]:
+        return set(self._contracts)
+
+    def list(self) -> list[NodeContract]:
+        return [self._contracts[kind] for kind in sorted(self._contracts)]
+
+    def get(self, kind: str) -> NodeContract | None:
+        return self._contracts.get(kind)
+
+    def require(self, kind: str) -> NodeContract:
+        contract = self.get(kind)
+        if contract is None:
+            raise KeyError(f"unknown workflow node kind: {kind}")
+        return contract
+
+    @property
+    def checksum(self) -> str:
+        return canonical_checksum(
+            [contract.to_safe_payload() for contract in self.list()]
+        )
+
+    def to_safe_payload(self) -> dict[str, Any]:
+        return {
+            "contract_version": NODE_CONTRACT_VERSION,
+            "contract_checksum": self.checksum,
+            "items": [contract.to_safe_payload() for contract in self.list()],
+        }
+
+
+class NodePolicyService:
+    def __init__(self, registry: NodeContractRegistry) -> None:
+        self.registry = registry
+
+    def decision(self, kind: str, entrypoint: str) -> NodePolicyDecision:
+        contract = self.registry.get(kind)
+        if contract is None:
+            return NodePolicyDecision(
+                allowed=False,
+                conditional=False,
+                code="unknown_node_kind",
+                message=f"Unknown workflow node kind: {kind}.",
+            )
+        rule = getattr(contract.availability, entrypoint, None)
+        if not isinstance(rule, NodeAvailabilityRule):
+            return NodePolicyDecision(
+                allowed=False,
+                conditional=False,
+                code="unknown_node_entrypoint",
+                message=f"Unknown node entrypoint: {entrypoint}.",
+            )
+        return NodePolicyDecision(
+            allowed=rule.state != "deny",
+            conditional=rule.state == "conditional",
+            code=rule.code,
+            message=rule.message,
+        )
+
+    def evolution_control_kinds(self) -> set[str]:
+        return {
+            contract.kind
+            for contract in self.registry.list()
+            if contract.contract_status == "complete"
+            and contract.planner.enabled
+            and contract.planner.support == "full"
+            and contract.planner.compilation_mode == "adapter"
+            and contract.availability.evolution.state == "allow"
+        }
+
+
+def _object_schema(
+    properties: dict[str, Any] | None = None,
+    *,
+    required: list[str] | None = None,
+    additional_properties: bool = True,
+) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": dict(properties or {}),
+        "required": list(required or []),
+        "additionalProperties": additional_properties,
+    }
+
+
+def _rule(
+    state: NodeAvailabilityState,
+    *,
+    code: str = "",
+    message: str = "",
+) -> NodeAvailabilityRule:
+    return NodeAvailabilityRule(state=state, code=code, message=message)
+
+
+def _availability(
+    *,
+    app: NodeAvailabilityRule | None = None,
+    evaluation: NodeAvailabilityRule | None = None,
+    evolution: NodeAvailabilityRule | None = None,
+) -> NodeAvailabilityPolicy:
+    return NodeAvailabilityPolicy(
+        app=app or _rule("conditional"),
+        evaluation=evaluation or _rule("conditional"),
+        evolution=evolution or _rule("deny"),
+    )
+
+
+def _planner(
+    *,
+    enabled: bool = False,
+    support: NodePlannerSupport = "unsupported",
+    compilation_mode: NodePlannerCompilationMode = "none",
+    adapter_version: str = "",
+    default_data: dict[str, Any] | None = None,
+    constraints: dict[str, Any] | None = None,
+    ir_config_schema: dict[str, Any] | None = None,
+) -> NodePlannerContract:
+    return NodePlannerContract(
+        enabled=enabled,
+        support=support,
+        compilation_mode=compilation_mode,
+        adapter_version=adapter_version,
+        default_data=dict(default_data or {}),
+        config_constraints=dict(constraints or {}),
+        ir_config_schema=dict(ir_config_schema or {}),
+    )
+
+
+def _compatibility_contract(kind: str) -> NodeContract:
+    return NodeContract(
+        kind=kind,
+        config_schema=_object_schema(),
+        planner=_planner(),
+    )
+
+
+def _complete_contracts() -> dict[str, NodeContract]:
+    any_value = WorkflowValueSchema()
+    string_value = WorkflowValueSchema(type="string")
+    object_value = WorkflowValueSchema(type="object")
+    array_object_value = WorkflowValueSchema(type="array", items=object_value)
+    planner_adapter_version = "node-contract-v3"
+    contracts: dict[str, NodeContract] = {}
+
+    contracts["input"] = NodeContract(
+        kind="input",
+        contract_status="complete",
+        config_schema=_object_schema(
+            {
+                "variableName": {"type": "string"},
+                "historyVariable": {"type": "string"},
+            }
+        ),
+        ports=(
+            NodePortContract(
+                name="user_input", direction="output", value_schema=string_value
+            ),
+            NodePortContract(
+                name="conversation_history",
+                direction="output",
+                value_schema=WorkflowValueSchema(
+                    type="array", items=WorkflowValueSchema(type="object")
+                ),
+                required=False,
+            ),
+        ),
+        execution=NodeExecutionPolicy(
+            side_effect="none",
+            deterministic=True,
+            idempotent=True,
+            error_semantics="fail_closed",
+            security_category="input",
+        ),
+        planner=_planner(
+            enabled=True,
+            support="full",
+            compilation_mode="compiler_managed",
+            default_data={"variableName": "user_input"},
+        ),
+    )
+    contracts["output"] = NodeContract(
+        kind="output",
+        contract_status="complete",
+        config_schema=_object_schema(
+            {
+                "outputVariable": {"type": "string"},
+                "template": {"type": "string"},
+            }
+        ),
+        ports=(
+            NodePortContract(
+                name="result", direction="input", value_schema=any_value, required=True
+            ),
+        ),
+        execution=NodeExecutionPolicy(
+            side_effect="none",
+            deterministic=True,
+            idempotent=True,
+            error_semantics="fail_closed",
+            security_category="output",
+        ),
+        planner=_planner(
+            enabled=True,
+            support="full",
+            compilation_mode="compiler_managed",
+        ),
+    )
+    contracts["workflow_agent"] = NodeContract(
+        kind="workflow_agent",
+        contract_status="complete",
+        config_schema=_object_schema(
+            {
+                "modelId": {"type": "string"},
+                "rolePrompt": {"type": "string"},
+                "taskInput": {"type": "string"},
+                "outputVariable": {"type": "string"},
+            },
+            required=["modelId", "rolePrompt", "taskInput", "outputVariable"],
+        ),
+        ports=(
+            NodePortContract(
+                name="task", direction="input", value_schema=string_value, required=True
+            ),
+            NodePortContract(
+                name="result", direction="output", value_schema=string_value
+            ),
+        ),
+        execution=NodeExecutionPolicy(
+            side_effect="external_read",
+            external_io=True,
+            error_semantics="exception_strategy",
+            security_category="model",
+        ),
+        availability=_availability(evolution=_rule("allow")),
+        planner=_planner(
+            enabled=True,
+            support="full",
+            compilation_mode="adapter",
+            adapter_version=planner_adapter_version,
+            default_data={
+                "toolMode": "none",
+                "maxIterations": "6",
+                "outputVariable": "agent_output",
+            },
+            constraints={
+                "required": ["modelId", "rolePrompt", "taskInput", "outputVariable"]
+            },
+            ir_config_schema=WorkflowAgentPlannerConfig.model_json_schema(),
+        ),
+    )
+
+    binding_specs = {
+        "external_xpert": (
+            "expert-binding",
+            "expert",
+            "xpert",
+            "xpertId",
+            "pinnedVersion",
+            _rule(
+                "deny",
+                code="app_external_xpert_forbidden",
+                message="Public Xpert Apps cannot deploy external Xpert collaborators.",
+            ),
+        ),
+        "knowledge_base": (
+            "knowledge-binding",
+            "knowledge",
+            "knowledge_base",
+            "knowledgeBaseId",
+            None,
+            _rule("conditional"),
+        ),
+        "toolset_resource": (
+            "toolset-binding",
+            "toolset",
+            "toolset",
+            "toolsetId",
+            "pinnedVersion",
+            _rule("conditional"),
+        ),
+        "plugin_resource": (
+            "plugin-binding",
+            "plugin",
+            "plugin",
+            "pluginId",
+            "pinnedVersion",
+            _rule(
+                "deny",
+                code="app_plugin_resource_forbidden",
+                message=(
+                    "Public Xpert Apps cannot deploy declarative Plugin resources. "
+                    "Bind public-safe Prompt Profiles directly instead."
+                ),
+            ),
+        ),
+    }
+    for kind, (
+        source_handle,
+        target_handle,
+        resource_kind,
+        id_field,
+        pinned_field,
+        app_rule,
+    ) in binding_specs.items():
+        properties: dict[str, Any] = {id_field: {"type": "string"}}
+        required_fields = [id_field]
+        if kind == "external_xpert":
+            properties.update(
+                {
+                    "toolName": {
+                        "type": "string",
+                        "pattern": r"^[A-Za-z_][A-Za-z0-9_-]{0,63}$",
+                    },
+                    "description": {"type": "string"},
+                }
+            )
+            required_fields.append("toolName")
+        elif kind == "knowledge_base":
+            properties.update(
+                {
+                    "topK": {"type": "integer", "minimum": 1, "maximum": 10},
+                    "scoreThreshold": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                    },
+                    "description": {"type": "string"},
+                }
+            )
+        else:
+            properties["description"] = {"type": "string"}
+        if pinned_field:
+            version_values = (
+                ["latest", "pinned"]
+                if kind == "plugin_resource"
+                else ["current_published", "pinned"]
+            )
+            properties.update(
+                {
+                    "versionPolicy": {"enum": version_values},
+                    pinned_field: {"type": ["integer", "null"]},
+                }
+            )
+        contracts[kind] = NodeContract(
+            kind=kind,
+            contract_status="complete",
+            config_schema=_object_schema(properties, required=required_fields),
+            ports=(),
+            edge=NodeEdgeContract(
+                modes=("binding",),
+                topology_modes=(),
+                allowed_source_handles=(source_handle,),
+                allowed_target_handles=(target_handle,),
+            ),
+            execution=NodeExecutionPolicy(
+                side_effect="read",
+                deterministic=False,
+                idempotent=True,
+                external_io=kind
+                in {"external_xpert", "toolset_resource", "plugin_resource"},
+                error_semantics="fail_closed",
+                security_category="resource",
+            ),
+            availability=_availability(app=app_rule),
+            resources=(
+                NodeResourceContract(
+                    kind=resource_kind,
+                    id_field=id_field,
+                    version_policy_field="versionPolicy" if pinned_field else None,
+                    pinned_version_field=pinned_field,
+                ),
+            ),
+            planner=_planner(
+                enabled=True,
+                support="binding_only",
+                compilation_mode="binding",
+                default_data=(
+                    {"versionPolicy": "pinned", "pinnedVersion": None}
+                    if pinned_field
+                    else {"topK": "5", "scoreThreshold": "0"}
+                ),
+                constraints={
+                    "required": required_fields,
+                    "target_handle": target_handle,
+                },
+            ),
+        )
+
+    contracts["json_serialize"] = NodeContract(
+        kind="json_serialize",
+        contract_status="complete",
+        config_schema=_object_schema(
+            {
+                "inputVariable": {"type": "string"},
+                "outputVariable": {"type": "string"},
+                "format": {"enum": ["compact", "pretty"]},
+            },
+            required=["inputVariable", "outputVariable"],
+        ),
+        ports=(
+            NodePortContract(name="value", direction="input", value_schema=any_value),
+            NodePortContract(name="json", direction="output", value_schema=string_value),
+        ),
+        execution=NodeExecutionPolicy(
+            side_effect="none",
+            deterministic=True,
+            idempotent=True,
+            error_semantics="legacy_inline_error",
+            security_category="transform",
+        ),
+        planner=_planner(
+            default_data={
+                "inputVariable": "json_value",
+                "outputVariable": "json_text",
+                "format": "compact",
+            },
+            constraints={
+                "required": ["inputVariable", "outputVariable"],
+                "format": ["compact", "pretty"],
+            },
+        ),
+    )
+    contracts["json_deserialize"] = NodeContract(
+        kind="json_deserialize",
+        contract_status="complete",
+        config_schema=_object_schema(
+            {
+                "inputVariable": {"type": "string"},
+                "outputVariable": {"type": "string"},
+            },
+            required=["inputVariable", "outputVariable"],
+        ),
+        ports=(
+            NodePortContract(name="json", direction="input", value_schema=string_value),
+            NodePortContract(name="value", direction="output", value_schema=any_value),
+        ),
+        execution=NodeExecutionPolicy(
+            side_effect="none",
+            deterministic=True,
+            idempotent=True,
+            error_semantics="legacy_inline_error",
+            security_category="transform",
+        ),
+        planner=_planner(
+            default_data={
+                "inputVariable": "json_text",
+                "outputVariable": "json_value",
+            },
+            constraints={"required": ["inputVariable", "outputVariable"]},
+        ),
+    )
+
+    contracts["knowledge_retrieval"] = NodeContract(
+        kind="knowledge_retrieval",
+        contract_status="complete",
+        config_schema=_object_schema(
+            {
+                "contractVersion": {"const": 2},
+                "knowledgeBaseId": {"type": "string"},
+                "queryVariable": {"type": "string"},
+                "top_k": {"type": ["string", "integer"]},
+                "returnMode": {"enum": ["context", "result"]},
+                "outputVariable": {"type": "string"},
+            },
+            required=["knowledgeBaseId", "queryVariable", "outputVariable"],
+        ),
+        ports=(
+            NodePortContract(name="query", direction="input", value_schema=string_value),
+            NodePortContract(
+                name="result",
+                direction="output",
+                value_schema=WorkflowValueSchema(
+                    any_of=(string_value, object_value)
+                ),
+            ),
+        ),
+        execution=NodeExecutionPolicy(
+            side_effect="read",
+            idempotent=True,
+            external_io=True,
+            error_semantics="fail_closed",
+            security_category="knowledge",
+        ),
+        resources=(
+            NodeResourceContract(
+                kind="knowledge_base",
+                id_field="knowledgeBaseId",
+                dynamic_schema=True,
+            ),
+        ),
+        planner=_planner(
+            default_data={
+                "contractVersion": 2,
+                "knowledgeBaseId": "",
+                "queryVariable": "user_input",
+                "top_k": "5",
+                "returnMode": "result",
+                "outputVariable": "knowledge_result",
+            },
+            constraints={
+                "required": ["knowledgeBaseId", "queryVariable", "outputVariable"],
+                "return_mode": ["context", "result"],
+            },
+        ),
+    )
+
+    app_table_denied = _rule(
+        "deny",
+        code="app_agent_table_forbidden",
+        message="Public Xpert Apps cannot deploy private Agent Table nodes.",
+    )
+    table_specs = {
+        "data_table_query": (
+            "read",
+            array_object_value,
+            {
+                "versionPolicy": "latest",
+                "selectFields": [],
+                "filter": None,
+                "sort": [],
+                "limit": 20,
+                "returnMode": "list",
+                "outputVariable": "table_records",
+            },
+        ),
+        "data_table_insert": (
+            "write",
+            object_value,
+            {
+                "versionPolicy": "latest",
+                "valueBindings": {},
+                "outputVariable": "inserted_record",
+            },
+        ),
+        "data_table_update": (
+            "write",
+            object_value,
+            {
+                "versionPolicy": "latest",
+                "filter": None,
+                "valueBindings": {},
+                "outputVariable": "update_result",
+            },
+        ),
+        "data_table_delete": (
+            "write",
+            object_value,
+            {
+                "versionPolicy": "latest",
+                "filter": None,
+                "outputVariable": "delete_result",
+            },
+        ),
+    }
+    for kind, (side_effect, output_schema, defaults) in table_specs.items():
+        contracts[kind] = NodeContract(
+            kind=kind,
+            contract_status="complete",
+            config_schema=_object_schema(
+                {
+                    "tableId": {"type": "string"},
+                    "versionPolicy": {"enum": ["latest", "pinned"]},
+                    "pinnedSchemaVersion": {"type": ["integer", "null"]},
+                    "selectFields": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "maxItems": 50,
+                    },
+                    "filter": {"type": ["object", "null"]},
+                    "sort": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                        "maxItems": 5,
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 200,
+                    },
+                    "returnMode": {"enum": ["list", "first"]},
+                    "valueBindings": {
+                        "type": "object",
+                        "maxProperties": 50,
+                    },
+                    "outputVariable": {"type": "string"},
+                },
+                required=["tableId", "outputVariable"],
+            ),
+            ports=(
+                NodePortContract(
+                    name="result", direction="output", value_schema=output_schema
+                ),
+            ),
+            execution=NodeExecutionPolicy(
+                side_effect=side_effect,
+                deterministic=True,
+                idempotent=True,
+                error_semantics="fail_closed",
+                security_category="private_data",
+            ),
+            availability=_availability(
+                app=app_table_denied,
+                evaluation=_rule(
+                    "deny",
+                    code="evaluation_unsafe_node",
+                    message=f"Evaluation does not allow node kind: {kind}.",
+                ),
+            ),
+            resources=(
+                NodeResourceContract(
+                    kind="data_table",
+                    id_field="tableId",
+                    version_policy_field="versionPolicy",
+                    pinned_version_field="pinnedSchemaVersion",
+                    dynamic_schema=True,
+                ),
+            ),
+            planner=_planner(default_data=defaults),
+        )
+
+    contracts["vision_understanding"] = NodeContract(
+        kind="vision_understanding",
+        contract_status="complete",
+        config_schema=_object_schema(
+            {
+                "assetIdVariable": {"type": "string"},
+                "visionModelId": {"type": "string"},
+                "pdfPageStrategy": {"enum": ["auto", "all", "scanned_only"]},
+                "maxPages": {"type": "integer", "minimum": 1, "maximum": 200},
+                "maxImageEdge": {"type": "integer", "minimum": 512, "maximum": 4096},
+                "failurePolicy": {"enum": ["continue_on_error", "strict"]},
+                "outputVariable": {"type": "string"},
+            },
+            required=["assetIdVariable", "visionModelId", "outputVariable"],
+        ),
+        ports=(
+            NodePortContract(
+                name="asset_id", direction="input", value_schema=string_value
+            ),
+            NodePortContract(
+                name="result", direction="output", value_schema=object_value
+            ),
+        ),
+        execution=NodeExecutionPolicy(
+            side_effect="external_read",
+            external_io=True,
+            error_semantics="exception_strategy",
+            security_category="private_file",
+        ),
+        availability=_availability(
+            app=_rule(
+                "deny",
+                code="app_vision_understanding_forbidden",
+                message=(
+                    "Public Xpert Apps cannot deploy vision understanding nodes "
+                    "because public attachment upload is disabled."
+                ),
+            ),
+            evaluation=_rule(
+                "deny",
+                code="evaluation_unsafe_node",
+                message=(
+                    "Evaluation does not allow vision understanding until "
+                    "evaluation datasets support explicit file assets."
+                ),
+            ),
+        ),
+        resources=(
+            NodeResourceContract(
+                kind="file_asset", id_field="assetIdVariable", dynamic_schema=True
+            ),
+        ),
+        planner=_planner(
+            default_data={
+                "assetIdVariable": "selected_file_asset_id",
+                "visionModelId": "",
+                "pdfPageStrategy": "auto",
+                "maxPages": 100,
+                "maxImageEdge": 2048,
+                "failurePolicy": "continue_on_error",
+                "outputVariable": "vision_result",
+            }
+        ),
+    )
+
+    contracts["annotation"] = NodeContract(
+        kind="annotation",
+        contract_status="complete",
+        config_schema=_object_schema({"content": {"type": "string", "maxLength": 20_000}}),
+        edge=NodeEdgeContract(
+            modes=(),
+            topology_modes=(),
+        ),
+        execution=NodeExecutionPolicy(
+            side_effect="none",
+            deterministic=True,
+            idempotent=True,
+            error_semantics="ignored",
+            security_category="metadata",
+        ),
+        planner=_planner(
+            support="metadata_only",
+            default_data={"content": ""},
+        ),
+    )
+    contracts["runtime_middleware"] = NodeContract(
+        kind="runtime_middleware",
+        contract_status="complete",
+        config_schema=_object_schema(
+            {
+                "runtimeMiddlewareId": {"type": "string"},
+                "runtimeMiddlewareConfig": {"type": "object"},
+                "middlewarePriority": {"type": ["string", "integer"]},
+                "configVersion": {"type": "integer"},
+            },
+            required=["runtimeMiddlewareId"],
+        ),
+        edge=NodeEdgeContract(
+            modes=("control", "binding"),
+            topology_modes=("control",),
+            allowed_source_handles=("middleware-binding",),
+            allowed_target_handles=("middleware",),
+        ),
+        execution=NodeExecutionPolicy(
+            side_effect="unknown",
+            external_io=True,
+            can_wait=True,
+            error_semantics="exception_strategy",
+            security_category="middleware",
+        ),
+        planner=_planner(support="binding_only", compilation_mode="binding"),
+    )
+    return contracts
+
+
+def build_builtin_node_contract_registry() -> NodeContractRegistry:
+    contracts = {
+        kind: _compatibility_contract(kind) for kind in get_args(NativeNodeKind)
+    }
+    contracts.update(_complete_contracts())
+
+    evaluation_denied = {
+        "agent_handoff",
+        "handoff_router",
+        "human_intervention",
+    }
+    app_denied = {
+        "human_intervention": (
+            "app_interactive_hitl_forbidden",
+            "Public Xpert Apps cannot deploy interactive HITL workflows.",
+        )
+    }
+    for kind in evaluation_denied | set(app_denied):
+        current = contracts[kind]
+        availability = current.availability.model_copy(
+            update={
+                **(
+                    {
+                        "evaluation": _rule(
+                            "deny",
+                            code="evaluation_unsafe_node",
+                            message=f"Evaluation does not allow node kind: {kind}.",
+                        )
+                    }
+                    if kind in evaluation_denied
+                    else {}
+                ),
+                **(
+                    {
+                        "app": _rule(
+                            "deny",
+                            code=app_denied[kind][0],
+                            message=app_denied[kind][1],
+                        )
+                    }
+                    if kind in app_denied
+                    else {}
+                ),
+            }
+        )
+        contracts[kind] = current.model_copy(update={"availability": availability})
+
+    condition = contracts["condition"]
+    contracts["condition"] = condition.model_copy(
+        update={
+            "edge": NodeEdgeContract(
+                allowed_source_handles=("true", "false"),
+            )
+        }
+    )
+    return NodeContractRegistry(list(contracts.values()))
+
+
+workflow_node_contract_registry = build_builtin_node_contract_registry()
+node_policy_service = NodePolicyService(workflow_node_contract_registry)

--- a/server/workflow_native/validate.py
+++ b/server/workflow_native/validate.py
@@ -10,6 +10,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError
 
+from .node_contracts import workflow_node_contract_registry
 from .schemas import (
     NativeWorkflowDefinition,
     NativeWorkflowEdge,
@@ -100,45 +101,7 @@ NODE_KIND_ALIASES = {
 }
 
 TEMPLATE_PATTERN = re.compile(r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}")
-SUPPORTED_NODE_KINDS = {
-    "input",
-    "llm",
-    "condition",
-    "code",
-    "variable_assign",
-    "template_transform",
-    "variable_aggregator",
-    "parameter_extractor",
-    "knowledge_retrieval",
-    "knowledge_citation",
-    "document_extractor",
-    "vision_understanding",
-    "human_intervention",
-    "question_classifier",
-    "agent",
-    "workflow_agent",
-    "external_xpert",
-    "knowledge_base",
-    "toolset_resource",
-    "plugin_resource",
-    "agent_task",
-    "agent_handoff",
-    "handoff_router",
-    "mcp_tool",
-    "time_tool",
-    "http_request",
-    "list_operation",
-    "iteration",
-    "json_serialize",
-    "json_deserialize",
-    "data_table_query",
-    "data_table_insert",
-    "data_table_update",
-    "data_table_delete",
-    "annotation",
-    "runtime_middleware",
-    "output",
-}
+SUPPORTED_NODE_KINDS = workflow_node_contract_registry.kinds()
 
 
 def node_kind(node: NativeWorkflowNode) -> str:
@@ -406,7 +369,7 @@ def validate_workflow_graph(workflow: NativeWorkflowDefinition) -> ValidateWorkf
     kinds_by_id = {node.id: node_kind(node) for node in workflow.nodes}
     for node in workflow.nodes:
         kind = kinds_by_id[node.id]
-        if kind not in SUPPORTED_NODE_KINDS:
+        if workflow_node_contract_registry.get(kind) is None:
             issues.append(
                 ValidationIssue(
                     code="unknown_node_kind",
@@ -3236,7 +3199,26 @@ def validate_edges(
             )
             continue
         valid_edges.append(edge)
+        source_contract = workflow_node_contract_registry.get(
+            kinds_by_id.get(edge.source, "")
+        )
         if is_non_control_binding_edge(edge):
+            if source_contract is not None and (
+                not source_contract.edge.supports("binding")
+                or str(edge.sourceHandle or "").strip()
+                not in source_contract.edge.allowed_source_handles
+                or str(edge.targetHandle or "").strip()
+                not in source_contract.edge.allowed_target_handles
+            ):
+                issues.append(
+                    ValidationIssue(
+                        code="invalid_node_contract_binding",
+                        message=(
+                            "Binding edge handles do not match the source node contract."
+                        ),
+                        edge_id=edge.id,
+                    )
+                )
             bindings_by_source[edge.source].append(edge)
             source_kind = kinds_by_id.get(edge.source)
             target_kind = kinds_by_id.get(edge.target)
@@ -3272,6 +3254,33 @@ def validate_edges(
                     )
                 )
         else:
+            if (
+                source_contract is not None
+                and not source_contract.edge.supports("control")
+            ):
+                issues.append(
+                    ValidationIssue(
+                        code="node_contract_control_edge_forbidden",
+                        message=(
+                            "The source node contract does not allow control-flow edges."
+                        ),
+                        edge_id=edge.id,
+                    )
+                )
+            source_handle = str(edge.sourceHandle or "").strip()
+            if (
+                source_contract is not None
+                and source_handle
+                and source_contract.edge.allowed_source_handles
+                and source_handle not in source_contract.edge.allowed_source_handles
+            ):
+                issues.append(
+                    ValidationIssue(
+                        code="invalid_node_contract_source_handle",
+                        message="Edge sourceHandle is not declared by the source node contract.",
+                        edge_id=edge.id,
+                    )
+                )
             control_node_ids.update({edge.source, edge.target})
             if str(edge.sourceHandle or "").strip() in {
                 "middleware-binding",

--- a/server/xpert_runtime/workflow_node_registry.py
+++ b/server/xpert_runtime/workflow_node_registry.py
@@ -4,14 +4,19 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+try:
+    from server.workflow_native.node_contracts import (
+        NODE_CONTRACT_VERSION,
+        workflow_node_contract_registry,
+    )
+except ModuleNotFoundError:
+    from workflow_native.node_contracts import (
+        NODE_CONTRACT_VERSION,
+        workflow_node_contract_registry,
+    )
+
 
 WorkflowNodeRegistryTab = Literal["workflow", "knowledge"]
-WorkflowPlannerSupport = Literal[
-    "full",
-    "binding_only",
-    "metadata_only",
-    "unsupported",
-]
 WorkflowNodeCategory = Literal[
     "logic",
     "transform",
@@ -41,17 +46,16 @@ class WorkflowPaletteItem:
     tags: list[str] = field(default_factory=list)
     enabled: bool = True
     metadata: dict[str, Any] = field(default_factory=dict)
-    planner_enabled: bool = True
-    planner_support: WorkflowPlannerSupport = "full"
-    planner_default_data: dict[str, Any] = field(default_factory=dict)
-    planner_config_constraints: dict[str, Any] = field(default_factory=dict)
-    input_contract: dict[str, Any] = field(default_factory=dict)
-    output_contract: dict[str, Any] = field(default_factory=dict)
-    resource_requirements: list[str] = field(default_factory=list)
-    deprecated: bool = False
-    replacement_kind: str | None = None
 
     def to_payload(self) -> dict[str, Any]:
+        contract = workflow_node_contract_registry.require(self.kind)
+        contract_payload = contract.to_safe_payload()
+        input_ports = [
+            port for port in contract_payload["ports"] if port["direction"] == "input"
+        ]
+        output_ports = [
+            port for port in contract_payload["ports"] if port["direction"] == "output"
+        ]
         return {
             "kind": self.kind,
             "title": self.title,
@@ -62,22 +66,28 @@ class WorkflowPaletteItem:
             "enabled": self.enabled,
             "metadata": dict(self.metadata),
             "contracts": {
-                "inputs": dict(self.input_contract),
-                "outputs": dict(self.output_contract),
-                "resources": list(self.resource_requirements),
-                "deprecated": self.deprecated,
-                "replacement_kind": self.replacement_kind,
+                "inputs": input_ports,
+                "outputs": output_ports,
+                "resources": list(contract_payload["resources"]),
+                "deprecated": contract.deprecated,
+                "replacement_kind": contract.replacement_kind,
             },
             "planner": {
-                "enabled": self.enabled and self.planner_enabled,
-                "support": self.planner_support,
+                "enabled": self.enabled and contract.planner.enabled,
+                "support": contract.planner.support,
+                "compilation_mode": contract.planner.compilation_mode,
+                "ir_version": contract.planner.ir_version,
+                "adapter_version": contract.planner.adapter_version,
+                "contract_checksum": contract.checksum,
+                "compiler_checksum": contract.compiler_checksum,
                 "default_data": {
                     "kind": self.kind,
                     "title": self.title,
-                    **dict(self.planner_default_data),
+                    **dict(contract.planner.default_data),
                 },
-                "config_constraints": dict(self.planner_config_constraints),
+                "config_constraints": dict(contract.planner.config_constraints),
             },
+            "contract": contract_payload,
         }
 
 
@@ -143,7 +153,8 @@ class WorkflowNodeRegistry:
     """Xpert-style metadata registry for classic workflow palette nodes."""
 
     def __init__(self) -> None:
-        self.version = "xpert-workflow-node-registry-v2"
+        self.version = "xpert-workflow-node-registry-v3"
+        self.contract_registry = workflow_node_contract_registry
         self._tabs: list[WorkflowPaletteTab] = []
         self._sections: list[WorkflowPaletteSection] = []
         self._knowledge_pipeline = KnowledgePipelinePalette()
@@ -181,6 +192,8 @@ class WorkflowNodeRegistry:
     def to_payload(self) -> dict[str, Any]:
         return {
             "version": self.version,
+            "contract_version": NODE_CONTRACT_VERSION,
+            "contract_checksum": self.contract_registry.checksum,
             "tabs": [tab.to_payload() for tab in self._tabs],
             "sections": [section.to_payload() for section in self._sections],
             "knowledge_pipeline": self._knowledge_pipeline.to_payload(),
@@ -309,16 +322,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     description="将一个类型化工作流变量转换为 JSON 字符串。",
                     category="transform",
                     tags=["json", "serialize", "typed-value"],
-                    planner_default_data={
-                        "inputVariable": "json_value",
-                        "outputVariable": "json_text",
-                        "format": "compact",
-                    },
-                    planner_config_constraints={
-                        "required": ["inputVariable", "outputVariable"],
-                        "format": ["compact", "pretty"],
-                    },
-                    planner_enabled=False,
                 ),
                 WorkflowPaletteItem(
                     kind="json_deserialize",
@@ -327,14 +330,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     description="将 JSON 字符串解析为真实的类型化工作流变量。",
                     category="transform",
                     tags=["json", "deserialize", "typed-value"],
-                    planner_default_data={
-                        "inputVariable": "json_text",
-                        "outputVariable": "json_value",
-                    },
-                    planner_config_constraints={
-                        "required": ["inputVariable", "outputVariable"],
-                    },
-                    planner_enabled=False,
                 ),
                 WorkflowPaletteItem(
                     kind="document_extractor",
@@ -351,10 +346,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                             "status_reason": "Workflow 文件资产变量当前未启用。"
                         }
                     ),
-                    planner_default_data={
-                        "assetIdVariable": "document_asset_id",
-                        "outputVariable": "document_text",
-                    },
                 ),
                 WorkflowPaletteItem(
                     kind="llm",
@@ -390,14 +381,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     description="Expose a pinned published Xpert as a synchronous collaborator tool.",
                     category="resource",
                     tags=["xpert", "expert", "resource", "binding"],
-                    planner_default_data={
-                        "versionPolicy": "pinned",
-                        "pinnedVersion": None,
-                    },
-                    planner_config_constraints={
-                        "required": ["xpertId", "toolName"],
-                        "target_handle": "expert",
-                    },
                 ),
                 WorkflowPaletteItem(
                     kind="toolset_resource",
@@ -409,14 +392,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     ),
                     category="resource",
                     tags=["mcp", "toolset", "resource", "binding"],
-                    planner_default_data={
-                        "versionPolicy": "pinned",
-                        "pinnedVersion": None,
-                    },
-                    planner_config_constraints={
-                        "required": ["toolsetId"],
-                        "target_handle": "toolset",
-                    },
                 ),
                 WorkflowPaletteItem(
                     kind="plugin_resource",
@@ -428,14 +403,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     ),
                     category="resource",
                     tags=["plugin", "prompt", "skill", "toolset", "binding"],
-                    planner_default_data={
-                        "versionPolicy": "pinned",
-                        "pinnedVersion": None,
-                    },
-                    planner_config_constraints={
-                        "required": ["pluginId"],
-                        "target_handle": "plugin",
-                    },
                 ),
             ],
         )
@@ -479,19 +446,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     description="执行一个模型驱动的 Agent 步骤，并写入输出变量。",
                     category="tool",
                     tags=["workflow-agent", "agent"],
-                    planner_default_data={
-                        "toolMode": "none",
-                        "maxIterations": "6",
-                        "outputVariable": "agent_output",
-                    },
-                    planner_config_constraints={
-                        "required": [
-                            "modelId",
-                            "rolePrompt",
-                            "taskInput",
-                            "outputVariable",
-                        ],
-                    },
                 ),
                 WorkflowPaletteItem(
                     kind="agent_task",
@@ -551,22 +505,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     description="按字段、条件和排序读取固定 Schema 的 Agent Table 记录。",
                     category="memory",
                     tags=["database", "agent-table", "query", "typed-value"],
-                    planner_default_data={
-                        "versionPolicy": "latest",
-                        "selectFields": [],
-                        "filter": None,
-                        "sort": [],
-                        "limit": 20,
-                        "returnMode": "list",
-                        "outputVariable": "table_records",
-                    },
-                    planner_config_constraints={
-                        "required": ["tableId", "outputVariable"],
-                        "versionPolicy": ["latest", "pinned"],
-                        "returnMode": ["list", "first"],
-                        "limit": {"minimum": 1, "maximum": 200},
-                    },
-                    planner_enabled=False,
                     metadata={"private_only": True, "side_effect": "read"},
                 ),
                 WorkflowPaletteItem(
@@ -576,16 +514,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     description="按类型化字段绑定向 Agent Table 插入一条记录。",
                     category="memory",
                     tags=["database", "agent-table", "insert", "typed-value"],
-                    planner_default_data={
-                        "versionPolicy": "latest",
-                        "valueBindings": {},
-                        "outputVariable": "inserted_record",
-                    },
-                    planner_config_constraints={
-                        "required": ["tableId", "valueBindings", "outputVariable"],
-                        "versionPolicy": ["latest", "pinned"],
-                    },
-                    planner_enabled=False,
                     metadata={"private_only": True, "side_effect": "write"},
                 ),
                 WorkflowPaletteItem(
@@ -595,18 +523,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     description="使用非空条件批量更新 Agent Table，单次最多 100 行。",
                     category="memory",
                     tags=["database", "agent-table", "update", "typed-value"],
-                    planner_default_data={
-                        "versionPolicy": "latest",
-                        "filter": None,
-                        "valueBindings": {},
-                        "outputVariable": "update_result",
-                    },
-                    planner_config_constraints={
-                        "required": ["tableId", "filter", "valueBindings", "outputVariable"],
-                        "versionPolicy": ["latest", "pinned"],
-                        "maxAffectedRows": 100,
-                    },
-                    planner_enabled=False,
                     metadata={"private_only": True, "side_effect": "write"},
                 ),
                 WorkflowPaletteItem(
@@ -616,17 +532,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     description="使用非空条件删除 Agent Table 记录，单次最多 100 行。",
                     category="memory",
                     tags=["database", "agent-table", "delete", "typed-value"],
-                    planner_default_data={
-                        "versionPolicy": "latest",
-                        "filter": None,
-                        "outputVariable": "delete_result",
-                    },
-                    planner_config_constraints={
-                        "required": ["tableId", "filter", "outputVariable"],
-                        "versionPolicy": ["latest", "pinned"],
-                        "maxAffectedRows": 100,
-                    },
-                    planner_enabled=False,
                     metadata={"private_only": True, "side_effect": "write"},
                 ),
             ],
@@ -652,8 +557,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                         "runtime": "ignored",
                         "max_content_length": 20_000,
                     },
-                    planner_default_data={"content": ""},
-                    planner_enabled=False,
                 )
             ],
         )
@@ -669,15 +572,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     description="将一个知识库绑定到工作流智能体的只读知识工具。",
                     category="resource",
                     tags=["knowledge", "rag", "resource", "binding"],
-                    planner_support="binding_only",
-                    planner_default_data={"topK": "5", "scoreThreshold": "0"},
-                    planner_config_constraints={
-                        "required": ["knowledgeBaseId"],
-                        "target_handle": "knowledge",
-                    },
-                    input_contract={"binding": "knowledge_base"},
-                    output_contract={"control_flow": False},
-                    resource_requirements=["knowledge_base"],
                 ),
                 WorkflowPaletteItem(
                     kind="knowledge_retrieval",
@@ -686,33 +580,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     description="检索指定知识库的活动版本并输出文本或类型化结果。",
                     category="transform",
                     tags=["rag", "knowledge", "retrieval"],
-                    planner_enabled=False,
-                    planner_support="unsupported",
-                    planner_default_data={
-                        "contractVersion": 2,
-                        "knowledgeBaseId": "",
-                        "queryVariable": "user_input",
-                        "top_k": "5",
-                        "returnMode": "result",
-                        "outputVariable": "knowledge_result",
-                    },
-                    planner_config_constraints={
-                        "required": [
-                            "knowledgeBaseId",
-                            "queryVariable",
-                            "outputVariable",
-                        ],
-                        "return_mode": ["context", "result"],
-                    },
-                    input_contract={
-                        "queryVariable": "string",
-                        "knowledgeBaseId": "resource:knowledge_base",
-                    },
-                    output_contract={
-                        "context": "string",
-                        "result": "object",
-                    },
-                    resource_requirements=["knowledge_base"],
                 ),
                 WorkflowPaletteItem(
                     kind="vision_understanding",
@@ -724,35 +591,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     ),
                     category="knowledge-pipeline",
                     tags=["vision", "ocr", "image", "pdf", "typed-value"],
-                    planner_enabled=False,
-                    planner_support="unsupported",
-                    planner_default_data={
-                        "assetIdVariable": "selected_file_asset_id",
-                        "visionModelId": "",
-                        "pdfPageStrategy": "auto",
-                        "maxPages": 100,
-                        "maxImageEdge": 2048,
-                        "failurePolicy": "continue_on_error",
-                        "outputVariable": "vision_result",
-                    },
-                    planner_config_constraints={
-                        "required": [
-                            "assetIdVariable",
-                            "visionModelId",
-                            "outputVariable",
-                        ],
-                        "pdfPageStrategy": ["auto", "all", "scanned_only"],
-                        "maxPages": {"minimum": 1, "maximum": 200},
-                        "maxImageEdge": {"minimum": 512, "maximum": 4096},
-                        "failurePolicy": ["continue_on_error", "strict"],
-                    },
-                    input_contract={
-                        "assetIdVariable": "resource:file_asset_id",
-                    },
-                    output_contract={
-                        "outputVariable": "object",
-                    },
-                    resource_requirements=["file_asset"],
                     metadata={
                         "private_only": True,
                         "supported_formats": ["png", "jpeg", "webp", "pdf"],

--- a/server/xperts/api.py
+++ b/server/xperts/api.py
@@ -48,6 +48,7 @@ try:
     from server.skills.api import get_skill_manager
     from server.skills.skill_manager import SkillManagerError
     from server.workflow_native.schemas import NativeWorkflowDefinition, ValidationIssue
+    from server.workflow_native.node_contracts import node_policy_service
 except ModuleNotFoundError:
     from file_assets.contracts import FileInputKind, FilePurpose
     from file_assets.registry import get_file_format_registry
@@ -60,6 +61,7 @@ except ModuleNotFoundError:
     from skills.api import get_skill_manager
     from skills.skill_manager import SkillManagerError
     from workflow_native.schemas import NativeWorkflowDefinition, ValidationIssue
+    from workflow_native.node_contracts import node_policy_service
 
 
 router = APIRouter(prefix="/api/xperts", tags=["xperts"])
@@ -742,6 +744,19 @@ def preview_xpert_for_publish(
         validate_xpert_definition(candidate),
     )
     feature_issues: list[ValidationIssue] = []
+    for node in candidate.draft.workflow.nodes:
+        data = node.data if isinstance(node.data, dict) else {}
+        kind = str(data.get("kind") or node.type or "")
+        policy = node_policy_service.decision(kind, "xpert")
+        if not policy.allowed:
+            feature_issues.append(
+                ValidationIssue(
+                    code=policy.code or "xpert_node_forbidden",
+                    message=policy.message
+                    or f"Xpert publish does not allow node kind: {kind}.",
+                    node_id=node.id,
+                )
+            )
     features = candidate.draft.features
     if (
         features.text_to_speech.enabled

--- a/server/xperts/app_api.py
+++ b/server/xperts/app_api.py
@@ -115,6 +115,11 @@ def _raise_app_error(exc: Exception) -> None:
 
 
 def _deployment_preflight(version: XpertVersion, policy: XpertAppPolicy) -> dict:
+    try:
+        from server.workflow_native.node_contracts import node_policy_service
+    except ModuleNotFoundError:
+        from workflow_native.node_contracts import node_policy_service
+
     issues: list[dict[str, str]] = []
     warnings: list[dict[str, str]] = []
     has_tool_call = False
@@ -134,11 +139,8 @@ def _deployment_preflight(version: XpertVersion, policy: XpertAppPolicy) -> dict
     has_file_memory_writeback = False
     has_datax_runtime = False
     has_datax_write = False
-    has_external_xpert = False
-    has_plugin_resource = False
     has_toolset_resource = False
-    has_agent_table = False
-    has_vision_understanding = False
+    node_policy_issues: dict[str, dict[str, str]] = {}
     toolset_resource_issues: list[dict[str, str]] = []
     datax_project_ids: set[str] = set()
     datax_model_ids: set[str] = set()
@@ -160,6 +162,17 @@ def _deployment_preflight(version: XpertVersion, policy: XpertAppPolicy) -> dict
     for node in version.workflow.nodes:
         data = node.data if isinstance(node.data, dict) else {}
         kind = str(data.get("kind") or node.type)
+        node_policy = node_policy_service.decision(kind, "app")
+        if not node_policy.allowed and kind != "human_intervention":
+            code = node_policy.code or "app_node_forbidden"
+            node_policy_issues.setdefault(
+                code,
+                {
+                    "code": code,
+                    "message": node_policy.message
+                    or f"Public Xpert Apps cannot deploy node kind: {kind}.",
+                },
+            )
         middleware_id = str(data.get("runtimeMiddlewareId") or "")
         if (
             kind == "runtime_middleware"
@@ -169,20 +182,8 @@ def _deployment_preflight(version: XpertVersion, policy: XpertAppPolicy) -> dict
             contract_forbidden_middleware.add(middleware_id)
         if kind == "mcp_tool":
             has_tool_call = True
-        if kind in {
-            "data_table_query",
-            "data_table_insert",
-            "data_table_update",
-            "data_table_delete",
-        }:
-            has_agent_table = True
-        if kind == "vision_understanding":
-            has_vision_understanding = True
         if kind == "external_xpert":
-            has_external_xpert = True
             has_tool_call = True
-        if kind == "plugin_resource":
-            has_plugin_resource = True
         if kind == "toolset_resource":
             has_toolset_resource = True
             has_tool_call = True
@@ -349,42 +350,7 @@ def _deployment_preflight(version: XpertVersion, policy: XpertAppPolicy) -> dict
                 "message": "This Xpert version uses Handoff, but App Handoff access is disabled.",
             }
         )
-    if has_external_xpert:
-        issues.append(
-            {
-                "code": "app_external_xpert_forbidden",
-                "message": "Public Xpert Apps cannot deploy external Xpert collaborators.",
-            }
-        )
-    if has_agent_table:
-        issues.append(
-            {
-                "code": "app_agent_table_forbidden",
-                "message": (
-                    "Public Xpert Apps cannot deploy private Agent Table nodes."
-                ),
-            }
-        )
-    if has_vision_understanding:
-        issues.append(
-            {
-                "code": "app_vision_understanding_forbidden",
-                "message": (
-                    "Public Xpert Apps cannot deploy vision understanding nodes "
-                    "because public attachment upload is disabled."
-                ),
-            }
-        )
-    if has_plugin_resource:
-        issues.append(
-            {
-                "code": "app_plugin_resource_forbidden",
-                "message": (
-                    "Public Xpert Apps cannot deploy declarative Plugin resources. "
-                    "Bind public-safe Prompt Profiles directly instead."
-                ),
-            }
-        )
+    issues.extend(node_policy_issues.values())
     unsafe_prompts = [
         profile.name
         for profile in version.prompt_profiles


### PR DESCRIPTION
## 变更摘要

- 新增 NodeContract V3，统一节点配置、端口、边、执行、安全、资源、入口和 Planner 契约。
- 将 Workflow Registry 与 Meta Planner Capability Snapshot 收口到同一契约来源。
- 通过 NodePolicyService 统一发布、Evaluator、App 与 Structure Evolution 的节点策略查询。
- 为现有 7 类 Planner 节点增加 Adapter checksum 和 compile/decompile 稳定性校验。
- 前端 Registry fallback 仅保留展示信息，服务端失联时不再伪造 Planner 能力。

## 行为边界

- Meta Planner 仍使用 Typed IR V2。
- Planner 可见节点仍严格保持 input、output、workflow_agent 和四类资源绑定节点。
- 不新增节点、不改变工作流 SSE、Store 或现有工作流行为。
- 未完整迁移的节点统一标记为 compatibility，并默认禁止 Planner 生成。

## 验证

- NodeContract、Validator、Meta Planner、Registry、Evolution 与数据表重点测试：133 passed。
- Xpert App、Publish 与 Evaluator 策略门禁：35 passed。
- 前端 Registry 测试：3 passed。
- 
pm.cmd run build 通过，仅保留既有大 chunk warning。
- git diff --check 通过。
- rebase 前全量后端：2959 passed、29 skipped、13 failed；13 项均在当时基线复现。最新 main 已包含相关测试加载修复，本 PR rebase 后重点回归全部通过。
- 独立预览器验证 Meta Planner capabilities-v3 与经典工作流旧草稿加载正常。

## 回退

本轮没有数据迁移。回退该提交即可恢复原 Registry 与策略查询路径，现有 Workflow、Proposal 和 XpertVersion 数据不受影响。