### PR TITLE
feature: 建立 Model Provider Control Plane Round 0–1C

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,14 @@
-# LLM 网关配置（推荐：newAPI）
+# 外部 OpenAI-compatible 数据面配置（可使用独立 newAPI）
 # 本文件是示例；后端本地 Docker 默认读取 server/.env。
-# 本机直接运行后端时使用 localhost；Docker Compose 中 server 会改用 http://new-api:3000。
-LLM_GATEWAY_URL=http://localhost:3000/v1/chat/completions
-LLM_GATEWAY_KEY=your-new-api-key
+# 核心 Compose 不提供隐式地址；加载 deploy/newapi Overlay 时才注入容器内 URL。
+LLM_GATEWAY_URL=
+LLM_GATEWAY_KEY=
+
+# 客户端运行时外部管理链接；不嵌入、代理或探测 newAPI 管理界面。
+NEWAPI_WEB_URL=http://localhost:3000
 
 # 回退：直接访问 OpenRouter（向后兼容）
-OPENROUTER_API_KEY=your-openrouter-key
+OPENROUTER_API_KEY=
 
 # OpenRouter 兼容请求头（可选）
 OPENROUTER_HTTP_REFERER=http://localhost:5173
@@ -49,13 +52,25 @@ OMNIROUTE_BUDGET_HEADERS_ENABLED=false
 # 原生算法紧急回退：legacy 只回退评分/选择；sidecar 回退完整执行引擎。
 MODEL_ROUTER_NATIVE_ALGORITHM=omniroute-parity-v2
 MODEL_ROUTER_CANARY_PERCENT=0
-MODEL_ROUTER_TENANT_ID=local
+MODELMIRROR_DEFAULT_TENANT_ID=local
+# 至少 32 字符；不要提交真实值。缺失时只锁定 Provider 管理面。
+MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET=
+# 动态内网 Provider 仅接受精确 host:port，逗号分隔；不支持通配符或 CIDR。
+MODEL_MIRROR_PROVIDER_INTERNAL_ALLOWLIST=
+# 生产环境外部注入规范主密钥；启用强制模式后不回退旧变量或本地密钥文件。
+MODEL_MIRROR_CREDENTIAL_MASTER_KEY=
+MODEL_MIRROR_REQUIRE_EXTERNAL_CREDENTIAL_MASTER_KEY=false
+# 旧变量仅供迁移期读取：MODEL_ROUTER_CREDENTIAL_MASTER_KEY=
 # 仅限灾备或已完成独立审计的运维覆盖。普通设置界面仍执行 14 天/500 次门禁。
 MODEL_ROUTER_ALLOW_NATIVE_OVERRIDE=false
 
 # Optional: keep persistent bind-mounted data in a stable directory while
 # building source from another Git worktree.
 MODELMIRROR_DATA_ROOT=.
+
+# Coding uses an independently managed provider network and never joins the
+# Model Provider Control Plane/newAPI network.
+CODING_PROVIDER_NETWORK_NAME=modelmirror-coding-provider
 
 # File asset migration mode: legacy keeps existing module stores authoritative;
 # shadow adds non-authoritative indexing; native is reserved for a later gate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Do not use for: refactoring, writing scripts from scratch, debugging business lo
 - Agent Table：`/data-tables` 提供本地类型化业务记录、Schema 版本和人工 CRUD；它不是 Data X 或外部 Database MCP。
 - 上下文：Xpert Chat 支持会话附件、文件理解、显式记忆和待确认记忆候选。
 - 运行观测：`/runtime` 聚合 MCP、Tool Registry、RunRegistry、Skill 和脱敏环境状态。
-- 设置：`/settings` 内嵌 newAPI 控制台。
+- 设置：`/settings` 提供 Provider 控制面和可选的 newAPI 外部管理链接；不得嵌入或代理 newAPI 管理界面。
 - 资源页：模型、智能体、MCP/Toolset、Skill、版本化 Prompt Command、声明式 Plugin、专家团。
 - 平台自编写：私有 Xpert 可创建版本化 Xpert/Skill 提案；批准只写草稿，发布与安装必须由用户另行确认。
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ AI 供给正在从少数通用模型，扩展为由模型、工具、知识库�
 - Data X：`/datax` 支持 CSV/XLSX/Parquet 快照、语义模型、版本化指标、受限分析和指标提案审批。
 - Agent Studio：创建智能体草稿、发布不可变版本，并通过 Goal、Handoff、文件、记忆与 Knowledge Pipeline 组合执行。
 - Agent App/API：把已发布版本固定部署为未列出分享 App，并提供带密钥、配额和回滚的 OpenAI 兼容接口。
-- newAPI：`/settings` 以内嵌 iframe 接入 newAPI 控制台，后端可优先走 OpenAI 兼容网关。
+- newAPI：作为独立可选数据面运行；`/settings` 只显示显式配置的外部管理链接，不嵌入或代理其管理界面。
 
 ## 目标架构
 
@@ -66,8 +66,8 @@ AI 供给正在从少数通用模型，扩展为由模型、工具、知识库�
 
 - 前端：React + TypeScript + Tailwind CSS + Vite + React Router + ReactMarkdown + @xyflow/react。
 - 后端：FastAPI + Pydantic + httpx + ChromaDB + DuckDB + MCP Python SDK。
-- 本地部署：Docker Compose 默认包含 `client`、`server`、`new-api`、
-  `browser` 和 `sandbox`；OmniRoute 与 Office host 使用可选 profile。
+- 本地部署：核心 Docker Compose 默认包含 `client`、`server`、`browser` 和
+  `sandbox`；newAPI 使用独立可选栈，OmniRoute 与 Office host 使用可选 profile。
 
 ## 快速启动
 
@@ -77,18 +77,21 @@ AI 供给正在从少数通用模型，扩展为由模型、工具、知识库�
 copy server\.env.example server\.env
 ```
 
-推荐通过 newAPI 管理模型渠道：
+至少显式配置一种模型访问方式。直接网关示例：
 
 ```bash
-LLM_GATEWAY_URL=http://localhost:3000/v1/chat/completions
-LLM_GATEWAY_KEY=your-new-api-key
+LLM_GATEWAY_URL=https://your-gateway.example/v1/chat/completions
+LLM_GATEWAY_KEY=your-gateway-key
 ```
 
-也可以回退到 OpenRouter：
+也可以只配置 OpenRouter：
 
 ```bash
 OPENROUTER_API_KEY=your-openrouter-key
 ```
+
+若使用 newAPI，请按[部署文档](docs/DEPLOYMENT.md)单独启动其 Compose 栈，
+并通过 Overlay 显式提供容器内 `LLM_GATEWAY_URL`；核心栈不管理 newAPI 生命周期。
 
 启动 Docker Compose：
 

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,3 +1,7 @@
+# 容器运行时配置（推荐）：修改后只需重启 client，无需重建前端镜像。
+NEWAPI_WEB_URL=http://localhost:3000
+
+# Vite 开发服务器或纯静态构建的兼容回退。
 VITE_NEWAPI_WEB_URL=http://localhost:3000
 
 # Legacy Dify iframe compatibility only; no current primary route consumes it.

--- a/client/server.mjs
+++ b/client/server.mjs
@@ -7,6 +7,30 @@ const port = Number(process.env.PORT || 80);
 const apiTarget = process.env.API_TARGET || "http://server:8000";
 const distDir = path.resolve("dist");
 
+function normalizePublicManagementUrl(value) {
+  const configured = String(value || "").trim().replace(/\/+$/, "");
+  if (!configured) return "";
+  try {
+    const url = new URL(configured);
+    if (
+      !["http:", "https:"].includes(url.protocol) ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) {
+      return "";
+    }
+    return url.toString();
+  } catch {
+    return "";
+  }
+}
+
+const runtimeConfig = JSON.stringify({
+  newApiWebUrl: normalizePublicManagementUrl(process.env.NEWAPI_WEB_URL),
+});
+
 const contentTypes = new Map([
   [".html", "text/html; charset=utf-8"],
   [".js", "application/javascript; charset=utf-8"],
@@ -87,8 +111,26 @@ async function serveStatic(req, res) {
   createReadStream(filePath).pipe(res);
 }
 
+function serveRuntimeConfig(req, res) {
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    res.writeHead(405, { Allow: "GET, HEAD" });
+    res.end();
+    return;
+  }
+  res.writeHead(200, {
+    "Cache-Control": "no-store",
+    "Content-Type": "application/json; charset=utf-8",
+  });
+  res.end(req.method === "HEAD" ? undefined : runtimeConfig);
+}
+
 createServer(async (req, res) => {
   try {
+    const requestPath = new URL(req.url || "/", "http://localhost").pathname;
+    if (requestPath === "/runtime-config.json") {
+      serveRuntimeConfig(req, res);
+      return;
+    }
     if ((req.url || "").startsWith("/api/")) {
       await proxyApi(req, res);
       return;

--- a/client/src/components/settings/ModelServiceConnections.tsx
+++ b/client/src/components/settings/ModelServiceConnections.tsx
@@ -66,9 +66,9 @@ const PROVIDERS: Record<
   },
   newapi: {
     label: "newAPI",
-    name: "本地 newAPI",
-    baseUrl: "http://localhost:3000/v1",
-    hint: "适合已经在模镜中配置好的本地模型渠道。",
+    name: "独立 newAPI",
+    baseUrl: "",
+    hint: "请输入独立数据面的显式地址；内网地址还需由服务端精确加入 host:port 白名单。",
     scopes: ["chat"],
   },
   openai_compatible: {
@@ -125,6 +125,8 @@ function healthClass(health: ConnectionHealth) {
 }
 
 async function readError(response: Response) {
+  if (response.status === 401) return "管理会话已失效，请重新配对。";
+  if (response.status === 503) return "Provider 管理面尚未配置或暂时不可用。";
   try {
     const payload = await response.json();
     const detail = payload?.detail;
@@ -136,7 +138,11 @@ async function readError(response: Response) {
   return "操作未完成，请检查服务状态后重试。";
 }
 
-export default function ModelServiceConnections() {
+export default function ModelServiceConnections({
+  csrfToken,
+}: {
+  csrfToken: string;
+}) {
   const [connections, setConnections] = useState<RouterConnection[]>([]);
   const [form, setForm] = useState<ConnectionForm>(INITIAL_FORM);
   const [testResult, setTestResult] = useState<ConnectionTestResult | null>(null);
@@ -211,7 +217,10 @@ export default function ModelServiceConnections() {
     try {
       const response = await fetch("/api/router/connections/test", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "X-ModelMirror-CSRF": csrfToken,
+        },
         body: JSON.stringify(payload),
       });
       if (!response.ok) throw new Error(await readError(response));
@@ -221,7 +230,7 @@ export default function ModelServiceConnections() {
     } finally {
       setTesting(false);
     }
-  }, [canTest, payload]);
+  }, [canTest, csrfToken, payload]);
 
   const saveConnection = useCallback(async () => {
     if (!testResult?.ok) return;
@@ -230,14 +239,17 @@ export default function ModelServiceConnections() {
     try {
       const response = await fetch("/api/router/connections", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "X-ModelMirror-CSRF": csrfToken,
+        },
         body: JSON.stringify(payload),
       });
       if (!response.ok) throw new Error(await readError(response));
       const created = (await response.json()) as RouterConnection;
       const tested = await fetch(
         `/api/router/connections/${encodeURIComponent(created.id)}/test`,
-        { method: "POST" },
+        { method: "POST", headers: { "X-ModelMirror-CSRF": csrfToken } },
       );
       if (!tested.ok) throw new Error(await readError(tested));
       setForm(INITIAL_FORM);
@@ -248,7 +260,7 @@ export default function ModelServiceConnections() {
     } finally {
       setSaving(false);
     }
-  }, [loadConnections, payload, testResult]);
+  }, [csrfToken, loadConnections, payload, testResult]);
 
   const testSavedConnection = useCallback(
     async (connectionId: string) => {
@@ -257,7 +269,7 @@ export default function ModelServiceConnections() {
       try {
         const response = await fetch(
           `/api/router/connections/${encodeURIComponent(connectionId)}/test`,
-          { method: "POST" },
+          { method: "POST", headers: { "X-ModelMirror-CSRF": csrfToken } },
         );
         if (!response.ok) throw new Error(await readError(response));
         await loadConnections();
@@ -268,7 +280,7 @@ export default function ModelServiceConnections() {
         setBusyId(null);
       }
     },
-    [loadConnections],
+    [csrfToken, loadConnections],
   );
 
   const toggleConnection = useCallback(
@@ -280,7 +292,10 @@ export default function ModelServiceConnections() {
           `/api/router/connections/${encodeURIComponent(connection.id)}`,
           {
             method: "PATCH",
-            headers: { "Content-Type": "application/json" },
+            headers: {
+              "Content-Type": "application/json",
+              "X-ModelMirror-CSRF": csrfToken,
+            },
             body: JSON.stringify({ enabled: !connection.enabled }),
           },
         );
@@ -292,7 +307,7 @@ export default function ModelServiceConnections() {
         setBusyId(null);
       }
     },
-    [loadConnections],
+    [csrfToken, loadConnections],
   );
 
   return (

--- a/client/src/components/settings/ProviderAdminGate.test.tsx
+++ b/client/src/components/settings/ProviderAdminGate.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ProviderAdminGate from "./ProviderAdminGate";
+
+function json(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("ProviderAdminGate", () => {
+  it("does not misreport a session fetch failure as unconfigured", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network unavailable"));
+    render(
+      <ProviderAdminGate>{() => <div>protected controls</div>}</ProviderAdminGate>,
+    );
+    expect(await screen.findByText("无法读取 Provider 管理会话")).toBeVisible();
+    expect(screen.getByRole("alert")).toHaveTextContent("network unavailable");
+    expect(screen.queryByText("Provider 管理面尚未配置")).toBeNull();
+  });
+
+  it("keeps management locked when pairing is not configured", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      json({ configured: false, authenticated: false }),
+    );
+    render(
+      <ProviderAdminGate>{() => <div>protected controls</div>}</ProviderAdminGate>,
+    );
+    expect(await screen.findByText("Provider 管理面尚未配置")).toBeVisible();
+    expect(screen.queryByText("protected controls")).toBeNull();
+  });
+
+  it("submits the secret once and exposes only the csrf session to children", async () => {
+    const requests: Array<{ url: string; body?: string }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      requests.push({ url: String(input), body: init?.body as string | undefined });
+      if (!init?.method) {
+        return json({ configured: true, authenticated: false });
+      }
+      return json({
+        configured: true,
+        authenticated: true,
+        expires_at: 12345,
+        csrf_token: "csrf-only",
+      });
+    });
+    render(
+      <ProviderAdminGate>
+        {({ csrfToken }) => <div>unlocked {csrfToken}</div>}
+      </ProviderAdminGate>,
+    );
+    const input = await screen.findByPlaceholderText("输入管理员配对密钥");
+    fireEvent.change(input, { target: { value: "one-time-secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "开始管理" }));
+    await screen.findByText("unlocked csrf-only");
+    expect(requests.at(-1)?.body).toContain("one-time-secret");
+    expect(screen.queryByPlaceholderText("输入管理员配对密钥")).toBeNull();
+    expect(localStorage.length).toBe(0);
+    expect(sessionStorage.length).toBe(0);
+  });
+
+  it("shows the server retry window after pairing rate limiting", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(json({ configured: true, authenticated: false }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: { code: "rate_limited" } }), {
+          status: 429,
+          headers: { "Content-Type": "application/json", "Retry-After": "245" },
+        }),
+      );
+    render(
+      <ProviderAdminGate>{() => <div>protected controls</div>}</ProviderAdminGate>,
+    );
+    const input = await screen.findByPlaceholderText("输入管理员配对密钥");
+    fireEvent.change(input, { target: { value: "wrong-secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "开始管理" }));
+    expect(
+      await screen.findByText("配对尝试过多，请在 245 秒后重试。"),
+    ).toBeVisible();
+  });
+});

--- a/client/src/components/settings/ProviderAdminGate.tsx
+++ b/client/src/components/settings/ProviderAdminGate.tsx
@@ -1,0 +1,210 @@
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from "react";
+import { CircleAlert, KeyRound, LoaderCircle, LogOut } from "lucide-react";
+
+interface AdminSession {
+  configured: boolean;
+  authenticated: boolean;
+  expires_at: number | null;
+  csrf_token: string | null;
+}
+
+interface ProviderAdminGateProps {
+  children: (session: { csrfToken: string }) => ReactNode;
+}
+
+async function readError(response: Response) {
+  if (response.status === 429) {
+    const retryAfter = response.headers.get("Retry-After") || "300";
+    return `配对尝试过多，请在 ${retryAfter} 秒后重试。`;
+  }
+  try {
+    const payload = await response.json();
+    if (payload?.detail?.code === "admin_session_required") {
+      return "管理会话已失效，请重新配对。";
+    }
+    if (payload?.detail?.code === "admin_pairing_not_configured") {
+      return "Provider 管理面尚未配置。";
+    }
+    if (typeof payload?.detail?.message === "string") {
+      return payload.detail.message as string;
+    }
+  } catch {
+    // Use the stable fallback below.
+  }
+  return "Provider 管理会话操作未完成，请稍后重试。";
+}
+
+export default function ProviderAdminGate({ children }: ProviderAdminGateProps) {
+  const [session, setSession] = useState<AdminSession | null>(null);
+  const [pairingSecret, setPairingSecret] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const response = await fetch("/api/router/admin/session");
+      if (!response.ok) throw new Error(await readError(response));
+      setSession((await response.json()) as AdminSession);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "无法读取管理会话。");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const pair = useCallback(
+    async (event: FormEvent) => {
+      event.preventDefault();
+      if (!pairingSecret) return;
+      setSubmitting(true);
+      setError("");
+      try {
+        const response = await fetch("/api/router/admin/session", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ pairing_secret: pairingSecret }),
+        });
+        if (!response.ok) throw new Error(await readError(response));
+        setSession((await response.json()) as AdminSession);
+      } catch (reason) {
+        setError(reason instanceof Error ? reason.message : "管理员配对失败。");
+      } finally {
+        setPairingSecret("");
+        setSubmitting(false);
+      }
+    },
+    [pairingSecret],
+  );
+
+  const logout = useCallback(async () => {
+    if (!session?.csrf_token) return;
+    setSubmitting(true);
+    setError("");
+    try {
+      const response = await fetch("/api/router/admin/session", {
+        method: "DELETE",
+        headers: { "X-ModelMirror-CSRF": session.csrf_token },
+      });
+      if (!response.ok) throw new Error(await readError(response));
+      await refresh();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "无法注销管理会话。");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [refresh, session]);
+
+  if (loading) {
+    return (
+      <section className="mb-6 rounded-lg border border-white/10 bg-ink-950/82 p-5 text-sm text-slate-300">
+        <LoaderCircle className="mr-2 inline h-4 w-4 animate-spin" />
+        正在读取 Provider 管理会话
+      </section>
+    );
+  }
+
+  if (!session) {
+    return (
+      <section className="mb-6 rounded-lg border border-rose-300/20 bg-rose-300/10 p-5">
+        <div className="flex items-start gap-3">
+          <CircleAlert className="mt-0.5 h-5 w-5 text-rose-200" />
+          <div>
+            <h2 className="font-semibold text-white">无法读取 Provider 管理会话</h2>
+            <p className="mt-1 text-sm leading-6 text-rose-100/80" role="alert">
+              {error || "请检查后端服务后重试。"}
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (!session?.configured) {
+    return (
+      <section className="mb-6 rounded-lg border border-amber-300/20 bg-amber-300/10 p-5">
+        <div className="flex items-start gap-3">
+          <CircleAlert className="mt-0.5 h-5 w-5 text-amber-200" />
+          <div>
+            <h2 className="font-semibold text-white">Provider 管理面尚未配置</h2>
+            <p className="mt-1 text-sm leading-6 text-amber-100/80">
+              请由运维人员注入 MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET。
+              模型调用与 Marble 设置不受影响。
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (!session.authenticated || !session.csrf_token) {
+    return (
+      <section className="mb-6 rounded-lg border border-white/10 bg-ink-950/82 p-5 shadow-prism">
+        <div className="flex items-center gap-2 text-hire-100">
+          <KeyRound className="h-4 w-4" />
+          <h2 className="font-semibold">Provider 管理员配对</h2>
+        </div>
+        <p className="mt-2 text-sm leading-6 text-slate-300">
+          配对密钥仅用于本次提交，不会写入浏览器存储、URL 或日志。
+        </p>
+        <form className="mt-4 flex max-w-2xl flex-col gap-3 sm:flex-row" onSubmit={pair}>
+          <input
+            autoComplete="new-password"
+            className="min-w-0 flex-1 rounded-lg border border-white/15 bg-slate-950 px-3 py-2.5 text-sm text-white outline-none focus:border-cyan-300/60"
+            onChange={(event) => setPairingSecret(event.target.value)}
+            placeholder="输入管理员配对密钥"
+            type="password"
+            value={pairingSecret}
+          />
+          <button
+            className="rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-slate-950 disabled:opacity-45"
+            disabled={!pairingSecret || submitting}
+            type="submit"
+          >
+            {submitting ? "正在配对" : "开始管理"}
+          </button>
+        </form>
+        {error ? (
+          <p className="mt-3 text-sm text-rose-200" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </section>
+    );
+  }
+
+  return (
+    <>
+      <div className="mb-4 flex items-center justify-between rounded-lg border border-emerald-300/20 bg-emerald-300/10 px-4 py-3 text-sm">
+        <span className="text-emerald-100">Provider 管理会话已解锁</span>
+        <button
+          className="inline-flex items-center gap-2 text-slate-200 hover:text-white disabled:opacity-45"
+          disabled={submitting}
+          onClick={() => void logout()}
+          type="button"
+        >
+          <LogOut className="h-4 w-4" />
+          注销
+        </button>
+      </div>
+      {error ? (
+        <p className="mb-4 text-sm text-rose-200" role="alert">
+          {error}
+        </p>
+      ) : null}
+      {children({ csrfToken: session.csrf_token })}
+    </>
+  );
+}

--- a/client/src/components/settings/SmartRoutingSettings.tsx
+++ b/client/src/components/settings/SmartRoutingSettings.tsx
@@ -130,6 +130,8 @@ const COMPRESSION_OPTIONS: Array<{
 ];
 
 async function readError(response: Response) {
+  if (response.status === 401) return "管理会话已失效，请重新配对。";
+  if (response.status === 503) return "Provider 管理面尚未配置或暂时不可用。";
   try {
     const payload = await response.json();
     if (typeof payload?.detail === "string") return payload.detail;
@@ -146,7 +148,11 @@ function percent(value?: number | null) {
   return value == null ? "暂无样本" : `${Math.round(value * 1000) / 10}%`;
 }
 
-export default function SmartRoutingSettings() {
+export default function SmartRoutingSettings({
+  csrfToken,
+}: {
+  csrfToken: string;
+}) {
   const [policy, setPolicy] = useState<RouterPolicy | null>(null);
   const [status, setStatus] = useState<RouterStatus | null>(null);
   const [diagnostics, setDiagnostics] = useState<RouterDiagnostics | null>(null);
@@ -205,7 +211,10 @@ export default function SmartRoutingSettings() {
     try {
       const response = await fetch("/api/router/policy", {
         method: "PUT",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "X-ModelMirror-CSRF": csrfToken,
+        },
         body: JSON.stringify(policy),
       });
       if (!response.ok) throw new Error(await readError(response));
@@ -217,7 +226,7 @@ export default function SmartRoutingSettings() {
     } finally {
       setSaving(false);
     }
-  }, [load, policy]);
+  }, [csrfToken, load, policy]);
 
   return (
     <section className="mb-6 overflow-hidden rounded-lg border border-white/10 bg-ink-950/82 shadow-prism">

--- a/client/src/pages/SystemSettingsPage.test.tsx
+++ b/client/src/pages/SystemSettingsPage.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import SystemSettingsPage, { resolveNewApiConsoleUrl } from "./SystemSettingsPage";
+
+vi.mock("../components/PageContainer", () => ({
+  default: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+}));
+vi.mock("../components/settings/ModelServiceConnections", () => ({
+  default: () => <div>connections</div>,
+}));
+vi.mock("../components/settings/MarbleConnectionSettings", () => ({
+  default: () => <div>marble</div>,
+}));
+vi.mock("../components/settings/SmartRoutingSettings", () => ({
+  default: () => <div>routing</div>,
+}));
+vi.mock("../components/settings/ProviderAdminGate", () => ({
+  default: ({
+    children,
+  }: {
+    children: (session: { csrfToken: string }) => ReactNode;
+  }) => <>{children({ csrfToken: "test-csrf" })}</>,
+}));
+
+describe("SystemSettingsPage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("accepts only safe external console URLs", () => {
+    expect(resolveNewApiConsoleUrl(undefined)).toBeNull();
+    expect(resolveNewApiConsoleUrl("javascript:alert(1)")).toBeNull();
+    expect(resolveNewApiConsoleUrl("https://user:secret@example.com")).toBeNull();
+    expect(resolveNewApiConsoleUrl("https://example.com/?token=secret")).toBeNull();
+    expect(resolveNewApiConsoleUrl("https://console.example.com/admin")?.host).toBe(
+      "console.example.com",
+    );
+  });
+
+  it("loads a safe runtime management URL without embedding the console", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ newApiWebUrl: "http://127.0.0.1:3000" }),
+      }),
+    );
+
+    render(<SystemSettingsPage />);
+    const link = await screen.findByRole("link", { name: "在新窗口管理" });
+    expect(link).toHaveAttribute("href", "http://127.0.0.1:3000/");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(screen.getByText("外部管理入口已配置")).toBeVisible();
+    expect(document.querySelector("iframe")).toBeNull();
+  });
+
+  it("shows an actionable runtime configuration instruction when unset", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ newApiWebUrl: "" }),
+      }),
+    );
+
+    render(<SystemSettingsPage />);
+    expect(await screen.findByText("外部管理入口未配置")).toBeVisible();
+    expect(screen.getByText(/请在 client 服务环境中配置后重启前端容器/)).toBeVisible();
+    expect(document.querySelector("iframe")).toBeNull();
+    expect(screen.queryByRole("link", { name: "在新窗口管理" })).toBeNull();
+  });
+});

--- a/client/src/pages/SystemSettingsPage.tsx
+++ b/client/src/pages/SystemSettingsPage.tsx
@@ -3,35 +3,67 @@ import PageContainer from "../components/PageContainer";
 import ModelServiceConnections from "../components/settings/ModelServiceConnections";
 import MarbleConnectionSettings from "../components/settings/MarbleConnectionSettings";
 import SmartRoutingSettings from "../components/settings/SmartRoutingSettings";
-
-const DEFAULT_NEWAPI_WEB_URL = "http://localhost:3000";
+import ProviderAdminGate from "../components/settings/ProviderAdminGate";
 
 function trimTrailingSlash(value: string) {
   return value.replace(/\/+$/, "");
 }
 
-function buildNewApiFrameUrl() {
-  const baseUrl = trimTrailingSlash(
-    import.meta.env.VITE_NEWAPI_WEB_URL || DEFAULT_NEWAPI_WEB_URL,
-  );
-  const url = new URL(baseUrl);
-  url.searchParams.set("embed", "true");
-  url.searchParams.set("source", "modelmirror");
-  return url.toString();
+export function resolveNewApiConsoleUrl(value: string | undefined) {
+  const configured = trimTrailingSlash(value?.trim() ?? "");
+  if (!configured) return null;
+  try {
+    const url = new URL(configured);
+    if (
+      !["http:", "https:"].includes(url.protocol) ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) {
+      return null;
+    }
+    return url;
+  } catch {
+    return null;
+  }
 }
 
-export default function SystemSettingsPage() {
-  const [loaded, setLoaded] = useState(false);
+type RuntimeConfig = {
+  newApiWebUrl?: string;
+};
 
-  const frameSrc = useMemo(() => buildNewApiFrameUrl(), []);
+export default function SystemSettingsPage() {
+  const buildTimeConsoleUrl = useMemo(
+    () => resolveNewApiConsoleUrl(import.meta.env.VITE_NEWAPI_WEB_URL),
+    [],
+  );
+  const [consoleUrl, setConsoleUrl] = useState<URL | null>(buildTimeConsoleUrl);
 
   useEffect(() => {
     document.title = "模镜 - 系统设置";
   }, []);
 
   useEffect(() => {
-    setLoaded(false);
-  }, [frameSrc]);
+    let active = true;
+    void fetch("/runtime-config.json", { cache: "no-store" })
+      .then(async (response) => {
+        if (!response.ok) return null;
+        return (await response.json()) as RuntimeConfig;
+      })
+      .then((config) => {
+        if (!active || !config) return;
+        setConsoleUrl(
+          resolveNewApiConsoleUrl(config.newApiWebUrl) ?? buildTimeConsoleUrl,
+        );
+      })
+      .catch(() => {
+        // Vite development and static-only deployments keep the build-time fallback.
+      });
+    return () => {
+      active = false;
+    };
+  }, [buildTimeConsoleUrl]);
 
   return (
     <PageContainer activeResource="agents" maxWidthClassName="max-w-[1760px]">
@@ -42,13 +74,19 @@ export default function SystemSettingsPage() {
         </h1>
         <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-300">
           在这里完成模型服务连接、Marble 世界生成、智能调度和上下文优化。
-          日常使用无需理解底层网关；newAPI 控制台仍作为高级渠道管理入口保留。
+          日常使用无需理解底层网关；外部数据面与 ModelMirror 控制面保持独立。
         </p>
       </header>
 
-      <ModelServiceConnections />
       <MarbleConnectionSettings />
-      <SmartRoutingSettings />
+      <ProviderAdminGate>
+        {({ csrfToken }) => (
+          <>
+            <ModelServiceConnections csrfToken={csrfToken} />
+            <SmartRoutingSettings csrfToken={csrfToken} />
+          </>
+        )}
+      </ProviderAdminGate>
 
       <section className="overflow-hidden rounded-lg border border-white/10 bg-ink-950/82 shadow-prism">
         <div className="flex flex-col gap-3 border-b border-white/10 bg-white/[0.035] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
@@ -57,55 +95,42 @@ export default function SystemSettingsPage() {
               newAPI Gateway
             </p>
             <h2 className="mt-2 text-2xl font-semibold text-white">
-              newAPI 统一网关管理
+              外部 newAPI 管理入口
             </h2>
             <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-400">
-              当前页面加载本地 newAPI 控制台。若 iframe 长时间空白，请确认
+              ModelMirror 不嵌入或代理 newAPI 管理界面。通过客户端容器环境变量
               <code className="mx-1 rounded bg-white/10 px-1 py-0.5">
-                modelmirror-new-api
+                NEWAPI_WEB_URL
               </code>
-              容器已启动，或通过
-              <code className="mx-1 rounded bg-white/10 px-1 py-0.5">
-                VITE_NEWAPI_WEB_URL
-              </code>
-              指定外部控制台地址。
+              配置后只需重启前端容器，无需重新构建镜像；该状态不代表网关运行健康。
             </p>
           </div>
-          <a
-            className="inline-flex items-center justify-center rounded-full border border-hire-300/30 bg-hire-300/10 px-4 py-2 text-sm font-semibold text-hire-100 transition hover:bg-hire-300/20"
-            href={frameSrc}
-            rel="noreferrer"
-            target="_blank"
-          >
-            新窗口打开
-          </a>
+          {consoleUrl ? (
+            <a
+              className="inline-flex items-center justify-center rounded-full border border-hire-300/30 bg-hire-300/10 px-4 py-2 text-sm font-semibold text-hire-100 transition hover:bg-hire-300/20"
+              href={consoleUrl.toString()}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              在新窗口管理
+            </a>
+          ) : null}
         </div>
 
-        <div className="relative h-[calc(100vh-300px)] min-h-[620px] bg-slate-950">
-          {!loaded ? (
-            <div className="absolute inset-0 z-10 flex items-center justify-center bg-slate-950">
-              <div className="w-full max-w-md rounded-lg border border-white/10 bg-white/[0.045] p-5 text-center">
-                <div className="mx-auto h-10 w-10 animate-pulse rounded-full border border-hire-300/35 bg-hire-300/15" />
-                <p className="mt-4 text-sm font-semibold text-white">
-                  正在连接 newAPI 控制台
-                </p>
-                <p className="mt-2 text-xs leading-5 text-slate-400">
-                  默认地址为
-                  <code className="mx-1 rounded bg-white/10 px-1 py-0.5">
-                    {DEFAULT_NEWAPI_WEB_URL}
-                  </code>
-                  。如果本地服务未启动，可先通过 Docker Compose 拉起。
-                </p>
-              </div>
-            </div>
-          ) : null}
-          <iframe
-            className="h-full w-full border-0"
-            onLoad={() => setLoaded(true)}
-            sandbox="allow-downloads allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
-            src={frameSrc}
-            title="newAPI 统一网关管理"
-          />
+        <div className="grid gap-4 px-5 py-5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+          <div>
+            <p className="text-sm font-semibold text-white">
+              {consoleUrl ? "外部管理入口已配置" : "外部管理入口未配置"}
+            </p>
+            <p className="mt-1 text-sm leading-6 text-slate-400">
+              {consoleUrl
+                ? `管理主机：${consoleUrl.host}`
+                : "未设置 NEWAPI_WEB_URL；请在 client 服务环境中配置后重启前端容器。ModelMirror 不会猜测或自动加载本地控制台。"}
+            </p>
+          </div>
+          <span className="rounded-full border border-white/10 bg-white/[0.045] px-3 py-1.5 text-xs text-slate-300">
+            {consoleUrl ? "仅外链" : "未配置"}
+          </span>
         </div>
       </section>
     </PageContainer>

--- a/deploy/newapi/compose.yml
+++ b/deploy/newapi/compose.yml
@@ -1,0 +1,28 @@
+services:
+  new-api:
+    image: calciumion/new-api:v1.0.0-rc.22@sha256:d600f20c2781e1a173c2a02f8c33b0c4b1b4e8e5a8b107bafaf2442ae2c9386c
+    restart: unless-stopped
+    ports:
+      - "${NEWAPI_BIND_HOST:-127.0.0.1}:${NEWAPI_PORT:-3000}:3000"
+    volumes:
+      - ${MODELMIRROR_DATA_ROOT:-../..}/new-api-data:/data
+    environment:
+      TZ: ${NEWAPI_TIMEZONE:-Asia/Shanghai}
+    networks:
+      provider:
+        aliases:
+          - new-api
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://localhost:3000/api/status >/dev/null 2>&1 || curl -fsS http://localhost:3000/api/status >/dev/null 2>&1",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+networks:
+  provider:
+    name: ${MODEL_PROVIDER_NETWORK_NAME:-modelmirror-provider}

--- a/deploy/newapi/modelmirror-overlay.yml
+++ b/deploy/newapi/modelmirror-overlay.yml
@@ -1,0 +1,13 @@
+services:
+  server:
+    environment:
+      LLM_GATEWAY_URL: ${LLM_GATEWAY_URL:?Set LLM_GATEWAY_URL explicitly before using modelmirror-overlay.yml}
+      MODEL_MIRROR_PROVIDER_INTERNAL_ALLOWLIST: ${MODEL_MIRROR_PROVIDER_INTERNAL_ALLOWLIST:-new-api:3000}
+    networks:
+      - default
+      - provider
+
+networks:
+  provider:
+    external: true
+    name: ${MODEL_PROVIDER_NETWORK_NAME:-modelmirror-provider}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -502,30 +502,6 @@ services:
       retries: 8
       start_period: 60s
 
-  new-api:
-    image: calciumion/new-api:latest
-    container_name: modelmirror-new-api
-    restart: always
-    ports:
-      - "3000:3000"
-    volumes:
-      - ${MODELMIRROR_DATA_ROOT:-.}/new-api-data:/data
-    environment:
-      TZ: Asia/Shanghai
-    networks:
-      - default
-      - coding_internal
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "wget -qO- http://localhost:3000/api/status >/dev/null 2>&1 || curl -fsS http://localhost:3000/api/status >/dev/null 2>&1",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
-
   server:
     build:
       context: ./server
@@ -551,13 +527,10 @@ services:
         condition: service_healthy
       mcp-database-local:
         condition: service_healthy
-      new-api:
-        condition: service_healthy
     env_file:
       - path: ${MODELMIRROR_DATA_ROOT:-.}/server/.env
         required: false
     environment:
-      LLM_GATEWAY_URL: http://new-api:3000/v1/chat/completions
       OMNIROUTE_BASE_URL: http://omniroute:20128
       OMNIROUTE_ENABLED: ${OMNIROUTE_ENABLED:-false}
       OMNIROUTE_API_KEY: ${OMNIROUTE_API_KEY:-}
@@ -565,7 +538,6 @@ services:
       OMNIROUTE_BUDGET_HEADERS_ENABLED: ${OMNIROUTE_BUDGET_HEADERS_ENABLED:-false}
       MODEL_ROUTER_ENGINE: ${MODEL_ROUTER_ENGINE:-}
       MODEL_ROUTER_CANARY_PERCENT: ${MODEL_ROUTER_CANARY_PERCENT:-0}
-      MODEL_ROUTER_TENANT_ID: ${MODEL_ROUTER_TENANT_ID:-local}
       MODEL_ROUTER_ALLOW_NATIVE_OVERRIDE: ${MODEL_ROUTER_ALLOW_NATIVE_OVERRIDE:-false}
       MODEL_ROUTER_STORAGE_DIR: /app/model_router/storage
       FILE_ASSET_STORE_MODE: ${FILE_ASSET_STORE_MODE:-legacy}
@@ -588,6 +560,8 @@ services:
       MODELMIRROR_DEFAULT_OWNER_ID: ${MODELMIRROR_DEFAULT_OWNER_ID:-local}
       MODEL_MIRROR_REQUIRE_EXTERNAL_CREDENTIAL_MASTER_KEY: ${MODEL_MIRROR_REQUIRE_EXTERNAL_CREDENTIAL_MASTER_KEY:-false}
       MODEL_MIRROR_CREDENTIAL_MASTER_KEY: ${MODEL_MIRROR_CREDENTIAL_MASTER_KEY:-}
+      MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET: ${MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET:-}
+      MODEL_MIRROR_PROVIDER_INTERNAL_ALLOWLIST: ${MODEL_MIRROR_PROVIDER_INTERNAL_ALLOWLIST:-}
       RAG_STORAGE_DIR: /app/rag/storage
       RAG_UPLOAD_DIR: /app/rag/uploads
       CHROMA_DB_PATH: /app/rag/storage/chroma_db
@@ -694,6 +668,8 @@ services:
     build:
       context: ./client
     container_name: modelmirror-client
+    environment:
+      NEWAPI_WEB_URL: ${NEWAPI_WEB_URL:-}
     depends_on:
       server:
         condition: service_healthy
@@ -708,14 +684,12 @@ services:
       context: .
       dockerfile: server/coding_worker/Dockerfile
     container_name: modelmirror-coding-runtime
-    depends_on:
-      new-api:
-        condition: service_healthy
     env_file:
       - path: ${MODELMIRROR_DATA_ROOT:-.}/server/.env
         required: false
     networks:
       - coding_internal
+      - coding_provider
     user: "65532:65532"
     read_only: true
     cap_drop:
@@ -734,6 +708,7 @@ services:
       CODING_VERIFIER_SOCKET_PATH: /run/modelmirror-coding/verifier.sock
       CODING_AGENT_MODE: ${CODING_AGENT_MODE:-readonly}
       CODING_AGENT_MODEL: ${CODING_AGENT_MODEL:-}
+      CODING_AGENT_MODEL_BASE_URL: ${CODING_AGENT_MODEL_BASE_URL:-}
       CODING_FILE_OPERATIONS_ENABLED: ${CODING_FILE_OPERATIONS_ENABLED:-true}
     volumes:
       - coding_socket:/run/modelmirror-coding
@@ -855,6 +830,9 @@ networks:
   coding_internal:
     driver: bridge
     internal: true
+  coding_provider:
+    external: true
+    name: ${CODING_PROVIDER_NETWORK_NAME:-modelmirror-coding-provider}
   mcp_public_egress:
     driver: bridge
   mcp_database_egress:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 > **文档范围：Current State。** 本文只描述当前主分支中能够由代码、配置和测试定位的已合并实现。AI Capability Compiler、Router Federation、统一 Capability Graph / Evaluation 与自演进闭环属于[目标架构](./architecture/ai-capability-compiler.md)，不能由本文件中的局部 Router、Runtime 或 Evaluation 入口外推为已经完成的平台能力。
 
-最后更新日期：2026-08-09
+最后更新日期：2026-08-13
 维护人：模镜团队
 
 ## 当前定位
@@ -31,7 +31,8 @@ Dify 不再承载 `/workflow` 或 `/rag` 主路径。仓库仍保留
 | React 19 + TypeScript + Vite | SPA、资源市场、工作区与任务界面。 |
 | Tailwind CSS + React Flow | 主题样式与 classic 工作流画布。 |
 | FastAPI + Pydantic + httpx | API 装配、校验、SSE 与外部服务适配。 |
-| newAPI / OpenAI-compatible | 默认模型服务连接与渠道管理。 |
+| Model Provider Control Plane | 单租户 Provider 连接、加密凭据、策略、诊断和受控出口。 |
+| newAPI / OpenAI-compatible | 独立可选数据面；只通过 URL/Key 契约接入，不嵌入其管理 UI。 |
 | OpenRouter | 默认网关不可用时的兼容回退，以及首期多模态能力来源。 |
 | 原生 Model Router | 目录、策略、熔断、预算、回执和上下文优化。 |
 | SQLite | 原生路由、连接、决策、视频任务元数据及单槽加密 Coding 恢复索引。 |
@@ -83,7 +84,7 @@ flowchart LR
   API <-->|"配对 / WebSocket 操作元数据"| HOST["Windows Project Host v2"]
   HOST -->|"拉取 90 秒单次负载 / no-store"| API
   HOST -->|"原子文件事务 / 固定 Git plumbing"| HOSTREPO["用户明确选择的 Windows Git 项目"]
-  CODER -->|"internal network"| GW
+  CODER -->|"独立外部网络 / 独立凭据"| CODEGW["Coding Provider"]
   CODER -->|"Patch + revision / Unix socket"| VERIFY["coding-verifier"]
   VERIFY -. "network_mode: none" .-> OFFLINE["无网络"]
   API -->|"独立 Unix socket"| APPLY["coding-applier"]
@@ -169,7 +170,8 @@ flowchart LR
   构建时排除私有环境文件、密钥和运行产物，仅保留仓库追踪的安全占位模板，再将
   净化源码快照复制到镜像内只读目录。
   Readonly 模式在会话副本上只读运行；Draft 模式把副本复制到 256 MiB 的
-  `nosuid,noexec` tmpfs。宿主仓库从不挂载给 Worker，网络仅可到内部 newAPI。
+  `nosuid,noexec` tmpfs。宿主仓库从不挂载给 Worker；模型出口只经独立的外部
+  `coding_provider` 网络到显式配置的 Coding Provider，不复用控制面 Provider 网络。
 - Coding Project Source 只在显式加载项目 overlay 后存在。它是唯一只读挂载
   `CODING_PROJECTS_ROOT` 的服务；Server 和 Runtime 既看不到整个项目根目录，也不接收
   物理路径。服务按固定清单校验干净独立 Git 克隆，通过 `git ls-tree` 与

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # 部署与运维指南
 
-最后更新日期：2026-08-01
+最后更新日期：2026-08-13
 维护人：模镜团队
 
 ## 支持边界
@@ -17,7 +17,6 @@ Dify 不是部署依赖。`/workflow` 和 `/rag` 分别由 classic 工作流和�
 | --- | --- | --- |
 | `client` | 是 | 前端静态站点，宿主端口 `5173`。 |
 | `server` | 是 | FastAPI，宿主端口 `8000`。 |
-| `new-api` | 是 | OpenAI-compatible 网关，宿主端口 `3000`。 |
 | `browser` | 是 | 受控浏览器 sidecar，不映射宿主端口。 |
 | `sandbox` | 是 | 无网络沙箱 sidecar。 |
 | `omniroute` | 否 | `omniroute` profile；只绑定 `127.0.0.1:20128`。 |
@@ -63,18 +62,40 @@ MODELMIRROR_DATA_ROOT=C:\absolute\path\to\stable\data\workspace
 
 固定使用 `-p modelmirror` 时，各 worktree 会共享容器名、镜像标签、端口和网络，因此同一时间
 只能由一个 worktree 重建活动栈。其他 worktree 应等待共享栈空闲，或仅运行不会重建活动容器的
-只读/临时测试。切换重建所有权后，应重新检查当前分支的 Server 路由，并确认 `new-api` 已加入
-`modelmirror_coding_internal`；不要把手工连接网络作为长期配置。
+只读/临时测试。newAPI 使用独立 Compose 项目，不得通过手工连接网络代替版本化 Overlay。
 
 ## 配置与密钥
 
-后端默认读取 `${MODELMIRROR_DATA_ROOT}/server/.env`。最低配置为 newAPI Key
-或 OpenRouter Key：
+后端默认读取 `${MODELMIRROR_DATA_ROOT}/server/.env`。使用外部 OpenAI-compatible
+数据面时必须同时显式配置 URL 与 Key，也可只配置 OpenRouter Key：
 
 ```bash
-LLM_GATEWAY_KEY=your-new-api-key
+LLM_GATEWAY_URL=https://gateway.example/v1/chat/completions
+LLM_GATEWAY_KEY=your-gateway-key
 OPENROUTER_API_KEY=your-openrouter-key
+NEWAPI_WEB_URL=http://localhost:3000
 ```
+
+`NEWAPI_WEB_URL` 只公开 newAPI 管理界面的外部 HTTP(S) 链接。它由 client
+容器在运行时提供给设置页，修改后只需重新创建 client，无需重新构建前端镜像。
+该变量不得包含 userinfo、query 或 fragment，也不能代替数据面健康检查。
+
+### 独立 newAPI 数据面
+
+newAPI 不属于核心 Compose。先启动独立栈，再按需加载互联 Overlay：
+
+```powershell
+$env:LLM_GATEWAY_URL = "http://new-api:3000/v1/chat/completions"
+docker compose -f deploy/newapi/compose.yml -p modelmirror-newapi up -d
+docker compose -f docker-compose.yml `
+  -f deploy/newapi/modelmirror-overlay.yml `
+  -p modelmirror up -d --build
+```
+
+独立栈固定官方未修改镜像 `v1.0.0-rc.22` 及多架构 digest，默认只把 UI 绑定到
+`127.0.0.1:3000`，并复用 `${MODELMIRROR_DATA_ROOT}/new-api-data`。停止或回退
+ModelMirror 不得删除该目录。newAPI 上游为带附加条款的 AGPLv3 项目；本仓库不
+嵌入或修改其管理 UI，部署者仍需自行完成许可证与业务使用合规审查。
 
 规则：
 
@@ -133,8 +154,10 @@ Compose 不会自动创建空证书目录；缺少 `localhost.crt` 或 `localhos
 ```bash
 CODING_AGENT_ENABLED=true
 CODING_AGENT_MODE=readonly
-CODING_AGENT_MODEL=your-new-api-model-id
+CODING_AGENT_MODEL=your-coding-model-id
+CODING_AGENT_MODEL_BASE_URL=https://your-coding-provider.example/v1
 CODING_AGENT_GATEWAY_KEY=your-dedicated-gateway-key
+CODING_PROVIDER_NETWORK_NAME=modelmirror-coding-provider
 ```
 
 `CODING_AGENT_MODE` 默认为 `readonly`。只有显式设置为 `draft`，代码助手才会在
@@ -150,7 +173,11 @@ docker compose -p modelmirror --profile coding --profile coding-verify ps
 curl http://localhost:8000/api/coding/capabilities
 ```
 
-`coding-runtime` 仅加入 `internal: true` 网络并通过 Unix socket 连接 FastAPI。
+`coding-runtime` 通过 `internal: true` 网络和 Unix socket 连接 FastAPI，并另外加入只供
+Coding 使用的外部 `coding_provider` 网络以访问显式 Provider URL。该网络必须由独立
+Provider 栈或运维预先创建；它不复用 `modelmirror-provider`，ModelMirror 也不管理其
+Provider、凭据或生命周期。缺少 URL 或外部网络时，Coding profile 应失败关闭，而不是
+回退到 newAPI 或 localhost。
 构建时会排除私有环境文件、密钥和运行产物，只保留仓库追踪的安全占位模板，再把
 净化源码快照复制进只读镜像目录；会话副本位于 256 MiB 的 `nosuid,noexec`
 tmpfs，容器根文件系统仍只读，且不映射宿主端口或宿主仓库。它是实验性本地
@@ -467,10 +494,18 @@ Publisher 无宿主端口、Docker socket 或工作区写权限，只能连接�
 location /api/ {
   proxy_pass http://modelmirror-server:8000;
   proxy_http_version 1.1;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_buffering off;
   proxy_read_timeout 3600s;
 }
 ```
+
+Provider 管理会话根据 ASGI `request.url.scheme` 决定是否设置 Secure Cookie。
+TLS 终止代理必须覆盖（而不是追加或透传客户端提供的）`X-Forwarded-Proto`，并在
+`server/.env` 通过 `FORWARDED_ALLOW_IPS` 只信任该代理的精确 IP 或最小 CIDR；
+不要使用 `*`。未被 Uvicorn 信任的转发头不会改变请求 scheme，管理配对会安全拒绝，
+核心数据面仍保持可用。
 
 视频内容代理可能返回较大响应，应设置合理的超时和响应体限制，但不得缓存含
 授权语义的上游临时地址。
@@ -571,7 +606,11 @@ CODING_WORKER_ROUTE_KEY=<dedicated-route-key>
 CODING_WORKER_BUILTIN_REVISION=<full-source-commit>
 ```
 
-`CODING_WORKER_MODEL_BASE_URL` 默认使用 `http://new-api:3000/v1`。若启用 `develop_networked`，还必须显式设置 `CODING_WORKER_NETWORK_ENABLED=true`、随机 `CODING_WORKER_EGRESS_GRANT_KEY` 和最小 `CODING_WORKER_NETWORK_DOMAINS`，并加载 `coding-worker-network` profile。不要把模型网关密钥复用为 slot、executor 或 egress token。
+`CODING_WORKER_MODEL_BASE_URL` 必须显式设置，且不得从 Provider Control Plane、Router
+SQLite 或 newAPI 互联 Overlay 继承。若启用 `develop_networked`，还必须显式设置
+`CODING_WORKER_NETWORK_ENABLED=true`、随机 `CODING_WORKER_EGRESS_GRANT_KEY` 和最小
+`CODING_WORKER_NETWORK_DOMAINS`，并加载 `coding-worker-network` profile。不要把模型
+网关密钥复用为 slot、executor 或 egress token。
 
 只做配置展开检查、不启动服务：
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -63,7 +63,7 @@ client/
 | `/rag/:kbId/evaluation` | `KnowledgeEvaluationPage` | 检索评测。 |
 | `/datax` | `DataXHomePage` | Data X 项目。 |
 | `/runtime` | `RuntimeOpsPage` | 运行诊断。 |
-| `/settings` | `SystemSettingsPage` | newAPI 控制台 iframe。 |
+| `/settings` | `SystemSettingsPage` | Provider 连接与策略；newAPI 仅通过 client 运行时 `NEWAPI_WEB_URL` 提供可选外部管理链接。 |
 
 `Xpert*` 仍是内部组件、类型和兼容 API 名称。面向用户的标题、按钮和帮助文案
 统一使用“智能体”“Agent Studio”“Agent App”，不要仅为改名破坏已持久化 ID

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -1,0 +1,75 @@
+# Model Provider Control Plane
+
+状态：Round 0–1C 建设批准，默认数据面切换未批准
+基线：`origin/main@6cc223505c4dc394f65902d3cb6e61f34ae11ea1`
+决策日期：2026-08-13
+
+## 决策
+
+ModelMirror 建设单租户 Model Provider Control Plane，统一管理动态 Provider
+连接、凭据、策略、诊断和安全出口。首期主体固定为 `tenant_id=local`，但认证、
+Service 与 Repository 接口继续保留租户边界。
+
+newAPI 是独立、未修改的 OpenAI-compatible 数据面，不是 ModelMirror 前端模块。
+ModelMirror 不嵌入、代理、复制或修改 newAPI 管理界面，只允许配置一个外部管理
+链接。newAPI 使用独立 Compose 项目、数据目录和生命周期；核心栈只通过显式
+URL/Key 契约连接。上游采用 AGPLv3 并包含附加条款，实际部署者仍需独立完成
+许可证与使用场景审查。
+
+Coding Runtime 继续使用自己的 Provider URL、Key、网络和审批边界，不读取
+Provider Control Plane 的会话、SQLite 或主密钥。它只加入独立外部
+`coding_provider` 网络，不加入控制面/newAPI 的 `provider` 网络。
+
+## 授权与门禁
+
+- 本决策解除 2026-07-28 对原生路由继续建设的功能冻结，仅批准控制面、安全与
+  兼容建设。
+- `native` 默认仍需至少 500 次真实请求、连续 14 天、无 P0/P1、故障演练和人工
+  验收；数据不能被修改来伪造门槛。
+- Round 0–1C 不改变 `/api/chat`、SSE、公开模型目录或默认路由协议。
+- newAPI 是否成为强制默认数据面由后续独立决策决定。
+- 任一门禁失败时保留现有静态数据面和 SQLite，不自动迁移或删除数据。
+
+## 部署边界
+
+- 核心栈：`docker-compose.yml`，能够在 newAPI 未运行时达到基础健康状态。
+- newAPI 栈：`deploy/newapi/compose.yml`，使用固定镜像 digest 并复用现有
+  `new-api-data`。
+- 互联：`deploy/newapi/modelmirror-overlay.yml`，只让 Server 加入显式共享网络并注入
+  URL；Coding Runtime 不加入该网络。
+- newAPI 栈必须先启动；核心 Compose 不使用跨项目 `depends_on`，也不接管其升级、
+  停止或数据恢复。
+
+## 管理会话与动态出口
+
+- `POST/GET/DELETE /api/router/admin/session` 使用外部注入、至少 32 字符的配对密钥；
+  服务端只保存 32-byte 随机会话令牌的哈希，会话绝对有效期 8 小时并随重启失效。
+- Cookie 限定 `HttpOnly; SameSite=Strict; Path=/api/router`；非 HTTPS 仅允许 loopback，
+  写操作还必须提供内存中的 `X-ModelMirror-CSRF`。
+- 动态 Provider 的公网目标仅允许 HTTPS；内网 HTTP(S) 必须精确加入
+  `MODEL_MIRROR_PROVIDER_INTERNAL_ALLOWLIST=host:port`。
+- 每次请求重新解析全部 A/AAAA 结果；混合公共/私有解析整体拒绝。实际连接固定到已批准
+  IP，同时保留原始 Host 与 TLS SNI，不跟随重定向且不读取代理环境变量。
+- Metadata、link-local、multicast、unspecified 与保留地址永久禁止，白名单不能覆盖。
+
+## 主密钥与显式迁移
+
+密钥优先级固定为：测试构造参数、`MODEL_MIRROR_CREDENTIAL_MASTER_KEY`、弃用的
+`MODEL_ROUTER_CREDENTIAL_MASTER_KEY`、开发模式本地 `credential-master.key`。启用
+`MODEL_MIRROR_REQUIRE_EXTERNAL_CREDENTIAL_MASTER_KEY=true` 后只接受规范变量；缺失时
+锁定动态控制面，不回退旧变量或本地文件。
+
+变更密钥必须显式运行：
+
+```powershell
+python -m server.model_router.migrate_credentials --storage-dir <path>
+```
+
+命令先全量解密预检，再使用 SQLite Backup API 创建时间戳备份，在
+`BEGIN IMMEDIATE` 中重加密并逐条回读验证，最后写入密钥指纹。失败会 Rollback；旧
+数据库备份和本地旧密钥文件不会被删除。回退时恢复备份并重新启用旧密钥来源。
+
+## 回退
+
+关闭管理面或回退路由不得删除 Provider SQLite、newAPI 数据目录、旧主密钥或迁移
+备份。部署回退通过恢复上一版本 Compose 与对应显式环境配置完成。

--- a/docs/MODEL_ROUTER_NATIVE.md
+++ b/docs/MODEL_ROUTER_NATIVE.md
@@ -1,6 +1,11 @@
 # 原生智能调度与上下文优化
 
-最后更新日期：2026-08-17
+最后更新日期：2026-08-20
+
+> **2026-08-13 决策更新：** 项目维护人已解除“禁止继续建设”的功能冻结，并批准
+> 建设 [Model Provider Control Plane](./MODEL_PROVIDER_CONTROL_PLANE.md)。解除冻结
+> 不等于批准提高灰度或切换 `native` 默认；500 次请求、14 天、无 P0/P1、故障演练
+> 与人工验收门禁全部保留。下方 2026-07-28 内容作为历史基线继续保留。
 
 ## 当前状态
 
@@ -146,7 +151,10 @@ PostgreSQL 时替换 repository 实现，不改变 service 或 API 契约。
 ## 配置
 
 ```dotenv
-MODEL_ROUTER_TENANT_ID=local
+MODELMIRROR_DEFAULT_TENANT_ID=local
+MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET=<至少 32 字符的外部 Secret>
+MODEL_MIRROR_PROVIDER_INTERNAL_ALLOWLIST=new-api:3000
+MODEL_MIRROR_CREDENTIAL_MASTER_KEY=<外部 Secret>
 MODEL_ROUTER_CANARY_PERCENT=0
 MODEL_ROUTER_ALLOW_NATIVE_OVERRIDE=false
 MODEL_ROUTER_NATIVE_ALGORITHM=omniroute-parity-v2

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -20,19 +20,25 @@ Dify 不是当前启动依赖。`/workflow` 和 `/rag` 均由 ModelMirror 原生
 Copy-Item server/.env.example server/.env
 ```
 
-至少配置一种模型访问方式。推荐先启动 newAPI，在
-`http://localhost:3000` 创建本地渠道和 ModelMirror 专用 Key，然后写入：
-
-```bash
-LLM_GATEWAY_KEY=your-new-api-key
-```
-
-Docker Compose 会把 `LLM_GATEWAY_URL` 指向容器内
-`http://new-api:3000/v1/chat/completions`。也可配置 OpenRouter 回退：
+至少配置一种模型访问方式。最简单的核心栈启动方式是在 `server/.env` 配置
+OpenRouter：
 
 ```bash
 OPENROUTER_API_KEY=your-openrouter-key
 ```
+
+若使用 newAPI，请先在 `http://localhost:3000` 创建本地渠道和 ModelMirror
+专用 Key，再显式启动独立栈和互联 Overlay：
+
+```powershell
+$env:LLM_GATEWAY_URL="http://new-api:3000/v1/chat/completions"
+docker compose -f deploy/newapi/compose.yml -p modelmirror-newapi up -d
+docker compose -f docker-compose.yml -f deploy/newapi/modelmirror-overlay.yml -p modelmirror up -d --build
+```
+
+同时在 `server/.env` 配置 `LLM_GATEWAY_KEY`。核心 Compose 不会启动 newAPI，
+Overlay 也不会替 ModelMirror 推断网关 URL；详细隔离和回滚方式见
+[`DEPLOYMENT.md`](DEPLOYMENT.md)。
 
 STT、TTS 和视频能力依赖 OpenRouter。视频入口默认关闭，完成人工费用验收后
 在 `server/.env` 启用：
@@ -64,8 +70,8 @@ curl http://localhost:8000/api/health
 curl http://localhost:5173/models
 ```
 
-核心服务为 `client`、`server`、`new-api`、`browser` 和 `sandbox`。
-`omniroute` 与 `office-host` 使用可选 profile，不属于默认启动前提。
+核心服务为 `client`、`server`、`browser` 和 `sandbox`。newAPI 使用独立可选
+Compose 栈；`omniroute` 与 `office-host` 使用可选 profile，不属于默认启动前提。
 
 ## 可选：本地热更新
 
@@ -104,7 +110,7 @@ npm.cmd run dev -- --host 0.0.0.0 --port 5173
 | 工作流 | `http://localhost:5173/workflow` | classic React Flow 画布可用。 |
 | RAG | `http://localhost:5173/rag` | 本地知识库与流水线状态可用。 |
 | Data X | `http://localhost:5173/datax` | 项目入口可用。 |
-| 设置 | `http://localhost:5173/settings` | newAPI 控制台与脱敏状态卡可见。 |
+| 设置 | `http://localhost:5173/settings` | Provider 管理面可配对；newAPI 仅显示显式配置的外部管理链接，不嵌入其界面。 |
 
 多模态验收需从模型招聘会选择对应 `operation`，不要把 STT、TTS 或视频生成
 模型当作普通文本模型调用。

--- a/docs/REPOSITORY_FACTS.md
+++ b/docs/REPOSITORY_FACTS.md
@@ -22,7 +22,7 @@
 | Data X | 文件快照、DuckDB、语义模型、指标、受限查询与提案审批 | `server/datax/`、`client/src/pages/DataX*.tsx` |
 | Prompt / Plugin | Prompt Profile 支持不可变版本和斜杠命令；Plugin 是声明式本地资源包，不加载动态后端代码 | `server/prompts/`、`server/plugins/`、`client/src/pages/PromptsPage.tsx`、`client/src/pages/PluginsPage.tsx` |
 | 持久化 | 多数 Runtime/Xpert 元数据使用文件型 Store；RAG 使用 Chroma/FTS，Data X 使用 DuckDB | `server/xpert_runtime/`、`server/xperts/`、`server/rag/`、`server/datax/` |
-| 隔离服务 | Compose 包含 Browser 和 Sandbox sidecar；另有 new-api、server、client，可选 office-host | `docker-compose.yml` |
+| 隔离服务 | 核心 Compose 包含 Browser、Sandbox、server 和 client；newAPI 位于独立可选 Compose 栈，另有可选 office-host | `docker-compose.yml`、`deploy/newapi/compose.yml` |
 | Dify | 只保留 `/api/dify/*` 兼容代理和旧 iframe 组件；主前端路由与 Compose 不依赖 Dify | `client/src/App.tsx`、`server/api/dify_proxy.py`、`docker-compose.yml` |
 | 多模态 | 图片识别与图片生成已按输入/输出方向拆分；图片生成使用专用完整响应工作区；另有 STT/TTS、Chat 音频附件、原生音频流、独立音乐任务、直接 OpenAI WebRTC 实时语音、视频理解和独立视频任务。入口均受实时能力与功能开关控制 | `server/multimodal/`、`client/src/components/*Workspace.tsx` |
 | 模型快照 | 当前合并 517 个 OpenRouter 快照模型（462 个实时目录模型与 55 个保留历史模型）；`/models` 额外展示 2 个直接 OpenAI Realtime 档案 | `client/src/data/models.ts`、`client/src/pages/ModelListPage.tsx` |

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,10 +1,9 @@
-# 推荐：newAPI 或其他 OpenAI-compatible 网关。
-# Docker Compose 会覆盖 URL 为 http://new-api:3000/v1/chat/completions。
-LLM_GATEWAY_URL=http://localhost:3000/v1/chat/completions
-LLM_GATEWAY_KEY=your-new-api-key
+# 独立 newAPI 或其他 OpenAI-compatible 数据面；核心 Compose 不提供隐式 URL。
+LLM_GATEWAY_URL=
+LLM_GATEWAY_KEY=
 
 # 回退与首期多模态能力。
-OPENROUTER_API_KEY=sk-or-v1-your-key-here
+OPENROUTER_API_KEY=
 ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 OPENROUTER_HTTP_REFERER=http://localhost:5173
 OPENROUTER_APP_TITLE=ModelMirror
@@ -81,7 +80,8 @@ MULTIMODAL_IMAGE_GENERATION_ENABLED=true
 # 实验性代码助手默认关闭且保持只读。Draft 只写容器内临时副本，不写回宿主仓库。
 CODING_AGENT_ENABLED=false
 CODING_AGENT_MODE=readonly
-CODING_AGENT_MODEL=your-new-api-model-id
+CODING_AGENT_MODEL=your-coding-model-id
+CODING_AGENT_MODEL_BASE_URL=https://coding-provider.example/v1
 CODING_AGENT_GATEWAY_KEY=your-dedicated-gateway-key
 
 # 视频能力默认关闭；完成模型与费用验收后再按需启用。
@@ -110,7 +110,12 @@ MODEL_ROUTER_DEFAULT=newapi
 MODEL_ROUTER_ENGINE=
 MODEL_ROUTER_NATIVE_ALGORITHM=omniroute-parity-v2
 MODEL_ROUTER_CANARY_PERCENT=0
-MODEL_ROUTER_TENANT_ID=local
+MODELMIRROR_DEFAULT_TENANT_ID=local
+MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET=
+MODEL_MIRROR_PROVIDER_INTERNAL_ALLOWLIST=
+MODEL_MIRROR_CREDENTIAL_MASTER_KEY=
+MODEL_MIRROR_REQUIRE_EXTERNAL_CREDENTIAL_MASTER_KEY=false
+# MODEL_ROUTER_CREDENTIAL_MASTER_KEY=  # Deprecated migration source only.
 MODEL_ROUTER_ALLOW_NATIVE_OVERRIDE=false
 OMNIROUTE_CATALOG_TTL_SECONDS=30
 OMNIROUTE_STALE_TTL_SECONDS=600

--- a/server/agent_workspace/gateway.py
+++ b/server/agent_workspace/gateway.py
@@ -70,9 +70,7 @@ class OpenAICompatibleGateway:
             url = self._gateway_url.strip()
             key = (self._gateway_key or "").strip()
         else:
-            local_url = os.getenv(
-                "LLM_GATEWAY_URL", "http://localhost:3000/v1/chat/completions"
-            ).strip()
+            local_url = os.getenv("LLM_GATEWAY_URL", "").strip()
             local_key = os.getenv("LLM_GATEWAY_KEY", "").strip()
             openrouter_key = os.getenv("OPENROUTER_API_KEY", "").strip()
             if local_url and local_key:

--- a/server/coding_runtime/worker.py
+++ b/server/coding_runtime/worker.py
@@ -15,6 +15,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from .acp_client import AcpClient, AcpProcessConfig, AcpRequestTimeout
 from .command_bridge import (
@@ -91,7 +92,6 @@ VERIFIER_SOCKET_PATH = Path(
 )
 OPENCODE_PATH = "/usr/local/bin/opencode"
 RIPGREP_PATH = "/usr/bin/rg"
-INTERNAL_GATEWAY_BASE_URL = "http://new-api:3000/v1"
 SAFE_MODEL_ID = re.compile(r"^[A-Za-z0-9._:/-]{1,200}$")
 SAFE_RECOVERY_REASON = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 SAFE_RUNNER_TOKEN = re.compile(r"^[A-Za-z0-9_-]{32,128}$")
@@ -242,6 +242,22 @@ def build_opencode_config(
             "Coding project commands are not configured safely.",
             code="not_configured",
         )
+    gateway_base_url = (
+        os.getenv("CODING_AGENT_MODEL_BASE_URL", "").strip().rstrip("/")
+    )
+    parsed_gateway = urlparse(gateway_base_url)
+    if (
+        parsed_gateway.scheme not in {"http", "https"}
+        or not parsed_gateway.netloc
+        or parsed_gateway.username
+        or parsed_gateway.password
+        or parsed_gateway.query
+        or parsed_gateway.fragment
+    ):
+        raise CodingWorkerError(
+            "Coding Agent model provider is not configured safely.",
+            code="not_configured",
+        )
     permission = _permission_for_mode(
         mode,
         commands_enabled=commands_enabled,
@@ -268,9 +284,9 @@ def build_opencode_config(
         "provider": {
             "modelmirror": {
                 "npm": "@ai-sdk/openai-compatible",
-                "name": "ModelMirror Internal Gateway",
+                "name": "Independent Coding Provider",
                 "options": {
-                    "baseURL": INTERNAL_GATEWAY_BASE_URL,
+                    "baseURL": gateway_base_url,
                     "apiKey": "{env:CODING_AGENT_GATEWAY_KEY}",
                 },
                 "models": {
@@ -352,6 +368,12 @@ def create_acp_client(
         ensure_ascii=False,
         separators=(",", ":"),
     )
+    provider_host = urlparse(
+        os.getenv("CODING_AGENT_MODEL_BASE_URL", "")
+    ).hostname
+    no_proxy = ",".join(
+        ["localhost", "127.0.0.1", *([provider_host] if provider_host else [])]
+    )
     child_environment = {
         "PATH": "/usr/local/bin:/usr/bin:/bin",
         "PYTHONPATH": "/opt/modelmirror",
@@ -369,8 +391,8 @@ def create_acp_client(
         "OPENCODE_DISABLE_MODELS_FETCH": "1",
         "OPENCODE_AUTH_CONTENT": "{}",
         "CODING_AGENT_GATEWAY_KEY": gateway_key,
-        "NO_PROXY": "new-api,localhost,127.0.0.1",
-        "no_proxy": "new-api,localhost,127.0.0.1",
+        "NO_PROXY": no_proxy,
+        "no_proxy": no_proxy,
     }
     return AcpClient(
         AcpProcessConfig(

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -11,7 +11,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import httpx
 from pydantic import Field
@@ -378,7 +378,7 @@ class OpenCodeProvider(CodingAgentProvider):
             "provider": {
                 "modelmirror": {
                     "npm": "@ai-sdk/openai-compatible",
-                    "name": "ModelMirror Internal Gateway",
+                    "name": "Independent Coding Provider",
                     "options": {
                         "baseURL": route.base_url,
                         "apiKey": "{env:CODING_WORKER_ROUTE_KEY}",
@@ -411,6 +411,10 @@ class OpenCodeProvider(CodingAgentProvider):
         password = secrets.token_urlsafe(32)
         port = _unused_loopback_port()
         broker_environment, revoke_broker = self._broker_environment(request.task_id)
+        provider_host = urlparse(route.base_url).hostname
+        no_proxy = ",".join(
+            ["localhost", "127.0.0.1", *([provider_host] if provider_host else [])]
+        )
         environment = {
             "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
             "HOME": str(home),
@@ -431,8 +435,8 @@ class OpenCodeProvider(CodingAgentProvider):
             "OPENCODE_AUTH_CONTENT": "{}",
             "OPENCODE_SERVER_PASSWORD": password,
             "CODING_WORKER_ROUTE_KEY": route.api_key,
-            "NO_PROXY": "127.0.0.1,localhost,new-api",
-            "no_proxy": "127.0.0.1,localhost,new-api",
+            "NO_PROXY": no_proxy,
+            "no_proxy": no_proxy,
             **OPENCODE_SECURITY_ENVIRONMENT,
             **broker_environment,
         }

--- a/server/main.py
+++ b/server/main.py
@@ -989,7 +989,7 @@ def env_int(name: str, default: int, minimum: int) -> int:
 
 LLM_GATEWAY_URL = os.getenv(
     "LLM_GATEWAY_URL",
-    "http://localhost:3000/v1/chat/completions",
+    "",
 ).strip()
 LLM_GATEWAY_KEY = os.getenv("LLM_GATEWAY_KEY", "").strip()
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "").strip()
@@ -3601,7 +3601,11 @@ def build_chat_payload_from_messages(
 
 def llm_client_kwargs() -> dict[str, Any]:
     timeout = httpx.Timeout(connect=15, read=None, write=30, pool=10)
-    client_kwargs: dict[str, Any] = {"timeout": timeout}
+    client_kwargs: dict[str, Any] = {
+        "timeout": timeout,
+        "follow_redirects": False,
+        "trust_env": False,
+    }
     proxy = proxy_url()
     if proxy:
         client_kwargs["proxy"] = proxy
@@ -3633,7 +3637,9 @@ async def get_shared_llm_client() -> httpx.AsyncClient:
         if _shared_llm_client is None or bool(
             getattr(_shared_llm_client, "is_closed", False)
         ):
-            _shared_llm_client = httpx.AsyncClient(**llm_client_kwargs())
+            client_kwargs = llm_client_kwargs()
+            client_kwargs.pop("proxy", None)
+            _shared_llm_client = httpx.AsyncClient(**client_kwargs)
             _shared_llm_client_factory = httpx.AsyncClient
         return _shared_llm_client
 
@@ -22085,6 +22091,23 @@ async def chat(payload: ChatRequest, request: Request):
         request_headers = llm_gateway_headers(gateway_key)
         if use_omniroute and gateway_url == url:
             request_headers.update(omniroute_routing_headers(payload.routing))
+        managed_native_url = bool(
+            use_native_router
+            and native_plan is not None
+            and any(
+                target.chat_completions_url == gateway_url
+                for target in native_plan.targets
+            )
+        )
+        if managed_native_url:
+            return await native_router_engine.service.egress_policy.request(
+                client,
+                "POST",
+                gateway_url,
+                headers=request_headers,
+                json=request_payload,
+                stream=True,
+            )
         return await client.send(
             client.build_request(
                 "POST",

--- a/server/model_router/admin_auth.py
+++ b/server/model_router/admin_auth.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import secrets
+import threading
+import time
+import math
+import logging
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from ipaddress import ip_address
+from urllib.parse import urlparse
+
+from fastapi import HTTPException, Request, Response, status
+from pydantic import BaseModel, Field, SecretStr
+
+
+PAIRING_SECRET_ENV = "MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET"
+COOKIE_NAME = "modelmirror_provider_admin"
+COOKIE_PATH = "/api/router"
+SESSION_TTL_SECONDS = 8 * 60 * 60
+MIN_PAIRING_SECRET_CHARS = 32
+MAX_SESSIONS = 128
+MAX_FAILED_ATTEMPTS = 5
+FAILED_ATTEMPT_WINDOW_SECONDS = 5 * 60
+logger = logging.getLogger("modelmirror.provider_admin")
+
+
+class AdminPairingRequest(BaseModel):
+    pairing_secret: SecretStr = Field(min_length=1, max_length=4096)
+
+
+class AdminSessionResponse(BaseModel):
+    configured: bool
+    authenticated: bool
+    expires_at: float | None = None
+    csrf_token: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderControlPrincipal:
+    tenant_id: str = "local"
+    role: str = "provider_admin"
+
+
+@dataclass(slots=True)
+class _Session:
+    csrf_token: str
+    expires_at: float
+    principal: ProviderControlPrincipal
+
+
+def _public_error(
+    code: str,
+    message: str,
+    status_code: int,
+    *,
+    headers: dict[str, str] | None = None,
+) -> HTTPException:
+    return HTTPException(
+        status_code=status_code,
+        detail={"code": code, "message": message},
+        headers=headers,
+    )
+
+
+class ProviderAdminAuth:
+    def __init__(self, pairing_secret: str | None = None) -> None:
+        configured_secret = (
+            pairing_secret
+            if pairing_secret is not None
+            else os.getenv(PAIRING_SECRET_ENV, "")
+        ).strip()
+        self._secret_digest = (
+            hashlib.sha256(configured_secret.encode("utf-8")).digest()
+            if len(configured_secret) >= MIN_PAIRING_SECRET_CHARS
+            else None
+        )
+        self._sessions: dict[str, _Session] = {}
+        self._failures: dict[str, deque[float]] = defaultdict(deque)
+        self._lock = threading.RLock()
+
+    @property
+    def configured(self) -> bool:
+        return self._secret_digest is not None
+
+    def status(self, request: Request) -> AdminSessionResponse:
+        session = self._session_from_request(request)
+        return AdminSessionResponse(
+            configured=self.configured,
+            authenticated=session is not None,
+            expires_at=session.expires_at if session else None,
+            csrf_token=session.csrf_token if session else None,
+        )
+
+    def pair(
+        self,
+        request: Request,
+        response: Response,
+        pairing_secret: str,
+    ) -> AdminSessionResponse:
+        if not self.configured:
+            raise _public_error(
+                "admin_pairing_not_configured",
+                "Provider 管理面尚未配置配对密钥。",
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        client_key = self._client_key(request)
+        source = self._source_fingerprint(client_key)
+        now = time.time()
+        with self._lock:
+            failures = self._active_failures(client_key, now)
+            if len(failures) >= MAX_FAILED_ATTEMPTS:
+                retry_after = max(
+                    1,
+                    math.ceil(
+                        failures[0] + FAILED_ATTEMPT_WINDOW_SECONDS - now
+                    ),
+                )
+                logger.warning("provider_admin_pairing_rate_limited source=%s", source)
+                raise _public_error(
+                    "admin_pairing_rate_limited",
+                    "配对尝试过多，请稍后重试。",
+                    status.HTTP_429_TOO_MANY_REQUESTS,
+                    headers={"Retry-After": str(retry_after)},
+                )
+            candidate = hashlib.sha256(pairing_secret.encode("utf-8")).digest()
+            if not hmac.compare_digest(candidate, self._secret_digest or b""):
+                failures.append(now)
+                logger.warning("provider_admin_pairing_failed source=%s", source)
+                raise _public_error(
+                    "admin_pairing_failed",
+                    "配对信息无效。",
+                    status.HTTP_401_UNAUTHORIZED,
+                )
+            failures.clear()
+            self._purge_expired(now)
+            if len(self._sessions) >= MAX_SESSIONS:
+                oldest = min(
+                    self._sessions,
+                    key=lambda key: self._sessions[key].expires_at,
+                )
+                self._sessions.pop(oldest, None)
+            token = secrets.token_urlsafe(32)
+            token_hash = self._token_hash(token)
+            session = _Session(
+                csrf_token=secrets.token_urlsafe(32),
+                expires_at=now + SESSION_TTL_SECONDS,
+                principal=ProviderControlPrincipal(),
+            )
+            self._sessions[token_hash] = session
+        logger.info("provider_admin_pairing_succeeded source=%s", source)
+        secure = self._secure_cookie_required(request)
+        response.set_cookie(
+            COOKIE_NAME,
+            token,
+            max_age=SESSION_TTL_SECONDS,
+            httponly=True,
+            secure=secure,
+            samesite="strict",
+            path=COOKIE_PATH,
+        )
+        return AdminSessionResponse(
+            configured=True,
+            authenticated=True,
+            expires_at=session.expires_at,
+            csrf_token=session.csrf_token,
+        )
+
+    def require(self, request: Request) -> ProviderControlPrincipal:
+        if not self.configured:
+            raise _public_error(
+                "admin_pairing_not_configured",
+                "Provider 管理面尚未配置配对密钥。",
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        session = self._session_from_request(request)
+        if session is None:
+            raise _public_error(
+                "admin_session_required",
+                "请先完成 Provider 管理员配对。",
+                status.HTTP_401_UNAUTHORIZED,
+            )
+        return session.principal
+
+    def require_csrf(self, request: Request) -> ProviderControlPrincipal:
+        principal = self.require(request)
+        session = self._session_from_request(request)
+        supplied = request.headers.get("X-ModelMirror-CSRF", "")
+        if session is None or not hmac.compare_digest(supplied, session.csrf_token):
+            raise _public_error(
+                "admin_csrf_invalid",
+                "管理会话校验失败，请刷新页面后重试。",
+                status.HTTP_403_FORBIDDEN,
+            )
+        return principal
+
+    def logout(self, request: Request, response: Response) -> None:
+        self.require_csrf(request)
+        token = request.cookies.get(COOKIE_NAME, "")
+        if token:
+            with self._lock:
+                self._sessions.pop(self._token_hash(token), None)
+        logger.info(
+            "provider_admin_session_ended source=%s",
+            self._source_fingerprint(self._client_key(request)),
+        )
+        response.delete_cookie(COOKIE_NAME, path=COOKIE_PATH, samesite="strict")
+
+    def _session_from_request(self, request: Request) -> _Session | None:
+        token = request.cookies.get(COOKIE_NAME, "")
+        if not token:
+            return None
+        now = time.time()
+        token_hash = self._token_hash(token)
+        with self._lock:
+            self._purge_expired(now)
+            return self._sessions.get(token_hash)
+
+    def _active_failures(self, client_key: str, now: float) -> deque[float]:
+        failures = self._failures[client_key]
+        cutoff = now - FAILED_ATTEMPT_WINDOW_SECONDS
+        while failures and failures[0] <= cutoff:
+            failures.popleft()
+        return failures
+
+    def _purge_expired(self, now: float) -> None:
+        for token_hash in [
+            key for key, session in self._sessions.items() if session.expires_at <= now
+        ]:
+            self._sessions.pop(token_hash, None)
+
+    @staticmethod
+    def _token_hash(token: str) -> str:
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _client_key(request: Request) -> str:
+        return request.client.host if request.client else "unknown"
+
+    @staticmethod
+    def _source_fingerprint(client_key: str) -> str:
+        return hashlib.sha256(client_key.encode("utf-8")).hexdigest()[:12]
+
+    @staticmethod
+    def _secure_cookie_required(request: Request) -> bool:
+        scheme = request.url.scheme.lower()
+        origin = request.headers.get("origin", "").strip()
+        origin_url = urlparse(origin) if origin else None
+        if scheme == "https":
+            return True
+        if scheme != "http" or (origin_url and origin_url.scheme != "http"):
+            raise _public_error(
+                "admin_https_required",
+                "Provider 管理配对仅允许 HTTPS 或本机回环地址。",
+                status.HTTP_403_FORBIDDEN,
+            )
+        host = (origin_url.hostname if origin_url else request.url.hostname) or ""
+        try:
+            loopback = ip_address(host).is_loopback
+        except ValueError:
+            loopback = host.casefold() == "localhost"
+        if not loopback:
+            raise _public_error(
+                "admin_https_required",
+                "Provider 管理配对仅允许 HTTPS 或本机回环地址。",
+                status.HTTP_403_FORBIDDEN,
+            )
+        return False
+
+
+_auth: ProviderAdminAuth | None = None
+
+
+def get_provider_admin_auth() -> ProviderAdminAuth:
+    global _auth
+    if _auth is None:
+        _auth = ProviderAdminAuth()
+    return _auth
+
+
+def reset_provider_admin_auth() -> None:
+    global _auth
+    _auth = None
+
+
+def require_provider_admin(request: Request) -> ProviderControlPrincipal:
+    return get_provider_admin_auth().require(request)
+
+
+def require_provider_admin_csrf(request: Request) -> ProviderControlPrincipal:
+    return get_provider_admin_auth().require_csrf(request)

--- a/server/model_router/api.py
+++ b/server/model_router/api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
 try:
     from server.omniroute.catalog import OmniRouteCatalogService
@@ -12,6 +12,15 @@ except ModuleNotFoundError:
     from omniroute.schemas import ModelCatalogResponse, RouterStatusResponse
 
 from .repository import RouterRepositoryError
+from .egress import ProviderEgressError
+from .admin_auth import (
+    AdminPairingRequest,
+    AdminSessionResponse,
+    ProviderControlPrincipal,
+    get_provider_admin_auth,
+    require_provider_admin,
+    require_provider_admin_csrf,
+)
 from .schemas import (
     ConnectionTestResult,
     RouterConnection,
@@ -81,11 +90,42 @@ def _raise_public_error(exc: Exception) -> None:
     ) from exc
 
 
+@router.post("/admin/session", response_model=AdminSessionResponse)
+def pair_admin_session(
+    payload: AdminPairingRequest,
+    request: Request,
+    response: Response,
+) -> AdminSessionResponse:
+    return get_provider_admin_auth().pair(
+        request,
+        response,
+        payload.pairing_secret.get_secret_value(),
+    )
+
+
+@router.get("/admin/session", response_model=AdminSessionResponse)
+def get_admin_session(request: Request) -> AdminSessionResponse:
+    return get_provider_admin_auth().status(request)
+
+
+@router.delete(
+    "/admin/session",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def delete_admin_session(request: Request) -> Response:
+    response = Response(status_code=status.HTTP_204_NO_CONTENT)
+    get_provider_admin_auth().logout(request, response)
+    return response
+
+
 @router.get("/connections", response_model=list[RouterConnection])
-def list_connections() -> list[RouterConnection]:
+def list_connections(
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin),
+) -> list[RouterConnection]:
     try:
         return get_model_router_service().list_connections()
-    except RouterRepositoryError as exc:
+    except (RouterServiceError, RouterRepositoryError) as exc:
         _raise_public_error(exc)
 
 
@@ -94,20 +134,25 @@ def list_connections() -> list[RouterConnection]:
     response_model=RouterConnection,
     status_code=status.HTTP_201_CREATED,
 )
-def create_connection(payload: RouterConnectionCreate) -> RouterConnection:
+async def create_connection(
+    payload: RouterConnectionCreate,
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin_csrf),
+) -> RouterConnection:
     try:
-        return get_model_router_service().create_connection(payload)
-    except (RouterServiceError, RouterRepositoryError) as exc:
+        return await get_model_router_service().create_connection(payload)
+    except (ProviderEgressError, RouterServiceError, RouterRepositoryError) as exc:
         _raise_public_error(exc)
 
 
 @router.patch("/connections/{connection_id}", response_model=RouterConnection)
-def update_connection(
-    connection_id: str, payload: RouterConnectionUpdate
+async def update_connection(
+    connection_id: str,
+    payload: RouterConnectionUpdate,
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin_csrf),
 ) -> RouterConnection:
     try:
-        return get_model_router_service().update_connection(connection_id, payload)
-    except (RouterServiceError, RouterRepositoryError) as exc:
+        return await get_model_router_service().update_connection(connection_id, payload)
+    except (ProviderEgressError, RouterServiceError, RouterRepositoryError) as exc:
         _raise_public_error(exc)
 
 
@@ -117,10 +162,11 @@ def update_connection(
 )
 async def test_unsaved_connection(
     payload: RouterConnectionCreate,
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin_csrf),
 ) -> ConnectionTestResult:
     try:
         return await get_model_router_service().test_unsaved_connection(payload)
-    except (RouterServiceError, RouterRepositoryError) as exc:
+    except (ProviderEgressError, RouterServiceError, RouterRepositoryError) as exc:
         _raise_public_error(exc)
 
 
@@ -128,23 +174,31 @@ async def test_unsaved_connection(
     "/connections/{connection_id}/test",
     response_model=ConnectionTestResult,
 )
-async def test_saved_connection(connection_id: str) -> ConnectionTestResult:
+async def test_saved_connection(
+    connection_id: str,
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin_csrf),
+) -> ConnectionTestResult:
     try:
         return await get_model_router_service().test_saved_connection(connection_id)
-    except (RouterServiceError, RouterRepositoryError) as exc:
+    except (ProviderEgressError, RouterServiceError, RouterRepositoryError) as exc:
         _raise_public_error(exc)
 
 
 @router.get("/policy", response_model=RouterPolicy)
-def get_policy() -> RouterPolicy:
+def get_policy(
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin),
+) -> RouterPolicy:
     try:
         return get_model_router_service().get_policy()
-    except RouterRepositoryError as exc:
+    except (RouterServiceError, RouterRepositoryError) as exc:
         _raise_public_error(exc)
 
 
 @router.put("/policy", response_model=RouterPolicy)
-def save_policy(policy: RouterPolicy) -> RouterPolicy:
+def save_policy(
+    policy: RouterPolicy,
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin_csrf),
+) -> RouterPolicy:
     try:
         return get_model_router_service().save_policy(policy)
     except (RouterServiceError, RouterRepositoryError) as exc:
@@ -152,24 +206,29 @@ def save_policy(policy: RouterPolicy) -> RouterPolicy:
 
 
 @router.get("/status", response_model=RouterStatus)
-def get_status() -> RouterStatus:
+def get_status(
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin),
+) -> RouterStatus:
     try:
         return get_model_router_service().status()
-    except RouterRepositoryError as exc:
+    except (RouterServiceError, RouterRepositoryError) as exc:
         _raise_public_error(exc)
 
 
 @router.get("/diagnostics")
-def get_diagnostics() -> dict[str, object]:
+def get_diagnostics(
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin),
+) -> dict[str, object]:
     try:
         return get_model_router_service().diagnostics()
-    except RouterRepositoryError as exc:
+    except (RouterServiceError, RouterRepositoryError) as exc:
         _raise_public_error(exc)
 
 
 @router.put("/gate/approval")
 def approve_native_gate(
     payload: RouterGateApprovalRequest,
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin_csrf),
 ) -> dict[str, object]:
     try:
         return get_model_router_service().approve_native_gate(
@@ -181,7 +240,9 @@ def approve_native_gate(
 
 
 @router.delete("/gate/approval")
-def revoke_native_gate() -> dict[str, object]:
+def revoke_native_gate(
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin_csrf),
+) -> dict[str, object]:
     try:
         return get_model_router_service().revoke_native_gate()
     except (RouterServiceError, RouterRepositoryError) as exc:

--- a/server/model_router/catalog.py
+++ b/server/model_router/catalog.py
@@ -27,8 +27,9 @@ except ModuleNotFoundError:
 
 from .api import get_model_router_service
 from .model_ids import is_realtime_chat_model_id
+from .repository import RouterRepositoryError
 from .schemas import RouterConnection
-from .service import ModelRouterService
+from .service import ModelRouterService, RouterServiceError
 
 
 CATALOG_TTL_SECONDS = 30.0
@@ -212,15 +213,21 @@ class CatalogCoordinator:
         self.native = native or NativeCatalogService()
 
     async def get_catalog(self) -> ModelCatalogResponse:
-        service = get_model_router_service()
-        policy = service.get_policy()
+        try:
+            service = get_model_router_service()
+            policy = service.get_policy()
+        except (RouterRepositoryError, RouterServiceError):
+            return await self.sidecar.get_catalog()
         if policy.engine in {"native", "native_canary"}:
             return await self.native.get_catalog(service, self.sidecar)
         return await self.sidecar.get_catalog()
 
     async def get_status(self) -> RouterStatusResponse:
-        service = get_model_router_service()
-        policy = service.get_policy()
+        try:
+            service = get_model_router_service()
+            policy = service.get_policy()
+        except (RouterRepositoryError, RouterServiceError):
+            return await self.sidecar.get_status()
         if policy.engine in {"native", "native_canary"}:
             return await self.native.get_status(service, self.sidecar)
         return await self.sidecar.get_status()

--- a/server/model_router/egress.py
+++ b/server/model_router/egress.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import os
+import socket
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import AsyncIterator, Callable, Iterable
+from urllib.parse import SplitResult, urlsplit, urlunsplit
+
+import httpx
+
+
+INTERNAL_ALLOWLIST_ENV = "MODEL_MIRROR_PROVIDER_INTERNAL_ALLOWLIST"
+PERMANENTLY_BLOCKED_HOSTS = frozenset(
+    {
+        "metadata",
+        "metadata.google.internal",
+        "instance-data",
+        "instance-data.ec2.internal",
+    }
+)
+PERMANENTLY_BLOCKED_IPS = frozenset(
+    {
+        ipaddress.ip_address("169.254.169.254"),
+        ipaddress.ip_address("100.100.100.200"),
+        ipaddress.ip_address("fd00:ec2::254"),
+    }
+)
+
+
+class ProviderEgressError(httpx.RequestError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizedProviderTarget:
+    original_url: str
+    pinned_urls: tuple[str, ...]
+    host_header: str
+    sni_hostname: str | None
+
+    def request_headers(self, headers: dict[str, str] | None = None) -> dict[str, str]:
+        merged = {
+            key: value
+            for key, value in (headers or {}).items()
+            if key.casefold() != "host"
+        }
+        merged["Host"] = self.host_header
+        return merged
+
+    @property
+    def extensions(self) -> dict[str, str]:
+        return {"sni_hostname": self.sni_hostname} if self.sni_hostname else {}
+
+
+Resolver = Callable[[str, int], Iterable[str]]
+
+
+def _system_resolver(host: str, port: int) -> Iterable[str]:
+    return {
+        item[4][0]
+        for item in socket.getaddrinfo(
+            host,
+            port,
+            family=socket.AF_UNSPEC,
+            type=socket.SOCK_STREAM,
+        )
+    }
+
+
+class ProviderEgressPolicy:
+    def __init__(
+        self,
+        *,
+        internal_allowlist: str | Iterable[str] | None = None,
+        resolver: Resolver | None = None,
+    ) -> None:
+        raw = (
+            internal_allowlist
+            if internal_allowlist is not None
+            else os.getenv(INTERNAL_ALLOWLIST_ENV, "")
+        )
+        entries = raw.split(",") if isinstance(raw, str) else raw
+        self.internal_allowlist = frozenset(
+            self._normalize_allowlist_entry(item) for item in entries if str(item).strip()
+        )
+        self._resolver = resolver or _system_resolver
+
+    def validate_for_storage(self, value: str) -> str:
+        parsed = self._parse(value)
+        host = self._normalized_host(parsed)
+        port = self._port(parsed)
+        authority = self._authority(host, port)
+        allowlisted = authority in self.internal_allowlist
+        if self._is_metadata_host(host):
+            raise self._blocked()
+        literal = self._literal_ip(host)
+        if literal is not None:
+            self._validate_addresses((literal,), allowlisted=allowlisted)
+        if parsed.scheme == "http" and not allowlisted:
+            raise ProviderEgressError(
+                "provider_https_required",
+                "公网模型服务必须使用 HTTPS；内网 HTTP 需要精确 host:port 白名单。",
+            )
+        return self._normalized_url(parsed, host, port)
+
+    async def authorize(self, value: str) -> AuthorizedProviderTarget:
+        normalized = self.validate_for_storage(value)
+        parsed = urlsplit(normalized)
+        host = self._normalized_host(parsed)
+        port = self._port(parsed)
+        authority = self._authority(host, port)
+        allowlisted = authority in self.internal_allowlist
+        literal = self._literal_ip(host)
+        if literal is not None:
+            addresses = (literal,)
+        else:
+            try:
+                resolved = await asyncio.to_thread(self._resolver, host, port)
+                addresses = tuple(
+                    sorted(
+                        {ipaddress.ip_address(item) for item in resolved},
+                        key=lambda item: (item.version, str(item)),
+                    )
+                )
+            except (OSError, ValueError) as exc:
+                raise ProviderEgressError(
+                    "provider_dns_failed",
+                    "模型服务地址无法解析，请检查主机名和网络配置。",
+                ) from exc
+        if not addresses:
+            raise ProviderEgressError(
+                "provider_dns_failed",
+                "模型服务地址没有可用的网络解析结果。",
+            )
+        self._validate_addresses(addresses, allowlisted=allowlisted)
+        pinned = tuple(self._pin_url(parsed, address) for address in addresses)
+        return AuthorizedProviderTarget(
+            original_url=normalized,
+            pinned_urls=pinned,
+            host_header=self._host_header(host, port, parsed.scheme),
+            sni_hostname=host if parsed.scheme == "https" else None,
+        )
+
+    async def request(
+        self,
+        client: httpx.AsyncClient,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        stream: bool = False,
+        **kwargs: object,
+    ) -> httpx.Response:
+        target = await self.authorize(url)
+        last_error: Exception | None = None
+        for pinned_url in target.pinned_urls:
+            request = client.build_request(
+                method,
+                pinned_url,
+                headers=target.request_headers(headers),
+                extensions=target.extensions,
+                **kwargs,
+            )
+            try:
+                return await client.send(
+                    request,
+                    stream=stream,
+                    follow_redirects=False,
+                )
+            except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+                last_error = exc
+        if last_error is not None:
+            raise last_error
+        raise ProviderEgressError(
+            "provider_unreachable",
+            "模型服务没有可连接的已批准地址。",
+        )
+
+    @staticmethod
+    def _parse(value: str) -> SplitResult:
+        raw = str(value or "").strip().rstrip("/")
+        parsed = urlsplit(raw)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ProviderEgressError(
+                "invalid_address",
+                "请输入以 http:// 或 https:// 开头的模型服务地址。",
+            )
+        if parsed.username or parsed.password or parsed.query or parsed.fragment:
+            raise ProviderEgressError(
+                "invalid_address",
+                "模型服务地址不能包含凭据、查询参数或片段。",
+            )
+        try:
+            _ = parsed.port
+        except ValueError as exc:
+            raise ProviderEgressError("invalid_address", "模型服务端口无效。") from exc
+        return parsed
+
+    @staticmethod
+    def _normalized_host(parsed: SplitResult) -> str:
+        host = (parsed.hostname or "").rstrip(".").casefold()
+        if not host or any(character.isspace() for character in host):
+            raise ProviderEgressError("invalid_address", "模型服务主机名无效。")
+        try:
+            ascii_host = host.encode("idna").decode("ascii")
+        except UnicodeError as exc:
+            raise ProviderEgressError("invalid_address", "模型服务主机名无效。") from exc
+        if ProviderEgressPolicy._literal_ip(ascii_host) is not None:
+            return ascii_host
+        labels = ascii_host.split(".")
+        if (
+            len(ascii_host) > 253
+            or any(
+                not label
+                or len(label) > 63
+                or label.startswith("-")
+                or label.endswith("-")
+                or not all(character.isalnum() or character == "-" for character in label)
+                for label in labels
+            )
+        ):
+            raise ProviderEgressError("invalid_address", "模型服务主机名无效。")
+        return ascii_host
+
+    @staticmethod
+    def _port(parsed: SplitResult) -> int:
+        return parsed.port or (443 if parsed.scheme == "https" else 80)
+
+    @staticmethod
+    def _authority(host: str, port: int) -> str:
+        return f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
+
+    @classmethod
+    def _normalize_allowlist_entry(cls, value: object) -> str:
+        raw = str(value).strip().casefold()
+        if "://" in raw or any(mark in raw for mark in ("/", "?", "#", "*")):
+            raise ProviderEgressError(
+                "invalid_internal_allowlist",
+                "Provider 内网白名单只接受精确 host:port。",
+            )
+        parsed = urlsplit(f"//{raw}")
+        host = cls._normalized_host(parsed)
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            raise ProviderEgressError(
+                "invalid_internal_allowlist",
+                "Provider 内网白名单端口无效。",
+            ) from exc
+        if port is None:
+            raise ProviderEgressError(
+                "invalid_internal_allowlist",
+                "Provider 内网白名单必须包含端口。",
+            )
+        return cls._authority(host, port)
+
+    @staticmethod
+    def _literal_ip(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+        try:
+            return ipaddress.ip_address(host)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _is_metadata_host(host: str) -> bool:
+        return host in PERMANENTLY_BLOCKED_HOSTS or host.endswith(".metadata.google.internal")
+
+    @classmethod
+    def _validate_addresses(
+        cls,
+        addresses: Iterable[ipaddress.IPv4Address | ipaddress.IPv6Address],
+        *,
+        allowlisted: bool,
+    ) -> None:
+        for address in addresses:
+            if (
+                address in PERMANENTLY_BLOCKED_IPS
+                or address.is_link_local
+                or address.is_multicast
+                or address.is_unspecified
+                or address.is_reserved
+            ):
+                raise cls._blocked()
+            unsafe = address.is_private or address.is_loopback
+            if unsafe and not allowlisted:
+                raise cls._blocked()
+
+    @staticmethod
+    def _blocked() -> ProviderEgressError:
+        return ProviderEgressError(
+            "provider_address_blocked",
+            "模型服务地址指向受保护网络；仅允许公网 HTTPS 或显式内网白名单。",
+        )
+
+    @staticmethod
+    def _normalized_url(parsed: SplitResult, host: str, port: int) -> str:
+        default = 443 if parsed.scheme == "https" else 80
+        authority_host = f"[{host}]" if ":" in host else host
+        netloc = authority_host if port == default else f"{authority_host}:{port}"
+        return urlunsplit((parsed.scheme, netloc, parsed.path.rstrip("/"), "", ""))
+
+    @staticmethod
+    def _pin_url(
+        parsed: SplitResult,
+        address: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    ) -> str:
+        default = 443 if parsed.scheme == "https" else 80
+        host = f"[{address}]" if address.version == 6 else str(address)
+        port = parsed.port or default
+        netloc = host if port == default else f"{host}:{port}"
+        return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, ""))
+
+    @staticmethod
+    def _host_header(host: str, port: int, scheme: str) -> str:
+        default = 443 if scheme == "https" else 80
+        display = f"[{host}]" if ":" in host else host
+        return display if port == default else f"{display}:{port}"
+
+
+async def request_provider_url(
+    client: httpx.AsyncClient,
+    policy: ProviderEgressPolicy,
+    connection_id: str | None,
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    stream: bool = False,
+    **kwargs: object,
+) -> httpx.Response:
+    """Apply egress authorization only to control-plane managed connections."""
+
+    if connection_id:
+        return await policy.request(
+            client,
+            method,
+            url,
+            headers=headers,
+            stream=stream,
+            **kwargs,
+        )
+    request = client.build_request(
+        method,
+        url,
+        headers=headers,
+        **kwargs,
+    )
+    return await client.send(request, stream=stream)
+
+
+@asynccontextmanager
+async def stream_provider_url(
+    client: httpx.AsyncClient,
+    policy: ProviderEgressPolicy,
+    connection_id: str | None,
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    **kwargs: object,
+) -> AsyncIterator[httpx.Response]:
+    response = await request_provider_url(
+        client,
+        policy,
+        connection_id,
+        method,
+        url,
+        headers=headers,
+        stream=True,
+        **kwargs,
+    )
+    try:
+        yield response
+    finally:
+        await response.aclose()

--- a/server/model_router/migrate_credentials.py
+++ b/server/model_router/migrate_credentials.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from .repository import (
+    CANONICAL_MASTER_KEY_ENV,
+    LEGACY_MASTER_KEY_ENV,
+    MASTER_KEY_FINGERPRINT_METADATA_KEY,
+    MASTER_KEY_VERSION_METADATA_KEY,
+    SQLiteRouterRepository,
+    utc_now,
+)
+
+
+@dataclass(frozen=True)
+class CredentialMigrationResult:
+    migrated_credentials: int
+    backup_path: str
+    status: str = "completed"
+
+
+class CredentialMigrationError(RuntimeError):
+    pass
+
+
+def migrate_credentials(
+    storage_dir: str | Path,
+    *,
+    source_key: str | bytes | None = None,
+    target_key: str | bytes | None = None,
+    fail_after: int | None = None,
+) -> CredentialMigrationResult:
+    directory = Path(storage_dir)
+    database_path = directory / "router.sqlite3"
+    key_path = directory / "credential-master.key"
+    if not database_path.is_file():
+        raise CredentialMigrationError(f"Router database not found: {database_path}")
+
+    target_raw = target_key or os.getenv(CANONICAL_MASTER_KEY_ENV, "").strip()
+    if not target_raw:
+        raise CredentialMigrationError(
+            f"{CANONICAL_MASTER_KEY_ENV} is required as the migration target."
+        )
+    source_raw = source_key or os.getenv(LEGACY_MASTER_KEY_ENV, "").strip()
+    if not source_raw and key_path.is_file():
+        source_raw = key_path.read_bytes().strip()
+    if not source_raw:
+        source_raw = target_raw
+
+    source = Fernet(SQLiteRouterRepository._normalize_key(source_raw))
+    target_bytes = SQLiteRouterRepository._normalize_key(target_raw)
+    target = Fernet(target_bytes)
+
+    connection = sqlite3.connect(database_path, timeout=15, isolation_level=None)
+    connection.row_factory = sqlite3.Row
+    try:
+        preflight_data_version = int(
+            connection.execute("PRAGMA data_version").fetchone()[0]
+        )
+        rows = connection.execute(
+            "SELECT tenant_id, id, api_key_ciphertext FROM router_connections "
+            "ORDER BY tenant_id, id"
+        ).fetchall()
+        plaintext_by_id: list[tuple[bytes, str, str]] = []
+        try:
+            for row in rows:
+                plaintext_by_id.append(
+                    (
+                        source.decrypt(
+                            str(row["api_key_ciphertext"]).encode("ascii")
+                        ),
+                        str(row["tenant_id"]),
+                        str(row["id"]),
+                    )
+                )
+        except (InvalidToken, ValueError) as exc:
+            raise CredentialMigrationError(
+                "Credential preflight failed with the old key; no database changes were made."
+            ) from exc
+
+        timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S-%f")
+        backup_path = directory / f"router.sqlite3.backup-{timestamp}"
+        backup = sqlite3.connect(backup_path)
+        try:
+            connection.backup(backup)
+        finally:
+            backup.close()
+
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            locked_data_version = int(
+                connection.execute("PRAGMA data_version").fetchone()[0]
+            )
+            if locked_data_version != preflight_data_version:
+                raise CredentialMigrationError(
+                    "Router database changed during credential migration; "
+                    "no changes were committed. Stop provider writes and retry."
+                )
+            for index, (plaintext, tenant_id, connection_id) in enumerate(
+                plaintext_by_id, start=1
+            ):
+                ciphertext = target.encrypt(plaintext).decode("ascii")
+                connection.execute(
+                    "UPDATE router_connections SET api_key_ciphertext = ? "
+                    "WHERE tenant_id = ? AND id = ?",
+                    (ciphertext, tenant_id, connection_id),
+                )
+                if fail_after is not None and index >= fail_after:
+                    raise CredentialMigrationError("Injected migration interruption.")
+
+            for plaintext, tenant_id, connection_id in plaintext_by_id:
+                row = connection.execute(
+                    "SELECT api_key_ciphertext FROM router_connections "
+                    "WHERE tenant_id = ? AND id = ?",
+                    (tenant_id, connection_id),
+                ).fetchone()
+                if row is None or target.decrypt(
+                    str(row["api_key_ciphertext"]).encode("ascii")
+                ) != plaintext:
+                    raise CredentialMigrationError(
+                        "Credential verification failed; migration was rolled back."
+                    )
+
+            connection.execute(
+                "CREATE TABLE IF NOT EXISTS router_metadata ("
+                "key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL)"
+            )
+            now = utc_now()
+            connection.executemany(
+                "INSERT INTO router_metadata (key, value, updated_at) VALUES (?, ?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value=excluded.value, "
+                "updated_at=excluded.updated_at",
+                (
+                    (
+                        MASTER_KEY_FINGERPRINT_METADATA_KEY,
+                        hashlib.sha256(target_bytes).hexdigest(),
+                        now,
+                    ),
+                    (MASTER_KEY_VERSION_METADATA_KEY, "1", now),
+                ),
+            )
+            connection.execute("COMMIT")
+        except Exception:
+            if connection.in_transaction:
+                connection.execute("ROLLBACK")
+            raise
+    finally:
+        connection.close()
+
+    return CredentialMigrationResult(
+        migrated_credentials=len(rows),
+        backup_path=str(backup_path),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Atomically migrate ModelMirror provider credentials."
+    )
+    parser.add_argument("--storage-dir", required=True)
+    args = parser.parse_args()
+    try:
+        result = migrate_credentials(args.storage_dir)
+    except CredentialMigrationError as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}))
+        return 1
+    print(json.dumps(asdict(result), ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import hmac
 import json
+import logging
 import os
 import sqlite3
 import threading
@@ -28,6 +30,14 @@ from .schemas import (
 
 SCHEMA_VERSION = 11
 DEFAULT_TENANT_ID = "local"
+CANONICAL_MASTER_KEY_ENV = "MODEL_MIRROR_CREDENTIAL_MASTER_KEY"
+LEGACY_MASTER_KEY_ENV = "MODEL_ROUTER_CREDENTIAL_MASTER_KEY"
+REQUIRE_EXTERNAL_MASTER_KEY_ENV = (
+    "MODEL_MIRROR_REQUIRE_EXTERNAL_CREDENTIAL_MASTER_KEY"
+)
+MASTER_KEY_FINGERPRINT_METADATA_KEY = "credential_master_key_fingerprint"
+MASTER_KEY_VERSION_METADATA_KEY = "credential_master_key_version"
+logger = logging.getLogger("modelmirror.model_router")
 
 
 class RouterRepositoryError(Exception):
@@ -87,8 +97,10 @@ class SQLiteRouterRepository:
         self.master_key_path = self.storage_dir / "credential-master.key"
         self._lock = threading.RLock()
         self.storage_dir.mkdir(parents=True, exist_ok=True)
-        self._fernet = Fernet(self._resolve_master_key(master_key))
+        self._master_key = self._resolve_master_key(master_key)
+        self._fernet = Fernet(self._master_key)
         self._initialize()
+        self._verify_or_record_master_key()
 
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(self.database_path, timeout=15)
@@ -99,6 +111,11 @@ class SQLiteRouterRepository:
 
     def _initialize(self) -> None:
         schema = """
+        CREATE TABLE IF NOT EXISTS router_metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
         CREATE TABLE IF NOT EXISTS router_connections (
             id TEXT NOT NULL,
             tenant_id TEXT NOT NULL,
@@ -2011,11 +2028,24 @@ class SQLiteRouterRepository:
     def _resolve_master_key(self, supplied: str | bytes | None) -> bytes:
         if supplied:
             return self._normalize_key(supplied)
-        environment_key = os.getenv(
-            "MODEL_ROUTER_CREDENTIAL_MASTER_KEY", ""
-        ).strip()
-        if environment_key:
-            return self._normalize_key(environment_key)
+        canonical_key = os.getenv(CANONICAL_MASTER_KEY_ENV, "").strip()
+        if canonical_key:
+            return self._normalize_key(canonical_key)
+        require_external = os.getenv(
+            REQUIRE_EXTERNAL_MASTER_KEY_ENV, "false"
+        ).strip().lower() in {"1", "true", "yes", "on"}
+        if require_external:
+            raise RouterCredentialUnavailable(
+                f"{CANONICAL_MASTER_KEY_ENV} is required for provider management."
+            )
+        legacy_key = os.getenv(LEGACY_MASTER_KEY_ENV, "").strip()
+        if legacy_key:
+            logger.warning(
+                "%s is deprecated; configure %s and run the credential migration command.",
+                LEGACY_MASTER_KEY_ENV,
+                CANONICAL_MASTER_KEY_ENV,
+            )
+            return self._normalize_key(legacy_key)
         if self.master_key_path.exists():
             return self._normalize_key(self.master_key_path.read_bytes().strip())
         key = Fernet.generate_key()
@@ -2027,6 +2057,52 @@ class SQLiteRouterRepository:
         except OSError:
             pass
         return key
+
+    def _verify_or_record_master_key(self) -> None:
+        fingerprint = self._key_fingerprint(self._master_key)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                "SELECT value FROM router_metadata WHERE key = ?",
+                (MASTER_KEY_FINGERPRINT_METADATA_KEY,),
+            ).fetchone()
+            if row is not None:
+                if not hmac.compare_digest(str(row["value"]), fingerprint):
+                    raise RouterCredentialUnavailable(
+                        "The configured credential master key does not match the router database. "
+                        "Run the explicit credential migration command or restore the previous key."
+                    )
+                return
+            encrypted_rows = connection.execute(
+                "SELECT api_key_ciphertext FROM router_connections"
+            ).fetchall()
+            try:
+                for encrypted in encrypted_rows:
+                    self._fernet.decrypt(
+                        str(encrypted["api_key_ciphertext"]).encode("ascii")
+                    )
+            except (InvalidToken, ValueError) as exc:
+                raise RouterCredentialUnavailable(
+                    "Existing provider credentials cannot be read with the configured master key. "
+                    "Run the explicit credential migration command."
+                ) from exc
+            now = utc_now()
+            connection.executemany(
+                """
+                INSERT INTO router_metadata (key, value, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                    value = excluded.value,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    (MASTER_KEY_FINGERPRINT_METADATA_KEY, fingerprint, now),
+                    (MASTER_KEY_VERSION_METADATA_KEY, "1", now),
+                ),
+            )
+
+    @staticmethod
+    def _key_fingerprint(key: bytes) -> str:
+        return hashlib.sha256(key).hexdigest()
 
     @staticmethod
     def _normalize_key(value: str | bytes) -> bytes:

--- a/server/model_router/service.py
+++ b/server/model_router/service.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
+import logging
 from collections.abc import Callable
-from urllib.parse import urlparse
 
 import httpx
 
@@ -13,6 +13,7 @@ from .repository import (
     SQLiteRouterRepository,
     utc_now,
 )
+from .egress import ProviderEgressError, ProviderEgressPolicy
 from .schemas import (
     ConnectionScope,
     ConnectionTestResult,
@@ -32,27 +33,6 @@ class RouterServiceError(Exception):
         self.status_code = status_code
 
 
-def normalize_base_url(value: str) -> str:
-    url = str(value or "").strip().rstrip("/")
-    parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise RouterServiceError(
-            "invalid_address",
-            "请输入以 http:// 或 https:// 开头的模型服务地址。",
-        )
-    if parsed.username or parsed.password:
-        raise RouterServiceError(
-            "invalid_address",
-            "服务地址不能包含用户名或密码，请单独填写密钥。",
-        )
-    if parsed.query or parsed.fragment:
-        raise RouterServiceError(
-            "invalid_address",
-            "服务地址不能包含查询参数或片段。",
-        )
-    return url
-
-
 class ModelRouterService:
     def __init__(
         self,
@@ -60,19 +40,50 @@ class ModelRouterService:
         *,
         tenant_id: str | None = None,
         client_factory: Callable[[], httpx.AsyncClient] | None = None,
+        egress_policy: ProviderEgressPolicy | None = None,
     ) -> None:
+        self.tenant_id = self._resolve_tenant_id(tenant_id)
         self.repository = repository or SQLiteRouterRepository()
-        self.tenant_id = (
-            tenant_id
-            or os.getenv("MODELMIRROR_DEFAULT_TENANT_ID", "").strip()
-            or DEFAULT_TENANT_ID
-        )
         self._client_factory = client_factory or (
             lambda: httpx.AsyncClient(
                 timeout=httpx.Timeout(12.0, connect=5.0),
                 follow_redirects=False,
+                trust_env=False,
             )
         )
+        self.egress_policy = egress_policy or ProviderEgressPolicy()
+
+    @staticmethod
+    def _resolve_tenant_id(explicit: str | None) -> str:
+        if explicit is not None:
+            clean = explicit.strip()
+            if not clean:
+                raise RouterServiceError(
+                    "invalid_tenant_configuration",
+                    "The injected provider tenant identifier cannot be empty.",
+                    status_code=503,
+                )
+            return clean
+        canonical = os.getenv("MODELMIRROR_DEFAULT_TENANT_ID", "").strip()
+        legacy = os.getenv("MODEL_ROUTER_TENANT_ID", "").strip()
+        if canonical and legacy and canonical != legacy:
+            raise RouterServiceError(
+                "tenant_configuration_conflict",
+                "MODELMIRROR_DEFAULT_TENANT_ID conflicts with MODEL_ROUTER_TENANT_ID.",
+                status_code=503,
+            )
+        selected = canonical or legacy or DEFAULT_TENANT_ID
+        if selected != DEFAULT_TENANT_ID:
+            raise RouterServiceError(
+                "unsupported_tenant",
+                "The initial provider control plane supports only tenant 'local'.",
+                status_code=503,
+            )
+        if legacy and not canonical:
+            logging.getLogger("modelmirror.model_router").warning(
+                "MODEL_ROUTER_TENANT_ID is deprecated; use MODELMIRROR_DEFAULT_TENANT_ID."
+            )
+        return selected
 
     def list_connections(
         self,
@@ -88,22 +99,22 @@ class ModelRouterService:
             if scope in connection.scopes
         ]
 
-    def create_connection(
+    async def create_connection(
         self, payload: RouterConnectionCreate
     ) -> RouterConnection:
-        normalized = payload.model_copy(
-            update={"base_url": normalize_base_url(payload.base_url)}
-        )
+        normalized_url = self.egress_policy.validate_for_storage(payload.base_url)
+        await self.egress_policy.authorize(normalized_url)
+        normalized = payload.model_copy(update={"base_url": normalized_url})
         return self.repository.create_connection(self.tenant_id, normalized)
 
-    def update_connection(
+    async def update_connection(
         self, connection_id: str, payload: RouterConnectionUpdate
     ) -> RouterConnection:
         normalized = payload
         if payload.base_url is not None:
-            normalized = payload.model_copy(
-                update={"base_url": normalize_base_url(payload.base_url)}
-            )
+            normalized_url = self.egress_policy.validate_for_storage(payload.base_url)
+            await self.egress_policy.authorize(normalized_url)
+            normalized = payload.model_copy(update={"base_url": normalized_url})
         return self.repository.update_connection(
             self.tenant_id, connection_id, normalized
         )
@@ -112,7 +123,7 @@ class ModelRouterService:
         self, payload: RouterConnectionCreate
     ) -> ConnectionTestResult:
         return await self._probe(
-            normalize_base_url(payload.base_url),
+            self.egress_policy.validate_for_storage(payload.base_url),
             payload.api_key.get_secret_value(),
         )
 
@@ -318,7 +329,11 @@ class ModelRouterService:
         headers = {"Authorization": f"Bearer {api_key.strip()}"}
         try:
             async with self._client_factory() as client:
-                response = await client.get(models_url, headers=headers)
+                response = await self.egress_policy.request(
+                    client, "GET", models_url, headers=headers
+                )
+        except ProviderEgressError:
+            raise
         except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout):
             return (
                 ConnectionTestResult(
@@ -481,6 +496,8 @@ class ModelRouterService:
 
 
 def translate_repository_error(exc: Exception) -> RouterServiceError:
+    if isinstance(exc, ProviderEgressError):
+        return RouterServiceError(exc.code, exc.message, status_code=422)
     if isinstance(exc, RouterConnectionNotFound):
         return RouterServiceError("not_found", str(exc), status_code=404)
     return RouterServiceError(

--- a/server/multimodal/audio_catalog.py
+++ b/server/multimodal/audio_catalog.py
@@ -12,9 +12,11 @@ import httpx
 from pydantic import BaseModel, Field
 
 try:
+    from server.model_router.egress import request_provider_url
     from server.model_router.schemas import RouterConnection
     from server.model_router.service import ModelRouterService
 except ModuleNotFoundError:
+    from model_router.egress import request_provider_url
     from model_router.schemas import RouterConnection
     from model_router.service import ModelRouterService
 
@@ -341,6 +343,7 @@ class AudioCatalogService:
     ) -> None:
         self.router_service = router_service
         self.client_factory = client_factory or self._default_client
+        self.managed_client_factory = client_factory or self._direct_client
         self._cache: _CachedAudioCatalog | None = None
         self._lock = asyncio.Lock()
 
@@ -530,8 +533,17 @@ class AudioCatalogService:
             if provider == "openrouter"
             else None
         )
-        async with self.client_factory() as client:
-            response = await client.get(
+        client_factory = (
+            self.managed_client_factory
+            if target.connection_id
+            else self.client_factory
+        )
+        async with client_factory() as client:
+            response = await request_provider_url(
+                client,
+                self.router_service.egress_policy,
+                target.connection_id,
+                "GET",
                 self._api_url(target.base_url, "models"),
                 headers=self._provider_headers(provider, target.api_key),
                 params=params,
@@ -1218,11 +1230,20 @@ class AudioCatalogService:
         ]
 
     @staticmethod
+    def _direct_client() -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=15, read=30, write=15, pool=10),
+            follow_redirects=False,
+            trust_env=False,
+        )
+
+    @staticmethod
     def _default_client() -> httpx.AsyncClient:
         timeout = httpx.Timeout(connect=15, read=30, write=15, pool=10)
         kwargs: dict[str, Any] = {
             "timeout": timeout,
             "follow_redirects": False,
+            "trust_env": False,
         }
         proxy = (
             os.getenv("OPENROUTER_PROXY")

--- a/server/multimodal/audio_jobs.py
+++ b/server/multimodal/audio_jobs.py
@@ -20,8 +20,10 @@ import httpx
 from pydantic import BaseModel, Field
 
 try:
+    from server.model_router.egress import ProviderEgressPolicy, stream_provider_url
     from server.model_router.service import ModelRouterService
 except ModuleNotFoundError:
+    from model_router.egress import ProviderEgressPolicy, stream_provider_url
     from model_router.service import ModelRouterService
 
 from .audio_catalog import AudioCatalogService, AudioChatProfile
@@ -159,8 +161,10 @@ class OpenRouterAudioJobAdapter:
         self,
         *,
         client_factory: Callable[[], httpx.AsyncClient] | None = None,
+        egress_policy: ProviderEgressPolicy | None = None,
     ) -> None:
         self._client_factory = client_factory or self._default_client
+        self._egress_policy = egress_policy
 
     async def generate(
         self,
@@ -195,7 +199,10 @@ class OpenRouterAudioJobAdapter:
 
         async with self._client_factory() as client:
             try:
-                async with client.stream(
+                async with stream_provider_url(
+                    client,
+                    self._egress_policy or ProviderEgressPolicy(),
+                    target.connection_id if self._egress_policy else None,
                     "POST",
                     self._api_url(target.base_url),
                     headers=self._headers(target.api_key),
@@ -301,6 +308,7 @@ class OpenRouterAudioJobAdapter:
         return httpx.AsyncClient(
             timeout=httpx.Timeout(180.0, connect=15.0),
             follow_redirects=False,
+            trust_env=False,
         )
 
     @staticmethod
@@ -391,7 +399,9 @@ class AudioJobService:
     ) -> None:
         self.router_service = router_service
         self.catalog_service = catalog_service
-        self.adapter = adapter or OpenRouterAudioJobAdapter()
+        self.adapter = adapter or OpenRouterAudioJobAdapter(
+            egress_policy=router_service.egress_policy
+        )
         self.output_dir = Path(
             output_dir
             or Path(tempfile.gettempdir()) / "modelmirror-audio-jobs"

--- a/server/multimodal/image_catalog.py
+++ b/server/multimodal/image_catalog.py
@@ -11,8 +11,10 @@ import httpx
 from pydantic import BaseModel, Field
 
 try:
+    from server.model_router.egress import request_provider_url
     from server.model_router.service import ModelRouterService
 except ModuleNotFoundError:
+    from model_router.egress import request_provider_url
     from model_router.service import ModelRouterService
 
 from .stt import MultimodalServiceError, OpenRouterTarget
@@ -89,6 +91,7 @@ class ImageCatalogService:
             lambda: httpx.AsyncClient(
                 timeout=httpx.Timeout(15.0, connect=5.0),
                 follow_redirects=False,
+                trust_env=False,
             )
         )
         self._cache: _CachedImageCatalog | None = None
@@ -183,7 +186,11 @@ class ImageCatalogService:
             requests = []
             if analysis_enabled:
                 requests.append(
-                    client.get(
+                    request_provider_url(
+                        client,
+                        self.router_service.egress_policy,
+                        target.connection_id,
+                        "GET",
                         self._api_url(target.base_url, "models"),
                         headers=headers,
                         params={"input_modalities": "image"},
@@ -191,7 +198,11 @@ class ImageCatalogService:
                 )
             if generation_enabled:
                 requests.append(
-                    client.get(
+                    request_provider_url(
+                        client,
+                        self.router_service.egress_policy,
+                        target.connection_id,
+                        "GET",
                         self._api_url(target.base_url, "images/models"),
                         headers=headers,
                     )
@@ -286,7 +297,11 @@ class ImageCatalogService:
     ) -> list[ImagePricingItem]:
         try:
             async with self.client_factory() as client:
-                response = await client.get(
+                response = await request_provider_url(
+                    client,
+                    self.router_service.egress_policy,
+                    target.connection_id,
+                    "GET",
                     self._api_url(
                         target.base_url,
                         f"images/models/{model_id}/endpoints",

--- a/server/multimodal/image_generation.py
+++ b/server/multimodal/image_generation.py
@@ -9,6 +9,11 @@ from typing import Any
 import httpx
 from pydantic import BaseModel, Field
 
+try:
+    from server.model_router.egress import request_provider_url
+except ModuleNotFoundError:
+    from model_router.egress import request_provider_url
+
 from .image_catalog import ImageCatalogService, ImageModelProfile
 from .stt import MultimodalServiceError, OpenRouterTarget
 
@@ -65,6 +70,7 @@ class ImageGenerationService:
             lambda: httpx.AsyncClient(
                 timeout=httpx.Timeout(180.0, connect=10.0),
                 follow_redirects=False,
+                trust_env=False,
             )
         )
 
@@ -169,7 +175,11 @@ class ImageGenerationService:
     ) -> httpx.Response:
         try:
             async with self.client_factory() as client:
-                response = await client.post(
+                response = await request_provider_url(
+                    client,
+                    self.catalog_service.router_service.egress_policy,
+                    target.connection_id,
+                    "POST",
                     self.catalog_service._api_url(target.base_url, "images"),
                     headers={"Authorization": f"Bearer {target.api_key}"},
                     json=payload,

--- a/server/multimodal/realtime.py
+++ b/server/multimodal/realtime.py
@@ -16,12 +16,14 @@ import httpx
 from pydantic import BaseModel
 
 try:
+    from server.model_router.egress import ProviderEgressPolicy, request_provider_url
     from server.model_router.repository import (
         RouterConnectionNotFound,
         utc_now,
     )
     from server.model_router.service import ModelRouterService
 except ModuleNotFoundError:
+    from model_router.egress import ProviderEgressPolicy, request_provider_url
     from model_router.repository import RouterConnectionNotFound, utc_now
     from model_router.service import ModelRouterService
 
@@ -95,8 +97,10 @@ class OpenAIRealtimeAdapter:
         self,
         *,
         client_factory: Callable[[], httpx.AsyncClient] | None = None,
+        egress_policy: ProviderEgressPolicy | None = None,
     ) -> None:
         self.client_factory = client_factory or self._default_client
+        self.egress_policy = egress_policy
 
     async def create_call(
         self,
@@ -119,7 +123,11 @@ class OpenAIRealtimeAdapter:
         }
         try:
             async with self.client_factory() as client:
-                response = await client.post(
+                response = await request_provider_url(
+                    client,
+                    self.egress_policy or ProviderEgressPolicy(),
+                    target.connection_id if self.egress_policy else None,
+                    "POST",
                     self._calls_url(target.base_url),
                     headers=self._headers(target),
                     files=files,
@@ -172,7 +180,11 @@ class OpenAIRealtimeAdapter:
             )
         try:
             async with self.client_factory() as client:
-                response = await client.post(
+                response = await request_provider_url(
+                    client,
+                    self.egress_policy or ProviderEgressPolicy(),
+                    target.connection_id if self.egress_policy else None,
+                    "POST",
                     (
                         f"{self._calls_url(target.base_url)}/"
                         f"{call_id}/hangup"
@@ -274,6 +286,7 @@ class OpenAIRealtimeAdapter:
                 pool=10.0,
             ),
             follow_redirects=False,
+            trust_env=False,
         )
 
 
@@ -288,7 +301,9 @@ class RealtimeVoiceService:
         self.router_service = router_service
         self.repository = router_service.repository
         self.tenant_id = router_service.tenant_id
-        self.adapter = adapter or OpenAIRealtimeAdapter()
+        self.adapter = adapter or OpenAIRealtimeAdapter(
+            egress_policy=router_service.egress_policy
+        )
         self.session_seconds = max(
             1,
             min(int(session_seconds), MAX_REALTIME_SESSION_SECONDS),

--- a/server/multimodal/stt.py
+++ b/server/multimodal/stt.py
@@ -13,8 +13,10 @@ from typing import Any
 import httpx
 
 try:
+    from server.model_router.egress import ProviderEgressPolicy, request_provider_url
     from server.model_router.service import ModelRouterService
 except ModuleNotFoundError:
+    from model_router.egress import ProviderEgressPolicy, request_provider_url
     from model_router.service import ModelRouterService
 
 
@@ -136,10 +138,13 @@ class OpenRouterSttAdapter:
         *,
         client_factory: Callable[[], httpx.AsyncClient] | None = None,
         catalog_cache_seconds: float = CATALOG_CACHE_SECONDS,
+        egress_policy: ProviderEgressPolicy | None = None,
     ) -> None:
         self._client_factory = client_factory or self._default_client
+        self._managed_client_factory = client_factory or self._direct_client
         self.catalog_cache_seconds = max(0.0, float(catalog_cache_seconds))
         self._catalog_cache: dict[str, tuple[float, set[str]]] = {}
+        self._egress_policy = egress_policy
 
     async def transcribe(
         self,
@@ -162,9 +167,18 @@ class OpenRouterSttAdapter:
         }
         if language:
             payload["language"] = language
-        async with self._client_factory() as client:
+        client_factory = (
+            self._managed_client_factory
+            if target.connection_id
+            else self._client_factory
+        )
+        async with client_factory() as client:
             try:
-                response = await client.post(
+                response = await request_provider_url(
+                    client,
+                    self._egress_policy or ProviderEgressPolicy(),
+                    target.connection_id if self._egress_policy else None,
+                    "POST",
                     self._api_url(target.base_url, "audio/transcriptions"),
                     headers=headers,
                     json=payload,
@@ -219,9 +233,18 @@ class OpenRouterSttAdapter:
         if cached and now - cached[0] <= self.catalog_cache_seconds:
             model_ids = cached[1]
         else:
-            async with self._client_factory() as client:
+            client_factory = (
+                self._managed_client_factory
+                if target.connection_id
+                else self._client_factory
+            )
+            async with client_factory() as client:
                 try:
-                    response = await client.get(
+                    response = await request_provider_url(
+                        client,
+                        self._egress_policy or ProviderEgressPolicy(),
+                        target.connection_id if self._egress_policy else None,
+                        "GET",
                         self._api_url(target.base_url, "models"),
                         headers=self._headers(target.api_key),
                         params={"output_modalities": "transcription"},
@@ -287,11 +310,20 @@ class OpenRouterSttAdapter:
             )
 
     @staticmethod
+    def _direct_client() -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=15, read=60, write=60, pool=10),
+            follow_redirects=False,
+            trust_env=False,
+        )
+
+    @staticmethod
     def _default_client() -> httpx.AsyncClient:
         timeout = httpx.Timeout(connect=15, read=60, write=60, pool=10)
         kwargs: dict[str, Any] = {
             "timeout": timeout,
             "follow_redirects": False,
+            "trust_env": False,
         }
         proxy = (
             os.getenv("OPENROUTER_PROXY")
@@ -412,7 +444,9 @@ class TranscriptionService:
         adapter: OpenRouterSttAdapter | None = None,
     ) -> None:
         self.router_service = router_service
-        self.adapter = adapter or OpenRouterSttAdapter()
+        self.adapter = adapter or OpenRouterSttAdapter(
+            egress_policy=router_service.egress_policy
+        )
 
     async def transcribe(
         self,

--- a/server/multimodal/tts.py
+++ b/server/multimodal/tts.py
@@ -11,8 +11,10 @@ from typing import Any
 import httpx
 
 try:
+    from server.model_router.egress import ProviderEgressPolicy, request_provider_url
     from server.model_router.service import ModelRouterService
 except ModuleNotFoundError:
+    from model_router.egress import ProviderEgressPolicy, request_provider_url
     from model_router.service import ModelRouterService
 
 from .stt import MultimodalServiceError, OpenRouterTarget
@@ -208,10 +210,13 @@ class OpenRouterTtsAdapter:
         *,
         client_factory: Callable[[], httpx.AsyncClient] | None = None,
         catalog_cache_seconds: float = CATALOG_CACHE_SECONDS,
+        egress_policy: ProviderEgressPolicy | None = None,
     ) -> None:
         self._client_factory = client_factory or self._default_client
+        self._managed_client_factory = client_factory or self._direct_client
         self.catalog_cache_seconds = max(0.0, float(catalog_cache_seconds))
         self._catalog_cache: dict[str, tuple[float, set[str]]] = {}
+        self._egress_policy = egress_policy
 
     async def synthesize(
         self,
@@ -226,9 +231,18 @@ class OpenRouterTtsAdapter:
         await self._verify_speech_model(target, model_id, provider=provider)
         output_format = speech_output_format(model_id)
         upstream_format = "pcm" if output_format == "wav" else "mp3"
-        async with self._client_factory() as client:
+        client_factory = (
+            self._managed_client_factory
+            if target.connection_id
+            else self._client_factory
+        )
+        async with client_factory() as client:
             try:
-                response = await client.post(
+                response = await request_provider_url(
+                    client,
+                    self._egress_policy or ProviderEgressPolicy(),
+                    target.connection_id if self._egress_policy else None,
+                    "POST",
                     self._api_url(target.base_url, "audio/speech"),
                     headers=self._headers(target.api_key, provider=provider),
                     json={
@@ -282,9 +296,18 @@ class OpenRouterTtsAdapter:
         if cached and now - cached[0] <= self.catalog_cache_seconds:
             model_ids = cached[1]
         else:
-            async with self._client_factory() as client:
+            client_factory = (
+                self._managed_client_factory
+                if target.connection_id
+                else self._client_factory
+            )
+            async with client_factory() as client:
                 try:
-                    response = await client.get(
+                    response = await request_provider_url(
+                        client,
+                        self._egress_policy or ProviderEgressPolicy(),
+                        target.connection_id if self._egress_policy else None,
+                        "GET",
                         self._api_url(target.base_url, "models"),
                         headers=self._headers(
                             target.api_key,
@@ -357,11 +380,20 @@ class OpenRouterTtsAdapter:
             )
 
     @staticmethod
+    def _direct_client() -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=15, read=90, write=30, pool=10),
+            follow_redirects=False,
+            trust_env=False,
+        )
+
+    @staticmethod
     def _default_client() -> httpx.AsyncClient:
         timeout = httpx.Timeout(connect=15, read=90, write=30, pool=10)
         kwargs: dict[str, Any] = {
             "timeout": timeout,
             "follow_redirects": False,
+            "trust_env": False,
         }
         proxy = (
             os.getenv("OPENROUTER_PROXY")
@@ -563,7 +595,9 @@ class SpeechService:
         adapter: OpenRouterTtsAdapter | None = None,
     ) -> None:
         self.router_service = router_service
-        self.adapter = adapter or OpenRouterTtsAdapter()
+        self.adapter = adapter or OpenRouterTtsAdapter(
+            egress_policy=router_service.egress_policy
+        )
 
     async def synthesize(
         self,

--- a/server/multimodal/video_analysis.py
+++ b/server/multimodal/video_analysis.py
@@ -13,8 +13,10 @@ from urllib.parse import urlsplit
 import httpx
 
 try:
+    from server.model_router.egress import ProviderEgressPolicy, request_provider_url
     from server.model_router.service import ModelRouterService
 except ModuleNotFoundError:
+    from model_router.egress import ProviderEgressPolicy, request_provider_url
     from model_router.service import ModelRouterService
 
 from .stt import MultimodalServiceError, OpenRouterTarget
@@ -64,8 +66,11 @@ class OpenRouterVideoAnalysisAdapter:
         self,
         *,
         client_factory: Callable[[], httpx.AsyncClient] | None = None,
+        egress_policy: ProviderEgressPolicy | None = None,
     ) -> None:
         self._client_factory = client_factory or self._default_client
+        self._managed_client_factory = client_factory or self._direct_client
+        self._egress_policy = egress_policy
 
     async def analyze(
         self,
@@ -91,9 +96,18 @@ class OpenRouterVideoAnalysisAdapter:
                 }
             ],
         }
-        async with self._client_factory() as client:
+        client_factory = (
+            self._managed_client_factory
+            if target.connection_id
+            else self._client_factory
+        )
+        async with client_factory() as client:
             try:
-                response = await client.post(
+                response = await request_provider_url(
+                    client,
+                    self._egress_policy or ProviderEgressPolicy(),
+                    target.connection_id if self._egress_policy else None,
+                    "POST",
                     self._api_url(target.base_url),
                     headers=self._headers(target.api_key),
                     json=payload,
@@ -139,11 +153,20 @@ class OpenRouterVideoAnalysisAdapter:
         return text, actual_model, usage
 
     @staticmethod
+    def _direct_client() -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=15, read=180, write=60, pool=10),
+            follow_redirects=False,
+            trust_env=False,
+        )
+
+    @staticmethod
     def _default_client() -> httpx.AsyncClient:
         timeout = httpx.Timeout(connect=15, read=180, write=60, pool=10)
         kwargs: dict[str, Any] = {
             "timeout": timeout,
             "follow_redirects": False,
+            "trust_env": False,
         }
         proxy = (
             os.getenv("OPENROUTER_PROXY")
@@ -285,7 +308,9 @@ class VideoAnalysisService:
     ) -> None:
         self.router_service = router_service
         self.catalog_service = catalog_service
-        self.adapter = adapter or OpenRouterVideoAnalysisAdapter()
+        self.adapter = adapter or OpenRouterVideoAnalysisAdapter(
+            egress_policy=router_service.egress_policy
+        )
 
     async def analyze(
         self,

--- a/server/multimodal/video_catalog.py
+++ b/server/multimodal/video_catalog.py
@@ -11,8 +11,10 @@ import httpx
 from pydantic import BaseModel, Field
 
 try:
+    from server.model_router.egress import request_provider_url
     from server.model_router.service import ModelRouterService
 except ModuleNotFoundError:
+    from model_router.egress import request_provider_url
     from model_router.service import ModelRouterService
 
 from .stt import (
@@ -174,6 +176,7 @@ class VideoCatalogService:
             lambda: httpx.AsyncClient(
                 timeout=httpx.Timeout(15.0, connect=5.0),
                 follow_redirects=False,
+                trust_env=False,
             )
         )
         self._cache: _CachedVideoCatalog | None = None
@@ -249,7 +252,11 @@ class VideoCatalogService:
             requests = []
             if analysis_enabled:
                 requests.append(
-                    client.get(
+                    request_provider_url(
+                        client,
+                        self.router_service.egress_policy,
+                        target.connection_id,
+                        "GET",
                         self._api_url(target.base_url, "models"),
                         headers=headers,
                         params={"input_modalities": "video"},
@@ -257,7 +264,11 @@ class VideoCatalogService:
                 )
             if generation_enabled:
                 requests.append(
-                    client.get(
+                    request_provider_url(
+                        client,
+                        self.router_service.egress_policy,
+                        target.connection_id,
+                        "GET",
                         self._api_url(target.base_url, "videos/models"),
                         headers=headers,
                     )

--- a/server/multimodal/video_jobs.py
+++ b/server/multimodal/video_jobs.py
@@ -16,8 +16,10 @@ import httpx
 from pydantic import BaseModel, Field
 
 try:
+    from server.model_router.egress import ProviderEgressPolicy, request_provider_url
     from server.model_router.service import ModelRouterService
 except ModuleNotFoundError:
+    from model_router.egress import ProviderEgressPolicy, request_provider_url
     from model_router.service import ModelRouterService
 
 from .stt import MultimodalServiceError, OpenRouterTarget
@@ -129,17 +131,29 @@ class OpenRouterVideoJobAdapter:
         self,
         *,
         client_factory: Callable[[], httpx.AsyncClient] | None = None,
+        egress_policy: ProviderEgressPolicy | None = None,
     ) -> None:
         self._client_factory = client_factory or self._default_client
+        self._managed_client_factory = client_factory or self._direct_client
+        self._egress_policy = egress_policy
 
     async def submit(
         self,
         target: OpenRouterTarget,
         payload: dict[str, object],
     ) -> dict[str, Any]:
-        async with self._client_factory() as client:
+        client_factory = (
+            self._managed_client_factory
+            if target.connection_id
+            else self._client_factory
+        )
+        async with client_factory() as client:
             try:
-                response = await client.post(
+                response = await request_provider_url(
+                    client,
+                    self._egress_policy or ProviderEgressPolicy(),
+                    target.connection_id if self._egress_policy else None,
+                    "POST",
                     self._api_url(target.base_url, "videos"),
                     headers=self._headers(target.api_key),
                     json=payload,
@@ -160,9 +174,18 @@ class OpenRouterVideoJobAdapter:
         target: OpenRouterTarget,
         upstream_job_id: str,
     ) -> dict[str, Any]:
-        async with self._client_factory() as client:
+        client_factory = (
+            self._managed_client_factory
+            if target.connection_id
+            else self._client_factory
+        )
+        async with client_factory() as client:
             try:
-                response = await client.get(
+                response = await request_provider_url(
+                    client,
+                    self._egress_policy or ProviderEgressPolicy(),
+                    target.connection_id if self._egress_policy else None,
+                    "GET",
                     self._api_url(
                         target.base_url, f"videos/{upstream_job_id}"
                     ),
@@ -186,9 +209,17 @@ class OpenRouterVideoJobAdapter:
         *,
         index: int,
     ) -> VideoContent:
-        client = self._client_factory()
+        client_factory = (
+            self._managed_client_factory
+            if target.connection_id
+            else self._client_factory
+        )
+        client = client_factory()
         try:
-            request = client.build_request(
+            response = await request_provider_url(
+                client,
+                self._egress_policy or ProviderEgressPolicy(),
+                target.connection_id if self._egress_policy else None,
                 "GET",
                 self._api_url(
                     target.base_url,
@@ -196,8 +227,8 @@ class OpenRouterVideoJobAdapter:
                 ),
                 headers=self._headers(target.api_key),
                 params={"index": index},
+                stream=True,
             )
-            response = await client.send(request, stream=True)
             self._raise_for_status(response, submitting=False)
             media_type = (
                 response.headers.get("content-type", "")
@@ -239,11 +270,20 @@ class OpenRouterVideoJobAdapter:
         )
 
     @staticmethod
+    def _direct_client() -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=15, read=180, write=60, pool=10),
+            follow_redirects=False,
+            trust_env=False,
+        )
+
+    @staticmethod
     def _default_client() -> httpx.AsyncClient:
         timeout = httpx.Timeout(connect=15, read=180, write=60, pool=10)
         kwargs: dict[str, Any] = {
             "timeout": timeout,
             "follow_redirects": False,
+            "trust_env": False,
         }
         proxy = (
             os.getenv("OPENROUTER_PROXY")
@@ -391,7 +431,9 @@ class VideoJobService:
     ) -> None:
         self.router_service = router_service
         self.catalog_service = catalog_service
-        self.adapter = adapter or OpenRouterVideoJobAdapter()
+        self.adapter = adapter or OpenRouterVideoJobAdapter(
+            egress_policy=router_service.egress_policy
+        )
 
     async def create(
         self,

--- a/server/tests/test_coding_command_bridge.py
+++ b/server/tests/test_coding_command_bridge.py
@@ -292,7 +292,12 @@ async def test_runner_mcp_exposes_only_structured_command_tool(monkeypatch) -> N
     assert json.loads(called["result"]["content"][0]["text"])["state"] == "rejected"
 
 
-def test_opencode_config_enables_only_internal_mcp_in_draft_mode() -> None:
+def test_opencode_config_enables_only_internal_mcp_in_draft_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "CODING_AGENT_MODEL_BASE_URL", "https://coding-provider.example/v1"
+    )
     config = build_opencode_config(
         "provider/model",
         "draft",

--- a/server/tests/test_coding_file_operations.py
+++ b/server/tests/test_coding_file_operations.py
@@ -174,7 +174,12 @@ async def test_file_tools_reject_binary_and_symlink_sources(tmp_path: Path) -> N
     assert target.read_text(encoding="utf-8") == "target\n"
 
 
-def test_opencode_config_exposes_file_tools_only_in_draft_mode() -> None:
+def test_opencode_config_exposes_file_tools_only_in_draft_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "CODING_AGENT_MODEL_BASE_URL", "https://coding-provider.example/v1"
+    )
     config = build_opencode_config(
         "provider/model",
         "draft",

--- a/server/tests/test_coding_runtime_acp.py
+++ b/server/tests/test_coding_runtime_acp.py
@@ -64,6 +64,9 @@ def test_worker_config_is_read_only_and_child_env_is_allowlisted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("CODING_AGENT_MODEL", "test-model")
+    monkeypatch.setenv(
+        "CODING_AGENT_MODEL_BASE_URL", "https://coding-provider.example/v1"
+    )
     monkeypatch.setenv("CODING_AGENT_GATEWAY_KEY", "test-only-key")
     monkeypatch.setenv("UNRELATED_SECRET", "must-not-be-inherited")
 
@@ -92,7 +95,7 @@ def test_worker_config_is_read_only_and_child_env_is_allowlisted(
     assert config["share"] == "disabled"
     assert config["autoupdate"] is False
     assert config["provider"]["modelmirror"]["options"] == {
-        "baseURL": "http://new-api:3000/v1",
+        "baseURL": "https://coding-provider.example/v1",
         "apiKey": "{env:CODING_AGENT_GATEWAY_KEY}",
     }
     assert "UNRELATED_SECRET" not in client._config.environment
@@ -121,6 +124,10 @@ def test_worker_config_is_read_only_and_child_env_is_allowlisted(
         "NO_PROXY",
         "no_proxy",
     }
+    assert client._config.environment["NO_PROXY"] == (
+        "localhost,127.0.0.1,coding-provider.example"
+    )
+    assert "new-api" not in client._config.environment["no_proxy"]
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_runtime_projects.py
+++ b/server/tests/test_coding_runtime_projects.py
@@ -385,7 +385,12 @@ async def test_worker_client_marks_writeback_only_restore(
     ]
 
 
-def test_runtime_keeps_project_config_disabled_and_uses_generic_agent_description() -> None:
+def test_runtime_keeps_project_config_disabled_and_uses_generic_agent_description(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "CODING_AGENT_MODEL_BASE_URL", "https://coding-provider.example/v1"
+    )
     root = Path(__file__).resolve().parents[2]
     worker = (root / "server/coding_runtime/worker.py").read_text(encoding="utf-8")
     dockerfile = (root / "server/coding_worker/Dockerfile").read_text(encoding="utf-8")

--- a/server/tests/test_coding_runtime_security.py
+++ b/server/tests/test_coding_runtime_security.py
@@ -20,7 +20,6 @@ from server.coding_runtime.models import (
     CodingSessionState,
 )
 from server.coding_runtime.worker import (
-    INTERNAL_GATEWAY_BASE_URL,
     MAX_AGENT_STEPS,
     MODEL_CONTEXT_TOKENS,
     MODEL_OUTPUT_TOKENS,
@@ -111,6 +110,9 @@ def test_agent_configuration_fails_closed_for_write_shell_and_extensions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("CODING_AGENT_MODEL", "deepseek/deepseek-v4-flash")
+    monkeypatch.setenv(
+        "CODING_AGENT_MODEL_BASE_URL", "https://coding-provider.example/v1"
+    )
     monkeypatch.setenv("CODING_AGENT_GATEWAY_KEY", "test-only-key")
     monkeypatch.setenv("UNRELATED_SECRET", "must-not-cross")
 
@@ -162,7 +164,7 @@ def test_agent_configuration_fails_closed_for_write_shell_and_extensions(
         "output": MODEL_OUTPUT_TOKENS,
     }
     assert config["provider"]["modelmirror"]["options"]["baseURL"] == (
-        INTERNAL_GATEWAY_BASE_URL
+        "https://coding-provider.example/v1"
     )
     assert "UNRELATED_SECRET" not in client._config.environment
 
@@ -171,6 +173,9 @@ def test_draft_mode_only_changes_edit_to_ask(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("CODING_AGENT_MODEL", "test-model")
+    monkeypatch.setenv(
+        "CODING_AGENT_MODEL_BASE_URL", "https://coding-provider.example/v1"
+    )
     monkeypatch.setenv("CODING_AGENT_GATEWAY_KEY", "test-only-key")
 
     client = create_acp_client("draft")

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -78,6 +78,8 @@ def test_config_disables_direct_tools_plugins_sharing_and_supplier_surface(tmp_p
         tool_broker_command=("python", "-m", "coding_worker.tool_mcp"),
     )
     config = provider.build_config(_route())
+
+    assert config["provider"]["modelmirror"]["name"] == "Independent Coding Provider"
     permission = config["permission"]
     assert permission["*"] == "deny"
     assert "modelmirror-tool-broker_*" not in permission

--- a/server/tests/test_model_router_admin_auth.py
+++ b/server/tests/test_model_router_admin_auth.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+from http.cookies import SimpleCookie
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from server.model_router.admin_auth import (
+    SESSION_TTL_SECONDS,
+    reset_provider_admin_auth,
+)
+from server.model_router.api import configure_model_router, router
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.service import ModelRouterService
+
+
+PAIRING_SECRET = "provider-admin-test-secret-at-least-32-chars"
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth() -> None:
+    reset_provider_admin_auth()
+    yield
+    reset_provider_admin_auth()
+
+
+def _app(tmp_path: Path) -> FastAPI:
+    configure_model_router(ModelRouterService(SQLiteRouterRepository(tmp_path)))
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_missing_pairing_secret_locks_only_management(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", raising=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=_app(tmp_path)),
+        base_url="http://localhost",
+    ) as client:
+        session = await client.get("/api/router/admin/session")
+        assert session.json() == {
+            "configured": False,
+            "authenticated": False,
+            "expires_at": None,
+            "csrf_token": None,
+        }
+        protected = await client.get("/api/router/connections")
+        assert protected.status_code == 503
+        assert protected.json()["detail"]["code"] == "admin_pairing_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_pairing_cookie_csrf_and_logout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", PAIRING_SECRET)
+    async with AsyncClient(
+        transport=ASGITransport(app=_app(tmp_path)),
+        base_url="http://localhost",
+    ) as client:
+        paired = await client.post(
+            "/api/router/admin/session",
+            json={"pairing_secret": PAIRING_SECRET},
+        )
+        assert paired.status_code == 200
+        payload = paired.json()
+        assert payload["authenticated"] is True
+        assert "provider-admin-test-secret" not in paired.text
+        cookie = paired.headers["set-cookie"].lower()
+        assert "httponly" in cookie
+        assert "samesite=strict" in cookie
+        assert "path=/api/router" in cookie
+        assert "secure" not in cookie
+        parsed_cookie = SimpleCookie()
+        parsed_cookie.load(paired.headers["set-cookie"])
+        assert parsed_cookie["modelmirror_provider_admin"].value not in paired.text
+
+        assert (await client.get("/api/router/connections")).status_code == 200
+        rejected = await client.post(
+            "/api/router/connections",
+            json={
+                "name": "OpenRouter",
+                "kind": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "test-key",
+            },
+        )
+        assert rejected.status_code == 403
+        assert rejected.json()["detail"]["code"] == "admin_csrf_invalid"
+        wrong_csrf = await client.post(
+            "/api/router/connections",
+            headers={"X-ModelMirror-CSRF": "wrong"},
+            json={
+                "name": "OpenRouter",
+                "kind": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "test-key",
+            },
+        )
+        assert wrong_csrf.status_code == 403
+
+        logged_out = await client.delete(
+            "/api/router/admin/session",
+            headers={"X-ModelMirror-CSRF": payload["csrf_token"]},
+        )
+        assert logged_out.status_code == 204
+        assert (await client.get("/api/router/admin/session")).json()[
+            "authenticated"
+        ] is False
+        assert (await client.get("/api/router/connections")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_pairing_requires_https_outside_loopback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", PAIRING_SECRET)
+    async with AsyncClient(
+        transport=ASGITransport(app=_app(tmp_path)),
+        base_url="http://admin.example",
+    ) as client:
+        for headers in (
+            {},
+            {"X-Forwarded-Proto": "https"},
+            {"Origin": "https://admin.example"},
+        ):
+            rejected = await client.post(
+                "/api/router/admin/session",
+                headers=headers,
+                json={"pairing_secret": PAIRING_SECRET},
+            )
+            assert rejected.status_code == 403
+            assert rejected.json()["detail"]["code"] == "admin_https_required"
+
+    reset_provider_admin_auth()
+    async with AsyncClient(
+        transport=ASGITransport(app=_app(tmp_path / "https")),
+        base_url="https://admin.example",
+    ) as client:
+        accepted = await client.post(
+            "/api/router/admin/session",
+            json={"pairing_secret": PAIRING_SECRET},
+        )
+        assert accepted.status_code == 200
+        assert "secure" in accepted.headers["set-cookie"].lower()
+
+
+@pytest.mark.asyncio
+async def test_native_gate_mutations_require_session_and_csrf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", PAIRING_SECRET)
+    async with AsyncClient(
+        transport=ASGITransport(app=_app(tmp_path)),
+        base_url="http://localhost",
+    ) as client:
+        approval = {
+            "no_open_p0_p1": True,
+            "drills": {
+                "connection_failure": True,
+                "rate_limit": True,
+                "stream_interrupt": True,
+            },
+        }
+        assert (
+            await client.put("/api/router/gate/approval", json=approval)
+        ).status_code == 401
+        assert (await client.delete("/api/router/gate/approval")).status_code == 401
+
+        paired = await client.post(
+            "/api/router/admin/session",
+            json={"pairing_secret": PAIRING_SECRET},
+        )
+        assert paired.status_code == 200
+        assert (
+            await client.put("/api/router/gate/approval", json=approval)
+        ).status_code == 403
+        assert (await client.delete("/api/router/gate/approval")).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_failed_pairing_is_rate_limited(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", PAIRING_SECRET)
+    async with AsyncClient(
+        transport=ASGITransport(app=_app(tmp_path)),
+        base_url="http://localhost",
+    ) as client:
+        for _ in range(5):
+            failed = await client.post(
+                "/api/router/admin/session",
+                json={"pairing_secret": "wrong"},
+            )
+            assert failed.status_code == 401
+        limited = await client.post(
+            "/api/router/admin/session",
+            json={"pairing_secret": PAIRING_SECRET},
+        )
+        assert limited.status_code == 429
+        assert 1 <= int(limited.headers["retry-after"]) <= 300
+
+
+@pytest.mark.asyncio
+async def test_pairing_rate_limit_window_recovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", PAIRING_SECRET)
+    clock = [2_000.0]
+    monkeypatch.setattr(
+        "server.model_router.admin_auth.time.time", lambda: clock[0]
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=_app(tmp_path)),
+        base_url="http://localhost",
+    ) as client:
+        for _ in range(5):
+            assert (
+                await client.post(
+                    "/api/router/admin/session",
+                    json={"pairing_secret": "wrong"},
+                )
+            ).status_code == 401
+        assert (
+            await client.post(
+                "/api/router/admin/session",
+                json={"pairing_secret": PAIRING_SECRET},
+            )
+        ).status_code == 429
+        clock[0] += 301
+        assert (
+            await client.post(
+                "/api/router/admin/session",
+                json={"pairing_secret": PAIRING_SECRET},
+            )
+        ).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_pairing_uses_constant_time_compare_and_logs_no_secret(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", PAIRING_SECRET)
+    calls = 0
+    original_compare = __import__("hmac").compare_digest
+
+    def compare(left: object, right: object) -> bool:
+        nonlocal calls
+        calls += 1
+        return original_compare(left, right)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("server.model_router.admin_auth.hmac.compare_digest", compare)
+    async with AsyncClient(
+        transport=ASGITransport(app=_app(tmp_path)),
+        base_url="http://localhost",
+    ) as client:
+        response = await client.post(
+            "/api/router/admin/session",
+            json={"pairing_secret": PAIRING_SECRET},
+        )
+    assert response.status_code == 200
+    assert calls >= 1
+    assert PAIRING_SECRET not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_short_pairing_secret_and_server_restart_keep_management_locked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", "too-short")
+    async with AsyncClient(
+        transport=ASGITransport(app=_app(tmp_path / "short")),
+        base_url="http://localhost",
+    ) as client:
+        response = await client.post(
+            "/api/router/admin/session", json={"pairing_secret": "too-short"}
+        )
+        assert response.status_code == 503
+
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", PAIRING_SECRET)
+    reset_provider_admin_auth()
+    async with AsyncClient(
+        transport=ASGITransport(app=_app(tmp_path / "restart")),
+        base_url="http://localhost",
+    ) as client:
+        assert (
+            await client.post(
+                "/api/router/admin/session",
+                json={"pairing_secret": PAIRING_SECRET},
+            )
+        ).status_code == 200
+        reset_provider_admin_auth()
+        assert (await client.get("/api/router/admin/session")).json()[
+            "authenticated"
+        ] is False
+
+
+@pytest.mark.asyncio
+async def test_session_expires_absolutely(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", PAIRING_SECRET)
+    clock = [1_000.0]
+    monkeypatch.setattr(
+        "server.model_router.admin_auth.time.time", lambda: clock[0]
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=_app(tmp_path)),
+        base_url="http://localhost",
+    ) as client:
+        paired = await client.post(
+            "/api/router/admin/session",
+            json={"pairing_secret": PAIRING_SECRET},
+        )
+        assert paired.status_code == 200
+        assert SESSION_TTL_SECONDS == 28_800
+        clock[0] += SESSION_TTL_SECONDS + 1
+        expired = await client.get("/api/router/admin/session")
+        assert expired.json()["authenticated"] is False

--- a/server/tests/test_model_router_credentials.py
+++ b/server/tests/test_model_router_credentials.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.model_router.migrate_credentials import (
+    CredentialMigrationError,
+    migrate_credentials,
+)
+from server.model_router.catalog import CatalogCoordinator
+from server.model_router.repository import (
+    CANONICAL_MASTER_KEY_ENV,
+    LEGACY_MASTER_KEY_ENV,
+    REQUIRE_EXTERNAL_MASTER_KEY_ENV,
+    RouterCredentialUnavailable,
+    SQLiteRouterRepository,
+)
+from server.model_router.schemas import RouterConnectionCreate
+from server.model_router.service import ModelRouterService, RouterServiceError
+
+
+def clear_master_key_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        CANONICAL_MASTER_KEY_ENV,
+        LEGACY_MASTER_KEY_ENV,
+        REQUIRE_EXTERNAL_MASTER_KEY_ENV,
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def create_connection(repository: SQLiteRouterRepository, key: str = "secret-value") -> str:
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Provider",
+            kind="openai_compatible",
+            base_url="https://provider.example/v1",
+            api_key=key,
+        ),
+    )
+    return connection.id
+
+
+def test_canonical_master_key_precedes_legacy_and_local_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(CANONICAL_MASTER_KEY_ENV, "canonical-key-material")
+    monkeypatch.setenv(LEGACY_MASTER_KEY_ENV, "legacy-key-material")
+    (tmp_path / "credential-master.key").write_text("local-key-material")
+
+    repository = SQLiteRouterRepository(tmp_path)
+    connection_id = create_connection(repository)
+
+    assert repository.resolve_api_key("local", connection_id) == "secret-value"
+    assert (
+        SQLiteRouterRepository(tmp_path, master_key="canonical-key-material")
+        .resolve_api_key("local", connection_id)
+        == "secret-value"
+    )
+
+
+def test_legacy_and_local_key_fallbacks_remain_compatible(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_master_key_environment(monkeypatch)
+    monkeypatch.setenv(LEGACY_MASTER_KEY_ENV, "legacy-key-material")
+    legacy = SQLiteRouterRepository(tmp_path / "legacy")
+    legacy_id = create_connection(legacy, "legacy-secret")
+    assert legacy.resolve_api_key("local", legacy_id) == "legacy-secret"
+
+    monkeypatch.delenv(LEGACY_MASTER_KEY_ENV)
+    local = SQLiteRouterRepository(tmp_path / "local")
+    local_id = create_connection(local, "local-secret")
+    assert (tmp_path / "local" / "credential-master.key").is_file()
+    assert SQLiteRouterRepository(tmp_path / "local").resolve_api_key(
+        "local", local_id
+    ) == "local-secret"
+
+
+def test_require_external_never_falls_back_to_legacy_or_local_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_master_key_environment(monkeypatch)
+    monkeypatch.setenv(REQUIRE_EXTERNAL_MASTER_KEY_ENV, "true")
+    monkeypatch.setenv(LEGACY_MASTER_KEY_ENV, "legacy-key-material")
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "credential-master.key").write_text("local-key-material")
+
+    with pytest.raises(RouterCredentialUnavailable):
+        SQLiteRouterRepository(tmp_path)
+
+
+def test_master_key_fingerprint_rejects_mismatched_key(tmp_path: Path) -> None:
+    repository = SQLiteRouterRepository(tmp_path, master_key="old-key")
+    create_connection(repository)
+
+    with pytest.raises(RouterCredentialUnavailable):
+        SQLiteRouterRepository(tmp_path, master_key="different-key")
+
+
+def test_atomic_credential_migration_preserves_backup_and_secrets(
+    tmp_path: Path,
+) -> None:
+    source_key = "old-key-material"
+    target_key = "new-key-material"
+    old_repository = SQLiteRouterRepository(tmp_path, master_key=source_key)
+    ids = [
+        create_connection(old_repository, "first-secret"),
+        create_connection(old_repository, "second-secret"),
+    ]
+
+    result = migrate_credentials(
+        tmp_path,
+        source_key=source_key,
+        target_key=target_key,
+    )
+
+    assert result.migrated_credentials == 2
+    assert Path(result.backup_path).is_file()
+    migrated = SQLiteRouterRepository(tmp_path, master_key=target_key)
+    assert [migrated.resolve_api_key("local", item) for item in ids] == [
+        "first-secret",
+        "second-secret",
+    ]
+    backup = sqlite3.connect(result.backup_path)
+    try:
+        ciphertext = backup.execute(
+            "SELECT api_key_ciphertext FROM router_connections ORDER BY id LIMIT 1"
+        ).fetchone()[0]
+    finally:
+        backup.close()
+    old_fernet = Fernet(SQLiteRouterRepository._normalize_key(source_key))
+    assert old_fernet.decrypt(ciphertext.encode("ascii")) in {
+        b"first-secret",
+        b"second-secret",
+    }
+
+
+def test_migration_preflight_and_interruption_leave_original_database_readable(
+    tmp_path: Path,
+) -> None:
+    repository = SQLiteRouterRepository(tmp_path, master_key="old-key")
+    connection_id = create_connection(repository)
+
+    with pytest.raises(CredentialMigrationError):
+        migrate_credentials(
+            tmp_path,
+            source_key="wrong-old-key",
+            target_key="new-key",
+        )
+    with pytest.raises(CredentialMigrationError):
+        migrate_credentials(
+            tmp_path,
+            source_key="old-key",
+            target_key="new-key",
+            fail_after=1,
+        )
+
+    restored = SQLiteRouterRepository(tmp_path, master_key="old-key")
+    assert restored.resolve_api_key("local", connection_id) == "secret-value"
+
+
+def test_migration_fails_closed_when_provider_data_changes_during_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = SQLiteRouterRepository(tmp_path, master_key="old-key")
+    first_id = create_connection(repository, "first-secret")
+    preflight_started = threading.Event()
+    original_decrypt = Fernet.decrypt
+
+    def delayed_first_decrypt(
+        self: Fernet,
+        token: bytes | str,
+        ttl: int | None = None,
+    ) -> bytes:
+        plaintext = original_decrypt(self, token, ttl)
+        if not preflight_started.is_set():
+            preflight_started.set()
+            time.sleep(0.25)
+        return plaintext
+
+    monkeypatch.setattr(Fernet, "decrypt", delayed_first_decrypt)
+    migration_errors: list[BaseException] = []
+
+    def run_migration() -> None:
+        try:
+            migrate_credentials(
+                tmp_path,
+                source_key="old-key",
+                target_key="new-key",
+            )
+        except BaseException as exc:
+            migration_errors.append(exc)
+
+    worker = threading.Thread(target=run_migration)
+    worker.start()
+    assert preflight_started.wait(timeout=5)
+    second_id = create_connection(repository, "second-secret")
+    worker.join(timeout=10)
+
+    assert not worker.is_alive()
+    assert len(migration_errors) == 1
+    assert isinstance(migration_errors[0], CredentialMigrationError)
+    assert "changed during credential migration" in str(migration_errors[0])
+    restored = SQLiteRouterRepository(tmp_path, master_key="old-key")
+    assert restored.resolve_api_key("local", first_id) == "first-secret"
+    assert restored.resolve_api_key("local", second_id) == "second-secret"
+
+
+def test_empty_database_migration_records_target_fingerprint(tmp_path: Path) -> None:
+    SQLiteRouterRepository(tmp_path, master_key="old-key")
+
+    result = migrate_credentials(
+        tmp_path,
+        source_key="old-key",
+        target_key="new-key",
+    )
+
+    assert result.migrated_credentials == 0
+    assert Path(result.backup_path).is_file()
+    assert SQLiteRouterRepository(tmp_path, master_key="new-key").list_connections(
+        "local"
+    ) == []
+
+
+def test_tenant_environment_is_local_only_and_conflicts_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = SQLiteRouterRepository(tmp_path, master_key="test-key")
+    monkeypatch.setenv("MODELMIRROR_DEFAULT_TENANT_ID", "local")
+    monkeypatch.setenv("MODEL_ROUTER_TENANT_ID", "local")
+    assert ModelRouterService(repository).tenant_id == "local"
+
+    monkeypatch.setenv("MODEL_ROUTER_TENANT_ID", "other")
+    with pytest.raises(RouterServiceError) as conflict:
+        ModelRouterService(repository)
+    assert conflict.value.code == "tenant_configuration_conflict"
+
+    monkeypatch.delenv("MODELMIRROR_DEFAULT_TENANT_ID")
+    with pytest.raises(RouterServiceError) as unsupported:
+        ModelRouterService(repository)
+    assert unsupported.value.code == "unsupported_tenant"
+
+    assert ModelRouterService(repository, tenant_id="other").tenant_id == "other"
+
+
+@pytest.mark.asyncio
+async def test_public_catalog_falls_back_when_dynamic_credentials_are_locked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Sidecar:
+        async def get_catalog(self) -> str:
+            return "public-catalog"
+
+        async def get_status(self) -> str:
+            return "public-status"
+
+    def locked_service() -> ModelRouterService:
+        raise RouterCredentialUnavailable("canonical master key required")
+
+    monkeypatch.setattr(
+        "server.model_router.catalog.get_model_router_service", locked_service
+    )
+    coordinator = CatalogCoordinator(Sidecar())  # type: ignore[arg-type]
+
+    assert await coordinator.get_catalog() == "public-catalog"
+    assert await coordinator.get_status() == "public-status"

--- a/server/tests/test_model_router_egress.py
+++ b/server/tests/test_model_router_egress.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import httpx
+import pytest
+from httpx import MockTransport, Request, Response
+
+from server.model_router.egress import ProviderEgressError, ProviderEgressPolicy
+
+
+@pytest.mark.asyncio
+async def test_public_https_is_pinned_and_public_http_is_rejected() -> None:
+    policy = ProviderEgressPolicy(
+        resolver=lambda _host, _port: ["8.8.8.8"]
+    )
+
+    target = await policy.authorize("https://provider.example/v1")
+
+    assert target.pinned_urls == ("https://8.8.8.8/v1",)
+    assert target.host_header == "provider.example"
+    assert target.sni_hostname == "provider.example"
+    with pytest.raises(ProviderEgressError) as exc_info:
+        await policy.authorize("http://provider.example/v1")
+    assert exc_info.value.code == "provider_https_required"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://127.0.0.1/v1",
+        "https://10.1.2.3/v1",
+        "https://[fd00::1]/v1",
+        "https://169.254.169.254/latest/meta-data",
+        "https://224.0.0.1/v1",
+        "https://0.0.0.0/v1",
+    ],
+)
+async def test_protected_addresses_fail_closed(url: str) -> None:
+    with pytest.raises(ProviderEgressError) as exc_info:
+        await ProviderEgressPolicy().authorize(url)
+    assert exc_info.value.code == "provider_address_blocked"
+
+
+@pytest.mark.asyncio
+async def test_exact_internal_allowlist_permits_newapi_but_not_metadata() -> None:
+    policy = ProviderEgressPolicy(
+        internal_allowlist="new-api:3000,169.254.169.254:80",
+        resolver=lambda host, _port: {
+            "new-api": ["172.20.0.4"],
+        }.get(host, ["169.254.169.254"]),
+    )
+
+    target = await policy.authorize("http://new-api:3000/v1")
+    assert target.pinned_urls == ("http://172.20.0.4:3000/v1",)
+    assert target.host_header == "new-api:3000"
+
+    with pytest.raises(ProviderEgressError) as exc_info:
+        await policy.authorize("http://169.254.169.254/latest/meta-data")
+    assert exc_info.value.code == "provider_address_blocked"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url,allowlist",
+    [
+        ("http://[fd00:ec2::254]:80/latest", "[fd00:ec2::254]:80"),
+        ("http://224.0.0.1:80/v1", "224.0.0.1:80"),
+        ("http://0.0.0.0:80/v1", "0.0.0.0:80"),
+        ("http://240.0.0.1:80/v1", "240.0.0.1:80"),
+    ],
+)
+async def test_internal_allowlist_cannot_override_permanent_blocks(
+    url: str,
+    allowlist: str,
+) -> None:
+    with pytest.raises(ProviderEgressError) as exc_info:
+        await ProviderEgressPolicy(internal_allowlist=allowlist).authorize(url)
+    assert exc_info.value.code == "provider_address_blocked"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://provider.example\\confused/v1",
+        "https://provider_example/v1",
+        "https://-provider.example/v1",
+    ],
+)
+def test_confusing_hostnames_are_rejected(value: str) -> None:
+    with pytest.raises(ProviderEgressError) as exc_info:
+        ProviderEgressPolicy().validate_for_storage(value)
+    assert exc_info.value.code == "invalid_address"
+
+
+@pytest.mark.asyncio
+async def test_mixed_public_and_private_dns_answers_reject_entire_target() -> None:
+    policy = ProviderEgressPolicy(
+        resolver=lambda _host, _port: ["8.8.8.8", "10.0.0.8"]
+    )
+
+    with pytest.raises(ProviderEgressError) as exc_info:
+        await policy.authorize("https://provider.example/v1")
+    assert exc_info.value.code == "provider_address_blocked"
+
+
+@pytest.mark.asyncio
+async def test_request_preserves_host_and_sni_and_does_not_follow_redirects() -> None:
+    requests: list[Request] = []
+
+    def handler(request: Request) -> Response:
+        requests.append(request)
+        return Response(302, headers={"location": "http://127.0.0.1/private"})
+
+    policy = ProviderEgressPolicy(
+        resolver=lambda _host, _port: ["8.8.8.8"]
+    )
+    async with httpx.AsyncClient(
+        transport=MockTransport(handler),
+        follow_redirects=True,
+        trust_env=False,
+    ) as client:
+        response = await policy.request(
+            client,
+            "GET",
+            "https://provider.example/v1/models",
+        )
+
+    assert response.status_code == 302
+    assert len(requests) == 1
+    assert requests[0].url == "https://8.8.8.8/v1/models"
+    assert requests[0].headers["host"] == "provider.example"
+    assert requests[0].extensions["sni_hostname"] == "provider.example"
+
+
+@pytest.mark.asyncio
+async def test_dns_rebinding_cannot_change_the_approved_connection_address() -> None:
+    resolutions = iter([["8.8.8.8"], ["127.0.0.1"]])
+    policy = ProviderEgressPolicy(
+        resolver=lambda _host, _port: next(resolutions)
+    )
+    seen_urls: list[str] = []
+
+    def handler(request: Request) -> Response:
+        seen_urls.append(str(request.url))
+        return Response(200, json={"data": []})
+
+    async with httpx.AsyncClient(transport=MockTransport(handler)) as client:
+        await policy.request(client, "GET", "https://provider.example/v1/models")
+
+    assert seen_urls == ["https://8.8.8.8/v1/models"]
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_retries_only_preapproved_addresses() -> None:
+    policy = ProviderEgressPolicy(
+        resolver=lambda _host, _port: ["8.8.8.8", "1.1.1.1"]
+    )
+    seen_hosts: list[str] = []
+
+    def handler(request: Request) -> Response:
+        seen_hosts.append(request.url.host or "")
+        if len(seen_hosts) == 1:
+            raise httpx.ConnectError("failed", request=request)
+        return Response(200)
+
+    async with httpx.AsyncClient(transport=MockTransport(handler)) as client:
+        response = await policy.request(client, "GET", "https://provider.example/v1")
+
+    assert response.status_code == 200
+    assert seen_hosts == ["1.1.1.1", "8.8.8.8"]
+
+
+@pytest.mark.asyncio
+async def test_saved_target_is_reauthorized_before_every_request() -> None:
+    resolutions = iter([["8.8.8.8"], ["127.0.0.1"]])
+    policy = ProviderEgressPolicy(
+        resolver=lambda _host, _port: next(resolutions)
+    )
+    async with httpx.AsyncClient(
+        transport=MockTransport(lambda _request: Response(200))
+    ) as client:
+        assert (
+            await policy.request(client, "GET", "https://provider.example/v1")
+        ).status_code == 200
+        with pytest.raises(ProviderEgressError) as exc_info:
+            await policy.request(client, "GET", "https://provider.example/v1")
+    assert exc_info.value.code == "provider_address_blocked"
+
+
+def test_dynamic_multimodal_consumers_do_not_call_target_base_url_directly() -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    files = [
+        "server/multimodal/audio_catalog.py",
+        "server/multimodal/audio_jobs.py",
+        "server/multimodal/image_catalog.py",
+        "server/multimodal/image_generation.py",
+        "server/multimodal/realtime.py",
+        "server/multimodal/stt.py",
+        "server/multimodal/tts.py",
+        "server/multimodal/video_analysis.py",
+        "server/multimodal/video_catalog.py",
+        "server/multimodal/video_jobs.py",
+    ]
+    violations: list[str] = []
+    for relative in files:
+        path = repository_root / relative
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr not in {"get", "post", "put", "patch", "request", "stream"}:
+                continue
+            if any(
+                isinstance(child, ast.Attribute)
+                and child.attr == "base_url"
+                and isinstance(child.value, ast.Name)
+                and child.value.id == "target"
+                for argument in (*node.args, *node.keywords)
+                for child in ast.walk(argument.value if isinstance(argument, ast.keyword) else argument)
+            ):
+                violations.append(f"{relative}:{node.lineno}")
+    assert violations == []

--- a/server/tests/test_model_router_foundation.py
+++ b/server/tests/test_model_router_foundation.py
@@ -8,11 +8,14 @@ from pathlib import Path
 
 import httpx
 import pytest
+from cryptography.fernet import Fernet
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient, MockTransport, Request, Response
 
 from server.model_router.api import configure_model_router, router
+from server.model_router.admin_auth import reset_provider_admin_auth
 from server.model_router.catalog import NativeCatalogService
+from server.model_router.egress import ProviderEgressPolicy
 from server.model_router.repository import (
     RouterConnectionNotFound,
     SCHEMA_VERSION,
@@ -27,6 +30,10 @@ from server.model_router.schemas import (
 from server.model_router.service import ModelRouterService
 from server.model_router.service import RouterServiceError
 from server.omniroute.schemas import ModelCatalogResponse
+
+
+def public_egress_policy() -> ProviderEgressPolicy:
+    return ProviderEgressPolicy(resolver=lambda _host, _port: ["8.8.8.8"])
 
 
 def connection_payload(**updates: object) -> RouterConnectionCreate:
@@ -72,6 +79,10 @@ def test_schema_and_credentials_are_tenant_scoped_and_persistent(
 def test_connection_scopes_default_by_provider_and_migrate_v7(
     tmp_path: Path,
 ) -> None:
+    migration_key = b"migration-test-key"
+    legacy_ciphertext = Fernet(
+        SQLiteRouterRepository._normalize_key(migration_key)
+    ).encrypt(b"legacy-secret").decode("ascii")
     legacy_dir = tmp_path / "legacy"
     legacy_dir.mkdir()
     legacy_database = legacy_dir / "router.sqlite3"
@@ -113,7 +124,7 @@ def test_connection_scopes_default_by_provider_and_migrate_v7(
                 "openrouter",
                 "https://openrouter.ai/api/v1",
                 "sk******cy",
-                "not-used-by-this-test",
+                legacy_ciphertext,
                 1,
                 "online",
                 "2026-07-29T00:00:00+00:00",
@@ -123,7 +134,7 @@ def test_connection_scopes_default_by_provider_and_migrate_v7(
 
     migrated = SQLiteRouterRepository(
         legacy_dir,
-        master_key=b"migration-test-key",
+        master_key=migration_key,
     )
     assert migrated.get_connection(
         "local", "legacy-openrouter"
@@ -396,11 +407,13 @@ async def test_connection_probe_returns_safe_actionable_results(
     service = ModelRouterService(
         SQLiteRouterRepository(tmp_path),
         client_factory=lambda: httpx.AsyncClient(transport=MockTransport(success)),
+        egress_policy=public_egress_policy(),
     )
     result = await service.test_unsaved_connection(connection_payload())
     assert result.ok is True
     assert result.model_count == 2
-    assert requests[0].url == "https://openrouter.ai/api/v1/models"
+    assert requests[0].url == "https://8.8.8.8/api/v1/models"
+    assert requests[0].headers["host"] == "openrouter.ai"
     assert requests[0].headers["authorization"] == "Bearer sk-test-secret-value"
 
     def unauthorized(_: Request) -> Response:
@@ -411,6 +424,7 @@ async def test_connection_probe_returns_safe_actionable_results(
         client_factory=lambda: httpx.AsyncClient(
             transport=MockTransport(unauthorized)
         ),
+        egress_policy=public_egress_policy(),
     )
     failed = await service.test_unsaved_connection(connection_payload())
     assert failed.ok is False
@@ -419,7 +433,10 @@ async def test_connection_probe_returns_safe_actionable_results(
 
 
 @pytest.mark.asyncio
-async def test_connection_api_is_redacted_and_records_health(tmp_path: Path) -> None:
+async def test_connection_api_is_redacted_and_records_health(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def success(_: Request) -> Response:
         return Response(200, json={"data": [{"id": "model-a"}]})
 
@@ -427,17 +444,27 @@ async def test_connection_api_is_redacted_and_records_health(tmp_path: Path) -> 
     service = ModelRouterService(
         repository,
         client_factory=lambda: httpx.AsyncClient(transport=MockTransport(success)),
+        egress_policy=public_egress_policy(),
     )
     configure_model_router(service)
+    pairing_secret = "provider-admin-foundation-secret-32-chars"
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", pairing_secret)
+    reset_provider_admin_auth()
     app = FastAPI()
     app.include_router(router)
 
     async with AsyncClient(
         transport=ASGITransport(app=app),
-        base_url="http://test",
+        base_url="http://localhost",
     ) as client:
+        paired_response = await client.post(
+            "/api/router/admin/session",
+            json={"pairing_secret": pairing_secret},
+        )
+        csrf = paired_response.json()["csrf_token"]
         created_response = await client.post(
             "/api/router/connections",
+            headers={"X-ModelMirror-CSRF": csrf},
             json=connection_payload().model_dump(mode="json"),
         )
         assert created_response.status_code == 201
@@ -448,7 +475,8 @@ async def test_connection_api_is_redacted_and_records_health(tmp_path: Path) -> 
         assert created["scopes"] == ["chat", "audio"]
 
         tested_response = await client.post(
-            f"/api/router/connections/{created['id']}/test"
+            f"/api/router/connections/{created['id']}/test",
+            headers={"X-ModelMirror-CSRF": csrf},
         )
         assert tested_response.status_code == 200
         assert tested_response.json()["model_count"] == 1
@@ -458,6 +486,7 @@ async def test_connection_api_is_redacted_and_records_health(tmp_path: Path) -> 
         assert status["tenant_id"] == "local"
         assert status["online_connection_count"] == 1
         assert status["ready"] is True
+    reset_provider_admin_auth()
 
 
 def test_behavior_baselines_and_direct_port_provenance_are_pinned() -> None:
@@ -562,6 +591,7 @@ async def test_native_catalog_uses_30_second_cache_and_stale_if_error(
     service = ModelRouterService(
         repository,
         client_factory=lambda: httpx.AsyncClient(transport=MockTransport(handler)),
+        egress_policy=public_egress_policy(),
     )
 
     class FallbackCatalog:

--- a/server/tests/test_multimodal_chat_audio.py
+++ b/server/tests/test_multimodal_chat_audio.py
@@ -18,6 +18,7 @@ from server.model_router import (
     configure_model_router,
     get_model_router_service,
 )
+from server.model_router.egress import ProviderEgressPolicy
 from server.multimodal.api import (
     configure_audio_catalog_service,
     configure_chat_attachment_store,
@@ -102,7 +103,12 @@ def configure_audio_test_services(
         error_code=None,
         error_hint=None,
     )
-    service = ModelRouterService(repository)
+    service = ModelRouterService(
+        repository,
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
     catalog_service = AudioCatalogService(
         service,
         client_factory=lambda: RealAsyncClient(
@@ -160,6 +166,7 @@ def fake_chat_client(
             url: str,
             headers: dict[str, str],
             json: dict[str, Any],
+            **_kwargs: object,
         ) -> dict[str, Any]:
             return {
                 "method": method,

--- a/server/tests/test_multimodal_chat_foundation.py
+++ b/server/tests/test_multimodal_chat_foundation.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient, MockTransport, Request, Response
 
 from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.egress import ProviderEgressPolicy
 from server.model_router.schemas import RouterConnectionCreate
 from server.model_router.service import ModelRouterService
 from server.multimodal.api import (
@@ -43,7 +44,12 @@ def openrouter_service(tmp_path: Path) -> ModelRouterService:
         error_code=None,
         error_hint=None,
     )
-    return ModelRouterService(repository)
+    return ModelRouterService(
+        repository,
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
 
 
 def audio_catalog_payload() -> dict[str, object]:
@@ -499,7 +505,7 @@ async def test_audio_catalog_marks_enabled_direct_openai_realtime_ready(
 
     def handler(request: Request) -> Response:
         requests.append(request)
-        if request.url.host == "api.openai.com":
+        if request.headers.get("host") == "api.openai.com":
             if not openai_available[0]:
                 return Response(503, text="private direct provider error")
             return Response(
@@ -515,7 +521,12 @@ async def test_audio_catalog_marks_enabled_direct_openai_realtime_ready(
         return Response(200, json=audio_catalog_payload())
 
     service = AudioCatalogService(
-        ModelRouterService(repository),
+        ModelRouterService(
+            repository,
+            egress_policy=ProviderEgressPolicy(
+                resolver=lambda _host, _port: ["8.8.8.8"]
+            ),
+        ),
         client_factory=lambda: httpx.AsyncClient(
             transport=MockTransport(handler)
         ),

--- a/server/tests/test_multimodal_image.py
+++ b/server/tests/test_multimodal_image.py
@@ -8,6 +8,7 @@ import pytest
 from httpx import MockTransport, Request, Response
 
 from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.egress import ProviderEgressPolicy
 from server.model_router.schemas import RouterConnectionCreate
 from server.model_router.service import ModelRouterService
 from server.multimodal.image_catalog import ImageCatalogService
@@ -38,7 +39,12 @@ def openrouter_service(tmp_path: Path) -> ModelRouterService:
         error_code=None,
         error_hint=None,
     )
-    return ModelRouterService(repository)
+    return ModelRouterService(
+        repository,
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
 
 
 def image_catalog_handler(request: Request) -> Response:

--- a/server/tests/test_multimodal_video_catalog.py
+++ b/server/tests/test_multimodal_video_catalog.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient, MockTransport, Request, Response
 
 from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.egress import ProviderEgressPolicy
 from server.model_router.schemas import RouterConnectionCreate
 from server.model_router.service import ModelRouterService
 from server.multimodal.api import (
@@ -77,7 +78,12 @@ def openrouter_service(tmp_path: Path) -> ModelRouterService:
         error_code=None,
         error_hint=None,
     )
-    return ModelRouterService(repository)
+    return ModelRouterService(
+        repository,
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_native_router_chat.py
+++ b/server/tests/test_native_router_chat.py
@@ -18,6 +18,7 @@ from server.model_router import (
     configure_model_router,
     get_model_router_service,
 )
+from server.model_router.egress import ProviderEgressPolicy
 
 
 @pytest_asyncio.fixture
@@ -42,6 +43,24 @@ class CatalogClient:
     async def get(self, _url: str, headers: dict[str, str]):
         assert headers["Authorization"] == "Bearer native-secret"
         return httpx.Response(200, json={"data": self.records})
+
+    def build_request(self, method: str, url: str, **kwargs: object):
+        return httpx.Request(method, url, **kwargs)
+
+    async def send(
+        self,
+        request: httpx.Request,
+        *,
+        stream: bool = False,
+        follow_redirects: bool = False,
+    ):
+        assert follow_redirects is False
+        assert request.headers["Authorization"] == "Bearer native-secret"
+        return httpx.Response(
+            200,
+            json={"data": self.records},
+            request=request,
+        )
 
 
 def native_service(tmp_path: Path) -> ModelRouterService:
@@ -91,6 +110,9 @@ def native_service(tmp_path: Path) -> ModelRouterService:
     return ModelRouterService(
         repository,
         client_factory=lambda: CatalogClient(records),  # type: ignore[arg-type]
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
     )
 
 
@@ -137,7 +159,7 @@ async def test_native_auto_retries_empty_stream_before_visible_output(
         def __init__(self, *args, **kwargs):
             pass
 
-        def build_request(self, method, url, headers, json):
+        def build_request(self, method, url, headers, json, **_kwargs):
             return {
                 "method": method,
                 "url": url,
@@ -145,8 +167,9 @@ async def test_native_auto_retries_empty_stream_before_visible_output(
                 "json": json,
             }
 
-        async def send(self, request, stream):
+        async def send(self, request, stream, follow_redirects=False):
             assert stream is True
+            assert follow_redirects is False
             model_id = request["json"]["model"]
             sent_models.append(model_id)
             return FakeResponse(model_id)
@@ -295,7 +318,7 @@ async def test_native_stream_requires_a_terminal_marker_and_reports_output_limit
         def __init__(self, *args, **kwargs):
             pass
 
-        def build_request(self, method, url, headers, json):
+        def build_request(self, method, url, headers, json, **_kwargs):
             return {
                 "method": method,
                 "url": url,
@@ -303,8 +326,9 @@ async def test_native_stream_requires_a_terminal_marker_and_reports_output_limit
                 "json": json,
             }
 
-        async def send(self, request, stream):
+        async def send(self, request, stream, follow_redirects=False):
             assert stream is True
+            assert follow_redirects is False
             return FakeResponse()
 
         async def aclose(self):

--- a/server/tests/test_workflow_deployments.py
+++ b/server/tests/test_workflow_deployments.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -12,6 +13,12 @@ from server.workflow_deployments import (
     WorkflowDeploymentStore,
     WorkflowDeploymentValidationError,
 )
+
+
+def test_server_image_includes_workflow_deployment_module() -> None:
+    dockerfile = Path(__file__).resolve().parents[1] / "Dockerfile"
+
+    assert "COPY workflow_deployments.py ." in dockerfile.read_text(encoding="utf-8")
 
 
 def manual_workflow() -> dict:


### PR DESCRIPTION
## 摘要

- 完成 Round 0：解除控制面建设冻结，将 newAPI 从核心 Compose 拆为独立可选数据面，并把设置页改为仅外链管理卡，不嵌入或代理其 UI。
- 完成 Round 1A：新增管理员配对会话、HttpOnly Cookie、CSRF、限流与统一 Router 管理接口门禁；未配置时只锁定管理面。
- 完成 Round 1B：统一动态 Provider 出口授权与 SSRF/DNS rebinding 防护，并覆盖 Chat、目录和多模态消费者。
- 完成 Round 1C：统一凭据主密钥与租户配置，提供带一致性备份、事务回滚和回读验证的一次性迁移命令。
- 保持 Coding Provider、凭据和生命周期隔离；不改变 `/api/chat`、SSE、公开目录或默认数据面策略。

## 针对性修复

- 不再把客户端可伪造的 `X-Forwarded-Proto` 直接当作 TLS 证明；仅信任 ASGI scheme，并补充可信代理部署约束。
- 为 gate approval 写接口补齐管理员会话与 CSRF 门禁。
- 凭据迁移在进入写事务后复核 SQLite `data_version`，检测并拒绝预检期间的并发写入。
- 修复核心 Compose 空值覆盖 `server/.env` 的配置根因；互联 Overlay 继续要求显式 `LLM_GATEWAY_URL`。

## 验证

- Provider、Native Chat、多模态、Coding 与最新基线交叉测试：`200 passed`。
- 前端：`82 files / 403 tests passed`；typecheck 与 production build 通过。
- 全量后端：`3307 passed, 29 skipped, 20 failed`；精确无补丁基线对照为相同的 20 个失败节点（对照子集 `20 failed, 64 passed`），未发现本分支新增失败。
- Compose：核心配置通过；独立 newAPI 配置通过；Overlay 缺少显式 URL 时按预期失败，提供 URL 时通过。
- 容器与浏览器验收：health/settings 200；未认证管理接口 401；配对、CSRF、Cookie、受保护读取与注销通过；页面无 iframe；配对密钥未写入 localStorage/sessionStorage。
- `git diff --check` 通过；敏感模式命中仅为两个测试文件中的假配对值。

## 风险与剩余门禁

- 全量后端的 20 个失败属于当前基线测试环境问题，已用相同 SHA 无补丁工作树复现；未以绿测名义隐藏。
- 最终基线预览没有再次消耗真实模型额度；此前获批的一次真实 `/chat` 调用已在前序预览通过。
- 生产 HTTPS 配对要求反向代理覆盖转发头，并把 `FORWARDED_ALLOW_IPS` 限定为实际代理 IP/CIDR，禁止使用 `*`。
- 本 PR 不批准 Native Router 或 newAPI 的默认数据面切换。

## 回滚

- 可回退本提交并恢复原核心 Compose 生命周期；不得删除独立 newAPI 数据目录。
- 凭据迁移保留时间戳数据库备份和旧密钥来源，失败时事务回滚，人工确认前不删除备份。