### PR TITLE
feature: V17 可执行认证与交互 Console

### DIFF
--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -7,7 +7,9 @@ const api = vi.hoisted(() => ({
   getCodingWorkerStatus: vi.fn(),
   listCodingWorkerTasks: vi.fn(),
   getCodingWorkerTask: vi.fn(),
+  getCodingWorkerTaskCapabilities: vi.fn(),
   getCodingWorkerPlan: vi.fn(),
+  getCodingWorkerTodo: vi.fn(),
   listCodingWorkerQuestions: vi.fn(),
   answerCodingWorkerQuestion: vi.fn(),
   getCodingWorkerTurnHistory: vi.fn(),
@@ -69,7 +71,27 @@ const task = {
   pinned: false,
   last_event_sequence: 1,
   reason: null,
+  runtime_protocol: "v17",
 } as const;
+
+const taskCapabilities = {
+  task_id: task.task_id,
+  observed_at: 1,
+  expires_at: 31,
+  capabilities: [
+    "task_runtime",
+    "professional_file_tools",
+    "shell",
+    "operation_output",
+    "changesets",
+    "code_intelligence",
+    "structured_plan",
+    "user_questions",
+    "context_compaction",
+    "turn_history",
+    "subtasks",
+  ].map((name) => ({ name, enabled: true, supported: true, available: true, reason: null })),
+};
 
 beforeEach(() => {
   Object.values(api).forEach((mock) => "mockReset" in mock && mock.mockReset());
@@ -78,7 +100,9 @@ beforeEach(() => {
   api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, acceptance_checks: ["python-pytest", "react-build"], model_routes: ["coding/default", "coding/quality"], reason: null, capabilities: { api_version: "v1", task_runtime: true, professional_file_tools: true, shell: true, operation_output: true, changesets: true, code_intelligence: true, structured_plan: true, user_questions: true, context_compaction: true, turn_history: true, subtasks: true } });
   api.listCodingWorkerTasks.mockResolvedValue([task]);
   api.getCodingWorkerTask.mockResolvedValue(task);
+  api.getCodingWorkerTaskCapabilities.mockResolvedValue(taskCapabilities);
   api.getCodingWorkerPlan.mockResolvedValue(null);
+  api.getCodingWorkerTodo.mockResolvedValue(null);
   api.listCodingWorkerQuestions.mockResolvedValue([]);
   api.answerCodingWorkerQuestion.mockResolvedValue({});
   api.getCodingWorkerTurnHistory.mockResolvedValue({ task_id: task.task_id, cursor: 0, checkpoints: [], pending_action: null });
@@ -210,6 +234,14 @@ describe("CodingWorkerConsole", () => {
   });
 
   it("shows public plans, exact shell approval, replayed output, changesets and diagnostics", async () => {
+    api.getCodingWorkerPlan.mockResolvedValue({
+      task_id: task.task_id,
+      sequence: 1,
+      turn_id: "turn_1",
+      explanation: "先复现失败，再修复并复测。",
+      items: [{ step: "复现失败", status: "in_progress" }],
+      updated_at: 1,
+    });
     api.listCodingWorkerApprovals.mockResolvedValue([{
       approval_id: "approval_1234567890abcdef1234567890abcdef",
       task_id: task.task_id,
@@ -261,9 +293,12 @@ describe("CodingWorkerConsole", () => {
     });
     api.connectCodingWorkerEvents.mockImplementation((_taskId, _after, handlers) => {
       queueMicrotask(() => {
-        handlers.onEvent({ sequence: 1, task_id: task.task_id, type: "provider_event", payload: { kind: "plan", data: { summary: "先复现失败，再修复并复测。" } }, created_at: 1 });
+        handlers.onEvent({ sequence: 1, task_id: task.task_id, type: "provider_event", payload: { kind: "plan", data: { summary: "供应商原生计划不应成为权威状态。" } }, created_at: 1 });
         handlers.onEvent({ sequence: 2, task_id: task.task_id, type: "tool_operation", payload: { operation_id: "operation_shell_1", state: "completed" }, created_at: 2 });
         handlers.onEvent({ sequence: 3, task_id: task.task_id, type: "provider_event", payload: { kind: "internal_frame" }, created_at: 3 });
+        handlers.onEvent({ sequence: 4, task_id: task.task_id, type: "turn_parking", payload: { turn_id: "turn_1", barrier: "approval" }, created_at: 4 });
+        handlers.onEvent({ sequence: 5, task_id: task.task_id, type: "turn_parked", payload: { turn_id: "turn_1", barrier: "approval" }, created_at: 5 });
+        handlers.onEvent({ sequence: 6, task_id: task.task_id, type: "operation_reconciled", payload: { turn_id: "turn_1", operation_id: "operation_shell_1", state: "completed" }, created_at: 6 });
       });
       return () => undefined;
     });
@@ -272,7 +307,10 @@ describe("CodingWorkerConsole", () => {
     render(<CodingWorkerConsole context="agent" />);
 
     expect((await screen.findAllByText("先复现失败，再修复并复测。")).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText("供应商原生计划不应成为权威状态。")).not.toBeInTheDocument();
     expect(screen.queryByText("provider event")).not.toBeInTheDocument();
+    expect(await screen.findByText("当前回合已停车")).toBeInTheDocument();
+    expect(await screen.findByText("工具结果已核对")).toBeInTheDocument();
     expect(await screen.findByText("Shell 单次审批")).toBeInTheDocument();
     await user.click(screen.getByText("查看操作绑定"));
     expect(screen.getByText((content) => content.includes("c".repeat(64)))).toBeInTheDocument();
@@ -312,6 +350,13 @@ describe("CodingWorkerConsole", () => {
         { step: "修复状态逻辑", status: "in_progress" },
       ],
       updated_at: 2,
+    });
+    api.getCodingWorkerTodo.mockResolvedValue({
+      task_id: task.task_id,
+      sequence: 4,
+      turn_id: "turn_1",
+      items: [{ todo_id: "todo_1", content: "复跑父任务必需检查", status: "pending" }],
+      updated_at: 3,
     });
     api.listCodingWorkerQuestions.mockResolvedValue([{
       task_id: task.task_id,
@@ -377,7 +422,7 @@ describe("CodingWorkerConsole", () => {
           sequence: 8,
           task_id: task.task_id,
           type: "provider_event",
-          payload: { kind: "todo", data: { items: [{ todo_id: "todo_1", content: "复跑父任务必需检查", status: "pending" }] } },
+          payload: { kind: "todo", data: { items: [{ todo_id: "todo_provider", content: "供应商待办不应成为权威状态", status: "pending" }] } },
           created_at: 3,
         });
         handlers.onEvent({
@@ -397,6 +442,8 @@ describe("CodingWorkerConsole", () => {
 
     expect(await screen.findByText("修复状态逻辑")).toBeInTheDocument();
     expect(screen.getByText("复跑父任务必需检查")).toBeInTheDocument();
+    expect(screen.queryByText("供应商待办不应成为权威状态")).not.toBeInTheDocument();
+    expect(screen.getByText("V17 · 固定路由")).toBeInTheDocument();
     expect(screen.getByText("上下文已在完整工具边界压缩", { exact: false })).toBeInTheDocument();
     expect(screen.getByText("父 Workspace 未被覆盖", { exact: false })).toBeInTheDocument();
     expect(screen.getAllByText("src/state.ts", { exact: false })).toHaveLength(2);

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -34,13 +34,16 @@ import type {
   CodingWorkerEntry,
   CodingWorkerEvent,
   CodingWorkerEvidence,
+  CodingWorkerFeatureName,
   CodingWorkerOperationOutputChunk,
   CodingWorkerPlan,
   CodingWorkerQuestion,
   CodingWorkerStatus,
   CodingWorkerSubtask,
   CodingWorkerTask,
+  CodingWorkerTaskCapabilities,
   CodingWorkerTaskSpec,
+  CodingWorkerTodo,
   CodingWorkerTurnHistory,
 } from "../types/codingWorker";
 import {
@@ -54,7 +57,9 @@ import {
   getCodingWorkerDiagnostics,
   getCodingWorkerPlan,
   getCodingWorkerTask,
+  getCodingWorkerTaskCapabilities,
   getCodingWorkerStatus,
+  getCodingWorkerTodo,
   getCodingWorkerTurnHistory,
   handoffCodingWorkerTask,
   listCodingWorkerApprovals,
@@ -97,46 +102,9 @@ import {
 
 type ConsoleContext = "coding" | "agent";
 type InspectorTab = "session" | "files" | "diff" | "changesets" | "diagnostics" | "evidence" | "terminal";
-type WorkerTodoItem = {
-  todo_id: string;
-  content: string;
-  status: "pending" | "in_progress" | "completed" | "cancelled";
-};
 
 function errorMessage(error: unknown, fallback: string) {
   return error instanceof Error ? error.message : fallback;
-}
-
-function publicPlanText(event: CodingWorkerEvent) {
-  if (event.type !== "provider_event" || event.payload.kind !== "plan") return null;
-  const data = event.payload.data;
-  if (typeof data === "string") return data;
-  if (!data || typeof data !== "object") return null;
-  const record = data as Record<string, unknown>;
-  const value = [record.summary, record.message, record.text].find((item) => typeof item === "string");
-  return typeof value === "string" ? value : "计划已更新。";
-}
-
-function publicTodoItems(event: CodingWorkerEvent) {
-  if (event.type !== "provider_event" || event.payload.kind !== "todo") return null;
-  const data = event.payload.data;
-  if (!data || typeof data !== "object") return null;
-  const items = (data as Record<string, unknown>).items;
-  if (!Array.isArray(items)) return null;
-  return items.flatMap((item) => {
-    if (!item || typeof item !== "object") return [];
-    const value = item as Record<string, unknown>;
-    if (
-      typeof value.todo_id !== "string"
-      || typeof value.content !== "string"
-      || !["pending", "in_progress", "completed", "cancelled"].includes(String(value.status))
-    ) return [];
-    return [{
-      todo_id: value.todo_id,
-      content: value.content,
-      status: value.status as "pending" | "in_progress" | "completed" | "cancelled",
-    } satisfies WorkerTodoItem];
-  }).slice(0, 256);
 }
 
 function approvalField(request: Record<string, unknown>, key: string) {
@@ -193,6 +161,29 @@ const mergeStateCopy = {
   failed: "子任务失败",
 } as const;
 
+const capabilityCopy: Record<CodingWorkerFeatureName, string> = {
+  task_runtime: "任务运行",
+  professional_file_tools: "专业文件工具",
+  shell: "受控 Shell",
+  operation_output: "终端补发",
+  changesets: "原子变更",
+  code_intelligence: "代码诊断",
+  structured_plan: "结构化计划",
+  user_questions: "用户提问",
+  context_compaction: "上下文压缩",
+  turn_history: "回合历史",
+  subtasks: "隔离子任务",
+};
+
+const capabilityReasonCopy = {
+  feature_disabled: "功能开关关闭",
+  provider_unavailable: "受控执行路由离线",
+  provider_unsupported: "当前路由不支持",
+  provider_binding_changed: "执行绑定已改变",
+  route_unavailable: "模型路由不可用",
+  legacy_task: "旧任务未保存能力快照",
+} as const;
+
 function approvalSummary(approval: CodingWorkerApproval) {
   const command = approval.request.command ?? approval.request.script;
   if (typeof command === "string" && command.trim()) return command;
@@ -226,6 +217,8 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   const [changesets, setChangesets] = useState<CodingWorkerChangeset[]>([]);
   const [diagnostics, setDiagnostics] = useState<CodingWorkerDiagnosticsSnapshot[]>([]);
   const [structuredPlan, setStructuredPlan] = useState<CodingWorkerPlan | null>(null);
+  const [todo, setTodo] = useState<CodingWorkerTodo | null>(null);
+  const [taskCapabilities, setTaskCapabilities] = useState<CodingWorkerTaskCapabilities | null>(null);
   const [questions, setQuestions] = useState<CodingWorkerQuestion[]>([]);
   const [turnHistory, setTurnHistory] = useState<CodingWorkerTurnHistory | null>(null);
   const [subtasks, setSubtasks] = useState<CodingWorkerSubtask[]>([]);
@@ -267,10 +260,6 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     });
     return [...ids].slice(-32);
   }, [events]);
-  const latestPlan = useMemo(
-    () => events.map(publicPlanText).filter((item): item is string => Boolean(item)).at(-1) ?? null,
-    [events],
-  );
   const latestCompaction = useMemo(
     () => events.filter((event) => event.type === "context_compacted").at(-1) ?? null,
     [events],
@@ -279,9 +268,13 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     () => questions.filter((question) => question.status === "pending"),
     [questions],
   );
-  const latestTodos = useMemo(
-    () => events.map(publicTodoItems).filter((items): items is WorkerTodoItem[] => items !== null).at(-1) ?? [],
-    [events],
+  const capabilityByName = useMemo(
+    () => new Map(taskCapabilities?.capabilities.map((item) => [item.name, item]) ?? []),
+    [taskCapabilities],
+  );
+  const taskCapabilityAvailable = useCallback(
+    (name: CodingWorkerFeatureName) => capabilityByName.get(name)?.available === true,
+    [capabilityByName],
   );
   const routeOptions = useMemo(
     () => status?.model_routes?.length ? status.model_routes : ["coding/default"],
@@ -354,6 +347,8 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
       tree,
       nextDiff,
       nextPlan,
+      nextTodo,
+      nextCapabilities,
       nextQuestions,
       nextHistory,
       nextChildren,
@@ -365,6 +360,8 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
       listCodingWorkerTree(taskId).catch(() => null),
       readCodingWorkerDiff(taskId).catch(() => ""),
       getCodingWorkerPlan(taskId).catch(() => null),
+      getCodingWorkerTodo(taskId).catch(() => null),
+      getCodingWorkerTaskCapabilities(taskId).catch(() => null),
       listCodingWorkerQuestions(taskId).catch(() => []),
       getCodingWorkerTurnHistory(taskId).catch(() => null),
       listCodingWorkerChildren(taskId).catch(() => ({ tasks: [], subtasks: [] })),
@@ -377,6 +374,8 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     setTreeHash(tree?.tree_hash ?? "");
     setDiff(nextDiff);
     setStructuredPlan(nextPlan);
+    setTodo(nextTodo);
+    setTaskCapabilities(nextCapabilities);
     setQuestions(nextQuestions);
     setTurnHistory(nextHistory);
     setSubtasks(nextChildren.subtasks);
@@ -450,7 +449,8 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
       setEvents([]); setApprovals([]); setEvidence([]); setArtifacts([]);
       setEntries([]); setPreview(null); setDiff(""); setTreeHash("");
       setOperationOutputs({}); setChangesets([]); setDiagnostics([]);
-      setStructuredPlan(null); setQuestions([]); setTurnHistory(null); setSubtasks([]); setChildTasks([]);
+      setStructuredPlan(null); setTodo(null); setTaskCapabilities(null);
+      setQuestions([]); setTurnHistory(null); setSubtasks([]); setChildTasks([]);
       return;
     }
     let active = true;
@@ -461,6 +461,8 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     setChangesets([]);
     setDiagnostics([]);
     setStructuredPlan(null);
+    setTodo(null);
+    setTaskCapabilities(null);
     setQuestions([]);
     setTurnHistory(null);
     setSubtasks([]);
@@ -535,17 +537,17 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     const loadStructuredInspector = async () => {
       setInspectorLoading(true);
       try {
-        if (tab === "terminal" && status?.capabilities.operation_output) {
+        if (tab === "terminal" && taskCapabilityAvailable("operation_output")) {
           const values = await Promise.all(operationIds.map(async (operationId) => [
             operationId,
             await listCodingWorkerOperationOutput(selectedTaskId, operationId).catch(() => []),
           ] as const));
           if (active) setOperationOutputs(Object.fromEntries(values));
-        } else if (tab === "changesets" && status?.capabilities.changesets) {
+        } else if (tab === "changesets" && taskCapabilityAvailable("changesets")) {
           const values = await Promise.all(operationIds.map((operationId) =>
             getCodingWorkerChangeset(selectedTaskId, operationId).catch(() => null)));
           if (active) setChangesets(values.filter((item): item is CodingWorkerChangeset => item !== null));
-        } else if (tab === "diagnostics" && status?.capabilities.code_intelligence) {
+        } else if (tab === "diagnostics" && taskCapabilityAvailable("code_intelligence")) {
           const values = await Promise.all(operationIds.map((operationId) =>
             getCodingWorkerDiagnostics(selectedTaskId, operationId).catch(() => null)));
           if (active) setDiagnostics(values.filter((item): item is CodingWorkerDiagnosticsSnapshot => item !== null));
@@ -556,7 +558,7 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     };
     void loadStructuredInspector();
     return () => { active = false; };
-  }, [operationIds, selectedTaskId, status?.capabilities, tab]);
+  }, [operationIds, selectedTaskId, tab, taskCapabilityAvailable]);
 
   const run = useCallback(async (operation: () => Promise<unknown>) => {
     if (operationRef.current) return;
@@ -867,7 +869,7 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
               <ul className="mt-2 flex flex-wrap gap-2">{selectedTask.spec.acceptance.required_checks.map((check) => { const state = evidenceStatus(check.check_id, evidence); return <li key={check.check_id} className="inline-flex min-h-9 items-center gap-2 rounded-lg bg-white/5 px-3 text-xs text-slate-200"><span className={state === "passed" ? "text-emerald-300" : state === "failed" ? "text-rose-300" : state === "invalidated" ? "text-amber-300" : "text-slate-500"}>{state === "passed" ? "通过" : state === "failed" ? "失败" : state === "invalidated" ? "已失效" : "待执行"}</span><span>{check.label}</span></li>; })}</ul>
             </section>
 
-            {latestPlan && <section className="border-b border-white/10 py-4" aria-labelledby="worker-plan-heading"><div className="flex items-center justify-between gap-3"><h2 id="worker-plan-heading" className="text-sm font-semibold text-white">当前计划</h2><span className="text-xs text-slate-500">公开摘要</span></div><p className="mt-2 max-w-[72ch] whitespace-pre-wrap break-words text-sm leading-6 text-slate-300">{latestPlan}</p></section>}
+            {structuredPlan && <section className="border-b border-white/10 py-4" aria-labelledby="worker-plan-heading"><div className="flex items-center justify-between gap-3"><h2 id="worker-plan-heading" className="text-sm font-semibold text-white">当前计划</h2><span className="text-xs text-slate-500">平台权威数据</span></div><p className="mt-2 max-w-[72ch] whitespace-pre-wrap break-words text-sm leading-6 text-slate-300">{structuredPlan.explanation ?? `${structuredPlan.items.filter((item) => item.status === "completed").length}/${structuredPlan.items.length} 项已完成`}</p></section>}
 
             <section className="min-h-0 flex-1 py-4" aria-label="任务进展" aria-live="polite">
               <h2 className="text-sm font-semibold text-white">任务进展</h2>
@@ -906,11 +908,11 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
                       </ol>
                     </div>
                   ) : <p className="mt-3 text-slate-400">Worker 尚未发布结构化计划。</p>}
-                  {latestTodos.length > 0 && (
+                  {todo && todo.items.length > 0 && (
                     <div className="mt-4">
                       <h4 className="text-xs font-medium uppercase tracking-wide text-slate-500">当前待办</h4>
                       <ul className="mt-2 divide-y divide-white/10 border-y border-white/10">
-                        {latestTodos.map((item) => (
+                        {todo.items.map((item) => (
                           <li key={item.todo_id} className="flex gap-3 py-3">
                             <span className="w-16 shrink-0 text-xs text-slate-500">{item.status === "in_progress" ? "进行中" : item.status === "completed" ? "已完成" : item.status === "cancelled" ? "已取消" : "待处理"}</span>
                             <span className={`min-w-0 break-words ${item.status === "completed" || item.status === "cancelled" ? "text-slate-500 line-through" : "text-slate-200"}`}>{item.content}</span>
@@ -919,6 +921,25 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
                       </ul>
                     </div>
                   )}
+                </section>
+
+                <section className="border-t border-white/10 pt-5" aria-labelledby="worker-task-capabilities-heading">
+                  <div className="flex items-center justify-between gap-3">
+                    <h3 id="worker-task-capabilities-heading" className="font-semibold text-white">任务能力</h3>
+                    <span className="text-xs text-slate-500">{selectedTask?.runtime_protocol.toUpperCase() ?? "V16"} · 固定路由</span>
+                  </div>
+                  {taskCapabilities ? (
+                    <ul className="mt-3 divide-y divide-white/10 border-y border-white/10">
+                      {taskCapabilities.capabilities.map((capability) => (
+                        <li key={capability.name} className="flex items-center justify-between gap-3 py-2.5">
+                          <span className="text-slate-200">{capabilityCopy[capability.name]}</span>
+                          <span className={`text-right text-xs ${capability.available ? "text-emerald-300" : "text-amber-200"}`}>
+                            {capability.available ? "可用" : capability.reason ? capabilityReasonCopy[capability.reason] : "不可用"}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : <p className="mt-3 text-amber-200" role="status">任务能力尚未完成实时核对，所有高级动作保持关闭。</p>}
                 </section>
 
                 <section className="border-t border-white/10 pt-5" aria-labelledby="worker-questions-heading">
@@ -955,9 +976,9 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
                   </div>
                   {latestCompaction && <p className="mt-3 border-l-2 border-cyan-300/60 pl-3 text-xs leading-5 text-slate-300">上下文已在完整工具边界压缩 · 事件 #{latestCompaction.sequence}</p>}
                   <div className="mt-3 grid gap-2 sm:grid-cols-3">
-                    <button type="button" disabled={busy || !status.capabilities.turn_history || !turnHistory || turnHistory.cursor <= 0 || turnHistory.pending_action !== null} onClick={() => void navigateTurn("undo")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200 disabled:opacity-40">撤销上一回合</button>
-                    <button type="button" disabled={busy || !status.capabilities.turn_history || !turnHistory || turnHistory.cursor >= turnHistory.checkpoints.length || turnHistory.pending_action !== null} onClick={() => void navigateTurn("redo")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200 disabled:opacity-40">重做下一回合</button>
-                    <button type="button" disabled={busy || !status.capabilities.turn_history || !turnHistory || turnHistory.checkpoints.length === 0 || turnHistory.pending_action !== null} onClick={() => void forkTask()} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200 disabled:opacity-40">从当前回合派生任务</button>
+                    <button type="button" disabled={busy || !taskCapabilityAvailable("turn_history") || !turnHistory || turnHistory.cursor <= 0 || turnHistory.pending_action !== null} onClick={() => void navigateTurn("undo")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200 disabled:opacity-40">撤销上一回合</button>
+                    <button type="button" disabled={busy || !taskCapabilityAvailable("turn_history") || !turnHistory || turnHistory.cursor >= turnHistory.checkpoints.length || turnHistory.pending_action !== null} onClick={() => void navigateTurn("redo")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200 disabled:opacity-40">重做下一回合</button>
+                    <button type="button" disabled={busy || !taskCapabilityAvailable("turn_history") || !turnHistory || turnHistory.checkpoints.length === 0 || turnHistory.pending_action !== null} onClick={() => void forkTask()} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200 disabled:opacity-40">从当前回合派生任务</button>
                   </div>
                   <p className="mt-2 text-xs leading-5 text-slate-500">仅回退 Workspace 与公开会话；外部服务副作用不会被撤销。</p>
                 </section>
@@ -994,8 +1015,8 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
             {tab === "diff" && <pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{diff || "工作区还没有变更。"}</pre>}
             {tab === "changesets" && (
               <div className="space-y-3" aria-busy={inspectorLoading}>
-                {!status.capabilities.changesets ? <p className="text-slate-400">原子 changeset 当前关闭。</p> : null}
-                {status.capabilities.changesets && changesets.length === 0 ? <p className="text-slate-400">{inspectorLoading ? "正在读取变更记录。" : "尚无 changeset。"}</p> : null}
+                {!taskCapabilityAvailable("changesets") ? <p className="text-slate-400">原子 changeset 对此任务不可用。</p> : null}
+                {taskCapabilityAvailable("changesets") && changesets.length === 0 ? <p className="text-slate-400">{inspectorLoading ? "正在读取变更记录。" : "尚无 changeset。"}</p> : null}
                 {changesets.map((changeset) => (
                   <section key={changeset.changeset_id} className="rounded-lg bg-white/5 p-3">
                     <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="break-all font-semibold text-white">{changeset.changeset_id}</h3><span className={changeset.state === "applied" ? "text-emerald-300" : "text-amber-200"}>{changeset.state}</span></div>
@@ -1009,8 +1030,8 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
             )}
             {tab === "diagnostics" && (
               <div className="space-y-3" aria-busy={inspectorLoading}>
-                {!status.capabilities.code_intelligence ? <p className="text-slate-400">代码诊断当前关闭。</p> : null}
-                {status.capabilities.code_intelligence && diagnostics.length === 0 ? <p className="text-slate-400">{inspectorLoading ? "正在读取诊断。" : "尚无诊断结果。"}</p> : null}
+                {!taskCapabilityAvailable("code_intelligence") ? <p className="text-slate-400">代码诊断对此任务不可用。</p> : null}
+                {taskCapabilityAvailable("code_intelligence") && diagnostics.length === 0 ? <p className="text-slate-400">{inspectorLoading ? "正在读取诊断。" : "尚无诊断结果。"}</p> : null}
                 {diagnostics.map((snapshot) => (
                   <section key={snapshot.operation_id} className="rounded-lg bg-white/5 p-3">
                     <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="break-all font-semibold text-white">{entries.find((entry) => entry.entry_id === snapshot.entry_id)?.display_path ?? snapshot.entry_id}</h3><span className="text-xs text-slate-400">{snapshot.language}</span></div>
@@ -1024,8 +1045,8 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
             {tab === "terminal" && (
               <div aria-busy={inspectorLoading}>
                 <p className="mb-2 text-xs text-slate-400">输出按 operation 归属并从持久事件补发；刷新页面不会丢失已归档片段。</p>
-                {!status.capabilities.operation_output ? <p className="text-slate-400">终端补发当前关闭。</p> : null}
-                {status.capabilities.operation_output && Object.values(operationOutputs).every((items) => items.length === 0) ? <p className="text-slate-400">{inspectorLoading ? "正在补发终端输出。" : "尚无命令输出。"}</p> : null}
+                {!taskCapabilityAvailable("operation_output") ? <p className="text-slate-400">终端补发对此任务不可用。</p> : null}
+                {taskCapabilityAvailable("operation_output") && Object.values(operationOutputs).every((items) => items.length === 0) ? <p className="text-slate-400">{inspectorLoading ? "正在补发终端输出。" : "尚无命令输出。"}</p> : null}
                 <div className="space-y-3">{Object.entries(operationOutputs).filter(([, chunks]) => chunks.length > 0).map(([operationId, chunks]) => <section key={operationId} className="overflow-hidden rounded-lg bg-slate-950/80"><h3 className="border-b border-white/10 px-3 py-2 break-all text-xs font-semibold text-cyan-100">{operationId}</h3><pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words p-3 text-xs">{chunks.map((chunk) => <span key={chunk.sequence} className={outputTone(chunk.stream)}>{chunk.text}{chunk.truncated ? "\n[输出已截断]\n" : ""}</span>)}</pre></section>)}</div>
               </div>
             )}

--- a/client/src/components/coding-worker/viewModel.ts
+++ b/client/src/components/coding-worker/viewModel.ts
@@ -19,6 +19,12 @@ export interface WorkerActivity {
   operationId: string | null;
 }
 
+interface PendingActivity extends WorkerActivity {
+  groupKey: string;
+  firstSequence: number;
+  count: number;
+}
+
 export const terminalTaskStates = new Set<CodingWorkerTaskState>([
   "completed", "blocked", "failed", "cancelled", "budget_limited", "expired",
 ]);
@@ -110,6 +116,13 @@ function eventTitle(event: CodingWorkerEvent) {
   if (event.type === "subtask_failed") return "子任务执行失败";
   if (event.type === "changeset_merged") return "子任务变更已合并";
   if (event.type === "changeset_conflicted") return "子任务变更存在冲突";
+  if (event.type === "turn_started") return "新回合已开始";
+  if (event.type === "turn_parking") return "当前回合正在安全停车";
+  if (event.type === "turn_parked") return "当前回合已停车";
+  if (event.type === "turn_resumed") return "当前回合已恢复";
+  if (event.type === "turn_completed") return "当前回合已完成";
+  if (event.type === "capability_changed") return "任务能力已更新";
+  if (event.type === "operation_reconciled") return "工具结果已核对";
   if (event.type === "tool_operation") {
     const state = event.payload.state;
     if (state === "completed") return "工具操作已完成";
@@ -122,16 +135,15 @@ function eventTitle(event: CodingWorkerEvent) {
   if (event.type === "acceptance_retry") return "检查未通过，开始修复";
   if (event.type === "steering_queued") return "追加指令已排队";
   if (event.type === "provider_event") {
-    if (event.payload.kind === "plan") return "执行计划已更新";
     if (event.payload.kind === "message") return "Worker 回复";
-    if (event.payload.kind === "tool_call") return "Worker 请求工具";
-    if (event.payload.kind === "turn_completed") return "本轮执行完成";
   }
   return event.type.replaceAll("_", " ");
 }
 
 function eventTone(event: CodingWorkerEvent): WorkerActivityTone {
   const combined = `${event.type} ${String(event.payload.state ?? "")}`;
+  if (/turn_(parking|parked|resumed)|capability_changed/.test(combined)) return "warning";
+  if (/operation_reconciled/.test(combined)) return "success";
   if (/failed|blocked|rejected/.test(combined)) return "danger";
   if (/unknown|approval|interrupted|retry/.test(combined)) return "warning";
   if (/completed|decided|evaluated/.test(combined)) return "success";
@@ -140,22 +152,50 @@ function eventTone(event: CodingWorkerEvent): WorkerActivityTone {
 }
 
 export function activitiesFromEvents(events: CodingWorkerEvent[]): WorkerActivity[] {
-  return events.filter((event) => {
+  const visible = events.filter((event) => {
     if (event.type !== "provider_event") return event.type !== "artifact_created";
-    return event.payload.kind === "message" || event.payload.kind === "turn_completed";
-  }).map((event) => {
+    return event.payload.kind === "message";
+  });
+  const grouped = new Map<string, PendingActivity>();
+  visible.forEach((event) => {
     const operationId = typeof event.payload.operation_id === "string"
       ? event.payload.operation_id
       : null;
-    return {
+    const turnId = typeof event.payload.turn_id === "string" ? event.payload.turn_id : null;
+    const intent = typeof event.payload.intent === "string"
+      ? event.payload.intent
+      : typeof event.payload.capability === "string"
+        ? event.payload.capability
+        : null;
+    const groupKey = operationId
+      ? `operation:${turnId ?? "none"}:${operationId}:${intent ?? "default"}`
+      : turnId && event.type.startsWith("turn_")
+        ? `turn:${turnId}`
+        : `event:${event.sequence}`;
+    const previous = grouped.get(groupKey);
+    const activity: PendingActivity = {
       sequence: event.sequence,
       title: eventTitle(event),
       detail: eventPayloadText(event) ?? eventDetail(event),
-      meta: `#${event.sequence}`,
+      meta: "",
       tone: eventTone(event),
       operationId,
+      groupKey,
+      firstSequence: previous?.firstSequence ?? event.sequence,
+      count: (previous?.count ?? 0) + 1,
     };
+    grouped.set(groupKey, activity);
   });
+  return [...grouped.values()].sort((a, b) => a.sequence - b.sequence).map((activity) => ({
+    sequence: activity.sequence,
+    title: activity.title,
+    detail: activity.detail,
+    meta: activity.count > 1
+      ? `#${activity.firstSequence}–#${activity.sequence} · ${activity.count} 次状态`
+      : `#${activity.sequence}`,
+    tone: activity.tone,
+    operationId: activity.operationId,
+  }));
 }
 
 function eventDetail(event: CodingWorkerEvent) {
@@ -169,6 +209,11 @@ function eventDetail(event: CodingWorkerEvent) {
   }
   if (event.type === "approval_requested") return "一次性审批已进入 Action Center。";
   if (event.type === "approval_decided") return "审批决定已持久保存。";
+  if (event.type === "turn_parking") return "正在停止 Provider 请求并写入精确 checkpoint。";
+  if (event.type === "turn_parked") return "任务已释放执行槽，等待审批、回答或核对结果。";
+  if (event.type === "turn_resumed") return "任务从绑定 Workspace tree 的 checkpoint 继续。";
+  if (event.type === "operation_reconciled") return "原 operation 已完成一次性核对，没有生成新的副作用 ID。";
+  if (event.type === "capability_changed") return "任务固定路由的能力状态已重新观测。";
   if (event.type === "acceptance_evaluated") {
     const evidence = event.payload.evidence;
     if (Array.isArray(evidence)) return `已记录 ${evidence.length} 项检查结果。`;

--- a/client/src/types/codingWorker.ts
+++ b/client/src/types/codingWorker.ts
@@ -71,6 +71,7 @@ export interface CodingWorkerTask {
   pinned: boolean;
   last_event_sequence: number;
   reason: string | null;
+  runtime_protocol: "v16" | "v17";
 }
 
 export interface CodingWorkerEvent {
@@ -107,6 +108,42 @@ export interface CodingWorkerStatus {
   model_routes?: string[];
   reason: string | null;
   capabilities: CodingWorkerCapabilities;
+}
+
+export type CodingWorkerFeatureName =
+  | "task_runtime"
+  | "professional_file_tools"
+  | "shell"
+  | "operation_output"
+  | "changesets"
+  | "code_intelligence"
+  | "structured_plan"
+  | "user_questions"
+  | "context_compaction"
+  | "turn_history"
+  | "subtasks";
+
+export type CodingWorkerCapabilityReason =
+  | "feature_disabled"
+  | "provider_unavailable"
+  | "provider_unsupported"
+  | "provider_binding_changed"
+  | "route_unavailable"
+  | "legacy_task";
+
+export interface CodingWorkerCapabilityStatus {
+  name: CodingWorkerFeatureName;
+  enabled: boolean;
+  supported: boolean;
+  available: boolean;
+  reason: CodingWorkerCapabilityReason | null;
+}
+
+export interface CodingWorkerTaskCapabilities {
+  task_id: string;
+  observed_at: number | null;
+  expires_at: number | null;
+  capabilities: CodingWorkerCapabilityStatus[];
 }
 
 export interface CodingWorkerApproval {
@@ -230,6 +267,18 @@ export interface CodingWorkerPlan {
   items: Array<{
     step: string;
     status: "pending" | "in_progress" | "completed";
+  }>;
+  updated_at: number;
+}
+
+export interface CodingWorkerTodo {
+  task_id: string;
+  sequence: number;
+  turn_id: string;
+  items: Array<{
+    todo_id: string;
+    content: string;
+    status: "pending" | "in_progress" | "completed" | "cancelled";
   }>;
   updated_at: number;
 }

--- a/client/src/utils/codingWorkerApi.ts
+++ b/client/src/utils/codingWorkerApi.ts
@@ -13,7 +13,9 @@ import type {
   CodingWorkerStatus,
   CodingWorkerSubtask,
   CodingWorkerTask,
+  CodingWorkerTaskCapabilities,
   CodingWorkerTaskSpec,
+  CodingWorkerTodo,
   CodingWorkerTurnHistory,
 } from "../types/codingWorker";
 
@@ -71,6 +73,8 @@ const taskEventTypes = [
   "plan_updated", "todo_updated", "question_requested", "question_resolved",
   "context_compacted", "subtask_created", "subtask_completed", "subtask_failed",
   "changeset_merge_started", "changeset_merged", "changeset_conflicted",
+  "turn_started", "turn_parking", "turn_parked", "turn_resumed", "turn_completed",
+  "capability_changed", "operation_reconciled",
 ] as const;
 
 export const getCodingWorkerStatus = () => request<CodingWorkerStatus>(API_ROOT);
@@ -81,6 +85,11 @@ export async function listCodingWorkerTasks() {
 
 export const getCodingWorkerTask = (taskId: string) =>
   request<CodingWorkerTask>(`${API_ROOT}/tasks/${encodeURIComponent(taskId)}`);
+
+export const getCodingWorkerTaskCapabilities = (taskId: string) =>
+  request<CodingWorkerTaskCapabilities>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/capabilities`,
+  );
 
 export const createCodingWorkerTask = (spec: CodingWorkerTaskSpec) =>
   request<CodingWorkerTask>(`${API_ROOT}/tasks`, {
@@ -105,6 +114,11 @@ export const sendCodingWorkerMessage = (taskId: string, message: string) =>
 export const getCodingWorkerPlan = (taskId: string) =>
   request<CodingWorkerPlan | null>(
     `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/plan`,
+  );
+
+export const getCodingWorkerTodo = (taskId: string) =>
+  request<CodingWorkerTodo | null>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/todo`,
   );
 
 export async function listCodingWorkerQuestions(taskId: string) {

--- a/docker-compose.coding-worker-v17-parity.yml
+++ b/docker-compose.coding-worker-v17-parity.yml
@@ -1,0 +1,172 @@
+services:
+  server:
+    environment:
+      CODING_WORKER_PARITY_ENABLED: "true"
+      CODING_WORKER_PARITY_PUBLIC_FIXTURES: /parity/public-fixtures.json
+    volumes:
+      - type: bind
+        source: ./server/tests/fixtures/coding_worker_v17_parity_assets.json
+        target: /parity/public-fixtures.json
+        read_only: true
+
+  coding-worker-parity-native:
+    profiles: [coding-worker-parity]
+    image: modelmirror-coding-worker-v17-parity:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.v14
+    command:
+      - python
+      - -m
+      - coding_worker.parity_sidecar
+      - native-runner
+      - --socket
+      - /run/modelmirror-parity/native.sock
+      - --token
+      - ${CODING_PARITY_NATIVE_TOKEN:?set a random parity native token}
+    networks: [coding_internal]
+    user: "65532:65532"
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    pids_limit: 192
+    mem_limit: 2g
+    cpus: 2.0
+    tmpfs:
+      - /tmp:rw,nosuid,size=256m,uid=65532,gid=65532,mode=0700
+      - /parity/workspaces:rw,nosuid,size=1g,uid=65532,gid=65532,mode=0700
+      - /home/coding:rw,nosuid,size=128m,uid=65532,gid=65532,mode=0700
+    environment:
+      CODING_PARITY_PUBLIC_FIXTURES: /parity/public-fixtures.json
+      CODING_PARITY_WORKSPACE_ROOT: /parity/workspaces
+      CODING_PARITY_EXPORT_ROOT: /parity/exports
+      CODING_PARITY_MODEL_ROUTE: coding/default
+      CODING_PARITY_ROUTE_CATALOG_SHA256: ${CODING_PARITY_ROUTE_CATALOG_SHA256:?set the frozen route catalog digest}
+      CODING_PARITY_ROUTE_RECEIPT_SHA256: ${CODING_PARITY_ROUTE_RECEIPT_SHA256:?set the one-round route receipt digest}
+      CODING_PARITY_MODEL_ID: ${CODING_WORKER_MODEL_ID:?set the controlled model id}
+      CODING_PARITY_MODEL_BASE_URL: ${CODING_WORKER_MODEL_BASE_URL:-http://new-api:3000/v1}
+      CODING_PARITY_ROUTE_KEY: ${CODING_WORKER_ROUTE_KEY:?set the dedicated Worker route key}
+    volumes:
+      - type: bind
+        source: ./server/tests/fixtures/coding_worker_v17_parity_assets.json
+        target: /parity/public-fixtures.json
+        read_only: true
+      - coding_worker_parity_exports:/parity/exports
+      - coding_worker_parity_native_socket:/run/modelmirror-parity
+    restart: "no"
+
+  coding-worker-parity-worker:
+    profiles: [coding-worker-parity]
+    image: modelmirror-coding-worker-v17-parity:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.v14
+    command:
+      - python
+      - -m
+      - coding_worker.parity_sidecar
+      - worker-runner
+      - --socket
+      - /run/modelmirror-parity/worker.sock
+      - --token
+      - ${CODING_PARITY_WORKER_TOKEN:?set a random parity Worker token}
+    networks: [default]
+    user: "65532:65532"
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    pids_limit: 64
+    mem_limit: 512m
+    cpus: 1.0
+    tmpfs:
+      - /tmp:rw,nosuid,size=128m,uid=65532,gid=65532,mode=0700
+    environment:
+      CODING_PARITY_PUBLIC_FIXTURES: /parity/public-fixtures.json
+      CODING_PARITY_EXPORT_ROOT: /parity/exports
+      CODING_PARITY_WORKER_API: http://server:8000
+      CODING_PARITY_MODEL_ROUTE: coding/default
+      CODING_PARITY_ROUTE_CATALOG_SHA256: ${CODING_PARITY_ROUTE_CATALOG_SHA256:?set the frozen route catalog digest}
+      CODING_PARITY_ROUTE_RECEIPT_SHA256: ${CODING_PARITY_ROUTE_RECEIPT_SHA256:?set the one-round route receipt digest}
+    volumes:
+      - type: bind
+        source: ./server/tests/fixtures/coding_worker_v17_parity_assets.json
+        target: /parity/public-fixtures.json
+        read_only: true
+      - coding_worker_parity_exports:/parity/exports
+      - coding_worker_parity_worker_socket:/run/modelmirror-parity
+    restart: "no"
+
+  coding-worker-parity-checker:
+    profiles: [coding-worker-parity]
+    image: modelmirror-coding-worker-v17-parity:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.v14
+    command:
+      - python
+      - -m
+      - coding_worker.parity_sidecar
+      - checker
+      - --socket
+      - /run/modelmirror-parity/checker.sock
+      - --token
+      - ${CODING_PARITY_CHECKER_TOKEN:?set a random parity checker token}
+    network_mode: none
+    user: "65532:65532"
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    pids_limit: 64
+    mem_limit: 512m
+    cpus: 1.0
+    tmpfs:
+      - /tmp:rw,nosuid,size=256m,uid=65532,gid=65532,mode=0700
+    environment:
+      CODING_PARITY_CHECKER_BUNDLE: /parity/checker.bundle
+      CODING_PARITY_EXPORT_ROOT: /parity/exports
+    volumes:
+      - type: bind
+        source: ${CODING_PARITY_CHECKER_BUNDLE:?set the absolute sealed checker bundle}
+        target: /parity/checker.bundle
+        read_only: true
+      - coding_worker_parity_exports:/parity/exports:ro
+      - coding_worker_parity_checker_socket:/run/modelmirror-parity
+    restart: "no"
+
+  coding-worker-parity-controller:
+    profiles: [coding-worker-parity]
+    image: modelmirror-coding-worker-v17-parity:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.v14
+    command: ["sleep", "infinity"]
+    network_mode: none
+    user: "65532:65532"
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    pids_limit: 32
+    mem_limit: 256m
+    cpus: 0.5
+    tmpfs:
+      - /tmp:rw,nosuid,noexec,size=64m,uid=65532,gid=65532,mode=0700
+      - /parity/output:rw,nosuid,noexec,size=256m,uid=65532,gid=65532,mode=0700
+    volumes:
+      - type: bind
+        source: ./server/tests/fixtures/coding_worker_v16_parity.json
+        target: /parity/manifest.json
+        read_only: true
+      - type: bind
+        source: ./server/tests/fixtures/coding_worker_v17_parity_assets.json
+        target: /parity/public-fixtures.json
+        read_only: true
+      - coding_worker_parity_native_socket:/run/modelmirror-parity-native:ro
+      - coding_worker_parity_worker_socket:/run/modelmirror-parity-worker:ro
+      - coding_worker_parity_checker_socket:/run/modelmirror-parity-checker:ro
+    restart: "no"
+
+volumes:
+  coding_worker_parity_exports:
+  coding_worker_parity_native_socket:
+  coding_worker_parity_worker_socket:
+  coding_worker_parity_checker_socket:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -371,3 +371,23 @@ V16 继续使用同一 `/api/coding-worker/v1` 与 `TaskSpec`，新增的是可�
 - 公开会话能力包含 plan/todo、一次性问题回答、完整工具边界 compaction、turn history、undo/redo/fork 与脱敏 export。旧任务没有 turn checkpoint 时保持可读，但不伪造这些控制能力。
 
 这些确定性安全与恢复能力不等于 OpenCode 能力等效。只有固定 24 项任务、两侧各三次、连续两轮真实模型门禁和无 P0/P1 人工验收全部通过后，才允许使用任务卡中唯一的范围限定表述。
+
+## V17 Turn Transaction 与可执行认证边界
+
+V17 为新任务写入 `runtime_protocol=v17`。审批、用户输入、子任务、压缩与未知工具结果不再由通用 Provider 事件推导，而是统一进入持久 Turn Transaction：`open → parking → parked → resuming → completed/interrupted`。屏障出现后，Server 先停止当前 Provider turn、确认无活动请求、写入绑定当前 tree 的 checkpoint，再释放执行槽。只有 durable `parked` 才能结算审批或回答；恢复继续使用原 turn、operation 与 checkpoint，不能换 ID 重放副作用。旧 V16 任务保持原恢复路径，不迁移私有 checkpoint。
+
+任务能力由 `enabled / supported / available / reason` 四元组表达，并绑定任务固定路由、sidecar generation 与短期健康观测。Console 使用任务级 capability、平台 Plan/Todo/Question/Turn/Evidence；Provider 原生 plan、question 或 compaction 帧只作为非权威公开提示，不能改变业务状态。`turn_parking`、`turn_parked`、`turn_resumed` 和 `operation_reconciled` 是状态事件，不是失败。
+
+认证执行面使用独立 profile，并保持四个角色分离：
+
+```mermaid
+flowchart LR
+  C["Controller\n无网络、无隐藏检查"] --> N["Native OpenCode runner\n固定 1.18.9"]
+  C --> W["Worker runner\n正式 Worker API"]
+  N --> A["不透明终态 Workspace Artifact"]
+  W --> A
+  A --> K["Checker\n无网络、唯一挂载密封 bundle"]
+  K --> R["绑定 run/task/tree/check 的 receipt"]
+```
+
+Controller 只能读取公开 manifest、fixture 与三个 Unix socket，不挂载 checker bundle、模型密钥或 Docker socket。Native runner 与 Worker runner 使用不同全新 Workspace/session；checker 是唯一读取隐藏检查正文的进程。公开报告只保存 digest、分类与脱敏 Artifact 清单。确定性 Fake smoke、Compose 展开、CLI 版本探针和本仓库自动测试只能证明协议与隔离结构，不能证明成功率等效。

--- a/docs/CODING_AGENT_INTEGRATION.md
+++ b/docs/CODING_AGENT_INTEGRATION.md
@@ -787,3 +787,21 @@ V16 只做向前兼容扩展，公共事件和响应继续隐藏供应商帧、P
 新增状态为 `waiting_input` 与 `waiting_subtasks`；新增事件包括 plan/todo、question、compaction、subtask 与 changeset merge/conflict。父任务委派后停车并释放槽位；子任务深度固定一、每父任务最多四个，全局执行并发仍为二。模块与浏览器不能提交子 Agent 类型以外的 Provider、系统提示词、权限或 MCP。
 
 Console 的“会话”检查器显示 plan/todo、待回答问题、压缩边界、turn history、undo/redo/fork 和子任务合并状态。冲突时必须明确显示父 Workspace 未被覆盖，并保留子 Fork；任何合并后都由父任务重新执行冻结 AcceptanceContract。
+
+## V17 Turn Transaction 与认证接口
+
+新建 V17 任务后，以下读取面属于平台权威数据；Provider 原生帧不能替代它们：
+
+| 接口 | 用途 |
+| --- | --- |
+| `GET /tasks/{task_id}/capabilities` | 任务固定路由的 `enabled/supported/available/reason` 能力快照；不暴露供应商、版本、端口或凭据 |
+| `GET /tasks/{task_id}/plan` | 平台持久结构化计划 |
+| `GET /tasks/{task_id}/todo` | 平台持久 Todo 与 turn 绑定 |
+| `GET /tasks/{task_id}/questions` | durable parked 后可一次结算的问题 |
+| `POST /tasks/{task_id}/workspace/parity-export` | 仅认证开关启用且任务终态时，导出绑定当前 tree 的不透明 Workspace Artifact |
+
+V17 公共事件新增 `turn_started`、`turn_parking`、`turn_parked`、`turn_resumed`、`turn_completed`、`capability_changed` 与 `operation_reconciled`。Console 按 turn 与 operation intent 聚合尝试、审批、恢复和对账状态；waiting、parking、parked、resuming 都用中立状态提示，不渲染成工具失败。SSE 断线仍按 sequence 补发，Provider 的 `plan/todo/turn_completed` 原生提示不再驱动按钮、计划或完成状态。
+
+Turn Transaction 每个任务最多一个未完成 turn。审批、输入、子任务、压缩或未知结果出现时，Tool Broker 原子创建对应对象并关闭本轮新 operation 接收；后续同批工具调用只得到稳定 `turn_parked` 控制结果。用户只能在 checkpoint 已持久化后的 `parked` 状态结算；任务随后重新排队，从原 checkpoint 和 tree 恢复。acceptance testing 前不得存在运行、待批准或未知 operation。
+
+Parity v2 的公开 fixture、目标和可见检查可进入 runner；隐藏检查正文只能由 checker 的只读密封 bundle 读取。Native OpenCode runner 与 Worker runner 都使用全新 Workspace/session，并把终态 tree 导出为 Artifact；checker 在无网络环境复核 digest 和绑定后执行隐藏检查。Claude 只参与六项真实交互兼容门禁，不进入 OpenCode 成功率差值。

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -653,3 +653,42 @@ CODING_WORKER_DOCUMENTATION_EGRESS_ENABLED=false
 部署前先加载 V14 overlay；需要 Claude 时再按 V15 既定顺序追加 Claude overlay。`config --quiet`、Fake Provider 和容器健康只证明配置/协议，不证明子任务调度或真实模型质量。人工验收至少包括：父任务停车后子任务取得空槽、第三任务仍排队、只读子任务修改被拒、两个非重叠 implement 顺序合并、同文件冲突不覆盖父树、合并后父检查重跑、Server/Provider/Executor 逐个重启、Host Snapshot 经 v13 写回。
 
 真实 24 项 × 两侧 × 三次的 144 次对照与连续两轮认证未通过前，保持 Experimental。回退只关闭上述开关并停止接收新 V16 任务；不得用回退删除持久数据或声称撤销外部副作用。
+
+## Coding Worker V17 与 parity profile
+
+V17 新任务依赖 V16 交互、会话控制和子任务能力，新增开关仍必须写入当前绝对数据根对应的 `server/.env`，默认关闭：
+
+```dotenv
+CODING_WORKER_V17_ENABLED=false
+CODING_WORKER_PARITY_ENABLED=false
+```
+
+关闭 V17 后，新任务回到 V16；已创建的 V17 任务进入 `interrupted` 并保留 Store、Workspace、Turn、Evidence、Artifact 和 v13 Recovery，不降级 checkpoint，也不重放旧 operation。任务级 capability 失败关闭不因回退重新变成全局“可用”。
+
+认证环境只在独立认证 worktree 加载 `docker-compose.coding-worker-v17-parity.yml`，不得加入共享产品栈。运行前必须冻结候选 commit、公开 fixture/manifest、runner image digest、受控 route catalog/receipt digest 和只读密封 checker bundle，并设置彼此不同的随机 RPC token：
+
+```dotenv
+CODING_PARITY_NATIVE_TOKEN=<random>
+CODING_PARITY_WORKER_TOKEN=<random>
+CODING_PARITY_CHECKER_TOKEN=<random>
+CODING_PARITY_ROUTE_CATALOG_SHA256=<sha256>
+CODING_PARITY_ROUTE_RECEIPT_SHA256=<sha256>
+CODING_PARITY_CHECKER_BUNDLE=C:\absolute\path\sealed-checker.bundle
+```
+
+只做配置展开，不启动 runner：
+
+```powershell
+docker compose `
+  -f docker-compose.yml `
+  -f docker-compose.coding-worker-v14.yml `
+  -f docker-compose.coding-worker-v17-parity.yml `
+  -p modelmirror-v17-certification `
+  --profile coding `
+  --profile coding-worker-parity `
+  config --quiet
+```
+
+Native runner 是唯一同时持有受控模型 route key 和原版 OpenCode 1.18.9 的对照进程；Worker runner 只调用正式 Worker API；checker `network_mode:none` 且唯一挂载密封隐藏检查；controller `network_mode:none`，不挂载 hidden bundle、route key、Docker socket 或 Workspace。两个 runner 都只能导出终态不透明 Artifact，checker 复核 run/task/tree/artifact/check 绑定后才执行隐藏检查。
+
+CLI 的 `validate`、Fake `smoke`、`report` 和 `certify` 可以在自动门禁中使用；真实 `run-round` 必须处于发布认证窗口。不同 round 的 run ID 必须不同，两个 round 必须绑定相同 candidate、manifest、route、bundle 和 runner image。当前实现交付时尚未运行两轮共 288 次真实模型认证，也未完成无 P0/P1 的 Console 人工门禁，因此 V17 只能保持 Experimental，禁止使用任何“接近 OpenCode”表述。

--- a/docs/HARNESS_ENGINEERING.md
+++ b/docs/HARNESS_ENGINEERING.md
@@ -438,3 +438,16 @@ curl http://localhost:5173/models
 60. **能力等效只能由冻结真实对照证明。** Fake、确定性 Harness、Compose、CLI 版本探针和单次人工任务均不
     能支持“接近 OpenCode”结论。必须满足任务卡中的 144 次、连续两轮、成功率/时长/token、安全与人工 UX
     全部门禁；任一失败时只能以 Experimental、默认关闭交付。
+61. **交互屏障必须是 Turn Transaction。** approval、input、subtask、compaction 或未知结果出现后，Provider
+    turn 先进入 `parking`，停止活动请求并写入精确 checkpoint；只有 durable `parked` 才能结算。屏障后的同批
+    工具调用不得创建新 operation。恢复只能使用原 turn、operation、tree 与 checkpoint。
+62. **平台数据优先于 Provider 提示。** Plan、Todo、Question、Turn、capability 和 Evidence 由 Store/API 权威
+    提供。Provider 原生 plan/question/compaction 帧只可作为公开提示，不能改变任务状态、开放动作或满足验收。
+63. **任务能力必须实时失败关闭。** `enabled`、`supported`、`available`、`reason` 绑定固定路由、sidecar generation
+    与健康窗口。离线、旧版本、缺工具、开关关闭、绑定改变或旧任务缺快照时不能用全局布尔值误报高级能力。
+64. **认证角色必须隔离。** Controller 不读取隐藏检查、模型 key 或 Workspace；runner 不读取隐藏 bundle；checker
+    无网络且是唯一读取隐藏正文的进程。任何 fixture、bundle、image、route、candidate 或 tree digest 不一致都必须
+    在隐藏检查前拒绝。runner 自报 passed 不能替代 checker receipt。
+65. **两轮认证必须拥有不同运行身份。** 每个 round 的 run ID 纳入 round ID、engine、task 与 attempt；跨 round
+    复用幂等任务是无效认证。两轮必须绑定同一候选、manifest、route、bundle 与 runner image，并连续完成共 288 次
+    真实运行。未运行、部分运行或人工修复过的矩阵不得写成绿色。

--- a/docs/tasks/CODING_WORKER_V17.md
+++ b/docs/tasks/CODING_WORKER_V17.md
@@ -1,0 +1,58 @@
+# V17 真实交互内核与可执行等效认证任务卡
+
+## 交付边界
+
+V17 只收口两项：持久 Turn Transaction 与真实可执行 parity v2。它不升级 Worker 内 OpenCode，不增加 Agent 深度、语言/LSP、Skill/MCP/plugin 注入、remote/push、自动 Provider 切换或分布式调度。
+
+唯一可能使用的认证表述是：
+
+> 在已验收的受控 Python/TypeScript 仓库开发任务上，ModelMirror Coding Worker 的任务成功率与恢复能力接近 OpenCode 1.18.9。
+
+在两轮 288 次真实运行和 Console 人工门禁全部通过前，该表述被禁止。代码、确定性测试与 Compose profile 可以作为 Experimental、默认关闭能力合并，但不能标记 Ready。
+
+## 顺序 PR
+
+| PR | 范围 | 分支/状态 |
+| --- | --- | --- |
+| A | capability 真实性、parity v2 契约、24 项公开 fixture、CLI 基座 | `codex/coding-worker-v17-harness`，Draft PR #199，HEAD `05671d7c` |
+| B | `runtime_protocol=v17`、Turn Transaction、平台 Plan/Todo/Input/Compaction、重启矩阵 | `codex/coding-worker-v17-turn-transactions`，Draft PR #200，HEAD `9342e5f7` |
+| C | 隔离 Native/Worker/checker/controller、终态导出、Console 权威状态、部署与认证封板 | `codex/coding-worker-v17-certification`，本 Draft PR |
+
+每个逻辑提交不超过五个文件；三个 PR 顺序基于前一 PR head，不复用或修改脏主工作树及 V14–V16 工作树。
+
+## PR C 自动证据
+
+- parity runner 与 checker 使用独立 argv/进程，runner request 不含 hidden bundle locator/hash；checker request 不含目标、模型或 Provider。
+- Worker 终态导出是 path-free、确定性 tar，绑定 task、tree、Artifact SHA/size 与预算摘要。
+- parity profile 中 checker/controller 无网络；checker 唯一挂载密封 bundle；controller 不挂载 bundle、route key、Docker socket 或 Workspace。
+- Native 与 Worker runner 都从公开 fixture 构造全新 Workspace；checker 安全解包普通文件并在隐藏检查前复核 run/task/tree/artifact/check 绑定。
+- round ID 进入 seed 与 run ID；不同 round 不会命中同一个幂等 Worker task。
+- Console 从任务 API读取 capability、Plan、Todo、Question、Turn 与 Evidence；Provider 原生 Plan/Todo 不再驱动业务状态。
+
+这些项目必须以实际命令结果填写，不能用代码审查代替：
+
+| 门禁 | 状态 |
+| --- | --- |
+| parity、source adapter、API、sidecar 专项 | PR C 完成前重跑并记录 |
+| 全部 Coding Worker 测试 | 待最终门禁 |
+| Agent Workspace、Coding 与后端全量 | 待最终门禁 |
+| 前端测试、typecheck/build | Console 定向 10/10 与 production build 已通过；全量待最终门禁 |
+| Compose `config --quiet` | V14 + V17 parity 临时配置已通过；最终组合待重跑 |
+| 敏感信息、禁止产物与每提交 ≤5 文件 | 待最终门禁 |
+
+## 真实认证与人工门禁
+
+以下项目在 Draft PR 创建时仍明确未执行：
+
+1. 同一候选、manifest、route、bundle 与 runner image 的两轮完整 144 格，共 288 次真实模型运行。
+2. Worker accepted-run ≥85%、落后原版 ≤5 个百分点、每类 ≥80%，以及原版 2/3 而 Worker 0/3 禁止项。
+3. 安全、原子性、跨任务隔离、重启唯一性 100%，`platform_coordination_failures`、重复副作用、未结算 operation 与孤立 approval/question 全为零。
+4. token 与活动时长中位数不超过原版 1.5 倍；等待批准时间不计入活动时长。
+5. OpenCode 与 Claude 各六项 plan/todo、审批恢复、用户问题、受控压缩、subtask 合并和 Provider/Server 重启真实交互门禁。
+6. Console 脚本化人工验收无 P0/P1；最新 OpenCode 能力差距审计已记录且没有用固定 1.18.9 隐藏新增差距。
+
+任何一项失败、未运行或环境不确定时，V17 继续保持 Experimental，`CODING_WORKER_V17_ENABLED=false` 与 `CODING_WORKER_PARITY_ENABLED=false`，不得宣布等效。
+
+## 回退
+
+关闭 V17 后，新任务回到 V16。已有 V17 任务进入 `interrupted` 并保留 Store、Workspace、Turn、Evidence、Artifact、fork 与 v13 Recovery；不得降级私有 checkpoint、自动重放工具副作用或删除用户数据。capability 的失败关闭是事实性修复，不因回退恢复虚假可用状态。

--- a/scripts/coding_worker_parity.py
+++ b/scripts/coding_worker_parity.py
@@ -267,6 +267,7 @@ def _command_smoke(args: argparse.Namespace) -> int:
         runners=runners,
         candidate_sha=args.candidate_sha,
         model_route_receipt_sha256=args.route_receipt_sha256,
+        round_id=args.round_id,
     )
     payload = _round_result(
         round_id=args.round_id,
@@ -300,6 +301,7 @@ def _command_run_round(args: argparse.Namespace) -> int:
         runners=runners,
         candidate_sha=args.candidate_sha,
         model_route_receipt_sha256=args.route_receipt_sha256,
+        round_id=args.round_id,
     )
     result = _round_result(
         round_id=args.round_id,

--- a/scripts/coding_worker_parity.py
+++ b/scripts/coding_worker_parity.py
@@ -31,7 +31,7 @@ from server.coding_worker.parity import (
 from server.coding_worker.parity_runner import (
     ParityRunRequest,
     ParityRunner,
-    SubprocessParityRunner,
+    SeparatedParityRunner,
     run_parity_matrix,
     run_parity_smoke,
 )
@@ -53,10 +53,12 @@ class RouteCatalogLock(StrictModel):
 class RunnerConfig(StrictModel):
     engine: ParityEngine
     image_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
-    argv: tuple[str, ...] = Field(min_length=1, max_length=32)
+    runner_argv: tuple[str, ...] = Field(min_length=1, max_length=32)
+    checker_argv: tuple[str, ...] = Field(min_length=1, max_length=32)
     timeout_seconds: int = Field(default=7200, ge=30, le=14_400)
+    checker_timeout_seconds: int = Field(default=900, ge=10, le=3600)
 
-    @field_validator("argv")
+    @field_validator("runner_argv", "checker_argv")
     @classmethod
     def validate_argv(cls, value: tuple[str, ...]) -> tuple[str, ...]:
         if any(not item or "\0" in item or len(item) > 2048 for item in value):
@@ -118,6 +120,9 @@ class DeterministicFakeRunner(ParityRunner):
             hidden_checker_bundle_sha256=request.hidden_checker_bundle_sha256,
             runner_image_digest=request.runner_image_digest,
             raw_artifact_manifest_sha256=artifact_sha,
+            checker_receipt_sha256=_canonical_sha256(
+                {"run_id": request.run_id, "checker": "fake-smoke"}
+            ),
             candidate_sha=request.candidate_sha,
             task_manifest_sha256=request.task_manifest_sha256,
             initial_tree_hash=request.initial_tree_hash,
@@ -195,7 +200,7 @@ def _validate_assets(
 
 def _runner_from_config(
     path: Path, engine: ParityEngine, manifest: FrozenParityManifest
-) -> SubprocessParityRunner:
+) -> SeparatedParityRunner:
     config = RunnerConfig.model_validate_json(path.read_text(encoding="utf-8"))
     expected_digest = (
         manifest.runner_images.native_opencode
@@ -204,10 +209,12 @@ def _runner_from_config(
     )
     if config.engine is not engine or config.image_digest != expected_digest:
         raise ValueError("runner configuration binding is invalid")
-    return SubprocessParityRunner(
+    return SeparatedParityRunner(
         engine=engine,
-        argv=config.argv,
+        runner_argv=config.runner_argv,
+        checker_argv=config.checker_argv,
         timeout_seconds=config.timeout_seconds,
+        checker_timeout_seconds=config.checker_timeout_seconds,
     )
 
 

--- a/server/coding_worker/Dockerfile.v14
+++ b/server/coding_worker/Dockerfile.v14
@@ -53,6 +53,7 @@ COPY server/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir --retries 5 --timeout 120 -r /tmp/requirements.txt
 
 COPY server/coding_worker ./coding_worker
+COPY scripts/coding_worker_parity.py ./scripts/coding_worker_parity.py
 COPY server/THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-coding/THIRD_PARTY_NOTICES.md
 
 USER 65532:65532

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 import os
+import tarfile
 from pathlib import PurePosixPath
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
@@ -1084,6 +1086,61 @@ async def workspace_diff(task_id: str) -> Response:
         )
     except Exception as exc:
         _raise_worker_error(exc)
+
+
+@router.post(
+    "/tasks/{task_id}/workspace/parity-export",
+    response_model=WorkerArtifact,
+)
+async def export_parity_workspace(task_id: str) -> WorkerArtifact:
+    """Create an opaque, deterministic terminal Workspace artifact for Checker.
+
+    The endpoint is absent unless the isolated parity profile is enabled. It
+    never exposes a Workspace path and cannot export a still-running task.
+    """
+
+    if not _feature_enabled("CODING_WORKER_PARITY_ENABLED"):
+        raise HTTPException(status_code=404, detail="Not found")
+    service, task = _task_workspace(task_id)
+    try:
+        if task.state not in TERMINAL_STATES:
+            raise WorkerConflictError(
+                "Parity export requires a terminal task.",
+                code="parity_task_not_terminal",
+            )
+        snapshot = service.workspace_broker.capture_snapshot(task.workspace_id)
+        files = service.workspace_broker.snapshot_files(task.workspace_id, snapshot)
+        content = _deterministic_workspace_tar(files)
+        usage = service.store.budget_usage(task_id)
+        return service.store.create_artifact(
+            task_id=task_id,
+            media_type="application/vnd.modelmirror.parity-workspace+tar",
+            content=content,
+            metadata={
+                "kind": "parity_workspace_export",
+                "workspace_tree_hash": snapshot.tree_hash,
+                "file_count": len(files),
+                "active_seconds": usage.active_seconds,
+                "tool_calls": usage.tool_calls,
+                "turns_started": usage.turns_started,
+            },
+        )
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+def _deterministic_workspace_tar(files: tuple[Any, ...]) -> bytes:
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+        for entry in sorted(files, key=lambda item: item.path):
+            info = tarfile.TarInfo(entry.path)
+            info.size = len(entry.content)
+            info.mode = 0o755 if entry.executable else 0o644
+            info.mtime = 0
+            info.uid = info.gid = 0
+            info.uname = info.gname = ""
+            archive.addfile(info, io.BytesIO(entry.content))
+    return output.getvalue()
 
 
 @router.get("/tasks/{task_id}/services/{service_id}/preview/{preview_path:path}")

--- a/server/coding_worker/broker_rpc.py
+++ b/server/coding_worker/broker_rpc.py
@@ -125,6 +125,19 @@ class BrokerRPCServer:
         await writer.wait_closed()
 
     async def _execute(self, request: BrokerRPCRequest) -> ToolResult:
+        task = self.broker.store.get_task(request.task_id)
+        if task.runtime_protocol is RuntimeProtocol.V17 and request.lease_id is None:
+            resumed_leases = self._approved_v17_leases(request)
+            if resumed_leases is not None:
+                lease_id, network_lease_id = resumed_leases
+                return await self.broker.execute(
+                    task_id=request.task_id,
+                    operation_id=request.operation_id,
+                    tool_name=request.tool_name,
+                    arguments=request.arguments,
+                    lease_id=lease_id,
+                    network_lease_id=network_lease_id,
+                )
         try:
             return await self.broker.execute(
                 task_id=request.task_id,
@@ -137,7 +150,6 @@ class BrokerRPCServer:
         except ToolBrokerError as exc:
             if exc.code != "approval_required" or request.lease_id is not None:
                 raise
-        task = self.broker.store.get_task(request.task_id)
         if task.runtime_protocol is RuntimeProtocol.V17:
             operation = self.broker.store.get_operation(request.operation_id)
             return ToolResult(
@@ -155,6 +167,59 @@ class BrokerRPCServer:
             lease_id=lease_id,
             network_lease_id=network_lease_id,
         )
+
+    def _approved_v17_leases(
+        self, request: BrokerRPCRequest
+    ) -> tuple[str, str | None] | None:
+        try:
+            operation = self.broker.store.get_operation(request.operation_id)
+        except Exception as exc:
+            if getattr(exc, "code", None) == "operation_not_found":
+                return None
+            raise
+        if operation.task_id != request.task_id or operation.state is not OperationState.PREPARED:
+            return None
+        required_ids = [request.operation_id]
+        if request.tool_name in {"install_dependencies", "query_documentation"}:
+            required_ids.append(
+                "network_"
+                + hashlib.sha256(request.operation_id.encode("utf-8")).hexdigest()[:32]
+            )
+        approvals = {
+            approval.operation_id: approval
+            for approval in self.broker.store.list_approvals(request.task_id)
+            if approval.operation_id in required_ids
+        }
+        if len(approvals) != len(required_ids):
+            return None
+        if any(
+            approval.status
+            in {
+                ApprovalStatus.REJECTED,
+                ApprovalStatus.CANCELLED,
+                ApprovalStatus.EXPIRED,
+            }
+            for approval in approvals.values()
+        ):
+            self.broker.store.transition_operation(
+                request.operation_id,
+                OperationState.FAILED,
+                result={"code": "approval_rejected"},
+                expected_state=OperationState.PREPARED,
+            )
+            raise BrokerRPCError(
+                "Tool approval was rejected.", code="approval_rejected"
+            )
+        if not all(
+            approval.status is ApprovalStatus.APPROVED and approval.lease is not None
+            for approval in approvals.values()
+        ):
+            return None
+        main = approvals[request.operation_id].lease
+        network = approvals.get(required_ids[1]).lease if len(required_ids) > 1 else None
+        if main is None:
+            return None
+        return main.lease_id, network.lease_id if network is not None else None
 
     async def _wait_for_approval(
         self, request: BrokerRPCRequest

--- a/server/coding_worker/parity.py
+++ b/server/coding_worker/parity.py
@@ -268,6 +268,9 @@ class ParityRunOutcome(StrictModel):
     hidden_checker_bundle_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
     runner_image_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
     raw_artifact_manifest_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    checker_receipt_sha256: str | None = Field(
+        default=None, pattern=r"^[a-f0-9]{64}$"
+    )
     candidate_sha: str = Field(pattern=r"^[a-f0-9]{40}$")
     task_manifest_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
     initial_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
@@ -372,6 +375,8 @@ class ParityReport(StrictModel):
 
     @model_validator(mode="after")
     def validate_matrix(self) -> "ParityReport":
+        if any(run.checker_receipt_sha256 is None for run in self.runs):
+            raise ValueError("parity certification requires sealed checker receipts")
         keys = [(run.engine, run.task_id, run.attempt) for run in self.runs]
         if len(keys) != len(set(keys)):
             raise ValueError("parity run matrix contains duplicate cells")

--- a/server/coding_worker/parity_runner.py
+++ b/server/coding_worker/parity_runner.py
@@ -359,12 +359,14 @@ def run_parity_matrix(
     runners: Mapping[ParityEngine, ParityRunner],
     candidate_sha: str,
     model_route_receipt_sha256: str,
+    round_id: str,
 ) -> tuple[ParityRunOutcome, ...]:
     return _run_cells(
         manifest=manifest,
         runners=runners,
         candidate_sha=candidate_sha,
         model_route_receipt_sha256=model_route_receipt_sha256,
+        round_id=round_id,
         tasks=manifest.tasks,
         attempts=range(1, ATTEMPTS_PER_ENGINE + 1),
     )
@@ -376,6 +378,7 @@ def run_parity_smoke(
     runners: Mapping[ParityEngine, ParityRunner],
     candidate_sha: str,
     model_route_receipt_sha256: str,
+    round_id: str,
 ) -> tuple[ParityRunOutcome, ...]:
     categories: dict[str, FrozenParityTask] = {}
     for task in manifest.tasks:
@@ -385,6 +388,7 @@ def run_parity_smoke(
         runners=runners,
         candidate_sha=candidate_sha,
         model_route_receipt_sha256=model_route_receipt_sha256,
+        round_id=round_id,
         tasks=tuple(categories.values()),
         attempts=(1,),
     )
@@ -396,6 +400,7 @@ def _run_cells(
     runners: Mapping[ParityEngine, ParityRunner],
     candidate_sha: str,
     model_route_receipt_sha256: str,
+    round_id: str,
     tasks: Sequence[FrozenParityTask],
     attempts: Sequence[int] | range,
 ) -> tuple[ParityRunOutcome, ...]:
@@ -413,8 +418,13 @@ def _run_cells(
         for attempt in attempts
         for engine in ParityEngine
     ]
+    if SAFE_ID.fullmatch(round_id) is None:
+        raise ValueError("parity round id is invalid")
     seed = int.from_bytes(
-        bytes.fromhex(manifest_sha)[:16] + bytes.fromhex(candidate_sha)[:16], "big"
+        bytes.fromhex(manifest_sha)[:12]
+        + bytes.fromhex(candidate_sha)[:12]
+        + hashlib.sha256(round_id.encode("utf-8")).digest()[:8],
+        "big",
     )
     random.Random(seed).shuffle(cells)
     outcomes: list[ParityRunOutcome] = []
@@ -427,6 +437,7 @@ def _run_cells(
             candidate_sha=candidate_sha,
             manifest_sha=manifest_sha,
             model_route_receipt_sha256=model_route_receipt_sha256,
+            round_id=round_id,
         )
         outcome = runners[engine].execute(request)
         _assert_bound_outcome(request, outcome)
@@ -443,9 +454,13 @@ def _request_for_cell(
     candidate_sha: str,
     manifest_sha: str,
     model_route_receipt_sha256: str,
+    round_id: str,
 ) -> ParityRunRequest:
+    cell_id = hashlib.sha256(
+        f"{round_id}\0{engine.value}\0{task.task_id}\0{attempt}".encode("utf-8")
+    ).hexdigest()[:32]
     return ParityRunRequest(
-        run_id=f"run_{engine.value}_{task.task_id}_{attempt}",
+        run_id=f"run_{cell_id}",
         task_id=task.task_id,
         engine=engine,
         attempt=attempt,

--- a/server/coding_worker/parity_runner.py
+++ b/server/coding_worker/parity_runner.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import random
 import subprocess
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, TypeVar
 
 from pydantic import Field, field_validator
 
@@ -18,11 +19,14 @@ from .parity import (
     FrozenParityManifest,
     FrozenParityTask,
     ParityEngine,
+    ParityFailureKind,
     ParityRunOutcome,
 )
 
 
 MAX_RUNNER_RESPONSE_BYTES = 1024 * 1024
+MAX_EXPORTED_WORKSPACE_BYTES = 1024 * 1024 * 1024
+ResponseModel = TypeVar("ResponseModel", bound=StrictModel)
 
 
 class ParityRunnerError(RuntimeError):
@@ -56,6 +60,140 @@ class ParityRunRequest(StrictModel):
         if SAFE_ID.fullmatch(value) is None:
             raise ValueError("runner identifiers must be opaque safe ids")
         return value
+
+
+class ParityExecutionRequest(StrictModel):
+    """Runner-visible request with no hidden-check locator or checker digest."""
+
+    protocol: str = PARITY_PROTOCOL
+    run_id: str
+    task_id: str
+    engine: ParityEngine
+    attempt: int = Field(ge=1, le=ATTEMPTS_PER_ENGINE)
+    objective: str = Field(min_length=1, max_length=4096)
+    fixture_id: str
+    fixture_revision: str = Field(pattern=r"^[a-f0-9]{64}$")
+    initial_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    fixture_bundle_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    runner_image_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    model_route_catalog_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    budget: FrozenParityBudget
+    model_route_receipt_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    candidate_sha: str = Field(pattern=r"^[a-f0-9]{40}$")
+    task_manifest_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+
+    @field_validator("run_id", "task_id", "fixture_id")
+    @classmethod
+    def validate_ids(cls, value: str) -> str:
+        if SAFE_ID.fullmatch(value) is None:
+            raise ValueError("runner identifiers must be opaque safe ids")
+        return value
+
+
+class ParityArtifactReference(StrictModel):
+    artifact_id: str
+    sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    size_bytes: int = Field(ge=1, le=MAX_EXPORTED_WORKSPACE_BYTES)
+
+    @field_validator("artifact_id")
+    @classmethod
+    def validate_artifact_id(cls, value: str) -> str:
+        if SAFE_ID.fullmatch(value) is None:
+            raise ValueError("parity artifact id is invalid")
+        return value
+
+
+class ParityExecutionExport(StrictModel):
+    """Untrusted runner result before the sealed checker evaluates it."""
+
+    protocol: str = PARITY_PROTOCOL
+    run_id: str
+    task_id: str
+    engine: ParityEngine
+    attempt: int = Field(ge=1, le=ATTEMPTS_PER_ENGINE)
+    engine_version: str = Field(min_length=1, max_length=128)
+    model_route_receipt_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    fixture_bundle_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    runner_image_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+    candidate_sha: str = Field(pattern=r"^[a-f0-9]{40}$")
+    task_manifest_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    initial_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    final_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    workspace_export: ParityArtifactReference
+    raw_artifact_manifest_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    policy_violations: tuple[str, ...] = Field(default=(), max_length=32)
+    timeout: bool = False
+    budget_limited: bool = False
+    stuck: bool = False
+    manual_repair: bool = False
+    undeclared_side_effect: bool = False
+    input_tokens: int = Field(ge=0)
+    output_tokens: int = Field(ge=0)
+    tool_calls: int = Field(ge=0)
+    active_seconds: float = Field(ge=0)
+
+    @field_validator("run_id", "task_id")
+    @classmethod
+    def validate_ids(cls, value: str) -> str:
+        if SAFE_ID.fullmatch(value) is None:
+            raise ValueError("parity export identifiers are invalid")
+        return value
+
+
+class ParityCheckRequest(StrictModel):
+    """Minimal request visible to the isolated checker.
+
+    It deliberately excludes the objective, model route, provider identity and
+    runner endpoint. The opaque artifact is resolved inside the parity profile.
+    """
+
+    protocol: str = PARITY_PROTOCOL
+    run_id: str
+    task_id: str
+    attempt: int = Field(ge=1, le=ATTEMPTS_PER_ENGINE)
+    hidden_check_bundle_id: str
+    hidden_check_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    hidden_checker_bundle_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    initial_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    final_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    workspace_export: ParityArtifactReference
+
+    @field_validator("run_id", "task_id", "hidden_check_bundle_id")
+    @classmethod
+    def validate_ids(cls, value: str) -> str:
+        if SAFE_ID.fullmatch(value) is None:
+            raise ValueError("parity checker identifiers are invalid")
+        return value
+
+
+class ParityCheckReceipt(StrictModel):
+    protocol: str = PARITY_PROTOCOL
+    run_id: str
+    task_id: str
+    attempt: int = Field(ge=1, le=ATTEMPTS_PER_ENGINE)
+    hidden_check_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    hidden_checker_bundle_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    initial_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    final_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    workspace_export_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    hidden_checks_passed: bool
+    allowed_diff: bool
+
+    @field_validator("run_id", "task_id")
+    @classmethod
+    def validate_ids(cls, value: str) -> str:
+        if SAFE_ID.fullmatch(value) is None:
+            raise ValueError("parity checker receipt identifiers are invalid")
+        return value
+
+    def canonical_sha256(self) -> str:
+        encoded = json.dumps(
+            self.model_dump(mode="json"),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
 
 
 class ParityRunner(Protocol):
@@ -123,6 +261,78 @@ class SubprocessParityRunner:
             outcome = ParityRunOutcome.model_validate_json(stdout)
         except ValueError as exc:
             raise ParityRunnerError("parity runner response is invalid") from exc
+        _assert_bound_outcome(request, outcome)
+        return outcome
+
+
+class SeparatedParityRunner:
+    """Run an untrusted engine and an isolated sealed checker separately.
+
+    The runner receives only ``ParityExecutionRequest``. The checker receives
+    only an opaque exported-workspace reference plus frozen checker bindings.
+    Neither process can self-attest the other process' portion of the result.
+    """
+
+    def __init__(
+        self,
+        *,
+        engine: ParityEngine,
+        runner_argv: Sequence[str],
+        checker_argv: Sequence[str],
+        timeout_seconds: int = 7200,
+        checker_timeout_seconds: int = 900,
+    ) -> None:
+        _validate_argv(runner_argv)
+        _validate_argv(checker_argv)
+        if tuple(runner_argv) == tuple(checker_argv):
+            raise ValueError("runner and checker commands must be independent")
+        if timeout_seconds < 30 or timeout_seconds > 14_400:
+            raise ValueError("runner timeout is invalid")
+        if checker_timeout_seconds < 10 or checker_timeout_seconds > 3600:
+            raise ValueError("checker timeout is invalid")
+        self._engine = engine
+        self._runner_argv = tuple(runner_argv)
+        self._checker_argv = tuple(checker_argv)
+        self._timeout_seconds = timeout_seconds
+        self._checker_timeout_seconds = checker_timeout_seconds
+
+    @property
+    def engine(self) -> ParityEngine:
+        return self._engine
+
+    def execute(self, request: ParityRunRequest) -> ParityRunOutcome:
+        if request.engine is not self.engine:
+            raise ParityRunnerError("runner engine binding is invalid")
+        execution_request = _execution_request(request)
+        execution = _invoke_json_process(
+            argv=self._runner_argv,
+            payload=execution_request.model_dump(mode="json"),
+            response_type=ParityExecutionExport,
+            timeout_seconds=self._timeout_seconds,
+            failure="parity runner",
+        )
+        _assert_bound_export(execution_request, execution)
+
+        check_request = ParityCheckRequest(
+            run_id=request.run_id,
+            task_id=request.task_id,
+            attempt=request.attempt,
+            hidden_check_bundle_id=request.hidden_check_bundle_id,
+            hidden_check_sha256=request.hidden_check_sha256,
+            hidden_checker_bundle_sha256=request.hidden_checker_bundle_sha256,
+            initial_tree_hash=request.initial_tree_hash,
+            final_tree_hash=execution.final_tree_hash,
+            workspace_export=execution.workspace_export,
+        )
+        receipt = _invoke_json_process(
+            argv=self._checker_argv,
+            payload=check_request.model_dump(mode="json"),
+            response_type=ParityCheckReceipt,
+            timeout_seconds=self._checker_timeout_seconds,
+            failure="parity checker",
+        )
+        _assert_bound_receipt(check_request, receipt)
+        outcome = _outcome_from_checked_export(request, execution, receipt)
         _assert_bound_outcome(request, outcome)
         return outcome
 
@@ -275,6 +485,190 @@ def _assert_bound_outcome(
     )
     if observed != expected:
         raise ParityRunnerError("parity outcome binding is invalid")
+
+
+def _execution_request(request: ParityRunRequest) -> ParityExecutionRequest:
+    return ParityExecutionRequest(
+        run_id=request.run_id,
+        task_id=request.task_id,
+        engine=request.engine,
+        attempt=request.attempt,
+        objective=request.objective,
+        fixture_id=request.fixture_id,
+        fixture_revision=request.fixture_revision,
+        initial_tree_hash=request.initial_tree_hash,
+        fixture_bundle_sha256=request.fixture_bundle_sha256,
+        runner_image_digest=request.runner_image_digest,
+        model_route_catalog_sha256=request.model_route_catalog_sha256,
+        budget=request.budget,
+        model_route_receipt_sha256=request.model_route_receipt_sha256,
+        candidate_sha=request.candidate_sha,
+        task_manifest_sha256=request.task_manifest_sha256,
+    )
+
+
+def _assert_bound_export(
+    request: ParityExecutionRequest, result: ParityExecutionExport
+) -> None:
+    expected = (
+        request.run_id,
+        request.task_id,
+        request.engine,
+        request.attempt,
+        request.model_route_receipt_sha256,
+        request.fixture_bundle_sha256,
+        request.runner_image_digest,
+        request.candidate_sha,
+        request.task_manifest_sha256,
+        request.initial_tree_hash,
+    )
+    observed = (
+        result.run_id,
+        result.task_id,
+        result.engine,
+        result.attempt,
+        result.model_route_receipt_sha256,
+        result.fixture_bundle_sha256,
+        result.runner_image_digest,
+        result.candidate_sha,
+        result.task_manifest_sha256,
+        result.initial_tree_hash,
+    )
+    if observed != expected:
+        raise ParityRunnerError("parity export binding is invalid")
+    if (
+        request.engine is ParityEngine.NATIVE_OPENCODE
+        and result.engine_version != "1.18.9"
+    ):
+        raise ParityRunnerError("native parity runner version is invalid")
+
+
+def _assert_bound_receipt(
+    request: ParityCheckRequest, receipt: ParityCheckReceipt
+) -> None:
+    expected = (
+        request.run_id,
+        request.task_id,
+        request.attempt,
+        request.hidden_check_sha256,
+        request.hidden_checker_bundle_sha256,
+        request.initial_tree_hash,
+        request.final_tree_hash,
+        request.workspace_export.sha256,
+    )
+    observed = (
+        receipt.run_id,
+        receipt.task_id,
+        receipt.attempt,
+        receipt.hidden_check_sha256,
+        receipt.hidden_checker_bundle_sha256,
+        receipt.initial_tree_hash,
+        receipt.final_tree_hash,
+        receipt.workspace_export_sha256,
+    )
+    if observed != expected:
+        raise ParityRunnerError("parity checker receipt binding is invalid")
+
+
+def _outcome_from_checked_export(
+    request: ParityRunRequest,
+    execution: ParityExecutionExport,
+    receipt: ParityCheckReceipt,
+) -> ParityRunOutcome:
+    failure_kind: ParityFailureKind | None = None
+    if execution.timeout:
+        failure_kind = ParityFailureKind.TIMEOUT
+    elif execution.budget_limited:
+        failure_kind = ParityFailureKind.BUDGET_LIMITED
+    elif execution.stuck:
+        failure_kind = ParityFailureKind.STUCK
+    elif execution.manual_repair:
+        failure_kind = ParityFailureKind.MANUAL_REPAIR
+    elif execution.undeclared_side_effect:
+        failure_kind = ParityFailureKind.UNDECLARED_SIDE_EFFECT
+    elif execution.policy_violations:
+        failure_kind = ParityFailureKind.POLICY_VIOLATION
+    elif not receipt.hidden_checks_passed:
+        failure_kind = ParityFailureKind.HIDDEN_CHECK
+    elif not receipt.allowed_diff:
+        failure_kind = ParityFailureKind.DIFF_POLICY
+    accepted = failure_kind is None
+    return ParityRunOutcome(
+        run_id=request.run_id,
+        task_id=request.task_id,
+        engine=request.engine,
+        attempt=request.attempt,
+        engine_version=execution.engine_version,
+        model_route_receipt_sha256=request.model_route_receipt_sha256,
+        fixture_bundle_sha256=request.fixture_bundle_sha256,
+        hidden_checker_bundle_sha256=request.hidden_checker_bundle_sha256,
+        runner_image_digest=request.runner_image_digest,
+        raw_artifact_manifest_sha256=execution.raw_artifact_manifest_sha256,
+        checker_receipt_sha256=receipt.canonical_sha256(),
+        candidate_sha=request.candidate_sha,
+        task_manifest_sha256=request.task_manifest_sha256,
+        initial_tree_hash=request.initial_tree_hash,
+        final_tree_hash=execution.final_tree_hash,
+        hidden_checks_passed=receipt.hidden_checks_passed,
+        allowed_diff=receipt.allowed_diff,
+        policy_violations=execution.policy_violations,
+        timeout=execution.timeout,
+        budget_limited=execution.budget_limited,
+        stuck=execution.stuck,
+        manual_repair=execution.manual_repair,
+        undeclared_side_effect=execution.undeclared_side_effect,
+        accepted=accepted,
+        input_tokens=execution.input_tokens,
+        output_tokens=execution.output_tokens,
+        tool_calls=execution.tool_calls,
+        active_seconds=execution.active_seconds,
+        failure_kind=failure_kind,
+    )
+
+
+def _validate_argv(argv: Sequence[str]) -> None:
+    if not argv or len(argv) > 32 or any(
+        not item or "\0" in item or len(item) > 2048 for item in argv
+    ):
+        raise ValueError("runner argv is invalid")
+
+
+def _invoke_json_process(
+    *,
+    argv: Sequence[str],
+    payload: object,
+    response_type: type[ResponseModel],
+    timeout_seconds: int,
+    failure: str,
+) -> ResponseModel:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    try:
+        completed = subprocess.run(
+            list(argv),
+            input=encoded,
+            capture_output=True,
+            check=False,
+            text=True,
+            encoding="utf-8",
+            errors="strict",
+            timeout=timeout_seconds,
+            shell=False,
+            env=_runner_environment(),
+        )
+    except (OSError, subprocess.TimeoutExpired, UnicodeError) as exc:
+        raise ParityRunnerError(f"{failure} is unavailable") from exc
+    stdout = completed.stdout.encode("utf-8")
+    if completed.returncode != 0 or not stdout or len(stdout) > MAX_RUNNER_RESPONSE_BYTES:
+        raise ParityRunnerError(f"{failure} failed")
+    try:
+        return response_type.model_validate_json(stdout)
+    except ValueError as exc:
+        raise ParityRunnerError(f"{failure} response is invalid") from exc
 
 
 def _runner_environment() -> dict[str, str]:

--- a/server/coding_worker/parity_runner.py
+++ b/server/coding_worker/parity_runner.py
@@ -11,7 +11,7 @@ from typing import Protocol, TypeVar
 
 from pydantic import Field, field_validator
 
-from .contracts import SAFE_ID, StrictModel
+from .contracts import SAFE_ID, SAFE_ROUTE, StrictModel
 from .parity import (
     ATTEMPTS_PER_ENGINE,
     PARITY_PROTOCOL,
@@ -49,6 +49,7 @@ class ParityRunRequest(StrictModel):
     hidden_checker_bundle_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
     runner_image_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
     model_route_catalog_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    model_route: str
     budget: FrozenParityBudget
     model_route_receipt_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
     candidate_sha: str = Field(pattern=r"^[a-f0-9]{40}$")
@@ -59,6 +60,13 @@ class ParityRunRequest(StrictModel):
     def validate_ids(cls, value: str) -> str:
         if SAFE_ID.fullmatch(value) is None:
             raise ValueError("runner identifiers must be opaque safe ids")
+        return value
+
+    @field_validator("model_route")
+    @classmethod
+    def validate_route(cls, value: str) -> str:
+        if SAFE_ROUTE.fullmatch(value) is None:
+            raise ValueError("model route is invalid")
         return value
 
 
@@ -77,6 +85,7 @@ class ParityExecutionRequest(StrictModel):
     fixture_bundle_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
     runner_image_digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
     model_route_catalog_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    model_route: str
     budget: FrozenParityBudget
     model_route_receipt_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
     candidate_sha: str = Field(pattern=r"^[a-f0-9]{40}$")
@@ -87,6 +96,13 @@ class ParityExecutionRequest(StrictModel):
     def validate_ids(cls, value: str) -> str:
         if SAFE_ID.fullmatch(value) is None:
             raise ValueError("runner identifiers must be opaque safe ids")
+        return value
+
+    @field_validator("model_route")
+    @classmethod
+    def validate_route(cls, value: str) -> str:
+        if SAFE_ROUTE.fullmatch(value) is None:
+            raise ValueError("model route is invalid")
         return value
 
 
@@ -447,6 +463,7 @@ def _request_for_cell(
             else manifest.runner_images.modelmirror_worker
         ),
         model_route_catalog_sha256=manifest.model_route_catalog_sha256,
+        model_route=manifest.model_route,
         budget=task.budget,
         model_route_receipt_sha256=model_route_receipt_sha256,
         candidate_sha=candidate_sha,
@@ -500,6 +517,7 @@ def _execution_request(request: ParityRunRequest) -> ParityExecutionRequest:
         fixture_bundle_sha256=request.fixture_bundle_sha256,
         runner_image_digest=request.runner_image_digest,
         model_route_catalog_sha256=request.model_route_catalog_sha256,
+        model_route=request.model_route,
         budget=request.budget,
         model_route_receipt_sha256=request.model_route_receipt_sha256,
         candidate_sha=request.candidate_sha,

--- a/server/coding_worker/parity_sidecar.py
+++ b/server/coding_worker/parity_sidecar.py
@@ -1,0 +1,828 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import io
+import json
+import os
+import shlex
+import shutil
+import socket
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import httpx
+
+from .parity import PARITY_PROTOCOL, PublicParityFixture, load_public_fixture_bundle
+from .parity_runner import (
+    MAX_RUNNER_RESPONSE_BYTES,
+    ParityArtifactReference,
+    ParityCheckReceipt,
+    ParityCheckRequest,
+    ParityExecutionExport,
+    ParityExecutionRequest,
+)
+
+
+MAX_RPC_BYTES = 2 * 1024 * 1024
+MAX_BUNDLE_BYTES = 64 * 1024 * 1024
+MAX_ARCHIVE_ENTRIES = 4096
+MAX_ARCHIVE_FILE_BYTES = 16 * 1024 * 1024
+TERMINAL_STATES = {
+    "completed",
+    "blocked",
+    "failed",
+    "cancelled",
+    "budget_limited",
+    "expired",
+}
+
+
+class ParitySidecarError(RuntimeError):
+    pass
+
+
+def _canonical_sha256(payload: object) -> str:
+    encoded = json.dumps(
+        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _required_environment(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value or "\0" in value:
+        raise ParitySidecarError("parity sidecar configuration is incomplete")
+    return value
+
+
+def _safe_child(root: Path, name: str, *, suffix: str = "") -> Path:
+    if not name or any(character not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.:-" for character in name):
+        raise ParitySidecarError("parity artifact identifier is invalid")
+    root = root.resolve()
+    candidate = root / f"{name}{suffix}"
+    if candidate.parent.resolve() != root or candidate.is_symlink():
+        raise ParitySidecarError("parity artifact path is unsafe")
+    return candidate
+
+
+def _load_fixture(request: ParityExecutionRequest) -> PublicParityFixture:
+    bundle = load_public_fixture_bundle(
+        Path(_required_environment("CODING_PARITY_PUBLIC_FIXTURES"))
+    )
+    fixture = next(
+        (item for item in bundle.fixtures if item.fixture_id == request.fixture_id),
+        None,
+    )
+    if (
+        fixture is None
+        or fixture.fixture_revision != request.fixture_revision
+        or fixture.initial_tree_hash != request.initial_tree_hash
+    ):
+        raise ParitySidecarError("parity fixture binding is invalid")
+    return fixture
+
+
+def _assert_route_binding(request: ParityExecutionRequest) -> None:
+    if (
+        request.model_route != _required_environment("CODING_PARITY_MODEL_ROUTE")
+        or request.model_route_catalog_sha256
+        != _required_environment("CODING_PARITY_ROUTE_CATALOG_SHA256")
+        or request.model_route_receipt_sha256
+        != _required_environment("CODING_PARITY_ROUTE_RECEIPT_SHA256")
+    ):
+        raise ParitySidecarError("parity model route binding is invalid")
+
+
+def _materialize_fixture(fixture: PublicParityFixture, repository: Path) -> None:
+    repository.mkdir(parents=True, exist_ok=False)
+    for entry in fixture.files:
+        relative = PurePosixPath(entry.path)
+        destination = repository.joinpath(*relative.parts)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        descriptor = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(entry.content_bytes())
+    environment = {
+        "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        "HOME": str(repository.parent / "home"),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+    (repository.parent / "home").mkdir(mode=0o700)
+    for argv in (
+        ("git", "init", "--quiet", "--initial-branch=parity"),
+        ("git", "add", "--all"),
+        (
+            "git",
+            "-c",
+            "user.name=ModelMirror Parity",
+            "-c",
+            "user.email=parity@modelmirror.local",
+            "commit",
+            "--quiet",
+            "-m",
+            "fixture",
+        ),
+    ):
+        completed = subprocess.run(
+            argv,
+            cwd=repository,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=60,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise ParitySidecarError("parity fixture could not be materialized")
+
+
+def _workspace_files(repository: Path) -> list[tuple[str, bytes, bool]]:
+    files: list[tuple[str, bytes, bool]] = []
+    for current, directories, names in os.walk(repository, topdown=True, followlinks=False):
+        current_path = Path(current)
+        if current_path == repository:
+            directories[:] = [name for name in directories if name != ".git"]
+        directories.sort()
+        for name in directories:
+            if (current_path / name).is_symlink():
+                raise ParitySidecarError("parity workspace contains a link")
+        for name in sorted(names):
+            path = current_path / name
+            if path.is_symlink() or not path.is_file():
+                raise ParitySidecarError("parity workspace entry is unsafe")
+            relative = path.relative_to(repository).as_posix()
+            content = path.read_bytes()
+            if len(content) > MAX_ARCHIVE_FILE_BYTES:
+                raise ParitySidecarError("parity workspace file is too large")
+            executable = bool(path.stat().st_mode & stat.S_IXUSR)
+            files.append((relative, content, executable))
+            if len(files) > MAX_ARCHIVE_ENTRIES:
+                raise ParitySidecarError("parity workspace has too many entries")
+    return files
+
+
+def _tree_hash(files: Sequence[tuple[str, bytes, bool]]) -> str:
+    digest = hashlib.sha256()
+    for relative, content, _executable in sorted(files):
+        encoded = relative.encode("utf-8")
+        digest.update(len(encoded).to_bytes(4, "big"))
+        digest.update(encoded)
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(hashlib.sha256(content).digest())
+    return digest.hexdigest()
+
+
+def _export_workspace(
+    *, run_id: str, repository: Path
+) -> tuple[ParityArtifactReference, str, str]:
+    files = _workspace_files(repository)
+    final_tree_hash = _tree_hash(files)
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+        for relative, content, executable in sorted(files):
+            info = tarfile.TarInfo(relative)
+            info.size = len(content)
+            info.mode = 0o755 if executable else 0o644
+            info.mtime = 0
+            info.uid = info.gid = 0
+            info.uname = info.gname = ""
+            archive.addfile(info, io.BytesIO(content))
+    content = output.getvalue()
+    digest = hashlib.sha256(content).hexdigest()
+    artifact_id = f"export_{hashlib.sha256(f'{run_id}:{digest}'.encode()).hexdigest()[:32]}"
+    root = Path(_required_environment("CODING_PARITY_EXPORT_ROOT"))
+    root.mkdir(parents=True, exist_ok=True)
+    destination = _safe_child(root, artifact_id, suffix=".tar")
+    temporary = _safe_child(root, f".{artifact_id}.building")
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+    manifest_sha = _canonical_sha256(
+        {
+            "artifact_id": artifact_id,
+            "sha256": digest,
+            "size": len(content),
+            "tree_hash": final_tree_hash,
+        }
+    )
+    return (
+        ParityArtifactReference(
+            artifact_id=artifact_id, sha256=digest, size_bytes=len(content)
+        ),
+        final_tree_hash,
+        manifest_sha,
+    )
+
+
+def _opencode_configuration(fixture: PublicParityFixture) -> dict[str, Any]:
+    model_id = _required_environment("CODING_PARITY_MODEL_ID")
+    allowed_commands = {"*": "deny"}
+    for check in fixture.visible_checks:
+        allowed_commands[shlex.join(check.argv)] = "allow"
+        allowed_commands[" ".join(check.argv)] = "allow"
+    permission: dict[str, Any] = {
+        "*": "deny",
+        "read": "allow",
+        "edit": "allow",
+        "glob": "allow",
+        "grep": "allow",
+        "list": "allow",
+        "lsp": "allow",
+        "bash": allowed_commands,
+        "task": "allow",
+        "todowrite": "allow",
+        "question": "deny",
+        "external_directory": "deny",
+        "webfetch": "deny",
+        "websearch": "deny",
+        "skill": "deny",
+    }
+    return {
+        "$schema": "https://opencode.ai/config.json",
+        "model": f"modelmirror/{model_id}",
+        "permission": permission,
+        "provider": {
+            "modelmirror": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "ModelMirror parity route",
+                "options": {
+                    "baseURL": _required_environment("CODING_PARITY_MODEL_BASE_URL"),
+                    "apiKey": "{env:CODING_PARITY_ROUTE_KEY}",
+                },
+                "models": {model_id: {"name": "Controlled parity model"}},
+            }
+        },
+        "plugin": [],
+        "mcp": {},
+        "instructions": [],
+        "share": "disabled",
+        "autoupdate": False,
+    }
+
+
+def _extract_usage(payload: object) -> tuple[int, int]:
+    best = (0, 0)
+    if isinstance(payload, dict):
+        usage = payload.get("usage")
+        if isinstance(usage, dict):
+            raw_input = usage.get("input_tokens", usage.get("inputTokens", 0))
+            raw_output = usage.get("output_tokens", usage.get("outputTokens", 0))
+            if isinstance(raw_input, int) and isinstance(raw_output, int):
+                best = (max(0, raw_input), max(0, raw_output))
+        for value in payload.values():
+            nested = _extract_usage(value)
+            if sum(nested) > sum(best):
+                best = nested
+    elif isinstance(payload, list):
+        for value in payload:
+            nested = _extract_usage(value)
+            if sum(nested) > sum(best):
+                best = nested
+    return best
+
+
+def _native_runner(request: ParityExecutionRequest) -> ParityExecutionExport:
+    _assert_route_binding(request)
+    fixture = _load_fixture(request)
+    runtime_root = Path(_required_environment("CODING_PARITY_WORKSPACE_ROOT"))
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    started = time.monotonic()
+    input_tokens = output_tokens = tool_calls = 0
+    timed_out = False
+    with tempfile.TemporaryDirectory(prefix="native-", dir=runtime_root) as temporary:
+        root = Path(temporary)
+        repository = root / "repo"
+        _materialize_fixture(fixture, repository)
+        version = subprocess.run(
+            ("opencode", "--version"),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if version.returncode != 0 or version.stdout.strip() != "1.18.9":
+            raise ParitySidecarError("native OpenCode version is not pinned")
+        home = root / "opencode-home"
+        home.mkdir(mode=0o700)
+        environment = {
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(home / ".config"),
+            "XDG_DATA_HOME": str(home / ".local/share"),
+            "XDG_STATE_HOME": str(home / ".local/state"),
+            "XDG_CACHE_HOME": str(home / ".cache"),
+            "OPENCODE_CONFIG_CONTENT": json.dumps(
+                _opencode_configuration(fixture), separators=(",", ":")
+            ),
+            "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
+            "OPENCODE_PURE": "1",
+            "OPENCODE_DISABLE_AUTOUPDATE": "1",
+            "OPENCODE_DISABLE_AUTOCOMPACT": "1",
+            "OPENCODE_DISABLE_MODELS_FETCH": "1",
+            "OPENCODE_AUTH_CONTENT": "{}",
+            "CODING_PARITY_ROUTE_KEY": _required_environment(
+                "CODING_PARITY_ROUTE_KEY"
+            ),
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+        }
+        try:
+            completed = subprocess.run(
+                (
+                    "opencode",
+                    "run",
+                    "--format",
+                    "json",
+                    "--dir",
+                    str(repository),
+                    request.objective,
+                ),
+                cwd=repository,
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="strict",
+                timeout=request.budget.max_active_seconds,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            completed = None
+        if completed is not None:
+            if len(completed.stdout.encode("utf-8")) > request.budget.max_output_bytes:
+                raise ParitySidecarError("native OpenCode output exceeded budget")
+            for line in completed.stdout.splitlines():
+                try:
+                    event = json.loads(line)
+                except ValueError:
+                    continue
+                if isinstance(event, dict) and event.get("type") == "tool_use":
+                    tool_calls += 1
+                observed = _extract_usage(event)
+                if sum(observed) > input_tokens + output_tokens:
+                    input_tokens, output_tokens = observed
+        artifact, final_tree, artifact_manifest = _export_workspace(
+            run_id=request.run_id, repository=repository
+        )
+        return ParityExecutionExport(
+            run_id=request.run_id,
+            task_id=request.task_id,
+            engine=request.engine,
+            attempt=request.attempt,
+            engine_version="1.18.9",
+            model_route_receipt_sha256=request.model_route_receipt_sha256,
+            fixture_bundle_sha256=request.fixture_bundle_sha256,
+            runner_image_digest=request.runner_image_digest,
+            candidate_sha=request.candidate_sha,
+            task_manifest_sha256=request.task_manifest_sha256,
+            initial_tree_hash=request.initial_tree_hash,
+            final_tree_hash=final_tree,
+            workspace_export=artifact,
+            raw_artifact_manifest_sha256=artifact_manifest,
+            timeout=timed_out,
+            stuck=(completed is not None and completed.returncode != 0),
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            tool_calls=tool_calls,
+            active_seconds=time.monotonic() - started,
+        )
+
+
+def _approval_allowed(approval: Mapping[str, Any], fixture: PublicParityFixture) -> bool:
+    request = approval.get("request")
+    if not isinstance(request, dict):
+        return False
+    allowed = {tuple(check.argv) for check in fixture.visible_checks}
+    argv = request.get("argv")
+    if isinstance(argv, list) and all(isinstance(item, str) for item in argv):
+        return tuple(argv) in allowed
+    script_sha256 = request.get("script_sha256")
+    if isinstance(script_sha256, str):
+        digests = {
+            hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+            for command in allowed
+            for rendered in (shlex.join(command), " ".join(command))
+        }
+        return script_sha256 in digests
+    return False
+
+
+def _worker_runner(request: ParityExecutionRequest) -> ParityExecutionExport:
+    _assert_route_binding(request)
+    fixture = _load_fixture(request)
+    server = _required_environment("CODING_PARITY_WORKER_API").rstrip("/")
+    started = time.monotonic()
+    deadline = started + request.budget.max_active_seconds + 900
+    with httpx.Client(base_url=server, timeout=30.0, trust_env=False) as client:
+        task_response = client.post(
+            "/api/coding-worker/v1/tasks",
+            json={
+                "client_task_id": request.run_id,
+                "objective": request.objective,
+                "workspace_source": {
+                    "kind": "builtin",
+                    "source_id": request.fixture_id,
+                    "revision": request.fixture_revision,
+                },
+                "acceptance": {
+                    "contract_id": f"parity_{request.task_id}",
+                    "required_checks": [
+                        {
+                            "check_id": check.check_id,
+                            "label": check.check_id,
+                            "kind": "command",
+                            "required": True,
+                        }
+                        for check in fixture.visible_checks
+                    ],
+                    "required_artifacts": [],
+                },
+                "policy_profile": "develop",
+                "model_route": request.model_route,
+                "budget": {
+                    "max_seconds": request.budget.max_active_seconds,
+                    "max_turns": request.budget.max_turns,
+                    "max_tool_calls": 2048,
+                    "max_output_bytes": request.budget.max_output_bytes,
+                },
+                "context_refs": [],
+            },
+        )
+        task_response.raise_for_status()
+        task = task_response.json()
+        task_id = str(task["task_id"])
+        rejected = False
+        while str(task.get("state")) not in TERMINAL_STATES:
+            if time.monotonic() >= deadline:
+                client.post(f"/api/coding-worker/v1/tasks/{task_id}/cancel")
+                break
+            if task.get("state") == "waiting_approval":
+                approvals = client.get(
+                    f"/api/coding-worker/v1/tasks/{task_id}/approvals"
+                ).json().get("approvals", [])
+                for approval in approvals:
+                    if approval.get("status") != "pending":
+                        continue
+                    allowed = _approval_allowed(approval, fixture)
+                    rejected = rejected or not allowed
+                    client.post(
+                        f"/api/coding-worker/v1/tasks/{task_id}/approvals",
+                        json={
+                            "approval_id": approval["approval_id"],
+                            "decision": "approve_once" if allowed else "reject",
+                            "ttl_seconds": 900,
+                        },
+                    ).raise_for_status()
+            elif task.get("state") == "waiting_input":
+                rejected = True
+                client.post(f"/api/coding-worker/v1/tasks/{task_id}/cancel")
+            elif task.get("state") == "interrupted":
+                client.post(f"/api/coding-worker/v1/tasks/{task_id}/resume").raise_for_status()
+            time.sleep(0.25)
+            task_response = client.get(f"/api/coding-worker/v1/tasks/{task_id}")
+            task_response.raise_for_status()
+            task = task_response.json()
+        export_response = client.post(
+            f"/api/coding-worker/v1/tasks/{task_id}/workspace/parity-export"
+        )
+        export_response.raise_for_status()
+        artifact_meta = export_response.json()
+        content_response = client.get(
+            f"/api/coding-worker/v1/tasks/{task_id}/artifacts/{artifact_meta['artifact_id']}"
+        )
+        content_response.raise_for_status()
+        content = content_response.content
+        digest = hashlib.sha256(content).hexdigest()
+        if digest != artifact_meta["sha256"] or len(content) != artifact_meta["size"]:
+            raise ParitySidecarError("Worker parity artifact binding is invalid")
+        artifact_id = f"export_{hashlib.sha256(f'{request.run_id}:{digest}'.encode()).hexdigest()[:32]}"
+        root = Path(_required_environment("CODING_PARITY_EXPORT_ROOT"))
+        root.mkdir(parents=True, exist_ok=True)
+        destination = _safe_child(root, artifact_id, suffix=".tar")
+        temporary = _safe_child(root, f".{artifact_id}.building")
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+        metadata = artifact_meta.get("metadata", {})
+        final_tree = str(metadata.get("workspace_tree_hash", ""))
+        usage = client.get(f"/api/coding-worker/v1/tasks/{task_id}/export").json()
+        input_tokens, output_tokens = _extract_usage(usage)
+        raw_manifest = _canonical_sha256(
+            {
+                "artifact_id": artifact_id,
+                "sha256": digest,
+                "size": len(content),
+                "tree_hash": final_tree,
+                "worker_artifact_id": artifact_meta["artifact_id"],
+            }
+        )
+        return ParityExecutionExport(
+            run_id=request.run_id,
+            task_id=request.task_id,
+            engine=request.engine,
+            attempt=request.attempt,
+            engine_version=request.candidate_sha,
+            model_route_receipt_sha256=request.model_route_receipt_sha256,
+            fixture_bundle_sha256=request.fixture_bundle_sha256,
+            runner_image_digest=request.runner_image_digest,
+            candidate_sha=request.candidate_sha,
+            task_manifest_sha256=request.task_manifest_sha256,
+            initial_tree_hash=request.initial_tree_hash,
+            final_tree_hash=final_tree,
+            workspace_export=ParityArtifactReference(
+                artifact_id=artifact_id, sha256=digest, size_bytes=len(content)
+            ),
+            raw_artifact_manifest_sha256=raw_manifest,
+            policy_violations=("unapproved_command_requested",) if rejected else (),
+            timeout=time.monotonic() >= deadline,
+            budget_limited=task.get("state") == "budget_limited",
+            stuck=task.get("state") not in {"completed", "blocked", "budget_limited"},
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            tool_calls=int(metadata.get("tool_calls", 0)),
+            active_seconds=float(metadata.get("active_seconds", 0.0)),
+        )
+
+
+def _safe_extract_tar(content: bytes, destination: Path) -> None:
+    total = 0
+    with tarfile.open(fileobj=io.BytesIO(content), mode="r:") as archive:
+        members = archive.getmembers()
+        if len(members) > MAX_ARCHIVE_ENTRIES:
+            raise ParitySidecarError("parity archive has too many entries")
+        for member in members:
+            relative = PurePosixPath(member.name)
+            if (
+                not member.isfile()
+                or relative.is_absolute()
+                or any(part in {"", ".", ".."} for part in relative.parts)
+                or member.size < 0
+                or member.size > MAX_ARCHIVE_FILE_BYTES
+            ):
+                raise ParitySidecarError("parity archive entry is unsafe")
+            total += member.size
+            if total > MAX_BUNDLE_BYTES:
+                raise ParitySidecarError("parity archive is too large")
+            source = archive.extractfile(member)
+            if source is None:
+                raise ParitySidecarError("parity archive entry is unavailable")
+            target = destination.joinpath(*relative.parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            descriptor = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o700 if member.mode & 0o111 else 0o600)
+            with os.fdopen(descriptor, "wb") as handle:
+                shutil.copyfileobj(source, handle, length=1024 * 1024)
+
+
+def _checker(request: ParityCheckRequest) -> ParityCheckReceipt:
+    bundle_path = Path(_required_environment("CODING_PARITY_CHECKER_BUNDLE"))
+    bundle_content = bundle_path.read_bytes()
+    if (
+        len(bundle_content) > MAX_BUNDLE_BYTES
+        or hashlib.sha256(bundle_content).hexdigest()
+        != request.hidden_checker_bundle_sha256
+    ):
+        raise ParitySidecarError("sealed checker bundle binding is invalid")
+    export_root = Path(_required_environment("CODING_PARITY_EXPORT_ROOT"))
+    export_path = _safe_child(
+        export_root, request.workspace_export.artifact_id, suffix=".tar"
+    )
+    export_content = export_path.read_bytes()
+    if (
+        len(export_content) != request.workspace_export.size_bytes
+        or hashlib.sha256(export_content).hexdigest()
+        != request.workspace_export.sha256
+    ):
+        raise ParitySidecarError("parity workspace export binding is invalid")
+    with tempfile.TemporaryDirectory(prefix="checker-") as temporary:
+        root = Path(temporary)
+        bundle_root = root / "bundle"
+        workspace = root / "workspace"
+        bundle_root.mkdir()
+        workspace.mkdir()
+        _safe_extract_tar(bundle_content, bundle_root)
+        _safe_extract_tar(export_content, workspace)
+        if _tree_hash(_workspace_files(workspace)) != request.final_tree_hash:
+            raise ParitySidecarError("checker workspace tree binding is invalid")
+        try:
+            manifest = json.loads(
+                (bundle_root / "checks.json").read_text(encoding="utf-8")
+            )
+            spec = manifest["checks"][request.hidden_check_bundle_id]
+        except (OSError, KeyError, TypeError, ValueError) as exc:
+            raise ParitySidecarError("sealed checker manifest is invalid") from exc
+        if not isinstance(spec, dict) or _canonical_sha256(spec) != request.hidden_check_sha256:
+            raise ParitySidecarError("hidden check binding is invalid")
+        check_argv = spec.get("check_argv")
+        diff_argv = spec.get("diff_argv")
+        cwd = spec.get("cwd", ".")
+        timeout_seconds = spec.get("timeout_seconds", 900)
+        if (
+            not isinstance(check_argv, list)
+            or not check_argv
+            or not all(isinstance(item, str) and item and "\0" not in item for item in check_argv)
+            or not isinstance(diff_argv, list)
+            or not diff_argv
+            or not all(isinstance(item, str) and item and "\0" not in item for item in diff_argv)
+            or not isinstance(cwd, str)
+            or PurePosixPath(cwd).is_absolute()
+            or ".." in PurePosixPath(cwd).parts
+            or not isinstance(timeout_seconds, int)
+            or not 1 <= timeout_seconds <= 1800
+        ):
+            raise ParitySidecarError("hidden check command is invalid")
+        check_cwd = workspace.joinpath(*PurePosixPath(cwd).parts).resolve()
+        if not check_cwd.is_relative_to(workspace.resolve()) or not check_cwd.is_dir():
+            raise ParitySidecarError("hidden check cwd is invalid")
+        environment = {
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "HOME": str(root / "home"),
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "NO_PROXY": "*",
+        }
+        (root / "home").mkdir(mode=0o700)
+        check = subprocess.run(
+            check_argv,
+            cwd=check_cwd,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        diff = subprocess.run(
+            diff_argv,
+            cwd=check_cwd,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        return ParityCheckReceipt(
+            run_id=request.run_id,
+            task_id=request.task_id,
+            attempt=request.attempt,
+            hidden_check_sha256=request.hidden_check_sha256,
+            hidden_checker_bundle_sha256=request.hidden_checker_bundle_sha256,
+            initial_tree_hash=request.initial_tree_hash,
+            final_tree_hash=request.final_tree_hash,
+            workspace_export_sha256=request.workspace_export.sha256,
+            hidden_checks_passed=check.returncode == 0,
+            allowed_diff=diff.returncode == 0,
+        )
+
+
+def _read_line(connection: socket.socket) -> bytes:
+    chunks = bytearray()
+    while len(chunks) <= MAX_RPC_BYTES:
+        block = connection.recv(min(65_536, MAX_RPC_BYTES + 1 - len(chunks)))
+        if not block:
+            break
+        chunks.extend(block)
+        if b"\n" in block:
+            break
+    line, separator, remainder = bytes(chunks).partition(b"\n")
+    if not separator or remainder or not line or len(line) > MAX_RPC_BYTES:
+        raise ParitySidecarError("parity RPC request is invalid")
+    return line
+
+
+def _serve(
+    *,
+    socket_path: Path,
+    token: str,
+    request_type: type[ParityExecutionRequest] | type[ParityCheckRequest],
+    handler: Callable[[Any], Any],
+) -> None:
+    if len(token) < 32:
+        raise ParitySidecarError("parity RPC token is invalid")
+    socket_path.parent.mkdir(parents=True, exist_ok=True)
+    socket_path.unlink(missing_ok=True)
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(str(socket_path))
+    socket_path.chmod(0o600)
+    server.listen(4)
+    try:
+        while True:
+            connection, _address = server.accept()
+            with connection:
+                try:
+                    envelope = json.loads(_read_line(connection))
+                    if (
+                        not isinstance(envelope, dict)
+                        or not hmac.compare_digest(str(envelope.get("token", "")), token)
+                    ):
+                        raise ParitySidecarError("parity RPC authentication failed")
+                    request = request_type.model_validate(envelope.get("payload"))
+                    result = handler(request)
+                    response = {"ok": True, "result": result.model_dump(mode="json")}
+                except Exception as exc:
+                    response = {
+                        "ok": False,
+                        "error": getattr(exc, "code", "parity_sidecar_failed"),
+                    }
+                connection.sendall(
+                    json.dumps(response, separators=(",", ":")).encode("utf-8") + b"\n"
+                )
+    finally:
+        server.close()
+        socket_path.unlink(missing_ok=True)
+
+
+def _rpc_client(socket_path: Path, token: str) -> None:
+    payload = sys.stdin.buffer.read(MAX_RPC_BYTES + 1)
+    if not payload or len(payload) > MAX_RPC_BYTES:
+        raise ParitySidecarError("parity RPC payload is invalid")
+    envelope = json.dumps(
+        {"token": token, "payload": json.loads(payload)}, separators=(",", ":")
+    ).encode("utf-8") + b"\n"
+    connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    connection.settimeout(14_400)
+    connection.connect(str(socket_path))
+    connection.sendall(envelope)
+    response = json.loads(_read_line(connection))
+    connection.close()
+    if response.get("ok") is not True:
+        raise ParitySidecarError("parity sidecar request failed")
+    encoded = json.dumps(response["result"], separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_RUNNER_RESPONSE_BYTES:
+        raise ParitySidecarError("parity sidecar response is too large")
+    sys.stdout.buffer.write(encoded)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="ModelMirror parity sidecar")
+    subparsers = parser.add_subparsers(dest="role", required=True)
+    for role in ("native-runner", "worker-runner", "checker"):
+        command = subparsers.add_parser(role)
+        command.add_argument("--socket", type=Path, required=True)
+        command.add_argument("--token", required=True)
+    client = subparsers.add_parser("rpc-client")
+    client.add_argument("--socket", type=Path, required=True)
+    client.add_argument("--token", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    try:
+        if arguments.role == "rpc-client":
+            _rpc_client(arguments.socket, arguments.token)
+        elif arguments.role == "native-runner":
+            _serve(
+                socket_path=arguments.socket,
+                token=arguments.token,
+                request_type=ParityExecutionRequest,
+                handler=_native_runner,
+            )
+        elif arguments.role == "worker-runner":
+            _serve(
+                socket_path=arguments.socket,
+                token=arguments.token,
+                request_type=ParityExecutionRequest,
+                handler=_worker_runner,
+            )
+        else:
+            _serve(
+                socket_path=arguments.socket,
+                token=arguments.token,
+                request_type=ParityCheckRequest,
+                handler=_checker,
+            )
+        return 0
+    except (OSError, ValueError, ParitySidecarError, httpx.HTTPError) as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/coding_worker/provider_rpc.py
+++ b/server/coding_worker/provider_rpc.py
@@ -24,6 +24,7 @@ from .executor import ExecutorSidecarClientPool, SidecarExecutor
 
 
 MAX_PROVIDER_RPC_BYTES = 8 * 1024 * 1024
+_CLIENT_DISCONNECTED = (BrokenPipeError, ConnectionAbortedError, ConnectionResetError)
 
 
 class ProviderRPCError(RuntimeError):
@@ -133,22 +134,32 @@ class ProviderRPCServer:
                 return
             result = await self._dispatch(request)
             await self._write(writer, {"ok": True, "result": result})
+        except _CLIENT_DISCONNECTED:
+            # Parking a turn closes the streaming client deliberately.  The
+            # provider may observe that close between yielding an event and
+            # draining it; it is a normal cancellation boundary, not a
+            # sidecar failure that should be written back to a dead socket.
+            return
         except Exception as exc:
-            await self._write(
-                writer,
-                {
-                    "ok": False,
-                    "error": {
-                        "code": getattr(exc, "code", "provider_failed"),
-                        "message": str(exc)
-                        if isinstance(exc, (ProviderRPCError, ValueError))
-                        else "Provider request failed.",
+            with contextlib.suppress(*_CLIENT_DISCONNECTED):
+                await self._write(
+                    writer,
+                    {
+                        "ok": False,
+                        "error": {
+                            "code": getattr(exc, "code", "provider_failed"),
+                            "message": str(exc)
+                            if isinstance(exc, (ProviderRPCError, ValueError))
+                            else "Provider request failed.",
+                        },
                     },
-                },
-            )
+                )
         finally:
             writer.close()
-            with contextlib.suppress(Exception):
+            with contextlib.suppress(
+                asyncio.TimeoutError,
+                *_CLIENT_DISCONNECTED,
+            ):
                 await asyncio.wait_for(writer.wait_closed(), timeout=1)
             if current is not None:
                 self._connections.pop(current, None)

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -14,7 +14,11 @@ from .provider_rpc import ProviderSidecarClientPool
 from .service import CodingWorkerService
 from .store import CodingWorkerStore, DEFAULT_RETENTION_SECONDS
 from .tool_broker import FrozenCheck, ToolBroker
-from .workspace import WorkspaceBroker, WorkspaceSourceAdapter
+from .workspace import (
+    InMemoryWorkspaceSourceAdapter,
+    WorkspaceBroker,
+    WorkspaceSourceAdapter,
+)
 from .source_adapters import (
     BuiltinGitWorkspaceSourceAdapter,
     HostSnapshotWorkspaceSourceAdapter,
@@ -283,6 +287,7 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         if value.strip()
     )
     source_adapters = dict(_SOURCE_ADAPTERS)
+    frozen_checks = {**_DEFAULT_FROZEN_CHECKS, **_FROZEN_CHECKS}
     builtin_root = os.getenv("CODING_WORKER_BUILTIN_SOURCE_ROOT")
     builtin_revision = os.getenv("CODING_WORKER_BUILTIN_REVISION")
     if bool(builtin_root) != bool(builtin_revision):
@@ -290,7 +295,37 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
             "Builtin Worker source configuration is incomplete.",
             code="coding_worker_config_invalid",
         )
-    if builtin_root and builtin_revision:
+    parity_enabled = os.getenv("CODING_WORKER_PARITY_ENABLED", "false").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    parity_assets = os.getenv("CODING_WORKER_PARITY_PUBLIC_FIXTURES")
+    if parity_enabled != bool(parity_assets):
+        raise CodingWorkerRuntimeError(
+            "Parity fixture configuration is incomplete.",
+            code="coding_worker_config_invalid",
+        )
+    if parity_enabled and (builtin_root or builtin_revision):
+        raise CodingWorkerRuntimeError(
+            "Parity fixtures cannot replace a configured builtin source.",
+            code="coding_worker_config_invalid",
+        )
+    if parity_enabled and parity_assets:
+        parity_adapter, parity_checks = _load_parity_public_fixtures(
+            Path(parity_assets)
+        )
+        source_adapters.setdefault("builtin", parity_adapter)
+        for check_id, check in parity_checks.items():
+            existing = frozen_checks.get(check_id)
+            if existing is not None and existing != check:
+                raise CodingWorkerRuntimeError(
+                    "Parity check conflicts with a frozen check.",
+                    code="coding_worker_config_invalid",
+                )
+            frozen_checks[check_id] = check
+    elif builtin_root and builtin_revision:
         source_adapters.setdefault(
             "builtin",
             BuiltinGitWorkspaceSourceAdapter(
@@ -336,7 +371,7 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         storage_root=root,
         slot_roots=slot_roots,
         source_adapters=source_adapters,
-        frozen_checks={**_DEFAULT_FROZEN_CHECKS, **_FROZEN_CHECKS},
+        frozen_checks=frozen_checks,
         provider_endpoints=endpoints,
         provider_tokens=tokens,
         executor_endpoints=executor_endpoints,
@@ -361,6 +396,41 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         route_context_tokens=_route_context_tokens_from_environment(),
         documentation_resources=_documentation_resources_from_environment(),
     )
+
+
+def _load_parity_public_fixtures(
+    path: Path,
+) -> tuple[InMemoryWorkspaceSourceAdapter, dict[str, FrozenCheck]]:
+    try:
+        from .parity import load_public_fixture_bundle
+
+        bundle = load_public_fixture_bundle(path)
+    except (OSError, ValueError) as exc:
+        raise CodingWorkerRuntimeError(
+            "Parity public fixture bundle is invalid.",
+            code="coding_worker_config_invalid",
+        ) from exc
+    snapshots: dict[tuple[str, str], dict[str, bytes]] = {}
+    checks: dict[str, FrozenCheck] = {}
+    for fixture in bundle.fixtures:
+        snapshots[(fixture.fixture_id, fixture.fixture_revision)] = {
+            entry.path: entry.content_bytes() for entry in fixture.files
+        }
+        for visible in fixture.visible_checks:
+            if visible.cwd != ".":
+                raise CodingWorkerRuntimeError(
+                    "Parity checks must execute at the fixture root.",
+                    code="coding_worker_config_invalid",
+                )
+            check = FrozenCheck(check_id=visible.check_id, argv=visible.argv)
+            existing = checks.get(check.check_id)
+            if existing is not None and existing != check:
+                raise CodingWorkerRuntimeError(
+                    "Parity check definitions conflict.",
+                    code="coding_worker_config_invalid",
+                )
+            checks[check.check_id] = check
+    return InMemoryWorkspaceSourceAdapter(snapshots), checks
 
 
 def _documentation_resources_from_environment() -> dict[str, str]:

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -1523,11 +1523,17 @@ class CodingWorkerService:
             current = self.store.get_task(task_id)
             if current.state not in TERMINAL_STATES:
                 self.store.transition(task_id, TaskState.FAILED, reason=exc.code)
-        except Exception:
+        except Exception as exc:
             current = self.store.get_task(task_id)
             if current.state not in TERMINAL_STATES:
+                code = getattr(exc, "code", "worker_failed")
+                reason = (
+                    code
+                    if isinstance(code, str) and SAFE_ID.fullmatch(code) is not None
+                    else "worker_failed"
+                )
                 with contextlib.suppress(WorkerConflictError):
-                    self.store.transition(task_id, TaskState.FAILED, reason="worker_failed")
+                    self.store.transition(task_id, TaskState.FAILED, reason=reason)
         finally:
             with contextlib.suppress(Exception):
                 self._settle_terminal_subtask(task_id)
@@ -1732,6 +1738,54 @@ class CodingWorkerService:
                 if resuming_turn and current_turn is not None
                 else f"turn_{uuid.uuid4().hex}"
             )
+            if (
+                resume_phase == "waiting_approval"
+                and resuming_turn
+                and current_turn is not None
+            ):
+                try:
+                    message = await self._resume_approved_operation(
+                        task_id, turn_id=current_turn.turn_id
+                    )
+                    resume_phase = None
+                except ToolBrokerError as exc:
+                    if exc.code == "operation_result_unknown":
+                        try:
+                            await self._park_v17_turn(
+                                task,
+                                session,
+                                turn_id=current_turn.turn_id,
+                                turns=turns,
+                                message_cursor=message_cursor,
+                                turn_before=turn_before,
+                                turn_public_before=turn_public_before,
+                            )
+                        except Exception:
+                            with contextlib.suppress(WorkerConflictError):
+                                self.store.finish_turn_transaction(
+                                    task_id=task_id,
+                                    turn_id=current_turn.turn_id,
+                                    state=TurnTransactionState.INTERRUPTED,
+                                )
+                            self.store.transition(
+                                task_id,
+                                TaskState.BLOCKED,
+                                reason="turn_checkpoint_failed",
+                                expected_state=TaskState.RUNNING,
+                            )
+                        return
+                    self.store.finish_turn_transaction(
+                        task_id=task_id,
+                        turn_id=current_turn.turn_id,
+                        state=TurnTransactionState.INTERRUPTED,
+                    )
+                    self.store.transition(
+                        task_id,
+                        TaskState.BLOCKED,
+                        reason=exc.code,
+                        expected_state=TaskState.RUNNING,
+                    )
+                    return
             if not resuming_turn:
                 if task.runtime_protocol is RuntimeProtocol.V17:
                     self.store.open_turn_transaction(
@@ -1756,6 +1810,11 @@ class CodingWorkerService:
                         provider_checkpoint = await self.provider.checkpoint(session)
                         entry_tree_hash = self.workspace_broker.current_tree_hash(
                             workspace_id or ""
+                        )
+                        provider_checkpoint = self._bind_provider_checkpoint_tree(
+                            provider_checkpoint,
+                            task_id=task_id,
+                            tree_hash=entry_tree_hash,
                         )
                         checkpoint = self.store.create_checkpoint(
                             task_id=task_id,
@@ -1970,6 +2029,9 @@ class CodingWorkerService:
                     tree_hash = self.workspace_broker.current_tree_hash(
                         self.store.get_task(task_id).workspace_id or ""
                     )
+                    provider_checkpoint = self._bind_provider_checkpoint_tree(
+                        provider_checkpoint, task_id=task_id, tree_hash=tree_hash
+                    )
                     self.store.create_checkpoint(
                         task_id=task_id,
                         workspace_tree_hash=tree_hash,
@@ -2034,6 +2096,9 @@ class CodingWorkerService:
                     tree_hash = self.workspace_broker.current_tree_hash(
                         current.workspace_id or ""
                     )
+                    provider_checkpoint = self._bind_provider_checkpoint_tree(
+                        provider_checkpoint, task_id=task_id, tree_hash=tree_hash
+                    )
                     self.store.create_checkpoint(
                         task_id=task_id,
                         workspace_tree_hash=tree_hash,
@@ -2075,6 +2140,9 @@ class CodingWorkerService:
                     tree_hash = self.workspace_broker.current_tree_hash(
                         current.workspace_id or ""
                     )
+                    provider_checkpoint = self._bind_provider_checkpoint_tree(
+                        provider_checkpoint, task_id=task_id, tree_hash=tree_hash
+                    )
                     self.store.create_checkpoint(
                         task_id=task_id,
                         workspace_tree_hash=tree_hash,
@@ -2106,6 +2174,9 @@ class CodingWorkerService:
                 provider_checkpoint = await self.provider.checkpoint(session)
                 tree_hash = self.workspace_broker.current_tree_hash(
                     self.store.get_task(task_id).workspace_id or ""
+                )
+                provider_checkpoint = self._bind_provider_checkpoint_tree(
+                    provider_checkpoint, task_id=task_id, tree_hash=tree_hash
                 )
                 self.store.create_checkpoint(
                     task_id=task_id,
@@ -2274,6 +2345,107 @@ class CodingWorkerService:
             "operation for the same intent."
         )
 
+    async def _resume_approved_operation(self, task_id: str, *, turn_id: str) -> str:
+        if self.tool_broker is None:
+            return self._approval_resume_message(task_id)
+        operations = {
+            operation.operation_id: operation
+            for operation in self.store.list_operations(task_id)
+            if operation.turn_id == turn_id
+        }
+        approvals = [
+            approval
+            for approval in self.store.list_approvals(task_id)
+            if approval.operation_id in operations
+        ]
+        if len(approvals) != 1:
+            raise ToolBrokerError(
+                "Approval does not bind one exact operation.",
+                code="approval_operation_conflict",
+            )
+        approval = approvals[0]
+        operation = operations[approval.operation_id]
+        if approval.status in {
+            ApprovalStatus.REJECTED,
+            ApprovalStatus.CANCELLED,
+            ApprovalStatus.EXPIRED,
+        }:
+            if operation.state is OperationState.PREPARED:
+                self.store.transition_operation(
+                    operation.operation_id,
+                    OperationState.FAILED,
+                    result={"code": "approval_rejected"},
+                    expected_state=OperationState.PREPARED,
+                )
+            return (
+                f"Approval was not granted for exact operation {operation.operation_id}. "
+                "The operation was not executed; do not retry it under another id."
+            )
+        if operation.state is OperationState.COMPLETED:
+            return (
+                f"Exact approved operation {operation.operation_id} is already complete. "
+                "Do not execute it again."
+            )
+        if (
+            operation.state is not OperationState.PREPARED
+            or approval.status is not ApprovalStatus.APPROVED
+            or approval.lease is None
+        ):
+            raise ToolBrokerError(
+                "Approved operation is not ready to resume.",
+                code="approval_operation_unavailable",
+            )
+        network_lease_id: str | None = None
+        if operation.tool_name in {"install_dependencies", "query_documentation"}:
+            network_operation_id = "network_" + hashlib.sha256(
+                operation.operation_id.encode("utf-8")
+            ).hexdigest()[:32]
+            network = next(
+                (
+                    item
+                    for item in self.store.list_approvals(task_id)
+                    if item.operation_id == network_operation_id
+                ),
+                None,
+            )
+            if (
+                network is None
+                or network.status is not ApprovalStatus.APPROVED
+                or network.lease is None
+            ):
+                raise ToolBrokerError(
+                    "Approved network operation is unavailable.",
+                    code="approval_operation_unavailable",
+                )
+            network_lease_id = network.lease.lease_id
+        result = await self.tool_broker.execute(
+            task_id=task_id,
+            operation_id=operation.operation_id,
+            tool_name=operation.tool_name,
+            arguments=operation.request.get("arguments", {}),
+            lease_id=approval.lease.lease_id,
+            network_lease_id=network_lease_id,
+        )
+        self.store.append_event(
+            task_id,
+            "operation_reconciled",
+            {
+                "operation_id": operation.operation_id,
+                "state": result.state.value,
+                "source": "approved_resume",
+            },
+        )
+        output = str(result.data.get("output", ""))[:4096]
+        exit_code = result.data.get("exit_code")
+        summary = (
+            f"Exact approved operation {operation.operation_id} completed once"
+            + (f" with exit code {exit_code}" if exit_code is not None else "")
+            + ". Do not execute it again."
+        )
+        if output:
+            summary += f"\n\nBounded operation output:\n{output}"
+        return summary
+
     async def _park_v17_turn(
         self,
         task: TaskRecord,
@@ -2297,6 +2469,9 @@ class CodingWorkerService:
         tree_hash = self.workspace_broker.current_tree_hash(workspace_id)
         await self.provider.interrupt_turn(session)
         provider_checkpoint = await self.provider.checkpoint(session)
+        provider_checkpoint = self._bind_provider_checkpoint_tree(
+            provider_checkpoint, task_id=task.task_id, tree_hash=tree_hash
+        )
         context = self._context_summary(
             task.task_id,
             tree_hash=tree_hash,
@@ -2529,6 +2704,9 @@ class CodingWorkerService:
                 code="context_compaction_too_large",
             )
         provider_checkpoint = await self.provider.checkpoint(session)
+        provider_checkpoint = self._bind_provider_checkpoint_tree(
+            provider_checkpoint, task_id=task_id, tree_hash=tree_hash
+        )
         self.store.create_checkpoint(
             task_id=task_id,
             workspace_tree_hash=tree_hash,
@@ -2553,6 +2731,26 @@ class CodingWorkerService:
                 "boundary_sequence": boundary,
                 "workspace_tree_hash": tree_hash,
             },
+        )
+
+    @staticmethod
+    def _bind_provider_checkpoint_tree(
+        checkpoint: ProviderCheckpoint, *, task_id: str, tree_hash: str
+    ) -> ProviderCheckpoint:
+        compatibility = checkpoint.compatibility
+        if compatibility is None:
+            return checkpoint
+        if compatibility.task_id != task_id:
+            raise WorkerConflictError(
+                "Provider checkpoint task binding changed.",
+                code="checkpoint_invalid",
+            )
+        return checkpoint.model_copy(
+            update={
+                "compatibility": compatibility.model_copy(
+                    update={"workspace_tree_hash": tree_hash}
+                )
+            }
         )
 
     def _controlled_compaction_summary(
@@ -2763,9 +2961,24 @@ class CodingWorkerService:
                 expected_state=TaskState.TESTING,
             )
             return None, message_cursor
+        acceptance_turn_id: str | None = None
+        if task.runtime_protocol is RuntimeProtocol.V17:
+            workspace_id = self.store.get_task(task_id).workspace_id or ""
+            acceptance_turn_id = f"turn_acceptance_{uuid.uuid4().hex}"
+            self.store.open_turn_transaction(
+                task_id=task_id,
+                turn_id=acceptance_turn_id,
+                workspace_tree_hash=self.workspace_broker.current_tree_hash(workspace_id),
+            )
         try:
             evidence = await self.harness_runner.run_required_checks(task_id)
         except ToolBrokerError as exc:
+            if acceptance_turn_id is not None:
+                self.store.finish_turn_transaction(
+                    task_id=task_id,
+                    turn_id=acceptance_turn_id,
+                    state=TurnTransactionState.INTERRUPTED,
+                )
             self.store.transition(
                 task_id,
                 TaskState.BLOCKED,
@@ -2773,6 +2986,20 @@ class CodingWorkerService:
                 expected_state=TaskState.TESTING,
             )
             return None, message_cursor
+        except Exception:
+            if acceptance_turn_id is not None:
+                self.store.finish_turn_transaction(
+                    task_id=task_id,
+                    turn_id=acceptance_turn_id,
+                    state=TurnTransactionState.INTERRUPTED,
+                )
+            raise
+        if acceptance_turn_id is not None:
+            self.store.finish_turn_transaction(
+                task_id=task_id,
+                turn_id=acceptance_turn_id,
+                state=TurnTransactionState.COMPLETED,
+            )
         self.store.append_event(
             task_id,
             "acceptance_evaluated",

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import io
+import tarfile
 from collections.abc import AsyncIterator
 from pathlib import Path
 
@@ -489,6 +491,36 @@ def test_workspace_endpoints_use_task_and_opaque_entry_ids(tmp_path: Path) -> No
         assert preview.text == "print('ok')\n"
         diff = client.get(f"/api/coding-worker/v1/tasks/{task_id}/workspace/diff")
         assert diff.status_code == 200 and diff.content == b""
+
+
+def test_parity_workspace_export_is_flagged_terminal_and_path_free(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, service = _client(tmp_path)
+    with client:
+        created = client.post("/api/coding-worker/v1/tasks", json=_payload()).json()
+        task_id = created["task_id"]
+        disabled = client.post(
+            f"/api/coding-worker/v1/tasks/{task_id}/workspace/parity-export"
+        )
+        assert disabled.status_code == 404
+        monkeypatch.setenv("CODING_WORKER_PARITY_ENABLED", "true")
+        asyncio.run(service.wait_for(task_id, lambda item: item.state.value == "blocked"))
+        exported = client.post(
+            f"/api/coding-worker/v1/tasks/{task_id}/workspace/parity-export"
+        )
+        assert exported.status_code == 200
+        artifact = exported.json()
+        assert artifact["metadata"]["kind"] == "parity_workspace_export"
+        assert "workspace_tree_hash" in artifact["metadata"]
+        assert "path" not in exported.text.lower()
+        download = client.get(
+            f"/api/coding-worker/v1/tasks/{task_id}/artifacts/{artifact['artifact_id']}"
+        )
+        with tarfile.open(fileobj=io.BytesIO(download.content), mode="r:") as archive:
+            member = archive.getmember("main.py")
+            assert member.mtime == 0 and member.uid == member.gid == 0
+            assert archive.extractfile(member).read() == b"print('ok')\n"
 
 
 def test_pin_unpin_and_delete_keep_active_task_safe(tmp_path: Path) -> None:

--- a/server/tests/test_coding_worker_broker_rpc.py
+++ b/server/tests/test_coding_worker_broker_rpc.py
@@ -18,8 +18,10 @@ from server.coding_worker.broker_mcp import (
 from server.coding_worker.contracts import (
     AcceptanceCheck,
     AcceptanceContract,
+    OperationState,
     Origin,
     PolicyProfile,
+    RuntimeProtocol,
     TaskSpec,
     TaskState,
     WorkspaceSource,
@@ -41,7 +43,11 @@ class _Executor:
         return {"exit_code": 0, "output": "approved\n"}
 
 
-async def _rpc(tmp_path: Path) -> tuple[BrokerRPCServer, str, str, _Executor]:
+async def _rpc(
+    tmp_path: Path,
+    *,
+    runtime_protocol: RuntimeProtocol = RuntimeProtocol.V16,
+) -> tuple[BrokerRPCServer, str, str, _Executor]:
     source = WorkspaceSource(kind="manifest", source_id="rpc", revision="h0")
     workspace = WorkspaceBroker(
         tmp_path / "workspace",
@@ -64,10 +70,17 @@ async def _rpc(tmp_path: Path) -> tuple[BrokerRPCServer, str, str, _Executor]:
             ),
             model_route="coding/default",
             policy_profile=PolicyProfile.DEVELOP,
-        )
+        ),
+        runtime_protocol=runtime_protocol,
     )
     store.transition(task.task_id, TaskState.PREPARING)
     store.transition(task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id)
+    if runtime_protocol is RuntimeProtocol.V17:
+        store.open_turn_transaction(
+            task_id=task.task_id,
+            turn_id="turn_rpc_v17",
+            workspace_tree_hash=prepared.baseline_tree_hash,
+        )
     executor = _Executor()
     server = BrokerRPCServer(
         ToolBroker(
@@ -452,6 +465,55 @@ async def test_rpc_waits_for_exact_approval_and_executes_same_operation_once(
     assert result["state"] == "completed"
     assert result["data"]["output"] == "approved\n"
     assert executor.calls == [("python", "-m", "pytest")]
+    await server.close()
+
+
+@pytest.mark.asyncio
+async def test_v17_rpc_reuses_the_approved_exact_operation_without_exposing_lease(
+    tmp_path: Path,
+) -> None:
+    server, task_id, endpoint, executor = await _rpc(
+        tmp_path, runtime_protocol=RuntimeProtocol.V17
+    )
+    client = BrokerRPCClient(
+        endpoint, token=server.register_task(task_id), task_id=task_id
+    )
+    request = {
+        "operation_id": "rpc-v17-command",
+        "tool_name": "run_command",
+        "arguments": {"argv": ["python", "-m", "pytest"], "timeout_seconds": 30},
+    }
+
+    parked = await client.call(**request)
+    assert parked["data"] == {"control": "turn_parking", "barrier": "approval"}
+    task = server.broker.store.get_task(task_id)
+    checkpoint = server.broker.store.create_checkpoint(
+        task_id=task_id,
+        workspace_tree_hash=server.broker.workspace_broker.current_tree_hash(
+            task.workspace_id or ""
+        ),
+        payload={"phase": "waiting_approval"},
+    )
+    server.broker.store.park_turn_transaction(
+        task_id=task_id,
+        turn_id="turn_rpc_v17",
+        checkpoint_id=checkpoint.checkpoint_id,
+    )
+    server.broker.store.transition(
+        task_id,
+        TaskState.WAITING_APPROVAL,
+        expected_state=TaskState.RUNNING,
+    )
+    approval = server.broker.store.list_approvals(task_id)[0]
+    server.broker.store.decide_approval(approval.approval_id, approved=True)
+
+    completed = await client.call(**request)
+
+    assert completed["state"] == "completed"
+    assert executor.calls == [("python", "-m", "pytest")]
+    operation = server.broker.store.get_operation("rpc-v17-command")
+    assert operation.state is OperationState.COMPLETED
+    assert operation.turn_id == "turn_rpc_v17"
     await server.close()
 
 

--- a/server/tests/test_coding_worker_parity.py
+++ b/server/tests/test_coding_worker_parity.py
@@ -282,6 +282,7 @@ def test_matrix_uses_independent_bound_runners_and_randomized_order() -> None:
         },
         candidate_sha=CANDIDATE,
         model_route_receipt_sha256=ROUTE_RECEIPT,
+        round_id="round_1",
     )
 
     assert len(outcomes) == 144
@@ -290,6 +291,22 @@ def test_matrix_uses_independent_bound_runners_and_randomized_order() -> None:
         item.task_id for item in manifest.tasks[:6]
     ]
     assert all(request.fixture_id.startswith("fixture_") for request in native.requests)
+
+    second_native = _RecordingRunner(ParityEngine.NATIVE_OPENCODE)
+    second_worker = _RecordingRunner(ParityEngine.MODELMIRROR_WORKER)
+    second = run_parity_matrix(
+        manifest=manifest,
+        runners={
+            ParityEngine.NATIVE_OPENCODE: second_native,
+            ParityEngine.MODELMIRROR_WORKER: second_worker,
+        },
+        candidate_sha=CANDIDATE,
+        model_route_receipt_sha256=ROUTE_RECEIPT,
+        round_id="round_2",
+    )
+    assert {item.run_id for item in outcomes}.isdisjoint(
+        {item.run_id for item in second}
+    )
 
 
 def test_matrix_rejects_shared_runner_and_foreign_outcome() -> None:
@@ -304,6 +321,7 @@ def test_matrix_rejects_shared_runner_and_foreign_outcome() -> None:
             },
             candidate_sha=CANDIDATE,
             model_route_receipt_sha256=ROUTE_RECEIPT,
+            round_id="round_1",
         )
 
     class _ForeignRunner(_RecordingRunner):
@@ -322,6 +340,7 @@ def test_matrix_rejects_shared_runner_and_foreign_outcome() -> None:
             },
             candidate_sha=CANDIDATE,
             model_route_receipt_sha256=ROUTE_RECEIPT,
+            round_id="round_1",
         )
 
 

--- a/server/tests/test_coding_worker_parity.py
+++ b/server/tests/test_coding_worker_parity.py
@@ -73,6 +73,9 @@ def _runs(*, worker_failures: set[str] | None = None) -> tuple[ParityRunOutcome,
                         raw_artifact_manifest_sha256=hashlib.sha256(
                             run_id.encode("utf-8")
                         ).hexdigest(),
+                        checker_receipt_sha256=hashlib.sha256(
+                            f"checker:{run_id}".encode("utf-8")
+                        ).hexdigest(),
                         candidate_sha=CANDIDATE,
                         task_manifest_sha256=manifest_hash,
                         initial_tree_hash=task.initial_tree_hash,
@@ -249,6 +252,9 @@ class _RecordingRunner:
             raw_artifact_manifest_sha256=hashlib.sha256(
                 request.run_id.encode("utf-8")
             ).hexdigest(),
+            checker_receipt_sha256=hashlib.sha256(
+                f"checker:{request.run_id}".encode("utf-8")
+            ).hexdigest(),
             candidate_sha=request.candidate_sha,
             task_manifest_sha256=request.task_manifest_sha256,
             initial_tree_hash=request.initial_tree_hash,
@@ -358,6 +364,7 @@ print(json.dumps({
   'hidden_checker_bundle_sha256':r['hidden_checker_bundle_sha256'],
   'runner_image_digest':r['runner_image_digest'],
   'raw_artifact_manifest_sha256':'a'*64,
+  'checker_receipt_sha256':'b'*64,
   'candidate_sha':r['candidate_sha'],'task_manifest_sha256':r['task_manifest_sha256'],
   'initial_tree_hash':r['initial_tree_hash'],'final_tree_hash':'f'*64,
   'hidden_checks_passed':True,'allowed_diff':True,'policy_violations':[],

--- a/server/tests/test_coding_worker_parity.py
+++ b/server/tests/test_coding_worker_parity.py
@@ -348,6 +348,7 @@ def test_subprocess_runner_accepts_only_exact_json_bound_outcome() -> None:
         model_route_catalog_sha256=(
             load_frozen_manifest(FIXTURE).model_route_catalog_sha256
         ),
+        model_route=load_frozen_manifest(FIXTURE).model_route,
         budget=task.budget,
         model_route_receipt_sha256=ROUTE_RECEIPT,
         candidate_sha=CANDIDATE,

--- a/server/tests/test_coding_worker_parity_cli.py
+++ b/server/tests/test_coding_worker_parity_cli.py
@@ -53,6 +53,7 @@ def _full_round(round_id: str) -> ParityRoundResult:
         },
         candidate_sha=CANDIDATE,
         model_route_receipt_sha256=ROUTE_RECEIPT,
+        round_id=round_id,
     )
     return ParityRoundResult(
         round_id=round_id,

--- a/server/tests/test_coding_worker_parity_execution.py
+++ b/server/tests/test_coding_worker_parity_execution.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from server.coding_worker.parity import ParityEngine, load_frozen_manifest
+from server.coding_worker.parity_runner import (
+    ParityRunRequest,
+    ParityRunnerError,
+    SeparatedParityRunner,
+)
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "coding_worker_v16_parity.json"
+CANDIDATE = "1" * 40
+ROUTE_RECEIPT = "2" * 64
+
+
+def _request() -> ParityRunRequest:
+    manifest = load_frozen_manifest(FIXTURE)
+    task = manifest.tasks[0]
+    return ParityRunRequest(
+        run_id="run_native_opencode_py_multifile_defect_1",
+        task_id=task.task_id,
+        engine=ParityEngine.NATIVE_OPENCODE,
+        attempt=1,
+        objective=task.objective,
+        fixture_id=task.fixture_id,
+        fixture_revision=task.fixture_revision,
+        initial_tree_hash=task.initial_tree_hash,
+        hidden_check_bundle_id=task.hidden_check_bundle_id,
+        hidden_check_sha256=task.hidden_check_sha256,
+        fixture_bundle_sha256=manifest.fixture_bundle_sha256,
+        hidden_checker_bundle_sha256=manifest.hidden_checker_bundle_sha256,
+        runner_image_digest=manifest.runner_images.native_opencode,
+        model_route_catalog_sha256=manifest.model_route_catalog_sha256,
+        budget=task.budget,
+        model_route_receipt_sha256=ROUTE_RECEIPT,
+        candidate_sha=CANDIDATE,
+        task_manifest_sha256=manifest.canonical_sha256(),
+    )
+
+
+RUNNER_SCRIPT = r"""
+import json,sys
+r=json.load(sys.stdin)
+assert 'hidden_check_bundle_id' not in r
+assert 'hidden_check_sha256' not in r
+assert 'hidden_checker_bundle_sha256' not in r
+print(json.dumps({
+  'protocol':r['protocol'],'run_id':r['run_id'],'task_id':r['task_id'],
+  'engine':r['engine'],'attempt':r['attempt'],'engine_version':'1.18.9',
+  'model_route_receipt_sha256':r['model_route_receipt_sha256'],
+  'fixture_bundle_sha256':r['fixture_bundle_sha256'],
+  'runner_image_digest':r['runner_image_digest'],'candidate_sha':r['candidate_sha'],
+  'task_manifest_sha256':r['task_manifest_sha256'],
+  'initial_tree_hash':r['initial_tree_hash'],'final_tree_hash':'f'*64,
+  'workspace_export':{'artifact_id':'workspace_export_1','sha256':'e'*64,'size_bytes':42},
+  'raw_artifact_manifest_sha256':'a'*64,'policy_violations':[],
+  'timeout':False,'budget_limited':False,'stuck':False,'manual_repair':False,
+  'undeclared_side_effect':False,'input_tokens':10,'output_tokens':5,
+  'tool_calls':2,'active_seconds':3.0
+}))
+"""
+
+
+CHECKER_SCRIPT = r"""
+import json,sys
+r=json.load(sys.stdin)
+assert 'objective' not in r
+assert 'engine' not in r
+assert 'model_route_receipt_sha256' not in r
+print(json.dumps({
+  'protocol':r['protocol'],'run_id':r['run_id'],'task_id':r['task_id'],
+  'attempt':r['attempt'],'hidden_check_sha256':r['hidden_check_sha256'],
+  'hidden_checker_bundle_sha256':r['hidden_checker_bundle_sha256'],
+  'initial_tree_hash':r['initial_tree_hash'],'final_tree_hash':r['final_tree_hash'],
+  'workspace_export_sha256':r['workspace_export']['sha256'],
+  'hidden_checks_passed':True,'allowed_diff':True
+}))
+"""
+
+
+def test_separated_runner_keeps_hidden_checks_out_of_runner_and_model_data_out_of_checker() -> None:
+    runner = SeparatedParityRunner(
+        engine=ParityEngine.NATIVE_OPENCODE,
+        runner_argv=(sys.executable, "-c", RUNNER_SCRIPT),
+        checker_argv=(sys.executable, "-c", CHECKER_SCRIPT),
+        timeout_seconds=30,
+        checker_timeout_seconds=30,
+    )
+
+    outcome = runner.execute(_request())
+
+    assert outcome.accepted is True
+    assert outcome.checker_receipt_sha256 is not None
+    assert outcome.final_tree_hash == "f" * 64
+
+
+def test_separated_runner_rejects_checker_receipt_for_a_different_export() -> None:
+    tampered = CHECKER_SCRIPT.replace(
+        "r['workspace_export']['sha256']", "'0'*64"
+    )
+    runner = SeparatedParityRunner(
+        engine=ParityEngine.NATIVE_OPENCODE,
+        runner_argv=(sys.executable, "-c", RUNNER_SCRIPT),
+        checker_argv=(sys.executable, "-c", tampered),
+        timeout_seconds=30,
+        checker_timeout_seconds=30,
+    )
+
+    with pytest.raises(ParityRunnerError, match="checker receipt binding"):
+        runner.execute(_request())
+
+
+def test_separated_runner_does_not_accept_runner_self_attestation() -> None:
+    self_attesting = RUNNER_SCRIPT.replace(
+        "'tool_calls':2,'active_seconds':3.0",
+        "'tool_calls':2,'active_seconds':3.0,'hidden_checks_passed':True",
+    )
+    runner = SeparatedParityRunner(
+        engine=ParityEngine.NATIVE_OPENCODE,
+        runner_argv=(sys.executable, "-c", self_attesting),
+        checker_argv=(sys.executable, "-c", CHECKER_SCRIPT),
+        timeout_seconds=30,
+        checker_timeout_seconds=30,
+    )
+
+    with pytest.raises(ParityRunnerError, match="runner response is invalid"):
+        runner.execute(_request())
+
+
+def test_separated_runner_requires_distinct_commands() -> None:
+    command = (sys.executable, "-c", RUNNER_SCRIPT)
+    with pytest.raises(ValueError, match="independent"):
+        SeparatedParityRunner(
+            engine=ParityEngine.NATIVE_OPENCODE,
+            runner_argv=command,
+            checker_argv=command,
+        )

--- a/server/tests/test_coding_worker_parity_execution.py
+++ b/server/tests/test_coding_worker_parity_execution.py
@@ -37,6 +37,7 @@ def _request() -> ParityRunRequest:
         hidden_checker_bundle_sha256=manifest.hidden_checker_bundle_sha256,
         runner_image_digest=manifest.runner_images.native_opencode,
         model_route_catalog_sha256=manifest.model_route_catalog_sha256,
+        model_route=manifest.model_route,
         budget=task.budget,
         model_route_receipt_sha256=ROUTE_RECEIPT,
         candidate_sha=CANDIDATE,

--- a/server/tests/test_coding_worker_parity_sidecar.py
+++ b/server/tests/test_coding_worker_parity_sidecar.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from server.coding_worker.parity import load_public_fixture_bundle
+from server.coding_worker.parity_runner import ParityCheckRequest
+from server.coding_worker.parity_sidecar import (
+    ParitySidecarError,
+    _approval_allowed,
+    _canonical_sha256,
+    _checker,
+    _export_workspace,
+    _opencode_configuration,
+    _safe_extract_tar,
+)
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+ASSETS = FIXTURES / "coding_worker_v17_parity_assets.json"
+
+
+def _tar(entries: dict[str, bytes]) -> bytes:
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+        for name, content in sorted(entries.items()):
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            info.mode = 0o644
+            info.mtime = 0
+            archive.addfile(info, io.BytesIO(content))
+    return output.getvalue()
+
+
+def _checker_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[ParityCheckRequest, Path]:
+    export_root = tmp_path / "exports"
+    export_root.mkdir(parents=True)
+    monkeypatch.setenv("CODING_PARITY_EXPORT_ROOT", str(export_root))
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    (repository / "answer.py").write_text("ANSWER = 42\n", encoding="utf-8")
+    artifact, final_tree, _manifest = _export_workspace(
+        run_id="run_checker_test", repository=repository
+    )
+    spec = {
+        "check_argv": [
+            "python",
+            "-c",
+            "from answer import ANSWER; assert ANSWER == 42",
+        ],
+        "diff_argv": ["python", "-c", "raise SystemExit(0)"],
+        "cwd": ".",
+        "timeout_seconds": 30,
+    }
+    check_id = "checks_unit"
+    bundle = _tar(
+        {
+            "checks.json": json.dumps(
+                {"schema_version": 1, "checks": {check_id: spec}},
+                sort_keys=True,
+            ).encode("utf-8")
+        }
+    )
+    bundle_path = tmp_path / "checker.bundle"
+    bundle_path.write_bytes(bundle)
+    monkeypatch.setenv("CODING_PARITY_CHECKER_BUNDLE", str(bundle_path))
+    request = ParityCheckRequest(
+        run_id="run_checker_test",
+        task_id="task_checker_test",
+        attempt=1,
+        hidden_check_bundle_id=check_id,
+        hidden_check_sha256=_canonical_sha256(spec),
+        hidden_checker_bundle_sha256=hashlib.sha256(bundle).hexdigest(),
+        initial_tree_hash="1" * 64,
+        final_tree_hash=final_tree,
+        workspace_export=artifact,
+    )
+    return request, bundle_path
+
+
+def test_checker_alone_reads_sealed_bundle_and_bound_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request, _bundle = _checker_request(tmp_path, monkeypatch)
+
+    receipt = _checker(request)
+
+    assert receipt.hidden_checks_passed is True
+    assert receipt.allowed_diff is True
+    assert receipt.workspace_export_sha256 == request.workspace_export.sha256
+
+
+def test_checker_rejects_tampered_bundle_and_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request, bundle = _checker_request(tmp_path, monkeypatch)
+    bundle.write_bytes(bundle.read_bytes() + b"tampered")
+    with pytest.raises(ParitySidecarError, match="bundle binding"):
+        _checker(request)
+
+    request, _bundle = _checker_request(tmp_path / "second", monkeypatch)
+    export = (
+        Path(os.environ["CODING_PARITY_EXPORT_ROOT"])
+        / f"{request.workspace_export.artifact_id}.tar"
+    )
+    export.write_bytes(export.read_bytes() + b"tampered")
+    with pytest.raises(ParitySidecarError, match="export binding"):
+        _checker(request)
+
+
+def test_archive_extraction_rejects_traversal(tmp_path: Path) -> None:
+    content = _tar({"../outside.py": b"print('unsafe')\n"})
+    destination = tmp_path / "extract"
+    destination.mkdir()
+    with pytest.raises(ParitySidecarError, match="entry is unsafe"):
+        _safe_extract_tar(content, destination)
+    assert not (tmp_path / "outside.py").exists()
+
+
+def test_worker_approval_matches_only_frozen_visible_command() -> None:
+    fixture = load_public_fixture_bundle(ASSETS).fixtures[0]
+    allowed = list(fixture.visible_checks[0].argv)
+    assert _approval_allowed({"request": {"argv": allowed}}, fixture) is True
+    assert (
+        _approval_allowed(
+            {"request": {"argv": ["python", "-m", "pytest", "-q", "--lf"]}},
+            fixture,
+        )
+        is False
+    )
+
+
+def test_native_configuration_denies_unfrozen_tools_and_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CODING_PARITY_MODEL_ID", "test-model")
+    monkeypatch.setenv("CODING_PARITY_MODEL_BASE_URL", "http://new-api:3000/v1")
+    fixture = load_public_fixture_bundle(ASSETS).fixtures[0]
+
+    config = _opencode_configuration(fixture)
+
+    permission = config["permission"]
+    assert permission["bash"]["*"] == "deny"
+    assert permission["webfetch"] == permission["websearch"] == "deny"
+    assert permission["skill"] == "deny"
+    assert config["plugin"] == [] and config["mcp"] == {}
+
+
+def test_compose_profile_keeps_checker_and_controller_off_network() -> None:
+    compose = (Path(__file__).parents[2] / "docker-compose.coding-worker-v17-parity.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "coding-worker-parity-checker:" in compose
+    assert "coding-worker-parity-controller:" in compose
+    assert compose.count("network_mode: none") == 2
+    assert "docker.sock" not in compose
+    controller = compose.split("coding-worker-parity-controller:", 1)[1]
+    assert "checker.bundle" not in controller
+    assert "CODING_PARITY_ROUTE_KEY" not in controller

--- a/server/tests/test_coding_worker_provider_rpc.py
+++ b/server/tests/test_coding_worker_provider_rpc.py
@@ -153,6 +153,10 @@ async def test_provider_sidecar_pool_streams_neutral_events_and_revokes_broker_t
 async def test_closing_provider_stream_aborts_the_unfinished_sidecar_turn(
     tmp_path: Path,
 ) -> None:
+    loop = asyncio.get_running_loop()
+    previous_handler = loop.get_exception_handler()
+    unhandled: list[dict[str, object]] = []
+    loop.set_exception_handler(lambda _loop, context: unhandled.append(context))
     store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
     workspace = WorkspaceBroker(tmp_path / "workspace", {}, id_key=b"z" * 32)
     broker_rpc = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
@@ -190,6 +194,8 @@ async def test_closing_provider_stream_aborts_the_unfinished_sidecar_turn(
     await pool.close(session)
     await server.close()
     await broker_rpc.close()
+    loop.set_exception_handler(previous_handler)
+    assert unhandled == []
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -14,6 +14,7 @@ from cryptography.fernet import Fernet
 from server.coding_worker.contracts import (
     AcceptanceCheck,
     AcceptanceContract,
+    OperationState,
     Origin,
     PolicyProfile,
     RuntimeProtocol,
@@ -33,12 +34,13 @@ from server.coding_worker.provider import (
     ProviderEvent,
     ProviderEventKind,
     ProviderCheckpoint,
+    ProviderCheckpointCompatibility,
     ProviderOpenRequest,
     ProviderSession,
 )
 from server.coding_worker.service import CodingWorkerService
 from server.coding_worker.store import CodingWorkerStore, WorkerConflictError
-from server.coding_worker.tool_broker import FrozenCheck, ToolBroker
+from server.coding_worker.tool_broker import FrozenCheck, ToolBroker, ToolBrokerError
 from server.coding_worker.workspace import (
     InMemoryWorkspaceSourceAdapter,
     WorkspaceBroker,
@@ -746,6 +748,201 @@ async def test_v17_acceptance_rejects_an_unsettled_turn(tmp_path: Path) -> None:
     blocked = service.store.get_task(task.task_id)
     assert blocked.state is TaskState.BLOCKED
     assert blocked.reason == "turn_settlement_incomplete"
+
+
+@pytest.mark.asyncio
+async def test_v17_frozen_acceptance_operations_are_bound_to_platform_turns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in (
+        "CODING_WORKER_V16_ENABLED",
+        "CODING_WORKER_INTERACTION_ENABLED",
+        "CODING_WORKER_SESSION_CONTROLS_ENABLED",
+        "CODING_WORKER_SUBAGENTS_ENABLED",
+        "CODING_WORKER_V17_ENABLED",
+    ):
+        monkeypatch.setenv(name, "true")
+    provider = _RepairingProvider()
+    service, broker = _service_with_harness(tmp_path, provider)
+    request = _request("v17-acceptance-turn").model_copy(
+        update={"policy_profile": PolicyProfile.DEVELOP}
+    )
+    task = await service.create_task(
+        Origin(module="test", object_id="v17-acceptance-turn"), request
+    )
+
+    async def repair() -> None:
+        content = "print('fixed')\n"
+        await broker.execute(
+            task_id=task.task_id,
+            operation_id="repair-v17-main",
+            tool_name="write_file",
+            arguments={
+                "path": "main.py",
+                "content": content,
+                "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+            },
+        )
+
+    provider.repair = repair
+    completed = await service.wait_for(
+        task.task_id, lambda item: item.state is TaskState.COMPLETED
+    )
+
+    assert completed.runtime_protocol is RuntimeProtocol.V17
+    acceptance_operations = [
+        operation
+        for operation in service.store.list_operations(task.task_id)
+        if operation.tool_name == "run_check"
+        and operation.operation_id.startswith("acceptance_")
+    ]
+    assert len(acceptance_operations) == 2
+    assert all(operation.turn_id is not None for operation in acceptance_operations)
+    assert all(
+        service.store.get_turn_transaction(task.task_id, operation.turn_id or "").state
+        is TurnTransactionState.COMPLETED
+        for operation in acceptance_operations
+    )
+    assert service.store.current_turn_transaction(task.task_id) is None
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_v17_acceptance_failure_interrupts_its_platform_turn(
+    tmp_path: Path,
+) -> None:
+    class _FailingHarness:
+        async def run_required_checks(self, _task_id: str) -> list[object]:
+            raise RuntimeError("harness unavailable")
+
+    service = _service(tmp_path, FakeCodingAgentProvider())
+    request = _request("v17-acceptance-failure")
+    prepared = await service.workspace_broker.prepare(request.workspace_source)
+    task = service.store.create_task(
+        TaskSpec(
+            **request.model_dump(),
+            origin=Origin(module="test", object_id="v17-acceptance-failure"),
+        ),
+        runtime_protocol=RuntimeProtocol.V17,
+    )
+    service.store.transition(task.task_id, TaskState.PREPARING)
+    running = service.store.transition(
+        task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id
+    )
+    service.harness_runner = _FailingHarness()  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError, match="harness unavailable"):
+        await service._evaluate_acceptance(running, 1, message_cursor=0)
+
+    transactions = service.store.list_turn_transactions(task.task_id)
+    assert len(transactions) == 1
+    assert transactions[0].state is TurnTransactionState.INTERRUPTED
+    assert service.store.current_turn_transaction(task.task_id) is None
+
+
+@pytest.mark.asyncio
+async def test_v17_approved_operation_executes_once_before_provider_resume(
+    tmp_path: Path,
+) -> None:
+    class _CommandExecutor:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, ...]] = []
+
+        async def run_process(self, **kwargs: object) -> dict[str, object]:
+            argv = tuple(str(item) for item in kwargs["argv"])  # type: ignore[index]
+            self.calls.append(argv)
+            return {"exit_code": 0, "output": "approved once\n"}
+
+    service, broker = _service_with_harness(tmp_path, FakeCodingAgentProvider())
+    executor = _CommandExecutor()
+    broker.executor = executor
+    request = _request("v17-approved-resume").model_copy(
+        update={"policy_profile": PolicyProfile.DEVELOP}
+    )
+    task = service.store.create_task(
+        TaskSpec(
+            **request.model_dump(),
+            origin=Origin(module="test", object_id="v17-approved-resume"),
+        ),
+        runtime_protocol=RuntimeProtocol.V17,
+    )
+    workspace = await service.workspace_broker.prepare(request.workspace_source)
+    service.store.transition(task.task_id, TaskState.PREPARING)
+    service.store.transition(
+        task.task_id, TaskState.RUNNING, workspace_id=workspace.workspace_id
+    )
+    turn = service.store.open_turn_transaction(
+        task_id=task.task_id,
+        turn_id="turn_v17_approved_resume",
+        workspace_tree_hash=workspace.baseline_tree_hash,
+    )
+    with pytest.raises(ToolBrokerError) as pending:
+        await broker.execute(
+                task_id=task.task_id,
+                operation_id="operation_v17_approved_resume",
+                tool_name="run_command",
+                arguments={"argv": ["python", "-V"], "timeout_seconds": 30},
+        )
+    assert pending.value.code == "approval_required"
+    checkpoint = service.store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash=workspace.baseline_tree_hash,
+        payload={"phase": "waiting_approval"},
+    )
+    service.store.park_turn_transaction(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        checkpoint_id=checkpoint.checkpoint_id,
+    )
+    service.store.transition(
+        task.task_id,
+        TaskState.WAITING_APPROVAL,
+        expected_state=TaskState.RUNNING,
+    )
+    approval = service.store.list_approvals(task.task_id)[0]
+    service.store.decide_approval(approval.approval_id, approved=True)
+
+    summary = await service._resume_approved_operation(
+        task.task_id, turn_id=turn.turn_id
+    )
+
+    assert "completed once" in summary
+    assert executor.calls == [("python", "-V")]
+    operation = service.store.get_operation("operation_v17_approved_resume")
+    assert operation.state is OperationState.COMPLETED
+    assert [
+        item.type
+        for item in service.store.list_events(task.task_id)
+        if item.type == "operation_reconciled"
+    ] == ["operation_reconciled"]
+    await service.shutdown()
+
+
+def test_provider_checkpoint_is_rebound_to_the_current_authenticated_tree() -> None:
+    checkpoint = ProviderCheckpoint(
+        checkpoint_id="checkpoint_tree_binding",
+        compatibility=ProviderCheckpointCompatibility(
+            provider_family="opencode",
+            provider_version="1.18.9",
+            task_id="task_tree_binding",
+            workspace_tree_hash="a" * 64,
+        ),
+        payload={"public_output": "safe"},
+    )
+
+    rebound = CodingWorkerService._bind_provider_checkpoint_tree(
+        checkpoint, task_id="task_tree_binding", tree_hash="b" * 64
+    )
+
+    assert rebound.compatibility is not None
+    assert rebound.compatibility.workspace_tree_hash == "b" * 64
+    assert checkpoint.compatibility is not None
+    assert checkpoint.compatibility.workspace_tree_hash == "a" * 64
+    with pytest.raises(WorkerConflictError) as mismatched:
+        CodingWorkerService._bind_provider_checkpoint_tree(
+            checkpoint, task_id="task_other", tree_hash="b" * 64
+        )
+    assert mismatched.value.code == "checkpoint_invalid"
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_source_adapters.py
+++ b/server/tests/test_coding_worker_source_adapters.py
@@ -13,8 +13,14 @@ from server.coding_worker.source_adapters import (
     HostSnapshotWorkspaceSourceAdapter,
     ProjectSnapshotWorkspaceSourceAdapter,
 )
-from server.coding_worker.workspace import WorkspaceError
-from server.coding_worker.runtime import build_runtime_from_environment
+from server.coding_worker.workspace import (
+    InMemoryWorkspaceSourceAdapter,
+    WorkspaceError,
+)
+from server.coding_worker.runtime import (
+    CodingWorkerRuntimeError,
+    build_runtime_from_environment,
+)
 
 
 class FakeProjectSource:
@@ -205,6 +211,60 @@ def test_runtime_wires_host_snapshot_to_live_project_host(
         "react-test",
         "react-build",
     }
+
+
+def test_runtime_parity_profile_registers_only_public_fixtures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assets = Path(__file__).parent / "fixtures" / "coding_worker_v17_parity_assets.json"
+    environment = {
+        "CODING_WORKER_STATE_ROOT": str(tmp_path / "state"),
+        "CODING_WORKER_SLOT_A_ROOT": str(tmp_path / "slot-a"),
+        "CODING_WORKER_SLOT_B_ROOT": str(tmp_path / "slot-b"),
+        "CODING_WORKER_SLOT_A_TOKEN": "a" * 32,
+        "CODING_WORKER_SLOT_B_TOKEN": "b" * 32,
+        "CODING_WORKER_EXECUTOR_A_TOKEN": "c" * 32,
+        "CODING_WORKER_EXECUTOR_B_TOKEN": "d" * 32,
+        "CODING_WORKER_BROKER_SOCKET": str(tmp_path / "broker.sock"),
+        "CODING_WORKER_PARITY_ENABLED": "true",
+        "CODING_WORKER_PARITY_PUBLIC_FIXTURES": str(assets),
+    }
+    for key, value in environment.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.delenv("CODING_WORKER_BUILTIN_SOURCE_ROOT", raising=False)
+    monkeypatch.delenv("CODING_WORKER_BUILTIN_REVISION", raising=False)
+
+    runtime = build_runtime_from_environment()
+
+    assert isinstance(
+        runtime.workspace_broker._adapters["builtin"],
+        InMemoryWorkspaceSourceAdapter,
+    )
+    assert {"pytest", "npm_test"}.issubset(runtime.tool_broker.frozen_checks)
+
+
+def test_runtime_rejects_parity_profile_mixed_with_builtin_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assets = Path(__file__).parent / "fixtures" / "coding_worker_v17_parity_assets.json"
+    values = {
+        "CODING_WORKER_STATE_ROOT": str(tmp_path / "state"),
+        "CODING_WORKER_SLOT_A_ROOT": str(tmp_path / "slot-a"),
+        "CODING_WORKER_SLOT_B_ROOT": str(tmp_path / "slot-b"),
+        "CODING_WORKER_SLOT_A_TOKEN": "a" * 32,
+        "CODING_WORKER_SLOT_B_TOKEN": "b" * 32,
+        "CODING_WORKER_EXECUTOR_A_TOKEN": "c" * 32,
+        "CODING_WORKER_EXECUTOR_B_TOKEN": "d" * 32,
+        "CODING_WORKER_PARITY_ENABLED": "true",
+        "CODING_WORKER_PARITY_PUBLIC_FIXTURES": str(assets),
+        "CODING_WORKER_BUILTIN_SOURCE_ROOT": str(tmp_path),
+        "CODING_WORKER_BUILTIN_REVISION": "a" * 40,
+    }
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+
+    with pytest.raises(CodingWorkerRuntimeError, match="cannot replace"):
+        build_runtime_from_environment()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 概要
- 增加隔离的 V17 parity native/Worker/checker/controller profile，并绑定公开 fixture、受控路由摘要与终态 Workspace Artifact。
- Console 改为读取任务级真实 capability、平台权威 Plan/Todo 和 V17 turn/operation 事件，不再从 provider_event 推导业务状态。
- 补齐 V17 架构、部署、Harness、数据保留与回退文档；默认关闭并保持 Experimental。

## 验证
- Coding Worker：259 passed, 5 skipped。
- Agent Workspace：44 passed。
- Coding：882 passed, 14 skipped。
- PR C parity/source/API 组合：52 passed；sidecar/API/execution：29 passed。
- Console 专项：10 passed；production build 通过。
- 前端全量：300 passed, 1 failed；失败 NodePalette 节点已在 PR B 基线原位复现。
- 后端全量：3137 passed, 29 skipped, 16 failed；16 项 Agency/Skill 失败已在 PR B 基线以相同节点复现（基线对照 43 passed, 16 failed）。
- Python py_compile、Compose config、git diff --check、提交≤5文件、禁止产物/依赖/凭据扫描通过。

## 发布边界
- 基于 PR B #200；请按 A → B → C 顺序审查。
- 未执行两轮 144 格真实模型认证（共 288 次），未执行最终人工 Console 无 P0/P1 门禁。
- 因此本 PR 仅为 Experimental/Draft，不标记 Ready，不宣称接近或等效 OpenCode。
- 回退：关闭 CODING_WORKER_V17_ENABLED 与 CODING_WORKER_PARITY_ENABLED，保留任务、Workspace、Turn、Evidence 和 Artifact。