### PR TITLE
fix: 精简并对齐 MCP 工具卡片

### DIFF
--- a/client/src/components/McpBrowserPanel.tsx
+++ b/client/src/components/McpBrowserPanel.tsx
@@ -30,6 +30,7 @@ interface McpBrowserArtifact {
 
 interface McpBrowserPanelProps {
   availability: McpAvailability;
+  compact?: boolean;
   connected: boolean;
   policy: McpBrowserPolicy | null;
   preflightStatus: McpDatabasePreflightStatus;
@@ -122,6 +123,7 @@ async function readError(response: Response) {
 
 export default function McpBrowserPanel({
   availability,
+  compact = false,
   connected,
   policy,
   preflightStatus,
@@ -251,19 +253,19 @@ export default function McpBrowserPanel({
 
   return (
     <section
-      aria-label="临时浏览器安全与会话状态"
+      aria-label={compact ? "Playwright 会话与截图" : "临时浏览器安全与会话状态"}
       className="relative mt-3 rounded-lg border border-cyan-300/20 bg-cyan-300/[0.05] p-3 text-xs"
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <h3 className="font-semibold text-cyan-100">临时浏览器安全状态</h3>
-        <div className="flex flex-wrap gap-2">
+        <h3 className="font-semibold text-cyan-100">{compact ? "会话与截图" : "临时浏览器安全状态"}</h3>
+        {!compact ? <div className="flex flex-wrap gap-2">
           <span className="rounded-full border border-cyan-300/25 bg-cyan-300/[0.08] px-2.5 py-1 font-semibold text-cyan-100">
             匿名临时会话
           </span>
           <span className="rounded-full border border-emerald-300/25 bg-emerald-300/[0.08] px-2.5 py-1 font-semibold text-emerald-100">
             仅截图产物
           </span>
-        </div>
+        </div> : null}
       </div>
 
       <dl className="mt-3 grid gap-2 sm:grid-cols-3">
@@ -273,12 +275,12 @@ export default function McpBrowserPanel({
             {loading && !session ? "正在读取状态" : sessionCopy[status].label}
           </dd>
         </div>
-        <div className="rounded-lg bg-black/15 p-2.5">
+        {!compact ? <div className="rounded-lg bg-black/15 p-2.5">
           <dt className="text-slate-400">浏览器预检</dt>
           <dd aria-live="polite" className={`mt-1 font-semibold ${preflightCopy[preflightStatus].className}`}>
             {preflightCopy[preflightStatus].label}
           </dd>
-        </div>
+        </div> : null}
         <div className="rounded-lg bg-black/15 p-2.5">
           <dt className="text-slate-400">操作额度</dt>
           <dd className="mt-1 font-semibold text-white">{actionCount} / {maxActions}</dd>
@@ -297,18 +299,18 @@ export default function McpBrowserPanel({
           <p className="mt-1 break-all font-medium text-slate-100">
             {session?.current_origin || "尚未导航"}
           </p>
-          <p className="mt-1 text-slate-400">
+          {!compact ? <p className="mt-1 text-slate-400">
             页面版本 {session?.page_revision ?? 0}；跨域后旧审批自动失效。
-          </p>
+          </p> : null}
         </div>
         <div className="rounded-lg bg-black/15 p-2.5">
           <p className="text-slate-400">会话有效期</p>
           <p className="mt-1 font-medium text-slate-100">
             {status === "active" ? `最晚 ${formatDate(session?.expires_at)} 结束` : "连接后开始计时"}
           </p>
-          <p className="mt-1 text-slate-400">
+          {!compact ? <p className="mt-1 text-slate-400">
             最长 {formatDuration(policy.session_ttl_seconds)}；闲置 {formatDuration(policy.idle_ttl_seconds)} 自动清理。
-          </p>
+          </p> : null}
         </div>
       </div>
 
@@ -325,7 +327,7 @@ export default function McpBrowserPanel({
         </div>
       ) : null}
 
-      <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.035] p-3 text-slate-300">
+      {!compact ? <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.035] p-3 text-slate-300">
         <p className="font-semibold text-white">固定边界</p>
         <p className="mt-1 leading-5">
           仅允许公网 {policy.allowed_schemes.map((item) => item.toUpperCase()).join("/")} 与端口 {policy.allowed_ports.join("、")}；DNS 固定后连接，跨 origin 请求与重定向直接拒绝。最多 {policy.max_pages} 个页面，全局最多 {policy.max_concurrent_sessions} 个并发会话。
@@ -342,15 +344,15 @@ export default function McpBrowserPanel({
         <p className="mt-2 leading-5 text-amber-100">
           页面仍可能自行呈现登录界面；本批不会把它作为可用能力，也不会采集、继承或保存登录态。请勿输入账号、密码、OTP 或其他认证信息。
         </p>
-      </div>
+      </div> : null}
 
       <div className="mt-3 border-t border-white/10 pt-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <div>
             <p className="font-semibold text-white">截图产物</p>
-            <p className="mt-1 text-slate-400">
+            {!compact ? <p className="mt-1 text-slate-400">
               单张最多 {formatBytes(policy.max_artifact_bytes)}；每项目最多 {policy.max_artifacts_per_project} 张 / {formatBytes(policy.max_artifact_storage_bytes)}，默认保留 {formatDuration(policy.artifact_ttl_seconds)}。
-            </p>
+            </p> : null}
           </div>
           <button
             className="min-h-11 rounded-full border border-cyan-300/20 px-3 py-2 font-semibold text-cyan-100 transition hover:border-cyan-300/35 hover:bg-cyan-300/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 disabled:cursor-not-allowed disabled:opacity-50"
@@ -376,9 +378,9 @@ export default function McpBrowserPanel({
                     <p className="mt-1 text-slate-400">
                       {formatBytes(artifact.size_bytes)} · {artifact.mime_type} · 到期 {formatDate(artifact.expires_at)}
                     </p>
-                    <p className="mt-1 truncate font-mono text-[11px] text-slate-400">
+                    {!compact ? <p className="mt-1 truncate font-mono text-[11px] text-slate-400">
                       SHA-256 {artifact.sha256.slice(0, 16)}…
-                    </p>
+                    </p> : null}
                   </div>
                   <div className="flex flex-wrap gap-2">
                     {safeDownloadUrl(artifact.download_url, projectId) ? (

--- a/client/src/components/McpServerCard.playwright-card.test.tsx
+++ b/client/src/components/McpServerCard.playwright-card.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { mcpProjects } from "../data/mcpProjects";
@@ -11,13 +11,19 @@ function project(projectId: string) {
 }
 
 describe("McpServerCard Playwright sample", () => {
-  it("shows only user-facing capability and boundary copy by default", () => {
+  it("uses the same ready-card structure while preserving Playwright copy", () => {
     render(<McpServerCard project={project("playwright-mcp")} />);
 
-    expect(screen.getByRole("heading", { name: "Playwright MCP" })).toBeVisible();
+    const heading = screen.getByRole("heading", { name: "Playwright MCP" });
+    expect(heading).toBeVisible();
+    const card = heading.closest("article");
+    expect(card).toHaveClass("border-white/10", "bg-ink-950/78");
+    expect(within(card as HTMLElement).getByText("浏览器与网页")).toBeVisible();
+    expect(within(card as HTMLElement).getByText("可用")).toBeVisible();
     expect(
       screen.getByText("打开网页、读取页面并执行受控点击、填写与截图。"),
     ).toBeVisible();
+    expect(screen.getByText("主要能力")).toBeVisible();
     expect(screen.getByText("打开网页")).toBeVisible();
     expect(screen.getByText("读取页面")).toBeVisible();
     expect(screen.getByText("点击与填写")).toBeVisible();
@@ -25,7 +31,7 @@ describe("McpServerCard Playwright sample", () => {
     expect(
       screen.getByText("临时匿名浏览器，不保留登录态；不支持上传和下载。"),
     ).toBeVisible();
-    expect(screen.getByRole("button", { name: "连接 Playwright" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "打开工具台" })).toBeVisible();
     expect(screen.getByRole("button", { name: "配置与使用" })).toBeVisible();
     expect(screen.queryByRole("dialog", { name: "Playwright MCP" })).not.toBeInTheDocument();
 
@@ -47,6 +53,35 @@ describe("McpServerCard Playwright sample", () => {
     expect(screen.queryByText("README 摘要")).not.toBeInTheDocument();
     expect(screen.queryByText("资料核验")).not.toBeInTheDocument();
     expect(screen.queryByText("本批生产验收门槛")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      "takashiishida-arxiv-latex-mcp",
+      "Arxiv Latex Mcp",
+      "读取 arXiv 论文摘要、章节结构和 LaTeX 正文。",
+      "论文摘要",
+    ],
+    [
+      "greptimeteam-greptimedb-mcp-server",
+      "GreptimeDB",
+      "查询固定 GreptimeDB 数据表的结构、时间范围和健康状态。",
+      "时序查询",
+    ],
+    [
+      "victoriametrics-community-mcp-victoriametrics",
+      "Mcp Victoriametrics",
+      "读取 VictoriaMetrics 指标、标签和限定时间范围的监控数据。",
+      "指标列表",
+    ],
+  ])("gives newly adapted %s concise ready copy", (projectId, name, description, capability) => {
+    render(<McpServerCard project={project(projectId)} />);
+
+    expect(screen.getByRole("heading", { name })).toBeVisible();
+    expect(screen.getByText(description)).toBeVisible();
+    expect(screen.getByText(capability)).toBeVisible();
+    expect(screen.getByText("可用")).toBeVisible();
+    expect(screen.queryByText(/当前判定为 ready/)).not.toBeInTheDocument();
   });
 
   it("opens the ready tool workbench as an overlay and restores focus", async () => {

--- a/client/src/components/McpServerCard.playwright-card.test.tsx
+++ b/client/src/components/McpServerCard.playwright-card.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { mcpProjects } from "../data/mcpProjects";
+import McpServerCard from "./McpServerCard";
+
+function project(projectId: string) {
+  const match = mcpProjects.find((item) => item.id === projectId);
+  if (!match) throw new Error(`Missing MCP fixture: ${projectId}`);
+  return match;
+}
+
+describe("McpServerCard Playwright sample", () => {
+  it("shows only user-facing capability and boundary copy by default", () => {
+    render(<McpServerCard project={project("playwright-mcp")} />);
+
+    expect(screen.getByRole("heading", { name: "Playwright MCP" })).toBeVisible();
+    expect(
+      screen.getByText("打开网页、读取页面并执行受控点击、填写与截图。"),
+    ).toBeVisible();
+    expect(screen.getByText("打开网页")).toBeVisible();
+    expect(screen.getByText("读取页面")).toBeVisible();
+    expect(screen.getByText("点击与填写")).toBeVisible();
+    expect(screen.getByText("生成截图")).toBeVisible();
+    expect(
+      screen.getByText("临时匿名浏览器，不保留登录态；不支持上传和下载。"),
+    ).toBeVisible();
+    expect(screen.getByRole("button", { name: "连接 Playwright" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "配置与使用" })).toBeVisible();
+    expect(screen.queryByRole("dialog", { name: "Playwright MCP" })).not.toBeInTheDocument();
+
+    expect(screen.queryByText("README 摘要")).not.toBeInTheDocument();
+    expect(screen.queryByText("资料核验")).not.toBeInTheDocument();
+    expect(screen.queryByText("适配批次")).not.toBeInTheDocument();
+    expect(screen.queryByText("风险等级")).not.toBeInTheDocument();
+    expect(screen.queryByText("本批生产验收门槛")).not.toBeInTheDocument();
+    expect(screen.queryByText("已验证运行隔离")).not.toBeInTheDocument();
+    expect(screen.queryByText("受控连接")).not.toBeInTheDocument();
+  });
+
+  it("extends the user-facing summary to other ready cards", () => {
+    render(<McpServerCard project={project("chrome-devtools-mcp")} />);
+
+    expect(screen.getByRole("heading", { name: "Chrome DevTools MCP" })).toBeVisible();
+    expect(screen.getByText("主要能力")).toBeVisible();
+    expect(screen.getByRole("button", { name: "打开工具台" })).toBeVisible();
+    expect(screen.queryByText("README 摘要")).not.toBeInTheDocument();
+    expect(screen.queryByText("资料核验")).not.toBeInTheDocument();
+    expect(screen.queryByText("本批生产验收门槛")).not.toBeInTheDocument();
+  });
+
+  it("opens the ready tool workbench as an overlay and restores focus", async () => {
+    const user = userEvent.setup();
+    render(<McpServerCard project={project("chrome-devtools-mcp")} />);
+
+    const trigger = screen.getByRole("button", { name: "打开工具台" });
+    await user.click(trigger);
+
+    expect(screen.getByRole("dialog", { name: "Chrome DevTools MCP" })).toBeVisible();
+    expect(screen.getAllByRole("heading", { name: "Chrome DevTools MCP" })).toHaveLength(2);
+
+    await user.click(screen.getByRole("button", { name: "关闭工具台" }));
+    expect(screen.queryByRole("dialog", { name: "Chrome DevTools MCP" })).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("keeps unavailable cards explicit while removing development details", () => {
+    render(<McpServerCard project={project("airbnb-mcp")} />);
+
+    const heading = screen.getByRole("heading", { name: /Airbnb/i });
+    expect(heading).toBeVisible();
+    expect(heading.closest("article")).toHaveClass("h-full");
+    expect(heading.closest("article")).not.toHaveClass("self-start");
+    expect(screen.getByText("未适配", { selector: "p" })).toBeVisible();
+    expect(screen.getByText("上游接口不稳定，恢复兼容后再开放。")).toBeVisible();
+    expect(screen.getByText("需要远程传输适配")).toBeVisible();
+    expect(screen.getByText("需要系统权限")).toBeVisible();
+    expect(screen.getByRole("button", { name: "未适配" })).toBeDisabled();
+    expect(screen.queryByText("README 摘要")).not.toBeInTheDocument();
+    expect(screen.queryByText("资料核验")).not.toBeInTheDocument();
+    expect(screen.queryByText("适配批次")).not.toBeInTheDocument();
+    expect(screen.queryByText("本批生产验收门槛")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "配置与使用" })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/McpServerCard.tsx
+++ b/client/src/components/McpServerCard.tsx
@@ -1,4 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Camera,
+  FileText,
+  Globe2,
+  Link2,
+  MousePointer2,
+  Settings2,
+  Star,
+  Wrench,
+  X,
+} from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import McpWorkspacePanel, {
@@ -10,16 +21,13 @@ import McpApprovalDialog, {
 } from "./McpApprovalDialog";
 import McpBrowserPanel from "./McpBrowserPanel";
 import {
-  mcpCatalogSources,
   mcpRequirementLabels,
   type McpProject,
 } from "../data/mcpProjects";
 import {
-  formatMcpCapability,
   formatMcpIsolation,
   mcpAvailabilityLabels,
   mcpConnectionKindLabels,
-  mcpRiskLabels,
   type McpCatalogAdapterStatus,
 } from "../data/mcpAdaptationPlan";
 
@@ -185,6 +193,43 @@ function formatStars(stars: number) {
   if (stars <= 0) return "官方包";
   if (stars >= 1000) return `${(stars / 1000).toFixed(1)}k`;
   return stars.toLocaleString("zh-CN");
+}
+
+function compactUnavailableReason(
+  availability: McpProject["availability"],
+  limitations: string[],
+  requirements: McpProject["requirements"],
+) {
+  const evidence = limitations.join(" ");
+  if (/归档|archiv/i.test(evidence)) return "上游项目已归档，暂不接入。";
+  if (/许可|license/i.test(evidence)) return "许可证信息尚未完成核验。";
+  if (/任意.*代码|代码执行|shell/i.test(evidence)) {
+    return "需要执行代码，当前安全沙箱尚未开放。";
+  }
+  if (/Docker Socket|docker.*权限/i.test(evidence)) {
+    return "需要 Docker 管理权限，当前不会开放。";
+  }
+  if (/登录态|浏览器扩展|本机浏览器/i.test(evidence)) {
+    return "依赖浏览器登录态，当前不会继承用户会话。";
+  }
+  if (/schema 漂移|上游.*契约|契约漂移/i.test(evidence)) {
+    return "上游接口不稳定，恢复兼容后再开放。";
+  }
+  if (requirements.includes("desktop-host")) {
+    return "需要桌面宿主，当前运行环境不支持。";
+  }
+  if (requirements.includes("system-permission")) {
+    return "需要高权限运行，当前安全边界不允许。";
+  }
+  if (requirements.includes("oauth") || requirements.includes("account-binding")) {
+    return "账号授权与权限边界尚未完成验证。";
+  }
+  if (requirements.includes("external-runtime")) {
+    return "所需运行环境尚未纳入受控部署。";
+  }
+  if (availability === "adapting") return "正在完成连接、权限和回退验证。";
+  if (availability === "blocked") return "当前接入方式尚未满足安全要求。";
+  return "已进入适配计划，完成验证后开放。";
 }
 
 function schemaType(property: JsonSchemaProperty) {
@@ -457,18 +502,28 @@ export default function McpServerCard({
   const [installState, setInstallState] = useState<InstallState>("checking");
   const [installError, setInstallError] = useState("");
   const [browserRefreshKey, setBrowserRefreshKey] = useState(0);
+  const [isWorkbenchOpen, setIsWorkbenchOpen] = useState(false);
   const [browserRefOptions, setBrowserRefOptions] = useState<BrowserElementOption[]>([]);
   const ignoredRestoredSessionRef = useRef<string | null>(null);
+  const workbenchTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const workbenchDialogRef = useRef<HTMLDivElement | null>(null);
+  const workbenchCloseRef = useRef<HTMLButtonElement | null>(null);
 
   const availability = adapterStatus?.availability ?? project.availability;
   const connectionKind = adapterStatus?.connection_kind ?? project.connectionKind;
-  const risk = adapterStatus?.risk ?? project.risk;
   const wave = adapterStatus?.wave ?? project.adaptationWave;
-  const requiredCapabilities =
-    adapterStatus?.required_capabilities ?? project.requiredCapabilities;
   const limitations = adapterStatus?.limitations ?? project.adaptationLimitations;
   const isStatefulSaas = wave === 6;
   const isBrowserAdapter = wave === 7;
+  const isPlaywrightCard = project.id === "playwright-mcp";
+  const isReadyProductCard = availability === "ready";
+  const isConnected = state === "connected" || adapterStatus?.connected === true;
+  const unavailableStatusLabel = availability === "adapting" ? "适配中" : "未适配";
+  const unavailableReason = compactUnavailableReason(
+    availability,
+    limitations,
+    project.requirements,
+  );
   const statefulSaasGateEnabled =
     !isStatefulSaas || adapterStatus?.stateful_saas_gate_enabled === true;
   const canConnect =
@@ -496,15 +551,46 @@ export default function McpServerCard({
         : `第 ${wave} 批 · ${mcpConnectionKindLabels[connectionKind]} · ${limitations[0] ?? "等待生产级验收"}`,
     [canConnect, connectionKind, limitations, wave],
   );
-  const sourceNames = useMemo(
-    () =>
-      project.sources
-        .map((sourceId) =>
-          mcpCatalogSources.find((source) => source.id === sourceId)?.name,
-        )
-        .filter((name) => name !== undefined),
-    [project.sources],
-  );
+  useEffect(() => {
+    if (!isWorkbenchOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    workbenchCloseRef.current?.focus();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsWorkbenchOpen(false);
+        workbenchTriggerRef.current?.focus();
+      }
+      if (event.key === "Tab") {
+        const focusable = Array.from(
+          workbenchDialogRef.current?.querySelectorAll<HTMLElement>(
+            'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+          ) ?? [],
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isWorkbenchOpen]);
+
+  function closeWorkbench() {
+    setIsWorkbenchOpen(false);
+    workbenchTriggerRef.current?.focus();
+  }
 
   useEffect(() => {
     setCatalogConfigured(adapterStatus?.configured ?? false);
@@ -611,6 +697,7 @@ export default function McpServerCard({
       await fetchTools();
       setState("connected");
       setBrowserRefreshKey((current) => current + 1);
+      if (isPlaywrightCard) setIsWorkbenchOpen(true);
       onConnectionChange?.();
     } catch (exc) {
       setState("error");
@@ -1128,8 +1215,198 @@ export default function McpServerCard({
   }
 
   return (
-    <article className="group relative isolate flex min-h-[360px] flex-col overflow-hidden rounded-lg border border-white/10 bg-ink-950/78 p-5 shadow-prism transition duration-200 hover:border-hire-300/40 hover:bg-surface-900/92">
+    <article
+      className={`group relative flex h-full w-full flex-col rounded-lg p-5 shadow-prism transition duration-200 ${
+        isReadyProductCard ? "min-h-[360px]" : "min-h-[280px]"
+      } ${
+        isReadyProductCard && isWorkbenchOpen ? "" : "isolate overflow-hidden"
+      } ${
+        isPlaywrightCard
+          ? "border border-cyan-300/25 bg-[linear-gradient(145deg,rgba(9,22,45,0.98),rgba(6,15,31,0.98))] hover:border-cyan-200/45"
+          : "border border-white/10 bg-ink-950/78 hover:border-hire-300/40 hover:bg-surface-900/92"
+      }`}
+    >
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_12%,rgba(251,146,60,0.16),transparent_34%),radial-gradient(circle_at_82%_82%,rgba(36,217,255,0.13),transparent_36%)] opacity-80" />
+      {isPlaywrightCard ? (
+        <>
+          <div className="relative flex items-start justify-between gap-4">
+            <div className="flex min-w-0 items-start gap-3">
+              <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-cyan-300/25 bg-cyan-300/[0.08] text-cyan-100 shadow-[0_0_24px_rgba(34,211,238,0.08)]">
+                <MousePointer2 aria-hidden="true" className="h-6 w-6" strokeWidth={1.8} />
+              </span>
+              <div className="min-w-0">
+                <h2 className="text-xl font-semibold leading-7 text-white">Playwright MCP</h2>
+                <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-slate-400">
+                  <a
+                    className="underline-offset-4 transition hover:text-cyan-100 hover:underline"
+                    href={project.repoUrl}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    {project.repoName}
+                  </a>
+                  <span aria-hidden="true">·</span>
+                  <span className="inline-flex items-center gap-1.5 text-slate-300">
+                    <Star aria-hidden="true" className="h-3.5 w-3.5 text-hire-200" strokeWidth={2} />
+                    {formatStars(project.stars)} stars
+                  </span>
+                </div>
+              </div>
+            </div>
+            <span
+              className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold ${
+                isConnected
+                  ? "border-emerald-300/25 bg-emerald-300/[0.08] text-emerald-100"
+                  : "border-white/10 bg-white/[0.045] text-slate-300"
+              }`}
+            >
+              <span aria-hidden="true" className={`mr-1.5 inline-block h-2 w-2 rounded-full ${isConnected ? "bg-emerald-300" : "bg-slate-400"}`} />
+              {isConnected ? "已连接" : "尚未连接"}
+            </span>
+          </div>
+
+          <p className="relative mt-5 text-sm leading-6 text-slate-200">
+            打开网页、读取页面并执行受控点击、填写与截图。
+          </p>
+
+          <div className="relative mt-5 border-y border-white/10 py-4">
+            <p className="text-xs font-semibold tracking-wide text-slate-400">可以做什么</p>
+            <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-4">
+              {[
+                [Globe2, "打开网页"],
+                [FileText, "读取页面"],
+                [MousePointer2, "点击与填写"],
+                [Camera, "生成截图"],
+              ].map(([Icon, label]) => (
+                <div className="flex items-center gap-2 text-sm font-medium text-slate-100" key={label as string}>
+                  <Icon aria-hidden="true" className="h-4 w-4 text-cyan-200" strokeWidth={1.8} />
+                  <span>{label as string}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="relative mt-4 rounded-lg border border-white/10 bg-white/[0.035] px-4 py-3">
+            <p className="text-xs font-semibold text-slate-300">使用边界</p>
+            <p className="mt-1 text-xs leading-5 text-slate-400">
+              临时匿名浏览器，不保留登录态；不支持上传和下载。
+            </p>
+          </div>
+
+          <div className="relative mt-4 flex flex-wrap gap-2">
+            <button
+              className="min-h-11 flex-1 rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:opacity-45"
+              disabled={!isConnected && (!canConnect || !canStartConnection || state === "connecting")}
+              onClick={() => {
+                if (isConnected) setIsWorkbenchOpen(true);
+                else void connect();
+              }}
+              ref={workbenchTriggerRef}
+              type="button"
+            >
+              {state === "connecting" ? "正在创建会话" : isConnected ? "打开工具台" : "连接 Playwright"}
+            </button>
+            <button
+              className="min-h-11 rounded-full border border-cyan-300/25 bg-cyan-300/[0.06] px-4 py-2 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-300/10"
+              onClick={() => setIsInstallOpen(true)}
+              type="button"
+            >
+              配置与使用
+            </button>
+          </div>
+        </>
+      ) : isReadyProductCard ? (
+        <>
+          <div className="relative flex items-start justify-between gap-4">
+            <div className="flex min-w-0 items-start gap-3">
+              <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-brand-300/20 bg-brand-300/[0.07] text-lg font-semibold text-brand-100">
+                {project.category.slice(0, 1)}
+              </span>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="rounded-full border border-brand-300/25 bg-brand-300/[0.08] px-2.5 py-1 text-xs font-semibold text-brand-100">
+                    {project.category}
+                  </span>
+                  <span className="rounded-full border border-emerald-300/25 bg-emerald-300/[0.08] px-2.5 py-1 text-xs font-semibold text-emerald-100">
+                    {isConnected ? "已连接" : "可用"}
+                  </span>
+                </div>
+                <h2 className="mt-3 line-clamp-2 text-xl font-semibold leading-7 text-white">
+                  {project.name}
+                </h2>
+                <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-slate-400">
+                  <a
+                    className="underline-offset-4 transition hover:text-brand-100 hover:underline"
+                    href={project.repoUrl}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    {project.repoName}
+                  </a>
+                  {project.stars > 0 ? (
+                    <>
+                      <span aria-hidden="true">·</span>
+                      <span className="inline-flex items-center gap-1.5 text-slate-300">
+                        <Star aria-hidden="true" className="h-3.5 w-3.5 text-hire-200" strokeWidth={2} />
+                        {formatStars(project.stars)} stars
+                      </span>
+                    </>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <p className="relative mt-5 line-clamp-3 text-sm leading-6 text-slate-200">
+            {project.description}
+          </p>
+
+          <div className="relative mt-5 border-y border-white/10 py-4">
+            <p className="text-xs font-semibold text-slate-400">主要能力</p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {project.tags.slice(0, 4).map((tag) => (
+                <span
+                  className="rounded-full border border-brand-300/20 bg-brand-300/[0.07] px-3 py-1.5 text-xs font-medium text-brand-50"
+                  key={tag}
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="relative mt-4 flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.035] px-4 py-3 text-xs text-slate-300">
+            <Settings2 aria-hidden="true" className="h-4 w-4 shrink-0 text-brand-100" strokeWidth={1.8} />
+            <span>
+              {workspacePolicy?.required
+                ? "连接前需选择受控工作区"
+                : needsCatalogConfiguration
+                  ? "连接前需完成一次配置"
+                  : "可直接连接并使用工具"}
+            </span>
+          </div>
+
+          <div className="relative mt-auto flex flex-wrap gap-2 pt-5">
+            <button
+              className="min-h-11 flex-1 rounded-full bg-brand-300 px-4 py-2 text-sm font-semibold text-ink-950 transition hover:bg-brand-200"
+              onClick={() => setIsWorkbenchOpen(true)}
+              ref={workbenchTriggerRef}
+              type="button"
+            >
+              <Wrench aria-hidden="true" className="mr-2 inline h-4 w-4" strokeWidth={2} />
+              打开工具台
+            </button>
+            <button
+              className="min-h-11 rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-hire-300/30 hover:bg-hire-300/[0.08] hover:text-hire-100"
+              onClick={() => setIsInstallOpen(true)}
+              type="button"
+            >
+              配置与使用
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
       <div className="relative flex items-start justify-between gap-3">
         <div className="flex min-w-0 items-start gap-3">
           <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/[0.06] text-lg font-semibold text-white">
@@ -1142,16 +1419,12 @@ export default function McpServerCard({
               </span>
               <span
                 className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${
-                  availability === "ready"
-                    ? "border-emerald-300/25 bg-emerald-300/10 text-emerald-100"
-                    : availability === "adapting"
-                      ? "border-cyan-300/25 bg-cyan-300/10 text-cyan-100"
-                      : availability === "blocked"
-                        ? "border-rose-300/25 bg-rose-300/10 text-rose-100"
+                  availability === "adapting"
+                    ? "border-cyan-300/25 bg-cyan-300/10 text-cyan-100"
                     : "border-amber-300/25 bg-amber-300/10 text-amber-100"
                 }`}
               >
-                {mcpAvailabilityLabels[availability]}
+                {unavailableStatusLabel}
               </span>
             </div>
             <h2 className="mt-3 line-clamp-2 text-xl font-semibold leading-7 text-white">
@@ -1165,9 +1438,6 @@ export default function McpServerCard({
             >
               {project.repoName}
             </a>
-            <p className="mt-1 text-[11px] leading-4 text-slate-500">
-              清单来源：{sourceNames.join(" / ")}
-            </p>
           </div>
         </div>
         {project.stars > 0 ? (
@@ -1175,114 +1445,96 @@ export default function McpServerCard({
             {formatStars(project.stars)} stars
           </span>
         ) : (
-          <span className="rounded-full border border-white/10 bg-white/[0.055] px-2.5 py-1 text-xs font-semibold text-slate-300">
-            已核验
-          </span>
+          null
         )}
       </div>
 
-      <p className="relative mt-5 text-sm leading-6 text-slate-300">
+      <p className="relative mt-4 line-clamp-2 text-sm leading-6 text-slate-300">
         {project.description}
       </p>
 
-      <div className="relative mt-5 rounded-lg border border-white/10 bg-white/[0.045] p-3">
-        <p className="text-xs font-semibold text-slate-200">README 摘要</p>
-        <p className="mt-2 line-clamp-4 text-xs leading-5 text-slate-400">
-          {project.readmeSummary}
-        </p>
-      </div>
-
-      <div className="relative mt-4 grid grid-cols-2 gap-3 text-sm">
-        <div className="rounded-lg border border-white/10 bg-white/[0.045] p-3">
-          <p className="text-xs text-slate-400">主要语言</p>
-          <p className="mt-1 font-semibold text-white">{project.language}</p>
-        </div>
-        <div className="rounded-lg border border-white/10 bg-white/[0.045] p-3">
-          <p className="text-xs text-slate-400">资料核验</p>
-          <p className="mt-1 font-semibold text-white">{project.verifiedAt}</p>
-        </div>
-      </div>
-
-      <div className="relative mt-3 grid grid-cols-1 gap-2 text-xs sm:grid-cols-3">
-        <div className="rounded-lg border border-white/10 bg-white/[0.035] p-2.5">
-          <p className="text-slate-500">适配批次</p>
-          <p className="mt-1 font-semibold text-white">{wave === 0 ? "基线" : `第 ${wave} 批`}</p>
-        </div>
-        <div className="rounded-lg border border-white/10 bg-white/[0.035] p-2.5">
-          <p className="text-slate-500">连接方式</p>
-          <p className="mt-1 font-semibold text-brand-100">
-            {mcpConnectionKindLabels[connectionKind]}
-          </p>
-        </div>
-        <div className="rounded-lg border border-white/10 bg-white/[0.035] p-2.5">
-          <p className="text-slate-500">风险等级</p>
-          <p className="mt-1 font-semibold text-hire-100">{mcpRiskLabels[risk]}</p>
-        </div>
-      </div>
-
-      <div className="relative mt-4 flex flex-wrap gap-2">
-        {project.tags.map((tag) => (
-          <span
-            className="rounded-full border border-white/10 bg-white/[0.055] px-2.5 py-1 text-xs font-medium text-slate-300"
-            key={tag}
-          >
-            {tag}
-          </span>
-        ))}
-      </div>
-
-      {project.requirements.length > 0 ? (
-        <div className="relative mt-4 rounded-lg border border-amber-300/20 bg-amber-300/[0.07] p-3">
-          <p className="text-xs font-semibold text-amber-100">当前接入条件</p>
-          <div className="mt-2 flex flex-wrap gap-2">
-            {project.requirements.map((requirement) => (
+      <div
+        className={`relative mt-4 rounded-lg border px-4 py-3 ${
+          availability === "adapting"
+            ? "border-cyan-300/20 bg-cyan-300/[0.06]"
+            : "border-amber-300/20 bg-amber-300/[0.06]"
+        }`}
+      >
+        <p className="text-xs font-semibold text-slate-200">{unavailableStatusLabel}</p>
+        <p className="mt-1 text-xs leading-5 text-slate-400">{unavailableReason}</p>
+        {project.requirements.length > 0 ? (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {project.requirements.slice(0, 3).map((requirement) => (
               <span
-                className="rounded-full border border-amber-300/20 bg-amber-300/10 px-2.5 py-1 text-xs font-medium text-amber-50"
+                className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 text-[11px] text-slate-300"
                 key={requirement}
               >
                 {mcpRequirementLabels[requirement]}
               </span>
             ))}
           </div>
-        </div>
-      ) : (
-        <div className="relative mt-4 rounded-lg border border-emerald-300/20 bg-emerald-300/[0.07] p-3 text-xs leading-5 text-emerald-50">
-          {wave === 2
-            ? "不需要 OAuth、Token 或用户安装运行时；由独立公网 sidecar 通过固定出口策略提供隔离 stdio 会话。"
-            : wave === 3
-              ? "不需要 OAuth、Token、桌面宿主或外部运行时；文件只进入断网受控工作区。"
-            : wave === 4
-              ? "需要在当前卡片的“加密凭据”区域保存 Token；凭据仅绑定当前 MCP，并通过固定出口的只读 sidecar 建立隔离 stdio 会话。"
-            : wave === 5
-              ? project.id === "duckdb-mcp"
-                ? "无需 Token 或远程数据库凭据；只读取当前卡片中上传、封存并绑定的本地 DuckDB 文件。"
-                : "数据库连接按只读策略运行；连接字段与加密凭据均在当前卡片独立配置，不接受完整连接串。"
-            : wave === 7
-              ? "无需 Token、OAuth、桌面宿主或本机浏览器；连接会创建匿名临时会话，不支持外站登录流程，也不会继承或保存登录状态。"
-            : "不需要 OAuth、Token、额外运行时或桌面宿主，可由当前模镜后端以本地 stdio 启动。"}
-        </div>
-      )}
-
-      <div className="relative mt-3 rounded-lg border border-cyan-300/15 bg-cyan-300/[0.05] p-3">
-        <p className="text-xs font-semibold text-cyan-100">本批生产验收门槛</p>
-        <div className="mt-2 flex flex-wrap gap-2">
-          {requiredCapabilities.map((capability) => (
-            <span
-              className="rounded-full border border-cyan-300/20 bg-cyan-300/10 px-2.5 py-1 text-xs text-cyan-50"
-              key={capability}
-            >
-              {formatMcpCapability(capability)}
-            </span>
-          ))}
-        </div>
-        {limitations.map((limitation) => (
-          <p className="mt-2 text-xs leading-5 text-slate-400" key={limitation}>
-            {limitation}
-          </p>
-        ))}
+        ) : null}
       </div>
 
-      {wave === 5 ? (
+      <button
+        className="relative mt-auto min-h-11 w-full cursor-not-allowed rounded-full border border-white/10 bg-white/[0.035] px-4 py-2 text-sm font-semibold text-slate-500"
+        disabled
+        type="button"
+      >
+        {unavailableStatusLabel}
+      </button>
+        </>
+      )}
+
+      {isReadyProductCard && isWorkbenchOpen ? (
+        <div
+          aria-labelledby={isReadyProductCard ? `mcp-workbench-${project.id}` : undefined}
+          aria-modal={isReadyProductCard ? "true" : undefined}
+          className={
+            isReadyProductCard
+              ? "fixed inset-0 z-[70] flex items-end justify-center bg-slate-950/80 p-0 backdrop-blur-sm sm:items-center sm:p-4"
+              : "contents"
+          }
+          onMouseDown={(event) => {
+            if (isReadyProductCard && event.target === event.currentTarget) closeWorkbench();
+          }}
+          role={isReadyProductCard ? "dialog" : undefined}
+          ref={isReadyProductCard ? workbenchDialogRef : undefined}
+        >
+          <section
+            className={
+              isReadyProductCard
+                ? "flex max-h-[92vh] w-full max-w-5xl flex-col overflow-hidden rounded-t-xl border border-white/10 bg-ink-950 sm:rounded-xl"
+                : "contents"
+            }
+            onMouseDown={(event) => {
+              if (isReadyProductCard) event.stopPropagation();
+            }}
+          >
+            {isReadyProductCard ? (
+              <header className="flex shrink-0 items-start justify-between gap-4 border-b border-white/10 bg-surface-900/95 px-4 py-4 sm:px-6">
+                <div className="min-w-0">
+                  <p className="text-xs font-semibold text-brand-100">MCP 工具台</p>
+                  <h2 className="mt-1 truncate text-xl font-semibold text-white" id={`mcp-workbench-${project.id}`}>
+                    {project.name}
+                  </h2>
+                  <p className="mt-1 text-xs text-slate-400">
+                    {isConnected ? "连接已建立，可选择工具执行" : "完成配置并建立连接后即可使用工具"}
+                  </p>
+                </div>
+                <button
+                  aria-label="关闭工具台"
+                  className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] text-slate-200 transition hover:bg-white/[0.09] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-200"
+                  onClick={closeWorkbench}
+                  ref={workbenchCloseRef}
+                  type="button"
+                >
+                  <X aria-hidden="true" className="h-5 w-5" />
+                </button>
+              </header>
+            ) : null}
+            <div className={isReadyProductCard ? "min-h-0 flex-1 overflow-y-auto px-4 pb-6 sm:px-6" : "contents"}>
+      {!isReadyProductCard && wave === 5 ? (
         <section
           aria-label="数据库安全与验证状态"
           className="relative mt-3 rounded-lg border border-emerald-300/20 bg-emerald-300/[0.055] p-3 text-xs"
@@ -1342,7 +1594,7 @@ export default function McpServerCard({
         </section>
       ) : null}
 
-      {wave === 6 ? (
+      {!isReadyProductCard && wave === 6 ? (
         <section
           aria-label="有状态 SaaS 账号与工具策略"
           className="relative mt-3 rounded-lg border border-violet-300/20 bg-violet-300/[0.055] p-3 text-xs"
@@ -1418,6 +1670,7 @@ export default function McpServerCard({
       {wave === 7 ? (
         <McpBrowserPanel
           availability={availability}
+          compact={isReadyProductCard}
           connected={state === "connected" || adapterStatus?.connected === true}
           policy={browserPolicy}
           preflightStatus={databasePreflight}
@@ -1426,7 +1679,7 @@ export default function McpServerCard({
         />
       ) : null}
 
-      {adapterStatus?.executable && adapterStatus.runtime_image ? (
+      {!isReadyProductCard && adapterStatus?.executable && adapterStatus.runtime_image ? (
         <div className="relative mt-3 rounded-lg border border-emerald-300/20 bg-emerald-300/[0.06] p-3 text-xs">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <p className="font-semibold text-emerald-100">已验证运行隔离</p>
@@ -1482,7 +1735,11 @@ export default function McpServerCard({
       <div className="relative mt-auto flex flex-wrap items-center gap-2 pt-5">
         {canConnect ? (
           <button
-            className="min-h-11 rounded-full bg-brand-300 px-4 py-2 text-sm font-semibold text-ink-950 shadow-[0_0_24px_rgba(34,211,238,0.18)] transition duration-200 hover:bg-brand-200 disabled:cursor-not-allowed disabled:opacity-45"
+            className={`min-h-11 rounded-full px-4 py-2 text-sm font-semibold text-ink-950 transition duration-200 disabled:cursor-not-allowed disabled:opacity-45 ${
+              isPlaywrightCard
+                ? "bg-hire-300 hover:bg-hire-200"
+                : "bg-brand-300 shadow-[0_0_24px_rgba(34,211,238,0.18)] hover:bg-brand-200"
+            }`}
             disabled={
               state === "connecting" ||
               state === "connected" ||
@@ -1491,6 +1748,9 @@ export default function McpServerCard({
             onClick={() => void connect()}
             type="button"
           >
+            {isPlaywrightCard && state !== "connecting" && state !== "connected" ? (
+              <Link2 aria-hidden="true" className="mr-2 inline h-4 w-4" strokeWidth={2} />
+            ) : null}
             {state === "connecting"
               ? isBrowserAdapter ? "正在创建临时会话" : "连接中..."
               : state === "connected"
@@ -1499,7 +1759,9 @@ export default function McpServerCard({
                   ? "先绑定工作区"
                   : needsCatalogConfiguration && !catalogConfigured
                     ? "先保存连接配置"
-                  : isBrowserAdapter ? "连接临时浏览器" : "连接 Server"}
+                  : isPlaywrightCard
+                    ? "连接 Playwright"
+                    : isBrowserAdapter ? "连接临时浏览器" : "连接 Server"}
           </button>
         ) : (
           <button
@@ -1507,17 +1769,13 @@ export default function McpServerCard({
             disabled
             type="button"
           >
-            {!adapterStatus && availability === "ready"
+            {!adapterStatus
               ? "同步服务端状态..."
-              : isStatefulSaas && availability === "ready" && !statefulSaasGateEnabled
+              : isStatefulSaas && !statefulSaasGateEnabled
                 ? "SaaS 门禁未开启"
-              : adapterStatus && availability === "ready" && !adapterStatus.feature_enabled
+              : !adapterStatus.feature_enabled
                 ? "项目开关未开启"
-              : availability === "adapting"
-                ? "正在适配"
-                : availability === "blocked"
-                  ? "适配受阻"
-                  : "等待安全适配"}
+                : "暂不可连接"}
           </button>
         )}
         {state === "connected" ? (
@@ -1529,7 +1787,7 @@ export default function McpServerCard({
             {isBrowserAdapter ? "结束临时会话" : "断开连接"}
           </button>
         ) : null}
-        {canInstall ? (
+        {canInstall && !isPlaywrightCard ? (
           <button
             className={`min-h-11 rounded-full border px-4 py-2 text-sm font-semibold transition duration-200 disabled:cursor-not-allowed disabled:opacity-60 ${
               installState === "installed"
@@ -1554,14 +1812,19 @@ export default function McpServerCard({
           </button>
         ) : null}
         <button
-          className="min-h-11 rounded-full border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-300 transition duration-200 hover:border-hire-300/35 hover:bg-hire-300/10 hover:text-hire-100"
+          className={`min-h-11 rounded-full border px-3 py-2 text-xs font-semibold transition duration-200 ${
+            isPlaywrightCard
+              ? "border-cyan-300/25 bg-cyan-300/[0.06] text-cyan-100 hover:bg-cyan-300/10"
+              : "border-white/10 bg-white/[0.04] text-slate-300 hover:border-hire-300/35 hover:bg-hire-300/10 hover:text-hire-100"
+          }`}
           onClick={() => setIsInstallOpen(true)}
           type="button"
         >
-          中文配置与使用
+          {isPlaywrightCard ? "配置与使用" : "中文配置与使用"}
         </button>
       </div>
 
+      {!isReadyProductCard ? (
       <div className="relative mt-4 rounded-lg border border-white/10 bg-slate-950/55 p-3">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div>
@@ -1583,6 +1846,7 @@ export default function McpServerCard({
           ) : null}
         </div>
       </div>
+      ) : null}
 
       {installError ? (
         <div className="relative mt-4 rounded-lg border border-amber-300/25 bg-amber-300/10 p-3 text-sm leading-6 text-amber-50">
@@ -1730,6 +1994,10 @@ export default function McpServerCard({
           )}
         </div>
       ) : null}
+            </div>
+          </section>
+        </div>
+      ) : null}
 
       {pendingApproval ? (
         <McpApprovalDialog
@@ -1751,7 +2019,7 @@ export default function McpServerCard({
             <div className="flex items-start justify-between gap-4">
               <div>
                 <p className="text-sm font-semibold text-hire-100">
-                  中文配置与使用指引
+                  {isPlaywrightCard ? "配置与使用" : "中文配置与使用指引"}
                 </p>
                 <h2
                   className="mt-2 text-2xl font-semibold text-white"
@@ -1769,7 +2037,14 @@ export default function McpServerCard({
                 关闭
               </button>
             </div>
-            <div
+            {isPlaywrightCard ? (
+              <div className="mt-5 rounded-lg border border-cyan-300/20 bg-cyan-300/[0.06] p-4">
+                <p className="text-sm font-semibold text-cyan-100">临时匿名浏览器</p>
+                <p className="mt-2 text-sm leading-6 text-slate-300">
+                  连接后即可打开公开网页、读取页面并执行受控点击、填写与截图。会话结束后登录状态不会保留。
+                </p>
+              </div>
+            ) : <div
               className={`mt-5 rounded-lg border p-4 ${
                 canConnect
                   ? "border-emerald-300/25 bg-emerald-300/[0.08]"
@@ -1793,9 +2068,9 @@ export default function McpServerCard({
                   本页不会要求输入 Token，也不会跳转到 OAuth 或外站登录页面。
                 </p>
               ) : null}
-            </div>
+            </div>}
 
-            {project.requirements.length > 0 ? (
+            {!isPlaywrightCard && project.requirements.length > 0 ? (
               <section className="mt-5">
                 <h3 className="text-sm font-semibold text-white">接入条件</h3>
                 <div className="mt-2 flex flex-wrap gap-2">
@@ -1814,7 +2089,13 @@ export default function McpServerCard({
             <section className="mt-5">
               <h3 className="text-sm font-semibold text-white">配置步骤</h3>
               <ol className="mt-3 space-y-3">
-                {project.configGuide.map((step, index) => (
+                {(isPlaywrightCard
+                  ? [
+                      "点击“连接 Playwright”创建临时浏览器会话。",
+                      "选择浏览器工具，填写公开网页地址或页面操作参数。",
+                      "截图会显示在会话与截图区域，可下载或清理。",
+                    ]
+                  : project.configGuide).map((step, index) => (
                   <li
                     className="flex gap-3 text-sm leading-6 text-slate-300"
                     key={step}
@@ -1831,7 +2112,9 @@ export default function McpServerCard({
             <section className="mt-5 rounded-lg border border-white/10 bg-white/[0.04] p-4">
               <h3 className="text-sm font-semibold text-white">可以怎么用</h3>
               <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-300">
-                {project.usageExamples.map((example) => (
+                {(isPlaywrightCard
+                  ? ["核对公开页面的标题、链接和关键文案", "在逐次确认后点击、填写并生成截图"]
+                  : project.usageExamples).map((example) => (
                   <li className="flex gap-2" key={example}>
                     <span aria-hidden="true" className="text-brand-100">
                       •
@@ -1842,7 +2125,7 @@ export default function McpServerCard({
               </ul>
             </section>
 
-            {canConnect ? (
+            {canConnect && !isPlaywrightCard ? (
               <section className="mt-5 rounded-lg border border-emerald-300/20 bg-emerald-300/[0.07] p-4">
                 <h3 className="text-sm font-semibold text-emerald-100">
                   服务端受控适配器

--- a/client/src/components/McpServerCard.tsx
+++ b/client/src/components/McpServerCard.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  Camera,
-  FileText,
-  Globe2,
   Link2,
-  MousePointer2,
   Settings2,
   Star,
   Wrench,
@@ -538,6 +534,44 @@ export default function McpServerCard({
   const needsCatalogConfiguration = Boolean(
     adapterStatus?.credential_fields.length || adapterStatus?.setting_fields.length,
   );
+  const readyCardCopy = useMemo(() => {
+    switch (project.id) {
+      case "playwright-mcp":
+        return {
+          description: "打开网页、读取页面并执行受控点击、填写与截图。",
+          tags: ["打开网页", "读取页面", "点击与填写", "生成截图"],
+          connectionNote: "临时匿名浏览器，不保留登录态；不支持上传和下载。",
+        };
+      case "takashiishida-arxiv-latex-mcp":
+        return {
+          description: "读取 arXiv 论文摘要、章节结构和 LaTeX 正文。",
+          tags: ["论文摘要", "章节目录", "LaTeX 正文", "只读访问"],
+          connectionNote: "仅访问 arXiv 官方公开论文，不编译 TeX 或加载外部资源。",
+        };
+      case "greptimeteam-greptimedb-mcp-server":
+        return {
+          description: "查询固定 GreptimeDB 数据表的结构、时间范围和健康状态。",
+          tags: ["表结构", "时序查询", "健康检查", "只读访问"],
+          connectionNote: "连接固定数据源，只允许服务端生成的只读查询。",
+        };
+      case "victoriametrics-community-mcp-victoriametrics":
+        return {
+          description: "读取 VictoriaMetrics 指标、标签和限定时间范围的监控数据。",
+          tags: ["指标列表", "标签查询", "即时查询", "范围查询"],
+          connectionNote: "连接固定监控目标，查询范围和返回数量均受限制。",
+        };
+      default:
+        return {
+          description: project.description,
+          tags: project.tags.slice(0, 4),
+          connectionNote: workspacePolicy?.required
+            ? "连接前需选择受控工作区"
+            : needsCatalogConfiguration
+              ? "连接前需完成一次配置"
+              : "可直接连接并使用工具",
+        };
+    }
+  }, [needsCatalogConfiguration, project.description, project.id, project.tags, workspacePolicy?.required]);
   const canStartConnection =
     canConnect &&
     (!isBrowserAdapter || Boolean(browserPolicy)) &&
@@ -1220,102 +1254,10 @@ export default function McpServerCard({
         isReadyProductCard ? "min-h-[360px]" : "min-h-[280px]"
       } ${
         isReadyProductCard && isWorkbenchOpen ? "" : "isolate overflow-hidden"
-      } ${
-        isPlaywrightCard
-          ? "border border-cyan-300/25 bg-[linear-gradient(145deg,rgba(9,22,45,0.98),rgba(6,15,31,0.98))] hover:border-cyan-200/45"
-          : "border border-white/10 bg-ink-950/78 hover:border-hire-300/40 hover:bg-surface-900/92"
-      }`}
+      } border border-white/10 bg-ink-950/78 hover:border-hire-300/40 hover:bg-surface-900/92`}
     >
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_12%,rgba(251,146,60,0.16),transparent_34%),radial-gradient(circle_at_82%_82%,rgba(36,217,255,0.13),transparent_36%)] opacity-80" />
-      {isPlaywrightCard ? (
-        <>
-          <div className="relative flex items-start justify-between gap-4">
-            <div className="flex min-w-0 items-start gap-3">
-              <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-cyan-300/25 bg-cyan-300/[0.08] text-cyan-100 shadow-[0_0_24px_rgba(34,211,238,0.08)]">
-                <MousePointer2 aria-hidden="true" className="h-6 w-6" strokeWidth={1.8} />
-              </span>
-              <div className="min-w-0">
-                <h2 className="text-xl font-semibold leading-7 text-white">Playwright MCP</h2>
-                <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-slate-400">
-                  <a
-                    className="underline-offset-4 transition hover:text-cyan-100 hover:underline"
-                    href={project.repoUrl}
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    {project.repoName}
-                  </a>
-                  <span aria-hidden="true">·</span>
-                  <span className="inline-flex items-center gap-1.5 text-slate-300">
-                    <Star aria-hidden="true" className="h-3.5 w-3.5 text-hire-200" strokeWidth={2} />
-                    {formatStars(project.stars)} stars
-                  </span>
-                </div>
-              </div>
-            </div>
-            <span
-              className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold ${
-                isConnected
-                  ? "border-emerald-300/25 bg-emerald-300/[0.08] text-emerald-100"
-                  : "border-white/10 bg-white/[0.045] text-slate-300"
-              }`}
-            >
-              <span aria-hidden="true" className={`mr-1.5 inline-block h-2 w-2 rounded-full ${isConnected ? "bg-emerald-300" : "bg-slate-400"}`} />
-              {isConnected ? "已连接" : "尚未连接"}
-            </span>
-          </div>
-
-          <p className="relative mt-5 text-sm leading-6 text-slate-200">
-            打开网页、读取页面并执行受控点击、填写与截图。
-          </p>
-
-          <div className="relative mt-5 border-y border-white/10 py-4">
-            <p className="text-xs font-semibold tracking-wide text-slate-400">可以做什么</p>
-            <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-4">
-              {[
-                [Globe2, "打开网页"],
-                [FileText, "读取页面"],
-                [MousePointer2, "点击与填写"],
-                [Camera, "生成截图"],
-              ].map(([Icon, label]) => (
-                <div className="flex items-center gap-2 text-sm font-medium text-slate-100" key={label as string}>
-                  <Icon aria-hidden="true" className="h-4 w-4 text-cyan-200" strokeWidth={1.8} />
-                  <span>{label as string}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="relative mt-4 rounded-lg border border-white/10 bg-white/[0.035] px-4 py-3">
-            <p className="text-xs font-semibold text-slate-300">使用边界</p>
-            <p className="mt-1 text-xs leading-5 text-slate-400">
-              临时匿名浏览器，不保留登录态；不支持上传和下载。
-            </p>
-          </div>
-
-          <div className="relative mt-4 flex flex-wrap gap-2">
-            <button
-              className="min-h-11 flex-1 rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:opacity-45"
-              disabled={!isConnected && (!canConnect || !canStartConnection || state === "connecting")}
-              onClick={() => {
-                if (isConnected) setIsWorkbenchOpen(true);
-                else void connect();
-              }}
-              ref={workbenchTriggerRef}
-              type="button"
-            >
-              {state === "connecting" ? "正在创建会话" : isConnected ? "打开工具台" : "连接 Playwright"}
-            </button>
-            <button
-              className="min-h-11 rounded-full border border-cyan-300/25 bg-cyan-300/[0.06] px-4 py-2 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-300/10"
-              onClick={() => setIsInstallOpen(true)}
-              type="button"
-            >
-              配置与使用
-            </button>
-          </div>
-        </>
-      ) : isReadyProductCard ? (
+      {isReadyProductCard ? (
         <>
           <div className="relative flex items-start justify-between gap-4">
             <div className="flex min-w-0 items-start gap-3">
@@ -1358,13 +1300,13 @@ export default function McpServerCard({
           </div>
 
           <p className="relative mt-5 line-clamp-3 text-sm leading-6 text-slate-200">
-            {project.description}
+            {readyCardCopy.description}
           </p>
 
           <div className="relative mt-5 border-y border-white/10 py-4">
             <p className="text-xs font-semibold text-slate-400">主要能力</p>
             <div className="mt-3 flex flex-wrap gap-2">
-              {project.tags.slice(0, 4).map((tag) => (
+              {readyCardCopy.tags.map((tag) => (
                 <span
                   className="rounded-full border border-brand-300/20 bg-brand-300/[0.07] px-3 py-1.5 text-xs font-medium text-brand-50"
                   key={tag}
@@ -1377,13 +1319,7 @@ export default function McpServerCard({
 
           <div className="relative mt-4 flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.035] px-4 py-3 text-xs text-slate-300">
             <Settings2 aria-hidden="true" className="h-4 w-4 shrink-0 text-brand-100" strokeWidth={1.8} />
-            <span>
-              {workspacePolicy?.required
-                ? "连接前需选择受控工作区"
-                : needsCatalogConfiguration
-                  ? "连接前需完成一次配置"
-                  : "可直接连接并使用工具"}
-            </span>
+            <span>{readyCardCopy.connectionNote}</span>
           </div>
 
           <div className="relative mt-auto flex flex-wrap gap-2 pt-5">

--- a/client/src/pages/McpBrowserPage.test.tsx
+++ b/client/src/pages/McpBrowserPage.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mcpProjects } from "../data/mcpProjects";
-import McpBrowserPage from "./McpBrowserPage";
+import McpBrowserPage, { prioritizeReadyProjects } from "./McpBrowserPage";
 
 vi.mock("../components/McpServerCard", () => ({
   default: ({ project }: { project: { name: string } }) => (
@@ -49,6 +49,26 @@ afterEach(() => {
 });
 
 describe("McpBrowserPage first-screen shell", () => {
+  it("puts ready tools first only in the unfiltered all view", async () => {
+    const projects = [
+      { id: "blocked-a", availability: "blocked" },
+      { id: "ready-a", availability: "ready" },
+      { id: "planned-a", availability: "planned" },
+      { id: "ready-b", availability: "ready" },
+    ];
+
+    expect(
+      prioritizeReadyProjects(projects, (project) => project.availability, true).map(
+        (project) => project.id,
+      ),
+    ).toEqual(["ready-a", "ready-b", "blocked-a", "planned-a"]);
+    expect(
+      prioritizeReadyProjects(projects, (project) => project.availability, false).map(
+        (project) => project.id,
+      ),
+    ).toEqual(projects.map((project) => project.id));
+  });
+
   it("keeps only the approved compact procurement information", async () => {
     renderPage([], [{ session_id: "session-1" }]);
 

--- a/client/src/pages/McpBrowserPage.tsx
+++ b/client/src/pages/McpBrowserPage.tsx
@@ -33,6 +33,22 @@ interface RegistryTool {
 }
 
 type CatalogCategory = "全部类别" | McpCategory;
+
+export function prioritizeReadyProjects<T>(
+  projects: readonly T[],
+  getAvailability: (project: T) => string,
+  enabled: boolean,
+): T[] {
+  if (!enabled) return [...projects];
+  return projects
+    .map((project, index) => ({ project, index }))
+    .sort((left, right) => {
+      const leftReady = getAvailability(left.project) === "ready";
+      const rightReady = getAvailability(right.project) === "ready";
+      return Number(rightReady) - Number(leftReady) || left.index - right.index;
+    })
+    .map(({ project }) => project);
+}
 type AvailabilityFilter = "all" | "ready" | "in_progress" | "blocked";
 
 const INITIAL_VISIBLE_COUNT = 18;
@@ -163,7 +179,7 @@ export default function McpBrowserPage() {
   );
   const filteredProjects = useMemo(() => {
     const normalizedQuery = query.trim().toLocaleLowerCase("zh-CN");
-    return mcpProjects.filter((project) => {
+    const matches = mcpProjects.filter((project) => {
       if (
         selectedCategory !== "全部类别" &&
         project.category !== selectedCategory
@@ -194,6 +210,11 @@ export default function McpBrowserPage() {
         .toLocaleLowerCase("zh-CN");
       return searchableText.includes(normalizedQuery);
     });
+    return prioritizeReadyProjects(
+      matches,
+      (project) => effectiveAvailability(project.id),
+      availabilityFilter === "all" && selectedCategory === "全部类别",
+    );
   }, [availabilityFilter, effectiveAvailability, query, selectedCategory]);
   const visibleProjects = useMemo(
     () => filteredProjects.slice(0, visibleCount),


### PR DESCRIPTION
## 变更摘要

- 以 Playwright MCP 为样板，精简 ready 工具卡片，只保留清晰介绍、核心能力、使用边界与操作入口。
- 将“配置与使用”改为浮层，支持 Esc、点击外部关闭、焦点恢复与焦点约束，避免展开后拉长卡片。
- 精简适配中/未适配卡片，删除 README、批次/风险、生产验收门槛和内联运行区，仅保留简短原因、最多 3 个必要条件及禁用状态。
- 统一卡片为行内等高布局，使同一网格行的卡片底部和操作区对齐。

## 范围

- 仅前端 MCP 工具卡片与浏览面板展示逻辑。
- 不修改后端 API、MCP 能力判定、连接状态或注册表协议。

## 验证

- MCP 聚焦测试：2 files / 8 tests passed。
- `npm.cmd run build`：passed（3109 modules；仅既有大 chunk warning）。
- `git diff --check`：passed。
- 独立预览 `15186`：桌面首行 3 张卡片等高；390×844 无横向溢出。

## 兼容与回退

- 能力状态和后端数据来源保持不变；仅调整信息层级与交互呈现。
- 回退可直接恢复本 PR 的三个前端文件，不涉及数据库或服务端迁移。

## 说明

- 组合执行 build 时曾遇到一次 Windows `tsbuildinfo` 临时文件 `EPERM`；独立重跑构建通过。
