### PR TITLE
feature: V17 turn transactions and interaction recovery

### DIFF
--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -187,11 +187,11 @@ def _provider_supports_feature(
     if feature is WorkerFeatureName.CODE_INTELLIGENCE:
         return "code_diagnostics" in tools
     if feature is WorkerFeatureName.STRUCTURED_PLAN:
-        return capabilities.supports_structured_plan or "update_plan" in tools
+        return "update_plan" in tools
     if feature is WorkerFeatureName.USER_QUESTIONS:
-        return capabilities.supports_questions or "request_user_input" in tools
+        return "request_user_input" in tools
     if feature is WorkerFeatureName.CONTEXT_COMPACTION:
-        return capabilities.supports_compaction or "compact_context" in tools
+        return "compact_context" in tools
     if feature is WorkerFeatureName.TURN_HISTORY:
         return True
     if feature is WorkerFeatureName.SUBTASKS:
@@ -239,6 +239,7 @@ def _task_capability_status(
     current: ProviderCapabilities | None,
     binding_matches: bool,
     current_reason: str | None,
+    v17_task: bool = False,
 ) -> WorkerCapabilityStatus:
     enabled = _feature_flag_enabled(feature)
     platform_owned = feature is WorkerFeatureName.TURN_HISTORY
@@ -252,6 +253,13 @@ def _task_capability_status(
             and _provider_supports_feature(current, feature)
         )
     )
+    if (
+        v17_task
+        and basic_runtime
+        and snapshot is not None
+        and not snapshot.supports_turn_interrupt
+    ):
+        supported = False
     reason: WorkerCapabilityReason | None = None
     if not enabled:
         reason = WorkerCapabilityReason.FEATURE_DISABLED
@@ -288,7 +296,9 @@ def _task_capability_status(
             if current_reason == "route_unavailable"
             else WorkerCapabilityReason.PROVIDER_UNAVAILABLE
         )
-    elif not _provider_supports_feature(current, feature):
+    elif not _provider_supports_feature(current, feature) or (
+        v17_task and basic_runtime and not current.supports_turn_interrupt
+    ):
         reason = WorkerCapabilityReason.PROVIDER_UNSUPPORTED
     return WorkerCapabilityStatus(
         name=feature,
@@ -485,6 +495,7 @@ async def get_task_capabilities(task_id: str) -> TaskCapabilities:
                     current=observation.capabilities,
                     binding_matches=binding_matches,
                     current_reason=observation.reason,
+                    v17_task=task.runtime_protocol.value == "v17",
                 )
                 for feature in WorkerFeatureName
             ),

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -33,6 +33,7 @@ from .contracts import (
     WorkerEvidence,
     WorkerDiagnostic,
     WorkerPlan,
+    WorkerTodo,
     WorkerQuestion,
     WorkerQuestionAnswer,
     WorkerTurnHistory,
@@ -538,6 +539,15 @@ async def task_plan(task_id: str) -> WorkerPlan | None:
     _require_interaction_enabled()
     try:
         return get_coding_worker_service().store.latest_plan(task_id)
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get("/tasks/{task_id}/todo", response_model=WorkerTodo | None)
+async def task_todo(task_id: str) -> WorkerTodo | None:
+    _require_interaction_enabled()
+    try:
+        return get_coding_worker_service().store.latest_todo(task_id)
     except Exception as exc:
         _raise_worker_error(exc)
 

--- a/server/coding_worker/broker_mcp.py
+++ b/server/coding_worker/broker_mcp.py
@@ -476,6 +476,53 @@ def build_server(client: BrokerRPCClient) -> FastMCP:
             operation_id=operation_id,
         )
 
+    @mcp.tool()
+    async def update_plan(
+        operation_id: str,
+        items: list[dict[str, str]],
+        explanation: str | None = None,
+    ) -> dict[str, Any]:
+        """Replace the platform-owned structured plan for the current turn."""
+        return await call(
+            "update_plan",
+            {"items": items, "explanation": explanation},
+            operation_id=operation_id,
+        )
+
+    @mcp.tool()
+    async def update_todo(
+        operation_id: str, items: list[dict[str, str]]
+    ) -> dict[str, Any]:
+        """Replace the platform-owned Todo list for the current turn."""
+        return await call(
+            "update_todo", {"items": items}, operation_id=operation_id
+        )
+
+    @mcp.tool()
+    async def request_user_input(
+        operation_id: str,
+        question_id: str,
+        prompt: str,
+        options: list[dict[str, str]] | None = None,
+    ) -> dict[str, Any]:
+        """Park the turn at one durable, single-settlement user question."""
+        return await call(
+            "request_user_input",
+            {
+                "question_id": question_id,
+                "prompt": prompt,
+                "options": options or [],
+            },
+            operation_id=operation_id,
+        )
+
+    @mcp.tool()
+    async def compact_context(operation_id: str, note: str | None = None) -> dict[str, Any]:
+        """Request platform-controlled compaction at the current complete tool boundary."""
+        return await call(
+            "compact_context", {"note": note}, operation_id=operation_id
+        )
+
     return mcp
 
 

--- a/server/coding_worker/broker_rpc.py
+++ b/server/coding_worker/broker_rpc.py
@@ -13,6 +13,7 @@ from pydantic import Field
 from .contracts import (
     ApprovalStatus,
     OperationState,
+    RuntimeProtocol,
     StrictModel,
     TaskState,
     TERMINAL_STATES,
@@ -136,6 +137,15 @@ class BrokerRPCServer:
         except ToolBrokerError as exc:
             if exc.code != "approval_required" or request.lease_id is not None:
                 raise
+        task = self.broker.store.get_task(request.task_id)
+        if task.runtime_protocol is RuntimeProtocol.V17:
+            operation = self.broker.store.get_operation(request.operation_id)
+            return ToolResult(
+                operation_id=operation.operation_id,
+                tool_name=operation.tool_name,
+                state=operation.state,
+                data={"control": "turn_parking", "barrier": "approval"},
+            )
         lease_id, network_lease_id = await self._wait_for_approval(request)
         return await self.broker.execute(
             task_id=request.task_id,

--- a/server/coding_worker/claude_provider.py
+++ b/server/coding_worker/claude_provider.py
@@ -141,6 +141,7 @@ class ClaudeCodeProvider(CodingAgentProvider):
             supports_steering=True,
             supports_usage=True,
             supports_tool_boundaries=True,
+            supports_turn_interrupt=True,
             tool_names=PROVIDER_TOOL_NAMES,
         )
 
@@ -297,6 +298,9 @@ class ClaudeCodeProvider(CodingAgentProvider):
             return False
         await _stop_process(process)
         return True
+
+    async def interrupt_turn(self, session: ProviderSession) -> bool:
+        return await self.cancel(session)
 
     async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
         handle = self._require_session(session)

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -99,6 +99,7 @@ _TRANSITIONS: dict[TaskState, frozenset[TaskState]] = {
     ),
     TaskState.RUNNING: frozenset(
         {
+            TaskState.QUEUED,
             TaskState.WAITING_APPROVAL,
             TaskState.WAITING_INPUT,
             TaskState.WAITING_SUBTASKS,

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -113,6 +113,7 @@ _TRANSITIONS: dict[TaskState, frozenset[TaskState]] = {
     ),
     TaskState.WAITING_APPROVAL: frozenset(
         {
+            TaskState.QUEUED,
             TaskState.RUNNING,
             TaskState.PAUSED,
             TaskState.INTERRUPTED,

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -1330,8 +1330,6 @@ class WorkerTurnTransaction(StrictModel):
         if self.state is TurnTransactionState.PARKED and self.checkpoint_id is None:
             raise ValueError("parked turn requires a checkpoint")
         if self.state in {
-            TurnTransactionState.OPEN,
-            TurnTransactionState.PARKING,
             TurnTransactionState.COMPLETED,
             TurnTransactionState.INTERRUPTED,
         } and self.checkpoint_id is not None:

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -44,6 +44,28 @@ class TaskState(StrEnum):
     EXPIRED = "expired"
 
 
+class RuntimeProtocol(StrEnum):
+    V16 = "v16"
+    V17 = "v17"
+
+
+class TurnTransactionState(StrEnum):
+    OPEN = "open"
+    PARKING = "parking"
+    PARKED = "parked"
+    RESUMING = "resuming"
+    COMPLETED = "completed"
+    INTERRUPTED = "interrupted"
+
+
+class TurnBarrier(StrEnum):
+    APPROVAL = "approval"
+    INPUT = "input"
+    SUBTASKS = "subtasks"
+    COMPACTION = "compaction"
+    OPERATION_UNKNOWN = "operation_unknown"
+
+
 BUDGET_ACTIVE_STATES = frozenset(
     {TaskState.PREPARING, TaskState.RUNNING, TaskState.TESTING}
 )
@@ -737,6 +759,7 @@ class TaskRecord(StrictModel):
     pinned: bool = False
     last_event_sequence: int = 0
     reason: str | None = None
+    runtime_protocol: RuntimeProtocol = RuntimeProtocol.V16
 
     @field_validator("task_id", "workspace_id", "provider_session_id")
     @classmethod
@@ -839,6 +862,34 @@ class WorkerPlan(StrictModel):
     def validate_plan_id(cls, value: str) -> str:
         if SAFE_ID.fullmatch(value) is None:
             raise ValueError("plan identifier is invalid")
+        return value
+
+
+class WorkerTodoItem(StrictModel):
+    todo_id: str
+    content: str = Field(min_length=1, max_length=4096)
+    status: Literal["pending", "in_progress", "completed", "cancelled"]
+
+    @field_validator("todo_id")
+    @classmethod
+    def validate_todo_id(cls, value: str) -> str:
+        if SAFE_ID.fullmatch(value) is None:
+            raise ValueError("todo identifier is invalid")
+        return value
+
+
+class WorkerTodo(StrictModel):
+    task_id: str
+    sequence: int = Field(ge=1)
+    turn_id: str
+    items: tuple[WorkerTodoItem, ...] = Field(max_length=256)
+    updated_at: float
+
+    @field_validator("task_id", "turn_id")
+    @classmethod
+    def validate_todo_binding(cls, value: str) -> str:
+        if SAFE_ID.fullmatch(value) is None:
+            raise ValueError("todo binding is invalid")
         return value
 
 
@@ -1235,5 +1286,52 @@ class WorkerOperation(StrictModel):
     state: OperationState
     request: dict[str, Any]
     result: dict[str, Any] | None = None
+    turn_id: str | None = None
     created_at: float
     updated_at: float
+
+    @field_validator("turn_id")
+    @classmethod
+    def validate_operation_turn_id(cls, value: str | None) -> str | None:
+        if value is not None and SAFE_ID.fullmatch(value) is None:
+            raise ValueError("operation turn identifier is invalid")
+        return value
+
+
+class WorkerTurnTransaction(StrictModel):
+    task_id: str
+    turn_id: str
+    generation: int = Field(ge=1)
+    state: TurnTransactionState
+    barrier: TurnBarrier | None = None
+    workspace_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    checkpoint_id: str | None = None
+    created_at: float
+    updated_at: float
+
+    @field_validator("task_id", "turn_id", "checkpoint_id")
+    @classmethod
+    def validate_turn_transaction_id(cls, value: str | None) -> str | None:
+        if value is not None and SAFE_ID.fullmatch(value) is None:
+            raise ValueError("turn transaction identifier is invalid")
+        return value
+
+    @model_validator(mode="after")
+    def validate_turn_transaction_state(self) -> "WorkerTurnTransaction":
+        waiting = self.state in {
+            TurnTransactionState.PARKING,
+            TurnTransactionState.PARKED,
+            TurnTransactionState.RESUMING,
+        }
+        if waiting != (self.barrier is not None):
+            raise ValueError("turn barrier is inconsistent with state")
+        if self.state is TurnTransactionState.PARKED and self.checkpoint_id is None:
+            raise ValueError("parked turn requires a checkpoint")
+        if self.state in {
+            TurnTransactionState.OPEN,
+            TurnTransactionState.PARKING,
+            TurnTransactionState.COMPLETED,
+            TurnTransactionState.INTERRUPTED,
+        } and self.checkpoint_id is not None:
+            raise ValueError("turn checkpoint is inconsistent with state")
+        return self

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -151,6 +151,7 @@ class OpenCodeProvider(CodingAgentProvider):
             supports_steering=True,
             supports_usage=True,
             supports_tool_boundaries=True,
+            supports_turn_interrupt=True,
             tool_names=PROVIDER_TOOL_NAMES,
         )
 
@@ -280,6 +281,9 @@ class OpenCodeProvider(CodingAgentProvider):
                 "OpenCode cancel failed.", code="provider_unavailable"
             ) from exc
         return value is True
+
+    async def interrupt_turn(self, session: ProviderSession) -> bool:
+        return await self.cancel(session)
 
     async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
         _handle, request = self._require_session(session)

--- a/server/coding_worker/provider.py
+++ b/server/coding_worker/provider.py
@@ -49,6 +49,10 @@ PROVIDER_TOOL_NAMES = (
     "stop_service",
     "create_subtask",
     "merge_subtask",
+    "update_plan",
+    "update_todo",
+    "request_user_input",
+    "compact_context",
 )
 INSPECT_PROVIDER_TOOLS = PROVIDER_TOOL_NAMES[:13] + (
     "list_acceptance_checks",

--- a/server/coding_worker/provider.py
+++ b/server/coding_worker/provider.py
@@ -18,7 +18,7 @@ from .contracts import (
 )
 
 
-PROVIDER_CONTRACT_VERSION = 3
+PROVIDER_CONTRACT_VERSION = 4
 PROVIDER_CHECKPOINT_FORMAT_VERSION = 2
 PROVIDER_TOOL_NAMES = (
     "list_files",
@@ -222,6 +222,7 @@ class ProviderCapabilities(StrictModel):
     supports_questions: bool = False
     supports_compaction: bool = False
     supports_tool_boundaries: bool = False
+    supports_turn_interrupt: bool = False
     tool_names: tuple[str, ...] = ()
 
 
@@ -367,6 +368,8 @@ class CodingAgentProvider(Protocol):
 
     async def cancel(self, session: ProviderSession) -> bool: ...
 
+    async def interrupt_turn(self, session: ProviderSession) -> bool: ...
+
     async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint: ...
 
     async def restore(
@@ -413,6 +416,7 @@ class FakeCodingAgentProvider:
             supports_questions=True,
             supports_compaction=True,
             supports_tool_boundaries=True,
+            supports_turn_interrupt=True,
             tool_names=PROVIDER_TOOL_NAMES,
         )
 
@@ -444,6 +448,9 @@ class FakeCodingAgentProvider:
             return False
         self._cancelled.add(session.session_id)
         return True
+
+    async def interrupt_turn(self, session: ProviderSession) -> bool:
+        return await self.cancel(session)
 
     async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
         request = self._requests.get(session.session_id)

--- a/server/coding_worker/provider_rpc.py
+++ b/server/coding_worker/provider_rpc.py
@@ -296,6 +296,8 @@ class ProviderRPCServer:
         self._require_active_session(session, controller_id, controller_generation)
         if request.action == "cancel":
             return {"cancelled": await self.provider.cancel(session)}
+        if request.action == "interrupt_turn":
+            return {"interrupted": await self.provider.interrupt_turn(session)}
         if request.action == "checkpoint":
             return (await self.provider.checkpoint(session)).model_dump(mode="json")
         if request.action == "close":
@@ -552,7 +554,7 @@ class ProviderSidecarClientPool(CodingAgentProvider):
             await writer.wait_closed()
             if not completed:
                 with contextlib.suppress(Exception):
-                    await self.cancel(session)
+                    await self.interrupt_turn(session)
 
     async def cancel(self, session: ProviderSession) -> bool:
         slot_id = self._require_session(session)
@@ -560,6 +562,15 @@ class ProviderSidecarClientPool(CodingAgentProvider):
             slot_id, "cancel", {"session": session.model_dump(mode="json")}
         )
         return result.get("cancelled") is True
+
+    async def interrupt_turn(self, session: ProviderSession) -> bool:
+        slot_id = self._require_session(session)
+        result = await self._call(
+            slot_id,
+            "interrupt_turn",
+            {"session": session.model_dump(mode="json")},
+        )
+        return result.get("interrupted") is True
 
     async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
         slot_id = self._require_session(session)

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -52,6 +52,7 @@ class CodingWorkerRuntime:
         sidecar_uid: int = 65532,
         sidecar_gid: int = 65532,
         route_slots: Mapping[str, Sequence[str]] | None = None,
+        route_context_tokens: Mapping[str, int] | None = None,
         documentation_resources: Mapping[str, str] | None = None,
     ) -> None:
         if (
@@ -131,6 +132,7 @@ class CodingWorkerRuntime:
             max_active_tasks=max_active_tasks,
             tool_broker=self.tool_broker,
             route_slots=route_slots,
+            route_context_tokens=route_context_tokens,
         )
         self.tool_broker.subtask_handler = self.service.create_subtask
         self.tool_broker.subtask_merge_handler = self.service.merge_subtask
@@ -356,6 +358,7 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         egress_proxy_url=os.getenv("CODING_WORKER_EGRESS_PROXY_URL") or None,
         network_grant_key=os.getenv("CODING_WORKER_EGRESS_GRANT_KEY") or None,
         route_slots=route_slots,
+        route_context_tokens=_route_context_tokens_from_environment(),
         documentation_resources=_documentation_resources_from_environment(),
     )
 
@@ -377,6 +380,32 @@ def _documentation_resources_from_environment() -> dict[str, str]:
     ):
         raise CodingWorkerRuntimeError(
             "Documentation resource catalog is invalid.",
+            code="coding_worker_config_invalid",
+        )
+    return dict(value)
+
+
+def _route_context_tokens_from_environment() -> dict[str, int]:
+    encoded = os.getenv("CODING_WORKER_ROUTE_CONTEXT_TOKENS_JSON", "").strip()
+    if not encoded:
+        return {}
+    try:
+        value = json.loads(encoded)
+    except json.JSONDecodeError as exc:
+        raise CodingWorkerRuntimeError(
+            "Worker route context catalog is invalid.",
+            code="coding_worker_config_invalid",
+        ) from exc
+    if not isinstance(value, dict) or any(
+        not isinstance(route_id, str)
+        or not route_id
+        or isinstance(tokens, bool)
+        or not isinstance(tokens, int)
+        or not 8_192 <= tokens <= 2_000_000
+        for route_id, tokens in value.items()
+    ):
+        raise CodingWorkerRuntimeError(
+            "Worker route context catalog is invalid.",
             code="coding_worker_config_invalid",
         )
     return dict(value)

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -403,16 +403,22 @@ class CodingWorkerService:
                     raise WorkerConflictError(
                         "Parked turn has no checkpoint.", code="turn_checkpoint_invalid"
                     )
-                if turn.barrier in {TurnBarrier.APPROVAL, TurnBarrier.INPUT}:
+                if turn.barrier in {
+                    TurnBarrier.APPROVAL,
+                    TurnBarrier.INPUT,
+                    TurnBarrier.SUBTASKS,
+                }:
                     raise WorkerConflictError(
                         "Turn still requires user settlement.",
                         code="turn_barrier_unresolved",
                     )
-                self.store.resume_turn_transaction(
+                resumed = self.store.settle_parked_turn(
                     task_id=task_id,
-                    turn_id=turn.turn_id,
-                    checkpoint_id=turn.checkpoint_id,
+                    barrier=TurnBarrier.OPERATION_UNKNOWN,
+                    expected_state=TaskState.INTERRUPTED,
                 )
+                self._wake.set()
+                return resumed
         resumed = self.store.transition(task_id, TaskState.QUEUED)
         self._wake.set()
         return resumed
@@ -2246,21 +2252,10 @@ class CodingWorkerService:
             checkpoint_id=checkpoint.checkpoint_id,
         )
         if transaction.barrier is TurnBarrier.COMPACTION:
-            self.store.transition(
-                task.task_id,
-                TaskState.INTERRUPTED,
-                reason="turn_parked_compaction",
-                expected_state=TaskState.RUNNING,
-            )
-            self.store.resume_turn_transaction(
+            self.store.settle_parked_turn(
                 task_id=task.task_id,
-                turn_id=turn_id,
-                checkpoint_id=checkpoint.checkpoint_id,
-            )
-            self.store.transition(
-                task.task_id,
-                TaskState.QUEUED,
-                expected_state=TaskState.INTERRUPTED,
+                barrier=TurnBarrier.COMPACTION,
+                expected_state=TaskState.RUNNING,
             )
             self._wake.set()
             return
@@ -2553,6 +2548,30 @@ class CodingWorkerService:
     ) -> tuple[str | None, int]:
         task_id = task.task_id
         turns = max(turns, self.store.budget_usage(task_id).turns_started)
+        if task.runtime_protocol is RuntimeProtocol.V17:
+            unsettled = any(
+                item.state
+                in {
+                    OperationState.PREPARED,
+                    OperationState.RUNNING,
+                    OperationState.UNKNOWN,
+                }
+                for item in self.store.list_operations(task_id)
+            ) or any(
+                item.status is ApprovalStatus.PENDING
+                for item in self.store.list_approvals(task_id)
+            ) or any(
+                item.status is QuestionStatus.PENDING
+                for item in self.store.list_questions(task_id)
+            ) or self.store.current_turn_transaction(task_id) is not None
+            if unsettled:
+                self.store.transition(
+                    task_id,
+                    TaskState.BLOCKED,
+                    reason="turn_settlement_incomplete",
+                    expected_state=TaskState.RUNNING,
+                )
+                return None, message_cursor
         ready_implementations = tuple(
             relation
             for relation in self.store.list_subtasks(task_id)

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -477,6 +477,9 @@ class CodingWorkerService:
         if active is not None:
             active.cancel()
         paused = self.store.transition(task_id, TaskState.PAUSED, reason="user_paused")
+        if active is not None:
+            with contextlib.suppress(asyncio.CancelledError):
+                await active
         self._wake.set()
         return paused
 
@@ -491,6 +494,9 @@ class CodingWorkerService:
         if active is not None:
             active.cancel()
         cancelled = self.store.transition(task_id, TaskState.CANCELLED, reason="user_cancelled")
+        if active is not None:
+            with contextlib.suppress(asyncio.CancelledError):
+                await active
         self._wake.set()
         return cancelled
 

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -242,9 +242,17 @@ class CodingWorkerService:
         observation = await self.provider_capability_observation(
             request.model_route, force=True
         )
+        runtime_protocol = self._runtime_protocol()
+        if runtime_protocol is RuntimeProtocol.V17 and not self._v17_route_ready(
+            observation.capabilities
+        ):
+            raise WorkerConflictError(
+                "Model route does not support the V17 interaction contract.",
+                code="v17_route_unavailable",
+            )
         task = self.store.create_task(
             spec,
-            runtime_protocol=self._runtime_protocol(),
+            runtime_protocol=runtime_protocol,
             capability_binding_sha256=observation.binding_sha256,
             capability_snapshot={
                 "available": observation.capabilities is not None,
@@ -259,6 +267,23 @@ class CodingWorkerService:
         )
         self._wake.set()
         return task
+
+    @staticmethod
+    def _v17_route_ready(capabilities: ProviderCapabilities | None) -> bool:
+        if capabilities is None:
+            return False
+        required_tools = {
+            "update_plan",
+            "update_todo",
+            "request_user_input",
+            "compact_context",
+        }
+        return (
+            capabilities.supports_checkpoint
+            and capabilities.supports_restore
+            and capabilities.supports_turn_interrupt
+            and required_tools.issubset(capabilities.tool_names)
+        )
 
     async def provider_capability_observation(
         self, model_route: str, *, force: bool = False
@@ -2871,6 +2896,9 @@ def _intersect_provider_capabilities(
         supports_compaction=all(item.supports_compaction for item in values),
         supports_tool_boundaries=all(
             item.supports_tool_boundaries for item in values
+        ),
+        supports_turn_interrupt=all(
+            item.supports_turn_interrupt for item in values
         ),
         tool_names=tuple(
             tool_name for tool_name in values[0].tool_names if tool_name in tool_names

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -465,29 +465,6 @@ class CodingWorkerService:
         self, task_id: str, question_id: str, answer: WorkerQuestionAnswer
     ) -> WorkerQuestion:
         resolved = self.store.resolve_question(task_id, question_id, answer)
-        task = self.store.get_task(task_id)
-        if task.runtime_protocol is RuntimeProtocol.V17:
-            turn = self.store.current_turn_transaction(task_id)
-            if (
-                turn is None
-                or turn.state is not TurnTransactionState.PARKED
-                or turn.barrier is not TurnBarrier.INPUT
-                or turn.checkpoint_id is None
-            ):
-                raise WorkerConflictError(
-                    "Question turn is not durably parked.",
-                    code="turn_not_parked",
-                )
-            self.store.resume_turn_transaction(
-                task_id=task_id,
-                turn_id=turn.turn_id,
-                checkpoint_id=turn.checkpoint_id,
-            )
-            self.store.transition(
-                task_id,
-                TaskState.QUEUED,
-                expected_state=TaskState.WAITING_INPUT,
-            )
         self._wake.set()
         return resolved
 
@@ -2788,25 +2765,18 @@ class CodingWorkerService:
             content=self._subtask_results_message(parent_task_id),
         )
         if parent.runtime_protocol is RuntimeProtocol.V17:
-            turn = self.store.current_turn_transaction(parent_task_id)
-            if (
-                turn is None
-                or turn.state is not TurnTransactionState.PARKED
-                or turn.barrier is not TurnBarrier.SUBTASKS
-                or turn.checkpoint_id is None
-            ):
-                return
-            self.store.resume_turn_transaction(
+            self.store.settle_parked_turn(
                 task_id=parent_task_id,
-                turn_id=turn.turn_id,
-                checkpoint_id=turn.checkpoint_id,
+                barrier=TurnBarrier.SUBTASKS,
+                expected_state=TaskState.WAITING_SUBTASKS,
             )
-        self.store.transition(
-            parent_task_id,
-            TaskState.QUEUED,
-            reason="subtasks_settled",
-            expected_state=TaskState.WAITING_SUBTASKS,
-        )
+        else:
+            self.store.transition(
+                parent_task_id,
+                TaskState.QUEUED,
+                reason="subtasks_settled",
+                expected_state=TaskState.WAITING_SUBTASKS,
+            )
         self._wake.set()
 
     def _subtask_results_message(self, parent_task_id: str) -> str:

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -1229,7 +1229,13 @@ class CodingWorkerService:
 
     async def _scheduler_loop(self) -> None:
         while True:
-            await self._wake.wait()
+            try:
+                await asyncio.wait_for(self._wake.wait(), timeout=0.25)
+            except TimeoutError:
+                # The queue is durable. Polling prevents a persisted runnable
+                # task from depending on one in-memory wakeup surviving a
+                # runner completion/settlement race.
+                pass
             self._wake.clear()
             capacity = min(
                 self.max_active_tasks,
@@ -1264,7 +1270,11 @@ class CodingWorkerService:
                 )
 
     def _select_queued_task(self) -> tuple[TaskRecord, str | None] | None:
-        queued = self.store.list_queued_tasks(limit=128)
+        queued = [
+            record
+            for record in self.store.list_queued_tasks(limit=128)
+            if record.task_id not in self._active
+        ]
         if not queued:
             return None
         if not self.workspace_broker.dedicated_slots:
@@ -1327,11 +1337,14 @@ class CodingWorkerService:
         return self._route_slots.get(model_route)
 
     def _task_finished(self, task_id: str, _task: asyncio.Task[None]) -> None:
-        self._active.pop(task_id, None)
-        self._task_slots.pop(task_id, None)
-        self._sessions.pop(task_id, None)
+        owned_runner = self._active.get(task_id) is _task
+        if owned_runner:
+            self._active.pop(task_id, None)
+            self._task_slots.pop(task_id, None)
+            self._sessions.pop(task_id, None)
         if not self._closing:
-            self._resume_parent_after_subtasks(task_id)
+            if owned_runner:
+                self._resume_parent_after_subtasks(task_id)
             self._wake.set()
 
     async def _run_task(self, task_id: str, *, slot_id: str | None = None) -> None:

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -21,12 +21,15 @@ from .contracts import (
     Origin,
     PolicyProfile,
     QuestionStatus,
+    RuntimeProtocol,
     SAFE_ID,
     TaskCreateRequest,
     TaskBudget,
     TaskRecord,
     TaskSpec,
     TaskState,
+    TurnBarrier,
+    TurnTransactionState,
     SubtaskKind,
     SubtaskMergeState,
     SubtaskRecord,
@@ -136,6 +139,25 @@ class CodingWorkerService:
         )
 
     @staticmethod
+    def _runtime_protocol() -> RuntimeProtocol:
+        enabled = {"1", "true", "yes", "on"}
+        required = (
+            "CODING_WORKER_V16_ENABLED",
+            "CODING_WORKER_INTERACTION_ENABLED",
+            "CODING_WORKER_SESSION_CONTROLS_ENABLED",
+            "CODING_WORKER_SUBAGENTS_ENABLED",
+            "CODING_WORKER_V17_ENABLED",
+        )
+        return (
+            RuntimeProtocol.V17
+            if all(
+                os.getenv(name, "false").strip().lower() in enabled
+                for name in required
+            )
+            else RuntimeProtocol.V16
+        )
+
+    @staticmethod
     def _subtask_role_contract(kind: SubtaskKind) -> str:
         common = (
             "You are a depth-one, platform-owned coding subtask. Do not create "
@@ -222,6 +244,7 @@ class CodingWorkerService:
         )
         task = self.store.create_task(
             spec,
+            runtime_protocol=self._runtime_protocol(),
             capability_binding_sha256=observation.binding_sha256,
             capability_snapshot={
                 "available": observation.capabilities is not None,
@@ -369,6 +392,27 @@ class CodingWorkerService:
             TaskState.BUDGET_LIMITED,
         }:
             raise WorkerConflictError("Task cannot be resumed.", code="task_state_conflict")
+        turn = self.store.current_turn_transaction(task_id)
+        if task.runtime_protocol is RuntimeProtocol.V17 and turn is not None:
+            if turn.state is TurnTransactionState.PARKING:
+                raise WorkerConflictError(
+                    "Turn checkpoint is not durable yet.", code="turn_not_parked"
+                )
+            if turn.state is TurnTransactionState.PARKED:
+                if turn.checkpoint_id is None:
+                    raise WorkerConflictError(
+                        "Parked turn has no checkpoint.", code="turn_checkpoint_invalid"
+                    )
+                if turn.barrier in {TurnBarrier.APPROVAL, TurnBarrier.INPUT}:
+                    raise WorkerConflictError(
+                        "Turn still requires user settlement.",
+                        code="turn_barrier_unresolved",
+                    )
+                self.store.resume_turn_transaction(
+                    task_id=task_id,
+                    turn_id=turn.turn_id,
+                    checkpoint_id=turn.checkpoint_id,
+                )
         resumed = self.store.transition(task_id, TaskState.QUEUED)
         self._wake.set()
         return resumed
@@ -421,6 +465,29 @@ class CodingWorkerService:
         self, task_id: str, question_id: str, answer: WorkerQuestionAnswer
     ) -> WorkerQuestion:
         resolved = self.store.resolve_question(task_id, question_id, answer)
+        task = self.store.get_task(task_id)
+        if task.runtime_protocol is RuntimeProtocol.V17:
+            turn = self.store.current_turn_transaction(task_id)
+            if (
+                turn is None
+                or turn.state is not TurnTransactionState.PARKED
+                or turn.barrier is not TurnBarrier.INPUT
+                or turn.checkpoint_id is None
+            ):
+                raise WorkerConflictError(
+                    "Question turn is not durably parked.",
+                    code="turn_not_parked",
+                )
+            self.store.resume_turn_transaction(
+                task_id=task_id,
+                turn_id=turn.turn_id,
+                checkpoint_id=turn.checkpoint_id,
+            )
+            self.store.transition(
+                task_id,
+                TaskState.QUEUED,
+                expected_state=TaskState.WAITING_INPUT,
+            )
         self._wake.set()
         return resolved
 
@@ -552,6 +619,19 @@ class CodingWorkerService:
         if self.store.get_task(subtask.child_task_id).workspace_id != workspace.workspace_id:
             self.workspace_broker.delete(workspace.workspace_id)
         current_parent = self.store.get_task(parent_task_id)
+        if current_parent.runtime_protocol is RuntimeProtocol.V17:
+            turn = self.store.current_turn_transaction(parent_task_id)
+            if turn is None:
+                raise WorkerConflictError(
+                    "V17 subtask has no current turn.", code="operation_turn_required"
+                )
+            self.store.begin_turn_parking(
+                task_id=parent_task_id,
+                turn_id=turn.turn_id,
+                barrier=TurnBarrier.SUBTASKS,
+            )
+            self._wake.set()
+            return subtask
         if current_parent.state in {
             TaskState.RUNNING,
             TaskState.PAUSED,
@@ -1070,6 +1150,29 @@ class CodingWorkerService:
         task = self.store.get_task(task_id)
         if task.state is not TaskState.WAITING_APPROVAL:
             return task
+        if task.runtime_protocol is RuntimeProtocol.V17:
+            turn = self.store.current_turn_transaction(task_id)
+            if (
+                turn is None
+                or turn.state is not TurnTransactionState.PARKED
+                or turn.barrier is not TurnBarrier.APPROVAL
+                or turn.checkpoint_id is None
+            ):
+                raise WorkerConflictError(
+                    "Approval turn is not durably parked.", code="turn_not_parked"
+                )
+            self.store.resume_turn_transaction(
+                task_id=task_id,
+                turn_id=turn.turn_id,
+                checkpoint_id=turn.checkpoint_id,
+            )
+            queued = self.store.transition(
+                task_id,
+                TaskState.QUEUED,
+                expected_state=TaskState.WAITING_APPROVAL,
+            )
+            self._wake.set()
+            return queued
         runner = self._active.get(task_id)
         if runner is not None and not runner.done():
             return self.store.transition(
@@ -1240,6 +1343,8 @@ class CodingWorkerService:
             resume_phase: str | None = None
             resume_context: dict[str, object] | None = None
             resume_question_id: str | None = None
+            resume_turn_before: WorkspaceSnapshot | None = None
+            resume_turn_public_before: dict[str, object] | None = None
             completed_turns = 0
             message_cursor = 0
             checkpoint = self.store.latest_checkpoint(task_id)
@@ -1282,6 +1387,18 @@ class CodingWorkerService:
                         resume_context = raw_context
                     if resume_phase == "waiting_input":
                         resume_question_id = str(checkpoint.payload["question_id"])
+                    raw_turn_before = checkpoint.payload.get("turn_before")
+                    if raw_turn_before is not None:
+                        resume_turn_before = WorkspaceSnapshot.model_validate(
+                            raw_turn_before
+                        )
+                    raw_turn_public_before = checkpoint.payload.get(
+                        "turn_public_before"
+                    )
+                    if raw_turn_public_before is not None:
+                        if not isinstance(raw_turn_public_before, dict):
+                            raise TypeError("turn public context is invalid")
+                        resume_turn_public_before = raw_turn_public_before
                 except (KeyError, TypeError, ValueError) as exc:
                     raise WorkerConflictError(
                         "Checkpoint payload is invalid.", code="checkpoint_invalid"
@@ -1290,9 +1407,11 @@ class CodingWorkerService:
                     resume_phase
                     not in {
                         "testing",
+                        "waiting_approval",
                         "waiting_input",
                         "waiting_subtasks",
                         "compacted",
+                        "operation_unknown",
                     }
                     or completed_turns < 1
                     or (resume_phase == "waiting_input" and not resume_question_id)
@@ -1334,6 +1453,8 @@ class CodingWorkerService:
                 resume_phase=resume_phase,
                 resume_context=resume_context,
                 resume_question_id=resume_question_id,
+                resume_turn_before=resume_turn_before,
+                resume_turn_public_before=resume_turn_public_before,
                 completed_turns=completed_turns,
                 message_cursor=message_cursor,
             )
@@ -1405,6 +1526,8 @@ class CodingWorkerService:
         resume_phase: str | None,
         resume_context: dict[str, object] | None,
         resume_question_id: str | None = None,
+        resume_turn_before: WorkspaceSnapshot | None = None,
+        resume_turn_public_before: dict[str, object] | None = None,
         completed_turns: int,
         message_cursor: int,
     ) -> None:
@@ -1415,6 +1538,8 @@ class CodingWorkerService:
                 resume_phase=resume_phase,
                 resume_context=resume_context,
                 resume_question_id=resume_question_id,
+                resume_turn_before=resume_turn_before,
+                resume_turn_public_before=resume_turn_public_before,
                 completed_turns=completed_turns,
                 message_cursor=message_cursor,
             ),
@@ -1447,6 +1572,8 @@ class CodingWorkerService:
         resume_phase: str | None,
         resume_context: dict[str, object] | None,
         resume_question_id: str | None,
+        resume_turn_before: WorkspaceSnapshot | None,
+        resume_turn_public_before: dict[str, object] | None,
         completed_turns: int,
         message_cursor: int,
     ) -> None:
@@ -1492,6 +1619,14 @@ class CodingWorkerService:
                 )
                 return
             message = answer
+        elif resume_phase == "waiting_approval":
+            message = self._approval_resume_message(task_id)
+        elif resume_phase == "operation_unknown":
+            message = self._restored_context_message(
+                resume_context,
+                "Reconcile only the exact unknown operation from the parked turn. "
+                "Do not create a replacement operation id or repeat its side effect.",
+            )
         elif resume_phase == "compacted":
             message = self._restored_context_message(
                 resume_context,
@@ -1508,29 +1643,62 @@ class CodingWorkerService:
         while True:
             durable_usage = self.store.budget_usage(task_id)
             turns = max(turns, durable_usage.turns_started)
-            if turns >= task.spec.budget.max_turns:
-                self.store.transition(
-                    task_id,
-                    TaskState.BUDGET_LIMITED,
-                    reason="turn_budget_exhausted",
-                    expected_state=TaskState.RUNNING,
-                )
-                return
-            turns += 1
+            current_turn = (
+                self.store.current_turn_transaction(task_id)
+                if task.runtime_protocol is RuntimeProtocol.V17
+                else None
+            )
+            resuming_turn = (
+                current_turn is not None
+                and current_turn.state is TurnTransactionState.RESUMING
+            )
+            if not resuming_turn:
+                if turns >= task.spec.budget.max_turns:
+                    self.store.transition(
+                        task_id,
+                        TaskState.BUDGET_LIMITED,
+                        reason="turn_budget_exhausted",
+                        expected_state=TaskState.RUNNING,
+                    )
+                    return
+                turns += 1
             workspace_id = self.store.get_task(task_id).workspace_id
             turn_before = (
-                self.workspace_broker.capture_snapshot(workspace_id)
+                resume_turn_before
+                if resuming_turn and resume_turn_before is not None
+                else self.workspace_broker.capture_snapshot(workspace_id)
                 if workspace_id is not None
                 else None
             )
-            turn_public_before = self._public_session_context(task_id)
-            turn_id = f"turn_{uuid.uuid4().hex}"
-            self.store.append_session_ledger(
-                task_id,
-                kind=SessionLedgerKind.TURN_STARTED,
-                turn_id=turn_id,
-                payload={},
+            turn_public_before = (
+                resume_turn_public_before
+                if resuming_turn and resume_turn_public_before is not None
+                else self._public_session_context(task_id)
             )
+            turn_id = (
+                current_turn.turn_id
+                if resuming_turn and current_turn is not None
+                else f"turn_{uuid.uuid4().hex}"
+            )
+            if not resuming_turn:
+                if task.runtime_protocol is RuntimeProtocol.V17:
+                    self.store.open_turn_transaction(
+                        task_id=task_id,
+                        turn_id=turn_id,
+                        workspace_tree_hash=(
+                            turn_before.tree_hash
+                            if turn_before is not None
+                            else self.workspace_broker.current_tree_hash(
+                                workspace_id or ""
+                            )
+                        ),
+                    )
+                self.store.append_session_ledger(
+                    task_id,
+                    kind=SessionLedgerKind.TURN_STARTED,
+                    turn_id=turn_id,
+                    payload={},
+                )
             outcome = "interrupted"
             question_data: dict[str, object] | None = None
             compaction_failed = False
@@ -1544,8 +1712,16 @@ class CodingWorkerService:
                     except StopAsyncIteration:
                         break
                     if event is None:
+                        transaction = (
+                            self.store.current_turn_transaction(task_id)
+                            if task.runtime_protocol is RuntimeProtocol.V17
+                            else None
+                        )
                         outcome = (
-                            "waiting_subtasks"
+                            "turn_parking"
+                            if transaction is not None
+                            and transaction.state is TurnTransactionState.PARKING
+                            else "waiting_subtasks"
                             if parked_state is TaskState.WAITING_SUBTASKS
                             else "waiting_approval"
                             if parked_state is TaskState.WAITING_APPROVAL
@@ -1561,11 +1737,17 @@ class CodingWorkerService:
                     if self.store.get_task(task_id).state is TaskState.WAITING_SUBTASKS:
                         outcome = "waiting_subtasks"
                         break
-                    if event.kind is ProviderEventKind.QUESTION:
+                    if (
+                        event.kind is ProviderEventKind.QUESTION
+                        and task.runtime_protocol is not RuntimeProtocol.V17
+                    ):
                         outcome = "waiting_input"
                         question_data = event.data
                         break
-                    if event.kind is ProviderEventKind.COMPACTION:
+                    if (
+                        event.kind is ProviderEventKind.COMPACTION
+                        and task.runtime_protocol is not RuntimeProtocol.V17
+                    ):
                         try:
                             await self._record_controlled_compaction(
                                 task,
@@ -1593,6 +1775,33 @@ class CodingWorkerService:
                     task_id, turn_id=turn_id, result_state="interrupted"
                 )
                 raise
+            if outcome == "turn_parking":
+                try:
+                    await self._park_v17_turn(
+                        task,
+                        session,
+                        turn_id=turn_id,
+                        turns=turns,
+                        message_cursor=message_cursor,
+                        turn_before=turn_before,
+                        turn_public_before=turn_public_before,
+                    )
+                except Exception:
+                    with contextlib.suppress(WorkerConflictError):
+                        self.store.finish_turn_transaction(
+                            task_id=task_id,
+                            turn_id=turn_id,
+                            state=TurnTransactionState.INTERRUPTED,
+                        )
+                    current = self.store.get_task(task_id)
+                    if current.state is TaskState.RUNNING:
+                        self.store.transition(
+                            task_id,
+                            TaskState.BLOCKED,
+                            reason="turn_checkpoint_failed",
+                            expected_state=TaskState.RUNNING,
+                        )
+                return
             if outcome == "completed" and workspace_id is not None and turn_before is not None:
                 turn_after = self.workspace_broker.capture_snapshot(workspace_id)
                 turn_public_after = self._public_session_context(task_id)
@@ -1609,10 +1818,22 @@ class CodingWorkerService:
                         "after_public_context": turn_public_after,
                     },
                 )
+                if task.runtime_protocol is RuntimeProtocol.V17:
+                    self.store.finish_turn_transaction(
+                        task_id=task_id,
+                        turn_id=turn_id,
+                        state=TurnTransactionState.COMPLETED,
+                    )
             else:
                 self.store.finish_session_turn(
                     task_id, turn_id=turn_id, result_state=outcome
                 )
+                if task.runtime_protocol is RuntimeProtocol.V17:
+                    self.store.finish_turn_transaction(
+                        task_id=task_id,
+                        turn_id=turn_id,
+                        state=TurnTransactionState.INTERRUPTED,
+                    )
             if outcome == "waiting_input":
                 if question_data is None:
                     raise WorkerConflictError(
@@ -1819,6 +2040,17 @@ class CodingWorkerService:
 
         while True:
             current = self.store.get_task(task_id)
+            transaction = (
+                self.store.current_turn_transaction(task_id)
+                if current.runtime_protocol is RuntimeProtocol.V17
+                else None
+            )
+            if (
+                transaction is not None
+                and transaction.state is TurnTransactionState.PARKING
+            ):
+                await self._close_provider_stream(stream)
+                return None, None
             if current.state is TaskState.WAITING_APPROVAL:
                 await self._close_provider_stream(stream)
                 while current.state is TaskState.WAITING_APPROVAL:
@@ -1838,6 +2070,17 @@ class CodingWorkerService:
         try:
             while True:
                 current = self.store.get_task(task_id)
+                transaction = (
+                    self.store.current_turn_transaction(task_id)
+                    if current.runtime_protocol is RuntimeProtocol.V17
+                    else None
+                )
+                if (
+                    transaction is not None
+                    and transaction.state is TurnTransactionState.PARKING
+                ):
+                    await self._close_provider_stream(stream, pending=pending)
+                    return None, None
                 if current.state is TaskState.WAITING_APPROVAL:
                     await self._close_provider_stream(stream, pending=pending)
                     while current.state is TaskState.WAITING_APPROVAL:
@@ -1857,7 +2100,19 @@ class CodingWorkerService:
                         await pending
                     return None, current.state
                 if pending.done():
-                    return pending.result(), None
+                    event = pending.result()
+                    transaction = (
+                        self.store.current_turn_transaction(task_id)
+                        if current.runtime_protocol is RuntimeProtocol.V17
+                        else None
+                    )
+                    if (
+                        transaction is not None
+                        and transaction.state is TurnTransactionState.PARKING
+                    ):
+                        await self._close_provider_stream(stream)
+                        return None, None
+                    return event, None
                 await asyncio.wait({pending}, timeout=0.05)
         except BaseException:
             if not pending.done():
@@ -1905,11 +2160,171 @@ class CodingWorkerService:
             "operation for the same intent."
         )
 
+    async def _park_v17_turn(
+        self,
+        task: TaskRecord,
+        session: ProviderSession,
+        *,
+        turn_id: str,
+        turns: int,
+        message_cursor: int,
+        turn_before: WorkspaceSnapshot | None,
+        turn_public_before: dict[str, object],
+    ) -> None:
+        transaction = self.store.get_turn_transaction(task.task_id, turn_id)
+        if (
+            transaction.state is not TurnTransactionState.PARKING
+            or transaction.barrier is None
+        ):
+            raise WorkerConflictError(
+                "Turn is not ready to park.", code="turn_state_conflict"
+            )
+        workspace_id = self.store.get_task(task.task_id).workspace_id or ""
+        tree_hash = self.workspace_broker.current_tree_hash(workspace_id)
+        await self.provider.interrupt_turn(session)
+        provider_checkpoint = await self.provider.checkpoint(session)
+        context = self._context_summary(
+            task.task_id,
+            tree_hash=tree_hash,
+            public_output=str(provider_checkpoint.payload.get("public_output", "")),
+        )
+        phase = {
+            TurnBarrier.APPROVAL: "waiting_approval",
+            TurnBarrier.INPUT: "waiting_input",
+            TurnBarrier.SUBTASKS: "waiting_subtasks",
+            TurnBarrier.COMPACTION: "compacted",
+            TurnBarrier.OPERATION_UNKNOWN: "operation_unknown",
+        }[transaction.barrier]
+        payload: dict[str, object] = {
+            "phase": phase,
+            "turn_id": turn_id,
+            "turn_generation": transaction.generation,
+            "completed_turns": turns,
+            "message_cursor": message_cursor,
+            "provider": provider_checkpoint.model_dump(mode="json"),
+            "context_summary": context,
+            "turn_before": (
+                turn_before.model_dump(mode="json")
+                if turn_before is not None
+                else None
+            ),
+            "turn_public_before": turn_public_before,
+        }
+        if transaction.barrier is TurnBarrier.INPUT:
+            pending = next(
+                (
+                    item
+                    for item in reversed(self.store.list_questions(task.task_id))
+                    if item.turn_id == turn_id
+                    and item.status is QuestionStatus.PENDING
+                ),
+                None,
+            )
+            if pending is None:
+                raise WorkerConflictError(
+                    "Parked input turn has no question.", code="question_not_found"
+                )
+            payload["question_id"] = pending.question_id
+        if transaction.barrier is TurnBarrier.COMPACTION:
+            boundary = self.store.session_tool_boundary_sequence(task.task_id, turn_id)
+            summary = self._controlled_compaction_summary(
+                task.task_id,
+                tree_hash=tree_hash,
+                provider_note="Platform-requested controlled compaction.",
+            )
+            encoded = json.dumps(
+                summary,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            if len(encoded.encode("utf-8")) > 65_536:
+                raise WorkerConflictError(
+                    "Controlled context is too large to compact.",
+                    code="context_compaction_too_large",
+                )
+            payload["context_summary"] = summary
+            self.store.append_session_ledger(
+                task.task_id,
+                kind=SessionLedgerKind.COMPACTION,
+                turn_id=turn_id,
+                payload={"summary": encoded, "boundary_sequence": boundary},
+            )
+            self.store.append_event(
+                task.task_id,
+                "context_compacted",
+                {
+                    "boundary_sequence": boundary,
+                    "workspace_tree_hash": tree_hash,
+                },
+            )
+        checkpoint = self.store.create_checkpoint(
+            task_id=task.task_id,
+            workspace_tree_hash=tree_hash,
+            payload=payload,
+        )
+        self.store.park_turn_transaction(
+            task_id=task.task_id,
+            turn_id=turn_id,
+            checkpoint_id=checkpoint.checkpoint_id,
+        )
+        if transaction.barrier is TurnBarrier.COMPACTION:
+            self.store.transition(
+                task.task_id,
+                TaskState.INTERRUPTED,
+                reason="turn_parked_compaction",
+                expected_state=TaskState.RUNNING,
+            )
+            self.store.resume_turn_transaction(
+                task_id=task.task_id,
+                turn_id=turn_id,
+                checkpoint_id=checkpoint.checkpoint_id,
+            )
+            self.store.transition(
+                task.task_id,
+                TaskState.QUEUED,
+                expected_state=TaskState.INTERRUPTED,
+            )
+            self._wake.set()
+            return
+        target = {
+            TurnBarrier.APPROVAL: TaskState.WAITING_APPROVAL,
+            TurnBarrier.INPUT: TaskState.WAITING_INPUT,
+            TurnBarrier.SUBTASKS: TaskState.WAITING_SUBTASKS,
+            TurnBarrier.OPERATION_UNKNOWN: TaskState.INTERRUPTED,
+        }[transaction.barrier]
+        self.store.transition(
+            task.task_id,
+            target,
+            reason=(
+                "operation_result_unknown"
+                if transaction.barrier is TurnBarrier.OPERATION_UNKNOWN
+                else f"turn_parked_{transaction.barrier.value}"
+            ),
+            expected_state=TaskState.RUNNING,
+        )
+
     def _record_provider_session_event(
         self, task_id: str, turn_id: str, event: ProviderEvent
     ) -> None:
         kind = event.kind
         data = event.data
+        authoritative_provider_kinds = {
+            ProviderEventKind.PLAN,
+            ProviderEventKind.TODO,
+            ProviderEventKind.QUESTION,
+            ProviderEventKind.COMPACTION,
+        }
+        if (
+            self.store.get_task(task_id).runtime_protocol is RuntimeProtocol.V17
+            and kind in authoritative_provider_kinds
+        ):
+            self.store.append_event(
+                task_id,
+                "provider_hint",
+                {"kind": kind.value, "turn_id": turn_id},
+            )
+            return
         if kind is ProviderEventKind.MESSAGE:
             self.store.append_message(task_id, role="assistant", content=str(data["text"]))
         elif kind is ProviderEventKind.PLAN:
@@ -2372,6 +2787,20 @@ class CodingWorkerService:
             role="system",
             content=self._subtask_results_message(parent_task_id),
         )
+        if parent.runtime_protocol is RuntimeProtocol.V17:
+            turn = self.store.current_turn_transaction(parent_task_id)
+            if (
+                turn is None
+                or turn.state is not TurnTransactionState.PARKED
+                or turn.barrier is not TurnBarrier.SUBTASKS
+                or turn.checkpoint_id is None
+            ):
+                return
+            self.store.resume_turn_transaction(
+                task_id=parent_task_id,
+                turn_id=turn.turn_id,
+                checkpoint_id=turn.checkpoint_id,
+            )
         self.store.transition(
             parent_task_id,
             TaskState.QUEUED,

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -85,6 +85,7 @@ class CodingWorkerService:
         max_active_tasks: int = 2,
         tool_broker: ToolBroker | None = None,
         route_slots: Mapping[str, Sequence[str]] | None = None,
+        route_context_tokens: Mapping[str, int] | None = None,
     ) -> None:
         if not 1 <= max_active_tasks <= 16:
             raise ValueError("active task capacity is outside the allowed range")
@@ -111,6 +112,15 @@ class CodingWorkerService:
                 for route_id, slot_ids in self._route_slots.items()
             ):
                 raise ValueError("provider route slot configuration is invalid")
+        self._route_context_tokens = dict(route_context_tokens or {})
+        if any(
+            not route_id
+            or isinstance(tokens, bool)
+            or not isinstance(tokens, int)
+            or not 8_192 <= tokens <= 2_000_000
+            for route_id, tokens in self._route_context_tokens.items()
+        ):
+            raise ValueError("provider route context configuration is invalid")
         self._active: dict[str, asyncio.Task[None]] = {}
         self._task_slots: dict[str, str] = {}
         self._sessions: dict[str, ProviderSession] = {}
@@ -1806,6 +1816,19 @@ class CodingWorkerService:
                         {"kind": event.kind.value, "data": event.data},
                     )
                     self._record_provider_session_event(task_id, turn_id, event)
+                    if self._should_auto_compact(task, event):
+                        transaction = self.store.current_turn_transaction(task_id)
+                        if transaction is not None and transaction.state in {
+                            TurnTransactionState.OPEN,
+                            TurnTransactionState.RESUMING,
+                        }:
+                            self.store.begin_turn_parking(
+                                task_id=task_id,
+                                turn_id=transaction.turn_id,
+                                barrier=TurnBarrier.COMPACTION,
+                            )
+                            outcome = "turn_parking"
+                            break
                     if self.store.get_task(task_id).state is TaskState.WAITING_SUBTASKS:
                         outcome = "waiting_subtasks"
                         break
@@ -2413,6 +2436,7 @@ class CodingWorkerService:
                     "summary": data["summary"],
                 },
             )
+
         elif kind is ProviderEventKind.TOOL_COMPLETED:
             self.store.append_session_ledger(
                 task_id,
@@ -2433,6 +2457,27 @@ class CodingWorkerService:
                 turn_id=turn_id,
                 payload=data,
             )
+
+    def _should_auto_compact(
+        self, task: TaskRecord, event: ProviderEvent
+    ) -> bool:
+        if (
+            task.runtime_protocol is not RuntimeProtocol.V17
+            or event.kind is not ProviderEventKind.USAGE
+        ):
+            return False
+        context_tokens = self._route_context_tokens.get(task.spec.model_route)
+        if context_tokens is None:
+            return False
+        usage = event.data.get("usage")
+        if not isinstance(usage, dict):
+            return False
+        input_tokens = usage.get("input_tokens")
+        return (
+            isinstance(input_tokens, int)
+            and not isinstance(input_tokens, bool)
+            and input_tokens * 4 >= context_tokens * 3
+        )
 
     async def _record_controlled_compaction(
         self,

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -622,6 +622,15 @@ class CodingWorkerService:
             ),
         )
         try:
+            parent_turn_id: str | None = None
+            if parent.runtime_protocol is RuntimeProtocol.V17:
+                turn = self.store.current_turn_transaction(parent_task_id)
+                if turn is None:
+                    raise WorkerConflictError(
+                        "V17 subtask has no current turn.",
+                        code="operation_turn_required",
+                    )
+                parent_turn_id = turn.turn_id
             subtask = self.store.create_subtask_task(
                 parent_task_id=parent_task_id,
                 client_subtask_id=request.client_subtask_id,
@@ -630,6 +639,7 @@ class CodingWorkerService:
                 spec=child_spec,
                 workspace_id=workspace.workspace_id,
                 base_tree_hash=base_tree_hash,
+                parent_turn_id=parent_turn_id,
             )
         except Exception:
             self.workspace_broker.delete(workspace.workspace_id)
@@ -638,16 +648,6 @@ class CodingWorkerService:
             self.workspace_broker.delete(workspace.workspace_id)
         current_parent = self.store.get_task(parent_task_id)
         if current_parent.runtime_protocol is RuntimeProtocol.V17:
-            turn = self.store.current_turn_transaction(parent_task_id)
-            if turn is None:
-                raise WorkerConflictError(
-                    "V17 subtask has no current turn.", code="operation_turn_required"
-                )
-            self.store.begin_turn_parking(
-                task_id=parent_task_id,
-                turn_id=turn.turn_id,
-                barrier=TurnBarrier.SUBTASKS,
-            )
             self._wake.set()
             return subtask
         if current_parent.state in {

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -1414,6 +1414,7 @@ class CodingWorkerService:
                 if (
                     resume_phase
                     not in {
+                        "turn_open",
                         "testing",
                         "waiting_approval",
                         "waiting_input",
@@ -1427,6 +1428,13 @@ class CodingWorkerService:
                     raise WorkerConflictError(
                         "Checkpoint phase is invalid.", code="checkpoint_invalid"
                     )
+                current_turn = self.store.current_turn_transaction(task_id)
+                if (
+                    current_turn is not None
+                    and current_turn.state is TurnTransactionState.RESUMING
+                    and current_turn.barrier is TurnBarrier.OPERATION_UNKNOWN
+                ):
+                    resume_phase = "operation_unknown"
                 session = await self.provider.restore(request, provider_checkpoint)
             else:
                 session = await self.provider.open(request)
@@ -1588,7 +1596,14 @@ class CodingWorkerService:
         task_id = task.task_id
         message = task.spec.objective
         turns = completed_turns
-        if resume_phase == "testing":
+        if resume_phase == "turn_open":
+            message = self._restored_context_message(
+                resume_context,
+                "The previous turn stopped before a deterministic completion. "
+                "Continue from the durable turn boundary and do not infer that "
+                "any unreceipted side effect failed.",
+            )
+        elif resume_phase == "testing":
             steering, message_cursor = self._next_steering(
                 task_id, after_sequence=message_cursor
             )
@@ -1707,6 +1722,55 @@ class CodingWorkerService:
                     turn_id=turn_id,
                     payload={},
                 )
+                if task.runtime_protocol is RuntimeProtocol.V17:
+                    try:
+                        provider_checkpoint = await self.provider.checkpoint(session)
+                        entry_tree_hash = self.workspace_broker.current_tree_hash(
+                            workspace_id or ""
+                        )
+                        checkpoint = self.store.create_checkpoint(
+                            task_id=task_id,
+                            workspace_tree_hash=entry_tree_hash,
+                            payload={
+                                "phase": "turn_open",
+                                "turn_id": turn_id,
+                                "completed_turns": turns,
+                                "message_cursor": message_cursor,
+                                "provider": provider_checkpoint.model_dump(mode="json"),
+                                "context_summary": self._context_summary(
+                                    task_id,
+                                    tree_hash=entry_tree_hash,
+                                    public_output="",
+                                ),
+                                "turn_before": (
+                                    turn_before.model_dump(mode="json")
+                                    if turn_before is not None
+                                    else None
+                                ),
+                                "turn_public_before": turn_public_before,
+                            },
+                        )
+                        self.store.bind_turn_recovery_checkpoint(
+                            task_id=task_id,
+                            turn_id=turn_id,
+                            checkpoint_id=checkpoint.checkpoint_id,
+                        )
+                    except Exception:
+                        self.store.finish_session_turn(
+                            task_id, turn_id=turn_id, result_state="interrupted"
+                        )
+                        self.store.finish_turn_transaction(
+                            task_id=task_id,
+                            turn_id=turn_id,
+                            state=TurnTransactionState.INTERRUPTED,
+                        )
+                        self.store.transition(
+                            task_id,
+                            TaskState.BLOCKED,
+                            reason="turn_entry_checkpoint_failed",
+                            expected_state=TaskState.RUNNING,
+                        )
+                        return
             outcome = "interrupted"
             question_data: dict[str, object] | None = None
             compaction_failed = False

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -118,8 +118,8 @@ class CodingWorkerStore:
         self.workspaces_root.mkdir(parents=True, exist_ok=True)
         self._initialize()
         self.mark_open_session_boundaries_interrupted()
-        self.mark_inflight_interrupted()
         self.mark_inflight_operations_unknown()
+        self.mark_inflight_interrupted()
 
     def allocate_controller_generation(self) -> int:
         """Allocate one durable, monotonic Server-to-sidecar fencing generation."""
@@ -1786,7 +1786,7 @@ class CodingWorkerStore:
             connection.execute(
                 """
                 UPDATE worker_turn_transactions
-                SET state = ?, barrier = ?, checkpoint_id = NULL, updated_at = ?
+                SET state = ?, barrier = ?, updated_at = ?
                 WHERE task_id = ? AND turn_id = ?
                 """,
                 (
@@ -1803,6 +1803,54 @@ class CodingWorkerStore:
                 event_type="turn_parking",
                 payload={"turn_id": turn_id, "barrier": barrier.value},
                 created_at=now,
+            )
+        return self.get_turn_transaction(task_id, turn_id)
+
+    def bind_turn_recovery_checkpoint(
+        self, *, task_id: str, turn_id: str, checkpoint_id: str
+    ) -> WorkerTurnTransaction:
+        """Bind the deterministic entry checkpoint before a V17 turn can use tools."""
+
+        if SAFE_ID.fullmatch(checkpoint_id) is None:
+            raise ValueError("turn checkpoint identifier is invalid")
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = self._require_turn_row(connection, task_id, turn_id)
+            current = self._turn_transaction(row)
+            if current.state is not TurnTransactionState.OPEN:
+                raise WorkerConflictError(
+                    "Turn entry checkpoint can no longer be bound.",
+                    code="turn_state_conflict",
+                )
+            checkpoint = connection.execute(
+                "SELECT task_id, workspace_tree_hash FROM worker_checkpoints WHERE checkpoint_id = ?",
+                (checkpoint_id,),
+            ).fetchone()
+            if (
+                checkpoint is None
+                or str(checkpoint["task_id"]) != task_id
+                or str(checkpoint["workspace_tree_hash"])
+                != current.workspace_tree_hash
+            ):
+                raise WorkerConflictError(
+                    "Turn entry checkpoint binding is invalid.",
+                    code="turn_checkpoint_invalid",
+                )
+            if current.checkpoint_id is not None:
+                if current.checkpoint_id != checkpoint_id:
+                    raise WorkerConflictError(
+                        "Turn entry checkpoint changed.",
+                        code="turn_checkpoint_conflict",
+                    )
+                return current
+            connection.execute(
+                """
+                UPDATE worker_turn_transactions
+                SET checkpoint_id = ?, updated_at = ?
+                WHERE task_id = ? AND turn_id = ?
+                """,
+                (checkpoint_id, now, task_id, turn_id),
             )
         return self.get_turn_transaction(task_id, turn_id)
 
@@ -2918,10 +2966,59 @@ class CodingWorkerStore:
                     and str(turn_row["barrier"]) == TurnBarrier.APPROVAL.value
                 ):
                     continue
+                unknown_operation = (
+                    connection.execute(
+                        """
+                        SELECT operation_id FROM worker_operations
+                        WHERE task_id = ? AND turn_id = ? AND state = ?
+                        ORDER BY created_at LIMIT 1
+                        """,
+                        (
+                            task_id,
+                            str(turn_row["turn_id"]),
+                            OperationState.UNKNOWN.value,
+                        ),
+                    ).fetchone()
+                    if (
+                        str(row["runtime_protocol"]) == RuntimeProtocol.V17.value
+                        and turn_row is not None
+                    )
+                    else None
+                )
+                if unknown_operation is not None and turn_row["checkpoint_id"] is not None:
+                    connection.execute(
+                        """
+                        UPDATE worker_turn_transactions
+                        SET state = ?, barrier = ?, updated_at = ?
+                        WHERE task_id = ? AND turn_id = ?
+                        """,
+                        (
+                            TurnTransactionState.PARKED.value,
+                            TurnBarrier.OPERATION_UNKNOWN.value,
+                            now,
+                            task_id,
+                            str(turn_row["turn_id"]),
+                        ),
+                    )
+                    self._append_event_locked(
+                        connection,
+                        task_id=task_id,
+                        event_type="turn_parked",
+                        payload={
+                            "turn_id": str(turn_row["turn_id"]),
+                            "barrier": TurnBarrier.OPERATION_UNKNOWN.value,
+                            "checkpoint_id": str(turn_row["checkpoint_id"]),
+                            "operation_id": str(unknown_operation["operation_id"]),
+                        },
+                        created_at=now,
+                    )
+                    reason = "operation_result_unknown"
+                else:
+                    reason = "server_restart"
                 if turn_row is not None and str(turn_row["state"]) in {
                     TurnTransactionState.OPEN.value,
                     TurnTransactionState.PARKING.value,
-                }:
+                } and unknown_operation is None:
                     connection.execute(
                         """
                         UPDATE worker_turn_transactions
@@ -2946,7 +3043,7 @@ class CodingWorkerStore:
                     "UPDATE worker_tasks SET state = ?, reason_ciphertext = ?, updated_at = ? WHERE task_id = ?",
                     (
                         TaskState.INTERRUPTED.value,
-                        self._codec.encrypt("server_restart"),
+                        self._codec.encrypt(reason),
                         now,
                         task_id,
                     ),
@@ -2958,7 +3055,7 @@ class CodingWorkerStore:
                     payload={
                         "from": str(row["state"]),
                         "to": TaskState.INTERRUPTED.value,
-                        "reason": "server_restart",
+                        "reason": reason,
                     },
                     created_at=now,
                 )

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -348,6 +348,7 @@ class CodingWorkerStore:
         spec: TaskSpec,
         workspace_id: str,
         base_tree_hash: str,
+        parent_turn_id: str | None = None,
     ) -> SubtaskRecord:
         now = self._now()
         expires_at = now + self.retention_seconds
@@ -356,7 +357,7 @@ class CodingWorkerStore:
         encrypted_objective = self._codec.encrypt(objective)
         with self._lock, self._connect() as connection:
             connection.execute("BEGIN IMMEDIATE")
-            self._require_task_row(connection, parent_task_id)
+            parent_row = self._require_task_row(connection, parent_task_id)
             if connection.execute(
                 "SELECT 1 FROM worker_subtasks WHERE child_task_id = ?",
                 (parent_task_id,),
@@ -382,6 +383,14 @@ class CodingWorkerStore:
                     raise WorkerConflictError(
                         "Subtask id is bound to another intent.",
                         code="subtask_intent_conflict",
+                    )
+                if parent_turn_id is not None:
+                    self._begin_turn_parking_locked(
+                        connection,
+                        task_id=parent_task_id,
+                        turn_id=parent_turn_id,
+                        barrier=TurnBarrier.SUBTASKS,
+                        now=now,
                     )
                 return current
             count = int(
@@ -459,6 +468,19 @@ class CodingWorkerStore:
                 },
                 created_at=now,
             )
+            if parent_turn_id is not None:
+                if RuntimeProtocol(str(parent_row["runtime_protocol"])) is not RuntimeProtocol.V17:
+                    raise WorkerConflictError(
+                        "Only V17 subtasks can park a parent turn.",
+                        code="turn_protocol_mismatch",
+                    )
+                self._begin_turn_parking_locked(
+                    connection,
+                    task_id=parent_task_id,
+                    turn_id=parent_turn_id,
+                    barrier=TurnBarrier.SUBTASKS,
+                    now=now,
+                )
         return self.get_subtask(parent_task_id, client_subtask_id)  # type: ignore[return-value]
 
     def finish_subtask(
@@ -1323,6 +1345,96 @@ class CodingWorkerStore:
             )
         return pending
 
+    def create_question_and_begin_turn_parking(
+        self,
+        *,
+        task_id: str,
+        question_id: str,
+        turn_id: str,
+        prompt: str,
+        options: tuple[WorkerQuestionOption, ...],
+    ) -> WorkerQuestion:
+        """Create the authoritative question and close the V17 turn atomically."""
+
+        now = self._now()
+        pending = WorkerQuestion(
+            task_id=task_id,
+            question_id=question_id,
+            turn_id=turn_id,
+            status=QuestionStatus.PENDING,
+            prompt=prompt,
+            options=options,
+            created_at=now,
+        )
+        request = {
+            "prompt": pending.prompt,
+            "options": [item.model_dump(mode="json") for item in pending.options],
+        }
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            task_row = self._require_task_row(connection, task_id)
+            if (
+                RuntimeProtocol(str(task_row["runtime_protocol"]))
+                is not RuntimeProtocol.V17
+                or TaskState(str(task_row["state"])) is not TaskState.RUNNING
+            ):
+                raise WorkerConflictError(
+                    "Task is not accepting a V17 provider question.",
+                    code="task_state_conflict",
+                )
+            existing = connection.execute(
+                "SELECT * FROM worker_questions WHERE task_id = ? AND question_id = ?",
+                (task_id, question_id),
+            ).fetchone()
+            if existing is not None:
+                current = self._question(existing)
+                if (
+                    current.turn_id != turn_id
+                    or current.prompt != pending.prompt
+                    or current.options != pending.options
+                ):
+                    raise WorkerConflictError(
+                        "Question identifier is already bound to another request.",
+                        code="question_intent_conflict",
+                    )
+                pending = current
+            else:
+                connection.execute(
+                    """
+                    INSERT INTO worker_questions (
+                        task_id, question_id, turn_id, status, request_ciphertext,
+                        answer_ciphertext, created_at, resolved_at
+                    ) VALUES (?, ?, ?, ?, ?, NULL, ?, NULL)
+                    """,
+                    (
+                        task_id,
+                        question_id,
+                        turn_id,
+                        QuestionStatus.PENDING.value,
+                        self._codec.encrypt(request),
+                        now,
+                    ),
+                )
+                self._append_event_locked(
+                    connection,
+                    task_id=task_id,
+                    event_type="question_requested",
+                    payload={
+                        "question_id": question_id,
+                        "prompt": pending.prompt,
+                        "options": request["options"],
+                    },
+                    created_at=now,
+                )
+            self._begin_turn_parking_locked(
+                connection,
+                task_id=task_id,
+                turn_id=turn_id,
+                barrier=TurnBarrier.INPUT,
+                now=now,
+            )
+        return pending
+
     def list_questions(self, task_id: str) -> list[WorkerQuestion]:
         with self._connect() as connection:
             self._require_task_row(connection, task_id)
@@ -1534,6 +1646,80 @@ class CodingWorkerStore:
                 created_at=now,
             )
         return self.get_approval(approval_id)
+
+    def create_approvals_and_begin_turn_parking(
+        self,
+        *,
+        task_id: str,
+        turn_id: str,
+        requests: tuple[tuple[str, CapabilityName, dict[str, Any]], ...],
+    ) -> tuple[WorkerApproval, ...]:
+        """Create all exact approvals and close the V17 turn in one transaction."""
+
+        if not requests:
+            raise ValueError("approval requests cannot be empty")
+        now = self._now()
+        approval_ids: list[str] = []
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            task_row = self._require_task_row(connection, task_id)
+            if RuntimeProtocol(str(task_row["runtime_protocol"])) is not RuntimeProtocol.V17:
+                raise WorkerConflictError(
+                    "Atomic approval parking requires V17.",
+                    code="turn_protocol_mismatch",
+                )
+            for operation_id, capability, request in requests:
+                existing = connection.execute(
+                    "SELECT * FROM worker_approvals WHERE operation_id = ?",
+                    (operation_id,),
+                ).fetchone()
+                if existing is not None:
+                    approval = self._approval(existing)
+                    if (
+                        approval.task_id != task_id
+                        or approval.capability != capability
+                        or approval.request != request
+                    ):
+                        raise WorkerConflictError(
+                            "Approval operation id is bound to another intent.",
+                            code="approval_intent_conflict",
+                        )
+                    approval_ids.append(approval.approval_id)
+                    continue
+                approval_id = f"approval_{uuid.uuid4().hex}"
+                connection.execute(
+                    """
+                    INSERT INTO worker_approvals (
+                        approval_id, task_id, operation_id, capability, status,
+                        request_ciphertext, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        approval_id,
+                        task_id,
+                        operation_id,
+                        capability,
+                        ApprovalStatus.PENDING.value,
+                        self._codec.encrypt(request),
+                        now,
+                    ),
+                )
+                self._append_event_locked(
+                    connection,
+                    task_id=task_id,
+                    event_type="approval_requested",
+                    payload={"approval_id": approval_id, "capability": capability},
+                    created_at=now,
+                )
+                approval_ids.append(approval_id)
+            self._begin_turn_parking_locked(
+                connection,
+                task_id=task_id,
+                turn_id=turn_id,
+                barrier=TurnBarrier.APPROVAL,
+                now=now,
+            )
+        return tuple(self.get_approval(item) for item in approval_ids)
 
     def get_approval(self, approval_id: str) -> WorkerApproval:
         with self._connect() as connection:
@@ -1767,44 +1953,61 @@ class CodingWorkerStore:
         now = self._now()
         with self._lock, self._connect() as connection:
             connection.execute("BEGIN IMMEDIATE")
-            row = self._require_turn_row(connection, task_id, turn_id)
-            current = self._turn_transaction(row)
-            if current.state is TurnTransactionState.PARKING:
-                if current.barrier is not barrier:
-                    raise WorkerConflictError(
-                        "Turn is parking for another barrier.",
-                        code="turn_barrier_conflict",
-                    )
-                return current
-            if current.state not in {
-                TurnTransactionState.OPEN,
-                TurnTransactionState.RESUMING,
-            }:
-                raise WorkerConflictError(
-                    "Turn cannot start parking.", code="turn_state_conflict"
-                )
-            connection.execute(
-                """
-                UPDATE worker_turn_transactions
-                SET state = ?, barrier = ?, updated_at = ?
-                WHERE task_id = ? AND turn_id = ?
-                """,
-                (
-                    TurnTransactionState.PARKING.value,
-                    barrier.value,
-                    now,
-                    task_id,
-                    turn_id,
-                ),
-            )
-            self._append_event_locked(
+            self._begin_turn_parking_locked(
                 connection,
                 task_id=task_id,
-                event_type="turn_parking",
-                payload={"turn_id": turn_id, "barrier": barrier.value},
-                created_at=now,
+                turn_id=turn_id,
+                barrier=barrier,
+                now=now,
             )
         return self.get_turn_transaction(task_id, turn_id)
+
+    def _begin_turn_parking_locked(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        task_id: str,
+        turn_id: str,
+        barrier: TurnBarrier,
+        now: float,
+    ) -> None:
+        row = self._require_turn_row(connection, task_id, turn_id)
+        current = self._turn_transaction(row)
+        if current.state is TurnTransactionState.PARKING:
+            if current.barrier is not barrier:
+                raise WorkerConflictError(
+                    "Turn is parking for another barrier.",
+                    code="turn_barrier_conflict",
+                )
+            return
+        if current.state not in {
+            TurnTransactionState.OPEN,
+            TurnTransactionState.RESUMING,
+        }:
+            raise WorkerConflictError(
+                "Turn cannot start parking.", code="turn_state_conflict"
+            )
+        connection.execute(
+            """
+            UPDATE worker_turn_transactions
+            SET state = ?, barrier = ?, updated_at = ?
+            WHERE task_id = ? AND turn_id = ?
+            """,
+            (
+                TurnTransactionState.PARKING.value,
+                barrier.value,
+                now,
+                task_id,
+                turn_id,
+            ),
+        )
+        self._append_event_locked(
+            connection,
+            task_id=task_id,
+            event_type="turn_parking",
+            payload={"turn_id": turn_id, "barrier": barrier.value},
+            created_at=now,
+        )
 
     def bind_turn_recovery_checkpoint(
         self, *, task_id: str, turn_id: str, checkpoint_id: str

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -19,6 +19,8 @@ from .contracts import (
     EvidenceStatus,
     CapabilityLease,
     OperationState,
+    RuntimeProtocol,
+    SAFE_ID,
     TERMINAL_STATES,
     Origin,
     SubtaskKind,
@@ -27,6 +29,8 @@ from .contracts import (
     TaskRecord,
     TaskSpec,
     TaskState,
+    TurnBarrier,
+    TurnTransactionState,
     WorkerEvent,
     WorkerEvidence,
     WorkerArtifact,
@@ -43,6 +47,7 @@ from .contracts import (
     WorkerQuestionOption,
     QuestionStatus,
     WorkerOperation,
+    WorkerTurnTransaction,
     WorkerSessionLedgerEntry,
     SessionLedgerKind,
     require_transition,
@@ -142,6 +147,7 @@ class CodingWorkerStore:
         capability_snapshot: dict[str, Any] | None = None,
         capability_observed_at: float | None = None,
         capability_expires_at: float | None = None,
+        runtime_protocol: RuntimeProtocol = RuntimeProtocol.V16,
     ) -> TaskRecord:
         capability_values = (
             capability_binding_sha256,
@@ -178,7 +184,7 @@ class CodingWorkerStore:
             ).fetchone()
             if existing is not None:
                 current = self._task(existing, connection)
-                if current.spec != spec:
+                if current.spec != spec or current.runtime_protocol is not runtime_protocol:
                     raise WorkerConflictError(
                         "The idempotency key is already bound to another task.",
                         code="task_intent_conflict",
@@ -188,8 +194,9 @@ class CodingWorkerStore:
                 """
                 INSERT INTO worker_tasks (
                     task_id, origin_module, origin_object_id, client_task_id,
-                    state, spec_ciphertext, created_at, updated_at, expires_at, pinned
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+                    state, spec_ciphertext, created_at, updated_at, expires_at, pinned,
+                    runtime_protocol
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
                 """,
                 (
                     task_id,
@@ -201,6 +208,7 @@ class CodingWorkerStore:
                     now,
                     now,
                     expires_at,
+                    runtime_protocol.value,
                 ),
             )
             if capability_snapshot is not None:
@@ -1635,6 +1643,300 @@ class CodingWorkerStore:
                 is not None
             )
 
+    def open_turn_transaction(
+        self, *, task_id: str, turn_id: str, workspace_tree_hash: str
+    ) -> WorkerTurnTransaction:
+        candidate = WorkerTurnTransaction(
+            task_id=task_id,
+            turn_id=turn_id,
+            generation=1,
+            state=TurnTransactionState.OPEN,
+            workspace_tree_hash=workspace_tree_hash,
+            created_at=self._now(),
+            updated_at=self._now(),
+        )
+        now = candidate.created_at
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            task = self._task(self._require_task_row(connection, task_id), connection)
+            if task.runtime_protocol is not RuntimeProtocol.V17:
+                raise WorkerConflictError(
+                    "Turn transactions require a V17 task.",
+                    code="turn_protocol_mismatch",
+                )
+            existing = connection.execute(
+                """
+                SELECT * FROM worker_turn_transactions
+                WHERE task_id = ? AND state IN ('open', 'parking', 'parked', 'resuming')
+                """,
+                (task_id,),
+            ).fetchone()
+            if existing is not None:
+                current = self._turn_transaction(existing)
+                if current.turn_id != turn_id:
+                    raise WorkerConflictError(
+                        "Task already has an unfinished turn.",
+                        code="turn_already_open",
+                    )
+                if current.workspace_tree_hash != workspace_tree_hash:
+                    raise WorkerConflictError(
+                        "Turn tree binding changed.", code="turn_tree_changed"
+                    )
+                return current
+            generation = int(
+                connection.execute(
+                    "SELECT COALESCE(MAX(generation), 0) + 1 FROM worker_turn_transactions WHERE task_id = ?",
+                    (task_id,),
+                ).fetchone()[0]
+            )
+            connection.execute(
+                """
+                INSERT INTO worker_turn_transactions (
+                    task_id, turn_id, generation, state, barrier,
+                    workspace_tree_hash, checkpoint_id, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, NULL, ?, NULL, ?, ?)
+                """,
+                (
+                    task_id,
+                    turn_id,
+                    generation,
+                    TurnTransactionState.OPEN.value,
+                    workspace_tree_hash,
+                    now,
+                    now,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="turn_started",
+                payload={
+                    "turn_id": turn_id,
+                    "generation": generation,
+                    "workspace_tree_hash": workspace_tree_hash,
+                },
+                created_at=now,
+            )
+        return self.get_turn_transaction(task_id, turn_id)
+
+    def begin_turn_parking(
+        self, *, task_id: str, turn_id: str, barrier: TurnBarrier
+    ) -> WorkerTurnTransaction:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = self._require_turn_row(connection, task_id, turn_id)
+            current = self._turn_transaction(row)
+            if current.state is TurnTransactionState.PARKING:
+                if current.barrier is not barrier:
+                    raise WorkerConflictError(
+                        "Turn is parking for another barrier.",
+                        code="turn_barrier_conflict",
+                    )
+                return current
+            if current.state not in {
+                TurnTransactionState.OPEN,
+                TurnTransactionState.RESUMING,
+            }:
+                raise WorkerConflictError(
+                    "Turn cannot start parking.", code="turn_state_conflict"
+                )
+            connection.execute(
+                """
+                UPDATE worker_turn_transactions
+                SET state = ?, barrier = ?, checkpoint_id = NULL, updated_at = ?
+                WHERE task_id = ? AND turn_id = ?
+                """,
+                (
+                    TurnTransactionState.PARKING.value,
+                    barrier.value,
+                    now,
+                    task_id,
+                    turn_id,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="turn_parking",
+                payload={"turn_id": turn_id, "barrier": barrier.value},
+                created_at=now,
+            )
+        return self.get_turn_transaction(task_id, turn_id)
+
+    def park_turn_transaction(
+        self, *, task_id: str, turn_id: str, checkpoint_id: str
+    ) -> WorkerTurnTransaction:
+        if SAFE_ID.fullmatch(checkpoint_id) is None:
+            raise ValueError("turn checkpoint identifier is invalid")
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = self._require_turn_row(connection, task_id, turn_id)
+            current = self._turn_transaction(row)
+            if current.state is TurnTransactionState.PARKED:
+                if current.checkpoint_id != checkpoint_id:
+                    raise WorkerConflictError(
+                        "Parked turn checkpoint changed.",
+                        code="turn_checkpoint_conflict",
+                    )
+                return current
+            if current.state is not TurnTransactionState.PARKING:
+                raise WorkerConflictError(
+                    "Turn is not parking.", code="turn_state_conflict"
+                )
+            checkpoint = connection.execute(
+                "SELECT task_id, workspace_tree_hash FROM worker_checkpoints WHERE checkpoint_id = ?",
+                (checkpoint_id,),
+            ).fetchone()
+            if (
+                checkpoint is None
+                or str(checkpoint["task_id"]) != task_id
+                or str(checkpoint["workspace_tree_hash"])
+                != current.workspace_tree_hash
+            ):
+                raise WorkerConflictError(
+                    "Turn checkpoint binding is invalid.",
+                    code="turn_checkpoint_invalid",
+                )
+            connection.execute(
+                """
+                UPDATE worker_turn_transactions
+                SET state = ?, checkpoint_id = ?, updated_at = ?
+                WHERE task_id = ? AND turn_id = ?
+                """,
+                (
+                    TurnTransactionState.PARKED.value,
+                    checkpoint_id,
+                    now,
+                    task_id,
+                    turn_id,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="turn_parked",
+                payload={
+                    "turn_id": turn_id,
+                    "barrier": current.barrier.value if current.barrier else None,
+                    "checkpoint_id": checkpoint_id,
+                },
+                created_at=now,
+            )
+        return self.get_turn_transaction(task_id, turn_id)
+
+    def resume_turn_transaction(
+        self, *, task_id: str, turn_id: str, checkpoint_id: str
+    ) -> WorkerTurnTransaction:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = self._require_turn_row(connection, task_id, turn_id)
+            current = self._turn_transaction(row)
+            if current.state is TurnTransactionState.RESUMING:
+                return current
+            if (
+                current.state is not TurnTransactionState.PARKED
+                or current.checkpoint_id != checkpoint_id
+            ):
+                raise WorkerConflictError(
+                    "Turn cannot resume from this checkpoint.",
+                    code="turn_checkpoint_conflict",
+                )
+            connection.execute(
+                """
+                UPDATE worker_turn_transactions SET state = ?, updated_at = ?
+                WHERE task_id = ? AND turn_id = ?
+                """,
+                (TurnTransactionState.RESUMING.value, now, task_id, turn_id),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="turn_resumed",
+                payload={"turn_id": turn_id, "checkpoint_id": checkpoint_id},
+                created_at=now,
+            )
+        return self.get_turn_transaction(task_id, turn_id)
+
+    def finish_turn_transaction(
+        self,
+        *,
+        task_id: str,
+        turn_id: str,
+        state: TurnTransactionState,
+    ) -> WorkerTurnTransaction:
+        if state not in {
+            TurnTransactionState.COMPLETED,
+            TurnTransactionState.INTERRUPTED,
+        }:
+            raise ValueError("turn terminal state is invalid")
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = self._require_turn_row(connection, task_id, turn_id)
+            current = self._turn_transaction(row)
+            if current.state in {
+                TurnTransactionState.COMPLETED,
+                TurnTransactionState.INTERRUPTED,
+            }:
+                if current.state is not state:
+                    raise WorkerConflictError(
+                        "Turn terminal state changed.", code="turn_state_conflict"
+                    )
+                return current
+            connection.execute(
+                """
+                UPDATE worker_turn_transactions
+                SET state = ?, barrier = NULL, checkpoint_id = NULL, updated_at = ?
+                WHERE task_id = ? AND turn_id = ?
+                """,
+                (state.value, now, task_id, turn_id),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type=(
+                    "turn_completed"
+                    if state is TurnTransactionState.COMPLETED
+                    else "turn_interrupted"
+                ),
+                payload={"turn_id": turn_id},
+                created_at=now,
+            )
+        return self.get_turn_transaction(task_id, turn_id)
+
+    def get_turn_transaction(
+        self, task_id: str, turn_id: str
+    ) -> WorkerTurnTransaction:
+        with self._connect() as connection:
+            row = self._require_turn_row(connection, task_id, turn_id)
+        return self._turn_transaction(row)
+
+    def current_turn_transaction(
+        self, task_id: str
+    ) -> WorkerTurnTransaction | None:
+        with self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            row = connection.execute(
+                """
+                SELECT * FROM worker_turn_transactions
+                WHERE task_id = ? AND state IN ('open', 'parking', 'parked', 'resuming')
+                """,
+                (task_id,),
+            ).fetchone()
+        return self._turn_transaction(row) if row is not None else None
+
+    def list_turn_transactions(self, task_id: str) -> list[WorkerTurnTransaction]:
+        with self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            rows = connection.execute(
+                "SELECT * FROM worker_turn_transactions WHERE task_id = ? ORDER BY generation",
+                (task_id,),
+            ).fetchall()
+        return [self._turn_transaction(row) for row in rows]
+
     def create_operation(
         self,
         *,
@@ -1643,11 +1945,47 @@ class CodingWorkerStore:
         tool_name: str,
         intent_sha256: str,
         request: dict[str, Any],
+        turn_id: str | None = None,
     ) -> WorkerOperation:
         now = self._now()
         with self._lock, self._connect() as connection:
             connection.execute("BEGIN IMMEDIATE")
             task = self._task(self._require_task_row(connection, task_id), connection)
+            if task.runtime_protocol is RuntimeProtocol.V17:
+                if turn_id is None or SAFE_ID.fullmatch(turn_id) is None:
+                    raise WorkerConflictError(
+                        "V17 operations require the current turn.",
+                        code="operation_turn_required",
+                    )
+                turn_row = connection.execute(
+                    """
+                    SELECT * FROM worker_turn_transactions
+                    WHERE task_id = ? AND state IN ('open', 'parking', 'parked', 'resuming')
+                    """,
+                    (task_id,),
+                ).fetchone()
+                if turn_row is None:
+                    raise WorkerConflictError(
+                        "V17 task has no current turn.", code="operation_turn_required"
+                    )
+                current_turn = self._turn_transaction(turn_row)
+                if current_turn.turn_id != turn_id:
+                    raise WorkerConflictError(
+                        "Operation is bound to a stale turn.", code="operation_turn_stale"
+                    )
+                if current_turn.state not in {
+                    TurnTransactionState.OPEN,
+                    TurnTransactionState.RESUMING,
+                }:
+                    existing = connection.execute(
+                        "SELECT * FROM worker_operations WHERE operation_id = ?",
+                        (operation_id,),
+                    ).fetchone()
+                    if existing is None or str(existing["turn_id"]) != turn_id:
+                        raise WorkerConflictError(
+                            "Turn is parked and rejects new operations.",
+                            code="turn_parked",
+                        )
             existing = connection.execute(
                 "SELECT * FROM worker_operations WHERE operation_id = ?", (operation_id,)
             ).fetchone()
@@ -1658,6 +1996,7 @@ class CodingWorkerStore:
                     or operation.tool_name != tool_name
                     or operation.intent_sha256 != intent_sha256
                     or operation.request != request
+                    or operation.turn_id != turn_id
                 ):
                     raise WorkerConflictError(
                         "Tool operation id is bound to another intent.",
@@ -1679,8 +2018,8 @@ class CodingWorkerStore:
                 """
                 INSERT INTO worker_operations (
                     operation_id, task_id, tool_name, intent_sha256, state,
-                    request_ciphertext, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    request_ciphertext, created_at, updated_at, turn_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     operation_id,
@@ -1691,6 +2030,7 @@ class CodingWorkerStore:
                     self._codec.encrypt(request),
                     now,
                     now,
+                    turn_id,
                 ),
             )
         return self.get_operation(operation_id)
@@ -2536,6 +2876,7 @@ class CodingWorkerStore:
                     updated_at REAL NOT NULL,
                     expires_at REAL NOT NULL,
                     pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0, 1)),
+                    runtime_protocol TEXT NOT NULL DEFAULT 'v16',
                     UNIQUE(origin_module, origin_object_id, client_task_id)
                 );
                 CREATE INDEX IF NOT EXISTS idx_worker_tasks_state
@@ -2642,6 +2983,7 @@ class CodingWorkerStore:
                     result_ciphertext TEXT,
                     created_at REAL NOT NULL,
                     updated_at REAL NOT NULL,
+                    turn_id TEXT,
                     FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
                 );
                 CREATE INDEX IF NOT EXISTS idx_worker_operations_task
@@ -2684,6 +3026,24 @@ class CodingWorkerStore:
                 );
                 CREATE INDEX IF NOT EXISTS idx_worker_checkpoints_task
                     ON worker_checkpoints(task_id, created_at);
+                CREATE TABLE IF NOT EXISTS worker_turn_transactions (
+                    task_id TEXT NOT NULL,
+                    turn_id TEXT NOT NULL,
+                    generation INTEGER NOT NULL CHECK (generation >= 1),
+                    state TEXT NOT NULL,
+                    barrier TEXT,
+                    workspace_tree_hash TEXT NOT NULL,
+                    checkpoint_id TEXT,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY(task_id, turn_id),
+                    UNIQUE(task_id, generation),
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE,
+                    FOREIGN KEY(checkpoint_id) REFERENCES worker_checkpoints(checkpoint_id)
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_worker_turn_unfinished
+                    ON worker_turn_transactions(task_id)
+                    WHERE state IN ('open', 'parking', 'parked', 'resuming');
                 CREATE TABLE IF NOT EXISTS worker_turn_checkpoints (
                     checkpoint_id TEXT PRIMARY KEY,
                     task_id TEXT NOT NULL,
@@ -2758,6 +3118,26 @@ class CodingWorkerStore:
                     VALUES (1, 0);
                 """
             )
+            task_columns = {
+                str(row["name"])
+                for row in connection.execute(
+                    "PRAGMA table_info(worker_tasks)"
+                ).fetchall()
+            }
+            if "runtime_protocol" not in task_columns:
+                connection.execute(
+                    "ALTER TABLE worker_tasks ADD COLUMN runtime_protocol TEXT NOT NULL DEFAULT 'v16'"
+                )
+            operation_columns = {
+                str(row["name"])
+                for row in connection.execute(
+                    "PRAGMA table_info(worker_operations)"
+                ).fetchall()
+            }
+            if "turn_id" not in operation_columns:
+                connection.execute(
+                    "ALTER TABLE worker_operations ADD COLUMN turn_id TEXT"
+                )
             subtask_columns = {
                 str(row["name"])
                 for row in connection.execute(
@@ -2852,6 +3232,7 @@ class CodingWorkerStore:
             pinned=bool(row["pinned"]),
             last_event_sequence=last_sequence,
             reason=reason,
+            runtime_protocol=RuntimeProtocol(str(row["runtime_protocol"])),
         )
 
     def _append_event_locked(
@@ -3096,12 +3477,40 @@ class CodingWorkerStore:
                 state=OperationState(row["state"]),
                 request=self._decrypt_dict(row["request_ciphertext"]),
                 result=result,
+                turn_id=(str(row["turn_id"]) if row["turn_id"] is not None else None),
                 created_at=float(row["created_at"]),
                 updated_at=float(row["updated_at"]),
             )
         except (WorkerCryptoError, ValueError) as exc:
             raise WorkerStoreError(
                 "Worker operation data is corrupt.", code="worker_data_corrupt"
+            ) from exc
+
+    @staticmethod
+    def _turn_transaction(row: sqlite3.Row) -> WorkerTurnTransaction:
+        try:
+            return WorkerTurnTransaction(
+                task_id=str(row["task_id"]),
+                turn_id=str(row["turn_id"]),
+                generation=int(row["generation"]),
+                state=TurnTransactionState(str(row["state"])),
+                barrier=(
+                    TurnBarrier(str(row["barrier"]))
+                    if row["barrier"] is not None
+                    else None
+                ),
+                workspace_tree_hash=str(row["workspace_tree_hash"]),
+                checkpoint_id=(
+                    str(row["checkpoint_id"])
+                    if row["checkpoint_id"] is not None
+                    else None
+                ),
+                created_at=float(row["created_at"]),
+                updated_at=float(row["updated_at"]),
+            )
+        except (TypeError, ValueError) as exc:
+            raise WorkerStoreError(
+                "Worker turn transaction is corrupt.", code="worker_data_corrupt"
             ) from exc
 
     def _artifact(self, row: sqlite3.Row) -> WorkerArtifact:
@@ -3216,6 +3625,20 @@ class CodingWorkerStore:
         ).fetchone()
         if row is None:
             raise WorkerNotFoundError("Worker task was not found.", code="task_not_found")
+        return row
+
+    @staticmethod
+    def _require_turn_row(
+        connection: sqlite3.Connection, task_id: str, turn_id: str
+    ) -> sqlite3.Row:
+        row = connection.execute(
+            "SELECT * FROM worker_turn_transactions WHERE task_id = ? AND turn_id = ?",
+            (task_id, turn_id),
+        ).fetchone()
+        if row is None:
+            raise WorkerNotFoundError(
+                "Worker turn was not found.", code="turn_not_found"
+            )
         return row
 
     def _decrypt_dict(self, ciphertext: str) -> dict[str, Any]:

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -40,6 +40,8 @@ from .contracts import (
     WorkerMessage,
     WorkerPlan,
     WorkerPlanItem,
+    WorkerTodo,
+    WorkerTodoItem,
     WorkerQuestion,
     WorkerTurnCheckpoint,
     WorkerTurnHistory,
@@ -1226,6 +1228,25 @@ class CodingWorkerStore:
             updated_at=entry.created_at,
         )
 
+    def latest_todo(self, task_id: str) -> WorkerTodo | None:
+        entry = self.latest_session_entry(task_id, SessionLedgerKind.TODO)
+        if entry is None:
+            return None
+        if entry.turn_id is None:
+            raise WorkerStoreError(
+                "Worker todo data is corrupt.", code="worker_data_corrupt"
+            )
+        return WorkerTodo(
+            task_id=task_id,
+            sequence=entry.sequence,
+            turn_id=entry.turn_id,
+            items=tuple(
+                WorkerTodoItem.model_validate(item)
+                for item in entry.payload["items"]
+            ),
+            updated_at=entry.created_at,
+        )
+
     def create_question(
         self,
         *,
@@ -1427,6 +1448,14 @@ class CodingWorkerStore:
                     },
                     created_at=now,
                 )
+            else:
+                self._settle_parked_turn_locked(
+                    connection,
+                    task_id=task_id,
+                    barrier=TurnBarrier.INPUT,
+                    expected_state=TaskState.WAITING_INPUT,
+                    now=now,
+                )
             resolved = connection.execute(
                 "SELECT * FROM worker_questions WHERE task_id = ? AND question_id = ?",
                 (task_id, question_id),
@@ -1546,13 +1575,15 @@ class CodingWorkerStore:
                 raise WorkerConflictError(
                     "Approval has already been decided.", code="approval_already_decided"
                 )
+            task_id = str(row["task_id"])
+            task_row = self._require_task_row(connection, task_id)
+            runtime_protocol = RuntimeProtocol(str(task_row["runtime_protocol"]))
             lease: CapabilityLease | None = None
             status = ApprovalStatus.APPROVED if approved else ApprovalStatus.REJECTED
             if approved:
-                task_row = self._require_task_row(connection, str(row["task_id"]))
                 lease = CapabilityLease(
                     lease_id=f"lease_{uuid.uuid4().hex}",
-                    task_id=str(row["task_id"]),
+                    task_id=task_id,
                     capability=str(row["capability"]),  # type: ignore[arg-type]
                     scope=self._decrypt_dict(row["request_ciphertext"]),
                     issued_at=now,
@@ -1590,11 +1621,19 @@ class CodingWorkerStore:
             )
             self._append_event_locked(
                 connection,
-                task_id=str(row["task_id"]),
+                task_id=task_id,
                 event_type="approval_decided",
                 payload={"approval_id": approval_id, "status": status.value},
                 created_at=now,
             )
+            if runtime_protocol is RuntimeProtocol.V17:
+                self._settle_parked_turn_locked(
+                    connection,
+                    task_id=task_id,
+                    barrier=TurnBarrier.APPROVAL,
+                    expected_state=TaskState.WAITING_APPROVAL,
+                    now=now,
+                )
         return self.get_approval(approval_id)
 
     def consume_lease(
@@ -1861,6 +1900,98 @@ class CodingWorkerStore:
                 created_at=now,
             )
         return self.get_turn_transaction(task_id, turn_id)
+
+    def settle_parked_turn(
+        self,
+        *,
+        task_id: str,
+        barrier: TurnBarrier,
+        expected_state: TaskState,
+    ) -> TaskRecord:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._settle_parked_turn_locked(
+                connection,
+                task_id=task_id,
+                barrier=barrier,
+                expected_state=expected_state,
+                now=now,
+            )
+        return self.get_task(task_id)
+
+    def _settle_parked_turn_locked(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        task_id: str,
+        barrier: TurnBarrier,
+        expected_state: TaskState,
+        now: float,
+    ) -> None:
+        task_row = self._require_task_row(connection, task_id)
+        if TaskState(str(task_row["state"])) is not expected_state:
+            raise WorkerConflictError(
+                "Task is not ready to settle this turn.", code="task_state_conflict"
+            )
+        turn_row = connection.execute(
+            """
+            SELECT * FROM worker_turn_transactions
+            WHERE task_id = ? AND state = ? ORDER BY generation DESC LIMIT 1
+            """,
+            (task_id, TurnTransactionState.PARKED.value),
+        ).fetchone()
+        if turn_row is None:
+            raise WorkerConflictError(
+                "Turn is not durably parked.", code="turn_not_parked"
+            )
+        turn = self._turn_transaction(turn_row)
+        if turn.barrier is not barrier or turn.checkpoint_id is None:
+            raise WorkerConflictError(
+                "Turn is parked for another barrier.", code="turn_barrier_conflict"
+            )
+        require_transition(expected_state, TaskState.QUEUED)
+        connection.execute(
+            """
+            UPDATE worker_turn_transactions SET state = ?, updated_at = ?
+            WHERE task_id = ? AND turn_id = ?
+            """,
+            (
+                TurnTransactionState.RESUMING.value,
+                now,
+                task_id,
+                turn.turn_id,
+            ),
+        )
+        connection.execute(
+            """
+            UPDATE worker_tasks
+            SET state = ?, reason_ciphertext = NULL, updated_at = ?
+            WHERE task_id = ?
+            """,
+            (TaskState.QUEUED.value, now, task_id),
+        )
+        self._append_event_locked(
+            connection,
+            task_id=task_id,
+            event_type="turn_resumed",
+            payload={
+                "turn_id": turn.turn_id,
+                "checkpoint_id": turn.checkpoint_id,
+            },
+            created_at=now,
+        )
+        self._append_event_locked(
+            connection,
+            task_id=task_id,
+            event_type="task_state",
+            payload={
+                "from": expected_state.value,
+                "to": TaskState.QUEUED.value,
+                "reason": None,
+            },
+            created_at=now,
+        )
 
     def finish_turn_transaction(
         self,

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -2244,6 +2244,20 @@ class CodingWorkerStore:
                 payload={"operation_id": operation_id, "state": target.value},
                 created_at=now,
             )
+            if current is OperationState.UNKNOWN and target in {
+                OperationState.COMPLETED,
+                OperationState.FAILED,
+            }:
+                self._append_event_locked(
+                    connection,
+                    task_id=str(row["task_id"]),
+                    event_type="operation_reconciled",
+                    payload={
+                        "operation_id": operation_id,
+                        "state": target.value,
+                    },
+                    created_at=now,
+                )
         return self.get_operation(operation_id)
 
     def mark_inflight_operations_unknown(self) -> int:

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -1398,14 +1398,16 @@ class CodingWorkerStore:
                 payload={"role": "user", "text": provider_message},
                 created_at=now,
             )
-            connection.execute(
-                """
-                UPDATE worker_tasks
-                SET state = ?, reason_ciphertext = NULL, updated_at = ?
-                WHERE task_id = ?
-                """,
-                (TaskState.QUEUED.value, now, task_id),
-            )
+            runtime_protocol = RuntimeProtocol(str(task_row["runtime_protocol"]))
+            if runtime_protocol is RuntimeProtocol.V16:
+                connection.execute(
+                    """
+                    UPDATE worker_tasks
+                    SET state = ?, reason_ciphertext = NULL, updated_at = ?
+                    WHERE task_id = ?
+                    """,
+                    (TaskState.QUEUED.value, now, task_id),
+                )
             self._append_event_locked(
                 connection,
                 task_id=task_id,
@@ -1413,17 +1415,18 @@ class CodingWorkerStore:
                 payload={"question_id": question_id},
                 created_at=now,
             )
-            self._append_event_locked(
-                connection,
-                task_id=task_id,
-                event_type="task_state",
-                payload={
-                    "from": TaskState.WAITING_INPUT.value,
-                    "to": TaskState.QUEUED.value,
-                    "reason": None,
-                },
-                created_at=now,
-            )
+            if runtime_protocol is RuntimeProtocol.V16:
+                self._append_event_locked(
+                    connection,
+                    task_id=task_id,
+                    event_type="task_state",
+                    payload={
+                        "from": TaskState.WAITING_INPUT.value,
+                        "to": TaskState.QUEUED.value,
+                        "reason": None,
+                    },
+                    created_at=now,
+                )
             resolved = connection.execute(
                 "SELECT * FROM worker_questions WHERE task_id = ? AND question_id = ?",
                 (task_id, question_id),
@@ -1792,8 +1795,6 @@ class CodingWorkerStore:
             if (
                 checkpoint is None
                 or str(checkpoint["task_id"]) != task_id
-                or str(checkpoint["workspace_tree_hash"])
-                != current.workspace_tree_hash
             ):
                 raise WorkerConflictError(
                     "Turn checkpoint binding is invalid.",
@@ -1802,11 +1803,12 @@ class CodingWorkerStore:
             connection.execute(
                 """
                 UPDATE worker_turn_transactions
-                SET state = ?, checkpoint_id = ?, updated_at = ?
+                SET state = ?, workspace_tree_hash = ?, checkpoint_id = ?, updated_at = ?
                 WHERE task_id = ? AND turn_id = ?
                 """,
                 (
                     TurnTransactionState.PARKED.value,
+                    str(checkpoint["workspace_tree_hash"]),
                     checkpoint_id,
                     now,
                     task_id,
@@ -2749,11 +2751,52 @@ class CodingWorkerStore:
         with self._lock, self._connect() as connection:
             connection.execute("BEGIN IMMEDIATE")
             rows = connection.execute(
-                f"SELECT task_id, state FROM worker_tasks WHERE state IN ({','.join('?' for _ in ACTIVE_ON_RESTART)})",
+                "SELECT task_id, state, runtime_protocol FROM worker_tasks "
+                f"WHERE state IN ({','.join('?' for _ in ACTIVE_ON_RESTART)})",
                 tuple(state.value for state in ACTIVE_ON_RESTART),
             ).fetchall()
             for row in rows:
                 task_id = str(row["task_id"])
+                turn_row = connection.execute(
+                    """
+                    SELECT * FROM worker_turn_transactions
+                    WHERE task_id = ? AND state IN ('open', 'parking', 'parked', 'resuming')
+                    ORDER BY generation DESC LIMIT 1
+                    """,
+                    (task_id,),
+                ).fetchone()
+                if (
+                    str(row["runtime_protocol"]) == RuntimeProtocol.V17.value
+                    and str(row["state"]) == TaskState.WAITING_APPROVAL.value
+                    and turn_row is not None
+                    and str(turn_row["state"]) == TurnTransactionState.PARKED.value
+                    and str(turn_row["barrier"]) == TurnBarrier.APPROVAL.value
+                ):
+                    continue
+                if turn_row is not None and str(turn_row["state"]) in {
+                    TurnTransactionState.OPEN.value,
+                    TurnTransactionState.PARKING.value,
+                }:
+                    connection.execute(
+                        """
+                        UPDATE worker_turn_transactions
+                        SET state = ?, barrier = NULL, checkpoint_id = NULL, updated_at = ?
+                        WHERE task_id = ? AND turn_id = ?
+                        """,
+                        (
+                            TurnTransactionState.INTERRUPTED.value,
+                            now,
+                            task_id,
+                            str(turn_row["turn_id"]),
+                        ),
+                    )
+                    self._append_event_locked(
+                        connection,
+                        task_id=task_id,
+                        event_type="turn_interrupted",
+                        payload={"turn_id": str(turn_row["turn_id"])},
+                        created_at=now,
+                    )
                 connection.execute(
                     "UPDATE worker_tasks SET state = ?, reason_ciphertext = ?, updated_at = ? WHERE task_id = ?",
                     (
@@ -2791,7 +2834,11 @@ class CodingWorkerStore:
                   ON finished.task_id = started.task_id
                  AND finished.turn_id = started.turn_id
                  AND finished.kind = ?
+                LEFT JOIN worker_turn_transactions AS transaction_state
+                  ON transaction_state.task_id = started.task_id
+                 AND transaction_state.turn_id = started.turn_id
                 WHERE started.kind = ? AND finished.ledger_id IS NULL
+                  AND COALESCE(transaction_state.state, '') NOT IN ('parked', 'resuming')
                 ORDER BY started.task_id, started.sequence
                 """,
                 (

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -28,6 +28,8 @@ from .contracts import (
     DiagnosticSeverity,
     OperationState,
     PolicyProfile,
+    RuntimeProtocol,
+    SessionLedgerKind,
     ShellApprovalScope,
     ShellMode,
     StrictModel,
@@ -36,7 +38,12 @@ from .contracts import (
     SubtaskRecord,
     SubtaskRequest,
     TaskState,
+    TurnBarrier,
+    TurnTransactionState,
     WorkerDiagnostic,
+    WorkerPlanItem,
+    WorkerQuestionOption,
+    WorkerTodoItem,
 )
 from .changeset import ChangesetEngine, ChangesetError
 from .process_manager import BackgroundProcessManager, ProcessManagerError
@@ -173,6 +180,11 @@ class ToolBroker:
             "workspace_id": task.workspace_id,
         }
         intent_sha256 = self._intent_sha256(tool_name, request)
+        current_turn = (
+            self.store.current_turn_transaction(task_id)
+            if task.runtime_protocol is RuntimeProtocol.V17
+            else None
+        )
         if task.state is TaskState.WAITING_APPROVAL:
             existing_operation_ids = {
                 operation.operation_id
@@ -190,6 +202,7 @@ class ToolBroker:
                 tool_name=tool_name,
                 intent_sha256=intent_sha256,
                 request=request,
+                turn_id=current_turn.turn_id if current_turn is not None else None,
             )
         except WorkerConflictError as exc:
             message = "Tool operation was rejected."
@@ -358,6 +371,12 @@ class ToolBroker:
                     result={"code": "operation_result_unknown"},
                     expected_state=current.state,
                 )
+                if task.runtime_protocol is RuntimeProtocol.V17 and current_turn is not None:
+                    self.store.begin_turn_parking(
+                        task_id=task_id,
+                        turn_id=current_turn.turn_id,
+                        barrier=TurnBarrier.OPERATION_UNKNOWN,
+                    )
             elif not awaiting_approval and current.state in {
                 OperationState.PREPARED,
                 OperationState.RUNNING,
@@ -635,6 +654,10 @@ class ToolBroker:
             "code_references",
             "code_hover",
             "code_diagnostics",
+            "update_plan",
+            "update_todo",
+            "request_user_input",
+            "compact_context",
         }
         if tool_name in readonly:
             return None
@@ -723,7 +746,19 @@ class ToolBroker:
             )
         if lease_id is None or (network_scope is not None and network_lease_id is None):
             task = self.store.get_task(task_id)
-            if task.state is TaskState.RUNNING:
+            if task.runtime_protocol is RuntimeProtocol.V17:
+                current_turn = self.store.current_turn_transaction(task_id)
+                if current_turn is None:
+                    raise ToolBrokerError(
+                        "V17 approval has no current turn.",
+                        code="operation_turn_required",
+                    )
+                self.store.begin_turn_parking(
+                    task_id=task_id,
+                    turn_id=current_turn.turn_id,
+                    barrier=TurnBarrier.APPROVAL,
+                )
+            elif task.state is TaskState.RUNNING:
                 self.store.transition(task_id, TaskState.WAITING_APPROVAL)
             raise ToolBrokerError("Tool requires approval.", code="approval_required")
         lease = self.store.consume_lease(lease_id, task_id=task_id, capability=capability)
@@ -751,6 +786,18 @@ class ToolBroker:
         *,
         network_lease: CapabilityLease | None,
     ) -> dict[str, Any]:
+        if tool_name in {
+            "update_plan",
+            "update_todo",
+            "request_user_input",
+            "compact_context",
+        }:
+            return self._dispatch_platform_interaction(
+                task_id=task_id,
+                operation_id=operation_id,
+                tool_name=tool_name,
+                arguments=arguments,
+            )
         if tool_name == "create_subtask":
             if self.subtask_handler is None:
                 raise ToolBrokerError(
@@ -1084,6 +1131,127 @@ class ToolBroker:
                 "source_artifact_id": artifact.artifact_id,
             }
         raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
+
+    def _dispatch_platform_interaction(
+        self,
+        *,
+        task_id: str,
+        operation_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        task = self.store.get_task(task_id)
+        if task.runtime_protocol is not RuntimeProtocol.V17:
+            raise ToolBrokerError(
+                "Platform interaction tools require V17.",
+                code="tool_not_allowed",
+            )
+        turn = self.store.current_turn_transaction(task_id)
+        if turn is None or turn.state not in {
+            TurnTransactionState.OPEN,
+            TurnTransactionState.RESUMING,
+        }:
+            raise ToolBrokerError("Turn is parked.", code="turn_parked")
+        if tool_name == "update_plan":
+            try:
+                items = tuple(
+                    WorkerPlanItem.model_validate(item)
+                    for item in arguments.get("items", ())
+                )
+                explanation = arguments.get("explanation")
+                if not items or len(items) > 128 or (
+                    explanation is not None
+                    and (not isinstance(explanation, str) or len(explanation) > 16_384)
+                ):
+                    raise ValueError
+            except (TypeError, ValueError, ValidationError) as exc:
+                raise ToolBrokerError(
+                    "Plan input is invalid.", code="tool_input_invalid"
+                ) from exc
+            payload = {
+                "explanation": explanation,
+                "items": [item.model_dump(mode="json") for item in items],
+            }
+            entry = self.store.append_session_ledger(
+                task_id,
+                kind=SessionLedgerKind.PLAN,
+                turn_id=turn.turn_id,
+                payload=payload,
+            )
+            self.store.append_event(
+                task_id,
+                "plan_updated",
+                {"turn_id": turn.turn_id, "sequence": entry.sequence},
+            )
+            return {"plan": payload, "sequence": entry.sequence}
+        if tool_name == "update_todo":
+            try:
+                items = tuple(
+                    WorkerTodoItem.model_validate(item)
+                    for item in arguments.get("items", ())
+                )
+                if len(items) > 256 or len({item.todo_id for item in items}) != len(items):
+                    raise ValueError
+            except (TypeError, ValueError, ValidationError) as exc:
+                raise ToolBrokerError(
+                    "Todo input is invalid.", code="tool_input_invalid"
+                ) from exc
+            payload = {"items": [item.model_dump(mode="json") for item in items]}
+            entry = self.store.append_session_ledger(
+                task_id,
+                kind=SessionLedgerKind.TODO,
+                turn_id=turn.turn_id,
+                payload=payload,
+            )
+            self.store.append_event(
+                task_id,
+                "todo_updated",
+                {"turn_id": turn.turn_id, "sequence": entry.sequence},
+            )
+            return {"todo": payload, "sequence": entry.sequence}
+        if tool_name == "request_user_input":
+            try:
+                question_id = str(arguments["question_id"])
+                prompt = str(arguments["prompt"])
+                options = tuple(
+                    WorkerQuestionOption.model_validate(item)
+                    for item in arguments.get("options", ())
+                )
+            except (KeyError, TypeError, ValueError, ValidationError) as exc:
+                raise ToolBrokerError(
+                    "Question input is invalid.", code="tool_input_invalid"
+                ) from exc
+            question = self.store.create_question(
+                task_id=task_id,
+                question_id=question_id,
+                turn_id=turn.turn_id,
+                prompt=prompt,
+                options=options,
+            )
+            self.store.begin_turn_parking(
+                task_id=task_id,
+                turn_id=turn.turn_id,
+                barrier=TurnBarrier.INPUT,
+            )
+            return {
+                "control": "turn_parking",
+                "barrier": TurnBarrier.INPUT.value,
+                "question_id": question.question_id,
+            }
+        note = arguments.get("note")
+        if note is not None and (not isinstance(note, str) or len(note) > 16_384):
+            raise ToolBrokerError(
+                "Compaction note is invalid.", code="tool_input_invalid"
+            )
+        self.store.begin_turn_parking(
+            task_id=task_id,
+            turn_id=turn.turn_id,
+            barrier=TurnBarrier.COMPACTION,
+        )
+        return {
+            "control": "turn_parking",
+            "barrier": TurnBarrier.COMPACTION.value,
+        }
 
     def _dependency_plan(
         self, workspace_id: str, arguments: Mapping[str, Any]

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -227,7 +227,24 @@ class ToolBroker:
                 data=operation.result or {},
             )
         if operation.state is OperationState.UNKNOWN:
-            return self.reconcile(operation_id)
+            try:
+                return self.reconcile(operation_id)
+            except ToolBrokerError as exc:
+                if (
+                    exc.code == "operation_result_unknown"
+                    and task.runtime_protocol is RuntimeProtocol.V17
+                    and current_turn is not None
+                    and current_turn.state in {
+                        TurnTransactionState.OPEN,
+                        TurnTransactionState.RESUMING,
+                    }
+                ):
+                    self.store.begin_turn_parking(
+                        task_id=task_id,
+                        turn_id=current_turn.turn_id,
+                        barrier=TurnBarrier.OPERATION_UNKNOWN,
+                    )
+                raise
         if operation.state is not OperationState.PREPARED:
             raise ToolBrokerError(
                 "Tool operation cannot be replayed.", code="operation_not_replayable"

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -744,23 +744,14 @@ class ToolBroker:
             network_scope = policy.approval_scope(
                 domains=plan["domains"], purpose="documentation-query"
             )
+        pending_requests: list[tuple[str, CapabilityName, dict[str, Any]]] = []
         if lease_id is None:
-            self.store.create_approval(
-                task_id=task_id,
-                operation_id=operation_id,
-                capability=capability,
-                request=approval_scope,
-            )
+            pending_requests.append((operation_id, capability, approval_scope))
         if network_scope is not None and network_lease_id is None:
             network_operation_id = "network_" + hashlib.sha256(
                 operation_id.encode("utf-8")
             ).hexdigest()[:32]
-            self.store.create_approval(
-                task_id=task_id,
-                operation_id=network_operation_id,
-                capability="network",
-                request=network_scope,
-            )
+            pending_requests.append((network_operation_id, "network", network_scope))
         if lease_id is None or (network_scope is not None and network_lease_id is None):
             task = self.store.get_task(task_id)
             if task.runtime_protocol is RuntimeProtocol.V17:
@@ -770,13 +761,21 @@ class ToolBroker:
                         "V17 approval has no current turn.",
                         code="operation_turn_required",
                     )
-                self.store.begin_turn_parking(
+                self.store.create_approvals_and_begin_turn_parking(
                     task_id=task_id,
                     turn_id=current_turn.turn_id,
-                    barrier=TurnBarrier.APPROVAL,
+                    requests=tuple(pending_requests),
                 )
-            elif task.state is TaskState.RUNNING:
-                self.store.transition(task_id, TaskState.WAITING_APPROVAL)
+            else:
+                for pending_operation_id, pending_capability, pending_request in pending_requests:
+                    self.store.create_approval(
+                        task_id=task_id,
+                        operation_id=pending_operation_id,
+                        capability=pending_capability,
+                        request=pending_request,
+                    )
+                if task.state is TaskState.RUNNING:
+                    self.store.transition(task_id, TaskState.WAITING_APPROVAL)
             raise ToolBrokerError("Tool requires approval.", code="approval_required")
         lease = self.store.consume_lease(lease_id, task_id=task_id, capability=capability)
         if lease.scope != approval_scope:
@@ -1238,17 +1237,12 @@ class ToolBroker:
                 raise ToolBrokerError(
                     "Question input is invalid.", code="tool_input_invalid"
                 ) from exc
-            question = self.store.create_question(
+            question = self.store.create_question_and_begin_turn_parking(
                 task_id=task_id,
                 question_id=question_id,
                 turn_id=turn.turn_id,
                 prompt=prompt,
                 options=options,
-            )
-            self.store.begin_turn_parking(
-                task_id=task_id,
-                turn_id=turn.turn_id,
-                barrier=TurnBarrier.INPUT,
             )
             return {
                 "control": "turn_parking",

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -151,6 +151,26 @@ class _UnavailableProvider(FakeCodingAgentProvider):
         return await super().capabilities()
 
 
+class _NativeInteractionOnlyProvider(FakeCodingAgentProvider):
+    async def capabilities(self) -> ProviderCapabilities:
+        capabilities = await super().capabilities()
+        return capabilities.model_copy(
+            update={
+                "tool_names": tuple(
+                    name
+                    for name in capabilities.tool_names
+                    if name
+                    not in {
+                        "update_plan",
+                        "update_todo",
+                        "request_user_input",
+                        "compact_context",
+                    }
+                )
+            }
+        )
+
+
 def teardown_function() -> None:
     configure_coding_worker_for_tests(None, enabled=None)
 
@@ -181,6 +201,23 @@ def test_feature_flag_is_default_deny(monkeypatch: pytest.MonkeyPatch) -> None:
         "subtasks": False,
     }
     assert client.post("/api/coding-worker/v1/tasks", json=_payload()).status_code == 404
+
+
+def test_native_provider_hints_do_not_enable_platform_interaction_capabilities(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CODING_WORKER_V16_ENABLED", "true")
+    monkeypatch.setenv("CODING_WORKER_INTERACTION_ENABLED", "true")
+    client, _service = _client(
+        tmp_path, provider=_NativeInteractionOnlyProvider()
+    )
+
+    with client:
+        capabilities = client.get("/api/coding-worker/v1/capabilities").json()
+
+    assert capabilities["structured_plan"] is False
+    assert capabilities["user_questions"] is False
+    assert capabilities["context_compaction"] is False
 
 
 def test_v15_capabilities_are_vendor_neutral_and_independently_gated(

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -108,6 +108,18 @@ class _QuestionProvider(FakeCodingAgentProvider):
                 },
             )
             yield ProviderEvent(
+                kind=ProviderEventKind.TODO,
+                data={
+                    "items": [
+                        {
+                            "todo_id": "confirm-scope",
+                            "content": "Confirm the repair scope",
+                            "status": "in_progress",
+                        }
+                    ]
+                },
+            )
+            yield ProviderEvent(
                 kind=ProviderEventKind.QUESTION,
                 data={
                     "question_id": "question_scope",
@@ -311,6 +323,15 @@ def test_v16_plan_and_question_resume_once_from_encrypted_waiting_state(
         assert [item["step"] for item in plan.json()["items"]] == [
             "inspect",
             "repair",
+        ]
+        todo = client.get(f"/api/coding-worker/v1/tasks/{task_id}/todo")
+        assert todo.status_code == 200
+        assert todo.json()["items"] == [
+            {
+                "todo_id": "confirm-scope",
+                "content": "Confirm the repair scope",
+                "status": "in_progress",
+            }
         ]
         questions = client.get(
             f"/api/coding-worker/v1/tasks/{task_id}/questions"

--- a/server/tests/test_coding_worker_broker_rpc.py
+++ b/server/tests/test_coding_worker_broker_rpc.py
@@ -152,6 +152,10 @@ async def test_mcp_exposes_only_modelmirror_broker_tools() -> None:
             "stop_service",
             "create_subtask",
             "merge_subtask",
+            "update_plan",
+            "update_todo",
+            "request_user_input",
+            "compact_context",
         }
     write = next(tool for tool in tools if tool.name == "write_file")
     assert set(write.inputSchema["required"]) == {"operation_id", "path", "content"}

--- a/server/tests/test_coding_worker_provider_conformance.py
+++ b/server/tests/test_coding_worker_provider_conformance.py
@@ -166,7 +166,7 @@ ProviderFactory = Callable[
 @pytest.mark.parametrize(
     "factory", [_fake_provider, _opencode_provider, _claude_provider]
 )
-async def test_provider_v3_conformance(
+async def test_provider_v4_conformance(
     factory: ProviderFactory, tmp_path: Path
 ) -> None:
     provider, request = factory(tmp_path)
@@ -176,6 +176,7 @@ async def test_provider_v3_conformance(
     assert capabilities.supports_checkpoint is True
     assert capabilities.supports_restore is True
     assert capabilities.supports_tool_boundaries is True
+    assert capabilities.supports_turn_interrupt is True
     assert capabilities.tool_names
     if isinstance(provider, FakeCodingAgentProvider):
         assert capabilities.supports_structured_plan is True
@@ -219,7 +220,7 @@ async def test_provider_v3_conformance(
         await provider.restore(changed, checkpoint)
 
 
-def test_provider_v3_rejects_raw_or_malformed_event_data() -> None:
+def test_provider_v4_rejects_raw_or_malformed_event_data() -> None:
     with pytest.raises(ValueError, match="Extra inputs|canonical"):
         ProviderEvent(
             kind=ProviderEventKind.FAILED,
@@ -247,11 +248,12 @@ def test_provider_capabilities_fail_closed_until_explicitly_declared() -> None:
         "supports_questions": False,
         "supports_compaction": False,
         "supports_tool_boundaries": False,
+        "supports_turn_interrupt": False,
         "tool_names": [],
     }
 
 
-def test_provider_v3_structured_event_vocabulary_is_canonical() -> None:
+def test_provider_v4_structured_event_vocabulary_is_canonical() -> None:
     events = (
         ProviderEvent(
             kind=ProviderEventKind.PLAN,

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -345,6 +345,34 @@ class _V17TurnParkingProvider(FakeCodingAgentProvider):
         return await super().interrupt_turn(session)
 
 
+class _V17CompactionParkingProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.store: CodingWorkerStore | None = None
+        self.messages: list[str] = []
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        assert self.store is not None
+        self.messages.append(text)
+        if len(self.messages) == 1:
+            turn = self.store.current_turn_transaction(session.task_id)
+            assert turn is not None
+            self.store.begin_turn_parking(
+                task_id=session.task_id,
+                turn_id=turn.turn_id,
+                barrier=TurnBarrier.COMPACTION,
+            )
+            for index in range(10):
+                yield ProviderEvent(
+                    kind=ProviderEventKind.MESSAGE,
+                    data={"text": f"late compaction event {index}"},
+                )
+            return
+        yield ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)
+
+
 class _CompactionRestoreProvider(_RestoreTrackingProvider):
     def __init__(self) -> None:
         super().__init__()
@@ -477,6 +505,80 @@ async def test_v17_turn_parks_once_and_resumes_exact_checkpoint(
     )
     assert transaction.state is TurnTransactionState.COMPLETED
     await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_v17_compaction_parks_and_requeues_without_a_user_action(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in (
+        "CODING_WORKER_V16_ENABLED",
+        "CODING_WORKER_INTERACTION_ENABLED",
+        "CODING_WORKER_SESSION_CONTROLS_ENABLED",
+        "CODING_WORKER_SUBAGENTS_ENABLED",
+        "CODING_WORKER_V17_ENABLED",
+    ):
+        monkeypatch.setenv(name, "true")
+    provider = _V17CompactionParkingProvider()
+    service = _service(tmp_path, provider)
+    provider.store = service.store
+    task = await service.create_task(
+        Origin(module="test", object_id="v17-compaction"),
+        _request("v17-compaction"),
+    )
+
+    terminal = await service.wait_for(
+        task.task_id,
+        lambda item: item.state in {TaskState.BLOCKED, TaskState.COMPLETED},
+    )
+
+    assert terminal.state is TaskState.BLOCKED
+    assert len(provider.messages) == 2
+    assert "controlled compaction boundary" in provider.messages[1]
+    transactions = service.store.list_turn_transactions(task.task_id)
+    assert len(transactions) == 1
+    assert transactions[0].state is TurnTransactionState.COMPLETED
+    ledger = service.store.list_session_ledger(task.task_id)
+    assert [item.kind for item in ledger].count(SessionLedgerKind.COMPACTION) == 1
+    assert [item for item in service.store.list_messages(task.task_id) if item.role == "assistant"] == []
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_v17_acceptance_rejects_an_unsettled_turn(tmp_path: Path) -> None:
+    service = _service(tmp_path, FakeCodingAgentProvider())
+    request = _request("v17-unsettled-acceptance")
+    task = service.store.create_task(
+        TaskSpec(
+            **request.model_dump(),
+            origin=Origin(module="test", object_id="v17-unsettled-acceptance"),
+        ),
+        runtime_protocol=RuntimeProtocol.V17,
+    )
+    service.store.transition(task.task_id, TaskState.PREPARING)
+    running = service.store.transition(task.task_id, TaskState.RUNNING)
+    turn = service.store.open_turn_transaction(
+        task_id=task.task_id,
+        turn_id="turn_unsettled_acceptance",
+        workspace_tree_hash="a" * 64,
+    )
+    service.store.create_operation(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        operation_id="operation_unsettled_acceptance",
+        tool_name="run_shell",
+        intent_sha256="b" * 64,
+        request={"workspace_id": "workspace_1", "arguments": {}},
+    )
+
+    feedback, cursor = await service._evaluate_acceptance(
+        running, 1, message_cursor=0
+    )
+
+    assert feedback is None and cursor == 0
+    blocked = service.store.get_task(task.task_id)
+    assert blocked.state is TaskState.BLOCKED
+    assert blocked.reason == "turn_settlement_incomplete"
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -127,6 +127,13 @@ class _OpenTrackingProvider(FakeCodingAgentProvider):
         return await super().open(request)
 
 
+class _NoTurnInterruptProvider(FakeCodingAgentProvider):
+    async def capabilities(self) -> ProviderCapabilities:
+        return (await super().capabilities()).model_copy(
+            update={"supports_turn_interrupt": False}
+        )
+
+
 class _LostTurnReceiptProvider(FakeCodingAgentProvider):
     def __init__(self) -> None:
         super().__init__()
@@ -504,6 +511,31 @@ async def test_v17_turn_parks_once_and_resumes_exact_checkpoint(
         task.task_id, transaction.turn_id
     )
     assert transaction.state is TurnTransactionState.COMPLETED
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_v17_task_creation_rejects_a_route_without_turn_interrupt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in (
+        "CODING_WORKER_V16_ENABLED",
+        "CODING_WORKER_INTERACTION_ENABLED",
+        "CODING_WORKER_SESSION_CONTROLS_ENABLED",
+        "CODING_WORKER_SUBAGENTS_ENABLED",
+        "CODING_WORKER_V17_ENABLED",
+    ):
+        monkeypatch.setenv(name, "true")
+    service = _service(tmp_path, _NoTurnInterruptProvider())
+
+    with pytest.raises(WorkerConflictError) as rejected:
+        await service.create_task(
+            Origin(module="test", object_id="v17-route-unavailable"),
+            _request("v17-route-unavailable"),
+        )
+
+    assert rejected.value.code == "v17_route_unavailable"
+    assert service.store.list_tasks() == []
     await service.shutdown()
 
 

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -358,6 +358,21 @@ class _V17TurnParkingProvider(FakeCodingAgentProvider):
         return await super().interrupt_turn(session)
 
 
+class _SlowCloseV17TurnParkingProvider(_V17TurnParkingProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.close_started = asyncio.Event()
+        self.release_close = asyncio.Event()
+        self.close_count = 0
+
+    async def close(self, session: ProviderSession) -> None:
+        self.close_count += 1
+        if self.close_count == 1:
+            self.close_started.set()
+            await self.release_close.wait()
+        await super().close(session)
+
+
 class _V17CompactionParkingProvider(FakeCodingAgentProvider):
     def __init__(self) -> None:
         super().__init__()
@@ -548,6 +563,48 @@ async def test_v17_turn_parks_once_and_resumes_exact_checkpoint(
         task.task_id, transaction.turn_id
     )
     assert transaction.state is TurnTransactionState.COMPLETED
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_v17_resume_waits_for_the_parked_runner_to_release(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in (
+        "CODING_WORKER_V16_ENABLED",
+        "CODING_WORKER_INTERACTION_ENABLED",
+        "CODING_WORKER_SESSION_CONTROLS_ENABLED",
+        "CODING_WORKER_SUBAGENTS_ENABLED",
+        "CODING_WORKER_V17_ENABLED",
+    ):
+        monkeypatch.setenv(name, "true")
+    provider = _SlowCloseV17TurnParkingProvider()
+    service = _service(tmp_path, provider)
+    provider.store = service.store
+    task = await service.create_task(
+        Origin(module="test", object_id="v17-runner-release"),
+        _request("v17-runner-release"),
+    )
+
+    await service.wait_for(
+        task.task_id,
+        lambda item: item.state is TaskState.WAITING_APPROVAL,
+    )
+    await asyncio.wait_for(provider.close_started.wait(), timeout=2)
+    approval = service.store.list_approvals(task.task_id)[0]
+    service.store.decide_approval(approval.approval_id, approved=True)
+    assert service.settle_approval_state(task.task_id).state is TaskState.QUEUED
+    await asyncio.sleep(0.1)
+    assert service.store.get_task(task.task_id).state is TaskState.QUEUED
+    assert len(provider.messages) == 1
+
+    provider.release_close.set()
+    resumed = await service.wait_for(
+        task.task_id,
+        lambda item: item.state is TaskState.BLOCKED,
+    )
+    assert resumed.reason == "acceptance_runner_pending"
+    assert len(provider.messages) == 2
     await service.shutdown()
 
 

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -67,6 +67,7 @@ def _service(
     provider: FakeCodingAgentProvider,
     *,
     files: dict[str, bytes] | None = None,
+    route_context_tokens: dict[str, int] | None = None,
 ) -> CodingWorkerService:
     store = CodingWorkerStore(tmp_path / "worker", master_key=Fernet.generate_key())
     adapter = InMemoryWorkspaceSourceAdapter(
@@ -78,7 +79,12 @@ def _service(
     broker = WorkspaceBroker(
         tmp_path / "worker", {"manifest": adapter}, id_key=b"s" * 32
     )
-    return CodingWorkerService(store=store, workspace_broker=broker, provider=provider)
+    return CodingWorkerService(
+        store=store,
+        workspace_broker=broker,
+        provider=provider,
+        route_context_tokens=route_context_tokens,
+    )
 
 
 class _RepairingProvider(FakeCodingAgentProvider):
@@ -380,6 +386,37 @@ class _V17CompactionParkingProvider(FakeCodingAgentProvider):
         yield ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)
 
 
+class _V17UsageCompactionProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: list[str] = []
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        self.messages.append(text)
+        if len(self.messages) == 1:
+            yield ProviderEvent(
+                kind=ProviderEventKind.USAGE,
+                data={
+                    "usage": {
+                        "input_tokens": 7_500,
+                        "output_tokens": 100,
+                        "cache_read_tokens": 0,
+                        "cache_write_tokens": 0,
+                        "cost_microusd": None,
+                    }
+                },
+            )
+            for index in range(10):
+                yield ProviderEvent(
+                    kind=ProviderEventKind.MESSAGE,
+                    data={"text": f"late usage event {index}"},
+                )
+            return
+        yield ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)
+
+
 class _CompactionRestoreProvider(_RestoreTrackingProvider):
     def __init__(self) -> None:
         super().__init__()
@@ -573,6 +610,47 @@ async def test_v17_compaction_parks_and_requeues_without_a_user_action(
     ledger = service.store.list_session_ledger(task.task_id)
     assert [item.kind for item in ledger].count(SessionLedgerKind.COMPACTION) == 1
     assert [item for item in service.store.list_messages(task.task_id) if item.role == "assistant"] == []
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_v17_usage_at_seventy_five_percent_uses_controlled_compaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in (
+        "CODING_WORKER_V16_ENABLED",
+        "CODING_WORKER_INTERACTION_ENABLED",
+        "CODING_WORKER_SESSION_CONTROLS_ENABLED",
+        "CODING_WORKER_SUBAGENTS_ENABLED",
+        "CODING_WORKER_V17_ENABLED",
+    ):
+        monkeypatch.setenv(name, "true")
+    provider = _V17UsageCompactionProvider()
+    service = _service(
+        tmp_path,
+        provider,
+        route_context_tokens={"coding/default": 10_000},
+    )
+    task = await service.create_task(
+        Origin(module="test", object_id="v17-usage-compaction"),
+        _request("v17-usage-compaction"),
+    )
+
+    terminal = await service.wait_for(
+        task.task_id,
+        lambda item: item.state in {TaskState.BLOCKED, TaskState.COMPLETED},
+    )
+
+    assert terminal.state is TaskState.BLOCKED
+    assert len(provider.messages) == 2
+    assert "controlled compaction boundary" in provider.messages[1]
+    assert not any(
+        item.content.startswith("late usage event")
+        for item in service.store.list_messages(task.task_id)
+    )
+    assert [
+        item.kind for item in service.store.list_session_ledger(task.task_id)
+    ].count(SessionLedgerKind.COMPACTION) == 1
     await service.shutdown()
 
 

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -16,11 +16,14 @@ from server.coding_worker.contracts import (
     AcceptanceContract,
     Origin,
     PolicyProfile,
+    RuntimeProtocol,
     SessionLedgerKind,
     TaskBudget,
     TaskCreateRequest,
     TaskSpec,
     TaskState,
+    TurnBarrier,
+    TurnTransactionState,
     WorkspaceSource,
 )
 from server.coding_worker.evidence import HarnessRunner
@@ -303,6 +306,45 @@ class _ApprovalParkingProvider(FakeCodingAgentProvider):
         yield ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)
 
 
+class _V17TurnParkingProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.store: CodingWorkerStore | None = None
+        self.messages: list[str] = []
+        self.interruptions = 0
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        assert self.store is not None
+        self.messages.append(text)
+        if len(self.messages) == 1:
+            turn = self.store.current_turn_transaction(session.task_id)
+            assert turn is not None
+            self.store.create_approval(
+                task_id=session.task_id,
+                operation_id="operation-v17-approval",
+                capability="command",
+                request={"argv": ["pytest"]},
+            )
+            self.store.begin_turn_parking(
+                task_id=session.task_id,
+                turn_id=turn.turn_id,
+                barrier=TurnBarrier.APPROVAL,
+            )
+            for index in range(10):
+                yield ProviderEvent(
+                    kind=ProviderEventKind.MESSAGE,
+                    data={"text": f"late event {index}"},
+                )
+            return
+        yield ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)
+
+    async def interrupt_turn(self, session: ProviderSession) -> bool:
+        self.interruptions += 1
+        return await super().interrupt_turn(session)
+
+
 class _CompactionRestoreProvider(_RestoreTrackingProvider):
     def __init__(self) -> None:
         super().__init__()
@@ -380,6 +422,60 @@ async def test_provider_stream_parks_while_exact_approval_is_pending(
     )
     await asyncio.wait_for(provider.resume_requested.wait(), timeout=1)
     assert "exact pending tool operation" in provider.messages[1]
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_v17_turn_parks_once_and_resumes_exact_checkpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in (
+        "CODING_WORKER_V16_ENABLED",
+        "CODING_WORKER_INTERACTION_ENABLED",
+        "CODING_WORKER_SESSION_CONTROLS_ENABLED",
+        "CODING_WORKER_SUBAGENTS_ENABLED",
+        "CODING_WORKER_V17_ENABLED",
+    ):
+        monkeypatch.setenv(name, "true")
+    provider = _V17TurnParkingProvider()
+    service = _service(tmp_path, provider)
+    provider.store = service.store
+    task = await service.create_task(
+        Origin(module="test", object_id="v17-turn-parking"),
+        _request("v17-turn-parking"),
+    )
+
+    parked_task = await service.wait_for(
+        task.task_id,
+        lambda item: item.state is TaskState.WAITING_APPROVAL,
+    )
+    assert parked_task.runtime_protocol is RuntimeProtocol.V17
+    transaction = service.store.current_turn_transaction(task.task_id)
+    assert transaction is not None
+    assert transaction.state is TurnTransactionState.PARKED
+    assert transaction.barrier is TurnBarrier.APPROVAL
+    assert transaction.checkpoint_id is not None
+    assert provider.interruptions == 1
+    assistants = [
+        item
+        for item in service.store.list_messages(task.task_id)
+        if item.role == "assistant"
+    ]
+    assert assistants == []
+
+    approval = service.store.list_approvals(task.task_id)[0]
+    service.store.decide_approval(approval.approval_id, approved=True)
+    assert service.settle_approval_state(task.task_id).state is TaskState.QUEUED
+    resumed = await service.wait_for(
+        task.task_id,
+        lambda item: item.state in {TaskState.BLOCKED, TaskState.COMPLETED},
+    )
+    assert resumed.state is TaskState.BLOCKED
+    assert len(provider.messages) == 2
+    transaction = service.store.get_turn_transaction(
+        task.task_id, transaction.turn_id
+    )
+    assert transaction.state is TurnTransactionState.COMPLETED
     await service.shutdown()
 
 

--- a/server/tests/test_coding_worker_store.py
+++ b/server/tests/test_coding_worker_store.py
@@ -10,9 +10,12 @@ from server.coding_worker.contracts import (
     AcceptanceCheck,
     AcceptanceContract,
     Origin,
+    RuntimeProtocol,
     SessionLedgerKind,
     TaskSpec,
     TaskState,
+    TurnBarrier,
+    TurnTransactionState,
     WorkspaceSource,
     WorkerSessionLedgerEntry,
 )
@@ -70,6 +73,105 @@ def test_idempotency_key_rejects_changed_intent(tmp_path: Path) -> None:
     with pytest.raises(WorkerConflictError) as raised:
         store.create_task(_spec(objective="Different"))
     assert raised.value.code == "task_intent_conflict"
+
+
+def test_v17_turn_transaction_parks_and_rejects_new_operations(tmp_path: Path) -> None:
+    store = CodingWorkerStore(tmp_path / "worker", master_key=Fernet.generate_key())
+    task = store.create_task(_spec(), runtime_protocol=RuntimeProtocol.V17)
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING)
+    tree_hash = "a" * 64
+    turn = store.open_turn_transaction(
+        task_id=task.task_id,
+        turn_id="turn_v17_1",
+        workspace_tree_hash=tree_hash,
+    )
+    assert turn.generation == 1
+    operation = store.create_operation(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        operation_id="operation_v17_1",
+        tool_name="run_command",
+        intent_sha256="b" * 64,
+        request={"arguments": {"argv": ["pytest"]}, "workspace_id": "workspace_1"},
+    )
+    assert operation.turn_id == turn.turn_id
+
+    parking = store.begin_turn_parking(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        barrier=TurnBarrier.APPROVAL,
+    )
+    assert parking.state is TurnTransactionState.PARKING
+    with pytest.raises(WorkerConflictError) as rejected:
+        store.create_operation(
+            task_id=task.task_id,
+            turn_id=turn.turn_id,
+            operation_id="operation_v17_2",
+            tool_name="run_command",
+            intent_sha256="c" * 64,
+            request={"arguments": {"argv": ["pytest", "-q"]}, "workspace_id": "workspace_1"},
+        )
+    assert rejected.value.code == "turn_parked"
+    assert (
+        store.create_operation(
+            task_id=task.task_id,
+            turn_id=turn.turn_id,
+            operation_id=operation.operation_id,
+            tool_name=operation.tool_name,
+            intent_sha256=operation.intent_sha256,
+            request=operation.request,
+        )
+        == operation
+    )
+
+    checkpoint = store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash=tree_hash,
+        payload={"phase": "approval"},
+    )
+    parked = store.park_turn_transaction(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        checkpoint_id=checkpoint.checkpoint_id,
+    )
+    assert parked.state is TurnTransactionState.PARKED
+    resumed = store.resume_turn_transaction(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        checkpoint_id=checkpoint.checkpoint_id,
+    )
+    assert resumed.state is TurnTransactionState.RESUMING
+    completed = store.finish_turn_transaction(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        state=TurnTransactionState.COMPLETED,
+    )
+    assert completed.state is TurnTransactionState.COMPLETED
+    assert [event.type for event in store.list_events(task.task_id)] == [
+        "task_created",
+        "task_state",
+        "task_state",
+        "turn_started",
+        "turn_parking",
+        "checkpoint_created",
+        "turn_parked",
+        "turn_resumed",
+        "turn_completed",
+    ]
+
+
+def test_existing_tasks_default_to_v16_and_reject_turn_transactions(tmp_path: Path) -> None:
+    store = CodingWorkerStore(tmp_path / "worker", master_key=Fernet.generate_key())
+    task = store.create_task(_spec())
+    assert task.runtime_protocol is RuntimeProtocol.V16
+    with pytest.raises(WorkerConflictError) as rejected:
+        store.open_turn_transaction(
+            task_id=task.task_id,
+            turn_id="turn_legacy",
+            workspace_tree_hash="d" * 64,
+        )
+    assert rejected.value.code == "turn_protocol_mismatch"
 
 
 def test_restart_interrupts_inflight_without_replaying_it(tmp_path: Path) -> None:

--- a/server/tests/test_coding_worker_store.py
+++ b/server/tests/test_coding_worker_store.py
@@ -17,6 +17,8 @@ from server.coding_worker.contracts import (
     TurnBarrier,
     TurnTransactionState,
     WorkspaceSource,
+    WorkerQuestionAnswer,
+    WorkerQuestionOption,
     WorkerSessionLedgerEntry,
 )
 from server.coding_worker.crypto import WorkerCryptoError
@@ -192,7 +194,7 @@ def test_restart_preserves_durably_parked_v17_approval_turn(tmp_path: Path) -> N
         turn_id=turn.turn_id,
         payload={},
     )
-    store.create_approval(
+    approval = store.create_approval(
         task_id=task.task_id,
         operation_id="operation_v17_restart",
         capability="command",
@@ -203,6 +205,10 @@ def test_restart_preserves_durably_parked_v17_approval_turn(tmp_path: Path) -> N
         turn_id=turn.turn_id,
         barrier=TurnBarrier.APPROVAL,
     )
+    with pytest.raises(WorkerConflictError) as too_early:
+        store.decide_approval(approval.approval_id, approved=True)
+    assert too_early.value.code == "task_state_conflict"
+    assert store.get_approval(approval.approval_id).status.value == "pending"
     checkpoint = store.create_checkpoint(
         task_id=task.task_id,
         workspace_tree_hash="b" * 64,
@@ -225,6 +231,63 @@ def test_restart_preserves_durably_parked_v17_approval_turn(tmp_path: Path) -> N
     assert [item.kind for item in restarted.list_session_ledger(task.task_id)] == [
         SessionLedgerKind.TURN_STARTED
     ]
+    decided = restarted.decide_approval(approval.approval_id, approved=True)
+    assert decided.status.value == "approved"
+    assert restarted.get_task(task.task_id).state is TaskState.QUEUED
+    resuming = restarted.current_turn_transaction(task.task_id)
+    assert resuming is not None
+    assert resuming.state is TurnTransactionState.RESUMING
+
+
+def test_v17_question_resolution_atomically_resumes_parked_turn(
+    tmp_path: Path,
+) -> None:
+    store = CodingWorkerStore(tmp_path / "worker", master_key=Fernet.generate_key())
+    task = store.create_task(_spec(), runtime_protocol=RuntimeProtocol.V17)
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING)
+    turn = store.open_turn_transaction(
+        task_id=task.task_id,
+        turn_id="turn_v17_input",
+        workspace_tree_hash="a" * 64,
+    )
+    store.create_question(
+        task_id=task.task_id,
+        question_id="question_v17_input",
+        turn_id=turn.turn_id,
+        prompt="Choose a repair.",
+        options=(
+            WorkerQuestionOption(option_id="safe", label="Safe repair"),
+        ),
+    )
+    store.begin_turn_parking(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        barrier=TurnBarrier.INPUT,
+    )
+    checkpoint = store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash="a" * 64,
+        payload={"phase": "waiting_input"},
+    )
+    store.park_turn_transaction(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        checkpoint_id=checkpoint.checkpoint_id,
+    )
+    store.transition(task.task_id, TaskState.WAITING_INPUT)
+
+    resolved = store.resolve_question(
+        task.task_id,
+        "question_v17_input",
+        WorkerQuestionAnswer(option_id="safe"),
+    )
+
+    assert resolved.status.value == "resolved"
+    assert store.get_task(task.task_id).state is TaskState.QUEUED
+    transaction = store.current_turn_transaction(task.task_id)
+    assert transaction is not None
+    assert transaction.state is TurnTransactionState.RESUMING
 
 
 def test_restart_interrupts_inflight_without_replaying_it(tmp_path: Path) -> None:

--- a/server/tests/test_coding_worker_store.py
+++ b/server/tests/test_coding_worker_store.py
@@ -174,6 +174,59 @@ def test_existing_tasks_default_to_v16_and_reject_turn_transactions(tmp_path: Pa
     assert rejected.value.code == "turn_protocol_mismatch"
 
 
+def test_restart_preserves_durably_parked_v17_approval_turn(tmp_path: Path) -> None:
+    root = tmp_path / "worker"
+    key = Fernet.generate_key()
+    store = CodingWorkerStore(root, master_key=key)
+    task = store.create_task(_spec(), runtime_protocol=RuntimeProtocol.V17)
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING)
+    turn = store.open_turn_transaction(
+        task_id=task.task_id,
+        turn_id="turn_v17_restart",
+        workspace_tree_hash="a" * 64,
+    )
+    store.append_session_ledger(
+        task.task_id,
+        kind=SessionLedgerKind.TURN_STARTED,
+        turn_id=turn.turn_id,
+        payload={},
+    )
+    store.create_approval(
+        task_id=task.task_id,
+        operation_id="operation_v17_restart",
+        capability="command",
+        request={"argv": ["pytest"]},
+    )
+    store.begin_turn_parking(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        barrier=TurnBarrier.APPROVAL,
+    )
+    checkpoint = store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash="b" * 64,
+        payload={"phase": "waiting_approval"},
+    )
+    store.park_turn_transaction(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        checkpoint_id=checkpoint.checkpoint_id,
+    )
+    store.transition(task.task_id, TaskState.WAITING_APPROVAL)
+
+    restarted = CodingWorkerStore(root, master_key=key)
+
+    assert restarted.get_task(task.task_id).state is TaskState.WAITING_APPROVAL
+    parked = restarted.current_turn_transaction(task.task_id)
+    assert parked is not None
+    assert parked.state is TurnTransactionState.PARKED
+    assert parked.workspace_tree_hash == "b" * 64
+    assert [item.kind for item in restarted.list_session_ledger(task.task_id)] == [
+        SessionLedgerKind.TURN_STARTED
+    ]
+
+
 def test_restart_interrupts_inflight_without_replaying_it(tmp_path: Path) -> None:
     root = tmp_path / "worker"
     key = Fernet.generate_key()

--- a/server/tests/test_coding_worker_store.py
+++ b/server/tests/test_coding_worker_store.py
@@ -239,6 +239,89 @@ def test_restart_preserves_durably_parked_v17_approval_turn(tmp_path: Path) -> N
     assert resuming is not None
     assert resuming.state is TurnTransactionState.RESUMING
 
+    resumed_again = CodingWorkerStore(root, master_key=key)
+    assert resumed_again.get_task(task.task_id).state is TaskState.QUEUED
+    resumed_turn = resumed_again.current_turn_transaction(task.task_id)
+    assert resumed_turn is not None
+    assert resumed_turn.state is TurnTransactionState.RESUMING
+    assert resumed_turn.checkpoint_id == checkpoint.checkpoint_id
+
+
+def test_restart_interrupts_v17_parking_before_checkpoint(tmp_path: Path) -> None:
+    root = tmp_path / "worker"
+    key = Fernet.generate_key()
+    store = CodingWorkerStore(root, master_key=key)
+    task = store.create_task(_spec(), runtime_protocol=RuntimeProtocol.V17)
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING)
+    turn = store.open_turn_transaction(
+        task_id=task.task_id,
+        turn_id="turn_v17_parking_restart",
+        workspace_tree_hash="a" * 64,
+    )
+    store.begin_turn_parking(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        barrier=TurnBarrier.INPUT,
+    )
+
+    restarted = CodingWorkerStore(root, master_key=key)
+
+    interrupted = restarted.get_task(task.task_id)
+    assert interrupted.state is TaskState.INTERRUPTED
+    assert interrupted.reason == "server_restart"
+    assert restarted.get_turn_transaction(
+        task.task_id, turn.turn_id
+    ).state is TurnTransactionState.INTERRUPTED
+
+
+@pytest.mark.parametrize(
+    ("barrier", "waiting_state"),
+    (
+        (TurnBarrier.INPUT, TaskState.WAITING_INPUT),
+        (TurnBarrier.SUBTASKS, TaskState.WAITING_SUBTASKS),
+    ),
+)
+def test_restart_preserves_v17_parked_input_and_subtask_turns(
+    tmp_path: Path, barrier: TurnBarrier, waiting_state: TaskState
+) -> None:
+    root = tmp_path / barrier.value
+    key = Fernet.generate_key()
+    store = CodingWorkerStore(root, master_key=key)
+    task = store.create_task(_spec(), runtime_protocol=RuntimeProtocol.V17)
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING)
+    turn = store.open_turn_transaction(
+        task_id=task.task_id,
+        turn_id=f"turn_v17_{barrier.value}_restart",
+        workspace_tree_hash="a" * 64,
+    )
+    store.begin_turn_parking(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        barrier=barrier,
+    )
+    checkpoint = store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash="a" * 64,
+        payload={"phase": f"waiting_{barrier.value}"},
+    )
+    store.park_turn_transaction(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        checkpoint_id=checkpoint.checkpoint_id,
+    )
+    store.transition(task.task_id, waiting_state)
+
+    restarted = CodingWorkerStore(root, master_key=key)
+
+    assert restarted.get_task(task.task_id).state is waiting_state
+    parked = restarted.current_turn_transaction(task.task_id)
+    assert parked is not None
+    assert parked.state is TurnTransactionState.PARKED
+    assert parked.barrier is barrier
+    assert parked.checkpoint_id == checkpoint.checkpoint_id
+
 
 def test_restart_parks_unknown_v17_operation_on_its_entry_checkpoint(
     tmp_path: Path,

--- a/server/tests/test_coding_worker_store.py
+++ b/server/tests/test_coding_worker_store.py
@@ -10,6 +10,7 @@ from server.coding_worker.contracts import (
     AcceptanceCheck,
     AcceptanceContract,
     Origin,
+    OperationState,
     RuntimeProtocol,
     SessionLedgerKind,
     TaskSpec,
@@ -288,6 +289,46 @@ def test_v17_question_resolution_atomically_resumes_parked_turn(
     transaction = store.current_turn_transaction(task.task_id)
     assert transaction is not None
     assert transaction.state is TurnTransactionState.RESUMING
+
+
+def test_unknown_operation_emits_one_reconciliation_receipt(tmp_path: Path) -> None:
+    store = CodingWorkerStore(tmp_path / "worker", master_key=Fernet.generate_key())
+    task = store.create_task(_spec())
+    operation = store.create_operation(
+        task_id=task.task_id,
+        operation_id="operation_reconcile_receipt",
+        tool_name="run_shell",
+        intent_sha256="a" * 64,
+        request={"workspace_id": "workspace_1", "arguments": {}},
+    )
+    store.transition_operation(
+        operation.operation_id,
+        OperationState.RUNNING,
+        expected_state=OperationState.PREPARED,
+    )
+    store.transition_operation(
+        operation.operation_id,
+        OperationState.UNKNOWN,
+        expected_state=OperationState.RUNNING,
+    )
+    store.transition_operation(
+        operation.operation_id,
+        OperationState.COMPLETED,
+        result={"exit_code": 0},
+        expected_state=OperationState.UNKNOWN,
+    )
+
+    receipts = [
+        event
+        for event in store.list_events(task.task_id)
+        if event.type == "operation_reconciled"
+    ]
+    assert [event.payload for event in receipts] == [
+        {
+            "operation_id": operation.operation_id,
+            "state": OperationState.COMPLETED.value,
+        }
+    ]
 
 
 def test_restart_interrupts_inflight_without_replaying_it(tmp_path: Path) -> None:

--- a/server/tests/test_coding_worker_store.py
+++ b/server/tests/test_coding_worker_store.py
@@ -240,6 +240,62 @@ def test_restart_preserves_durably_parked_v17_approval_turn(tmp_path: Path) -> N
     assert resuming.state is TurnTransactionState.RESUMING
 
 
+def test_restart_parks_unknown_v17_operation_on_its_entry_checkpoint(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "worker"
+    key = Fernet.generate_key()
+    store = CodingWorkerStore(root, master_key=key)
+    task = store.create_task(_spec(), runtime_protocol=RuntimeProtocol.V17)
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING)
+    turn = store.open_turn_transaction(
+        task_id=task.task_id,
+        turn_id="turn_v17_unknown_restart",
+        workspace_tree_hash="c" * 64,
+    )
+    checkpoint = store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash="c" * 64,
+        payload={
+            "phase": "turn_open",
+            "completed_turns": 1,
+            "provider": {"checkpoint_id": "provider_entry", "payload": {}},
+        },
+    )
+    store.bind_turn_recovery_checkpoint(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        checkpoint_id=checkpoint.checkpoint_id,
+    )
+    operation = store.create_operation(
+        task_id=task.task_id,
+        operation_id="operation_v17_unknown_restart",
+        tool_name="write_file",
+        intent_sha256="d" * 64,
+        request={"path": "result.txt"},
+        turn_id=turn.turn_id,
+    )
+    store.transition_operation(
+        operation.operation_id,
+        OperationState.RUNNING,
+        expected_state=OperationState.PREPARED,
+    )
+
+    restarted = CodingWorkerStore(root, master_key=key)
+
+    assert restarted.get_operation(operation.operation_id).state is OperationState.UNKNOWN
+    interrupted = restarted.get_task(task.task_id)
+    assert interrupted.state is TaskState.INTERRUPTED
+    assert interrupted.reason == "operation_result_unknown"
+    parked = restarted.current_turn_transaction(task.task_id)
+    assert parked is not None
+    assert parked.turn_id == turn.turn_id
+    assert parked.state is TurnTransactionState.PARKED
+    assert parked.barrier is TurnBarrier.OPERATION_UNKNOWN
+    assert parked.checkpoint_id == checkpoint.checkpoint_id
+
+
 def test_v17_question_resolution_atomically_resumes_parked_turn(
     tmp_path: Path,
 ) -> None:

--- a/server/tests/test_coding_worker_subtasks.py
+++ b/server/tests/test_coding_worker_subtasks.py
@@ -13,12 +13,15 @@ from server.coding_worker.contracts import (
     AcceptanceContract,
     Origin,
     PolicyProfile,
+    RuntimeProtocol,
     SubtaskKind,
     SubtaskMergeState,
     SubtaskRequest,
     TaskState,
     TaskSpec,
     WorkspaceSource,
+    TurnBarrier,
+    TurnTransactionState,
 )
 from server.coding_worker.store import CodingWorkerStore, WorkerConflictError
 from server.coding_worker.provider import (
@@ -208,6 +211,48 @@ def test_subtasks_are_depth_one_and_limited_to_four(tmp_path: Path) -> None:
     with pytest.raises(WorkerConflictError) as depth:
         _create(store, first.child_task_id, client_subtask_id="nested")
     assert depth.value.code == "subtask_depth_exceeded"
+
+
+def test_v17_subtask_creation_and_parent_parking_are_atomic(tmp_path: Path) -> None:
+    store = CodingWorkerStore(
+        tmp_path / "worker", master_key=Fernet.generate_key()
+    )
+    parent = store.create_task(_spec(), runtime_protocol=RuntimeProtocol.V17)
+    store.transition(parent.task_id, TaskState.PREPARING)
+    store.transition(parent.task_id, TaskState.RUNNING)
+    turn = store.open_turn_transaction(
+        task_id=parent.task_id,
+        turn_id="turn_v17_subtask_atomic",
+        workspace_tree_hash="a" * 64,
+    )
+    child_spec = _spec("child-v17-atomic").model_copy(
+        update={
+            "origin": Origin(
+                module="coding-worker-subtask", object_id=parent.task_id
+            )
+        }
+    )
+
+    relation = store.create_subtask_task(
+        parent_task_id=parent.task_id,
+        client_subtask_id="v17-atomic",
+        kind=SubtaskKind.EXPLORE,
+        objective="Inspect the dependency graph.",
+        spec=child_spec,
+        workspace_id="workspace-v17-atomic",
+        base_tree_hash="a" * 64,
+        parent_turn_id=turn.turn_id,
+    )
+
+    assert store.get_task(relation.child_task_id).state is TaskState.QUEUED
+    parked = store.current_turn_transaction(parent.task_id)
+    assert parked is not None
+    assert parked.state is TurnTransactionState.PARKING
+    assert parked.barrier is TurnBarrier.SUBTASKS
+    events = store.list_events(parent.task_id)
+    subtask_event = next(item for item in events if item.type == "subtask_created")
+    parking_event = next(item for item in events if item.type == "turn_parking")
+    assert subtask_event.sequence + 1 == parking_event.sequence
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -145,6 +145,70 @@ async def test_v17_platform_plan_todo_and_question_are_turn_bound(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_v17_unresolved_unknown_operation_reparks_the_same_turn(
+    tmp_path: Path,
+) -> None:
+    broker, store, task_id, _ = await _broker(
+        tmp_path, runtime_protocol=RuntimeProtocol.V17
+    )
+    task = store.get_task(task_id)
+    turn = store.current_turn_transaction(task_id)
+    assert task.workspace_id is not None and turn is not None
+    content = "print('unconfirmed')\n"
+    arguments = {
+        "path": "app.py",
+        "content": content,
+        "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+    }
+    request = {"arguments": arguments, "workspace_id": task.workspace_id}
+    operation = store.create_operation(
+        task_id=task_id,
+        operation_id="unknown-write-v17",
+        tool_name="write_file",
+        intent_sha256=broker._intent_sha256("write_file", request),
+        request=request,
+        turn_id=turn.turn_id,
+    )
+    store.transition_operation(
+        operation.operation_id,
+        OperationState.RUNNING,
+        expected_state=OperationState.PREPARED,
+    )
+    store.transition_operation(
+        operation.operation_id,
+        OperationState.UNKNOWN,
+        result={"code": "operation_result_unknown"},
+        expected_state=OperationState.RUNNING,
+    )
+
+    with pytest.raises(ToolBrokerError) as unresolved:
+        await broker.execute(
+            task_id=task_id,
+            operation_id=operation.operation_id,
+            tool_name="write_file",
+            arguments=arguments,
+        )
+    assert unresolved.value.code == "operation_result_unknown"
+    parked = store.current_turn_transaction(task_id)
+    assert parked is not None
+    assert parked.turn_id == turn.turn_id
+    assert parked.state is TurnTransactionState.PARKING
+    assert parked.barrier is TurnBarrier.OPERATION_UNKNOWN
+
+    with pytest.raises(ToolBrokerError) as late:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="late-after-unknown",
+            tool_name="read_file",
+            arguments={"path": "app.py"},
+        )
+    assert late.value.code == "turn_parked"
+    assert "late-after-unknown" not in {
+        item.operation_id for item in store.list_operations(task_id)
+    }
+
+
+@pytest.mark.asyncio
 async def test_develop_can_write_search_diff_and_run_frozen_check(tmp_path: Path) -> None:
     broker, _, task_id, repository = await _broker(tmp_path)
     content = "print('new')\n"

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -15,9 +15,13 @@ from server.coding_worker.contracts import (
     Origin,
     PolicyProfile,
     OperationState,
+    RuntimeProtocol,
+    SessionLedgerKind,
     TaskSpec,
     TaskState,
     WorkspaceSource,
+    TurnBarrier,
+    TurnTransactionState,
 )
 from server.coding_worker.store import CodingWorkerStore
 from server.coding_worker.process_manager import BackgroundProcessManager
@@ -28,7 +32,10 @@ from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, Works
 
 
 async def _broker(
-    tmp_path: Path, *, profile: PolicyProfile = PolicyProfile.DEVELOP
+    tmp_path: Path,
+    *,
+    profile: PolicyProfile = PolicyProfile.DEVELOP,
+    runtime_protocol: RuntimeProtocol = RuntimeProtocol.V16,
 ) -> tuple[ToolBroker, CodingWorkerStore, str, Path]:
     source = WorkspaceSource(kind="manifest", source_id="source", revision="h0")
     workspace = WorkspaceBroker(
@@ -50,10 +57,23 @@ async def _broker(
             ),
             policy_profile=profile,
             model_route="coding/default",
-        )
+        ),
+        runtime_protocol=runtime_protocol,
     )
     store.transition(task.task_id, TaskState.PREPARING)
     store.transition(task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id)
+    if runtime_protocol is RuntimeProtocol.V17:
+        store.open_turn_transaction(
+            task_id=task.task_id,
+            turn_id="turn_broker_v17",
+            workspace_tree_hash=workspace.current_tree_hash(prepared.workspace_id),
+        )
+        store.append_session_ledger(
+            task.task_id,
+            kind=SessionLedgerKind.TURN_STARTED,
+            turn_id="turn_broker_v17",
+            payload={},
+        )
     broker = ToolBroker(
         store=store,
         workspace_broker=workspace,
@@ -62,6 +82,66 @@ async def _broker(
         },
     )
     return broker, store, task.task_id, workspace.repository_path(prepared.workspace_id)
+
+
+@pytest.mark.asyncio
+async def test_v17_platform_plan_todo_and_question_are_turn_bound(tmp_path: Path) -> None:
+    broker, store, task_id, _ = await _broker(
+        tmp_path, runtime_protocol=RuntimeProtocol.V17
+    )
+    plan = await broker.execute(
+        task_id=task_id,
+        operation_id="platform-plan",
+        tool_name="update_plan",
+        arguments={
+            "explanation": "Reproduce first.",
+            "items": [{"step": "run tests", "status": "in_progress"}],
+        },
+    )
+    assert plan.data["sequence"] >= 1
+    assert store.latest_plan(task_id).items[0].step == "run tests"
+    todo = await broker.execute(
+        task_id=task_id,
+        operation_id="platform-todo",
+        tool_name="update_todo",
+        arguments={
+            "items": [
+                {"todo_id": "todo_repro", "content": "reproduce", "status": "pending"}
+            ]
+        },
+    )
+    assert todo.data["todo"]["items"][0]["todo_id"] == "todo_repro"
+    parked = await broker.execute(
+        task_id=task_id,
+        operation_id="platform-question",
+        tool_name="request_user_input",
+        arguments={
+            "question_id": "question_scope",
+            "prompt": "Which scope?",
+            "options": [{"option_id": "scope_small", "label": "Small"}],
+        },
+    )
+    assert parked.data == {
+        "control": "turn_parking",
+        "barrier": TurnBarrier.INPUT.value,
+        "question_id": "question_scope",
+    }
+    turn = store.current_turn_transaction(task_id)
+    assert turn is not None
+    assert turn.state is TurnTransactionState.PARKING
+    assert turn.barrier is TurnBarrier.INPUT
+    assert store.list_questions(task_id)[0].question_id == "question_scope"
+    with pytest.raises(ToolBrokerError) as late:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="platform-late-plan",
+            tool_name="update_plan",
+            arguments={"items": [{"step": "late", "status": "pending"}]},
+        )
+    assert late.value.code == "turn_parked"
+    assert "platform-late-plan" not in {
+        operation.operation_id for operation in store.list_operations(task_id)
+    }
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -131,6 +131,13 @@ async def test_v17_platform_plan_todo_and_question_are_turn_bound(tmp_path: Path
     assert turn.state is TurnTransactionState.PARKING
     assert turn.barrier is TurnBarrier.INPUT
     assert store.list_questions(task_id)[0].question_id == "question_scope"
+    question_event = next(
+        item for item in store.list_events(task_id) if item.type == "question_requested"
+    )
+    parking_event = next(
+        item for item in store.list_events(task_id) if item.type == "turn_parking"
+    )
+    assert question_event.sequence + 1 == parking_event.sequence
     with pytest.raises(ToolBrokerError) as late:
         await broker.execute(
             task_id=task_id,
@@ -206,6 +213,39 @@ async def test_v17_unresolved_unknown_operation_reparks_the_same_turn(
     assert "late-after-unknown" not in {
         item.operation_id for item in store.list_operations(task_id)
     }
+
+
+@pytest.mark.asyncio
+async def test_v17_approval_and_turn_parking_are_one_durable_boundary(
+    tmp_path: Path,
+) -> None:
+    broker, store, task_id, _ = await _broker(
+        tmp_path, runtime_protocol=RuntimeProtocol.V17
+    )
+
+    with pytest.raises(ToolBrokerError) as required:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="v17-command-approval",
+            tool_name="run_command",
+            arguments={"argv": ["python", "-V"], "timeout_seconds": 30},
+        )
+
+    assert required.value.code == "approval_required"
+    approvals = store.list_approvals(task_id)
+    assert len(approvals) == 1
+    assert approvals[0].operation_id == "v17-command-approval"
+    turn = store.current_turn_transaction(task_id)
+    assert turn is not None
+    assert turn.state is TurnTransactionState.PARKING
+    assert turn.barrier is TurnBarrier.APPROVAL
+    approval_event = next(
+        item for item in store.list_events(task_id) if item.type == "approval_requested"
+    )
+    parking_event = next(
+        item for item in store.list_events(task_id) if item.type == "turn_parking"
+    )
+    assert approval_event.sequence + 1 == parking_event.sequence
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- persist V17 turn transactions and bind every V17 operation to its active turn
- park and restore approval, input, subtask, compaction, and unknown-operation barriers from exact checkpoints
- add provider v4 turn interruption plus platform-authoritative plan/todo/input/compaction tools
- fail closed on late provider events, duplicate side effects, stale runner callbacks, and incomplete turn settlement
- trigger controlled compaction at the configured route context threshold

## Validation
- `243 passed, 5 skipped` — all `test_coding_worker*.py` in a network-free Linux container
- `124 passed` — PR B core Store/Broker/Service/Subtask/API suite
- `4 passed` — parking/parked/resuming restart matrix
- full backend: `3124 passed, 29 skipped, 16 failed`; all 16 failures reproduced unchanged on PR A (`AgencyWorker` build output absent and Skill TS generator environment)
- frontend: production build passed; `300 passed, 1 failed`, with the NodePalette registry mock failure reproduced on PR A
- standard Worker and Claude Compose `config --quiet` passed
- 19 changed Python files compiled; diff/dependency/forbidden artifact/credential scans passed

## Release state
Experimental and default-off. This PR does not claim OpenCode parity or V17 readiness. It is stacked on #199 and should be reviewed/merged after that PR.