### PR TITLE
fix: 统一 MCP 已适配卡片展示

### DIFF
--- a/client/src/components/McpServerCard.playwright-card.test.tsx
+++ b/client/src/components/McpServerCard.playwright-card.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { mcpProjects } from "../data/mcpProjects";
@@ -11,13 +11,19 @@ function project(projectId: string) {
 }
 
 describe("McpServerCard Playwright sample", () => {
-  it("shows only user-facing capability and boundary copy by default", () => {
+  it("uses the same ready-card structure while preserving Playwright copy", () => {
     render(<McpServerCard project={project("playwright-mcp")} />);
 
-    expect(screen.getByRole("heading", { name: "Playwright MCP" })).toBeVisible();
+    const heading = screen.getByRole("heading", { name: "Playwright MCP" });
+    expect(heading).toBeVisible();
+    const card = heading.closest("article");
+    expect(card).toHaveClass("border-white/10", "bg-ink-950/78");
+    expect(within(card as HTMLElement).getByText("浏览器与网页")).toBeVisible();
+    expect(within(card as HTMLElement).getByText("可用")).toBeVisible();
     expect(
       screen.getByText("打开网页、读取页面并执行受控点击、填写与截图。"),
     ).toBeVisible();
+    expect(screen.getByText("主要能力")).toBeVisible();
     expect(screen.getByText("打开网页")).toBeVisible();
     expect(screen.getByText("读取页面")).toBeVisible();
     expect(screen.getByText("点击与填写")).toBeVisible();
@@ -25,7 +31,7 @@ describe("McpServerCard Playwright sample", () => {
     expect(
       screen.getByText("临时匿名浏览器，不保留登录态；不支持上传和下载。"),
     ).toBeVisible();
-    expect(screen.getByRole("button", { name: "连接 Playwright" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "打开工具台" })).toBeVisible();
     expect(screen.getByRole("button", { name: "配置与使用" })).toBeVisible();
     expect(screen.queryByRole("dialog", { name: "Playwright MCP" })).not.toBeInTheDocument();
 
@@ -47,6 +53,35 @@ describe("McpServerCard Playwright sample", () => {
     expect(screen.queryByText("README 摘要")).not.toBeInTheDocument();
     expect(screen.queryByText("资料核验")).not.toBeInTheDocument();
     expect(screen.queryByText("本批生产验收门槛")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      "takashiishida-arxiv-latex-mcp",
+      "Arxiv Latex Mcp",
+      "读取 arXiv 论文摘要、章节结构和 LaTeX 正文。",
+      "论文摘要",
+    ],
+    [
+      "greptimeteam-greptimedb-mcp-server",
+      "GreptimeDB",
+      "查询固定 GreptimeDB 数据表的结构、时间范围和健康状态。",
+      "时序查询",
+    ],
+    [
+      "victoriametrics-community-mcp-victoriametrics",
+      "Mcp Victoriametrics",
+      "读取 VictoriaMetrics 指标、标签和限定时间范围的监控数据。",
+      "指标列表",
+    ],
+  ])("gives newly adapted %s concise ready copy", (projectId, name, description, capability) => {
+    render(<McpServerCard project={project(projectId)} />);
+
+    expect(screen.getByRole("heading", { name })).toBeVisible();
+    expect(screen.getByText(description)).toBeVisible();
+    expect(screen.getByText(capability)).toBeVisible();
+    expect(screen.getByText("可用")).toBeVisible();
+    expect(screen.queryByText(/当前判定为 ready/)).not.toBeInTheDocument();
   });
 
   it("opens the ready tool workbench as an overlay and restores focus", async () => {

--- a/client/src/components/McpServerCard.tsx
+++ b/client/src/components/McpServerCard.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  Camera,
-  FileText,
-  Globe2,
   Link2,
-  MousePointer2,
   Settings2,
   Star,
   Wrench,
@@ -538,6 +534,44 @@ export default function McpServerCard({
   const needsCatalogConfiguration = Boolean(
     adapterStatus?.credential_fields.length || adapterStatus?.setting_fields.length,
   );
+  const readyCardCopy = useMemo(() => {
+    switch (project.id) {
+      case "playwright-mcp":
+        return {
+          description: "打开网页、读取页面并执行受控点击、填写与截图。",
+          tags: ["打开网页", "读取页面", "点击与填写", "生成截图"],
+          connectionNote: "临时匿名浏览器，不保留登录态；不支持上传和下载。",
+        };
+      case "takashiishida-arxiv-latex-mcp":
+        return {
+          description: "读取 arXiv 论文摘要、章节结构和 LaTeX 正文。",
+          tags: ["论文摘要", "章节目录", "LaTeX 正文", "只读访问"],
+          connectionNote: "仅访问 arXiv 官方公开论文，不编译 TeX 或加载外部资源。",
+        };
+      case "greptimeteam-greptimedb-mcp-server":
+        return {
+          description: "查询固定 GreptimeDB 数据表的结构、时间范围和健康状态。",
+          tags: ["表结构", "时序查询", "健康检查", "只读访问"],
+          connectionNote: "连接固定数据源，只允许服务端生成的只读查询。",
+        };
+      case "victoriametrics-community-mcp-victoriametrics":
+        return {
+          description: "读取 VictoriaMetrics 指标、标签和限定时间范围的监控数据。",
+          tags: ["指标列表", "标签查询", "即时查询", "范围查询"],
+          connectionNote: "连接固定监控目标，查询范围和返回数量均受限制。",
+        };
+      default:
+        return {
+          description: project.description,
+          tags: project.tags.slice(0, 4),
+          connectionNote: workspacePolicy?.required
+            ? "连接前需选择受控工作区"
+            : needsCatalogConfiguration
+              ? "连接前需完成一次配置"
+              : "可直接连接并使用工具",
+        };
+    }
+  }, [needsCatalogConfiguration, project.description, project.id, project.tags, workspacePolicy?.required]);
   const canStartConnection =
     canConnect &&
     (!isBrowserAdapter || Boolean(browserPolicy)) &&
@@ -1220,102 +1254,10 @@ export default function McpServerCard({
         isReadyProductCard ? "min-h-[360px]" : "min-h-[280px]"
       } ${
         isReadyProductCard && isWorkbenchOpen ? "" : "isolate overflow-hidden"
-      } ${
-        isPlaywrightCard
-          ? "border border-cyan-300/25 bg-[linear-gradient(145deg,rgba(9,22,45,0.98),rgba(6,15,31,0.98))] hover:border-cyan-200/45"
-          : "border border-white/10 bg-ink-950/78 hover:border-hire-300/40 hover:bg-surface-900/92"
-      }`}
+      } border border-white/10 bg-ink-950/78 hover:border-hire-300/40 hover:bg-surface-900/92`}
     >
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_12%,rgba(251,146,60,0.16),transparent_34%),radial-gradient(circle_at_82%_82%,rgba(36,217,255,0.13),transparent_36%)] opacity-80" />
-      {isPlaywrightCard ? (
-        <>
-          <div className="relative flex items-start justify-between gap-4">
-            <div className="flex min-w-0 items-start gap-3">
-              <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-cyan-300/25 bg-cyan-300/[0.08] text-cyan-100 shadow-[0_0_24px_rgba(34,211,238,0.08)]">
-                <MousePointer2 aria-hidden="true" className="h-6 w-6" strokeWidth={1.8} />
-              </span>
-              <div className="min-w-0">
-                <h2 className="text-xl font-semibold leading-7 text-white">Playwright MCP</h2>
-                <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-slate-400">
-                  <a
-                    className="underline-offset-4 transition hover:text-cyan-100 hover:underline"
-                    href={project.repoUrl}
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    {project.repoName}
-                  </a>
-                  <span aria-hidden="true">·</span>
-                  <span className="inline-flex items-center gap-1.5 text-slate-300">
-                    <Star aria-hidden="true" className="h-3.5 w-3.5 text-hire-200" strokeWidth={2} />
-                    {formatStars(project.stars)} stars
-                  </span>
-                </div>
-              </div>
-            </div>
-            <span
-              className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold ${
-                isConnected
-                  ? "border-emerald-300/25 bg-emerald-300/[0.08] text-emerald-100"
-                  : "border-white/10 bg-white/[0.045] text-slate-300"
-              }`}
-            >
-              <span aria-hidden="true" className={`mr-1.5 inline-block h-2 w-2 rounded-full ${isConnected ? "bg-emerald-300" : "bg-slate-400"}`} />
-              {isConnected ? "已连接" : "尚未连接"}
-            </span>
-          </div>
-
-          <p className="relative mt-5 text-sm leading-6 text-slate-200">
-            打开网页、读取页面并执行受控点击、填写与截图。
-          </p>
-
-          <div className="relative mt-5 border-y border-white/10 py-4">
-            <p className="text-xs font-semibold tracking-wide text-slate-400">可以做什么</p>
-            <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-4">
-              {[
-                [Globe2, "打开网页"],
-                [FileText, "读取页面"],
-                [MousePointer2, "点击与填写"],
-                [Camera, "生成截图"],
-              ].map(([Icon, label]) => (
-                <div className="flex items-center gap-2 text-sm font-medium text-slate-100" key={label as string}>
-                  <Icon aria-hidden="true" className="h-4 w-4 text-cyan-200" strokeWidth={1.8} />
-                  <span>{label as string}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="relative mt-4 rounded-lg border border-white/10 bg-white/[0.035] px-4 py-3">
-            <p className="text-xs font-semibold text-slate-300">使用边界</p>
-            <p className="mt-1 text-xs leading-5 text-slate-400">
-              临时匿名浏览器，不保留登录态；不支持上传和下载。
-            </p>
-          </div>
-
-          <div className="relative mt-4 flex flex-wrap gap-2">
-            <button
-              className="min-h-11 flex-1 rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:opacity-45"
-              disabled={!isConnected && (!canConnect || !canStartConnection || state === "connecting")}
-              onClick={() => {
-                if (isConnected) setIsWorkbenchOpen(true);
-                else void connect();
-              }}
-              ref={workbenchTriggerRef}
-              type="button"
-            >
-              {state === "connecting" ? "正在创建会话" : isConnected ? "打开工具台" : "连接 Playwright"}
-            </button>
-            <button
-              className="min-h-11 rounded-full border border-cyan-300/25 bg-cyan-300/[0.06] px-4 py-2 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-300/10"
-              onClick={() => setIsInstallOpen(true)}
-              type="button"
-            >
-              配置与使用
-            </button>
-          </div>
-        </>
-      ) : isReadyProductCard ? (
+      {isReadyProductCard ? (
         <>
           <div className="relative flex items-start justify-between gap-4">
             <div className="flex min-w-0 items-start gap-3">
@@ -1358,13 +1300,13 @@ export default function McpServerCard({
           </div>
 
           <p className="relative mt-5 line-clamp-3 text-sm leading-6 text-slate-200">
-            {project.description}
+            {readyCardCopy.description}
           </p>
 
           <div className="relative mt-5 border-y border-white/10 py-4">
             <p className="text-xs font-semibold text-slate-400">主要能力</p>
             <div className="mt-3 flex flex-wrap gap-2">
-              {project.tags.slice(0, 4).map((tag) => (
+              {readyCardCopy.tags.map((tag) => (
                 <span
                   className="rounded-full border border-brand-300/20 bg-brand-300/[0.07] px-3 py-1.5 text-xs font-medium text-brand-50"
                   key={tag}
@@ -1377,13 +1319,7 @@ export default function McpServerCard({
 
           <div className="relative mt-4 flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.035] px-4 py-3 text-xs text-slate-300">
             <Settings2 aria-hidden="true" className="h-4 w-4 shrink-0 text-brand-100" strokeWidth={1.8} />
-            <span>
-              {workspacePolicy?.required
-                ? "连接前需选择受控工作区"
-                : needsCatalogConfiguration
-                  ? "连接前需完成一次配置"
-                  : "可直接连接并使用工具"}
-            </span>
+            <span>{readyCardCopy.connectionNote}</span>
           </div>
 
           <div className="relative mt-auto flex flex-wrap gap-2 pt-5">

--- a/client/src/pages/McpBrowserPage.test.tsx
+++ b/client/src/pages/McpBrowserPage.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mcpProjects } from "../data/mcpProjects";
-import McpBrowserPage from "./McpBrowserPage";
+import McpBrowserPage, { prioritizeReadyProjects } from "./McpBrowserPage";
 
 vi.mock("../components/McpServerCard", () => ({
   default: ({ project }: { project: { name: string } }) => (
@@ -49,6 +49,26 @@ afterEach(() => {
 });
 
 describe("McpBrowserPage first-screen shell", () => {
+  it("puts ready tools first only in the unfiltered all view", async () => {
+    const projects = [
+      { id: "blocked-a", availability: "blocked" },
+      { id: "ready-a", availability: "ready" },
+      { id: "planned-a", availability: "planned" },
+      { id: "ready-b", availability: "ready" },
+    ];
+
+    expect(
+      prioritizeReadyProjects(projects, (project) => project.availability, true).map(
+        (project) => project.id,
+      ),
+    ).toEqual(["ready-a", "ready-b", "blocked-a", "planned-a"]);
+    expect(
+      prioritizeReadyProjects(projects, (project) => project.availability, false).map(
+        (project) => project.id,
+      ),
+    ).toEqual(projects.map((project) => project.id));
+  });
+
   it("keeps only the approved compact procurement information", async () => {
     renderPage([], [{ session_id: "session-1" }]);
 

--- a/client/src/pages/McpBrowserPage.tsx
+++ b/client/src/pages/McpBrowserPage.tsx
@@ -33,6 +33,22 @@ interface RegistryTool {
 }
 
 type CatalogCategory = "全部类别" | McpCategory;
+
+export function prioritizeReadyProjects<T>(
+  projects: readonly T[],
+  getAvailability: (project: T) => string,
+  enabled: boolean,
+): T[] {
+  if (!enabled) return [...projects];
+  return projects
+    .map((project, index) => ({ project, index }))
+    .sort((left, right) => {
+      const leftReady = getAvailability(left.project) === "ready";
+      const rightReady = getAvailability(right.project) === "ready";
+      return Number(rightReady) - Number(leftReady) || left.index - right.index;
+    })
+    .map(({ project }) => project);
+}
 type AvailabilityFilter = "all" | "ready" | "in_progress" | "blocked";
 
 const INITIAL_VISIBLE_COUNT = 18;
@@ -163,7 +179,7 @@ export default function McpBrowserPage() {
   );
   const filteredProjects = useMemo(() => {
     const normalizedQuery = query.trim().toLocaleLowerCase("zh-CN");
-    return mcpProjects.filter((project) => {
+    const matches = mcpProjects.filter((project) => {
       if (
         selectedCategory !== "全部类别" &&
         project.category !== selectedCategory
@@ -194,6 +210,11 @@ export default function McpBrowserPage() {
         .toLocaleLowerCase("zh-CN");
       return searchableText.includes(normalizedQuery);
     });
+    return prioritizeReadyProjects(
+      matches,
+      (project) => effectiveAvailability(project.id),
+      availabilityFilter === "all" && selectedCategory === "全部类别",
+    );
   }, [availabilityFilter, effectiveAvailability, query, selectedCategory]);
   const visibleProjects = useMemo(
     () => filteredProjects.slice(0, visibleCount),


### PR DESCRIPTION
﻿## 变更

- 将 Playwright 样例卡改为与其他已适配 MCP 相同的卡片结构，同时保留简洁能力与使用边界文案。
- 在“全部”且未选择分类时，将已适配工具稳定排列到最前；筛选后的目录顺序保持不变。
- 为 Arxiv Latex、GreptimeDB、VictoriaMetrics 补充简洁的已适配卡片文案。

## 验证

- `npm.cmd exec vitest run src/components/McpServerCard.playwright-card.test.tsx src/pages/McpBrowserPage.test.tsx`：12 passed
- `docker run --rm --network none ... python -m pytest -p no:cacheprovider server/tests/test_mcp_catalog.py -q`：62 passed
- `npm.cmd run build`：通过
- `git diff --check`：通过

## 范围

这是基于 MCP 卡片清理 PR 的小型堆叠 PR；不包含 Skill 页面改动、后端协议或共享栈变更。
