### PR TITLE
feature: 更新 OpenRouter 模型快照并修复显式模型回退

### DIFF
--- a/client/src/data/models.refresh.test.ts
+++ b/client/src/data/models.refresh.test.ts
@@ -40,6 +40,12 @@ const august16ModelIds = [
   "qwen/qwen3.8-27b",
 ];
 
+const august20ModelIds = [
+  "liquid/lfm-2.5-embedding-350m:free",
+  "z-ai/glm-5.3",
+  "~z-ai/glm-latest",
+];
+
 describe("OpenRouter model refresh", () => {
   it("restores V4 Flash ahead of V4 Pro and keeps Seedream in row four", () => {
     expect(models[2]?.id).toBe("deepseek/deepseek-v4-flash-0731");
@@ -148,6 +154,52 @@ describe("OpenRouter model refresh", () => {
         providers: ["Chutes"],
       },
     });
+  });
+
+  it("adds the three August 20 snapshots below the first six rows", () => {
+    for (const modelId of august20ModelIds) {
+      const matches = models.filter((model) => model.id === modelId);
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        catalog_status: "live",
+        catalog_counted: true,
+        active: true,
+      });
+      expect(models.findIndex((model) => model.id === modelId)).toBeGreaterThanOrEqual(
+        2 + 6 * 3,
+      );
+    }
+  });
+
+  it("keeps the August 20 endpoint contracts and current prices", () => {
+    const byId = new Map(models.map((model) => [model.id, model]));
+
+    expect(byId.get("liquid/lfm-2.5-embedding-350m:free")).toMatchObject({
+      input_modalities: ["text"],
+      output_modalities: ["embeddings"],
+      primary_operation: "embed",
+      interaction_status: "ready",
+      ui_entrypoint: "rag",
+      context_length: 512,
+      pricing: { input: 0, output: 0 },
+      pricing_status: "free",
+      pricing_basis: "free",
+    });
+    for (const modelId of ["z-ai/glm-5.3", "~z-ai/glm-latest"]) {
+      expect(byId.get(modelId)).toMatchObject({
+        input_modalities: ["text"],
+        output_modalities: ["text"],
+        primary_operation: "chat",
+        interaction_status: "ready",
+        ui_entrypoint: "chat",
+        context_length: 1_048_576,
+        pricing: { input: 1.4, output: 4.4 },
+        reasoning_declared: true,
+        openrouter_market: {
+          author: "z-ai",
+        },
+      });
+    }
   });
 
   it("routes the August 14 specialized models by their dedicated contracts", () => {

--- a/client/src/data/models.ts
+++ b/client/src/data/models.ts
@@ -1,6 +1,6 @@
-﻿// Merged with OpenRouter model catalog on 2026-08-17T01:38:03.086Z.
-// Current OpenRouter refresh verified on 2026-08-16 against the live all-modalities catalog.
-// Refreshed with entries published through 2026-08-14T15:55:10.000Z.
+﻿// Merged with OpenRouter model catalog on 2026-08-20T10:16:33.909Z.
+// Current OpenRouter refresh verified on 2026-08-20 against the live all-modalities catalog.
+// Refreshed with entries published through 2026-08-19T14:50:53.000Z.
 // Source: https://openrouter.ai/api/v1/models?output_modalities=all&sort=newest&offset=0&limit=1000
 // Full OpenRouter catalog audit refresh: 2026-08-16. Batch catalog entries are
 // attached to their canonical models as serving variants and excluded from
@@ -208,6 +208,107 @@ interface RawCatalogModel {
 }
 
 const rawCatalogModels: RawCatalogModel[] = [
+  {
+    "id": "~z-ai/glm-latest",
+    "canonical_slug": "~z-ai/glm-latest",
+    "name": "Z.ai: GLM Latest",
+    "raw_description": "This model always redirects to the latest GLM model from Z.ai.",
+    "context_length": 1048576,
+    "pricing": {
+      "input": 1.4,
+      "output": 4.4
+    },
+    "input_modalities": [
+      "text"
+    ],
+    "output_modalities": [
+      "text"
+    ],
+    "tokenizer": "Router",
+    "supported_parameters": [
+      "include_reasoning",
+      "max_tokens",
+      "reasoning",
+      "reasoning_effort",
+      "response_format",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_k",
+      "top_p"
+    ],
+    "created": 1787151053,
+    "expiration_date": 4070822400,
+    "model_author": "Z.ai",
+    "reasoning_declared": true
+  },
+  {
+    "id": "z-ai/glm-5.3",
+    "canonical_slug": "z-ai/glm-5.3-20260816",
+    "name": "Z.ai: GLM 5.3",
+    "raw_description": "GLM-5.3 is a large-scale reasoning model from Z.ai, built for complex software engineering and long-horizon agent tasks. It supports text input and output with a 1M-token context window.",
+    "context_length": 1048576,
+    "pricing": {
+      "input": 1.4,
+      "output": 4.4
+    },
+    "input_modalities": [
+      "text"
+    ],
+    "output_modalities": [
+      "text"
+    ],
+    "tokenizer": "Other",
+    "supported_parameters": [
+      "include_reasoning",
+      "max_tokens",
+      "reasoning",
+      "reasoning_effort",
+      "response_format",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_k",
+      "top_p"
+    ],
+    "created": 1787086655,
+    "expiration_date": 4070822400,
+    "model_author": "Z.ai",
+    "reasoning_declared": true
+  },
+  {
+    "id": "liquid/lfm-2.5-embedding-350m:free",
+    "canonical_slug": "liquid/lfm-2.5-embedding-350m-20260818",
+    "name": "LiquidAI: LFM2.5-Embedding-350M (free)",
+    "raw_description": "LFM2.5-Embedding-350M is a text embedding model from Liquid AI. It produces 1,024-dimensional embeddings for retrieval and semantic search. Successful OpenRouter requests and embeddings may be retained and used to train models.",
+    "context_length": 512,
+    "pricing": {
+      "input": 0,
+      "output": 0
+    },
+    "input_modalities": [
+      "text"
+    ],
+    "output_modalities": [
+      "embeddings"
+    ],
+    "tokenizer": "Other",
+    "supported_parameters": [
+      "frequency_penalty",
+      "max_tokens",
+      "min_p",
+      "presence_penalty",
+      "repetition_penalty",
+      "seed",
+      "stop",
+      "temperature",
+      "top_k",
+      "top_p"
+    ],
+    "created": 1787077908,
+    "expiration_date": null,
+    "model_author": "LiquidAI"
+  },
   {
     "id": "qwen/qwen3.8-27b",
     "canonical_slug": "qwen/qwen3.8-27b-20260814",
@@ -22265,7 +22366,7 @@ function marketSnapshotFor(raw: RawCatalogModel): OpenRouterMarketSnapshot {
   return {
     ...EMPTY_OPENROUTER_MARKET_SNAPSHOT,
     series: inferOpenRouterMarketSeries(raw),
-    author: raw.id.split("/", 1)[0] ?? "",
+    author: raw.id.replace(/^~/, "").split("/", 1)[0] ?? "",
     created_at: raw.created > 0 ? raw.created : null,
     artificial_analysis: {},
     design_arena: {},
@@ -22876,6 +22977,9 @@ const MID_CATALOG_MODEL_IDS = [
   "inclusionai/ling-3.0-tiny:free",
 ];
 const LATEST_REFRESH_MODEL_IDS = [
+  "~z-ai/glm-latest",
+  "z-ai/glm-5.3",
+  "liquid/lfm-2.5-embedding-350m:free",
   "qwen/qwen3.8-27b",
   "dots-studio/dots-3-note-preview:free",
   "nvidia/nemotron-3.5-asr-streaming-multilingual-0.6b",

--- a/docs/OMNIROUTE_INTEGRATION.md
+++ b/docs/OMNIROUTE_INTEGRATION.md
@@ -72,6 +72,16 @@ OmniRoute 或供应商密钥写入前端环境变量。
 内部完成。路由回执只暴露允许名单内的模型、供应商、成本、延迟和请求
 标识，不透传内部决策体。
 
+`MODEL_ROUTER_DEFAULT=omniroute` 只为仍以 `gateway=default` 调用的
+`auto/*` 兼容请求选择侧车。用户显式选择的模型 ID 始终走统一
+newAPI/OpenRouter 网关；否则 `poolside/...`、`xiaomi/...` 等 OpenRouter
+发布者前缀会被侧车误解为需要独立凭据的本地供应商。
+
+若本地 newAPI 明确返回 `model_not_found` 或 `No available channel for model`，
+且后端已配置 `OPENROUTER_API_KEY`，显式模型请求会在正文输出前使用同一个
+模型 ID 有限回退到 OpenRouter。普通 `503`、Batch 契约错误和已经开始输出的
+响应不会触发该回退；成功回退后的计费与数据处理遵循 OpenRouter 连接配置。
+
 运行时 `3.8.48` 不提供 `release/v3.8.49` 文档中的 API Key 范围
 `/v1/auto-combo/{channel}/candidates` 接口。适配器因此以同一次
 `/v1/models?configuredOnly=true` 返回的 `auto/*` 模型作为可调用性依据：

--- a/docs/multimodal-readiness.json
+++ b/docs/multimodal-readiness.json
@@ -1,18 +1,18 @@
 {
   "schema_version": 1,
-  "reviewed_at": "2026-08-16",
+  "reviewed_at": "2026-08-20",
   "catalog": {
-    "snapshot_total": 545,
+    "snapshot_total": 548,
     "serving_variant_total": 63,
     "serving_variants_by_type": {
       "batch": 63
     },
     "serving_variants_counted_in_snapshot": false,
-    "live": 484,
+    "live": 487,
     "uncertain": 55,
     "expired": 6,
-    "onsite_openrouter": 539,
-    "adaptation_denominator": 539,
+    "onsite_openrouter": 542,
+    "adaptation_denominator": 542,
     "uncertain_included_in_onsite": true,
     "expired_excluded_from_onsite": true
   },

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -71,6 +71,7 @@ COPY xperts ./xperts
 COPY evaluations ./evaluations
 COPY benchmarks ./benchmarks
 COPY evolutions ./evolutions
+COPY workflow_deployments.py .
 COPY workflow_native ./workflow_native
 COPY world ./world
 COPY xpert_runtime ./xpert_runtime

--- a/server/main.py
+++ b/server/main.py
@@ -2593,6 +2593,21 @@ def is_gateway_auth_or_user_error(
     )
 
 
+def is_gateway_model_or_channel_unavailable(
+    status_code: int,
+    message: str,
+    data: dict[str, Any] | None,
+) -> bool:
+    lowered = json.dumps(data or {}, ensure_ascii=False).lower()
+    lowered += f" {message.lower()}"
+    markers = (
+        '"code": "model_not_found"',
+        '"code":"model_not_found"',
+        "no available channel for model",
+    )
+    return status_code in {404, 503} and any(marker in lowered for marker in markers)
+
+
 def should_fallback_gateway_to_openrouter(
     status_code: int,
     message: str,
@@ -2605,7 +2620,9 @@ def should_fallback_gateway_to_openrouter(
         return False
     if not is_local_gateway_url(primary_url):
         return False
-    return is_gateway_auth_or_user_error(status_code, message, data)
+    return is_gateway_auth_or_user_error(
+        status_code, message, data
+    ) or is_gateway_model_or_channel_unavailable(status_code, message, data)
 
 
 def should_fallback_model(
@@ -20474,6 +20491,7 @@ async def chat(payload: ChatRequest, request: Request):
         or (
             payload.gateway == "default"
             and omniroute_settings.default_router == "omniroute"
+            and is_omniroute_auto_model(payload.model_id)
         )
     )
     if use_native_router:

--- a/server/tests/test_omniroute_integration.py
+++ b/server/tests/test_omniroute_integration.py
@@ -481,6 +481,170 @@ async def test_omniroute_chat_forwards_headers_and_emits_one_receipt(
 
 
 @pytest.mark.asyncio
+async def test_explicit_model_bypasses_default_omniroute_sidecar(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sent_requests: list[dict[str, Any]] = []
+
+    class FakeResponse:
+        status_code = 200
+        headers: dict[str, str] = {}
+        content = b""
+
+        async def aiter_text(self):
+            yield 'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+            yield "data: [DONE]\n\n"
+
+        async def aread(self):
+            return self.content
+
+        async def aclose(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def build_request(self, method, url, headers, json):
+            request = {
+                "method": method,
+                "url": url,
+                "headers": headers,
+                "json": json,
+            }
+            sent_requests.append(request)
+            return request
+
+        async def send(self, request, stream):
+            assert stream is True
+            return FakeResponse()
+
+        async def aclose(self):
+            return None
+
+    settings = enabled_settings()
+    settings = OmniRouteSettings(
+        **{
+            **settings.__dict__,
+            "default_router": "omniroute",
+        }
+    )
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+    monkeypatch.setattr(main_module, "get_omniroute_settings", lambda: settings)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://new-api:3000/v1/chat/completions", "gateway-key"),
+    )
+    monkeypatch.setattr(main_module.httpx, "AsyncClient", FakeClient)
+
+    response = await client.post(
+        "/api/chat",
+        json={
+            "model_id": "xiaomi/mimo-v2.5-pro",
+            "gateway": "default",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert sent_requests[0]["url"] == "http://new-api:3000/v1/chat/completions"
+    assert sent_requests[0]["json"]["model"] == "xiaomi/mimo-v2.5-pro"
+    assert "X-OmniRoute-Mode" not in sent_requests[0]["headers"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_model_missing_from_newapi_falls_back_to_openrouter(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sent_requests: list[dict[str, Any]] = []
+
+    class FakeResponse:
+        def __init__(self, status_code: int, content: bytes = b"") -> None:
+            self.status_code = status_code
+            self.content = content
+            self.headers: dict[str, str] = {}
+
+        async def aiter_text(self):
+            yield 'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+            yield "data: [DONE]\n\n"
+
+        async def aread(self):
+            return self.content
+
+        async def aclose(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def build_request(self, method, url, headers, json):
+            request = {
+                "method": method,
+                "url": url,
+                "headers": headers,
+                "json": json,
+            }
+            sent_requests.append(request)
+            return request
+
+        async def send(self, request, stream):
+            assert stream is True
+            if request["url"] == "http://new-api:3000/v1/chat/completions":
+                return FakeResponse(
+                    503,
+                    b'{"error":{"code":"model_not_found","message":"No available channel for model ~z-ai/glm-latest under group default","type":"new_api_error"}}',
+                )
+            return FakeResponse(200)
+
+        async def aclose(self):
+            return None
+
+    settings = enabled_settings()
+    settings = OmniRouteSettings(
+        **{
+            **settings.__dict__,
+            "default_router": "omniroute",
+        }
+    )
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+    monkeypatch.setattr(main_module, "get_omniroute_settings", lambda: settings)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://new-api:3000/v1/chat/completions", "gateway-key"),
+    )
+    monkeypatch.setattr(main_module, "OPENROUTER_API_KEY", "openrouter-key")
+    monkeypatch.setattr(main_module.httpx, "AsyncClient", FakeClient)
+
+    response = await client.post(
+        "/api/chat",
+        json={
+            "model_id": "~z-ai/glm-latest",
+            "gateway": "default",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    request_urls = [request["url"] for request in sent_requests]
+    assert request_urls[0] == "http://new-api:3000/v1/chat/completions"
+    assert main_module.CHAT_COMPLETIONS_URL in request_urls
+    assert request_urls.index(main_module.CHAT_COMPLETIONS_URL) > request_urls.index(
+        "http://new-api:3000/v1/chat/completions"
+    )
+    assert all(
+        request["json"]["model"] == "~z-ai/glm-latest"
+        for request in sent_requests
+    )
+    assert "已自动切换到 OpenRouter" in response.text
+    assert "ok" in response.text
+
+
+@pytest.mark.asyncio
 async def test_omniroute_empty_success_stream_becomes_explicit_error(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/server/tests/test_xpert_runtime_chat.py
+++ b/server/tests/test_xpert_runtime_chat.py
@@ -403,6 +403,29 @@ def test_newapi_user_error_can_fallback_to_openrouter(
         )
         is False
     )
+    assert (
+        main_module.should_fallback_gateway_to_openrouter(
+            503,
+            "No available channel for model ~z-ai/glm-latest under group default",
+            {
+                "error": {
+                    "code": "model_not_found",
+                    "type": "new_api_error",
+                }
+            },
+            "http://new-api:3000/v1/chat/completions",
+        )
+        is True
+    )
+    assert (
+        main_module.should_fallback_gateway_to_openrouter(
+            503,
+            "upstream temporarily unavailable",
+            {"error": {"code": "upstream_error"}},
+            "http://new-api:3000/v1/chat/completions",
+        )
+        is False
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 摘要

- 纳入 Liquid LFM embedding、GLM 5.3 与 GLM Latest 快照，更新统计与契约
- 显式模型仅经统一 newAPI/OpenRouter 网关，避免被 OmniRoute 当作独立供应商
- newAPI 明确缺少模型渠道时，在正文输出前以同模型有限回退 OpenRouter
- 补齐 workflow_deployments 后端镜像打包

## 验证

- OmniRoute、聊天网关回退与 Batch：39 passed
- 前端模型与列表测试：27/27 passed
- 前端生产构建：passed
- 共享栈：30/30 服务健康
- GLM Latest 实际冒烟：newAPI 503 后 OpenRouter 200，别名解析为 z-ai/glm-5.3

## 风险与回退

- 回退只覆盖显式模型经本地 newAPI 返回模型或渠道不可用的场景；通用 503 与 Batch 路由不受影响
- 可回退后端快照或 revert 本 PR 的单一提交