### PR TITLE
fix: 更新音频契约版本断言

### DIFF
--- a/server/tests/test_multimodal_chat_foundation.py
+++ b/server/tests/test_multimodal_chat_foundation.py
@@ -314,7 +314,7 @@ async def test_audio_catalog_only_marks_verified_interactions_ready(
 
     assert result.status == "online"
     assert result.catalog_version == (
-        "modelmirror-audio-contracts-2026-08-13-c1"
+        "modelmirror-audio-contracts-2026-08-14-c2"
     )
     assert by_id["openai/gpt-audio"].provider == "openrouter"
     assert by_id["openai/gpt-audio"].operations == ["analyze_audio"]
@@ -659,7 +659,7 @@ async def test_audio_catalog_endpoint_does_not_expose_credentials(
     assert response.status_code == 200
     assert response.json()["profiles"]
     assert response.json()["catalog_version"] == (
-        "modelmirror-audio-contracts-2026-08-13-c1"
+        "modelmirror-audio-contracts-2026-08-14-c2"
     )
     assert response.json()["microphone_enabled"] is True
     assert "audio-catalog-secret" not in response.text


### PR DESCRIPTION
## 摘要

- 将音频目录测试中的两处过期契约版本断言从 2026-08-13-c1 更新为当前实现使用的 2026-08-14-c2。
- 不修改运行时代码，不混入 R1.5 工作流功能。

## 复现

- 修改前两个目标测试均因服务返回 c2、测试仍期望 c1 而失败。

## 验证

- 音频目标测试：2 passed
- Agency Worker：75 passed
- 工作流合同：6 passed
- 剩余后端：3258 passed, 29 skipped
- git diff --check：通过

## 边界

- 本 PR 仅恢复主线测试基线。
- 失败处置入口与子流程调用将在基线合并后分别交付。