### PR TITLE
feat: 优化 Runtime 运维诊断首屏

### DIFF
--- a/client/src/pages/RuntimeOpsPage.test.tsx
+++ b/client/src/pages/RuntimeOpsPage.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import RuntimeOpsPage from "./RuntimeOpsPage";
+
+const environmentSummary = {
+  git_available: true,
+  llm_gateway_configured: true,
+  model_gateway_ready: true,
+  node_available: true,
+  npm_available: true,
+  npx_available: true,
+  openrouter_configured: true,
+  python_available: true,
+  redacted: true,
+  updated_at: 1_723_500_000,
+};
+
+function responseFor(url: string) {
+  let payload: unknown = [];
+  if (url === "/api/mcp/sessions") payload = { sessions: [] };
+  if (url === "/api/registry/tools") payload = { tools: [] };
+  if (url === "/api/skills/installed") payload = { skills: [] };
+  if (url === "/api/runtime/environment-summary") payload = environmentSummary;
+  if (url === "/api/runtime/client-hosts") payload = { hosts: [] };
+
+  return Promise.resolve({
+    json: () => Promise.resolve(payload),
+    ok: true,
+  } as Response);
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <RuntimeOpsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("RuntimeOpsPage diagnostic-first shell", () => {
+  const fetchMock = vi.fn((input: RequestInfo | URL) => responseFor(String(input)));
+
+  beforeEach(() => {
+    fetchMock.mockClear();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("puts health and run diagnostics before client pairing with one global refresh", async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "刷新全部" })).toBeEnabled(),
+    );
+
+    expect(screen.getByRole("heading", { name: "Runtime 运维" })).toBeInTheDocument();
+    expect(screen.getByLabelText("运行健康摘要")).toBeInTheDocument();
+    ["运行状态", "MCP 连接", "客户端宿主", "环境依赖"].forEach((label) =>
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0),
+    );
+
+    const runHeading = screen.getByRole("heading", { name: "运行记录" });
+    const clientHeading = screen.getByRole("heading", { name: "客户端宿主" });
+    expect(
+      runHeading.compareDocumentPosition(clientHeading) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    expect(screen.getAllByRole("button", { name: "刷新全部" })).toHaveLength(1);
+    expect(screen.queryByText("应用并刷新")).not.toBeInTheDocument();
+    expect(screen.queryByText("重试待接入")).not.toBeInTheDocument();
+    expect(screen.queryByText("重试能力待接入")).not.toBeInTheDocument();
+  });
+
+  it("refreshes only run records when the run filter changes", async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "刷新全部" })).toBeEnabled(),
+    );
+    fetchMock.mockClear();
+
+    fireEvent.change(screen.getByLabelText("运行类型"), {
+      target: { value: "workflow" },
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/runtime/runs?limit=20&run_type=workflow",
+    );
+  });
+
+  it("keeps client pairing actions compact and moves setup links into one help row", async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "配对 Chrome" })).toBeEnabled(),
+    );
+
+    expect(screen.getByRole("button", { name: "配对 Office" })).toBeEnabled();
+    expect(screen.getByRole("link", { name: "下载 Chrome 扩展" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "下载 Office Manifest" })).toBeInTheDocument();
+    expect(screen.getAllByText("首次使用")).toHaveLength(1);
+  });
+
+  it("shows one runtime resource view at a time with pressed-button semantics", async () => {
+    renderPage();
+
+    const mcpTab = await screen.findByRole("button", { name: "MCP 连接 0" });
+    const toolsTab = screen.getByRole("button", { name: "工具 0" });
+    const skillsTab = screen.getByRole("button", { name: "Skill 0" });
+    const environmentTab = screen.getByRole("button", { name: "环境依赖 8/8" });
+
+    expect(mcpTab).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText("没有符合条件的 MCP 连接")).toBeInTheDocument();
+
+    fireEvent.click(toolsTab);
+    expect(toolsTab).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText("当前没有注册工具")).toBeInTheDocument();
+    expect(screen.queryByText("没有符合条件的 MCP 连接")).not.toBeInTheDocument();
+
+    fireEvent.click(skillsTab);
+    expect(screen.getByText("暂无已安装 Skill")).toBeInTheDocument();
+
+    fireEvent.click(environmentTab);
+    expect(screen.getByText("模型网关")).toBeInTheDocument();
+    expect(screen.getByText("python")).toBeInTheDocument();
+  });
+
+  it("uses localized run states and offers a reversible filter reset", async () => {
+    renderPage();
+
+    const statusSelect = await screen.findByLabelText("运行状态");
+    const clearButton = screen.getByRole("button", { name: "清除筛选" });
+
+    ["等待中", "运行中", "已完成", "失败", "已取消"].forEach((label) =>
+      expect(screen.getByRole("option", { name: label })).toBeInTheDocument(),
+    );
+    expect(clearButton).toBeDisabled();
+
+    fireEvent.change(statusSelect, { target: { value: "failed" } });
+    expect(clearButton).toBeEnabled();
+    fireEvent.click(clearButton);
+
+    expect(statusSelect).toHaveValue("all");
+    expect(clearButton).toBeDisabled();
+  });
+});

--- a/client/src/pages/RuntimeOpsPage.tsx
+++ b/client/src/pages/RuntimeOpsPage.tsx
@@ -115,6 +115,7 @@ interface ClientPairingPayload {
 type RuntimeFilter = "all" | "workflow" | "workflow_agent" | "agent_task" | "agent_handoff" | "chat" | "goal";
 type StatusFilter = "all" | "pending" | "running" | "completed" | "failed" | "cancelled";
 type McpStatusFilter = "all" | "active" | "failed" | "closed" | "unknown";
+type RuntimeResourceView = "mcp" | "tools" | "skills" | "environment";
 
 const dateFormatter = new Intl.DateTimeFormat("zh-CN", {
   month: "2-digit",
@@ -135,11 +136,11 @@ const runTypeFilters: Array<{ label: string; value: RuntimeFilter }> = [
 
 const statusFilters: Array<{ label: string; value: StatusFilter }> = [
   { label: "全部状态", value: "all" },
-  { label: "pending", value: "pending" },
-  { label: "running", value: "running" },
-  { label: "completed", value: "completed" },
-  { label: "failed", value: "failed" },
-  { label: "cancelled", value: "cancelled" },
+  { label: "等待中", value: "pending" },
+  { label: "运行中", value: "running" },
+  { label: "已完成", value: "completed" },
+  { label: "失败", value: "failed" },
+  { label: "已取消", value: "cancelled" },
 ];
 
 const mcpStatusFilters: Array<{ label: string; value: McpStatusFilter }> = [
@@ -189,6 +190,21 @@ function getMcpStatusBucket(status: string | null | undefined): Exclude<McpStatu
     return "closed";
   }
   return "unknown";
+}
+
+function getFriendlyMcpStatusLabel(status: string | null | undefined) {
+  const bucket = getMcpStatusBucket(status);
+  if (bucket === "active") return "活跃";
+  if (bucket === "failed") return "异常";
+  if (bucket === "closed") return "已关闭";
+  return "未知";
+}
+
+function getFriendlySeverityLabel(severity: string | null | undefined) {
+  const normalized = normalizeStatus(severity);
+  if (normalized === "error") return "错误";
+  if (normalized === "warning") return "警告";
+  return "信息";
 }
 
 function statusClass(status: string) {
@@ -246,13 +262,13 @@ function severityCounts(checkpoints: RuntimeCheckpointPayload[]) {
   );
 }
 
-function MetricCard({
-  hint,
+function HealthSummaryItem({
+  detail,
   label,
   tone = "neutral",
   value,
 }: {
-  hint: string;
+  detail: string;
   label: string;
   tone?: "neutral" | "brand" | "success" | "warning" | "error";
   value: string | number;
@@ -266,10 +282,12 @@ function MetricCard({
   } as const;
 
   return (
-    <div className="rounded-lg border border-white/10 bg-ink-950/72 p-4 shadow-prism">
-      <p className="text-xs text-slate-400">{label}</p>
-      <p className={`mt-2 text-3xl font-semibold ${toneMap[tone]}`}>{value}</p>
-      <p className="mt-2 text-xs leading-5 text-slate-500">{hint}</p>
+    <div className="min-w-0 px-4 py-3.5">
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-sm font-medium text-slate-300">{label}</p>
+        <p className={`text-lg font-semibold ${toneMap[tone]}`}>{value}</p>
+      </div>
+      <p className="mt-1 truncate text-xs leading-5 text-slate-400">{detail}</p>
     </div>
   );
 }
@@ -297,7 +315,7 @@ function SectionShell({
         {action}
       </div>
       {error ? (
-        <div className="m-4 rounded-lg border border-rose-300/20 bg-rose-300/10 px-3 py-2 text-sm text-rose-100">
+        <div className="m-4 rounded-lg border border-rose-300/20 bg-rose-300/10 px-3 py-2 text-sm text-rose-100" role="alert">
           {error}
         </div>
       ) : (
@@ -324,8 +342,11 @@ export default function RuntimeOpsPage() {
   const [runType, setRunType] = useState<RuntimeFilter>("all");
   const [status, setStatus] = useState<StatusFilter>("all");
   const [mcpStatusFilter, setMcpStatusFilter] = useState<McpStatusFilter>("all");
+  const [resourceView, setResourceView] = useState<RuntimeResourceView>("mcp");
   const [keyword, setKeyword] = useState("");
   const [selectedRunId, setSelectedRunId] = useState("");
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<number | null>(null);
+  const [refreshing, setRefreshing] = useState(true);
   const [checkpoints, setCheckpoints] = useState(
     createLoadable<RuntimeCheckpointPayload[]>([]),
   );
@@ -425,14 +446,25 @@ export default function RuntimeOpsPage() {
     }
   }, []);
 
-  const refreshAll = useCallback(() => {
-    void loadMcp();
-    void loadTools();
-    void loadRuns();
-    void loadSkills();
-    void loadEnvironment();
-    void loadClientHosts();
-  }, [loadClientHosts, loadEnvironment, loadMcp, loadRuns, loadSkills, loadTools]);
+  const refreshOverview = useCallback(async () => {
+    await Promise.all([
+      loadMcp(),
+      loadTools(),
+      loadSkills(),
+      loadEnvironment(),
+      loadClientHosts(),
+    ]);
+  }, [loadClientHosts, loadEnvironment, loadMcp, loadSkills, loadTools]);
+
+  const refreshAll = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await Promise.all([refreshOverview(), loadRuns()]);
+      setLastRefreshedAt(Date.now());
+    } finally {
+      setRefreshing(false);
+    }
+  }, [loadRuns, refreshOverview]);
 
   async function createClientPairing(hostType: "chrome" | "office") {
     setClientHostBusy(`pairing-${hostType}`);
@@ -496,8 +528,24 @@ export default function RuntimeOpsPage() {
   }
 
   useEffect(() => {
-    refreshAll();
-  }, [refreshAll]);
+    let cancelled = false;
+
+    setRefreshing(true);
+    void refreshOverview().finally(() => {
+      if (!cancelled) {
+        setLastRefreshedAt(Date.now());
+        setRefreshing(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshOverview]);
+
+  useEffect(() => {
+    void loadRuns();
+  }, [loadRuns]);
 
   useEffect(() => {
     if (!selectedRunId) {
@@ -633,6 +681,19 @@ export default function RuntimeOpsPage() {
     ];
   }, [environment.data]);
 
+  const clientHostSummary = useMemo(() => {
+    const total = clientHosts.data.length;
+    const active = clientHosts.data.filter(
+      (host) => !host.revoked && getMcpStatusBucket(host.status) === "active",
+    ).length;
+    return { active, attention: Math.max(0, total - active), total };
+  }, [clientHosts.data]);
+
+  const readyDependencyCount = useMemo(
+    () => dependencyRows.filter((item) => item.value).length,
+    [dependencyRows],
+  );
+
   return (
     <PageContainer
       activeResource="runtime"
@@ -642,80 +703,72 @@ export default function RuntimeOpsPage() {
       sidebar={<ModelWorkbenchSidebar />}
       sidebarGridClassName="xl:grid-cols-[230px_minmax(0,1fr)] xl:gap-x-[54px]"
     >
-      <header className="mb-6 border-y border-hire-300/20 py-5">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="rounded-full border border-hire-300/30 bg-hire-300/10 px-3 py-1 text-xs font-semibold text-hire-100">
-                智能体运行诊断 Beta
-              </span>
-              <span className="rounded-full border border-white/10 bg-white/[0.055] px-3 py-1 text-xs text-slate-300">
-                只读观测，不改变运行协议
-              </span>
-            </div>
-            <h1 className="mt-3 text-2xl font-semibold text-white sm:text-3xl">
-              Runtime 运维
-            </h1>
-            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">
-              汇总 MCP Runtime、工具注册表、RunRegistry 与 Skill 安装状态。这里先做观测与跳转，管理操作继续保留在各自页面。
-            </p>
+      <header className="mb-4 flex flex-col gap-4 border-b border-white/10 pb-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-2xl font-semibold text-white sm:text-3xl">Runtime 运维</h1>
+            <span className="rounded-full border border-hire-300/25 bg-hire-300/10 px-2.5 py-1 text-xs font-semibold text-hire-100">
+              只读诊断
+            </span>
           </div>
-          <div className="flex flex-wrap gap-2">
-            <button
-              className="rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-ink-950 transition hover:bg-hire-200"
-              onClick={refreshAll}
-              type="button"
-            >
-              刷新运行态
-            </button>
-            <Link
-              className="rounded-full border border-white/10 bg-white/[0.055] px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-hire-300/35 hover:bg-hire-300/10 hover:text-hire-100"
-              to="/mcps"
-            >
-              连接 MCP
-            </Link>
-          </div>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-300">
+            集中查看运行异常、MCP 连接和环境状态，管理操作仍在对应页面完成。
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <p aria-live="polite" className="text-xs text-slate-400">
+            {refreshing
+              ? "正在刷新全部状态"
+              : lastRefreshedAt
+                ? `最近更新 ${formatTime(lastRefreshedAt)}`
+                : "尚未刷新"}
+          </p>
+          <button
+            className="min-h-11 rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-wait disabled:opacity-65"
+            disabled={refreshing}
+            onClick={() => void refreshAll()}
+            type="button"
+          >
+            {refreshing ? "刷新中" : "刷新全部"}
+          </button>
         </div>
       </header>
 
-      <section className="mb-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
-        <MetricCard
-          hint={`${mcpStatus.active} 活跃 · ${mcpStatus.failed} 异常 · ${mcpStatus.closed} 已关闭 · ${mcpStatus.unknown} 未知`}
-          label="MCP 实例"
-          tone="brand"
-          value={mcpSessions.loading ? "..." : mcpStatus.total}
-        />
-        <MetricCard
-          hint="来自全局 ToolRegistry"
-          label="注册工具"
-          tone="success"
-          value={registryTools.loading ? "..." : registryTools.data.length}
-        />
-        <MetricCard
-          hint={`${runStatusSummary.running} running · ${runStatusSummary.cancelled} cancelled`}
-          label="最近失败 Run"
+      <section
+        aria-label="运行健康摘要"
+        className="mb-4 grid divide-y divide-white/10 overflow-hidden rounded-lg border border-white/10 bg-ink-950/62 md:grid-cols-4 md:divide-x md:divide-y-0"
+      >
+        <HealthSummaryItem
+          detail={`${runStatusSummary.running} 运行中 · ${runStatusSummary.cancelled} 已取消`}
+          label="运行状态"
           tone={runStatusSummary.failed > 0 ? "error" : "success"}
-          value={runs.loading ? "..." : runStatusSummary.failed}
+          value={runs.loading ? "..." : runStatusSummary.failed > 0 ? `${runStatusSummary.failed} 项异常` : "正常"}
         />
-        <MetricCard
-          hint="来自本地 Skill runtime"
-          label="已安装 Skill"
-          tone="success"
-          value={skills.loading ? "..." : skills.data.length}
+        <HealthSummaryItem
+          detail={`${mcpStatus.failed} 异常 · ${mcpStatus.unknown} 未知`}
+          label="MCP 连接"
+          tone={mcpStatus.failed > 0 ? "error" : mcpStatus.active > 0 ? "brand" : "neutral"}
+          value={mcpSessions.loading ? "..." : mcpStatus.total > 0 ? `${mcpStatus.active}/${mcpStatus.total} 活跃` : "未连接"}
         />
-        <MetricCard
-          hint="仅显示布尔就绪态，不展示密钥值"
-          label="环境摘要"
+        <HealthSummaryItem
+          detail={clientHostSummary.total > 0 ? `${clientHostSummary.attention} 个需要检查` : "可配对 Chrome 或 Office"}
+          label="客户端宿主"
+          tone={clientHostSummary.attention > 0 ? "warning" : clientHostSummary.active > 0 ? "success" : "neutral"}
+          value={clientHosts.loading ? "..." : clientHostSummary.total > 0 ? `${clientHostSummary.active}/${clientHostSummary.total} 在线` : "未配对"}
+        />
+        <HealthSummaryItem
+          detail="仅显示就绪状态，不展示密钥"
+          label="环境依赖"
           tone={environment.data?.model_gateway_ready ? "success" : "warning"}
-          value={environment.loading ? "..." : environment.data?.model_gateway_ready ? "就绪" : "检查"}
+          value={environment.loading ? "..." : `${readyDependencyCount}/${dependencyRows.length} 就绪`}
         />
       </section>
 
-      <section className="mb-5 grid gap-3 rounded-lg border border-white/10 bg-white/[0.045] p-4 lg:grid-cols-[minmax(0,1fr)_180px_180px_auto] lg:items-end">
+      <section className="mb-4 grid gap-3 rounded-lg border border-white/10 bg-white/[0.045] p-4 lg:grid-cols-[minmax(0,1fr)_170px_170px_auto] lg:items-end">
         <label className="block">
           <span className="text-xs font-semibold text-slate-300">搜索运行资源</span>
           <input
-            className="mt-2 h-11 w-full rounded-lg border border-white/10 bg-ink-950/72 px-3 text-sm text-white outline-none transition placeholder:text-slate-500 hover:border-white/20 focus:border-hire-300/70 focus:ring-4 focus:ring-hire-300/10"
+            className="mt-2 h-11 w-full rounded-lg border border-white/10 bg-ink-950/72 px-3 text-sm text-white outline-none transition placeholder:text-slate-400 hover:border-white/20 focus:border-hire-300/70 focus:ring-4 focus:ring-hire-300/10"
             onChange={(event) => setKeyword(event.target.value)}
             placeholder="MCP session、工具名、run id、Skill"
             type="search"
@@ -723,7 +776,7 @@ export default function RuntimeOpsPage() {
           />
         </label>
         <label className="block">
-          <span className="text-xs font-semibold text-slate-300">Run 类型</span>
+          <span className="text-xs font-semibold text-slate-300">运行类型</span>
           <select
             className="mt-2 h-11 w-full rounded-lg border border-white/10 bg-ink-950/72 px-3 text-sm text-white outline-none transition focus:border-hire-300/70"
             onChange={(event) => setRunType(event.target.value as RuntimeFilter)}
@@ -737,7 +790,7 @@ export default function RuntimeOpsPage() {
           </select>
         </label>
         <label className="block">
-          <span className="text-xs font-semibold text-slate-300">Run 状态</span>
+          <span className="text-xs font-semibold text-slate-300">运行状态</span>
           <select
             className="mt-2 h-11 w-full rounded-lg border border-white/10 bg-ink-950/72 px-3 text-sm text-white outline-none transition focus:border-hire-300/70"
             onChange={(event) => setStatus(event.target.value as StatusFilter)}
@@ -751,31 +804,183 @@ export default function RuntimeOpsPage() {
           </select>
         </label>
         <button
-          className="h-11 rounded-lg border border-hire-300/25 bg-hire-300/10 px-4 text-sm font-semibold text-hire-100 transition hover:bg-hire-300/20"
-          onClick={refreshAll}
+          className="min-h-11 rounded-lg border border-white/10 bg-white/[0.045] px-4 text-sm font-semibold text-slate-200 transition hover:border-white/20 hover:bg-white/[0.075] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hire-300/60 disabled:cursor-default disabled:opacity-40"
+          disabled={!keyword && runType === "all" && status === "all"}
+          onClick={() => {
+            setKeyword("");
+            setRunType("all");
+            setStatus("all");
+          }}
           type="button"
         >
-          应用并刷新
+          清除筛选
         </button>
       </section>
+
+      <div
+        className={`mb-5 grid gap-4 ${
+          selectedRunId
+            ? "xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.46fr)]"
+            : ""
+        }`}
+      >
+        <SectionShell
+          action={
+            <span className="rounded-full border border-hire-300/25 bg-hire-300/10 px-3 py-1.5 text-xs font-semibold text-hire-100">
+              {visibleRuns.length} 条
+            </span>
+          }
+          description="优先查看失败和运行中的工作流、对话及智能体任务。"
+          error={runs.error}
+          title="运行记录"
+        >
+          {runs.loading ? (
+            <div className="p-4 text-sm text-slate-300">运行记录加载中...</div>
+          ) : visibleRuns.length === 0 ? (
+            <div className="px-4 py-7 text-center">
+              <p className="text-base font-semibold text-white">暂无匹配运行记录</p>
+              <p className="mt-2 text-sm text-slate-300">
+                运行工作流或开启 Chat Runtime Toolset 后，记录会显示在这里。
+              </p>
+            </div>
+          ) : (
+            <div className="max-h-[34rem] divide-y divide-white/10 overflow-y-auto overscroll-contain">
+              {visibleRuns.map((run) => (
+                <button
+                  aria-controls="runtime-run-detail"
+                  aria-expanded={selectedRunId === run.run_id}
+                  className={`block w-full border border-transparent px-4 py-3 text-left transition hover:bg-white/[0.045] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-hire-300/60 ${
+                    selectedRunId === run.run_id
+                      ? "border-hire-300/30 bg-hire-300/10"
+                      : ""
+                  } ${
+                    run.status === "failed"
+                      ? "border-rose-300/20 bg-rose-300/10"
+                      : run.status === "cancelled"
+                        ? "border-slate-300/15 bg-white/[0.055]"
+                        : ""
+                  }`}
+                  key={run.run_id}
+                  onClick={() =>
+                    setSelectedRunId((current) =>
+                      current === run.run_id ? "" : run.run_id,
+                    )
+                  }
+                  type="button"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-white">
+                        {replaceLegacyAgentTerms(
+                          run.title || getFriendlyRunTypeLabel(run.run_type),
+                        )}
+                      </p>
+                      <p className="mt-1 text-xs text-slate-400">
+                        {getFriendlyRunTypeLabel(run.run_type)} · {shortId(run.run_id)}
+                      </p>
+                    </div>
+                    <span
+                      className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-semibold ${statusClass(run.status)}`}
+                    >
+                      {getFriendlyRunStatusLabel(run.status)}
+                    </span>
+                  </div>
+                  <p className="mt-2 line-clamp-1 text-xs text-slate-300">
+                    {metadataPreview(run.metadata)}
+                  </p>
+                  {run.error ? (
+                    <p className="mt-2 line-clamp-2 rounded-md border border-rose-300/20 bg-rose-300/10 px-2 py-1 text-xs leading-5 text-rose-100">
+                      {run.error}
+                    </p>
+                  ) : null}
+                  <p className="mt-2 text-xs text-slate-400">
+                    更新于 {formatTime(run.updated_at ?? run.created_at)}
+                  </p>
+                </button>
+              ))}
+            </div>
+          )}
+        </SectionShell>
+
+        {selectedRunId ? (
+          <section className="rounded-lg border border-hire-300/20 bg-ink-950/72 xl:sticky xl:top-24 xl:self-start" id="runtime-run-detail">
+            <div className="flex items-start justify-between gap-3 border-b border-white/10 p-4">
+              <div>
+                <h2 className="text-base font-semibold text-white">运行详情</h2>
+                <p className="mt-1 text-xs text-slate-300">
+                  {shortId(selectedRunId)} 的最近 30 条检查点
+                </p>
+              </div>
+              <button
+                className="min-h-9 rounded-full border border-white/10 bg-white/[0.055] px-3 text-xs font-semibold text-slate-200 transition hover:bg-white/10"
+                onClick={() => setSelectedRunId("")}
+                type="button"
+              >
+                关闭详情
+              </button>
+            </div>
+            {selectedRun ? (
+              <div className="border-b border-white/10 p-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${statusClass(selectedRun.status)}`}
+                  >
+                    {getFriendlyRunStatusLabel(selectedRun.status)}
+                  </span>
+                  <span className="text-xs text-rose-100">错误 {selectedCheckpointCounts.error}</span>
+                  <span className="text-xs text-hire-100">警告 {selectedCheckpointCounts.warning}</span>
+                  <span className="text-xs text-slate-300">信息 {selectedCheckpointCounts.info}</span>
+                </div>
+                {selectedRun.error ? (
+                  <p className="mt-3 line-clamp-3 text-xs leading-5 text-rose-100">
+                    {selectedRun.error}
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+            {checkpoints.loading ? (
+              <p className="p-4 text-sm text-slate-300">检查点加载中...</p>
+            ) : checkpoints.error ? (
+              <p className="m-4 rounded-lg border border-rose-300/20 bg-rose-300/10 px-3 py-2 text-sm text-rose-100">
+                {checkpoints.error}
+              </p>
+            ) : checkpoints.data.length === 0 ? (
+              <p className="p-4 text-sm text-slate-300">该运行暂无检查点。</p>
+            ) : (
+              <div className="divide-y divide-white/10">
+                {checkpoints.data.slice(0, 8).map((checkpoint) => (
+                  <article className="px-4 py-3" key={checkpoint.checkpoint_id}>
+                    <div className="flex items-start justify-between gap-3">
+                      <p className="text-xs font-semibold text-white">
+                        {checkpoint.title || checkpoint.event_type}
+                      </p>
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${statusClass(checkpoint.severity)}`}
+                      >
+                        {getFriendlySeverityLabel(checkpoint.severity)}
+                      </span>
+                    </div>
+                    {checkpoint.summary ? (
+                      <p className="mt-2 line-clamp-2 text-xs leading-5 text-slate-300">
+                        {checkpoint.summary}
+                      </p>
+                    ) : null}
+                    <p className="mt-2 text-xs text-slate-400">
+                      {checkpoint.event_type} · {formatTime(checkpoint.created_at)}
+                    </p>
+                  </article>
+                ))}
+              </div>
+            )}
+          </section>
+        ) : null}
+      </div>
 
       <SectionShell
         action={
           <div className="flex flex-wrap gap-2">
-            <a
-              className="rounded-full border border-white/10 bg-white/[0.055] px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-cyan-300/30 hover:text-cyan-100"
-              href="/api/runtime/client-hosts/extension.zip"
-            >
-              下载 Chrome 扩展
-            </a>
-            <a
-              className="rounded-full border border-white/10 bg-white/[0.055] px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-emerald-300/30 hover:text-emerald-100"
-              href="/api/runtime/office-host/manifest.xml"
-            >
-              下载 Office Manifest
-            </a>
             <button
-              className="rounded-full bg-cyan-300 px-3 py-1.5 text-xs font-semibold text-slate-950 disabled:opacity-50"
+              className="min-h-11 rounded-full bg-cyan-300 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 disabled:opacity-50"
               disabled={clientHostBusy.startsWith("pairing-")}
               onClick={() => void createClientPairing("chrome")}
               type="button"
@@ -783,7 +988,7 @@ export default function RuntimeOpsPage() {
               配对 Chrome
             </button>
             <button
-              className="rounded-full bg-emerald-300 px-3 py-1.5 text-xs font-semibold text-slate-950 disabled:opacity-50"
+              className="min-h-11 rounded-full border border-emerald-300/30 bg-emerald-300/10 px-4 py-2 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-300/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-200 disabled:opacity-50"
               disabled={clientHostBusy.startsWith("pairing-")}
               onClick={() => void createClientPairing("office")}
               type="button"
@@ -792,10 +997,17 @@ export default function RuntimeOpsPage() {
             </button>
           </div>
         }
-        description="Chrome 绑定当前标签页；Office 加载项绑定当前 Word、Excel 或 PowerPoint 文档。Token 只保存在各宿主本地。Office 需要先运行证书脚本并启动 office profile。"
+        description="配对 Chrome 当前标签页或 Office 当前文档。Token 只保存在客户端。"
         error={clientHosts.error}
         title="客户端宿主"
       >
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-white/10 px-4 py-2.5 text-xs text-slate-400">
+          <span className="font-medium text-slate-300">首次使用</span>
+          <a className="hover:text-cyan-100" href="/api/runtime/client-hosts/extension.zip">下载 Chrome 扩展</a>
+          <a className="hover:text-emerald-100" href="/api/runtime/office-host/manifest.xml">下载 Office Manifest</a>
+          <a className="hover:text-cyan-100" href="/api/runtime/client-tools/fixture" rel="noreferrer" target="_blank">打开测试页</a>
+          <a className="sm:ml-auto hover:text-emerald-100" href="https://localhost:8443" rel="noreferrer" target="_blank">检查 Office HTTPS</a>
+        </div>
         {clientPairing ? (
           <div className="border-b border-white/10 bg-cyan-300/[0.07] px-4 py-3">
             <p className="text-xs text-cyan-100">
@@ -813,17 +1025,17 @@ export default function RuntimeOpsPage() {
         {clientHosts.loading ? (
           <div className="p-4 text-sm text-slate-400">客户端宿主加载中...</div>
         ) : clientHosts.data.length === 0 ? (
-          <div className="p-8 text-center">
-            <p className="text-base font-semibold text-white">尚未配对客户端宿主</p>
-            <p className="mt-2 text-sm text-slate-400">下载对应宿主并使用一次性配对码连接。配对后仍需主动绑定当前标签页或 Office 文档。</p>
-            <a className="mt-3 inline-flex text-xs font-semibold text-cyan-200 hover:text-cyan-100" href="/api/runtime/client-tools/fixture" target="_blank" rel="noreferrer">打开无敏感数据测试页</a>
+          <div className="flex flex-col gap-1 px-4 py-5 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm font-semibold text-white">尚未配对客户端宿主</p>
+            <p className="text-sm text-slate-400">选择上方宿主生成一次性配对码。</p>
           </div>
         ) : (
           <>
             <div className="flex flex-wrap gap-2 border-b border-white/10 px-4 py-3">
               {(["all", "chrome", "office"] as const).map((type) => (
                 <button
-                  className={`rounded-full border px-3 py-1 text-xs font-semibold ${clientHostType === type ? "border-cyan-300/40 bg-cyan-300/15 text-cyan-100" : "border-white/10 text-slate-300"}`}
+                  aria-pressed={clientHostType === type}
+                  className={`rounded-full border px-3 py-1 text-xs font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 ${clientHostType === type ? "border-cyan-300/40 bg-cyan-300/15 text-cyan-100" : "border-white/10 text-slate-300"}`}
                   key={type}
                   onClick={() => setClientHostType(type)}
                   type="button"
@@ -831,7 +1043,6 @@ export default function RuntimeOpsPage() {
                   {type === "all" ? "全部" : type === "chrome" ? "Chrome" : "Office"}
                 </button>
               ))}
-              <a className="ml-auto text-xs text-emerald-200 hover:text-emerald-100" href="https://localhost:8443" target="_blank" rel="noreferrer">检查 Office HTTPS</a>
             </div>
             <div className="grid gap-3 p-4 lg:grid-cols-2">
             {clientHosts.data
@@ -843,7 +1054,7 @@ export default function RuntimeOpsPage() {
                     <p className="truncate text-sm font-semibold text-white">{host.name}</p>
                     <p className="mt-1 truncate font-mono text-[10px] text-slate-500">{host.host_id} · {host.token_prefix}...</p>
                   </div>
-                  <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${statusClass(host.status)}`}>{host.status}</span>
+                  <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${statusClass(host.status)}`}>{getFriendlyMcpStatusLabel(host.status)}</span>
                 </div>
                 <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-400">
                   <p>{(host.host_type ?? "chrome") === "office" ? `Office ${host.office_app || "未识别"}` : "Chrome 扩展"} v{host.version || "-"}</p>
@@ -877,32 +1088,63 @@ export default function RuntimeOpsPage() {
         )}
       </SectionShell>
 
-      <div className="mt-5 grid gap-5 2xl:grid-cols-[minmax(0,1fr)_minmax(360px,0.58fr)]">
-        <div className="space-y-5">
-          <SectionShell
-            action={
-              <Link
-                className="rounded-full border border-white/10 bg-white/[0.055] px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-hire-300/35 hover:bg-hire-300/10 hover:text-hire-100"
-                to="/mcps"
-              >
+      <div className="mt-5">
+        <SectionShell
+          action={
+            resourceView === "mcp" ? (
+              <Link className="rounded-full border border-white/10 bg-white/[0.055] px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-hire-300/35 hover:bg-hire-300/10 hover:text-hire-100" to="/mcps">
                 管理 MCP
               </Link>
-            }
-            description="查看由 MCP 管理器启动的 stdio runtime 实例。"
-            error={mcpSessions.error}
-            title="MCP Runtime"
-          >
-            {mcpSessions.loading ? (
-              <div className="p-4 text-sm text-slate-400">MCP runtime 加载中...</div>
+            ) : resourceView === "skills" ? (
+              <Link className="rounded-full border border-white/10 bg-white/[0.055] px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-hire-300/35 hover:bg-hire-300/10 hover:text-hire-100" to="/skills">
+                管理 Skill
+              </Link>
+            ) : resourceView === "environment" && environment.data?.redacted ? (
+              <span className="rounded-full border border-emerald-300/25 bg-emerald-300/10 px-3 py-1.5 text-xs font-semibold text-emerald-100">已脱敏</span>
+            ) : (
+              <span className="rounded-full border border-brand-300/25 bg-brand-300/10 px-3 py-1.5 text-xs font-semibold text-brand-100">{visibleTools.length} 个工具</span>
+            )
+          }
+          description="在一个面板中切换查看连接、工具、Skill 和运行依赖。"
+          error={resourceView === "mcp" ? mcpSessions.error : resourceView === "tools" ? registryTools.error : resourceView === "skills" ? skills.error : environment.error}
+          title="运行资源"
+        >
+          <div aria-label="运行资源视图" className="flex flex-wrap gap-2 border-b border-white/10 px-4 py-3">
+            {([
+              { count: mcpSessions.data.length, label: "MCP 连接", value: "mcp" },
+              { count: visibleTools.length, label: "工具", value: "tools" },
+              { count: visibleSkills.length, label: "Skill", value: "skills" },
+              { count: `${readyDependencyCount}/${dependencyRows.length}`, label: "环境依赖", value: "environment" },
+            ] as const).map((item) => (
+              <button
+                aria-pressed={resourceView === item.value}
+                className={`min-h-11 rounded-full border px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hire-300/60 ${
+                  resourceView === item.value
+                    ? "border-hire-300/40 bg-hire-300/15 text-hire-100"
+                    : "border-white/10 bg-white/[0.04] text-slate-300 hover:border-white/20 hover:bg-white/[0.075]"
+                }`}
+                key={item.value}
+                onClick={() => setResourceView(item.value)}
+                type="button"
+              >
+                {item.label} <span className="ml-1 text-xs opacity-70">{item.count}</span>
+              </button>
+            ))}
+          </div>
+
+          {resourceView === "mcp" ? (
+            mcpSessions.loading ? (
+              <div className="p-4 text-sm text-slate-400">MCP 连接加载中...</div>
             ) : (
               <>
                 <div className="flex flex-wrap gap-2 border-b border-white/10 px-4 py-3">
                   {mcpStatusFilters.map((filter) => (
                     <button
-                      className={`rounded-full border px-3 py-1 text-xs font-semibold transition ${
+                      aria-pressed={mcpStatusFilter === filter.value}
+                      className={`rounded-full border px-3 py-1 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 ${
                         mcpStatusFilter === filter.value
-                          ? "border-hire-300/40 bg-hire-300/15 text-hire-100"
-                          : "border-white/10 bg-white/[0.045] text-slate-300 hover:border-white/20 hover:bg-white/[0.075]"
+                          ? "border-cyan-300/35 bg-cyan-300/10 text-cyan-100"
+                          : "border-white/10 text-slate-400 hover:text-white"
                       }`}
                       key={filter.value}
                       onClick={() => setMcpStatusFilter(filter.value)}
@@ -913,16 +1155,14 @@ export default function RuntimeOpsPage() {
                   ))}
                 </div>
                 {visibleSessions.length === 0 ? (
-                  <div className="p-8 text-center">
-                    <p className="text-base font-semibold text-white">未找到 MCP runtime</p>
-                    <p className="mt-2 text-sm text-slate-400">
-                      在 `/mcps` 连接 MCP Server 后，runtime 实例会显示在这里。
-                    </p>
+                  <div className="flex flex-col gap-1 px-4 py-5 sm:flex-row sm:items-center sm:justify-between">
+                    <p className="text-sm font-semibold text-white">没有符合条件的 MCP 连接</p>
+                    <p className="text-sm text-slate-400">前往 MCP 工具采购连接服务。</p>
                   </div>
                 ) : (
                   <div className="overflow-x-auto">
                     <table className="min-w-full divide-y divide-white/10 text-sm">
-                      <thead className="bg-white/[0.04] text-left text-xs text-slate-400">
+                      <thead className="bg-white/[0.035] text-left text-xs text-slate-400">
                         <tr>
                           <th className="px-4 py-3">Session</th>
                           <th className="px-4 py-3">状态</th>
@@ -934,21 +1174,11 @@ export default function RuntimeOpsPage() {
                       <tbody className="divide-y divide-white/10">
                         {visibleSessions.map((session) => (
                           <tr className="align-top text-slate-300" key={session.session_id}>
-                            <td className="px-4 py-3 font-mono text-xs text-brand-100">
-                              {shortId(session.session_id)}
-                            </td>
-                            <td className="px-4 py-3">
-                              <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusClass(session.status ?? "unknown")}`}>
-                                {session.status ?? "unknown"}
-                              </span>
-                            </td>
+                            <td className="px-4 py-3 font-mono text-xs text-brand-100">{shortId(session.session_id)}</td>
+                            <td className="px-4 py-3"><span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusClass(session.status ?? "unknown")}`}>{getFriendlyMcpStatusLabel(session.status)}</span></td>
                             <td className="px-4 py-3 text-white">{session.tools_count ?? 0}</td>
-                            <td className="px-4 py-3 text-slate-400">
-                              {Math.max(0, Math.floor(session.uptime_seconds ?? 0))}s
-                            </td>
-                            <td className="max-w-xl px-4 py-3 font-mono text-xs text-slate-500">
-                              {(session.server_command ?? []).join(" ") || "未记录"}
-                            </td>
+                            <td className="px-4 py-3 text-slate-400">{Math.max(0, Math.floor(session.uptime_seconds ?? 0))}s</td>
+                            <td className="max-w-xl px-4 py-3 font-mono text-xs text-slate-500">{(session.server_command ?? []).join(" ") || "未记录"}</td>
                           </tr>
                         ))}
                       </tbody>
@@ -956,304 +1186,67 @@ export default function RuntimeOpsPage() {
                   </div>
                 )}
               </>
-            )}
-          </SectionShell>
-
-          <SectionShell
-            action={
-              <span className="rounded-full border border-brand-300/25 bg-brand-300/10 px-3 py-1.5 text-xs font-semibold text-brand-100">
-                {visibleTools.length} 个工具
-              </span>
-            }
-            description="聚合已连接 MCP Server 暴露的工具，供 workflow/chat/runtime toolset 复用。"
-            error={registryTools.error}
-            title="Tool Registry"
-          >
-            {registryTools.loading ? (
+            )
+          ) : resourceView === "tools" ? (
+            registryTools.loading ? (
               <div className="p-4 text-sm text-slate-400">工具注册表加载中...</div>
             ) : visibleTools.length === 0 ? (
-              <div className="p-8 text-center">
-                <p className="text-base font-semibold text-white">当前没有注册工具</p>
-                <p className="mt-2 text-sm text-slate-400">
-                  连接 MCP Server 后，工具会进入全局 ToolRegistry。
-                </p>
-              </div>
-            ) : (
-              <div className="grid gap-3 p-4 lg:grid-cols-2">
-                {visibleTools.slice(0, 12).map((tool) => (
-                  <article
-                    className="rounded-lg border border-white/10 bg-white/[0.045] p-3"
-                    key={`${tool.session_id ?? tool.server_id ?? "tool"}-${tool.name}`}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-semibold text-white">{tool.name}</p>
-                        <p className="mt-1 text-xs text-brand-100">
-                          {tool.server_id ?? "unknown server"}
-                        </p>
-                      </div>
-                      <span className="shrink-0 rounded-full border border-white/10 bg-white/[0.055] px-2 py-0.5 text-[11px] text-slate-300">
-                        {schemaFieldCount(tool)} 参数
-                      </span>
-                    </div>
-                    <p className="mt-2 line-clamp-2 text-xs leading-5 text-slate-400">
-                      {tool.description || "暂无工具描述"}
-                    </p>
-                  </article>
-                ))}
-              </div>
-            )}
-          </SectionShell>
-        </div>
-
-        <div className="space-y-5">
-          <SectionShell
-            action={
-              <span className="rounded-full border border-hire-300/25 bg-hire-300/10 px-3 py-1.5 text-xs font-semibold text-hire-100">
-                {visibleRuns.length} 条
-              </span>
-            }
-            description="查看最近 workflow、chat、agent_task、agent_handoff 等运行记录。"
-            error={runs.error}
-            title="RunRegistry"
-          >
-            {runs.loading ? (
-              <div className="p-4 text-sm text-slate-400">运行记录加载中...</div>
-            ) : visibleRuns.length === 0 ? (
-              <div className="p-8 text-center">
-                <p className="text-base font-semibold text-white">暂无匹配运行记录</p>
-                <p className="mt-2 text-sm text-slate-400">
-                  运行工作流或开启 Chat Runtime Toolset 后会产生 run。
-                </p>
+              <div className="flex flex-col gap-1 px-4 py-5 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-sm font-semibold text-white">当前没有注册工具</p>
+                <p className="text-sm text-slate-400">连接 MCP 服务后，工具会显示在这里。</p>
               </div>
             ) : (
               <div className="divide-y divide-white/10">
-                {visibleRuns.map((run) => (
-                  <button
-                    className={`block w-full border border-transparent px-4 py-3 text-left transition hover:bg-white/[0.045] ${
-                      selectedRunId === run.run_id ? "border-hire-300/30 bg-hire-300/10" : ""
-                    } ${
-                      run.status === "failed"
-                        ? "border-rose-300/20 bg-rose-300/10"
-                        : run.status === "cancelled"
-                          ? "border-slate-300/15 bg-white/[0.055]"
-                          : ""
-                    }`}
-                    key={run.run_id}
-                    onClick={() => setSelectedRunId((current) => (current === run.run_id ? "" : run.run_id))}
-                    type="button"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-semibold text-white">
-                          {replaceLegacyAgentTerms(
-                            run.title || getFriendlyRunTypeLabel(run.run_type),
-                          )}
-                        </p>
-                        <p className="mt-1 text-xs text-slate-500">
-                          {getFriendlyRunTypeLabel(run.run_type)} · {shortId(run.run_id)}
-                        </p>
-                      </div>
-                      <span className={`shrink-0 rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusClass(run.status)}`}>
-                        {getFriendlyRunStatusLabel(run.status)}
-                      </span>
+                {visibleTools.slice(0, 12).map((tool) => (
+                  <article className="grid gap-2 px-4 py-3 sm:grid-cols-[minmax(180px,0.35fr)_minmax(0,1fr)_auto] sm:items-center" key={`${tool.session_id ?? tool.server_id ?? "tool"}-${tool.name}`}>
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-white">{tool.name}</p>
+                      <p className="mt-1 truncate text-xs text-brand-100">{tool.server_id ?? "unknown server"}</p>
                     </div>
-                    <p className="mt-2 line-clamp-1 text-xs text-slate-400">
-                      {metadataPreview(run.metadata)}
-                    </p>
-                    {run.error ? (
-                      <p className="mt-2 line-clamp-2 rounded-md border border-rose-300/20 bg-rose-300/10 px-2 py-1 text-xs leading-5 text-rose-100">
-                        {run.error}
-                      </p>
-                    ) : null}
-                    {run.status === "failed" || run.status === "cancelled" ? (
-                      <span className="mt-2 inline-flex rounded-full border border-white/10 bg-white/[0.055] px-2.5 py-1 text-[11px] font-semibold text-slate-300">
-                        重试待接入
-                      </span>
-                    ) : null}
-                    <p className="mt-2 text-xs text-slate-500">
-                      更新于 {formatTime(run.updated_at ?? run.created_at)}
-                    </p>
-                  </button>
+                    <p className="line-clamp-2 text-xs leading-5 text-slate-400">{tool.description || "暂无工具描述"}</p>
+                    <span className="w-fit rounded-full border border-white/10 bg-white/[0.055] px-2 py-0.5 text-[11px] text-slate-300">{schemaFieldCount(tool)} 参数</span>
+                  </article>
                 ))}
               </div>
-            )}
-          </SectionShell>
-
-          {selectedRunId ? (
-            <section className="rounded-lg border border-hire-300/20 bg-hire-300/10 p-4">
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <h2 className="text-sm font-semibold text-white">Checkpoint 摘要</h2>
-                  <p className="mt-1 text-xs text-slate-400">
-                    Run {shortId(selectedRunId)} 的最近 30 条 checkpoint。
-                  </p>
-                </div>
-                <button
-                  className="rounded-full border border-white/10 bg-white/[0.055] px-2.5 py-1 text-xs font-semibold text-slate-200 transition hover:bg-white/10"
-                  onClick={() => setSelectedRunId("")}
-                  type="button"
-                >
-                  关闭
-                </button>
-              </div>
-              {selectedRun ? (
-                <div className="mt-4 rounded-lg border border-white/10 bg-ink-950/60 p-3">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusClass(selectedRun.status)}`}>
-                      {selectedRun.status}
-                    </span>
-                    <span className="rounded-full border border-white/10 bg-white/[0.055] px-2 py-0.5 text-[11px] text-slate-300">
-                      error {selectedCheckpointCounts.error}
-                    </span>
-                    <span className="rounded-full border border-white/10 bg-white/[0.055] px-2 py-0.5 text-[11px] text-slate-300">
-                      warning {selectedCheckpointCounts.warning}
-                    </span>
-                    <span className="rounded-full border border-white/10 bg-white/[0.055] px-2 py-0.5 text-[11px] text-slate-300">
-                      info {selectedCheckpointCounts.info}
-                    </span>
-                  </div>
-                  {selectedRun.error ? (
-                    <p className="mt-3 line-clamp-3 text-xs leading-5 text-rose-100">
-                      {selectedRun.error}
-                    </p>
-                  ) : null}
-                  {selectedRun.status === "failed" || selectedRun.status === "cancelled" ? (
-                    <button
-                      className="mt-3 rounded-full border border-white/10 bg-white/[0.055] px-3 py-1 text-xs font-semibold text-slate-400"
-                      disabled
-                      type="button"
-                    >
-                      重试能力待接入
-                    </button>
-                  ) : null}
-                </div>
-              ) : null}
-              {checkpoints.loading ? (
-                <p className="mt-4 text-sm text-slate-400">Checkpoint 加载中...</p>
-              ) : checkpoints.error ? (
-                <p className="mt-4 rounded-lg border border-rose-300/20 bg-rose-300/10 px-3 py-2 text-sm text-rose-100">
-                  {checkpoints.error}
-                </p>
-              ) : checkpoints.data.length === 0 ? (
-                <p className="mt-4 rounded-lg border border-white/10 bg-white/[0.045] px-3 py-2 text-sm text-slate-400">
-                  该 run 暂无 checkpoint。
-                </p>
-              ) : (
-                <div className="mt-4 space-y-2">
-                  {checkpoints.data.slice(0, 8).map((checkpoint) => (
-                    <article
-                      className="rounded-lg border border-white/10 bg-ink-950/60 p-3"
-                      key={checkpoint.checkpoint_id}
-                    >
-                      <div className="flex items-start justify-between gap-3">
-                        <p className="text-xs font-semibold text-white">
-                          {checkpoint.title || checkpoint.event_type}
-                        </p>
-                        <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusClass(checkpoint.severity)}`}>
-                          {checkpoint.severity}
-                        </span>
-                      </div>
-                      <p className="mt-1 text-xs text-brand-100">{checkpoint.event_type}</p>
-                      {checkpoint.summary ? (
-                        <p className="mt-2 line-clamp-2 text-xs leading-5 text-slate-400">
-                          {checkpoint.summary}
-                        </p>
-                      ) : null}
-                      <p className="mt-2 text-xs text-slate-500">
-                        {formatTime(checkpoint.created_at)}
-                      </p>
-                    </article>
-                  ))}
-                </div>
-              )}
-            </section>
-          ) : null}
-
-          <SectionShell
-            action={
-              <Link
-                className="rounded-full border border-white/10 bg-white/[0.055] px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-hire-300/35 hover:bg-hire-300/10 hover:text-hire-100"
-                to="/skills"
-              >
-                管理 Skill
-              </Link>
-            }
-            description="展示当前已安装 Skill，完整安装和卸载仍在 Skill 页面完成。"
-            error={skills.error}
-            title="Skill Runtime"
-          >
-            {skills.loading ? (
+            )
+          ) : resourceView === "skills" ? (
+            skills.loading ? (
               <div className="p-4 text-sm text-slate-400">Skill 状态加载中...</div>
             ) : visibleSkills.length === 0 ? (
-              <div className="p-8 text-center">
-                <p className="text-base font-semibold text-white">暂无已安装 Skill</p>
-                <p className="mt-2 text-sm text-slate-400">
-                  前往 `/skills` 安装后，这里会显示运行态摘要。
-                </p>
+              <div className="flex flex-col gap-1 px-4 py-5 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-sm font-semibold text-white">暂无已安装 Skill</p>
+                <p className="text-sm text-slate-400">前往 Skill 技能培训安装后查看。</p>
               </div>
             ) : (
               <div className="divide-y divide-white/10">
-                {visibleSkills.slice(0, 6).map((skill) => (
-                  <article className="px-4 py-3" key={skill.skill_id}>
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-semibold text-white">
-                          {skill.name}
-                        </p>
-                        <p className="mt-1 line-clamp-1 text-xs text-slate-400">
-                          {skill.description || "暂无描述"}
-                        </p>
-                      </div>
-                      <span className="shrink-0 rounded-full border border-emerald-300/25 bg-emerald-300/10 px-2 py-0.5 text-[11px] font-semibold text-emerald-100">
-                        已安装
-                      </span>
+                {visibleSkills.slice(0, 8).map((skill) => (
+                  <article className="grid gap-2 px-4 py-3 sm:grid-cols-[minmax(180px,0.35fr)_minmax(0,1fr)_auto] sm:items-center" key={skill.skill_id}>
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-white">{skill.name}</p>
+                      <p className="mt-1 truncate text-xs text-slate-500">{skill.repo_url ?? "本地 Skill"}</p>
                     </div>
-                    <p className="mt-2 text-xs text-slate-500">
-                      {skill.repo_url ?? "本地 Skill"} {skill.installed_at ? `· ${formatTime(skill.installed_at)}` : ""}
-                    </p>
+                    <p className="line-clamp-2 text-xs leading-5 text-slate-400">{skill.description || "暂无描述"}</p>
+                    <span className="w-fit rounded-full border border-emerald-300/25 bg-emerald-300/10 px-2 py-0.5 text-[11px] font-semibold text-emerald-100">已安装</span>
                   </article>
                 ))}
               </div>
-            )}
-          </SectionShell>
-
-          <SectionShell
-            action={
-              environment.data?.redacted ? (
-                <span className="rounded-full border border-emerald-300/25 bg-emerald-300/10 px-3 py-1.5 text-xs font-semibold text-emerald-100">
-                  已脱敏
-                </span>
-              ) : null
-            }
-            description="只展示网关与运行依赖的布尔就绪态，不读取或显示密钥值。"
-            error={environment.error}
-            title="环境与依赖观测"
-          >
-            {environment.loading ? (
-              <div className="p-4 text-sm text-slate-400">环境摘要加载中...</div>
-            ) : environment.data ? (
-              <div className="grid gap-2 p-4 sm:grid-cols-2">
-                {dependencyRows.map((item) => (
-                  <div
-                    className="flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-white/[0.045] px-3 py-2"
-                    key={item.label}
-                  >
-                    <span className="text-sm text-slate-300">{item.label}</span>
-                    <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${booleanTone(item.value)}`}>
-                      {booleanStatus(item.value)}
-                    </span>
-                  </div>
-                ))}
-                <p className="sm:col-span-2 text-xs leading-5 text-slate-500">
-                  更新时间 {formatTime(environment.data.updated_at)}。该区不展示 `.env` 内容、API key 或本地路径。
-                </p>
-              </div>
-            ) : (
-              <div className="p-4 text-sm text-slate-400">暂无环境摘要。</div>
-            )}
-          </SectionShell>
-        </div>
+            )
+          ) : environment.loading ? (
+            <div className="p-4 text-sm text-slate-400">环境摘要加载中...</div>
+          ) : environment.data ? (
+            <div className="grid gap-x-6 gap-y-2 p-4 sm:grid-cols-2 lg:grid-cols-4">
+              {dependencyRows.map((item) => (
+                <div className="flex items-center justify-between gap-3 border-b border-white/10 py-2" key={item.label}>
+                  <span className="text-sm text-slate-300">{item.label}</span>
+                  <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${booleanTone(item.value)}`}>{booleanStatus(item.value)}</span>
+                </div>
+              ))}
+              <p className="sm:col-span-2 lg:col-span-4 text-xs leading-5 text-slate-500">更新时间 {formatTime(environment.data.updated_at)}。不展示 `.env` 内容、API key 或本地路径。</p>
+            </div>
+          ) : (
+            <div className="p-4 text-sm text-slate-400">暂无环境摘要。</div>
+          )}
+        </SectionShell>
       </div>
     </PageContainer>
   );


### PR DESCRIPTION
## 变更内容

- 将 Runtime 运维页重排为诊断优先的信息层级：紧凑页头、健康摘要、运行记录、客户端宿主和统一运行资源面板。
- 收敛重复刷新与空占位操作，运行筛选只刷新运行记录。
- 将 MCP、工具、Skill 与环境依赖合并为单面板切换视图。
- 完成运行状态中文化、清除筛选、错误提示、键盘焦点和 pressed 状态等可访问性加固。
- 补充 Runtime 页面聚焦组件测试。

## 用户影响

运维页首屏更聚焦于异常定位与运行状态，减少重复操作和信息噪音；现有后端 API、连接流程和管理入口保持不变。

## 验证

- `npm.cmd run test:run -- src/pages/RuntimeOpsPage.test.tsx src/pages/ResourcePageSidebarConsistency.test.tsx`：2 个测试文件、7 项通过。
- `npm.cmd run build`：通过，保留既有大 chunk 警告。
- `git diff --check`：通过。
- 独立预览 `http://127.0.0.1:15188/runtime`：资源切换、筛选状态与布局实机检查通过；无控制台错误，仅既有 React Router future flag 警告。

## 兼容与回退

未修改后端接口、数据库或运行协议。回退仅需恢复 `RuntimeOpsPage.tsx` 及其测试文件。
