### PR TITLE
feature: 建立 Skill 应用凭据基础

### DIFF
--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -348,6 +348,7 @@ interface InstalledSkill extends TrustSelectableSkill {
   repo_url: string;
   sub_path: string;
   installed_at: number;
+  content_digest: string;
 }
 
 interface InstalledSkillsResponse {
@@ -2989,6 +2990,13 @@ function ChatConversationPage() {
               format: "mp3",
             }
           : undefined,
+        skillApplication:
+          selectedSkill && /^[0-9a-f]{64}$/i.test(selectedSkill.content_digest)
+            ? {
+                skill_id: selectedSkill.skill_id,
+                expected_content_digest: selectedSkill.content_digest,
+              }
+            : undefined,
         fileScopeId: chatFileScopeId,
         outputMode: requestFileOutput ? "allowlisted" : "none",
         outputContextId: assistantId,

--- a/client/src/utils/fetchChatStream.test.ts
+++ b/client/src/utils/fetchChatStream.test.ts
@@ -68,6 +68,30 @@ describe("fetchChatStream file completion gate", () => {
     });
   });
 
+  it("sends the server-bound Skill application contract without altering messages", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(streamResponse("data: [DONE]\n\n"));
+    vi.stubGlobal("fetch", fetchMock);
+    const contentDigest = "a".repeat(64);
+
+    await fetchChatStream({
+      modelId: "openai/text-model",
+      messages: textMessages,
+      skillApplication: {
+        skill_id: "incident-review",
+        expected_content_digest: contentDigest,
+      },
+      onDelta: vi.fn(),
+    });
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toMatchObject({
+      messages: textMessages,
+      skill_application: {
+        skill_id: "incident-review",
+        expected_content_digest: contentDigest,
+      },
+    });
+  });
+
   it("preserves server-confirmed output bindings on existing media inputs", async () => {
     const fetchMock = vi.fn().mockResolvedValue(streamResponse("data: [DONE]\n\n"));
     vi.stubGlobal("fetch", fetchMock);

--- a/client/src/utils/fetchChatStream.ts
+++ b/client/src/utils/fetchChatStream.ts
@@ -84,6 +84,11 @@ export interface ChatResponseAudioOptions {
   format: "mp3";
 }
 
+export interface ChatSkillApplication {
+  skill_id: string;
+  expected_content_digest: string;
+}
+
 export interface ChatAudioDelta {
   data?: string;
   transcript?: string;
@@ -148,6 +153,7 @@ interface FetchChatStreamOptions {
   routing?: ChatRoutingOptions;
   compression?: ChatCompressionOptions;
   responseAudio?: ChatResponseAudioOptions;
+  skillApplication?: ChatSkillApplication;
   fileScopeId?: string;
   outputMode?: "none" | "allowlisted";
   outputContextId?: string;
@@ -430,6 +436,7 @@ export async function fetchChatStream({
   routing,
   compression,
   responseAudio,
+  skillApplication,
   fileScopeId,
   outputMode = "none",
   outputContextId,
@@ -460,6 +467,7 @@ export async function fetchChatStream({
       routing,
       compression,
       response_audio: responseAudio,
+      skill_application: skillApplication,
       file_scope_id: fileScopeId,
       output_mode: outputMode,
       output_context_id: outputContextId,

--- a/server/.env.example
+++ b/server/.env.example
@@ -35,6 +35,10 @@ SKILL_LIFECYCLE_ENABLED=true
 SKILL_LIFECYCLE_STORAGE_DIR=./skills/lifecycle
 SKILL_LIFECYCLE_MAX_VERSIONS=5
 SKILL_LIFECYCLE_MAX_BYTES=1073741824
+# Skill 应用凭据默认仅审计，不改变普通聊天或工作流结果。
+# off 可关闭写入；enforce 会在凭据不可写时使 Skill 应用失败关闭。
+# Creator Evaluation V2 后续还会对其内部运行强制校验 verified 凭据。
+SKILL_APPLICATION_RECEIPT_MODE=audit
 # The semantic provider remains disabled until explicitly configured. Router
 # shadow mode never changes the lexical skill-need-local-v3 result order.
 SKILL_SEMANTIC_RERANK_PROVIDER=none

--- a/server/main.py
+++ b/server/main.py
@@ -200,6 +200,12 @@ except ModuleNotFoundError:
     )
 
 try:
+    from server.skills.application_receipts import (
+        SkillApplicationObserver,
+        SkillApplicationReceiptError,
+        SkillApplicationReceiptStore,
+        application_receipt_mode,
+    )
     from server.skills.api import (
         get_builtin_skill_library,
         get_skill_draft_store,
@@ -208,6 +214,7 @@ try:
         router as skills_router,
     )
     from server.skills.local_import_api import router as skill_local_import_router
+    from server.skills.trust_service import SkillRuntimeEnvironment
     from server.skills.creator_api import (
         configure_skill_creator,
         configure_skill_creator_evaluation,
@@ -269,6 +276,12 @@ try:
         SkillCreatorSessionStore,
     )
 except ModuleNotFoundError:
+    from skills.application_receipts import (
+        SkillApplicationObserver,
+        SkillApplicationReceiptError,
+        SkillApplicationReceiptStore,
+        application_receipt_mode,
+    )
     from skills.api import (
         get_builtin_skill_library,
         get_skill_draft_store,
@@ -277,6 +290,7 @@ except ModuleNotFoundError:
         router as skills_router,
     )
     from skills.local_import_api import router as skill_local_import_router
+    from skills.trust_service import SkillRuntimeEnvironment
     from skills.creator_api import (
         configure_skill_creator,
         configure_skill_creator_evaluation,
@@ -1292,9 +1306,150 @@ run_registry = RunRegistry()
 workflow_execution_store = WorkflowExecutionStore(
     storage_dir=AGENT_TASK_STORAGE_DIR or None
 )
+skill_application_receipt_store = SkillApplicationReceiptStore(
+    storage_dir=AGENT_TASK_STORAGE_DIR or None
+)
+skill_application_observer = SkillApplicationObserver(
+    skill_application_receipt_store,
+    lambda: get_skill_manager(),
+)
 workflow_deployment_store = WorkflowDeploymentStore(
     storage_dir=AGENT_TASK_STORAGE_DIR or None
 )
+
+
+def record_skill_application(
+    *,
+    skill_id: str,
+    run_id: str | None,
+    task_id: str | None,
+    node_id: str | None,
+    runtime_kind: str,
+    version_id: str | None = None,
+    source_kind: str | None = None,
+    content_digest: str | None = None,
+    trust_fingerprint: str | None = None,
+    policy: Literal["advisory", "require_read", "require_stage"] = "require_read",
+    required_resource_paths: Iterable[str] = (),
+    method: Literal["prompt_injected", "skill_read", "skill_stage"] | None = None,
+    resource_paths: Iterable[str] = (),
+    resource_digests: dict[str, str] | None = None,
+    expected_resource_digests: dict[str, str] | None = None,
+    tool_name: str | None = None,
+    error_code: str | None = None,
+) -> str | None:
+    """Record audit evidence; only explicit enforce mode fails runtime closed."""
+
+    if application_receipt_mode() == "off":
+        return None
+    try:
+        receipt = skill_application_observer.record(
+            skill_id=skill_id,
+            run_id=run_id,
+            task_id=task_id,
+            node_id=node_id,
+            runtime_kind=runtime_kind,
+            version_id=version_id,
+            source_kind=source_kind,
+            content_digest=content_digest,
+            trust_fingerprint=trust_fingerprint,
+            policy=policy,
+            required_resource_paths=required_resource_paths,
+            method=method,
+            resource_paths=resource_paths,
+            resource_digests=resource_digests,
+            expected_resource_digests=expected_resource_digests,
+            tool_name=tool_name,
+            error_code=error_code,
+        )
+        return receipt.receipt_id if receipt is not None else None
+    except Exception as exc:
+        logger.warning(
+            "Skill application receipt unavailable: code=%s",
+            str(getattr(exc, "code", "skill_application_receipt_unavailable")),
+        )
+        if application_receipt_mode() == "enforce":
+            if isinstance(exc, SkillApplicationReceiptError):
+                raise
+            raise SkillApplicationReceiptError(
+                "Skill application receipt could not be persisted.",
+                code="skill_application_receipt_unavailable",
+            ) from exc
+        return None
+
+
+def record_expert_team_method_skill_applications(
+    result: dict[str, Any],
+    skills: Iterable[AgencySkillDefinition],
+) -> None:
+    for skill in skills:
+        record_skill_application(
+            skill_id=skill.skill_id,
+            run_id=str(result.get("run_id") or "").strip() or None,
+            task_id=str(result.get("task_id") or "").strip() or None,
+            node_id="agency-orchestrator",
+            runtime_kind="expert_team",
+            version_id=f"builtin:{skill.digest}",
+            source_kind="builtin",
+            content_digest=skill.digest,
+            policy="advisory",
+            method="prompt_injected",
+        )
+
+
+def resolve_chat_skill_application(
+    application: "ChatSkillApplication",
+    messages: Iterable["ChatMessage"],
+) -> dict[str, str]:
+    """Resolve one client selection to the exact server-owned injected package."""
+
+    manager = get_skill_manager()
+    skill_id = application.skill_id
+    expected_digest = application.expected_content_digest.lower()
+    installed = manager.require_activation(
+        skill_id,
+        runtime_environment=SkillRuntimeEnvironment(),
+    )
+    if str(installed.content_digest or "").lower() != expected_digest:
+        raise SkillApplicationReceiptError(
+            "The selected Skill changed before the chat request was sent.",
+            code="skill_application_contract_stale",
+        )
+    bindings = manager.bind_skill_versions({skill_id})
+    version_id = str(bindings.get(skill_id) or "").strip()
+    if not version_id:
+        raise SkillApplicationReceiptError(
+            "The selected Skill has no immutable runtime version.",
+            code="skill_application_version_missing",
+        )
+    version = manager.lifecycle_store.require_version(version_id)
+    if (
+        version.skill_id != skill_id
+        or str(version.package_digest or "").lower() != expected_digest
+    ):
+        raise SkillApplicationReceiptError(
+            "The selected Skill version no longer matches the chat request.",
+            code="skill_application_contract_stale",
+        )
+    skill_markdown = manager.get_skill_content(skill_id, version_id=version_id)
+    if not any(
+        message.role == "system"
+        and skill_markdown in message_text(message.content)
+        for message in messages
+    ):
+        raise SkillApplicationReceiptError(
+            "The selected Skill was not present in the server-bound chat prompt.",
+            code="skill_application_prompt_missing",
+        )
+    return {
+        "skill_id": skill_id,
+        "version_id": version_id,
+        "source_kind": str(version.source_kind),
+        "content_digest": expected_digest,
+        "trust_fingerprint": str(version.trust_fingerprint or ""),
+    }
+
+
 workflow_trigger_coordinator = WorkflowTriggerCoordinator(
     poll_seconds=env_float("WORKFLOW_TRIGGER_POLL_SECONDS", 1.0, 0.1)
 )
@@ -1810,6 +1965,19 @@ class ChatResponseAudioOptions(BaseModel):
     format: Literal["mp3"] = "mp3"
 
 
+class ChatSkillApplication(BaseModel):
+    skill_id: str = Field(
+        min_length=1,
+        max_length=120,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$",
+    )
+    expected_content_digest: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+    )
+
+
 class ChatRequest(BaseModel):
     model_id: str = Field(min_length=1, max_length=256)
     messages: list[ChatMessage] = Field(min_length=1, max_length=80)
@@ -1826,6 +1994,7 @@ class ChatRequest(BaseModel):
     routing: ChatRoutingOptions | None = None
     compression: ChatCompressionOptions | None = None
     response_audio: ChatResponseAudioOptions | None = None
+    skill_application: ChatSkillApplication | None = None
     file_scope_id: str | None = Field(
         default=None,
         min_length=1,
@@ -6132,6 +6301,11 @@ async def start_expert_team_dag_run(
             capability_snapshot_hash=payload.capability_snapshot_hash,
             upstream_revision=payload.upstream_revision,
         )
+        await asyncio.to_thread(
+            record_expert_team_method_skill_applications,
+            result,
+            method_skills.values(),
+        )
     except AgencyExecutionCapacityError as exc:
         return agency_execution_error(
             429, "agency_execution_capacity_reached", str(exc)
@@ -6455,6 +6629,11 @@ async def retry_expert_team_dag_run(task_id: str, request: Request):
             source_task_id=task_id,
             prepared=prepared,
         )
+        await asyncio.to_thread(
+            record_expert_team_method_skill_applications,
+            result,
+            prepared.skills,
+        )
     except AgencyExecutionCapacityError as exc:
         return agency_execution_error(
             429, "agency_execution_capacity_reached", str(exc)
@@ -6530,6 +6709,11 @@ async def revise_expert_team_dag_run(
             target_task_id=revision_request.target_task_id,
             feedback=revision_request.feedback,
             prepared=prepared,
+        )
+        await asyncio.to_thread(
+            record_expert_team_method_skill_applications,
+            result,
+            prepared.skills,
         )
     except AgencyExecutionCapacityError as exc:
         return agency_execution_error(
@@ -9923,6 +10107,27 @@ async def _run_workflow_response(
                 ).items()
                 if str(skill_id).strip() and str(version_id).strip()
             }
+            skill_application_policy = str(
+                runtime_metadata.get("skill_application_policy") or "require_read"
+            ).strip()
+            if skill_application_policy not in {
+                "advisory",
+                "require_read",
+                "require_stage",
+            }:
+                skill_application_policy = "require_read"
+            raw_application_paths = runtime_metadata.get(
+                "skill_application_required_resource_paths"
+            )
+            skill_application_required_paths = (
+                [
+                    str(path)
+                    for path in raw_application_paths
+                    if isinstance(path, str) and path.strip()
+                ]
+                if isinstance(raw_application_paths, list)
+                else []
+            )
             if include_skills:
                 skills_config_for_bindings = dict(
                     skills_spec.config if skills_spec is not None else {}
@@ -9962,6 +10167,20 @@ async def _run_workflow_response(
                     runtime_metadata["skill_version_bindings"] = dict(
                         sorted(skill_version_bindings.items())
                     )
+                    for selected_skill_id, selected_version_id in sorted(
+                        skill_version_bindings.items()
+                    ):
+                        await asyncio.to_thread(
+                            record_skill_application,
+                            skill_id=selected_skill_id,
+                            run_id=workflow_run.run_id,
+                            task_id=task_id,
+                            node_id=node.id,
+                            runtime_kind=runtime_run_type,
+                            version_id=selected_version_id,
+                            policy=skill_application_policy,
+                            required_resource_paths=skill_application_required_paths,
+                        )
             if middleware_context is not None:
                 middleware_context.metadata["skill_version_bindings"] = (
                     skill_version_bindings
@@ -9983,6 +10202,35 @@ async def _run_workflow_response(
                 int(pending_state.get("catalog_install_count") or 0),
             )
             run_tool_memory: list[str] = []
+
+            async def record_skill_runtime_failure(
+                tool_name: str,
+                arguments: dict[str, Any],
+                *,
+                error_code: str,
+            ) -> None:
+                if tool_name not in {"skill_read", "skill_stage"}:
+                    return
+                application_skill_id = str(
+                    arguments.get("skill_id") or ""
+                ).strip()
+                if not application_skill_id:
+                    return
+                await asyncio.to_thread(
+                    record_skill_application,
+                    skill_id=application_skill_id,
+                    run_id=workflow_run.run_id,
+                    task_id=task_id,
+                    node_id=node.id,
+                    runtime_kind=runtime_run_type,
+                    version_id=(
+                        skill_version_bindings.get(application_skill_id) or None
+                    ),
+                    policy=skill_application_policy,
+                    required_resource_paths=skill_application_required_paths,
+                    tool_name=tool_name,
+                    error_code=error_code,
+                )
 
             async def apply_skill_runtime_result(
                 tool_name: str,
@@ -10023,6 +10271,109 @@ async def _run_workflow_response(
                             runtime_metadata["skill_version_bindings"] = dict(
                                 sorted(skill_version_bindings.items())
                             )
+                    activated_version_id = skill_version_bindings.get(
+                        activated_skill_id
+                    )
+                    if activated_version_id:
+                        await asyncio.to_thread(
+                            record_skill_application,
+                            skill_id=activated_skill_id,
+                            run_id=workflow_run.run_id,
+                            task_id=task_id,
+                            node_id=node.id,
+                            runtime_kind=runtime_run_type,
+                            version_id=activated_version_id,
+                            policy=skill_application_policy,
+                            required_resource_paths=skill_application_required_paths,
+                        )
+                application_method = str(
+                    metadata.get("application_method") or ""
+                ).strip()
+                if not application_method and tool_name in {
+                    "skill_read",
+                    "skill_stage",
+                }:
+                    application_method = tool_name
+                if application_method in {"skill_read", "skill_stage"}:
+                    application_skill_id = str(
+                        metadata.get("skill_id")
+                        or arguments.get("skill_id")
+                        or ""
+                    ).strip()
+                    application_paths = metadata.get(
+                        "application_resource_paths"
+                    )
+                    application_digests = metadata.get(
+                        "application_resource_digests"
+                    )
+                    expected_application_digests = metadata.get(
+                        "application_expected_resource_digests"
+                    )
+                    if application_skill_id:
+                        application_failed = bool(result.is_error)
+                        await asyncio.to_thread(
+                            record_skill_application,
+                            skill_id=application_skill_id,
+                            run_id=workflow_run.run_id,
+                            task_id=task_id,
+                            node_id=node.id,
+                            runtime_kind=runtime_run_type,
+                            version_id=(
+                                str(
+                                    metadata.get("application_version_id")
+                                    or metadata.get("skill_version_id")
+                                    or skill_version_bindings.get(
+                                        application_skill_id
+                                    )
+                                    or ""
+                                ).strip()
+                                or None
+                            ),
+                            source_kind=(
+                                str(
+                                    metadata.get("application_source_kind")
+                                    or ""
+                                ).strip()
+                                or None
+                            ),
+                            content_digest=(
+                                str(
+                                    metadata.get("application_content_digest")
+                                    or ""
+                                ).strip()
+                                or None
+                            ),
+                            policy=skill_application_policy,
+                            required_resource_paths=skill_application_required_paths,
+                            method=(None if application_failed else application_method),
+                            resource_paths=(
+                                application_paths
+                                if not application_failed
+                                and isinstance(application_paths, list)
+                                else ()
+                            ),
+                            resource_digests=(
+                                dict(application_digests)
+                                if not application_failed
+                                and isinstance(application_digests, dict)
+                                else None
+                            ),
+                            expected_resource_digests=(
+                                dict(expected_application_digests)
+                                if not application_failed
+                                and isinstance(expected_application_digests, dict)
+                                else None
+                            ),
+                            tool_name=tool_name,
+                            error_code=(
+                                str(
+                                    metadata.get("error_code")
+                                    or "skill_application_tool_failed"
+                                )
+                                if application_failed
+                                else None
+                            ),
+                        )
                 trust_authorization = metadata.get("trust_authorization")
                 if isinstance(trust_authorization, dict):
                     authorized_skill_id = str(
@@ -10092,6 +10443,34 @@ async def _run_workflow_response(
                         "run_id": run_id,
                     }
                 )
+
+            async def call_workflow_runtime_tool_observed(
+                *,
+                tool_name: str,
+                arguments: dict[str, Any],
+                metadata: dict[str, Any],
+            ) -> RuntimeToolResult:
+                try:
+                    return await call_workflow_runtime_tool(
+                        tool_name=tool_name,
+                        arguments=arguments,
+                        node=node,
+                        title=title,
+                        metadata=metadata,
+                        pipeline=pipeline,
+                        middleware_context=middleware_context,
+                        middleware_specs=middleware_specs,
+                    )
+                except RuntimeToolError as exc:
+                    await record_skill_runtime_failure(
+                        tool_name,
+                        arguments,
+                        error_code=str(
+                            getattr(exc, "code", "skill_application_tool_failed")
+                            or "skill_application_tool_failed"
+                        ),
+                    )
+                    raise
 
             async def remember_tool_result(
                 tool: Any,
@@ -10244,15 +10623,10 @@ async def _run_workflow_response(
                 if isinstance(client_payload, dict):
                     resume_metadata["resolved_client_tool"] = client_payload
                 try:
-                    call_result = await call_workflow_runtime_tool(
+                    call_result = await call_workflow_runtime_tool_observed(
                         tool_name=pending_tool_name,
                         arguments=pending_arguments,
-                        node=node,
-                        title=title,
                         metadata=resume_metadata,
-                        pipeline=pipeline,
-                        middleware_context=middleware_context,
-                        middleware_specs=middleware_specs,
                     )
                 except RuntimeInterrupt as interrupt:
                     pending_state["resolved_approval"] = (
@@ -10546,19 +10920,14 @@ async def _run_workflow_response(
                         batch_tool_name, batch_arguments, batch_tool = batch_item
                         started_at = time.perf_counter()
                         try:
-                            batch_result = await call_workflow_runtime_tool(
+                            batch_result = await call_workflow_runtime_tool_observed(
                                 tool_name=batch_tool_name,
                                 arguments=batch_arguments,
-                                node=node,
-                                title=title,
                                 metadata=tool_call_metadata(
                                     iteration=iteration_index + 1,
                                     batch_id=batch_id,
                                     batch_index=batch_index,
                                 ),
-                                pipeline=pipeline,
-                                middleware_context=middleware_context,
-                                middleware_specs=middleware_specs,
                             )
                             await append_skill_runtime_event(
                                 batch_tool_name,
@@ -10733,17 +11102,12 @@ async def _run_workflow_response(
                 else:
                     ensure_tool_call_budget(1)
                     try:
-                        call_result = await call_workflow_runtime_tool(
+                        call_result = await call_workflow_runtime_tool_observed(
                             tool_name=tool_name,
                             arguments=arguments,
-                            node=node,
-                            title=title,
                             metadata=tool_call_metadata(
                                 iteration=iteration_index + 1
                             ),
-                            pipeline=pipeline,
-                            middleware_context=middleware_context,
-                            middleware_specs=middleware_specs,
                         )
                     except RuntimeInterrupt as interrupt:
                         interrupt.continuation["agent_state"] = {
@@ -20450,6 +20814,9 @@ async def get_openrouter_batch(batch_id: str):
 
 @app.post("/api/chat")
 async def chat(payload: ChatRequest, request: Request):
+    runtime_task_id = uuid.uuid4().hex
+    chat_skill_application: dict[str, str] | None = None
+    chat_skill_application_recorded = False
     omniroute_settings = get_omniroute_settings()
     native_router_engine = get_native_router_engine()
     native_router_policy = get_model_router_service().get_policy()
@@ -20644,6 +21011,17 @@ async def chat(payload: ChatRequest, request: Request):
             trust_gateway_catalog=use_omniroute or use_native_router,
         )
         validate_content(payload.messages)
+        if payload.skill_application is not None:
+            if direct_audio_requested or direct_video_requested:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Direct audio or video analysis cannot apply a Skill prompt.",
+                )
+            chat_skill_application = await asyncio.to_thread(
+                resolve_chat_skill_application,
+                payload.skill_application,
+                payload.messages,
+            )
         if direct_file_requested:
             selections = tuple(
                 ChatFileSelection(
@@ -20705,12 +21083,39 @@ async def chat(payload: ChatRequest, request: Request):
             status_code=exc.status_code,
             content={"error": exc.message, "code": exc.error_code},
         )
+    except SkillApplicationReceiptError as exc:
+        return JSONResponse(
+            status_code=409,
+            content={"error": str(exc), "code": exc.code},
+        )
     except Exception:
         logger.exception("Chat request validation failed")
         return JSONResponse(
             status_code=500,
             content={"error": "后端校验请求时出错，请查看服务日志。"},
         )
+
+    async def record_chat_skill_application_once() -> None:
+        nonlocal chat_skill_application_recorded
+        if chat_skill_application is None or chat_skill_application_recorded:
+            return
+        receipt_id = await asyncio.to_thread(
+            record_skill_application,
+            skill_id=chat_skill_application["skill_id"],
+            run_id=None,
+            task_id=runtime_task_id,
+            node_id="chat",
+            runtime_kind="chat",
+            version_id=chat_skill_application["version_id"],
+            source_kind=chat_skill_application["source_kind"],
+            content_digest=chat_skill_application["content_digest"],
+            trust_fingerprint=(
+                chat_skill_application["trust_fingerprint"] or None
+            ),
+            policy="advisory",
+            method="prompt_injected",
+        )
+        chat_skill_application_recorded = receipt_id is not None
 
     if payload.output_mode == "allowlisted":
         try:
@@ -20741,6 +21146,7 @@ async def chat(payload: ChatRequest, request: Request):
                 output_context_id=payload.output_context_id or "",
                 provider_tag=provider_tag,
             )
+            await record_chat_skill_application_once()
         except ChatOutputError as exc:
             return JSONResponse(
                 status_code=exc.status_code,
@@ -21300,7 +21706,6 @@ async def chat(payload: ChatRequest, request: Request):
 
     runtime_pipeline = None
     runtime_context = None
-    runtime_task_id = uuid.uuid4().hex
     if not native_audio_requested and not direct_file_requested:
         try:
             runtime_pipeline, runtime_context = create_default_runtime()
@@ -21633,6 +22038,7 @@ async def chat(payload: ChatRequest, request: Request):
                 yield chat_sse_error(str(exc))
             finally:
                 if runtime_status == "completed":
+                    await record_chat_skill_application_once()
                     try:
                         await run_registry.update_run(
                             chat_run.run_id,
@@ -22599,6 +23005,8 @@ async def chat(payload: ChatRequest, request: Request):
         else:
             yield route_receipt_sse(receipt)
             yield b"data: [DONE]\n\n"
+        if runtime_status in {"completed", "output_limit"}:
+            await record_chat_skill_application_once()
         await close_request_client()
         await finalize_runtime(
             runtime_status,
@@ -23221,6 +23629,8 @@ async def chat(payload: ChatRequest, request: Request):
                 deferred_done or native_audio_succeeded or captured_outputs
             ):
                 yield b"data: [DONE]\n\n"
+            if runtime_status in {"completed", "output_limit"}:
+                await record_chat_skill_application_once()
             await response.aclose()
             await close_request_client()
             await finalize_runtime(

--- a/server/skills/application_receipts.py
+++ b/server/skills/application_receipts.py
@@ -1,0 +1,963 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import re
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, Iterable, Literal, Mapping
+
+
+APPLICATION_RECEIPT_VERSION = "skill-application-receipt-v1"
+ApplicationPolicy = Literal["advisory", "require_read", "require_stage"]
+ApplicationMethod = Literal["prompt_injected", "skill_read", "skill_stage"]
+ApplicationStatus = Literal["selected", "applied", "failed"]
+ComplianceStatus = Literal["verified", "incomplete", "unverified"]
+
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,239}$")
+_METHOD_ORDER = {"prompt_injected": 0, "skill_read": 1, "skill_stage": 2}
+_MAX_RESOURCE_PATHS = 500
+_MAX_REFERENCES = 64
+_MAX_RECEIPTS = 2_000
+_RETENTION_SECONDS = 30 * 24 * 60 * 60
+_MAX_SNAPSHOT_BYTES = 64 * 1024 * 1024
+
+
+class SkillApplicationReceiptError(RuntimeError):
+    def __init__(self, message: str, *, code: str = "skill_application_receipt_error"):
+        super().__init__(message)
+        self.code = code
+
+
+class SkillApplicationReceiptStorageError(SkillApplicationReceiptError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class SkillApplicationContractV1:
+    contract_id: str
+    version: str
+    skill_id: str
+    source_kind: str
+    version_id: str | None
+    content_digest: str | None
+    trust_fingerprint: str | None
+    policy: ApplicationPolicy
+    required_resource_paths: tuple[str, ...]
+    fingerprint: str
+
+
+@dataclass(frozen=True, slots=True)
+class SkillApplicationScope:
+    run_id: str | None
+    task_id: str | None
+    node_id: str | None
+    runtime_kind: str
+
+
+@dataclass(slots=True)
+class SkillApplicationReceiptV1:
+    receipt_id: str
+    version: str
+    revision: int
+    contract_id: str
+    contract_fingerprint: str
+    run_id: str | None
+    task_id: str | None
+    node_ids: tuple[str, ...]
+    runtime_kind: str
+    skill_id: str
+    source_kind: str
+    version_id: str | None
+    content_digest: str | None
+    trust_fingerprint: str | None
+    policy: ApplicationPolicy
+    required_resource_paths: tuple[str, ...]
+    methods: tuple[ApplicationMethod, ...] = ()
+    read_resource_paths: tuple[str, ...] = ()
+    staged_resource_paths: tuple[str, ...] = ()
+    resource_paths: tuple[str, ...] = ()
+    resource_digests: dict[str, str] = field(default_factory=dict)
+    resource_manifest_digest: str | None = None
+    expected_resource_digests: dict[str, str] = field(default_factory=dict)
+    expected_resource_manifest_digest: str | None = None
+    resource_paths_truncated: bool = False
+    tool_names: tuple[str, ...] = ()
+    error_codes: tuple[str, ...] = ()
+    references: tuple[str, ...] = ()
+    application_status: ApplicationStatus = "selected"
+    compliance_status: ComplianceStatus = "incomplete"
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+
+def application_receipt_mode() -> Literal["off", "audit", "enforce"]:
+    value = os.getenv("SKILL_APPLICATION_RECEIPT_MODE", "audit").strip().lower()
+    return value if value in {"off", "audit", "enforce"} else "audit"  # type: ignore[return-value]
+
+
+def build_application_contract(
+    *,
+    skill_id: str,
+    source_kind: str,
+    version_id: str | None,
+    content_digest: str | None,
+    trust_fingerprint: str | None = None,
+    policy: ApplicationPolicy = "require_read",
+    required_resource_paths: Iterable[str] = (),
+) -> SkillApplicationContractV1:
+    clean_skill_id = _safe_identifier(skill_id, "skill ID")
+    clean_source = _safe_identifier(source_kind, "source kind")
+    clean_version = _optional_identifier(version_id, "version ID")
+    clean_digest = _optional_digest(content_digest, "content digest")
+    clean_trust = _optional_digest(trust_fingerprint, "trust fingerprint")
+    if policy not in {"advisory", "require_read", "require_stage"}:
+        raise SkillApplicationReceiptError(
+            "Invalid Skill application policy.", code="skill_application_contract_invalid"
+        )
+    clean_paths, paths_truncated = _resource_paths(required_resource_paths)
+    if paths_truncated:
+        raise SkillApplicationReceiptError(
+            "Skill application contract declares too many resource paths.",
+            code="skill_application_contract_limit",
+        )
+    identity = {
+        "version": APPLICATION_RECEIPT_VERSION,
+        "skill_id": clean_skill_id,
+        "source_kind": clean_source,
+        "version_id": clean_version,
+        "content_digest": clean_digest,
+        "trust_fingerprint": clean_trust,
+        "policy": policy,
+        "required_resource_paths": list(clean_paths),
+    }
+    fingerprint = _sha256_json(identity)
+    return SkillApplicationContractV1(
+        contract_id=f"skillappcontract_{fingerprint[:32]}",
+        version=APPLICATION_RECEIPT_VERSION,
+        skill_id=clean_skill_id,
+        source_kind=clean_source,
+        version_id=clean_version,
+        content_digest=clean_digest,
+        trust_fingerprint=clean_trust,
+        policy=policy,
+        required_resource_paths=clean_paths,
+        fingerprint=fingerprint,
+    )
+
+
+class SkillApplicationReceiptStore:
+    """Atomic, bounded evidence that a frozen Skill was actually applied."""
+
+    SCHEMA_VERSION = 1
+
+    def __init__(self, storage_dir: str | Path | None = None) -> None:
+        package_dir = Path(__file__).resolve().parent
+        runtime_dir = os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
+        self.storage_dir = Path(storage_dir or runtime_dir or package_dir / "storage")
+        self.snapshot_path = self.storage_dir / "skill_application_receipts.json"
+        self._lock = threading.RLock()
+        self._receipts: dict[str, SkillApplicationReceiptV1] = {}
+        self._quarantine: list[dict[str, Any]] = []
+        self._load_error: str | None = None
+        self._load()
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "version": APPLICATION_RECEIPT_VERSION,
+                "mode": application_receipt_mode(),
+                "available": self._load_error is None,
+                "receipt_count": len(self._receipts),
+                "quarantine_count": len(self._quarantine),
+                "error_code": (
+                    "skill_application_receipt_store_corrupt"
+                    if self._load_error
+                    else None
+                ),
+            }
+
+    def record_selection(
+        self,
+        contract: SkillApplicationContractV1,
+        scope: SkillApplicationScope,
+    ) -> SkillApplicationReceiptV1 | None:
+        return self.observe(contract, scope)
+
+    def observe(
+        self,
+        contract: SkillApplicationContractV1,
+        scope: SkillApplicationScope,
+        *,
+        method: ApplicationMethod | None = None,
+        resource_paths: Iterable[str] = (),
+        resource_digests: Mapping[str, str] | None = None,
+        expected_resource_digests: Mapping[str, str] | None = None,
+        tool_name: str | None = None,
+        error_code: str | None = None,
+    ) -> SkillApplicationReceiptV1 | None:
+        if application_receipt_mode() == "off":
+            return None
+        clean_scope = self._scope(scope)
+        if method is not None and method not in _METHOD_ORDER:
+            raise SkillApplicationReceiptError(
+                "Invalid Skill application method.",
+                code="skill_application_receipt_invalid",
+            )
+        paths, paths_truncated = _resource_paths(resource_paths)
+        digests = self._resource_digests(resource_digests or {}, allowed_paths=paths)
+        expected_digests = self._resource_digests(
+            expected_resource_digests or {},
+            allowed_paths={*paths, *contract.required_resource_paths},
+        )
+        clean_tool = _optional_identifier(tool_name, "tool name")
+        clean_error = _optional_identifier(error_code, "error code")
+        receipt_id = self._receipt_id(contract, clean_scope)
+        with self._lock:
+            self._ensure_writable_unlocked()
+            previous = copy.deepcopy(self._receipts)
+            previous_quarantine = copy.deepcopy(self._quarantine)
+            existing = self._receipts.get(receipt_id)
+            now = time.time()
+            if existing is None:
+                item = SkillApplicationReceiptV1(
+                    receipt_id=receipt_id,
+                    version=APPLICATION_RECEIPT_VERSION,
+                    revision=1,
+                    contract_id=contract.contract_id,
+                    contract_fingerprint=contract.fingerprint,
+                    run_id=clean_scope.run_id,
+                    task_id=clean_scope.task_id,
+                    node_ids=(clean_scope.node_id,) if clean_scope.node_id else (),
+                    runtime_kind=clean_scope.runtime_kind,
+                    skill_id=contract.skill_id,
+                    source_kind=contract.source_kind,
+                    version_id=contract.version_id,
+                    content_digest=contract.content_digest,
+                    trust_fingerprint=contract.trust_fingerprint,
+                    policy=contract.policy,
+                    required_resource_paths=contract.required_resource_paths,
+                    created_at=now,
+                    updated_at=now,
+                )
+            else:
+                item = copy.deepcopy(existing)
+            methods = set(item.methods)
+            if method is not None and clean_error is None:
+                methods.add(method)
+            merged_paths = set(item.resource_paths)
+            merged_paths.update(paths)
+            all_paths, merged_truncated = _resource_paths(merged_paths)
+            errors = set(item.error_codes)
+            merged_digests = dict(item.resource_digests)
+            for path, digest in digests.items():
+                previous_digest = merged_digests.get(path)
+                if previous_digest is not None and previous_digest != digest:
+                    errors.add("skill_application_resource_digest_changed")
+                    continue
+                merged_digests[path] = digest
+            merged_digests = {
+                path: merged_digests[path]
+                for path in all_paths
+                if path in merged_digests
+            }
+            merged_expected_digests = dict(item.expected_resource_digests)
+            for path, digest in expected_digests.items():
+                previous_digest = merged_expected_digests.get(path)
+                if previous_digest is not None and previous_digest != digest:
+                    errors.add("skill_application_expected_digest_changed")
+                    continue
+                merged_expected_digests[path] = digest
+            merged_expected_digests = {
+                path: merged_expected_digests[path]
+                for path in all_paths
+                if path in merged_expected_digests
+            }
+            tools = set(item.tool_names)
+            if clean_tool:
+                tools.add(clean_tool)
+            if clean_error:
+                errors.add(clean_error)
+            updated = copy.deepcopy(item)
+            updated.node_ids = tuple(
+                sorted(
+                    {
+                        *item.node_ids,
+                        *(
+                            (clean_scope.node_id,)
+                            if clean_scope.node_id
+                            else ()
+                        ),
+                    }
+                )
+            )
+            updated.methods = tuple(sorted(methods, key=_METHOD_ORDER.__getitem__))
+            read_paths = set(item.read_resource_paths)
+            staged_paths = set(item.staged_resource_paths)
+            if method == "skill_read" and clean_error is None:
+                read_paths.update(paths)
+            if method == "skill_stage" and clean_error is None:
+                staged_paths.update(paths)
+            updated.read_resource_paths = _resource_paths(read_paths)[0]
+            updated.staged_resource_paths = _resource_paths(staged_paths)[0]
+            updated.resource_paths = all_paths
+            updated.resource_digests = dict(sorted(merged_digests.items()))
+            updated.resource_manifest_digest = (
+                _sha256_json(updated.resource_digests)
+                if updated.resource_digests
+                else None
+            )
+            updated.expected_resource_digests = dict(
+                sorted(merged_expected_digests.items())
+            )
+            updated.expected_resource_manifest_digest = (
+                _sha256_json(updated.expected_resource_digests)
+                if updated.expected_resource_digests
+                else None
+            )
+            evidence_paths = {
+                *updated.read_resource_paths,
+                *updated.staged_resource_paths,
+            }
+            if any(
+                path not in updated.resource_digests
+                or path not in updated.expected_resource_digests
+                for path in evidence_paths
+            ):
+                errors.add("skill_application_resource_digest_missing")
+            if any(
+                path in updated.resource_digests
+                and path in updated.expected_resource_digests
+                and updated.resource_digests[path]
+                != updated.expected_resource_digests[path]
+                for path in evidence_paths
+            ):
+                errors.add("skill_application_resource_digest_mismatch")
+            updated.resource_paths_truncated = bool(
+                item.resource_paths_truncated or paths_truncated or merged_truncated
+            )
+            updated.tool_names = tuple(sorted(tools))[:64]
+            updated.error_codes = tuple(sorted(errors))[:64]
+            updated.application_status = (
+                "applied"
+                if updated.methods
+                else ("failed" if updated.error_codes else "selected")
+            )
+            updated.compliance_status = self._compliance_status(updated)
+            updated.updated_at = now
+            if existing is not None and self._equivalent(existing, updated):
+                return copy.deepcopy(existing)
+            if existing is not None:
+                updated.revision = existing.revision + 1
+            self._receipts[receipt_id] = updated
+            self._prune_unlocked(now=now)
+            try:
+                self._save_unlocked()
+            except Exception:
+                self._receipts = previous
+                self._quarantine = previous_quarantine
+                raise
+            return copy.deepcopy(updated)
+
+    def protect(self, receipt_id: str, *, reference_id: str) -> SkillApplicationReceiptV1:
+        clean_receipt_id = _safe_identifier(receipt_id, "receipt ID")
+        clean_reference = _safe_identifier(reference_id, "reference ID")
+        with self._lock:
+            self._ensure_writable_unlocked()
+            item = self._receipts.get(clean_receipt_id)
+            if item is None:
+                raise SkillApplicationReceiptError(
+                    "Skill application receipt was not found.",
+                    code="skill_application_receipt_missing",
+                )
+            references = tuple(sorted({*item.references, clean_reference}))
+            if references == item.references:
+                return copy.deepcopy(item)
+            if len(references) > _MAX_REFERENCES:
+                raise SkillApplicationReceiptError(
+                    "Skill application receipt has too many references.",
+                    code="skill_application_receipt_reference_limit",
+                )
+            previous = copy.deepcopy(self._receipts)
+            updated = copy.deepcopy(item)
+            updated.references = references
+            updated.revision += 1
+            updated.updated_at = time.time()
+            self._receipts[clean_receipt_id] = updated
+            try:
+                self._save_unlocked()
+            except Exception:
+                self._receipts = previous
+                raise
+            return copy.deepcopy(updated)
+
+    def require(self, receipt_id: str) -> SkillApplicationReceiptV1:
+        clean = _safe_identifier(receipt_id, "receipt ID")
+        with self._lock:
+            self._ensure_readable_unlocked()
+            item = self._receipts.get(clean)
+            if item is None:
+                raise SkillApplicationReceiptError(
+                    "Skill application receipt was not found.",
+                    code="skill_application_receipt_missing",
+                )
+            return copy.deepcopy(item)
+
+    def require_verified(self, receipt_id: str) -> SkillApplicationReceiptV1:
+        item = self.require(receipt_id)
+        if item.compliance_status != "verified":
+            raise SkillApplicationReceiptError(
+                "Skill application receipt is incomplete.",
+                code="skill_application_receipt_incomplete",
+            )
+        return item
+
+    def list_receipts(
+        self,
+        *,
+        run_id: str | None = None,
+        task_id: str | None = None,
+        skill_id: str | None = None,
+    ) -> list[SkillApplicationReceiptV1]:
+        with self._lock:
+            self._ensure_readable_unlocked()
+            items = list(self._receipts.values())
+            if run_id is not None:
+                items = [item for item in items if item.run_id == run_id]
+            if task_id is not None:
+                items = [item for item in items if item.task_id == task_id]
+            if skill_id is not None:
+                items = [item for item in items if item.skill_id == skill_id]
+            return [
+                copy.deepcopy(item)
+                for item in sorted(items, key=lambda value: (value.created_at, value.receipt_id))
+            ]
+
+    def _load(self) -> None:
+        if not self.snapshot_path.exists():
+            return
+        try:
+            raw_bytes = self.snapshot_path.read_bytes()
+            if len(raw_bytes) > _MAX_SNAPSHOT_BYTES:
+                raise ValueError("snapshot too large")
+            payload = json.loads(raw_bytes.decode("utf-8"))
+            if not isinstance(payload, dict) or payload.get("schema_version") != self.SCHEMA_VERSION:
+                raise ValueError("invalid schema")
+            raw_receipts = payload.get("receipts")
+            if not isinstance(raw_receipts, list):
+                raise ValueError("invalid receipts")
+            receipts: dict[str, SkillApplicationReceiptV1] = {}
+            raw_quarantine = payload.get("quarantine") or []
+            if not isinstance(raw_quarantine, list):
+                raise ValueError("invalid quarantine")
+            quarantine = [
+                item
+                for item in (
+                    _decode_quarantine_record(raw) for raw in raw_quarantine[-200:]
+                )
+                if item is not None
+            ]
+            for raw in raw_receipts:
+                try:
+                    item = self._decode_receipt(raw)
+                    if item.receipt_id in receipts:
+                        raise ValueError("duplicate receipt")
+                    receipts[item.receipt_id] = item
+                except Exception:
+                    encoded = json.dumps(
+                        raw, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+                    ).encode("utf-8", errors="replace")
+                    quarantine.append(
+                        {
+                            "code": "skill_application_receipt_record_invalid",
+                            "sha256": hashlib.sha256(encoded).hexdigest(),
+                            "size_bytes": len(encoded),
+                        }
+                    )
+            self._receipts = receipts
+            self._quarantine = quarantine[-200:]
+        except Exception as exc:
+            self._load_error = f"skill_application_receipt_store_corrupt:{type(exc).__name__}"
+
+    def _save_unlocked(self) -> None:
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": self.SCHEMA_VERSION,
+            "version": APPLICATION_RECEIPT_VERSION,
+            "receipts": [
+                asdict(item)
+                for item in sorted(self._receipts.values(), key=lambda value: value.receipt_id)
+            ],
+            "quarantine": list(self._quarantine[-200:]),
+        }
+        content = json.dumps(
+            payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        if len(content) > _MAX_SNAPSHOT_BYTES:
+            raise SkillApplicationReceiptStorageError(
+                "Skill application receipt store reached its bounded capacity.",
+                code="skill_application_receipt_store_limit",
+            )
+        temporary = self.snapshot_path.with_name(
+            f".{self.snapshot_path.name}.{uuid.uuid4().hex}.tmp"
+        )
+        try:
+            with temporary.open("xb") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.snapshot_path)
+        finally:
+            if temporary.exists():
+                temporary.unlink()
+
+    def _prune_unlocked(self, *, now: float) -> None:
+        expired = [
+            receipt_id
+            for receipt_id, item in self._receipts.items()
+            if not item.references and now - item.updated_at > _RETENTION_SECONDS
+        ]
+        for receipt_id in expired:
+            self._receipts.pop(receipt_id, None)
+        unprotected = sorted(
+            (item for item in self._receipts.values() if not item.references),
+            key=lambda item: (item.updated_at, item.receipt_id),
+        )
+        overflow = max(0, len(self._receipts) - _MAX_RECEIPTS)
+        for item in unprotected[:overflow]:
+            self._receipts.pop(item.receipt_id, None)
+
+    @classmethod
+    def _decode_receipt(cls, raw: Any) -> SkillApplicationReceiptV1:
+        if not isinstance(raw, dict):
+            raise ValueError("receipt must be an object")
+        contract = build_application_contract(
+            skill_id=raw.get("skill_id"),
+            source_kind=raw.get("source_kind"),
+            version_id=raw.get("version_id"),
+            content_digest=raw.get("content_digest"),
+            trust_fingerprint=raw.get("trust_fingerprint"),
+            policy=raw.get("policy"),
+            required_resource_paths=raw.get("required_resource_paths") or (),
+        )
+        if raw.get("version") != APPLICATION_RECEIPT_VERSION:
+            raise ValueError("invalid version")
+        if raw.get("contract_id") != contract.contract_id or raw.get("contract_fingerprint") != contract.fingerprint:
+            raise ValueError("invalid contract identity")
+        scope = cls._scope(
+            SkillApplicationScope(
+                run_id=raw.get("run_id"),
+                task_id=raw.get("task_id"),
+                node_id=raw.get("node_id"),
+                runtime_kind=raw.get("runtime_kind"),
+            )
+        )
+        receipt_id = cls._receipt_id(contract, scope)
+        if raw.get("receipt_id") != receipt_id:
+            raise ValueError("invalid receipt identity")
+        raw_methods = raw.get("methods") or []
+        if not isinstance(raw_methods, list):
+            raise ValueError("invalid methods")
+        methods = tuple(raw_methods)
+        if any(item not in _METHOD_ORDER for item in methods) or len(set(methods)) != len(methods):
+            raise ValueError("invalid methods")
+        raw_paths = raw.get("resource_paths") or []
+        if not isinstance(raw_paths, list):
+            raise ValueError("invalid resource paths")
+        paths, paths_truncated = _resource_paths(raw_paths)
+        read_paths = _decode_resource_path_list(raw.get("read_resource_paths"))
+        staged_paths = _decode_resource_path_list(
+            raw.get("staged_resource_paths")
+        )
+        if not set(read_paths).issubset(paths) or not set(staged_paths).issubset(
+            paths
+        ):
+            raise ValueError("invalid method resource paths")
+        digests = cls._resource_digests(raw.get("resource_digests") or {}, allowed_paths=paths)
+        manifest = _sha256_json(digests) if digests else None
+        if raw.get("resource_manifest_digest") != manifest:
+            raise ValueError("invalid resource manifest")
+        expected_digests = cls._resource_digests(
+            raw.get("expected_resource_digests") or {}, allowed_paths=paths
+        )
+        expected_manifest = _sha256_json(expected_digests) if expected_digests else None
+        if raw.get("expected_resource_manifest_digest") != expected_manifest:
+            raise ValueError("invalid expected resource manifest")
+        application_status = raw.get("application_status")
+        compliance_status = raw.get("compliance_status")
+        if application_status not in {"selected", "applied", "failed"}:
+            raise ValueError("invalid application status")
+        if compliance_status not in {"verified", "incomplete", "unverified"}:
+            raise ValueError("invalid compliance status")
+        item = SkillApplicationReceiptV1(
+            receipt_id=receipt_id,
+            version=APPLICATION_RECEIPT_VERSION,
+            revision=max(1, int(raw.get("revision") or 0)),
+            contract_id=contract.contract_id,
+            contract_fingerprint=contract.fingerprint,
+            run_id=scope.run_id,
+            task_id=scope.task_id,
+            node_ids=_decode_identifier_list(
+                raw.get("node_ids"), field_name="node ID", limit=128
+            ),
+            runtime_kind=scope.runtime_kind,
+            skill_id=contract.skill_id,
+            source_kind=contract.source_kind,
+            version_id=contract.version_id,
+            content_digest=contract.content_digest,
+            trust_fingerprint=contract.trust_fingerprint,
+            policy=contract.policy,
+            required_resource_paths=contract.required_resource_paths,
+            methods=tuple(sorted(methods, key=_METHOD_ORDER.__getitem__)),
+            read_resource_paths=read_paths,
+            staged_resource_paths=staged_paths,
+            resource_paths=paths,
+            resource_digests=digests,
+            resource_manifest_digest=manifest,
+            expected_resource_digests=expected_digests,
+            expected_resource_manifest_digest=expected_manifest,
+            resource_paths_truncated=bool(raw.get("resource_paths_truncated") or paths_truncated),
+            tool_names=_decode_identifier_list(
+                raw.get("tool_names"), field_name="tool name", limit=64
+            ),
+            error_codes=_decode_identifier_list(
+                raw.get("error_codes"), field_name="error code", limit=64
+            ),
+            references=_decode_identifier_list(
+                raw.get("references"), field_name="reference ID", limit=64
+            ),
+            application_status=application_status,
+            compliance_status=compliance_status,
+            created_at=float(raw.get("created_at") or 0),
+            updated_at=float(raw.get("updated_at") or 0),
+        )
+        if item.compliance_status != cls._compliance_status(item):
+            raise ValueError("invalid compliance status")
+        return item
+
+    @staticmethod
+    def _scope(scope: SkillApplicationScope) -> SkillApplicationScope:
+        run_id = _optional_identifier(scope.run_id, "run ID")
+        task_id = _optional_identifier(scope.task_id, "task ID")
+        if not run_id and not task_id:
+            raise SkillApplicationReceiptError(
+                "A run ID or task ID is required.",
+                code="skill_application_scope_invalid",
+            )
+        return SkillApplicationScope(
+            run_id=run_id,
+            task_id=task_id,
+            node_id=_optional_identifier(scope.node_id, "node ID"),
+            runtime_kind=_safe_identifier(scope.runtime_kind, "runtime kind"),
+        )
+
+    @staticmethod
+    def _receipt_id(
+        contract: SkillApplicationContractV1, scope: SkillApplicationScope
+    ) -> str:
+        fingerprint = _sha256_json(
+            {
+                "version": APPLICATION_RECEIPT_VERSION,
+                "contract_fingerprint": contract.fingerprint,
+                "run_id": scope.run_id,
+                "task_id": scope.task_id,
+                "runtime_kind": scope.runtime_kind,
+            }
+        )
+        return f"skillappreceipt_{fingerprint[:32]}"
+
+    @staticmethod
+    def _resource_digests(
+        values: Mapping[str, str], *, allowed_paths: Iterable[str]
+    ) -> dict[str, str]:
+        allowed = set(allowed_paths)
+        result: dict[str, str] = {}
+        for raw_path, raw_digest in values.items():
+            path = _resource_path(raw_path)
+            digest = _optional_digest(raw_digest, "resource digest")
+            if path in allowed and digest:
+                result[path] = digest
+        return dict(sorted(result.items()))
+
+    @staticmethod
+    def _compliance_status(item: SkillApplicationReceiptV1) -> ComplianceStatus:
+        if not item.version_id or not item.content_digest:
+            return "unverified"
+        if item.source_kind in {"git", "local_import"} and not item.trust_fingerprint:
+            return "unverified"
+        integrity_errors = {
+            "skill_application_resource_digest_changed",
+            "skill_application_expected_digest_changed",
+            "skill_application_resource_digest_missing",
+            "skill_application_resource_digest_mismatch",
+        }
+        if integrity_errors.intersection(item.error_codes):
+            return "unverified"
+        evidence_paths = {*item.read_resource_paths, *item.staged_resource_paths}
+        if any(
+            path not in item.resource_digests
+            or path not in item.expected_resource_digests
+            or item.resource_digests[path] != item.expected_resource_digests[path]
+            for path in evidence_paths
+        ):
+            return "unverified"
+        methods = set(item.methods)
+        if item.policy == "advisory":
+            satisfied = bool(methods)
+        elif item.policy == "require_read":
+            satisfied = "skill_read" in methods and set(
+                item.required_resource_paths
+            ).issubset(item.read_resource_paths)
+        else:
+            satisfied = {"skill_read", "skill_stage"}.issubset(methods) and set(
+                item.required_resource_paths
+            ).issubset(item.staged_resource_paths)
+        return "verified" if satisfied else "incomplete"
+
+    @staticmethod
+    def _equivalent(
+        left: SkillApplicationReceiptV1, right: SkillApplicationReceiptV1
+    ) -> bool:
+        ignored = {"revision", "updated_at"}
+        left_payload = asdict(left)
+        right_payload = asdict(right)
+        for key in ignored:
+            left_payload.pop(key, None)
+            right_payload.pop(key, None)
+        return left_payload == right_payload
+
+    def _ensure_readable_unlocked(self) -> None:
+        if self._load_error:
+            raise SkillApplicationReceiptStorageError(
+                "Skill application receipt store is unavailable.",
+                code="skill_application_receipt_store_corrupt",
+            )
+
+    def _ensure_writable_unlocked(self) -> None:
+        self._ensure_readable_unlocked()
+
+
+class SkillApplicationObserver:
+    """Resolve server-owned Skill identity before appending application evidence."""
+
+    def __init__(
+        self,
+        store: SkillApplicationReceiptStore,
+        skill_manager_provider: Callable[[], Any],
+    ) -> None:
+        self.store = store
+        self.skill_manager_provider = skill_manager_provider
+
+    def resolve_contract(
+        self,
+        skill_id: str,
+        *,
+        version_id: str | None = None,
+        source_kind: str | None = None,
+        content_digest: str | None = None,
+        trust_fingerprint: str | None = None,
+        policy: ApplicationPolicy = "require_read",
+        required_resource_paths: Iterable[str] = (),
+    ) -> SkillApplicationContractV1:
+        manager = self.skill_manager_provider()
+        clean_skill_id = str(skill_id or "").strip()
+        clean_version_id = str(version_id or "").strip() or None
+        clean_source_kind = str(source_kind or "").strip() or None
+        clean_content_digest = str(content_digest or "").strip() or None
+        clean_trust_fingerprint = str(trust_fingerprint or "").strip() or None
+        if clean_version_id and (
+            not clean_content_digest or not clean_source_kind
+        ):
+            snapshot = manager.lifecycle_store.require_version(clean_version_id)
+            if snapshot.skill_id != clean_skill_id:
+                raise SkillApplicationReceiptError(
+                    "Skill application version does not match the selected Skill.",
+                    code="skill_application_contract_mismatch",
+                )
+            clean_source_kind = clean_source_kind or snapshot.source_kind
+            clean_content_digest = clean_content_digest or snapshot.package_digest
+            clean_trust_fingerprint = (
+                clean_trust_fingerprint or snapshot.trust_fingerprint
+            )
+        if not clean_content_digest or not clean_source_kind:
+            installed = next(
+                (
+                    item
+                    for item in manager.list_installed_skills()
+                    if item.skill_id == clean_skill_id
+                ),
+                None,
+            )
+            if installed is not None:
+                clean_source_kind = clean_source_kind or installed.source_kind
+                clean_content_digest = (
+                    clean_content_digest or installed.content_digest or None
+                )
+                clean_trust_fingerprint = (
+                    clean_trust_fingerprint or installed.trust_fingerprint
+                )
+        return build_application_contract(
+            skill_id=clean_skill_id,
+            source_kind=clean_source_kind or "unknown",
+            version_id=clean_version_id,
+            content_digest=clean_content_digest,
+            trust_fingerprint=clean_trust_fingerprint,
+            policy=policy,
+            required_resource_paths=required_resource_paths,
+        )
+
+    def record(
+        self,
+        *,
+        skill_id: str,
+        run_id: str | None,
+        task_id: str | None,
+        node_id: str | None,
+        runtime_kind: str,
+        version_id: str | None = None,
+        source_kind: str | None = None,
+        content_digest: str | None = None,
+        trust_fingerprint: str | None = None,
+        policy: ApplicationPolicy = "require_read",
+        required_resource_paths: Iterable[str] = (),
+        method: ApplicationMethod | None = None,
+        resource_paths: Iterable[str] = (),
+        resource_digests: Mapping[str, str] | None = None,
+        expected_resource_digests: Mapping[str, str] | None = None,
+        tool_name: str | None = None,
+        error_code: str | None = None,
+    ) -> SkillApplicationReceiptV1 | None:
+        contract = self.resolve_contract(
+            skill_id,
+            version_id=version_id,
+            source_kind=source_kind,
+            content_digest=content_digest,
+            trust_fingerprint=trust_fingerprint,
+            policy=policy,
+            required_resource_paths=required_resource_paths,
+        )
+        return self.store.observe(
+            contract,
+            SkillApplicationScope(
+                run_id=run_id,
+                task_id=task_id,
+                node_id=node_id,
+                runtime_kind=runtime_kind,
+            ),
+            method=method,
+            resource_paths=resource_paths,
+            resource_digests=resource_digests,
+            expected_resource_digests=expected_resource_digests,
+            tool_name=tool_name,
+            error_code=error_code,
+        )
+
+
+def _sha256_json(value: Any) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _safe_identifier(value: Any, field_name: str) -> str:
+    clean = str(value or "").strip()
+    if not _SAFE_ID_RE.fullmatch(clean) or any(ord(char) < 32 for char in clean):
+        raise SkillApplicationReceiptError(
+            f"Invalid {field_name}.", code="skill_application_receipt_invalid"
+        )
+    return clean
+
+
+def _optional_identifier(value: Any, field_name: str) -> str | None:
+    if value is None or not str(value).strip():
+        return None
+    return _safe_identifier(value, field_name)
+
+
+def _optional_digest(value: Any, field_name: str) -> str | None:
+    if value is None or not str(value).strip():
+        return None
+    clean = str(value).strip().lower()
+    if not _DIGEST_RE.fullmatch(clean):
+        raise SkillApplicationReceiptError(
+            f"Invalid {field_name}.", code="skill_application_receipt_invalid"
+        )
+    return clean
+
+
+def _resource_path(value: Any) -> str:
+    clean = str(value or "").replace("\\", "/").strip()
+    path = PurePosixPath(clean)
+    if (
+        not clean
+        or clean.startswith("/")
+        or path.is_absolute()
+        or any(part in {"", ".", ".."} for part in path.parts)
+        or len(clean) > 240
+    ):
+        raise SkillApplicationReceiptError(
+            "Invalid Skill resource path.",
+            code="skill_application_receipt_invalid",
+        )
+    return path.as_posix()
+
+
+def _resource_paths(values: Iterable[Any]) -> tuple[tuple[str, ...], bool]:
+    normalized = sorted({_resource_path(value) for value in values})
+    return tuple(normalized[:_MAX_RESOURCE_PATHS]), len(normalized) > _MAX_RESOURCE_PATHS
+
+
+def _decode_identifier_list(
+    value: Any, *, field_name: str, limit: int
+) -> tuple[str, ...]:
+    raw = value or []
+    if not isinstance(raw, list) or len(raw) > limit:
+        raise ValueError(f"invalid {field_name} list")
+    return tuple(sorted({_safe_identifier(item, field_name) for item in raw}))
+
+
+def _decode_resource_path_list(value: Any) -> tuple[str, ...]:
+    raw = value or []
+    if not isinstance(raw, list):
+        raise ValueError("invalid resource path list")
+    paths, truncated = _resource_paths(raw)
+    if truncated:
+        raise ValueError("resource path list exceeds limit")
+    return paths
+
+
+def _decode_quarantine_record(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    code = str(value.get("code") or "").strip()
+    digest = str(value.get("sha256") or "").strip().lower()
+    try:
+        size_bytes = max(0, int(value.get("size_bytes") or 0))
+    except (TypeError, ValueError):
+        return None
+    if code != "skill_application_receipt_record_invalid" or not _DIGEST_RE.fullmatch(
+        digest
+    ):
+        return None
+    return {"code": code, "sha256": digest, "size_bytes": size_bytes}
+
+
+__all__ = [
+    "APPLICATION_RECEIPT_VERSION",
+    "SkillApplicationContractV1",
+    "SkillApplicationReceiptError",
+    "SkillApplicationObserver",
+    "SkillApplicationReceiptStorageError",
+    "SkillApplicationReceiptStore",
+    "SkillApplicationReceiptV1",
+    "SkillApplicationScope",
+    "application_receipt_mode",
+    "build_application_contract",
+]

--- a/server/tests/test_skill_application_receipts.py
+++ b/server/tests/test_skill_application_receipts.py
@@ -1,0 +1,695 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from server.skills.application_receipts import (
+    APPLICATION_RECEIPT_VERSION,
+    SkillApplicationObserver,
+    SkillApplicationReceiptError,
+    SkillApplicationReceiptStorageError,
+    SkillApplicationReceiptStore,
+    SkillApplicationScope,
+    build_application_contract,
+)
+from server.xpert_runtime.sandbox_store import SandboxWorkspace
+from server.xpert_runtime.sandbox_toolset import SandboxToolsetProvider
+from server.xpert_runtime.toolset import RuntimeToolCall
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _contract(*, policy: str = "require_read", required=()):
+    return build_application_contract(
+        skill_id="incident-review",
+        source_kind="git",
+        version_id="skillversion_incident_v1",
+        content_digest=_digest("package-v1"),
+        trust_fingerprint=_digest("trust-v1"),
+        policy=policy,
+        required_resource_paths=required,
+    )
+
+
+def _scope() -> SkillApplicationScope:
+    return SkillApplicationScope(
+        run_id="run_receipt_1",
+        task_id="task_receipt_1",
+        node_id="workflow-agent",
+        runtime_kind="workflow",
+    )
+
+
+def test_contract_and_receipt_distinguish_selection_from_application(tmp_path):
+    store = SkillApplicationReceiptStore(tmp_path)
+    contract = _contract()
+
+    selected = store.record_selection(contract, _scope())
+    assert selected is not None
+    assert selected.version == APPLICATION_RECEIPT_VERSION
+    assert selected.application_status == "selected"
+    assert selected.compliance_status == "incomplete"
+    assert selected.methods == ()
+
+    read_digest = _digest("full skill markdown")
+    applied = store.observe(
+        contract,
+        _scope(),
+        method="skill_read",
+        resource_paths=["SKILL.md"],
+        resource_digests={"SKILL.md": read_digest},
+        expected_resource_digests={"SKILL.md": read_digest},
+        tool_name="skill_read",
+    )
+    assert applied is not None
+    assert applied.application_status == "applied"
+    assert applied.compliance_status == "verified"
+    assert applied.methods == ("skill_read",)
+    assert applied.resource_digests == {"SKILL.md": read_digest}
+
+    replay = store.observe(
+        contract,
+        _scope(),
+        method="skill_read",
+        resource_paths=["SKILL.md"],
+        resource_digests={"SKILL.md": read_digest},
+        expected_resource_digests={"SKILL.md": read_digest},
+        tool_name="skill_read",
+    )
+    assert replay is not None
+    assert replay.revision == applied.revision
+
+    second_node = store.observe(
+        contract,
+        SkillApplicationScope(
+            run_id="run_receipt_1",
+            task_id="task_receipt_1",
+            node_id="second-agent",
+            runtime_kind="workflow",
+        ),
+        method="skill_read",
+    )
+    assert second_node is not None
+    assert second_node.receipt_id == applied.receipt_id
+    assert second_node.node_ids == ("second-agent", "workflow-agent")
+
+
+def test_third_party_receipt_without_trust_fingerprint_stays_unverified(tmp_path):
+    contract = build_application_contract(
+        skill_id="legacy-skill",
+        source_kind="git",
+        version_id="skillversion_legacy_v1",
+        content_digest=_digest("legacy-package"),
+    )
+    receipt = SkillApplicationReceiptStore(tmp_path).observe(
+        contract,
+        _scope(),
+        method="skill_read",
+        resource_paths=["SKILL.md"],
+    )
+
+    assert receipt is not None
+    assert receipt.application_status == "applied"
+    assert receipt.compliance_status == "unverified"
+
+
+def test_contract_rejects_more_resource_paths_than_receipt_can_prove():
+    with pytest.raises(SkillApplicationReceiptError) as captured:
+        build_application_contract(
+            skill_id="large-skill",
+            source_kind="workspace_draft",
+            version_id="skillversion_large_v1",
+            content_digest=_digest("large-package"),
+            policy="require_stage",
+            required_resource_paths=[f"references/{index}.md" for index in range(501)],
+        )
+
+    assert captured.value.code == "skill_application_contract_limit"
+
+
+def test_stage_policy_requires_read_and_declared_resource_paths(tmp_path):
+    store = SkillApplicationReceiptStore(tmp_path)
+    contract = _contract(
+        policy="require_stage",
+        required=("SKILL.md", "references/guide.md"),
+    )
+
+    staged = store.observe(
+        contract,
+        _scope(),
+        method="skill_stage",
+        resource_paths=["SKILL.md", "references/guide.md"],
+        resource_digests={
+            "SKILL.md": _digest("skill"),
+            "references/guide.md": _digest("guide"),
+        },
+        expected_resource_digests={
+            "SKILL.md": _digest("skill"),
+            "references/guide.md": _digest("guide"),
+        },
+        tool_name="skill_stage",
+    )
+    assert staged is not None
+    assert staged.compliance_status == "incomplete"
+
+    verified = store.observe(
+        contract,
+        _scope(),
+        method="skill_read",
+        resource_paths=["SKILL.md"],
+        resource_digests={"SKILL.md": _digest("skill")},
+        expected_resource_digests={"SKILL.md": _digest("skill")},
+        tool_name="skill_read",
+    )
+    assert verified is not None
+    assert verified.compliance_status == "verified"
+    assert verified.methods == ("skill_read", "skill_stage")
+
+
+def test_required_resource_without_expected_digest_is_not_verified(tmp_path):
+    receipt = SkillApplicationReceiptStore(tmp_path).observe(
+        _contract(required=("SKILL.md",)),
+        _scope(),
+        method="skill_read",
+        resource_paths=["SKILL.md"],
+        resource_digests={"SKILL.md": _digest("skill")},
+    )
+
+    assert receipt is not None
+    assert receipt.compliance_status == "unverified"
+    assert "skill_application_resource_digest_missing" in receipt.error_codes
+
+
+def test_resource_digest_mismatch_and_change_fail_closed(tmp_path):
+    store = SkillApplicationReceiptStore(tmp_path)
+    first = store.observe(
+        _contract(required=("SKILL.md",)),
+        _scope(),
+        method="skill_read",
+        resource_paths=["SKILL.md"],
+        resource_digests={"SKILL.md": _digest("unexpected")},
+        expected_resource_digests={"SKILL.md": _digest("expected")},
+    )
+    assert first is not None
+    assert first.compliance_status == "unverified"
+    assert "skill_application_resource_digest_mismatch" in first.error_codes
+
+    changed = store.observe(
+        _contract(required=("SKILL.md",)),
+        _scope(),
+        method="skill_read",
+        resource_paths=["SKILL.md"],
+        resource_digests={"SKILL.md": _digest("changed-again")},
+        expected_resource_digests={"SKILL.md": _digest("expected")},
+    )
+    assert changed is not None
+    assert changed.compliance_status == "unverified"
+    assert "skill_application_resource_digest_changed" in changed.error_codes
+    assert changed.resource_digests == first.resource_digests
+
+
+def test_store_quarantines_one_bad_record_without_losing_valid_receipts(tmp_path):
+    store = SkillApplicationReceiptStore(tmp_path)
+    valid = store.observe(
+        _contract(),
+        _scope(),
+        method="skill_read",
+        resource_paths=["SKILL.md"],
+        resource_digests={"SKILL.md": _digest("skill")},
+        expected_resource_digests={"SKILL.md": _digest("skill")},
+    )
+    assert valid is not None
+    payload = json.loads(store.snapshot_path.read_text(encoding="utf-8"))
+    payload["receipts"].append(
+        {"receipt_id": "forged", "prompt": "must-not-survive"}
+    )
+    store.snapshot_path.write_text(
+        json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+    )
+
+    recovered = SkillApplicationReceiptStore(tmp_path)
+    assert recovered.status()["available"] is True
+    assert recovered.status()["quarantine_count"] == 1
+    assert recovered.require(valid.receipt_id).compliance_status == "verified"
+
+    recovered.protect(valid.receipt_id, reference_id="evaluation:run-1")
+    rewritten = recovered.snapshot_path.read_text(encoding="utf-8")
+    assert "must-not-survive" not in rewritten
+    assert "prompt" not in rewritten
+    assert "evaluation:run-1" in rewritten
+
+
+def test_top_level_corruption_fails_closed_without_overwriting_snapshot(tmp_path):
+    snapshot = tmp_path / "skill_application_receipts.json"
+    snapshot.parent.mkdir(parents=True, exist_ok=True)
+    original = b'{"schema_version":'
+    snapshot.write_bytes(original)
+
+    store = SkillApplicationReceiptStore(tmp_path)
+    assert store.status()["available"] is False
+    with pytest.raises(SkillApplicationReceiptStorageError) as captured:
+        store.observe(_contract(), _scope(), method="skill_read")
+    assert captured.value.code == "skill_application_receipt_store_corrupt"
+    assert snapshot.read_bytes() == original
+
+
+def test_atomic_save_failure_rolls_back_in_memory_state(tmp_path, monkeypatch):
+    store = SkillApplicationReceiptStore(tmp_path)
+    monkeypatch.setattr(
+        store,
+        "_save_unlocked",
+        lambda: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    with pytest.raises(OSError, match="disk full"):
+        store.observe(_contract(), _scope(), method="skill_read")
+
+    assert store.list_receipts() == []
+    assert store.snapshot_path.exists() is False
+
+
+def test_snapshot_capacity_failure_rolls_back_without_publishing(tmp_path, monkeypatch):
+    store = SkillApplicationReceiptStore(tmp_path)
+    monkeypatch.setattr(
+        "server.skills.application_receipts._MAX_SNAPSHOT_BYTES",
+        1,
+    )
+
+    with pytest.raises(SkillApplicationReceiptStorageError) as captured:
+        store.observe(_contract(), _scope(), method="skill_read")
+
+    assert captured.value.code == "skill_application_receipt_store_limit"
+    assert store.list_receipts() == []
+    assert store.snapshot_path.exists() is False
+
+
+def test_off_mode_skips_persistence(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILL_APPLICATION_RECEIPT_MODE", "off")
+    store = SkillApplicationReceiptStore(tmp_path)
+
+    assert store.observe(_contract(), _scope(), method="skill_read") is None
+    assert store.snapshot_path.exists() is False
+
+
+def test_referenced_receipts_survive_retention_pruning(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILL_APPLICATION_RECEIPT_MODE", "audit")
+    store = SkillApplicationReceiptStore(tmp_path)
+    unprotected = store.observe(_contract(), _scope(), method="skill_read")
+    protected = store.observe(
+        _contract(),
+        SkillApplicationScope(
+            run_id="run_receipt_2",
+            task_id="task_receipt_2",
+            node_id="workflow-agent",
+            runtime_kind="workflow",
+        ),
+        method="skill_read",
+    )
+    assert unprotected is not None and protected is not None
+    store.protect(protected.receipt_id, reference_id="evaluation:run-1")
+    old = 1.0
+    with store._lock:
+        store._receipts[unprotected.receipt_id].updated_at = old
+        store._receipts[protected.receipt_id].updated_at = old
+
+    store.observe(
+        _contract(),
+        SkillApplicationScope(
+            run_id="run_receipt_3",
+            task_id="task_receipt_3",
+            node_id="workflow-agent",
+            runtime_kind="workflow",
+        ),
+        method="skill_read",
+    )
+
+    retained_ids = {item.receipt_id for item in store.list_receipts()}
+    assert unprotected.receipt_id not in retained_ids
+    assert protected.receipt_id in retained_ids
+
+
+def test_snapshot_contains_only_bounded_evidence_not_private_content(tmp_path):
+    store = SkillApplicationReceiptStore(tmp_path)
+    private_body = "private prompt, arguments, Skill body, and model output"
+    store.observe(
+        _contract(),
+        _scope(),
+        method="skill_stage",
+        resource_paths=["assets/template.txt"],
+        resource_digests={"assets/template.txt": _digest(private_body)},
+        tool_name="skill_stage",
+    )
+
+    persisted = store.snapshot_path.read_text(encoding="utf-8")
+    assert private_body not in persisted
+    for forbidden_key in ('"prompt"', '"arguments"', '"output"', '"content"'):
+        assert forbidden_key not in persisted
+
+
+class _InstalledSkillManager:
+    def __init__(self, package_root: Path) -> None:
+        self.package_root = package_root
+
+    def list_installed_skills(self):
+        return [SimpleNamespace(skill_id="incident-review")]
+
+    def get_skill_content(self, _skill_id, *, version_id=None):
+        assert version_id == "skillversion_incident_v1"
+        return (self.package_root / "SKILL.md").read_text(encoding="utf-8")
+
+    def get_skill_directory(self, _skill_id, *, version_id=None):
+        assert version_id == "skillversion_incident_v1"
+        return self.package_root
+
+
+@pytest.mark.asyncio
+async def test_skill_tools_emit_application_evidence_for_installed_package(tmp_path):
+    package_root = tmp_path / "package"
+    (package_root / "references").mkdir(parents=True)
+    skill_markdown_bytes = b"# Incident review\r\n"
+    (package_root / "SKILL.md").write_bytes(skill_markdown_bytes)
+    (package_root / "references" / "guide.md").write_text(
+        "# Guide\n", encoding="utf-8"
+    )
+    workspace_root = tmp_path / "workspaces"
+    client = SimpleNamespace(request=AsyncMock(return_value={"ok": True}))
+    provider = SandboxToolsetProvider(
+        SimpleNamespace(workspace_root=workspace_root),
+        client,
+        skill_manager=_InstalledSkillManager(package_root),
+    )
+    call_metadata = {
+        "task_id": "task_receipt_1",
+        "run_id": "run_receipt_1",
+        "node_id": "workflow-agent",
+        "skill_version_bindings": {
+            "incident-review": "skillversion_incident_v1"
+        },
+    }
+
+    read = provider._skill_read(
+        RuntimeToolCall(
+            "skill_read", {"skill_id": "incident-review"}, call_metadata
+        )
+    )
+    assert read.metadata["application_method"] == "skill_read"
+    assert read.metadata["application_resource_paths"] == ["SKILL.md"]
+    assert read.metadata["application_resource_digests"]["SKILL.md"] == (
+        hashlib.sha256(skill_markdown_bytes).hexdigest()
+    )
+    assert read.metadata["application_expected_resource_digests"] == (
+        read.metadata["application_resource_digests"]
+    )
+
+    stage = await provider._skill_stage(
+        SandboxWorkspace(
+            workspace_id="workspace-receipt",
+            scope_type="workflow",
+            scope_id="task:node",
+            node_id="workflow-agent",
+            quota_bytes=1024 * 1024,
+        ),
+        RuntimeToolCall(
+            "skill_stage", {"skill_id": "incident-review"}, call_metadata
+        ),
+    )
+    assert stage.metadata["application_method"] == "skill_stage"
+    assert stage.metadata["application_resource_paths"] == [
+        "SKILL.md",
+        "references/guide.md",
+    ]
+    assert stage.metadata["application_expected_resource_digests"] == (
+        stage.metadata["application_resource_digests"]
+    )
+    assert set(stage.metadata["application_resource_digests"]) == {
+        "SKILL.md",
+        "references/guide.md",
+    }
+    assert client.request.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_evaluation_overlay_uses_same_application_evidence_contract(tmp_path):
+    package = {
+        "skill_markdown": "# Evaluation Skill\n",
+        "files": {"references/guide.md": "# Evidence\n"},
+    }
+    overlay = SimpleNamespace(
+        overlay_id="skill_eval_overlay_candidate",
+        content_digest=_digest("evaluation-package"),
+        package=package,
+    )
+    provider = SandboxToolsetProvider(
+        SimpleNamespace(workspace_root=tmp_path / "workspaces"),
+        SimpleNamespace(),
+        skill_manager=SimpleNamespace(list_installed_skills=lambda: []),
+    )
+    provider.configure_skill_evaluation(lambda _overlay_id: overlay)
+    metadata = {
+        "runtime_run_type": "skill_evaluation",
+        "skill_evaluation_item_id": "item-candidate",
+        "skill_evaluation_overlay_id": overlay.overlay_id,
+    }
+
+    read = provider._skill_read(
+        RuntimeToolCall(
+            "skill_read", {"skill_id": "evaluation-skill"}, metadata
+        )
+    )
+    staged = await provider._skill_stage(
+        SandboxWorkspace(
+            workspace_id="workspace-evaluation",
+            scope_type="workflow",
+            scope_id="task:node",
+            node_id="evaluation-agent",
+            quota_bytes=1024 * 1024,
+        ),
+        RuntimeToolCall(
+            "skill_stage", {"skill_id": "evaluation-skill"}, metadata
+        ),
+    )
+
+    assert read.metadata["application_source_kind"] == "evaluation_overlay"
+    assert read.metadata["application_version_id"] == overlay.overlay_id
+    assert read.metadata["application_expected_resource_digests"] == (
+        read.metadata["application_resource_digests"]
+    )
+    assert staged.metadata["application_content_digest"] == overlay.content_digest
+    assert staged.metadata["application_resource_paths"] == [
+        "SKILL.md",
+        "references/guide.md",
+    ]
+    assert staged.metadata["application_expected_resource_digests"] == (
+        staged.metadata["application_resource_digests"]
+    )
+
+
+def test_advisory_contract_verifies_actual_prompt_injection(tmp_path):
+    digest = _digest("builtin-method")
+    contract = build_application_contract(
+        skill_id="research-method",
+        source_kind="builtin",
+        version_id=f"builtin:{digest}",
+        content_digest=digest,
+        policy="advisory",
+    )
+    store = SkillApplicationReceiptStore(tmp_path)
+    receipt = store.observe(
+        contract,
+        SkillApplicationScope(
+            run_id="run_expert_1",
+            task_id="task_expert_1",
+            node_id="agency-orchestrator",
+            runtime_kind="expert_team",
+        ),
+        method="prompt_injected",
+    )
+
+    assert receipt is not None
+    assert receipt.methods == ("prompt_injected",)
+    assert receipt.compliance_status == "verified"
+
+
+def test_main_observer_resolves_server_frozen_version_identity(
+    tmp_path, monkeypatch
+):
+    import server.main as main
+
+    receipt_store = SkillApplicationReceiptStore(tmp_path / "receipts")
+    snapshot = SimpleNamespace(
+        skill_id="incident-review",
+        source_kind="git",
+        package_digest=_digest("package-v1"),
+        trust_fingerprint=_digest("trust-v1"),
+    )
+    manager = SimpleNamespace(
+        lifecycle_store=SimpleNamespace(
+            require_version=lambda _version_id: snapshot
+        ),
+        list_installed_skills=lambda: [],
+    )
+    monkeypatch.setattr(main, "get_skill_manager", lambda: manager)
+    monkeypatch.setattr(
+        main,
+        "skill_application_observer",
+        SkillApplicationObserver(receipt_store, lambda: main.get_skill_manager()),
+    )
+
+    selected_id = main.record_skill_application(
+        skill_id="incident-review",
+        run_id="run_receipt_main",
+        task_id="task_receipt_main",
+        node_id="workflow-agent",
+        runtime_kind="workflow",
+        version_id="skillversion_incident_v1",
+    )
+    applied_id = main.record_skill_application(
+        skill_id="incident-review",
+        run_id="run_receipt_main",
+        task_id="task_receipt_main",
+        node_id="workflow-agent",
+        runtime_kind="workflow",
+        version_id="skillversion_incident_v1",
+        method="skill_read",
+        resource_paths=["SKILL.md"],
+        resource_digests={"SKILL.md": _digest("skill body")},
+        expected_resource_digests={"SKILL.md": _digest("skill body")},
+        tool_name="skill_read",
+    )
+
+    assert selected_id == applied_id
+    receipt = receipt_store.require(str(applied_id))
+    assert receipt.content_digest == snapshot.package_digest
+    assert receipt.trust_fingerprint == snapshot.trust_fingerprint
+    assert receipt.compliance_status == "verified"
+
+
+def test_main_observer_records_sanitized_failed_application(tmp_path, monkeypatch):
+    import server.main as main
+
+    receipt_store = SkillApplicationReceiptStore(tmp_path / "receipts")
+    snapshot = SimpleNamespace(
+        skill_id="incident-review",
+        source_kind="git",
+        package_digest=_digest("package-v1"),
+        trust_fingerprint=_digest("trust-v1"),
+    )
+    monkeypatch.setattr(
+        main,
+        "skill_application_observer",
+        SkillApplicationObserver(
+            receipt_store,
+            lambda: SimpleNamespace(
+                lifecycle_store=SimpleNamespace(
+                    require_version=lambda _version_id: snapshot
+                ),
+                list_installed_skills=lambda: [],
+            ),
+        ),
+    )
+
+    receipt_id = main.record_skill_application(
+        skill_id="incident-review",
+        run_id="run_receipt_failed",
+        task_id="task_receipt_failed",
+        node_id="workflow-agent",
+        runtime_kind="workflow",
+        version_id="skillversion_incident_v1",
+        tool_name="skill_stage",
+        error_code="skill_runtime_incompatible",
+    )
+
+    receipt = receipt_store.require(str(receipt_id))
+    assert receipt.application_status == "failed"
+    assert receipt.compliance_status == "incomplete"
+    assert receipt.error_codes == ("skill_runtime_incompatible",)
+    persisted = receipt_store.snapshot_path.read_text(encoding="utf-8")
+    assert "arguments" not in persisted
+    assert "output" not in persisted
+
+
+def test_enforce_mode_propagates_receipt_failures(monkeypatch):
+    import server.main as main
+
+    class BrokenObserver:
+        def record(self, **_kwargs):
+            raise SkillApplicationReceiptError(
+                "store unavailable",
+                code="skill_application_receipt_store_corrupt",
+            )
+
+    monkeypatch.setenv("SKILL_APPLICATION_RECEIPT_MODE", "enforce")
+    monkeypatch.setattr(main, "skill_application_observer", BrokenObserver())
+
+    with pytest.raises(SkillApplicationReceiptError) as captured:
+        main.record_skill_application(
+            skill_id="incident-review",
+            run_id="run_receipt_enforce",
+            task_id="task_receipt_enforce",
+            node_id="workflow-agent",
+            runtime_kind="workflow",
+        )
+    assert captured.value.code == "skill_application_receipt_store_corrupt"
+
+
+def test_chat_application_resolves_exact_injected_frozen_skill(monkeypatch):
+    import server.main as main
+
+    skill_markdown = "# Incident review\n\nFollow the frozen workflow.\n"
+    package_digest = _digest("chat-package")
+    trust_fingerprint = _digest("chat-trust")
+    installed = SimpleNamespace(content_digest=package_digest)
+    version = SimpleNamespace(
+        skill_id="incident-review",
+        source_kind="git",
+        package_digest=package_digest,
+        trust_fingerprint=trust_fingerprint,
+    )
+    manager = SimpleNamespace(
+        require_activation=lambda _skill_id, **_kwargs: installed,
+        bind_skill_versions=lambda _skill_ids: {
+            "incident-review": "skillversion_chat_v1"
+        },
+        lifecycle_store=SimpleNamespace(require_version=lambda _version_id: version),
+        get_skill_content=lambda _skill_id, version_id=None: skill_markdown,
+    )
+    monkeypatch.setattr(main, "get_skill_manager", lambda: manager)
+
+    resolved = main.resolve_chat_skill_application(
+        main.ChatSkillApplication(
+            skill_id="incident-review",
+            expected_content_digest=package_digest,
+        ),
+        [
+            main.ChatMessage(
+                role="system",
+                content=f"Current Skill\n\n{skill_markdown}",
+            ),
+            main.ChatMessage(role="user", content="Create the report."),
+        ],
+    )
+
+    assert resolved == {
+        "skill_id": "incident-review",
+        "version_id": "skillversion_chat_v1",
+        "source_kind": "git",
+        "content_digest": package_digest,
+        "trust_fingerprint": trust_fingerprint,
+    }
+
+    with pytest.raises(SkillApplicationReceiptError) as captured:
+        main.resolve_chat_skill_application(
+            main.ChatSkillApplication(
+                skill_id="incident-review",
+                expected_content_digest=package_digest,
+            ),
+            [main.ChatMessage(role="user", content="No Skill prompt here.")],
+        )
+    assert captured.value.code == "skill_application_prompt_missing"

--- a/server/xpert_runtime/sandbox_toolset.py
+++ b/server/xpert_runtime/sandbox_toolset.py
@@ -577,10 +577,18 @@ class SandboxToolsetProvider:
                         "skill_id": "evaluation-skill",
                         "skill_evaluation_read": True,
                         "overlay_available": False,
+                        "application_method": "skill_read",
+                        "application_source_kind": "evaluation_baseline_empty",
+                        "application_resource_paths": [],
+                        "application_resource_digests": {},
+                        "application_expected_resource_digests": {},
                     },
                 )
             package = dict(getattr(overlay, "package", {}) or {})
             content = str(package.get("skill_markdown") or "")
+            skill_markdown_digest = hashlib.sha256(
+                content.encode("utf-8")
+            ).hexdigest()
             return RuntimeToolResult(
                 output=content[:50_000],
                 metadata={
@@ -590,6 +598,21 @@ class SandboxToolsetProvider:
                     "overlay_available": True,
                     "overlay_id": getattr(overlay, "overlay_id", None),
                     "content_digest": getattr(overlay, "content_digest", None),
+                    "application_method": "skill_read",
+                    "application_source_kind": "evaluation_overlay",
+                    "application_version_id": getattr(
+                        overlay, "overlay_id", None
+                    ),
+                    "application_content_digest": getattr(
+                        overlay, "content_digest", None
+                    ),
+                    "application_resource_paths": ["SKILL.md"],
+                    "application_resource_digests": {
+                        "SKILL.md": skill_markdown_digest
+                    },
+                    "application_expected_resource_digests": {
+                        "SKILL.md": skill_markdown_digest
+                    },
                     "truncated": len(content) > 50_000,
                 },
             )
@@ -600,7 +623,35 @@ class SandboxToolsetProvider:
             if version_id
             else self.skill_manager.get_skill_content(skill_id)
         )
-        return RuntimeToolResult(output=content[:50_000], metadata={"content_types": ["text"], "skill_id": skill_id, "skill_version_id": version_id, "truncated": len(content) > 50_000})
+        try:
+            package_root = (
+                self.skill_manager.get_skill_directory(
+                    skill_id, version_id=version_id
+                )
+                if version_id
+                else self.skill_manager.get_skill_directory(skill_id)
+            )
+            skill_markdown_bytes = (package_root / "SKILL.md").read_bytes()
+        except Exception:
+            skill_markdown_bytes = content.encode("utf-8")
+        return RuntimeToolResult(
+            output=content[:50_000],
+            metadata={
+                "content_types": ["text"],
+                "skill_id": skill_id,
+                "skill_version_id": version_id,
+                "application_method": "skill_read",
+                "application_version_id": version_id,
+                "application_resource_paths": ["SKILL.md"],
+                "application_resource_digests": {
+                    "SKILL.md": hashlib.sha256(skill_markdown_bytes).hexdigest()
+                },
+                "application_expected_resource_digests": {
+                    "SKILL.md": hashlib.sha256(skill_markdown_bytes).hexdigest()
+                },
+                "truncated": len(content) > 50_000,
+            },
+        )
 
     def _skill_find(
         self, call: RuntimeToolCall, *, recall: bool = False
@@ -862,9 +913,26 @@ class SandboxToolsetProvider:
                         "skill_id": "evaluation-skill",
                         "file_count": 0,
                         "workspace_id": workspace.workspace_id,
+                        "application_method": "skill_stage",
+                        "application_source_kind": "evaluation_baseline_empty",
+                        "application_resource_paths": [],
+                        "application_resource_digests": {},
+                        "application_expected_resource_digests": {},
                     },
                 )
             package = dict(getattr(overlay, "package", {}) or {})
+            package_resources = {
+                "SKILL.md": str(package.get("skill_markdown") or ""),
+                **{
+                    str(path): str(content)
+                    for path, content in dict(package.get("files") or {}).items()
+                },
+            }
+            application_resource_paths = sorted(package_resources)
+            application_resource_digests = {
+                path: hashlib.sha256(content.encode("utf-8")).hexdigest()
+                for path, content in sorted(package_resources.items())
+            }
             files = [
                 "skills/evaluation-skill/SKILL.md",
                 *[
@@ -887,6 +955,19 @@ class SandboxToolsetProvider:
                     "skill_id": "evaluation-skill",
                     "file_count": len(files),
                     "workspace_id": workspace.workspace_id,
+                    "application_method": "skill_stage",
+                    "application_source_kind": "evaluation_overlay",
+                    "application_version_id": getattr(
+                        overlay, "overlay_id", None
+                    ),
+                    "application_content_digest": getattr(
+                        overlay, "content_digest", None
+                    ),
+                    "application_resource_paths": application_resource_paths,
+                    "application_resource_digests": application_resource_digests,
+                    "application_expected_resource_digests": (
+                        application_resource_digests
+                    ),
                 },
             )
         self._require_enabled_skill(call, skill_id)
@@ -959,6 +1040,8 @@ class SandboxToolsetProvider:
                 code="skill_runtime_incompatible",
             )
         files: list[str] = []
+        application_resource_paths: list[str] = []
+        application_resource_digests: dict[str, str] = {}
         for _source, relative, content in package_files:
             destination = f"skills/{skill_id}/{relative.as_posix()}"
             await self.client.request(
@@ -972,9 +1055,27 @@ class SandboxToolsetProvider:
                 }
             )
             files.append(destination)
+            relative_path = relative.as_posix()
+            application_resource_paths.append(relative_path)
+            application_resource_digests[relative_path] = hashlib.sha256(
+                content
+            ).hexdigest()
         return RuntimeToolResult(
             output=json.dumps({"skill_id": skill_id, "workspace_id": workspace.workspace_id, "files": files}, ensure_ascii=False),
-            metadata={"content_types": ["text"], "skill_id": skill_id, "file_count": len(files), "workspace_id": workspace.workspace_id},
+            metadata={
+                "content_types": ["text"],
+                "skill_id": skill_id,
+                "skill_version_id": version_id,
+                "file_count": len(files),
+                "workspace_id": workspace.workspace_id,
+                "application_method": "skill_stage",
+                "application_version_id": version_id,
+                "application_resource_paths": application_resource_paths,
+                "application_resource_digests": application_resource_digests,
+                "application_expected_resource_digests": (
+                    application_resource_digests
+                ),
+            },
         )
 
     async def _stage_context_attachments(self, workspace: SandboxWorkspace, call: RuntimeToolCall) -> None:


### PR DESCRIPTION
## 增量

- 新增版本化 SkillApplicationContractV1 与 SkillApplicationReceiptV1，区分已选择、实际 prompt 注入、skill_read 和 skill_stage。
- 使用原子、限额、可隔离损坏记录的本地 Store；默认 audit，off 可回退，enforce 仅在凭据无法持久化时失败关闭。
- 统一观察工作流、Router、专家团、聊天注入和 Creator 评测 overlay；不保存 prompt、工具参数、Skill 正文或模型输出。
- Chat 请求绑定服务端校验的不可变 Skill digest；read/stage 凭据同时绑定实际与预期原始字节摘要。

## 提交前证伪与修复

- 缺失、错配或运行中变化的资源摘要现在稳定标记 unverified，不再产生伪 verified receipt。
- enforce 模式不再吞掉 Store 错误；工具失败会写脱敏失败凭据并保留原 RuntimeToolError。
- Store 达到快照上限时回滚内存状态，不发布部分记录。
- 保持当前单 Uvicorn worker 的单写者边界；本 PR 不引入跨进程锁或改变部署拓扑。

## 验证

- 后端受影响回归：248 passed，4 个既有 FastAPI on_event 弃用警告。
- 前端 Vitest：80 files / 396 tests passed。
- TypeScript app/node 工程检查通过。
- 生产构建通过；仅保留既有大 chunk warning。
- git diff --check、路径白名单、敏感信息与临时配置扫描通过。

## 运行边界

- 默认 SKILL_APPLICATION_RECEIPT_MODE=audit，不改变普通聊天或工作流结果。
- 未重建或重启共享 Docker；Creator V2 的强制消费留给后续串行 PR。