### PR TITLE
fix: 修复 RAG P0 检索一致性与评测门禁

### DIFF
--- a/client/src/pages/RagPage.tsx
+++ b/client/src/pages/RagPage.tsx
@@ -159,6 +159,7 @@ interface PipelineDraftEdits {
   childChunkSize: string;
   childChunkOverlap: string;
   childSeparators: string;
+  embeddingProvider: "hash" | "openai_compatible";
   embeddingModel: string;
   retrievalMode: "vector" | "fulltext" | "hybrid";
   vectorWeight: string;
@@ -535,10 +536,22 @@ function numericProfileValue(profile: Record<string, unknown>, key: string, fall
   return Number.isFinite(value) ? value : fallback;
 }
 
+function embeddingProfileSection(
+  profile: Record<string, unknown> | undefined,
+  key: "requested" | "effective",
+) {
+  const value = profile?.[key];
+  return isUnknownRecord(value) ? value : {};
+}
+
 function draftEditsFromResponse(draft: PipelineDraftResponse): PipelineDraftEdits {
   const processor = draft.stages.find((stage) => stage.kind === "processor")?.config ?? {};
   const chunker = draft.stages.find((stage) => stage.kind === "chunker")?.config ?? {};
   const retrieval = draft.retrieval_profile ?? {};
+  const requestedEmbedding = embeddingProfileSection(
+    draft.embedding_profile,
+    "requested",
+  );
   const strategy = chunker.strategy === "parent_child" ? "parent_child" : "recursive_character";
   const retrievalMode = ["vector", "fulltext", "hybrid"].includes(String(retrieval.mode))
     ? String(retrieval.mode) as PipelineDraftEdits["retrievalMode"]
@@ -567,8 +580,14 @@ function draftEditsFromResponse(draft: PipelineDraftResponse): PipelineDraftEdit
     childChunkSize: String(chunker.child_chunk_size ?? 400),
     childChunkOverlap: String(chunker.child_chunk_overlap ?? 50),
     childSeparators: separatorsToText(chunker.child_separators),
+    embeddingProvider:
+      requestedEmbedding.provider === "openai_compatible"
+        ? "openai_compatible"
+        : "hash",
     embeddingModel: String(
-      draft.embedding_profile?.model ?? DEFAULT_EMBEDDING_MODEL_ID,
+      requestedEmbedding.model
+        ?? draft.embedding_profile?.model
+        ?? DEFAULT_EMBEDDING_MODEL_ID,
     ),
     retrievalMode,
     vectorWeight: String(numericProfileValue(retrieval, "vector_weight", 0.7)),
@@ -751,6 +770,7 @@ export default function RagPage() {
     childChunkSize: "",
     childChunkOverlap: "",
     childSeparators: "",
+    embeddingProvider: "openai_compatible",
     embeddingModel: DEFAULT_EMBEDDING_MODEL_ID,
     retrievalMode: "hybrid",
     vectorWeight: "0.7",
@@ -836,6 +856,14 @@ export default function RagPage() {
           (item.deletion_status ?? "active") === "active",
       ) ?? null,
     [knowledgeBases, selectedKbId],
+  );
+  const requestedEmbeddingProfile = embeddingProfileSection(
+    pipelineDraft?.embedding_profile,
+    "requested",
+  );
+  const effectiveEmbeddingProfile = embeddingProfileSection(
+    pipelineDraft?.embedding_profile,
+    "effective",
   );
   const ragFileSelectionDisabled = ragCapabilityDisabled || Boolean(selectedKnowledgeBase?.corpus_locked);
 
@@ -1150,6 +1178,7 @@ export default function RagPage() {
             },
           },
           embedding_profile: {
+            provider: pipelineDraftEdits.embeddingProvider,
             model: pipelineDraftEdits.embeddingModel.trim(),
           },
           retrieval_profile: {
@@ -2420,6 +2449,7 @@ export default function RagPage() {
                                     className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2 text-sm text-white outline-none focus:border-hire-300/50"
                                     onChange={(event) => setPipelineDraftEdits((current) => ({
                                       ...current,
+                                      embeddingProvider: "openai_compatible",
                                       embeddingModel: event.target.value,
                                     }))}
                                     value={pipelineDraftEdits.embeddingModel}
@@ -2441,6 +2471,24 @@ export default function RagPage() {
                                   </select>
                                 </label>
                               </div>
+                              {pipelineDraft ? (
+                                <p
+                                  className={`mt-2 text-[11px] leading-5 ${
+                                    effectiveEmbeddingProfile.ready === false
+                                      ? "text-amber-200"
+                                      : "text-slate-500"
+                                  }`}
+                                >
+                                  请求：{String(requestedEmbeddingProfile.provider || "未设置")} / {String(requestedEmbeddingProfile.model || "未设置")}
+                                  {" · "}
+                                  生效：{String(effectiveEmbeddingProfile.provider || "未设置")} / {String(effectiveEmbeddingProfile.model || "未设置")}
+                                  {effectiveEmbeddingProfile.ready === false
+                                    ? "（不可用，预检与执行将被阻止）"
+                                    : effectiveEmbeddingProfile.degraded
+                                      ? "（显式降级模式）"
+                                      : ""}
+                                </p>
+                              ) : null}
 
                               {pipelineDraftEdits.strategy === "recursive_character" ? (
                                 <div className="mt-3 grid gap-3 sm:grid-cols-2">

--- a/docs/RAG_INTEGRATION.md
+++ b/docs/RAG_INTEGRATION.md
@@ -2,12 +2,28 @@
 
 本文件说明模镜本地 RAG 模块的架构、API、扩展方式和测试方法。该模块位于 `server/rag/`，前端入口为 `/rag`，聊天页可选择知识库进行检索增强问答。
 
-最后更新日期：2026-08-11
+最后更新日期：2026-08-17
 
 > **当前状态：** `/rag` 是 ModelMirror 本地主路径。知识流水线已支持候选版本、
 > 人工激活/回滚、Processor、可选视觉理解、向量 + FTS5 双索引、检索评测和
 > Promotion Gate。下方按日期保留的段落是增量记录；较早段落中的“planned”
 > 只代表当时状态。
+
+## 2026-08-17 P0：Embedding 请求与生效合同
+
+Pipeline Draft 的 `embedding_profile` 现在同时返回安全的 `requested` 与 `effective`
+摘要。原有顶层 `provider / model / dimension / degraded` 保留为 `effective` 的兼容投影，
+不得再把请求的语义模型名称附着在实际 hash 向量上。
+
+- 新建本地/CI 草稿在没有 `EMBEDDING_API_KEY` 时显式使用
+  `hash / deterministic-hash-v1`。
+- 选择 `openai_compatible` 模型但 Provider 当前不可用时，草稿保留请求信息，
+  `effective.ready=false` 且 Provider 为 `unavailable`；预检和 Job 创建均 fail-closed，
+  不会静默生成 hash 索引。
+- 旧版 `hash + 语义模型名` 草稿按历史静默降级记录读取为未就绪的真实模型请求；
+  已发布版本和活动索引不做原地修改。
+- `requested/effective` 只包含 Provider、模型、维度、状态和安全原因码，不返回 endpoint、
+  API Key 或其他凭据。
 
 ## 2026-08-10 增量：Benchmark 驱动的 RAG Strategy Auto Tuner
 
@@ -401,7 +417,7 @@ FastAPI RAG Router
         |
         +--> document_parser.py  解析 TXT / Markdown / PDF
         +--> splitter.py         本地递归字符 / 父子分段与字符偏移
-        +--> embedder.py         OpenAI-compatible Embedding API，缺失 key 时 hash fallback
+        +--> embedder.py         OpenAI-compatible Embedding API；显式 hash 仅用于本地/CI
         +--> vector_store.py     ChromaDB 持久化，缺失依赖时 LocalJsonVectorStore fallback
         +--> lexical_store.py    SQLite FTS5 与中英文规范化词元
         +--> reranker.py         专用 Rerank API / LLM JSON fail-open
@@ -616,7 +632,11 @@ EMBEDDING_API_KEY=sk-...
 EMBEDDING_MODEL=text-embedding-3-small
 ```
 
-如果没有 `EMBEDDING_API_KEY`，系统会自动使用确定性 hash embedding，便于本地开发和 CI 测试。生产环境建议配置真实 Embedding API。
+如果没有 `EMBEDDING_API_KEY`，新草稿默认显式使用
+`hash / deterministic-hash-v1`，便于本地开发和 CI 测试。用户选择真实语义模型后，
+系统会保存 `requested` 配置，但将 `effective` 标记为 `unavailable`，并阻止预检通过和
+索引 Job 创建；不会再自动回退到 hash。生产索引应配置真实 Embedding API，并在执行前
+确认 `embedding_profile.effective.ready=true`。
 
 RAG 回答生成使用 OpenRouter：
 
@@ -723,3 +743,26 @@ POST  /api/rag/knowledge-write-proposals/{proposal_id}/reject
 ```
 
 工具响应、审计和 checkpoint 只保留 ID、状态、分数诊断、长度与安全错误摘要，不保存完整知识正文、提议正文、prompt、路径、embedding 或密钥。GraphRAG、实体关系抽取、社区摘要和图检索继续暂缓。
+
+## 2026-08-17 增量：RAG P0 1B–1D 检索一致性修复
+
+本轮修复将查询、检索和评测证据绑定到不可变 Pipeline Version，边界止于 1D；不迁移或激活现有索引，也不修改共享持久化数据。
+
+- 1B：查询按版本中保存的 requested/effective embedding 身份选择 embedder，并校验服务实际返回的向量维度。Chroma 新写入按版本 namespace 使用独立 collection，因此不同维度可以并存；旧 `modelmirror_rag_chunks` collection 保持只读兼容回退。
+- 1C：weighted RRF 使用理论 rank-1 上限归一化，分数不再随候选池最小值/最大值漂移。`score_threshold` 只判断融合召回分数并在 rerank 前执行；最终选择先去重同一 parent context，再优先覆盖不同文档。
+- 1D：专用 rerank API 与 chat-completions LLM rerank 使用各自模型身份；`auto` 从 API 回退 LLM 时不会传递 reranker-only model。Provider 返回结果在验证后按分数降序截断。Evaluation case 和 benchmark provisioning 保存脱敏的实际检索 receipt、版本配置指纹与来源清单指纹。
+- 1D.1 验收闭环：Promotion Gate 的默认 `min_no_result_accuracy` 从 `0` 收紧为 `0.8`。含无答案样例的评测若全部误召回，将默认判为未通过；运维者仍可显式保存 `0` 以兼容既有策略，但测试和审计不得再隐式依赖该宽松值。
+
+版本证据描述“该索引建成时保存的身份”，不会因当前凭据增加或撤销而改变 fingerprint；实际 vector 查询仍会重新检查当前凭据并 fail-closed。证据不包含 API key、端点、原文、路径、embedding 向量或完整 prompt。
+
+真实 API 隔离 smoke：
+
+```bash
+python scripts/rag_real_api_smoke.py
+```
+
+脚本只使用临时上传、向量和 SQLite 目录，不生成答案、不激活候选版本。环境需要可用的 `LLM_GATEWAY_URL`、`LLM_GATEWAY_KEY`、LLM rerank model，以及显式 Embedding 配置或 `OPENROUTER_API_KEY`。若 Embedding provider 不可用，脚本失败退出，不回退到 hash。详细脱敏结果见 `docs/task-cards/rag-p0-round1b-1d-evidence.json`。
+
+独立预览器使用同一不可变 6-case Gold v1 复测后，fulltext v1 与 hybrid + LLM rerank v2 的无答案准确率均为 `0`、误召回率均为 `1`，两者现在都因默认 80% 门槛被正确阻断；v2 还因 citation hit rate 回退和 P95 延迟超限而失败。测试过程中没有激活候选版本。语料相关的阈值校准、Rerank 延迟和 citation precision 调优不属于 1D.1 正确性修复。
+
+回退时只需撤销本轮代码文件；由于没有活动版本切换或共享数据写入，不需要数据回滚。人工验收通过前不得迁移索引、部署或将候选版本设为活动版本。

--- a/docs/task-cards/rag-p0-round0-r1a-baseline.json
+++ b/docs/task-cards/rag-p0-round0-r1a-baseline.json
@@ -1,0 +1,160 @@
+{
+  "schema_version": "modelmirror-rag-p0-baseline-v1",
+  "captured_at": "2026-08-18T02:38:27.4050124Z",
+  "task_contract": {
+    "objective": "Capture a reproducible RAG baseline and make requested versus effective embedding configuration truthful and fail-closed.",
+    "included": [
+      "source-runtime-data baseline evidence",
+      "P0 regression tests for silent embedding degradation",
+      "requested and effective embedding profile contract",
+      "pipeline preflight and job creation guard when the requested provider is unavailable"
+    ],
+    "excluded": [
+      "query-time version-scoped embedder selection",
+      "vector collection isolation",
+      "hybrid scoring and threshold changes",
+      "retrieval diversity",
+      "rerank protocol changes",
+      "benchmark generation changes",
+      "active index migration or deployment"
+    ],
+    "allowed_paths": [
+      "server/rag/rag_service.py",
+      "server/rag/pipeline_executor.py",
+      "server/tests/test_rag_pipeline.py",
+      "client/src/pages/RagPage.tsx",
+      "docs/RAG_INTEGRATION.md",
+      "docs/task-cards/rag-p0-round0-r1a-baseline.json"
+    ],
+    "file_count_exception": "Six files are required because the executor must consume the new effective profile; omitting it would cause canonical hash model metadata to instantiate a different embedder and break execution identity.",
+    "protected_state": [
+      "server/rag/storage",
+      "the active knowledge version",
+      "shared Docker services and persistent volumes",
+      "the dirty primary checkout"
+    ],
+    "public_api_impact": "Embedding profiles add requested and effective safe metadata while retaining flat effective fields for compatibility. Draft execution becomes fail-closed when a requested provider is unavailable.",
+    "data_migration": "none",
+    "dependency_change": "none",
+    "risk": "high correctness risk, low data-mutation risk"
+  },
+  "source_control": {
+    "repository_base": "origin/main",
+    "base_commit": "9d441c736c1f74842c560ff44762cefc0e035ebf",
+    "branch": "codex/rag-p0-r1a",
+    "isolated_worktree": true,
+    "primary_checkout_modified": false
+  },
+  "runtime": {
+    "health": {
+      "status": "ok"
+    },
+    "container": {
+      "container_id": "3b03f35f426384515f181a1fff3fb31811c05388ffbd90cffb114b853c2d29ca",
+      "image_id": "sha256:3112e04d783e459eea0b240ac947cc3d2135dace74946a7b9e37c41bcbc90b90",
+      "created_at": "2026-08-17T13:32:32.938637644Z",
+      "image_name": "modelmirror-server"
+    },
+    "retrieval_capabilities": {
+      "version": "rag-retrieval-capabilities-v2",
+      "index_schema_version": 2,
+      "vector": {
+        "available": true,
+        "backend": "ChromaVectorStore"
+      },
+      "fulltext": {
+        "available": true,
+        "backend": "sqlite_fts5"
+      },
+      "embedding": {
+        "provider": "hash",
+        "model": "text-embedding-3-small",
+        "dimension": 384,
+        "degraded": true
+      },
+      "rerank": {
+        "api_configured": false,
+        "api_model": "",
+        "llm_configured": true,
+        "llm_model": "deepseek/deepseek-chat"
+      },
+      "modes": [
+        "vector",
+        "fulltext",
+        "hybrid"
+      ]
+    }
+  },
+  "protected_data_summary": {
+    "raw_files_copied": false,
+    "document_content_recorded": false,
+    "secret_values_recorded": false,
+    "metadata_sha256": "ad2d7a612ad5c92bcdb1fb3ba19305b5eda140e028a1b791601483e3b006dd72",
+    "evaluations_sha256": "83d0dabfc1ce662da904f5a097740f11776f0e095067182f89b61c499d97cd05",
+    "knowledge_base_id": "kb_8018fa2ae4a2489db7bb9fdfaab978a3",
+    "active_version_id": "kpv_4c7c7a47a21f455fa8207b64022907b7",
+    "pipeline_version_count": 1,
+    "active_chunk_count": 4006,
+    "active_embedding_profile": {
+      "provider": "hash",
+      "model": "baai/bge-m3",
+      "dimension": 384,
+      "degraded": true
+    },
+    "active_retrieval_profile": {
+      "mode": "fulltext",
+      "vector_weight": 0.0,
+      "fulltext_weight": 1.0,
+      "top_k": 10,
+      "score_threshold": 0.0,
+      "candidate_multiplier": 4,
+      "rerank_enabled": true,
+      "rerank_provider": "llm",
+      "rerank_model": "cohere/rerank-4-fast",
+      "rerank_top_n": 10
+    },
+    "evaluation_run_count": 1,
+    "evaluation_target_count": 2,
+    "evaluation_targets_present_in_current_metadata": 0,
+    "evaluation_status": "orphaned_unreproducible"
+  },
+  "acceptance": {
+    "normal": "An explicitly configured provider reports matching requested and effective provider/model metadata.",
+    "degraded_local": "An explicitly selected hash provider reports deterministic hash as both requested and effective without a semantic model label.",
+    "blocked": "An OpenAI-compatible request without credentials is persisted as unavailable, preflight is not ready, and no pipeline job is created.",
+    "rollback": "Revert only the six files listed in task_contract.allowed_paths; no active version or persistent data pointer changes are required."
+  },
+  "verification": {
+    "red_phase": {
+      "result": "4 failed as expected",
+      "covered_failures": [
+        "requested profile metadata absent",
+        "real provider request silently downgraded to hash",
+        "unavailable provider did not block execution",
+        "configured provider did not expose requested and effective identity"
+      ]
+    },
+    "green_phase": {
+      "pipeline_tests": "24 passed",
+      "all_rag_tests": "175 passed",
+      "frontend_tests": "385 passed",
+      "frontend_production_build": "passed",
+      "backend_syntax": "passed",
+      "baseline_manifest_json": "passed",
+      "diff_check": "passed"
+    },
+    "full_backend_regression": {
+      "branch_result": "3193 passed, 22 failed, 29 skipped",
+      "failed_areas": [
+        "agency worker build artifact unavailable",
+        "agency execution worker unavailable",
+        "multimodal catalog environment baseline",
+        "skill Node and TypeScript execution environment"
+      ],
+      "base_commit_comparison": "The same 22 tests failed when rerun from the detached source commit; no RAG test failed."
+    },
+    "external_provider_calls": 0,
+    "active_version_mutations": 0,
+    "shared_service_mutations": 0
+  }
+}

--- a/docs/task-cards/rag-p0-round1b-1d-evidence.json
+++ b/docs/task-cards/rag-p0-round1b-1d-evidence.json
@@ -1,0 +1,214 @@
+{
+  "schema_version": "modelmirror-rag-p0-round1b-1d-evidence-v2",
+  "captured_at": "2026-08-20T10:11:19Z",
+  "scope": {
+    "base_commit": "9d441c736c1f74842c560ff44762cefc0e035ebf",
+    "submission_base_commit": "c7cec3800ed00ea5b0c8c28768c7c52baf601ddf",
+    "branch": "codex/rag-p0-r1a",
+    "isolated_worktree": true,
+    "through_batch": "1D",
+    "acceptance_closure": "1D.1",
+    "supersedes_round0_1a_exclusions": [
+      "query-time version-scoped embedder selection",
+      "vector collection isolation",
+      "hybrid scoring and threshold changes",
+      "retrieval diversity",
+      "rerank protocol changes",
+      "benchmark evidence changes"
+    ],
+    "still_excluded": [
+      "active index migration",
+      "candidate activation",
+      "deployment",
+      "shared persistent storage mutation",
+      "production configuration changes",
+      "work beyond 1D"
+    ],
+    "manual_acceptance_required": true
+  },
+  "batches": {
+    "1B": {
+      "objective": "Pin query embeddings to immutable version identity and isolate Chroma dimensions by version namespace.",
+      "red_phase": "3 failed as expected",
+      "green_phase": "3 passed",
+      "affected_regression": "55 passed, 4 warnings",
+      "acceptance": [
+        "hash versions do not use a conflicting process-level embedder",
+        "real-provider versions persist the provider-returned dimension and fail closed when credentials disappear",
+        "two Chroma namespaces with different dimensions can coexist and be deleted independently"
+      ]
+    },
+    "1C": {
+      "objective": "Make fused scores candidate-pool invariant and apply recall threshold before rerank with parent and document diversity.",
+      "red_phase": "2 failed as expected",
+      "green_phase": "2 passed",
+      "affected_regression": "58 passed, 4 warnings",
+      "acceptance": [
+        "adding a tail candidate does not change existing weighted-RRF scores",
+        "score_threshold is evaluated against fused recall scores",
+        "duplicate parent contexts are removed and distinct documents are selected before same-document fill"
+      ]
+    },
+    "1D": {
+      "objective": "Separate rerank protocols and persist credential-free, reproducible evaluation evidence.",
+      "red_phase": "4 failed as expected; one additional evidence-stability test failed as expected during final review",
+      "green_phase": "4 passed; additional evidence-stability test 1 passed",
+      "affected_regression": "46 passed, 4 warnings",
+      "acceptance": [
+        "an API reranker model is never forwarded to chat-completions during auto fallback",
+        "provider results are sorted by validated score before top_n",
+        "explicit LLM rerank rejects reranker-only model identifiers without an HTTP request",
+        "evaluation cases record the actual embedding and rerank receipt",
+        "benchmark provisioning records an immutable version fingerprint",
+        "credential changes do not alter the stored version fingerprint"
+      ]
+    },
+    "1D.1": {
+      "objective": "Fail closed by default when an evaluation set contains no-result cases that the retrieval configuration answers with false positives.",
+      "red_phase": "2 failed as expected: the unit gate and evaluation-gate API both exposed a zero no-result floor",
+      "green_phase": "2 passed",
+      "affected_regression": "201 passed, 4 warnings",
+      "acceptance": [
+        "the default minimum no-result accuracy is 0.8 in the evaluator and PATCH request contract",
+        "zero no-result accuracy fails the default promotion gate",
+        "an operator can still explicitly set the minimum to 0.0 for compatibility",
+        "strategy-tuner tests that require the legacy permissive behavior declare the override explicitly"
+      ]
+    }
+  },
+  "real_api_smoke": {
+    "status": "passed",
+    "isolation": {
+      "temporary_container": true,
+      "temporary_upload_storage": true,
+      "temporary_vector_storage": true,
+      "temporary_lexical_storage": true,
+      "active_version_mutations": 0,
+      "shared_storage_mutations": 0,
+      "answer_generation_calls": 0
+    },
+    "successful_run": {
+      "embedding": {
+        "provider": "openai_compatible",
+        "route": "openrouter",
+        "model": "openai/text-embedding-3-small",
+        "dimension": 1536,
+        "successful_requests": 2
+      },
+      "rerank": {
+        "provider": "llm",
+        "model": "deepseek/deepseek-chat",
+        "applied": true,
+        "successful_requests": 1
+      },
+      "retrieval": {
+        "source_count": 2,
+        "top_document": "release.txt",
+        "version_fingerprint": "7841f9a41b5aee73318b48e643a9585abec35b66d8737363be02c3034334b0a6"
+      }
+    },
+    "diagnostic_attempts": [
+      {
+        "stage": "process startup",
+        "result": "failed before any provider request because the script entrypoint lacked the repository root on sys.path"
+      },
+      {
+        "stage": "newAPI embedding route",
+        "result": "one embedding request failed closed with HTTP 503; no hash fallback occurred"
+      }
+    ],
+    "catalog_reads": 2,
+    "successful_inference_requests": 3,
+    "failed_inference_requests": 1,
+    "secret_values_recorded": false,
+    "endpoint_values_recorded": false,
+    "document_content_recorded": false
+  },
+  "real_ui_acceptance": {
+    "status": "p0_gate_fix_passed_candidate_quality_blocked",
+    "isolation": {
+      "independent_preview": true,
+      "temporary_rag_storage": true,
+      "shared_storage_mutations": 0,
+      "production_configuration_changes": 0,
+      "candidate_activation": false
+    },
+    "dataset": {
+      "document_count": 2,
+      "pipeline_version_count": 2,
+      "evaluation_set_version": 1,
+      "case_count": 6,
+      "positive_case_count": 5,
+      "no_result_case_count": 1
+    },
+    "evaluation_run": {
+      "run_id": "evalrun_daa24c0f67ec44a4ad621ce26be980ec",
+      "status": "succeeded",
+      "gate_policy": {
+        "min_recall_at_5": 0.8,
+        "min_no_result_accuracy": 0.8,
+        "max_p95_latency_ratio": 2.0
+      },
+      "baseline_v1": {
+        "mode": "fulltext",
+        "recall_at_1": 0.6,
+        "recall_at_5": 1.0,
+        "mrr_at_10": 0.75,
+        "citation_coverage": 1.0,
+        "no_result_accuracy": 0.0,
+        "false_positive_rate": 1.0,
+        "p95_latency_ms": 5.187,
+        "gate_passed": false,
+        "failed_gate_checks": [
+          "min_no_result_accuracy"
+        ]
+      },
+      "candidate_v2": {
+        "mode": "hybrid",
+        "recall_at_1": 0.8,
+        "recall_at_5": 1.0,
+        "mrr_at_10": 0.84,
+        "citation_coverage": 1.0,
+        "no_result_accuracy": 0.0,
+        "false_positive_rate": 1.0,
+        "p95_latency_ms": 6275.771,
+        "gate_passed": false,
+        "failed_gate_checks": [
+          "min_no_result_accuracy",
+          "max_citation_hit_regression",
+          "max_p95_latency_ratio"
+        ]
+      }
+    },
+    "provider_receipts": {
+      "embedding_provider": "openai_compatible",
+      "embedding_model": "openai/text-embedding-3-small",
+      "embedding_dimension": 1536,
+      "rerank_provider": "llm",
+      "rerank_model": "deepseek/deepseek-chat",
+      "rerank_applied_cases": 6,
+      "billed_request_count_asserted": false
+    },
+    "quality_decision": "Both versions are correctly blocked by the no-result floor. The active baseline remains unchanged and v2 is not eligible for promotion. Threshold calibration, rerank latency, and citation precision remain follow-up tuning work."
+  },
+  "final_verification": {
+    "p0_default_gate_red": "2 failed as expected",
+    "p0_default_gate_green": "2 passed, 4 warnings",
+    "rag_and_knowledge_workflow": "201 passed, 4 warnings",
+    "frontend_tests_pre_rebase": "78 files passed, 385 tests passed",
+    "frontend_tests_post_rebase": "The full 80-file run completed 77 files and 390 tests successfully; three unrelated Agent/Skill page tests hit the shared 5-second timeout. Each affected file passed when rerun alone: 10/10, 9/9, and 2/2 tests.",
+    "frontend_production_build": "passed with the pre-existing large-chunk warning",
+    "full_backend": "3203 passed, 22 failed, 29 skipped, 6 warnings",
+    "full_backend_baseline_comparison": "The same 22 non-RAG tests failed on detached base commit 9d441c736c1f74842c560ff44762cefc0e035ebf; no RAG test failed.",
+    "chroma_adapter_compatibility": "One final-regression failure was reproduced, fixed, and then passed before the 187-test rerun.",
+    "commit_created": true,
+    "push_performed": false,
+    "pull_request_created": false,
+    "deployment_performed": false
+  },
+  "rollback": {
+    "code": "Revert only the files listed by the final scoped diff.",
+    "data": "No data rollback is required because no candidate was activated and shared persistent RAG storage was not mutated.",
+    "compatibility": "The legacy Chroma collection remains readable; new version namespaces can be removed independently."
+  }
+}

--- a/scripts/rag_real_api_smoke.py
+++ b/scripts/rag_real_api_smoke.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from server.rag.embedder import EmbeddingClient
+from server.rag.lexical_store import SqliteLexicalStore
+from server.rag.pipeline_executor import KnowledgePipelineExecutor
+from server.rag.rag_service import RagService
+from server.rag.vector_store import LocalJsonVectorStore
+
+
+def _gateway_base() -> str:
+    url = os.getenv("LLM_GATEWAY_URL", "").strip().rstrip("/")
+    suffix = "/chat/completions"
+    return url[: -len(suffix)] if url.endswith(suffix) else url
+
+
+async def _embedding_models(base: str, key: str) -> list[str]:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(20.0, connect=10.0)) as client:
+        response = await client.get(
+            f"{base}/embeddings/models",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+    items = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(items, list):
+        return []
+    return [
+        str(item.get("id") or "")
+        for item in items
+        if isinstance(item, dict) and str(item.get("id") or "")
+    ]
+
+
+def _embedding_model(model_ids: list[str]) -> str:
+    configured = (
+        os.getenv("RAG_REAL_SMOKE_EMBEDDING_MODEL", "").strip()
+        or os.getenv("EMBEDDING_MODEL", "").strip()
+    )
+    if configured:
+        return configured
+    preferred = [
+        "openai/text-embedding-3-small",
+        "text-embedding-3-small",
+        "baai/bge-m3",
+        "qwen/qwen3-embedding-8b",
+    ]
+    by_lower = {item.lower(): item for item in model_ids}
+    for candidate in preferred:
+        if candidate.lower() in by_lower:
+            return by_lower[candidate.lower()]
+    candidates = [
+        item
+        for item in model_ids
+        if any(token in item.lower() for token in ("embedding", "embed", "bge-m3"))
+    ]
+    return candidates[0] if candidates else preferred[0]
+
+
+def _embedding_route(gateway_base: str, gateway_key: str) -> tuple[str, str, str]:
+    configured_key = os.getenv("EMBEDDING_API_KEY", "").strip()
+    configured_base = os.getenv("EMBEDDING_API_BASE", "").strip().rstrip("/")
+    if configured_key and configured_base:
+        return configured_base, configured_key, "configured"
+
+    openrouter_key = os.getenv("OPENROUTER_API_KEY", "").strip()
+    if openrouter_key:
+        return "https://openrouter.ai/api/v1", openrouter_key, "openrouter"
+    return gateway_base, gateway_key, "gateway"
+
+
+def _safe_failure(exc: Exception) -> dict[str, Any]:
+    return {
+        "schema_version": "rag-p0-real-api-smoke-v1",
+        "status": "failed",
+        "error_type": exc.__class__.__name__,
+        "secrets_recorded": False,
+        "shared_storage_mutated": False,
+    }
+
+
+async def _run() -> dict[str, Any]:
+    gateway_key = os.getenv("LLM_GATEWAY_KEY", "").strip()
+    gateway_base = _gateway_base()
+    chat_model = (
+        os.getenv("RAG_RERANK_LLM_MODEL", "").strip()
+        or os.getenv("OPENROUTER_TEXT_FALLBACK_MODEL", "").strip()
+    )
+    if not gateway_key or not gateway_base or not chat_model:
+        raise RuntimeError("Required real API smoke configuration is unavailable.")
+
+    embedding_base, embedding_key, embedding_route = _embedding_route(
+        gateway_base,
+        gateway_key,
+    )
+    model_ids = await _embedding_models(embedding_base, embedding_key)
+    embedding_model = _embedding_model(model_ids)
+    embedder = EmbeddingClient(
+        api_base=embedding_base,
+        api_key=embedding_key,
+        model=embedding_model,
+        dimension=384,
+    )
+    embedder.embedding_mode = ""
+
+    with tempfile.TemporaryDirectory(prefix="modelmirror-rag-real-smoke-") as root:
+        root_path = Path(root)
+        storage = root_path / "storage"
+        service = RagService(
+            storage_dir=storage,
+            uploads_dir=root_path / "uploads",
+            embedder=embedder,
+            vector_store=LocalJsonVectorStore(storage / "vectors.json"),
+            lexical_store=SqliteLexicalStore(storage / "lexical.sqlite3"),
+            llm_enabled=False,
+        )
+        kb = service.create_knowledge_base("real-api-smoke")
+        relevant = await service.upload_document(
+            kb["id"],
+            "release.txt",
+            (
+                "ORBIT-SAFFRON production release requires a signed safety review "
+                "before deployment."
+            ).encode("utf-8"),
+            pipeline_only=True,
+        )
+        distractor = await service.upload_document(
+            kb["id"],
+            "office.txt",
+            "Office badges are renewed every twelve months.".encode("utf-8"),
+            pipeline_only=True,
+        )
+        draft = service.update_pipeline_draft(
+            kb["id"],
+            {},
+            embedding_profile={
+                "provider": "openai_compatible",
+                "model": embedding_model,
+            },
+            retrieval_profile={
+                "mode": "hybrid",
+                "top_k": 2,
+                "score_threshold": 0.0,
+                "candidate_multiplier": 2,
+                "rerank_enabled": True,
+                "rerank_provider": "llm",
+                "rerank_model": chat_model,
+                "rerank_top_n": 2,
+            },
+        )
+        job = service.create_pipeline_job(
+            kb["id"],
+            draft_version=draft["version"],
+            source_document_ids=[relevant["id"], distractor["id"]],
+        )
+        if not await KnowledgePipelineExecutor(service).run_once():
+            raise RuntimeError("Pipeline executor did not claim the smoke job.")
+        completed = service.get_pipeline_job(job["job_id"])
+        if completed["status"] != "succeeded":
+            raise RuntimeError("Real embedding pipeline did not succeed.")
+        version_id = str(completed["candidate_version_id"])
+        result = await service.query_pipeline_version(
+            version_id,
+            "What review is required before ORBIT-SAFFRON deployment?",
+            retrieval={"mode": "hybrid", "top_k": 2},
+            generate_answer=False,
+        )
+        retrieval = dict(result.get("retrieval") or {})
+        sources = list(result.get("sources") or [])
+        if not sources or retrieval.get("rerank_provider_used") != "llm":
+            raise RuntimeError("Real retrieval or LLM rerank was not applied.")
+        evidence = service.pipeline_version_evidence(version_id)
+        return {
+            "schema_version": "rag-p0-real-api-smoke-v1",
+            "status": "passed",
+            "embedding": {
+                "provider": retrieval.get("embedding_provider"),
+                "model": retrieval.get("embedding_model"),
+                "dimension": retrieval.get("embedding_dimension"),
+                "route": embedding_route,
+                "expected_api_calls": 2,
+            },
+            "rerank": {
+                "provider": retrieval.get("rerank_provider_used"),
+                "model": retrieval.get("rerank_model_used"),
+                "applied": retrieval.get("rerank_applied"),
+                "expected_llm_calls": 1,
+            },
+            "retrieval": {
+                "source_count": len(sources),
+                "top_document": str(sources[0].get("document_name") or ""),
+                "version_fingerprint": evidence["version_fingerprint"],
+            },
+            "secrets_recorded": False,
+            "shared_storage_mutated": False,
+        }
+
+
+def main() -> int:
+    try:
+        result = asyncio.run(_run())
+    except Exception as exc:
+        result = _safe_failure(exc)
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0 if result["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/benchmarks/knowledge_executor.py
+++ b/server/benchmarks/knowledge_executor.py
@@ -63,6 +63,11 @@ class KnowledgeBenchmarkProvisioner:
             await self._ensure_pipeline_draft(job_id, kb_id, state)
             pipeline_job = await self._ensure_pipeline_job(job_id, kb_id, state)
             version_id = await self._wait_for_pipeline(job_id, pipeline_job, state)
+            state["version_evidence"] = await asyncio.to_thread(
+                self.rag_service.pipeline_version_evidence,
+                version_id,
+            )
+            await self._save(job_id, state)
             resolved_cases = await asyncio.to_thread(
                 self._resolve_gold_cases,
                 kb_id,

--- a/server/rag/api.py
+++ b/server/rag/api.py
@@ -767,7 +767,7 @@ class EvaluationGateUpdateRequest(BaseModel):
     max_mrr_regression: float = Field(ge=0, le=1)
     max_citation_hit_regression: float = Field(ge=0, le=1)
     max_no_result_increase: float = Field(ge=0, le=1)
-    min_no_result_accuracy: float = Field(default=0, ge=0, le=1)
+    min_no_result_accuracy: float = Field(default=0.8, ge=0, le=1)
     min_citation_coverage: float = Field(default=0, ge=0, le=1)
     max_p95_latency_ratio: float = Field(ge=1, le=10)
     require_zero_errors: bool = True
@@ -2100,6 +2100,9 @@ async def create_evaluation_run(payload: EvaluationRunCreateRequest) -> dict[str
                     "version": int(version["version"]),
                     "label": target.label or f"v{version['version']}",
                     "retrieval": target.retrieval.model_dump(exclude_none=True) if target.retrieval else {},
+                    "version_evidence": get_rag_service().pipeline_version_evidence(
+                        target.version_id
+                    ),
                 }
             )
         run = get_evaluation_store().create_run(

--- a/server/rag/evaluation.py
+++ b/server/rag/evaluation.py
@@ -43,7 +43,7 @@ DEFAULT_GATE_POLICY: dict[str, Any] = {
     "max_mrr_regression": 0.03,
     "max_citation_hit_regression": 0.02,
     "max_no_result_increase": 0.05,
-    "min_no_result_accuracy": 0.0,
+    "min_no_result_accuracy": 0.8,
     "min_citation_coverage": 0.0,
     "max_p95_latency_ratio": 2.0,
     "require_zero_errors": True,
@@ -58,6 +58,7 @@ def evaluate_retrieval_case(
     latency_ms: float = 0.0,
     warnings: list[str] | None = None,
     expected_no_result: bool = False,
+    retrieval_receipt: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Score one ranked retrieval response against stable relevance references."""
 
@@ -79,6 +80,7 @@ def evaluate_retrieval_case(
             "warning_count": len(warnings or []),
             "warnings": [str(item)[:240] for item in (warnings or [])[:10]],
             "ranking": [_ranking_item(source, rank) for rank, source in enumerate(sources, 1)],
+            "retrieval_receipt": _safe_retrieval_receipt(retrieval_receipt),
         }
     relevant_ranks: list[int] = []
     matched_ref_indexes: set[int] = set()
@@ -154,6 +156,7 @@ def evaluate_retrieval_case(
         "warning_count": len(warnings or []),
         "warnings": [str(item)[:240] for item in (warnings or [])[:10]],
         "ranking": ranking,
+        "retrieval_receipt": _safe_retrieval_receipt(retrieval_receipt),
     }
 
 
@@ -1174,6 +1177,37 @@ def _float_or_none(value: Any) -> float | None:
         return round(float(value), 6)
     except (TypeError, ValueError):
         return None
+
+
+def _safe_retrieval_receipt(value: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    allowed = {
+        "mode",
+        "vector_weight",
+        "fulltext_weight",
+        "top_k",
+        "score_threshold",
+        "candidate_multiplier",
+        "rerank_enabled",
+        "rerank_provider",
+        "rerank_model",
+        "rerank_top_n",
+        "rerank_provider_used",
+        "rerank_model_used",
+        "rerank_applied",
+        "embedding_provider",
+        "embedding_model",
+        "embedding_dimension",
+        "vector_candidate_count",
+        "fulltext_candidate_count",
+    }
+    receipt: dict[str, Any] = {}
+    for key in allowed:
+        item = value.get(key)
+        if isinstance(item, (str, int, float, bool, type(None))):
+            receipt[key] = item
+    return receipt
 
 
 def _ranking_item(source: dict[str, Any], rank: int) -> dict[str, Any]:

--- a/server/rag/evaluation_executor.py
+++ b/server/rag/evaluation_executor.py
@@ -127,6 +127,7 @@ class KnowledgeEvaluationExecutor:
                             latency_ms=(time.perf_counter() - started) * 1000,
                             warnings=list(retrieval.get("warnings") or []),
                             expected_no_result=bool(case.get("expected_no_result")),
+                            retrieval_receipt=dict(retrieval.get("retrieval") or {}),
                         )
                     except asyncio.CancelledError:
                         raise

--- a/server/rag/pipeline_executor.py
+++ b/server/rag/pipeline_executor.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from .embedder import EmbeddingClient
+from .embedder import EmbeddingClient, EmbeddingError
 from .lexical_store import LexicalChunk
 from .rag_service import RagService
 from .splitter import ParentChildTextSplitter, TextSplitter
@@ -578,31 +578,57 @@ class KnowledgePipelineExecutor:
         job = self.service.get_pipeline_job(job_id)
         snapshot = job["config_snapshot"]
         profile = snapshot.get("embedding_profile", {}) if isinstance(snapshot, dict) else {}
-        model = str(profile.get("model") or self.service.embedder.model)
+        effective = profile.get("effective") if isinstance(profile, dict) else None
+        effective_profile = effective if isinstance(effective, dict) else profile
+        provider = str(effective_profile.get("provider") or profile.get("provider") or "")
+        dimension = int(
+            effective_profile.get("dimension")
+            or profile.get("dimension")
+            or self.service.embedder.dimension
+        )
+        model = str(
+            effective_profile.get("model")
+            or profile.get("model")
+            or self.service.embedder.model
+        )
         embedder = self.service.embedder
         if (
-            str(profile.get("provider") or "") == "hash"
-            and bool(self.service.embedder.api_key)
-            and getattr(self.service.embedder, "embedding_mode", "hash") != "hash"
+            provider == "hash"
+            and (
+                bool(self.service.embedder.api_key)
+                or self.service.embedder.dimension != dimension
+            )
         ):
             embedder = EmbeddingClient(
                 api_base="",
                 api_key="",
                 model=model,
-                dimension=self.service.embedder.dimension,
+                dimension=dimension,
             )
             embedder.api_key = ""
             embedder.embedding_mode = "hash"
-        elif model != self.service.embedder.model:
+        elif provider != "hash" and model != self.service.embedder.model:
             embedder = EmbeddingClient(
                 api_base=self.service.embedder.api_base,
                 api_key=self.service.embedder.api_key,
                 model=model,
-                dimension=self.service.embedder.dimension,
+                dimension=dimension,
             )
-        return await embedder.embed_texts(
+        embeddings = await embedder.embed_texts(
             [str(item.get("index_text") or "") for item in chunks]
         )
+        if len(embeddings) != len(chunks):
+            raise EmbeddingError(
+                "Embedding provider returned a different number of vectors than inputs."
+            )
+        dimensions = {len(vector) for vector in embeddings}
+        if not dimensions or 0 in dimensions or len(dimensions) != 1:
+            raise EmbeddingError(
+                "Embedding provider returned empty or inconsistent vector dimensions."
+            )
+        actual_dimension = next(iter(dimensions))
+        self.service.update_pipeline_embedding_dimension(job_id, actual_dimension)
+        return embeddings
 
     async def _store_chunks(
         self,

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -42,7 +42,12 @@ from .document_processor import ProcessedDocument, StructuredDocumentProcessor
 from .embedder import EmbeddingClient, EmbeddingError
 from .lexical_store import LexicalChunk, LexicalSearchResult, SqliteLexicalStore
 from .reranker import RerankDocument, RerankService
-from .retrieval import RetrievalCandidate, RetrievalConfig, fuse_rankings
+from .retrieval import (
+    RetrievalCandidate,
+    RetrievalConfig,
+    fuse_rankings,
+    select_candidates,
+)
 from .source_metadata import normalize_heading_path
 from .processor_generator import ProcessorGenerationService
 from .pipeline_graph import (
@@ -74,6 +79,15 @@ MAX_DOCUMENT_WARNINGS = 20
 MAX_DOCUMENT_WARNING_CHARACTERS = 500
 MAX_DOCUMENT_WARNINGS_CHARACTERS = 4_000
 MAX_FILE_OUTPUT_SECTION_SOURCES = 2_000
+HASH_EMBEDDING_MODEL = "deterministic-hash-v1"
+HASH_EMBEDDING_MODEL_ALIASES = {
+    "hash",
+    "modelmirror-hash-v1",
+    HASH_EMBEDDING_MODEL,
+}
+EMBEDDING_PROVIDER_HASH = "hash"
+EMBEDDING_PROVIDER_OPENAI_COMPATIBLE = "openai_compatible"
+EMBEDDING_PROVIDER_UNAVAILABLE = "unavailable"
 _WARNING_CONTROL_CHARACTERS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 
 
@@ -1901,18 +1915,14 @@ class RagService:
                 "truncated": len(items) > 20,
             }
         if kind == "embedding":
+            profile = self._validated_embedding_profile(config, None)
             return {
                 "node_id": node_id,
                 "kind": kind,
                 "preview_type": "capability",
                 "item_count": 0,
                 "items": [],
-                "metadata": {
-                    "provider": config.get("provider", self._default_embedding_profile()["provider"]),
-                    "model": config.get("model", self.embedder.model),
-                    "dimension": self.embedder.dimension,
-                    "degraded": self._default_embedding_profile()["degraded"],
-                },
+                "metadata": profile,
             }
         if kind == "dual_index":
             return {
@@ -2031,6 +2041,8 @@ class RagService:
         vision_stage = stages["stage_image_understanding"]
         vision_config = dict(vision_stage.get("config") or {})
         vision_capabilities = self.vision_processor.capabilities()
+        embedding_profile = dict(draft.get("embedding_profile") or {})
+        embedding_effective = dict(embedding_profile.get("effective") or {})
         visual_document_count = int(
             vision_stage.get("metadata", {}).get("visual_document_count", 0)
         )
@@ -2041,6 +2053,13 @@ class RagService:
             warnings.append("当前没有可检索 Artifact，上传文档后处理器才会产生结果。")
         if chunk_count == 0:
             warnings.append("当前没有 KnowledgeChunk，RAG 检索不会返回引用片段。")
+        if not bool(embedding_effective.get("ready")):
+            requested = dict(embedding_profile.get("requested") or {})
+            warnings.append(
+                "Embedding provider is unavailable for the requested model "
+                f"{str(requested.get('model') or '(unset)')[:200]}; configure "
+                "EMBEDDING_API_KEY before executing this pipeline."
+            )
         if processor_mode in {"qa", "summary"} and not processor_capabilities.get(
             "llm_configured"
         ):
@@ -2271,6 +2290,7 @@ class RagService:
                 raise PipelineJobStateError(
                     f"Pipeline draft changed. Expected v{draft_version}, current v{draft['version']}."
                 )
+            self._ensure_embedding_profile_ready(draft["embedding_profile"])
             graph = self._pipeline_graph_record(metadata, kb_id, draft)
             if graph_revision is not None and int(graph_revision) != int(graph["graph_revision"]):
                 raise PipelineGraphRevisionError(
@@ -3473,6 +3493,76 @@ class RagService:
         self._ensure_kb_exists(metadata, str(version.get("kb_id") or ""))
         return json.loads(json.dumps(version))
 
+    def pipeline_version_evidence(self, version_id: str) -> dict[str, Any]:
+        """Return a credential-free identity receipt for one immutable index."""
+
+        version = self.get_pipeline_version(version_id)
+        stored_embedding = version.get("embedding_profile")
+        if (
+            isinstance(stored_embedding, dict)
+            and isinstance(stored_embedding.get("requested"), dict)
+            and isinstance(stored_embedding.get("effective"), dict)
+        ):
+            embedding = json.loads(json.dumps(stored_embedding))
+        else:
+            embedding = self._resolved_embedding_profile_for_query(stored_embedding)
+        requested = dict(embedding.get("requested") or {})
+        effective = dict(embedding.get("effective") or {})
+        safe_embedding = {
+            "requested": {
+                "provider": str(requested.get("provider") or ""),
+                "model": str(requested.get("model") or ""),
+            },
+            "effective": {
+                "provider": str(effective.get("provider") or ""),
+                "model": str(effective.get("model") or ""),
+                "dimension": int(effective.get("dimension") or 0),
+                "degraded": bool(effective.get("degraded")),
+                "ready": bool(effective.get("ready")),
+                "reason": str(effective.get("reason") or "") or None,
+            },
+        }
+        retrieval = self._retrieval_config_for_version(
+            version,
+            None,
+            top_k=None,
+        ).payload()
+        source_manifest_fingerprint = self._mapping_sha256(
+            {"sources": list(version.get("source_summary") or [])}
+        )
+        configuration_fingerprint = self._mapping_sha256(
+            {
+                "index_schema_version": int(version.get("index_schema_version") or 1),
+                "embedding": safe_embedding,
+                "retrieval": retrieval,
+                "processor": dict(version.get("processor_profile") or {}),
+                "vision": dict(version.get("vision_profile") or {}),
+            }
+        )
+        version_fingerprint = self._mapping_sha256(
+            {
+                "version_id": version_id,
+                "version": int(version.get("version") or 0),
+                "source_manifest_fingerprint": source_manifest_fingerprint,
+                "configuration_fingerprint": configuration_fingerprint,
+                "document_count": int(version.get("document_count") or 0),
+                "chunk_count": int(version.get("chunk_count") or 0),
+            }
+        )
+        return {
+            "schema_version": "rag-version-evidence-v1",
+            "version_id": version_id,
+            "version": int(version.get("version") or 0),
+            "index_schema_version": int(version.get("index_schema_version") or 1),
+            "document_count": int(version.get("document_count") or 0),
+            "chunk_count": int(version.get("chunk_count") or 0),
+            "embedding": safe_embedding,
+            "retrieval": retrieval,
+            "source_manifest_fingerprint": source_manifest_fingerprint,
+            "configuration_fingerprint": configuration_fingerprint,
+            "version_fingerprint": version_fingerprint,
+        }
+
     def pipeline_version_payload(
         self,
         version: dict[str, Any],
@@ -3637,6 +3727,7 @@ class RagService:
             question,
             config=profile,
             lexical_ready=bool(version.get("lexical_index_ready")),
+            embedding_profile=version.get("embedding_profile"),
             generate_answer=generate_answer,
         )
         result = self._with_source_document_ids(result, version_id)
@@ -3776,6 +3867,30 @@ class RagService:
                 source_id = str(result.get("source_id") or "")
                 if source_id in counts:
                     result["chunk_count"] = int(counts[source_id])
+
+        self._update_pipeline_job(job_id, update)
+
+    def update_pipeline_embedding_dimension(
+        self,
+        job_id: str,
+        dimension: int,
+    ) -> None:
+        if dimension <= 0:
+            raise PipelineJobStateError("Embedding dimension must be positive.")
+
+        def update(job: dict[str, Any]) -> None:
+            snapshot = job.get("config_snapshot")
+            if not isinstance(snapshot, dict):
+                raise PipelineJobStateError("Pipeline embedding snapshot is missing.")
+            profile = snapshot.get("embedding_profile")
+            if not isinstance(profile, dict):
+                raise PipelineJobStateError("Pipeline embedding profile is missing.")
+            effective = profile.get("effective")
+            if not isinstance(effective, dict) or not bool(effective.get("ready")):
+                raise PipelineJobStateError("Pipeline embedding profile is unavailable.")
+            effective["dimension"] = int(dimension)
+            profile["effective"] = effective
+            profile["dimension"] = int(dimension)
 
         self._update_pipeline_job(job_id, update)
 
@@ -4018,6 +4133,9 @@ class RagService:
             question,
             config=config,
             lexical_ready=bool(isinstance(version, dict) and version.get("lexical_index_ready")),
+            embedding_profile=(
+                version.get("embedding_profile") if isinstance(version, dict) else None
+            ),
             generate_answer=False,
         )
         version_id = str(version.get("version_id") or "") if isinstance(version, dict) else None
@@ -4586,6 +4704,7 @@ class RagService:
             question,
             config=config,
             lexical_ready=bool(version and version.get("lexical_index_ready")),
+            embedding_profile=version.get("embedding_profile") if version else None,
         )
         return self._with_source_document_ids(
             result,
@@ -4600,6 +4719,7 @@ class RagService:
         *,
         config: RetrievalConfig,
         lexical_ready: bool,
+        embedding_profile: dict[str, Any] | None = None,
         generate_answer: bool = True,
     ) -> dict[str, Any]:
         """Query one explicit index namespace while preserving public KB identity."""
@@ -4616,10 +4736,19 @@ class RagService:
         warnings: list[str] = []
         vector_results: list[SearchResult] = []
         lexical_results: list[LexicalSearchResult] = []
+        resolved_embedding_profile = self._resolved_embedding_profile_for_query(
+            embedding_profile
+        )
+
+        async def query_vector_candidates() -> list[SearchResult]:
+            query_embedding = await self._embed_query(
+                clean_question,
+                resolved_embedding_profile,
+            )
+            return self.vector_store.query(namespace, query_embedding, candidate_count)
 
         if config.mode in {"vector", "hybrid"}:
-            query_embedding = (await self.embedder.embed_texts([clean_question]))[0]
-            vector_results = self.vector_store.query(namespace, query_embedding, candidate_count)
+            vector_results = await query_vector_candidates()
         if config.mode in {"fulltext", "hybrid"}:
             if lexical_ready or self.lexical_store.count_namespace(namespace) > 0:
                 lexical_results = self.lexical_store.query(namespace, clean_question, candidate_count)
@@ -4651,8 +4780,7 @@ class RagService:
                 {**config.payload(), "mode": "vector", "rerank_enabled": config.rerank_enabled}
             )
             if not vector_candidates:
-                query_embedding = (await self.embedder.embed_texts([clean_question]))[0]
-                vector_results = self.vector_store.query(namespace, query_embedding, candidate_count)
+                vector_results = await query_vector_candidates()
                 vector_results = [
                     item
                     for item in vector_results
@@ -4662,8 +4790,12 @@ class RagService:
                 ]
                 vector_candidates = [self._candidate_from_vector(item) for item in vector_results]
         fused = fuse_rankings(vector_candidates, lexical_candidates, effective_config)
+        fused = [
+            item for item in fused if item.fused_score >= config.score_threshold
+        ]
 
         rerank_provider = "none"
+        rerank_model = ""
         if config.rerank_enabled and fused:
             outcome = await self.reranker.rerank(
                 clean_question,
@@ -4673,6 +4805,7 @@ class RagService:
                 top_n=min(config.rerank_top_n, len(fused)),
             )
             rerank_provider = outcome.provider
+            rerank_model = outcome.model
             if outcome.warning:
                 warnings.append(outcome.warning)
             by_id = {item.chunk_id: item for item in fused}
@@ -4688,14 +4821,17 @@ class RagService:
             )
 
         deleted_document_ids = self._deleted_document_ids()
-        results = [
-            item
-            for item in fused
-            if item.score >= config.score_threshold
-            and not self._indexed_document_is_deleted(
-                str(item.doc_id), deleted_document_ids
-            )
-        ][: config.top_k]
+        results = select_candidates(
+            [
+                item
+                for item in fused
+                if not self._indexed_document_is_deleted(
+                    str(item.doc_id), deleted_document_ids
+                )
+            ],
+            score_threshold=config.score_threshold,
+            top_k=config.top_k,
+        )
         if not results:
             return {
                 "answer": "没有在该知识库中找到相关内容，请尝试换一种问法或上传更多资料。",
@@ -4706,6 +4842,8 @@ class RagService:
                     vector_count=len(vector_results),
                     fulltext_count=len(lexical_results),
                     rerank_provider=rerank_provider,
+                    rerank_model=rerank_model,
+                    embedding_profile=resolved_embedding_profile,
                 ),
             }
 
@@ -4745,6 +4883,8 @@ class RagService:
                 vector_count=len(vector_results),
                 fulltext_count=len(lexical_results),
                 rerank_provider=rerank_provider,
+                rerank_model=rerank_model,
+                embedding_profile=resolved_embedding_profile,
             ),
         }
 
@@ -4927,52 +5067,257 @@ class RagService:
         vector_count: int,
         fulltext_count: int,
         rerank_provider: str,
+        rerank_model: str,
+        embedding_profile: dict[str, Any],
     ) -> dict[str, Any]:
+        effective = dict(embedding_profile.get("effective") or {})
         return {
             **config.payload(),
             "vector_candidate_count": vector_count,
             "fulltext_candidate_count": fulltext_count,
             "rerank_provider_used": rerank_provider,
+            "rerank_model_used": rerank_model,
+            "rerank_applied": rerank_provider != "none",
+            "embedding_provider": str(effective.get("provider") or ""),
+            "embedding_model": str(effective.get("model") or ""),
+            "embedding_dimension": int(effective.get("dimension") or 0),
         }
 
+    def _resolved_embedding_profile_for_query(
+        self,
+        profile: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        if not isinstance(profile, dict):
+            return self._default_embedding_profile()
+        resolved = self._validated_embedding_profile(profile, None)
+        stored_effective = profile.get("effective")
+        if not isinstance(stored_effective, dict):
+            stored_effective = profile
+        resolved_effective = dict(resolved.get("effective") or {})
+        stored_dimension = int(stored_effective.get("dimension") or 0)
+        if (
+            bool(resolved_effective.get("ready"))
+            and stored_dimension > 0
+            and str(stored_effective.get("provider") or "")
+            == str(resolved_effective.get("provider") or "")
+            and str(stored_effective.get("model") or "")
+            == str(resolved_effective.get("model") or "")
+        ):
+            resolved_effective["dimension"] = stored_dimension
+            resolved["dimension"] = stored_dimension
+            resolved["effective"] = resolved_effective
+        return resolved
+
+    async def _embed_query(
+        self,
+        text: str,
+        profile: dict[str, Any],
+    ) -> list[float]:
+        self._ensure_embedding_profile_ready(profile)
+        effective = dict(profile.get("effective") or {})
+        provider = str(effective.get("provider") or "")
+        model = str(effective.get("model") or "")
+        dimension = int(effective.get("dimension") or 0)
+        if dimension <= 0:
+            raise EmbeddingError("Embedding profile has no valid vector dimension.")
+
+        if provider == EMBEDDING_PROVIDER_HASH:
+            embedder = EmbeddingClient(
+                api_base="",
+                api_key="",
+                model=HASH_EMBEDDING_MODEL,
+                dimension=dimension,
+            )
+            embedder.api_key = ""
+            embedder.embedding_mode = "hash"
+        else:
+            if model == self.embedder.model:
+                embedder = self.embedder
+            else:
+                embedder = EmbeddingClient(
+                    api_base=self.embedder.api_base,
+                    api_key=self.embedder.api_key,
+                    model=model,
+                    dimension=dimension,
+                )
+        vectors = await embedder.embed_texts([text])
+        if len(vectors) != 1 or len(vectors[0]) != dimension:
+            actual = len(vectors[0]) if vectors else 0
+            raise EmbeddingError(
+                "Embedding query dimension mismatch: "
+                f"expected {dimension}, received {actual}."
+            )
+        return vectors[0]
+
     def _default_embedding_profile(self) -> dict[str, Any]:
-        degraded = self.embedder.embedding_mode == "hash" or not self.embedder.api_key
-        return {
-            "provider": "hash" if degraded else "openai_compatible",
-            "model": self.embedder.model,
-            "dimension": self.embedder.dimension,
-            "degraded": degraded,
-        }
+        use_hash = self.embedder.embedding_mode == "hash" or not self.embedder.api_key
+        return self._embedding_profile_from_request(
+            provider=(
+                EMBEDDING_PROVIDER_HASH
+                if use_hash
+                else EMBEDDING_PROVIDER_OPENAI_COMPATIBLE
+            ),
+            model=HASH_EMBEDDING_MODEL if use_hash else self.embedder.model,
+        )
 
     def _validated_embedding_profile(
         self,
         current: dict[str, Any] | None,
         patch: dict[str, Any] | None,
     ) -> dict[str, Any]:
-        config = {**self._default_embedding_profile(), **dict(current or {})}
+        requested = self._requested_embedding_profile(current)
         if patch:
             unknown = set(patch) - {"model", "provider"}
             if unknown:
                 raise PipelineDraftValidationError(
                     f"Unsupported embedding profile field: {sorted(unknown)[0]}"
                 )
-            model = str(patch.get("model") or config["model"]).strip()
-            if not model or len(model) > 200:
-                raise PipelineDraftValidationError("embedding_profile.model is invalid.")
-            config["model"] = model
-            provider = str(patch.get("provider") or config.get("provider") or "").strip()
-            if provider not in {"hash", "openai_compatible"}:
+            provider_supplied = "provider" in patch and bool(
+                str(patch.get("provider") or "").strip()
+            )
+            model_supplied = "model" in patch and bool(
+                str(patch.get("model") or "").strip()
+            )
+            provider = str(
+                patch.get("provider") if provider_supplied else requested["provider"]
+            ).strip()
+            model = str(
+                patch.get("model") if model_supplied else requested["model"]
+            ).strip()
+            if provider not in {
+                EMBEDDING_PROVIDER_HASH,
+                EMBEDDING_PROVIDER_OPENAI_COMPATIBLE,
+            }:
                 raise PipelineDraftValidationError(
                     "embedding_profile.provider must be hash or openai_compatible."
                 )
-            config["provider"] = provider
-        provider = str(config.get("provider") or self._default_embedding_profile()["provider"])
-        if provider == "openai_compatible" and not self.embedder.api_key:
-            provider = "hash"
-        config["provider"] = provider
-        config["dimension"] = self.embedder.dimension
-        config["degraded"] = provider == "hash"
-        return config
+            if (
+                model_supplied
+                and not provider_supplied
+                and provider == EMBEDDING_PROVIDER_HASH
+                and model not in HASH_EMBEDDING_MODEL_ALIASES
+            ):
+                provider = EMBEDDING_PROVIDER_OPENAI_COMPATIBLE
+            if provider == EMBEDDING_PROVIDER_HASH:
+                if model_supplied and model not in HASH_EMBEDDING_MODEL_ALIASES:
+                    raise PipelineDraftValidationError(
+                        "hash embedding does not accept a semantic model label; use "
+                        "provider=openai_compatible for that model."
+                    )
+                model = HASH_EMBEDDING_MODEL
+            elif not model or model in HASH_EMBEDDING_MODEL_ALIASES or len(model) > 200:
+                raise PipelineDraftValidationError("embedding_profile.model is invalid.")
+            requested = {"provider": provider, "model": model}
+        return self._embedding_profile_from_request(
+            provider=str(requested["provider"]),
+            model=str(requested["model"]),
+        )
+
+    def _requested_embedding_profile(
+        self,
+        current: dict[str, Any] | None,
+    ) -> dict[str, str]:
+        profile = dict(current or {})
+        nested = profile.get("requested")
+        if isinstance(nested, dict):
+            provider = str(nested.get("provider") or "").strip()
+            model = str(nested.get("model") or "").strip()
+        else:
+            defaults = self._default_embedding_profile()["requested"]
+            provider = str(profile.get("provider") or defaults["provider"]).strip()
+            model = str(profile.get("model") or defaults["model"]).strip()
+            if provider == EMBEDDING_PROVIDER_UNAVAILABLE:
+                provider = EMBEDDING_PROVIDER_OPENAI_COMPATIBLE
+            if (
+                provider == EMBEDDING_PROVIDER_HASH
+                and model not in {"", *HASH_EMBEDDING_MODEL_ALIASES}
+            ):
+                # Legacy profiles retained the requested semantic model label after
+                # silently downgrading the effective provider to hash.
+                provider = EMBEDDING_PROVIDER_OPENAI_COMPATIBLE
+
+        if provider not in {
+            EMBEDDING_PROVIDER_HASH,
+            EMBEDDING_PROVIDER_OPENAI_COMPATIBLE,
+        }:
+            defaults = self._default_embedding_profile()["requested"]
+            return {
+                "provider": str(defaults["provider"]),
+                "model": str(defaults["model"]),
+            }
+        if provider == EMBEDDING_PROVIDER_HASH:
+            model = HASH_EMBEDDING_MODEL
+        elif not model or model in HASH_EMBEDDING_MODEL_ALIASES:
+            model = self.embedder.model
+        return {"provider": provider, "model": model[:200]}
+
+    def _embedding_profile_from_request(
+        self,
+        *,
+        provider: str,
+        model: str,
+    ) -> dict[str, Any]:
+        requested = {"provider": provider, "model": model}
+        if provider == EMBEDDING_PROVIDER_HASH:
+            effective = {
+                "provider": EMBEDDING_PROVIDER_HASH,
+                "model": HASH_EMBEDDING_MODEL,
+                "dimension": self.embedder.dimension,
+                "degraded": True,
+                "ready": True,
+                "reason": None,
+            }
+        else:
+            reason: str | None = None
+            if not self.embedder.api_key:
+                reason = "embedding_credentials_missing"
+            elif self.embedder.embedding_mode == "hash":
+                reason = "embedding_hash_mode_forced"
+            if reason:
+                effective = {
+                    "provider": EMBEDDING_PROVIDER_UNAVAILABLE,
+                    "model": "",
+                    "dimension": 0,
+                    "degraded": False,
+                    "ready": False,
+                    "reason": reason,
+                }
+            else:
+                effective = {
+                    "provider": EMBEDDING_PROVIDER_OPENAI_COMPATIBLE,
+                    "model": model,
+                    "dimension": self.embedder.dimension,
+                    "degraded": False,
+                    "ready": True,
+                    "reason": None,
+                }
+        return {
+            "provider": effective["provider"],
+            "model": effective["model"],
+            "dimension": effective["dimension"],
+            "degraded": effective["degraded"],
+            "ready": effective["ready"],
+            "reason": effective["reason"],
+            "requested": requested,
+            "effective": effective,
+        }
+
+    @staticmethod
+    def _ensure_embedding_profile_ready(profile: dict[str, Any]) -> None:
+        effective = profile.get("effective")
+        if isinstance(effective, dict) and bool(effective.get("ready")):
+            return
+        requested = profile.get("requested")
+        requested_model = (
+            str(requested.get("model") or "")
+            if isinstance(requested, dict)
+            else str(profile.get("model") or "")
+        )
+        raise PipelineDraftValidationError(
+            "Embedding provider is unavailable for the requested model "
+            f"{requested_model[:200] or '(unset)'}; configure EMBEDDING_API_KEY "
+            "before creating a pipeline job."
+        )
 
     def _default_pipeline_draft_stages(self) -> dict[str, dict[str, Any]]:
         return {

--- a/server/rag/reranker.py
+++ b/server/rag/reranker.py
@@ -25,6 +25,7 @@ class RerankItem:
 class RerankOutcome:
     items: list[RerankItem]
     provider: str
+    model: str = ""
     warning: str | None = None
 
 
@@ -51,7 +52,7 @@ class RerankService:
         top_n: int,
     ) -> RerankOutcome:
         if not documents:
-            return RerankOutcome(items=[], provider="none")
+            return RerankOutcome(items=[], provider="none", model="")
         providers = [provider]
         if provider == "auto":
             providers = ["api", "llm"]
@@ -60,14 +61,36 @@ class RerankService:
         for candidate in providers:
             try:
                 if candidate == "api" and self.capabilities()["api_configured"]:
+                    effective_model = model or self._api_model()
                     return RerankOutcome(
-                        items=await self._rerank_api(query, documents, model=model, top_n=top_n),
+                        items=await self._rerank_api(
+                            query,
+                            documents,
+                            model=effective_model,
+                            top_n=top_n,
+                        ),
                         provider="api",
+                        model=effective_model,
                     )
                 if candidate == "llm" and self.capabilities()["llm_configured"]:
+                    effective_model = self._llm_model()
+                    if provider == "llm" and model:
+                        effective_model = model
+                    if _looks_like_reranker_model(effective_model):
+                        warnings.append(
+                            "llm rerank unavailable: reranker-only model cannot be sent "
+                            "to a chat-completions endpoint"
+                        )
+                        continue
                     return RerankOutcome(
-                        items=await self._rerank_llm(query, documents, model=model, top_n=top_n),
+                        items=await self._rerank_llm(
+                            query,
+                            documents,
+                            model=effective_model,
+                            top_n=top_n,
+                        ),
                         provider="llm",
+                        model=effective_model,
                     )
             except Exception as exc:
                 warnings.append(f"{candidate} rerank unavailable: {str(exc)[:160]}")
@@ -75,6 +98,7 @@ class RerankService:
         return RerankOutcome(
             items=[],
             provider="none",
+            model="",
             warning="; ".join(warnings) or "No rerank provider is configured; fused ranking was used.",
         )
 
@@ -234,11 +258,14 @@ def _parse_ranked_items(
                 score=max(0.0, min(1.0, score)),
             )
         )
-        if len(items) >= top_n:
-            break
     if not items:
         raise ValueError("Rerank provider returned no valid candidates.")
-    return items
+    return sorted(items, key=lambda item: -item.score)[:top_n]
+
+
+def _looks_like_reranker_model(model: str) -> bool:
+    normalized = model.strip().lower()
+    return "rerank" in normalized or "reranker" in normalized
 
 
 def _parse_json_object(content: str) -> dict[str, Any]:

--- a/server/rag/retrieval.py
+++ b/server/rag/retrieval.py
@@ -167,12 +167,58 @@ def fuse_rankings(
 
     if not raw_scores:
         return []
-    minimum = min(raw_scores.values())
-    maximum = max(raw_scores.values())
-    spread = maximum - minimum
+    # Normalize against the theoretical rank-1 maximum, not the observed
+    # candidate min/max. Observed min/max makes every result set manufacture a
+    # score of both 0 and 1 and changes existing scores when a tail candidate is
+    # added, so thresholds cannot be compared across queries or benchmarks.
+    maximum = (
+        config.vector_weight / (RRF_CONSTANT + 1)
+        + config.fulltext_weight / (RRF_CONSTANT + 1)
+    )
     for chunk_id, raw_score in raw_scores.items():
-        by_id[chunk_id].fused_score = 1.0 if spread == 0 else (raw_score - minimum) / spread
+        by_id[chunk_id].fused_score = max(
+            0.0,
+            min(1.0, raw_score / maximum if maximum > 0 else 0.0),
+        )
     return sorted(by_id.values(), key=lambda item: (-item.fused_score, item.chunk_id))
+
+
+def select_candidates(
+    items: list[RetrievalCandidate],
+    *,
+    score_threshold: float,
+    top_k: int,
+) -> list[RetrievalCandidate]:
+    """Apply a stable recall threshold, parent dedupe, then document diversity."""
+
+    eligible = [item for item in items if item.fused_score >= score_threshold]
+    deduplicated: list[RetrievalCandidate] = []
+    seen_parent_groups: set[tuple[str, str]] = set()
+    for item in eligible:
+        if item.parent_chunk_id:
+            group = (item.doc_id, item.parent_chunk_id)
+            if group in seen_parent_groups:
+                continue
+            seen_parent_groups.add(group)
+        deduplicated.append(item)
+
+    selected: list[RetrievalCandidate] = []
+    deferred: list[RetrievalCandidate] = []
+    seen_documents: set[str] = set()
+    for item in deduplicated:
+        if item.doc_id in seen_documents:
+            deferred.append(item)
+            continue
+        selected.append(item)
+        seen_documents.add(item.doc_id)
+        if len(selected) >= top_k:
+            return selected
+
+    for item in deferred:
+        selected.append(item)
+        if len(selected) >= top_k:
+            break
+    return selected
 
 
 def _coerce_int(value: Any, name: str) -> int:

--- a/server/rag/vector_store.py
+++ b/server/rag/vector_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import time
@@ -229,6 +230,9 @@ class LocalJsonVectorStore:
 class ChromaVectorStore:
     """ChromaDB-backed vector store with local persistence."""
 
+    _LEGACY_COLLECTION = "modelmirror_rag_chunks"
+    _NAMESPACE_COLLECTION_PREFIX = "modelmirror_rag_v2_"
+
     def __init__(self, persist_path: Path) -> None:
         try:
             import chromadb  # type: ignore[import-not-found]
@@ -237,12 +241,25 @@ class ChromaVectorStore:
 
         persist_path.mkdir(parents=True, exist_ok=True)
         self._client = chromadb.PersistentClient(path=str(persist_path))
-        self._collection = self._client.get_or_create_collection("modelmirror_rag_chunks")
+        # Keep the original collection readable for existing installations. New
+        # writes use one deterministic collection per immutable version namespace
+        # because Chroma fixes a collection's dimension on its first insert.
+        self._collection = self._client.get_or_create_collection(self._LEGACY_COLLECTION)
 
     def add_chunks(self, chunks: list[VectorChunk]) -> None:
         if not chunks:
             return
-        self._collection.upsert(
+        grouped: dict[str, list[VectorChunk]] = {}
+        for chunk in chunks:
+            grouped.setdefault(chunk.kb_id, []).append(chunk)
+        for namespace, namespace_chunks in grouped.items():
+            collection = self._namespace_collection(namespace, create=True)
+            if collection is None:  # pragma: no cover - create=True is total.
+                raise RuntimeError("Unable to create the Chroma namespace collection.")
+            self._upsert(collection, namespace_chunks)
+
+    def _upsert(self, collection: Any, chunks: list[VectorChunk]) -> None:
+        collection.upsert(
             ids=[chunk.id for chunk in chunks],
             embeddings=[chunk.embedding for chunk in chunks],
             documents=[chunk.text for chunk in chunks],
@@ -271,11 +288,35 @@ class ChromaVectorStore:
         )
 
     def query(self, kb_id: str, embedding: list[float], top_k: int) -> list[SearchResult]:
-        response = self._collection.query(
-            query_embeddings=[embedding],
-            n_results=top_k,
-            where={"kb_id": kb_id},
-            include=["documents", "metadatas", "distances"],
+        collection = self._namespace_collection(kb_id, create=False)
+        if collection is not None and collection.count() > 0:
+            return self._query_collection(collection, kb_id, embedding, top_k)
+        return self._query_collection(
+            self._collection,
+            kb_id,
+            embedding,
+            top_k,
+            legacy=True,
+        )
+
+    def _query_collection(
+        self,
+        collection: Any,
+        kb_id: str,
+        embedding: list[float],
+        top_k: int,
+        *,
+        legacy: bool = False,
+    ) -> list[SearchResult]:
+        query: dict[str, Any] = {
+            "query_embeddings": [embedding],
+            "n_results": top_k,
+            "include": ["documents", "metadatas", "distances"],
+        }
+        if legacy:
+            query["where"] = {"kb_id": kb_id}
+        response = collection.query(
+            **query,
         )
         ids = (response.get("ids") or [[]])[0]
         documents = (response.get("documents") or [[]])[0]
@@ -311,16 +352,32 @@ class ChromaVectorStore:
         return results
 
     def delete_document(self, doc_id: str) -> None:
-        self._collection.delete(where={"doc_id": doc_id})
+        for collection in self._managed_collections():
+            collection.delete(where={"doc_id": doc_id})
 
     def delete_knowledge_base(self, kb_id: str) -> None:
+        collection_name = self._namespace_collection_name(kb_id)
+        if self._get_collection(collection_name) is not None:
+            self._client.delete_collection(collection_name)
         self._collection.delete(where={"kb_id": kb_id})
 
     def list_document_chunks(self, doc_id: str) -> list[StoredVectorChunk]:
-        response = self._collection.get(
-            where={"doc_id": doc_id},
-            include=["documents", "metadatas"],
-        )
+        chunks: dict[tuple[str, str], StoredVectorChunk] = {}
+        for collection in self._managed_collections():
+            response = collection.get(
+                where={"doc_id": doc_id},
+                include=["documents", "metadatas"],
+            )
+            for chunk in self._stored_chunks(response, fallback_doc_id=doc_id):
+                chunks[(chunk.kb_id, chunk.chunk_id)] = chunk
+        return sorted(chunks.values(), key=lambda item: item.chunk_index)
+
+    def _stored_chunks(
+        self,
+        response: dict[str, Any],
+        *,
+        fallback_doc_id: str,
+    ) -> list[StoredVectorChunk]:
         ids = response.get("ids") or []
         documents = response.get("documents") or []
         metadatas = response.get("metadatas") or []
@@ -333,7 +390,7 @@ class ChromaVectorStore:
                 StoredVectorChunk(
                     chunk_id=str(chunk_id),
                     kb_id=str(metadata.get("kb_id", "")),
-                    doc_id=str(metadata.get("doc_id", doc_id)),
+                    doc_id=str(metadata.get("doc_id", fallback_doc_id)),
                     document_name=str(metadata.get("document_name", "")),
                     text=str(documents[index] if index < len(documents) else ""),
                     chunk_index=int(metadata.get("chunk_index", index)),
@@ -350,14 +407,36 @@ class ChromaVectorStore:
                     source_block_id=str(metadata.get("source_block_id") or "") or None,
                 )
             )
-        return sorted(chunks, key=lambda item: item.chunk_index)
+        return chunks
 
     def get_chunk(self, kb_id: str, chunk_id: str) -> StoredVectorChunk | None:
-        response = self._collection.get(
-            ids=[chunk_id],
-            where={"kb_id": kb_id},
-            include=["documents", "metadatas"],
+        collection = self._namespace_collection(kb_id, create=False)
+        if collection is not None:
+            chunk = self._get_chunk_from_collection(collection, kb_id, chunk_id)
+            if chunk is not None:
+                return chunk
+        return self._get_chunk_from_collection(
+            self._collection,
+            kb_id,
+            chunk_id,
+            legacy=True,
         )
+
+    def _get_chunk_from_collection(
+        self,
+        collection: Any,
+        kb_id: str,
+        chunk_id: str,
+        *,
+        legacy: bool = False,
+    ) -> StoredVectorChunk | None:
+        query: dict[str, Any] = {
+            "ids": [chunk_id],
+            "include": ["documents", "metadatas"],
+        }
+        if legacy:
+            query["where"] = {"kb_id": kb_id}
+        response = collection.get(**query)
         ids = response.get("ids") or []
         if not ids:
             return None
@@ -383,6 +462,50 @@ class ChromaVectorStore:
             visual_kind=str(metadata.get("visual_kind") or "") or None,
             source_block_id=str(metadata.get("source_block_id") or "") or None,
         )
+
+    @classmethod
+    def _namespace_collection_name(cls, namespace: str) -> str:
+        digest = hashlib.sha256(namespace.encode("utf-8")).hexdigest()[:32]
+        return f"{cls._NAMESPACE_COLLECTION_PREFIX}{digest}"
+
+    def _namespace_collection(self, namespace: str, *, create: bool) -> Any | None:
+        if not hasattr(self, "_client"):
+            # Preserve the small adapter/test seam that injects a collection
+            # directly without constructing a persistent Chroma client.
+            return self._collection if create else None
+        name = self._namespace_collection_name(namespace)
+        if not create:
+            return self._get_collection(name)
+        collection = self._client.get_or_create_collection(
+            name,
+            metadata={
+                "modelmirror_namespace": namespace,
+                "modelmirror_schema_version": 2,
+            },
+        )
+        stored_namespace = str((collection.metadata or {}).get("modelmirror_namespace") or "")
+        if stored_namespace and stored_namespace != namespace:
+            raise RuntimeError("Chroma namespace collection identity collision.")
+        return collection
+
+    def _get_collection(self, name: str) -> Any | None:
+        try:
+            return self._client.get_collection(name)
+        except Exception:
+            return None
+
+    def _managed_collections(self) -> list[Any]:
+        collections: list[Any] = []
+        for item in self._client.list_collections():
+            name = item if isinstance(item, str) else str(getattr(item, "name", ""))
+            if name != self._LEGACY_COLLECTION and not name.startswith(
+                self._NAMESPACE_COLLECTION_PREFIX
+            ):
+                continue
+            collection = self._get_collection(name)
+            if collection is not None:
+                collections.append(collection)
+        return collections
 
 
 def create_vector_store(storage_dir: Path) -> VectorStore:

--- a/server/tests/test_rag_benchmark_standard.py
+++ b/server/tests/test_rag_benchmark_standard.py
@@ -64,6 +64,11 @@ async def test_managed_rag_benchmark_builds_real_indexes_and_immutable_gold(
     assert state["phase"] == "completed"
     assert state["uploaded_document_count"] == 12
     assert state["resolved_case_count"] == 40
+    assert state["version_evidence"]["version_id"] == state["version_id"]
+    assert state["version_evidence"]["version_fingerprint"]
+    assert state["version_evidence"]["embedding"]["effective"]["model"] == (
+        "deterministic-hash-v1"
+    )
 
     kb_id = str(state["kb_id"])
     knowledge_base = next(item for item in service.list_knowledge_bases() if item["id"] == kb_id)

--- a/server/tests/test_rag_evaluation.py
+++ b/server/tests/test_rag_evaluation.py
@@ -187,6 +187,74 @@ def test_source_block_and_no_result_metrics_are_aggregated_separately() -> None:
     assert aggregate["false_positive_rate"] == 0.5
 
 
+def test_default_gate_rejects_false_positive_no_result_behavior() -> None:
+    positive = evaluate_retrieval_case(
+        [{"chunk_id": "answer", "source_document_id": "doc-a", "score": 0.9}],
+        [{"document_id": "doc-a"}],
+        ks=[1, 5, 10],
+    )
+    false_positive = evaluate_retrieval_case(
+        [{"chunk_id": "noise", "source_document_id": "doc-z", "score": 0.1}],
+        [],
+        ks=[1, 5, 10],
+        expected_no_result=True,
+    )
+    aggregate = aggregate_target_metrics([positive, false_positive], ks=[1, 5, 10])
+
+    gate = evaluate_promotion_gate(aggregate, baseline=None)
+    no_result_check = next(
+        item for item in gate["checks"] if item["id"] == "min_no_result_accuracy"
+    )
+
+    assert aggregate["no_result_accuracy"] == 0.0
+    assert no_result_check["threshold"] == 0.8
+    assert no_result_check["passed"] is False
+    assert gate["passed"] is False
+
+    explicitly_disabled = evaluate_promotion_gate(
+        aggregate,
+        baseline=None,
+        policy={"min_no_result_accuracy": 0.0},
+    )
+    assert explicitly_disabled["passed"] is True
+
+
+@pytest.mark.asyncio
+async def test_evaluation_gate_api_defaults_no_result_floor_and_allows_explicit_override(
+    evaluation_runtime,
+) -> None:
+    client, _service, _pipeline_executor, _evaluation_executor, _registry = evaluation_runtime
+    kb_id = await _create_kb(client, "default no-result gate")
+
+    default_response = await client.get(f"/api/rag/evaluation-gate/{kb_id}")
+    assert default_response.status_code == 200, default_response.text
+    assert default_response.json()["min_no_result_accuracy"] == 0.8
+
+    payload = {
+        "mode": "advisory",
+        "min_recall_at_5": 0.8,
+        "max_mrr_regression": 0.03,
+        "max_citation_hit_regression": 0.02,
+        "max_no_result_increase": 0.05,
+        "min_citation_coverage": 0.0,
+        "max_p95_latency_ratio": 2.0,
+        "require_zero_errors": True,
+    }
+    omitted_response = await client.patch(
+        f"/api/rag/evaluation-gate/{kb_id}",
+        json=payload,
+    )
+    assert omitted_response.status_code == 200, omitted_response.text
+    assert omitted_response.json()["min_no_result_accuracy"] == 0.8
+
+    override_response = await client.patch(
+        f"/api/rag/evaluation-gate/{kb_id}",
+        json={**payload, "min_no_result_accuracy": 0.0},
+    )
+    assert override_response.status_code == 200, override_response.text
+    assert override_response.json()["min_no_result_accuracy"] == 0.0
+
+
 def test_promotion_gate_does_not_penalize_correct_no_result_abstention() -> None:
     positive = evaluate_retrieval_case(
         [{"chunk_id": "answer", "source_document_id": "doc-a", "score": 0.9}],
@@ -442,9 +510,20 @@ async def test_evaluation_api_runs_versions_and_enforces_required_gate(
     )
     assert candidate["metrics"]["recall_at_5"] == 1.0, candidate
     assert candidate["promotion_gate"]["passed"] is True
+    evidence = candidate["version_evidence"]
+    assert evidence["version_id"] == candidate_version
+    assert evidence["version_fingerprint"]
+    assert evidence["embedding"]["effective"]["provider"] == "hash"
+    assert evidence["embedding"]["effective"]["model"] == "deterministic-hash-v1"
+    receipt = candidate["case_results"][0]["retrieval_receipt"]
+    assert receipt["embedding_provider"] == "hash"
+    assert receipt["embedding_model"] == "deterministic-hash-v1"
+    assert receipt["embedding_dimension"] == 128
+    assert receipt["rerank_provider_used"] == "none"
     serialized = str(completed).lower()
     assert "project orion deployment requires a signed" not in serialized
-    assert "embedding" not in serialized
+    assert "api_key" not in serialized
+    assert "endpoint" not in serialized
     assert "stored_path" not in serialized
     assert "sk-" not in serialized
 

--- a/server/tests/test_rag_pipeline.py
+++ b/server/tests/test_rag_pipeline.py
@@ -117,6 +117,18 @@ async def test_rag_pipeline_draft_empty_knowledge_base(client: httpx.AsyncClient
     assert data["index_schema_version"] == 2
     assert data["retrieval_profile"]["mode"] == "hybrid"
     assert data["embedding_profile"]["degraded"] is True
+    assert data["embedding_profile"]["requested"] == {
+        "provider": "hash",
+        "model": "deterministic-hash-v1",
+    }
+    assert data["embedding_profile"]["effective"] == {
+        "provider": "hash",
+        "model": "deterministic-hash-v1",
+        "dimension": 128,
+        "degraded": True,
+        "ready": True,
+        "reason": None,
+    }
     assert stages["chunker"]["config"]["strategy"] == "recursive_character"
     assert stages["chunker"]["config"]["chunk_size"] == 500
     assert stages["chunker"]["config"]["chunk_overlap"] == 50
@@ -160,7 +172,10 @@ async def test_rag_pipeline_draft_patch_persists_chunker_config(
     response = await client.patch(
         f"/api/rag/pipeline/draft/{kb_id}",
         json={
-            "embedding_profile": {"model": "text-embedding-3-small"},
+            "embedding_profile": {
+                "provider": "openai_compatible",
+                "model": "text-embedding-3-small",
+            },
             "retrieval_profile": {
                 "mode": "hybrid",
                 "vector_weight": 0.6,
@@ -191,7 +206,16 @@ async def test_rag_pipeline_draft_patch_persists_chunker_config(
     assert patched["retrieval_profile"]["vector_weight"] == 0.6
     assert patched["retrieval_profile"]["fulltext_weight"] == 0.4
     assert patched["retrieval_profile"]["top_k"] == 8
-    assert patched["embedding_profile"]["model"] == "text-embedding-3-small"
+    assert patched["embedding_profile"]["provider"] == "unavailable"
+    assert patched["embedding_profile"]["model"] == ""
+    assert patched["embedding_profile"]["requested"] == {
+        "provider": "openai_compatible",
+        "model": "text-embedding-3-small",
+    }
+    assert patched["embedding_profile"]["effective"]["ready"] is False
+    assert patched["embedding_profile"]["effective"]["reason"] == (
+        "embedding_credentials_missing"
+    )
 
     response = await client.get(f"/api/rag/pipeline/draft?kb_id={kb_id}")
     assert response.status_code == 200, response.text
@@ -201,6 +225,128 @@ async def test_rag_pipeline_draft_patch_persists_chunker_config(
     assert chunker["config"]["chunk_size"] == 800
     assert chunker["config"]["chunk_overlap"] == 120
     assert data["retrieval_profile"]["score_threshold"] == 0.2
+
+
+@pytest.mark.asyncio
+async def test_rag_pipeline_blocks_unavailable_requested_embedding(
+    client: httpx.AsyncClient,
+) -> None:
+    kb_id = await create_kb(client, "blocked semantic embedding")
+    document = await upload_pipeline_document(client, kb_id)
+
+    response = await client.patch(
+        f"/api/rag/pipeline/draft/{kb_id}",
+        json={
+            "embedding_profile": {
+                "provider": "openai_compatible",
+                "model": "baai/bge-m3",
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+    draft = response.json()
+    assert draft["embedding_profile"]["requested"]["model"] == "baai/bge-m3"
+    assert draft["embedding_profile"]["effective"]["ready"] is False
+    assert draft["embedding_profile"]["effective"]["provider"] == "unavailable"
+
+    preflight = await client.post(f"/api/rag/pipeline/draft/{kb_id}/preflight")
+    assert preflight.status_code == 200, preflight.text
+    assert preflight.json()["ready"] is False
+    assert any("Embedding" in warning for warning in preflight.json()["warnings"])
+
+    execute = await client.post(
+        f"/api/rag/pipeline/draft/{kb_id}/execute",
+        json={
+            "draft_version": draft["version"],
+            "source_document_ids": [document["id"]],
+            "xpert_file_refs": [],
+        },
+    )
+    assert execute.status_code == 400, execute.text
+    assert "Embedding provider is unavailable" in execute.text
+
+    jobs = await client.get(f"/api/rag/pipeline/jobs?kb_id={kb_id}")
+    assert jobs.status_code == 200, jobs.text
+    assert jobs.json()["job_count"] == 0
+
+
+def test_rag_pipeline_reclassifies_legacy_silent_hash_profile(
+    tmp_path: Path,
+) -> None:
+    service = RagService(
+        storage_dir=tmp_path / "legacy-storage",
+        uploads_dir=tmp_path / "legacy-uploads",
+        embedder=EmbeddingClient(
+            api_base="https://embedding.test/v1",
+            api_key="",
+            model="text-embedding-3-small",
+            dimension=96,
+        ),
+        vector_store=LocalJsonVectorStore(tmp_path / "legacy-storage" / "vectors.json"),
+        llm_enabled=False,
+    )
+
+    profile = service._validated_embedding_profile(
+        {
+            "provider": "hash",
+            "model": "baai/bge-m3",
+            "dimension": 96,
+            "degraded": True,
+        },
+        None,
+    )
+
+    assert profile["requested"] == {
+        "provider": "openai_compatible",
+        "model": "baai/bge-m3",
+    }
+    assert profile["effective"]["provider"] == "unavailable"
+    assert profile["effective"]["ready"] is False
+    assert profile["effective"]["reason"] == "embedding_credentials_missing"
+
+
+def test_rag_pipeline_records_ready_requested_and_effective_embedding(
+    tmp_path: Path,
+) -> None:
+    service = RagService(
+        storage_dir=tmp_path / "configured-storage",
+        uploads_dir=tmp_path / "configured-uploads",
+        embedder=EmbeddingClient(
+            api_base="https://embedding.test/v1",
+            api_key="test-key",
+            model="text-embedding-3-small",
+            dimension=96,
+        ),
+        vector_store=LocalJsonVectorStore(
+            tmp_path / "configured-storage" / "vectors.json"
+        ),
+        llm_enabled=False,
+    )
+    kb = service.create_knowledge_base("configured semantic embedding")
+    draft = service.update_pipeline_draft(
+        kb["id"],
+        {},
+        embedding_profile={
+            "provider": "openai_compatible",
+            "model": "baai/bge-m3",
+        },
+    )
+
+    profile = draft["embedding_profile"]
+    assert profile["requested"] == {
+        "provider": "openai_compatible",
+        "model": "baai/bge-m3",
+    }
+    assert profile["effective"] == {
+        "provider": "openai_compatible",
+        "model": "baai/bge-m3",
+        "dimension": 96,
+        "degraded": False,
+        "ready": True,
+        "reason": None,
+    }
+    assert profile["provider"] == "openai_compatible"
+    assert profile["model"] == "baai/bge-m3"
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_rag_retrieval_v2.py
+++ b/server/tests/test_rag_retrieval_v2.py
@@ -6,14 +6,16 @@ from pathlib import Path
 import httpx
 import pytest
 
+from server.rag import retrieval as retrieval_module
 from server.rag.embedder import EmbeddingClient
 from server.rag.lexical_store import LexicalChunk, SqliteLexicalStore, tokenize_for_search
 from server.rag.pipeline_executor import KnowledgePipelineExecutor
 from server.rag.rag_service import RagService
+from server.rag.rag_service import PipelineDraftValidationError
 from server.rag.reranker import RerankDocument, RerankService
-from server.rag.retrieval import RetrievalConfig
+from server.rag.retrieval import RetrievalCandidate, RetrievalConfig, fuse_rankings
 from server.rag.splitter import ParentChildTextSplitter, TextSplitter
-from server.rag.vector_store import LocalJsonVectorStore
+from server.rag.vector_store import ChromaVectorStore, LocalJsonVectorStore, VectorChunk
 
 
 def build_service(tmp_path: Path, *, reranker=None) -> RagService:
@@ -237,6 +239,161 @@ async def test_v2_candidate_builds_dual_index_and_lifts_parent_context(tmp_path:
     assert result["retrieval"]["fulltext_candidate_count"] > 0
 
 
+@pytest.mark.asyncio
+async def test_version_query_uses_pinned_hash_embedder_not_process_default(
+    tmp_path: Path,
+) -> None:
+    service = build_service(tmp_path)
+    kb = service.create_knowledge_base("version-pinned embedding")
+    document = await service.upload_document(
+        kb["id"],
+        "pinned.txt",
+        "PINNED-ORBIT requires a version-scoped embedding query.".encode(),
+    )
+    draft = service.update_pipeline_draft(
+        kb["id"],
+        {},
+        retrieval_profile={"mode": "vector", "top_k": 2},
+    )
+    job = service.create_pipeline_job(
+        kb["id"],
+        draft_version=draft["version"],
+        source_document_ids=[document["id"]],
+    )
+    assert await KnowledgePipelineExecutor(service).run_once() is True
+    version = service.get_pipeline_version(job["candidate_version_id"])
+
+    wrong_process_embedder = EmbeddingClient(
+        api_base="https://wrong-embedding.test/v1",
+        api_key="configured-but-wrong",
+        model="wrong-process-model",
+        dimension=32,
+    )
+
+    async def reject_process_default(_texts: list[str]) -> list[list[float]]:
+        raise AssertionError("query used the process-level embedder")
+
+    wrong_process_embedder.embed_texts = reject_process_default  # type: ignore[method-assign]
+    service.embedder = wrong_process_embedder
+
+    result = await service.query_pipeline_version(
+        version["version_id"],
+        "PINNED-ORBIT",
+        retrieval={"mode": "vector", "top_k": 2},
+        generate_answer=False,
+    )
+
+    assert result["sources"]
+    assert result["retrieval"]["embedding_provider"] == "hash"
+    assert result["retrieval"]["embedding_model"] == "deterministic-hash-v1"
+    assert result["retrieval"]["embedding_dimension"] == 64
+
+
+@pytest.mark.asyncio
+async def test_real_embedding_version_records_actual_dimension_and_fails_closed(
+    tmp_path: Path,
+) -> None:
+    storage = tmp_path / "real-storage"
+    embedder = EmbeddingClient(
+        api_base="https://embedding.test/v1",
+        api_key="configured",
+        model="real-model",
+        dimension=64,
+    )
+
+    async def fake_real_embeddings(texts: list[str]) -> list[list[float]]:
+        return [[1.0, float(len(text) % 7), 0.25] for text in texts]
+
+    embedder.embed_texts = fake_real_embeddings  # type: ignore[method-assign]
+    service = RagService(
+        storage_dir=storage,
+        uploads_dir=tmp_path / "real-uploads",
+        embedder=embedder,
+        vector_store=LocalJsonVectorStore(storage / "vectors.json"),
+        lexical_store=SqliteLexicalStore(storage / "lexical.sqlite3"),
+        llm_enabled=False,
+    )
+    kb = service.create_knowledge_base("real embedding identity")
+    document = await service.upload_document(
+        kb["id"],
+        "real.txt",
+        "REAL-VECTOR-IDENTITY must remain pinned.".encode(),
+    )
+    draft = service.update_pipeline_draft(
+        kb["id"],
+        {},
+        embedding_profile={
+            "provider": "openai_compatible",
+            "model": "real-model",
+        },
+        retrieval_profile={"mode": "vector", "top_k": 2},
+    )
+    job = service.create_pipeline_job(
+        kb["id"],
+        draft_version=draft["version"],
+        source_document_ids=[document["id"]],
+    )
+    assert await KnowledgePipelineExecutor(service).run_once() is True
+    version = service.get_pipeline_version(job["candidate_version_id"])
+    assert version["embedding_profile"]["effective"]["dimension"] == 3
+    assert version["embedding_profile"]["dimension"] == 3
+    evidence_before = service.pipeline_version_evidence(version["version_id"])
+
+    embedder.api_key = ""
+    evidence_after = service.pipeline_version_evidence(version["version_id"])
+    assert evidence_after["version_fingerprint"] == evidence_before["version_fingerprint"]
+    assert evidence_after["embedding"]["effective"]["provider"] == (
+        "openai_compatible"
+    )
+    with pytest.raises(PipelineDraftValidationError, match="unavailable"):
+        await service.query_pipeline_version(
+            version["version_id"],
+            "REAL-VECTOR-IDENTITY",
+            retrieval={"mode": "vector"},
+            generate_answer=False,
+        )
+
+
+def test_chroma_isolates_namespaces_with_different_dimensions(tmp_path: Path) -> None:
+    pytest.importorskip("chromadb")
+    store = ChromaVectorStore(tmp_path / "chroma")
+    store.add_chunks(
+        [
+            VectorChunk(
+                id="chunk-two",
+                kb_id="kb::version-two",
+                doc_id="doc-two",
+                document_name="two.txt",
+                text="two dimensional vector",
+                embedding=[1.0, 0.0],
+                chunk_index=0,
+            )
+        ]
+    )
+    store.add_chunks(
+        [
+            VectorChunk(
+                id="chunk-three",
+                kb_id="kb::version-three",
+                doc_id="doc-three",
+                document_name="three.txt",
+                text="three dimensional vector",
+                embedding=[1.0, 0.0, 0.0],
+                chunk_index=0,
+            )
+        ]
+    )
+
+    assert store.query("kb::version-two", [1.0, 0.0], 1)[0].chunk_id == "chunk-two"
+    assert (
+        store.query("kb::version-three", [1.0, 0.0, 0.0], 1)[0].chunk_id
+        == "chunk-three"
+    )
+    store.delete_knowledge_base("kb::version-two")
+    assert store.query("kb::version-two", [1.0, 0.0], 1) == []
+    assert store.query("kb::version-three", [1.0, 0.0, 0.0], 1)
+
+
 def test_retrieval_config_validates_weights_and_limits() -> None:
     config = RetrievalConfig.from_mapping(
         {"mode": "hybrid", "vector_weight": 0.7, "fulltext_weight": 0.3, "top_k": 10}
@@ -247,6 +404,99 @@ def test_retrieval_config_validates_weights_and_limits() -> None:
         RetrievalConfig.from_mapping({"top_k": 51})
     with pytest.raises(ValueError):
         RetrievalConfig.from_mapping({"score_threshold": 1.1})
+
+
+def _retrieval_candidate(
+    chunk_id: str,
+    doc_id: str,
+    *,
+    vector_score: float | None = None,
+    fulltext_score: float | None = None,
+    fused_score: float = 0.0,
+    rerank_score: float | None = None,
+    parent_chunk_id: str | None = None,
+) -> RetrievalCandidate:
+    return RetrievalCandidate(
+        chunk_id=chunk_id,
+        doc_id=doc_id,
+        document_name=f"{doc_id}.txt",
+        matched_text=chunk_id,
+        context_text=chunk_id,
+        vector_score=vector_score,
+        fulltext_score=fulltext_score,
+        fused_score=fused_score,
+        rerank_score=rerank_score,
+        parent_chunk_id=parent_chunk_id,
+    )
+
+
+def test_weighted_rrf_score_is_candidate_pool_invariant() -> None:
+    config = RetrievalConfig.from_mapping(
+        {
+            "mode": "hybrid",
+            "vector_weight": 0.7,
+            "fulltext_weight": 0.3,
+        }
+    )
+    base = fuse_rankings(
+        [
+            _retrieval_candidate("shared", "doc-a", vector_score=0.9),
+            _retrieval_candidate("vector-only", "doc-b", vector_score=0.8),
+        ],
+        [_retrieval_candidate("shared", "doc-a", fulltext_score=1.0)],
+        config,
+    )
+    expanded = fuse_rankings(
+        [
+            _retrieval_candidate("shared", "doc-a", vector_score=0.9),
+            _retrieval_candidate("vector-only", "doc-b", vector_score=0.8),
+            _retrieval_candidate("tail", "doc-c", vector_score=0.1),
+        ],
+        [_retrieval_candidate("shared", "doc-a", fulltext_score=1.0)],
+        config,
+    )
+
+    base_scores = {item.chunk_id: item.fused_score for item in base}
+    expanded_scores = {item.chunk_id: item.fused_score for item in expanded}
+    assert expanded_scores["shared"] == pytest.approx(base_scores["shared"])
+    assert expanded_scores["vector-only"] == pytest.approx(
+        base_scores["vector-only"]
+    )
+    assert 0 < expanded_scores["tail"] < expanded_scores["vector-only"] < 1
+
+
+def test_candidate_selection_uses_fused_threshold_then_parent_and_doc_diversity() -> None:
+    candidates = [
+        _retrieval_candidate(
+            "a-parent-best",
+            "doc-a",
+            fused_score=0.95,
+            rerank_score=0.1,
+            parent_chunk_id="parent-a",
+        ),
+        _retrieval_candidate(
+            "a-parent-duplicate",
+            "doc-a",
+            fused_score=0.94,
+            rerank_score=0.99,
+            parent_chunk_id="parent-a",
+        ),
+        _retrieval_candidate("a-second", "doc-a", fused_score=0.93),
+        _retrieval_candidate("b-first", "doc-b", fused_score=0.92),
+        _retrieval_candidate("c-below-threshold", "doc-c", fused_score=0.79),
+    ]
+
+    selected = retrieval_module.select_candidates(
+        candidates,
+        score_threshold=0.8,
+        top_k=3,
+    )
+
+    assert [item.chunk_id for item in selected] == [
+        "a-parent-best",
+        "b-first",
+        "a-second",
+    ]
 
 
 @pytest.mark.asyncio
@@ -370,3 +620,110 @@ async def test_llm_rerank_falls_back_from_gateway_to_openrouter(
         "http://gateway.test/v1/chat/completions",
         "https://openrouter.ai/api/v1/chat/completions",
     ]
+
+
+@pytest.mark.asyncio
+async def test_auto_rerank_keeps_api_model_out_of_llm_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    documents = [RerankDocument("a", "alpha"), RerankDocument("b", "beta")]
+    service = RerankService()
+    payloads: list[tuple[str, dict]] = []
+    monkeypatch.setenv("RERANK_API_URL", "https://rerank.test/v1/rerank")
+    monkeypatch.setenv("RERANK_API_KEY", "rerank-key")
+    monkeypatch.setenv("RERANK_MODEL", "default-reranker")
+    monkeypatch.setenv("LLM_GATEWAY_URL", "https://gateway.test/v1")
+    monkeypatch.setenv("LLM_GATEWAY_KEY", "gateway-key")
+    monkeypatch.setenv("RAG_RERANK_LLM_MODEL", "deepseek/deepseek-chat")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    async def post(self, url, **kwargs):
+        payloads.append((url, dict(kwargs["json"])))
+        if url == "https://rerank.test/v1/rerank":
+            return httpx.Response(
+                503,
+                json={"error": "rerank unavailable"},
+                request=httpx.Request("POST", url),
+            )
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {"message": {"content": '{"results":[{"index":1,"score":0.9}]}'}}
+                ]
+            },
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", post)
+    outcome = await service.rerank(
+        "beta",
+        documents,
+        provider="auto",
+        model="cohere/rerank-4-fast",
+        top_n=1,
+    )
+
+    assert outcome.provider == "llm"
+    assert outcome.model == "deepseek/deepseek-chat"
+    assert payloads[0][1]["model"] == "cohere/rerank-4-fast"
+    assert payloads[1][1]["model"] == "deepseek/deepseek-chat"
+
+
+@pytest.mark.asyncio
+async def test_rerank_provider_results_are_sorted_by_validated_score(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    documents = [RerankDocument("a", "alpha"), RerankDocument("b", "beta")]
+    service = RerankService()
+    monkeypatch.setenv("RERANK_API_URL", "https://rerank.test/v1/rerank")
+    monkeypatch.setenv("RERANK_API_KEY", "test-key")
+    monkeypatch.setenv("RERANK_MODEL", "test-reranker")
+
+    async def post(self, url, **kwargs):
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"index": 0, "relevance_score": 0.2},
+                    {"index": 1, "relevance_score": 0.9},
+                ]
+            },
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", post)
+    outcome = await service.rerank("beta", documents, provider="api", top_n=2)
+
+    assert [item.chunk_id for item in outcome.items] == ["b", "a"]
+    assert outcome.model == "test-reranker"
+
+
+@pytest.mark.asyncio
+async def test_explicit_llm_rerank_rejects_reranker_only_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = RerankService()
+    calls: list[str] = []
+    monkeypatch.setenv("LLM_GATEWAY_URL", "https://gateway.test/v1")
+    monkeypatch.setenv("LLM_GATEWAY_KEY", "gateway-key")
+    monkeypatch.setenv("RAG_RERANK_LLM_MODEL", "deepseek/deepseek-chat")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    async def post(self, url, **kwargs):
+        calls.append(url)
+        raise AssertionError("reranker-only model reached chat completions")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", post)
+    outcome = await service.rerank(
+        "alpha",
+        [RerankDocument("a", "alpha")],
+        provider="llm",
+        model="cohere/rerank-4-fast",
+        top_n=1,
+    )
+
+    assert outcome.provider == "none"
+    assert outcome.model == ""
+    assert "reranker-only model" in str(outcome.warning)
+    assert calls == []

--- a/server/tests/test_rag_strategy_tuner.py
+++ b/server/tests/test_rag_strategy_tuner.py
@@ -1073,6 +1073,10 @@ async def test_tuner_materializes_ready_candidate_without_switching_active_versi
     eval_set_id, eval_version = await _published_set_for_version(
         service, evaluation_store, kb_id, base_version_id
     )
+    evaluation_store.set_gate_policy(
+        kb_id,
+        {"min_no_result_accuracy": 0.0},
+    )
     request = {
         "kb_id": kb_id,
         "base_version_id": base_version_id,


### PR DESCRIPTION
## 范围

- 完成 RAG 修复第 0 轮及第 1A–1D 批，包含 1D.1 的 P0 默认门禁闭环。
- 变更限定为 RAG 检索、评测、基准证据、定向测试和 `/rag` 展示，共 19 个文件。
- 不包含候选版本激活、索引迁移、共享持久化数据变更、部署或 1D 之后的调优工作。

## 关键修复

- 区分 requested/effective embedding 配置，真实向量配置缺失凭据时 fail closed，不再静默回退哈希向量。
- 按不可变版本身份隔离向量集合和维度，允许不同维度版本共存并独立删除。
- 使用候选池稳定的加权 RRF；在 rerank 前执行召回阈值、父块去重和文档多样性选择。
- 分离 reranker API 与 LLM rerank 协议，校验模型/协议匹配，并持久化无凭据执行回执与版本指纹。
- 将无结果准确率默认晋级门槛从 0 提升到 0.8；仍允许操作者显式覆盖为 0.0 以保持兼容。

## 验证

- 变基到 `main@c7cec3800ed00ea5b0c8c28768c7c52baf601ddf` 后：RAG/Knowledge 定向回归 `201 passed, 4 warnings`。
- `RagPage` 定向测试：`14 passed`。
- 前端生产构建通过；保留既有大 chunk 警告。
- 前端全套测试：`77/80` 个文件、`390/393` 个用例通过；3 个非 RAG Agent/Skill 页面用例触发共享 5 秒超时。三个受影响文件逐一重跑分别 `10/10`、`9/9`、`2/2` 通过。
- 变基前全量后端：`3203 passed, 22 failed, 29 skipped`；同一基线也有相同 22 个非 RAG 失败，本次无 RAG 失败。
- `git diff --check` 通过。

## 真实 API / UI 证据

- 独立预览环境使用 6 条固定 Gold cases 完成真实 embedding 与 rerank 调用；运行 ID：`evalrun_daa24c0f67ec44a4ad621ce26be980ec`。
- embedding：`openai/text-embedding-3-small`，实际维度 1536；rerank：`deepseek/deepseek-chat`，6/6 cases 应用。
- v1 与 v2 均因无结果准确率为 0 被新的 0.8 默认门禁正确阻断；v2 还因引用命中回归和 p95 延迟比被阻断。
- 未激活 v2，未修改共享 RAG 存储或生产配置。

## 已知后续

- 下一轮继续处理无结果阈值校准、rerank 延迟和引用精度；本 PR 不声称候选策略已达到晋级质量。
- 最终产品质量仍需人工验收。

## 回退

- 回退本 PR 提交即可恢复代码；因未激活候选版本且未改共享持久化数据，无需数据回滚。
