### PR TITLE
feature: 增加 Skill Creator 可复用评测套件

### DIFF
--- a/docs/SKILL_EXPERIENCE_AUDIT.md
+++ b/docs/SKILL_EXPERIENCE_AUDIT.md
@@ -141,6 +141,8 @@ node scripts/audit-skill-experience.mjs
 
 评测合同：客观 Skill 必须完成与当前 digest 绑定的恰好 3 个用例；主观创作类 Skill 可运行同一三例，或由本地控制台填写原因并二次确认豁免。新 Skill 的 baseline 不加载 Skill；升级 Skill 的 baseline 固定为会话开始时已安装的 digest；Candidate 使用当前不可变 Overlay。两侧使用同一实际模型与参数，只开放 `skill_read`、`skill_stage` 和固定离线 Sandbox；不开放网络、MCP、浏览器、安装或 HITL。接受或豁免均不会自动安装，当前 digest 仍需单独确认全局安装。
 
+`SKILL_CREATOR_EVOLUTION_V2_ENABLED=true` 时，可显式把旧三例无模型迁移为不可变评测套件，或由固定 Creator Agent 生成“正常、歧义/信息不足、边界/失败”三个核心案例。用户确认的失败案例最多追加 9 条回归案例；模型不得自行写入回归集。V2 run 冻结套件 revision/digest，Candidate 每项必须持有与 Overlay、资源路径和实际 `skill_read`/`skill_stage` 一致的 verified 应用凭据；人工接受和崩溃恢复时都会重新核对权威凭据 Store。该开关在跨版本回归治理完成前默认关闭，旧会话不会被静默迁移。
+
 资源化创作在行为质量门之前增加了“澄清 → 资源计划 → 用户确认 → 逐资源生成与验证 → 最终 `SKILL.md` → 提案确认”的阶段：
 
 - 根据任务重复性与确定性，主动判断是否应生成 `scripts/`，并要求脚本具有清晰入口、失败行为、语法检查和实际测试证据；不为凑目录生成脆弱脚本。

--- a/server/.env.example
+++ b/server/.env.example
@@ -22,6 +22,8 @@ EXPERT_TEAM_AGENCY_HITL_ENABLED=0
 SKILL_CREATOR_V2_ENABLED=true
 # 资源化 Creator 已具备规划、分段构建和脚本离线实测；PR 3 工作台完成前默认关闭。
 SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED=true
+# 可复用评测套件与进化流程在最终治理轮完成前保持显式启用。
+SKILL_CREATOR_EVOLUTION_V2_ENABLED=false
 # 第三方 Git Skill 信任门默认 enforce：确定恶意或不可安装内容会被阻断；
 # 其余风险需确认精确凭据，可疑项不进入 Agent Router。可切回 audit 或 off 即时回退。
 SKILL_TRUST_GATE_MODE=enforce
@@ -36,7 +38,7 @@ SKILL_LIFECYCLE_MAX_VERSIONS=5
 SKILL_LIFECYCLE_MAX_BYTES=1073741824
 # Skill 应用凭据默认仅审计，不改变普通聊天或工作流结果。
 # off 可关闭写入；enforce 会在凭据不可写时使 Skill 应用失败关闭。
-# Creator Evaluation V2 后续还会对其内部运行强制校验 verified 凭据。
+# Creator Evaluation V2 内部始终强制复核 verified 凭据，不受 audit 回退影响。
 SKILL_APPLICATION_RECEIPT_MODE=audit
 # The semantic provider remains disabled until explicitly configured. Router
 # shadow mode never changes the lexical skill-need-local-v3 result order.

--- a/server/main.py
+++ b/server/main.py
@@ -218,6 +218,7 @@ try:
     from server.skills.creator_api import (
         configure_skill_creator,
         configure_skill_creator_evaluation,
+        configure_skill_creator_evaluation_suite,
         configure_skill_creator_resource_build,
         configure_skill_creator_resource_planning,
         router as skill_creator_router,
@@ -267,6 +268,14 @@ try:
     from server.skills.creator_evaluation_service import (
         SkillCreatorEvaluationService,
     )
+    from server.skills.creator_evaluation_suite import SkillEvaluationSuiteStore
+    from server.skills.creator_evaluation_suite_runtime import (
+        EvaluationSuiteWorkflowInvocation,
+        WorkflowCreatorEvaluationSuiteGenerator,
+    )
+    from server.skills.creator_evaluation_suite_service import (
+        SkillCreatorEvaluationSuiteService,
+    )
     from server.skills.creator_service import (
         SkillCreatorService,
         configure_creator_generation_executor,
@@ -294,6 +303,7 @@ except ModuleNotFoundError:
     from skills.creator_api import (
         configure_skill_creator,
         configure_skill_creator_evaluation,
+        configure_skill_creator_evaluation_suite,
         configure_skill_creator_resource_build,
         configure_skill_creator_resource_planning,
         router as skill_creator_router,
@@ -337,6 +347,14 @@ except ModuleNotFoundError:
         skill_evaluation_model_temperature,
     )
     from skills.creator_evaluation_service import SkillCreatorEvaluationService
+    from skills.creator_evaluation_suite import SkillEvaluationSuiteStore
+    from skills.creator_evaluation_suite_runtime import (
+        EvaluationSuiteWorkflowInvocation,
+        WorkflowCreatorEvaluationSuiteGenerator,
+    )
+    from skills.creator_evaluation_suite_service import (
+        SkillCreatorEvaluationSuiteService,
+    )
     from skills.creator_service import (
         SkillCreatorService,
         configure_creator_generation_executor,
@@ -1035,8 +1053,10 @@ WORKFLOW_AGENT_MAX_TOKENS = 1024
 SKILL_CREATOR_AGENT_MAX_TOKENS = 12_288
 SKILL_CREATOR_RESOURCE_PLANNER_MAX_TOKENS = 8_192
 SKILL_CREATOR_RESOURCE_BUILDER_MAX_TOKENS = 8_192
+SKILL_CREATOR_EVALUATION_SUITE_MAX_TOKENS = 8_192
 SKILL_CREATOR_RESOURCE_PLANNER_TEMPERATURE = 0.1
 SKILL_CREATOR_RESOURCE_BUILDER_TEMPERATURE = 0.1
+SKILL_CREATOR_EVALUATION_SUITE_TEMPERATURE = 0.1
 SKILL_EVALUATION_AGENT_MAX_TOKENS = 4_096
 AGENT_TASK_STORAGE_DIR = os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
 
@@ -1063,11 +1083,26 @@ def workflow_agent_token_budget(runtime_metadata: dict[str, Any] | None) -> int:
             return SKILL_CREATOR_RESOURCE_PLANNER_MAX_TOKENS
         if metadata.get("creator_phase") == "resource_build":
             return SKILL_CREATOR_RESOURCE_BUILDER_MAX_TOKENS
+        if metadata.get("creator_phase") == "evaluation_suite":
+            return SKILL_CREATOR_EVALUATION_SUITE_MAX_TOKENS
         return SKILL_CREATOR_AGENT_MAX_TOKENS
     metadata = dict(runtime_metadata or {})
     if is_trusted_skill_evaluation_metadata(metadata):
         return SKILL_EVALUATION_AGENT_MAX_TOKENS
     return WORKFLOW_AGENT_MAX_TOKENS
+
+
+def workflow_agent_temperature(runtime_metadata: dict[str, Any] | None) -> float:
+    metadata = dict(runtime_metadata or {})
+    if is_trusted_skill_creator_runtime(metadata):
+        phase = metadata.get("creator_phase")
+        if phase == "resource_plan":
+            return SKILL_CREATOR_RESOURCE_PLANNER_TEMPERATURE
+        if phase == "resource_build":
+            return SKILL_CREATOR_RESOURCE_BUILDER_TEMPERATURE
+        if phase == "evaluation_suite":
+            return SKILL_CREATOR_EVALUATION_SUITE_TEMPERATURE
+    return skill_evaluation_model_temperature(metadata, default=0.7)
 
 
 HANDOFF_EXECUTOR_ENABLED = os.getenv(
@@ -1512,6 +1547,15 @@ skill_creator_resource_build_service = SkillCreatorResourceBuildService(
     skill_creator_resource_build_store,
     script_runner=SandboxCreatorScriptRunner(sandbox_sidecar_client),
 )
+skill_creator_evaluation_suite_store = SkillEvaluationSuiteStore(
+    storage_dir=AGENT_TASK_STORAGE_DIR or None
+)
+skill_creator_evaluation_suite_service = SkillCreatorEvaluationSuiteService(
+    skill_creator_service,
+    skill_creator_evaluation_suite_store,
+    skill_evaluation_store,
+    resource_plan_store=skill_creator_resource_plan_store,
+)
 workflow_xpert_authoring_provider = AuthoringToolsetProvider(
     authoring_service, "xpert"
 )
@@ -1522,6 +1566,7 @@ configure_runtime_authoring(authoring_service)
 configure_skill_creator(skill_creator_service)
 configure_skill_creator_resource_planning(skill_creator_resource_planning_service)
 configure_skill_creator_resource_build(skill_creator_resource_build_service)
+configure_skill_creator_evaluation_suite(skill_creator_evaluation_suite_service)
 runtime_capabilities.register(
     "mcp_tools",
     workflow_mcp_provider,
@@ -13929,22 +13974,7 @@ async def _run_workflow_response(
                         actual_model_successful_responses = 0
                         actual_model_missing_count = 0
                         evaluation_token_usage: dict[str, int] = {}
-                        agent_temperature = (
-                            (
-                                SKILL_CREATOR_RESOURCE_PLANNER_TEMPERATURE
-                                if run_context.get("creator_phase") == "resource_plan"
-                                else SKILL_CREATOR_RESOURCE_BUILDER_TEMPERATURE
-                            )
-                            if (
-                                is_trusted_skill_creator_runtime(run_context)
-                                and run_context.get("creator_phase")
-                                in {"resource_plan", "resource_build"}
-                            )
-                            else skill_evaluation_model_temperature(
-                                run_context,
-                                default=0.7,
-                            )
-                        )
+                        agent_temperature = workflow_agent_temperature(run_context)
 
                         def observe_actual_model(reported_model_id: str) -> None:
                             nonlocal actual_model_missing_count
@@ -17103,6 +17133,48 @@ skill_creator_resource_builder = WorkflowCreatorResourceBuilder(
 skill_creator_resource_build_service.builder = skill_creator_resource_builder
 
 
+async def run_skill_creator_evaluation_suite_generation(
+    invocation: EvaluationSuiteWorkflowInvocation,
+) -> str:
+    payload = WorkflowRunRequest.model_validate(
+        {"workflow": invocation.workflow, "inputs": invocation.inputs}
+    )
+    session_id = str(
+        invocation.runtime_metadata.get("creator_session_id") or ""
+    ).strip()
+    response = await _run_workflow_response(
+        payload,
+        None,
+        runtime_run_type="workflow",
+        runtime_source_id=session_id,
+        runtime_metadata=dict(invocation.runtime_metadata),
+    )
+    final_event = await consume_workflow_stream(response)
+    if final_event.get("event") in {
+        "runtime_approval_pending",
+        "client_tool_waiting",
+    }:
+        raise RuntimeError(
+            "The dedicated Skill Creator evaluation designer cannot pause for tools."
+        )
+    output = str(final_event.get("final_output") or "").strip()
+    if not output:
+        raise RuntimeError(
+            "The Skill Creator evaluation designer returned no suite."
+        )
+    return output
+
+
+skill_creator_evaluation_suite_generator = WorkflowCreatorEvaluationSuiteGenerator(
+    model_id=TEXT_FALLBACK_MODEL,
+    model_available=lambda: bool(get_llm_gateway_config()[0]),
+    runner=run_skill_creator_evaluation_suite_generation,
+)
+skill_creator_evaluation_suite_service.generator = (
+    skill_creator_evaluation_suite_generator
+)
+
+
 async def execute_external_xpert_resource(
     resource: dict[str, Any],
     task: str,
@@ -19368,6 +19440,37 @@ async def run_skill_evaluation_item(
             )
         child = completed[0]
         actual_model = require_skill_evaluation_actual_model(child.metadata)
+        application_receipt = None
+        if item.target == "candidate" and run.evaluation_suite_id is not None:
+            expected_policy = (
+                "require_stage" if case.required_resource_paths else "require_read"
+            )
+            candidates = await asyncio.to_thread(
+                skill_application_receipt_store.list_receipts,
+                run_id=runtime_run_id,
+                skill_id="evaluation-skill",
+            )
+            verified = [
+                receipt
+                for receipt in candidates
+                if receipt.compliance_status == "verified"
+                and receipt.source_kind == "evaluation_overlay"
+                and receipt.version_id == getattr(overlay, "overlay_id", None)
+                and receipt.content_digest == getattr(overlay, "content_digest", None)
+                and receipt.policy == expected_policy
+                and tuple(receipt.required_resource_paths)
+                == tuple(case.required_resource_paths)
+            ]
+            if len(verified) != 1:
+                raise SkillEvaluationValidationError(
+                    "Skill evaluation could not prove one verified application receipt.",
+                    code="skill_application_receipt_missing",
+                )
+            application_receipt = await asyncio.to_thread(
+                skill_application_receipt_store.protect,
+                verified[0].receipt_id,
+                reference_id=f"evaluation-item:{item.item_id}",
+            )
         raw_usage = child.metadata.get("token_usage")
         raw_usage = raw_usage if isinstance(raw_usage, dict) else {}
         usage = {
@@ -19383,6 +19486,17 @@ async def run_skill_evaluation_item(
             work_manifest=manifest,
             usage=usage,
             runtime_run_id=runtime_run_id or None,
+            application_receipt_id=(
+                application_receipt.receipt_id if application_receipt else None
+            ),
+            application_receipt_revision=(
+                application_receipt.revision if application_receipt else None
+            ),
+            application_compliance=(
+                application_receipt.compliance_status
+                if application_receipt
+                else None
+            ),
         )
     finally:
         # Do not let model-visible traces retain case inputs, tool outputs, or
@@ -19456,6 +19570,44 @@ async def iterate_skill_creator_from_evaluation(
     )
 
 
+def verify_skill_evaluation_application_receipts(run: Any) -> None:
+    if run.evaluation_suite_id is None:
+        return
+    cases = {case.case_id: case for case in run.cases}
+    for item in run.items:
+        if item.target != "candidate":
+            continue
+        try:
+            receipt = skill_application_receipt_store.require_verified(
+                item.application_receipt_id or ""
+            )
+        except SkillApplicationReceiptError as exc:
+            raise SkillEvaluationValidationError(
+                "A verified Skill application receipt is unavailable.",
+                code=exc.code,
+            ) from exc
+        case = cases[item.case_id]
+        expected_policy = (
+            "require_stage" if case.required_resource_paths else "require_read"
+        )
+        if (
+            receipt.revision != item.application_receipt_revision
+            or receipt.run_id != item.runtime_run_id
+            or receipt.skill_id != "evaluation-skill"
+            or receipt.source_kind != "evaluation_overlay"
+            or receipt.version_id != item.overlay_id
+            or receipt.content_digest != run.frozen_digest
+            or receipt.policy != expected_policy
+            or tuple(receipt.required_resource_paths)
+            != tuple(case.required_resource_paths)
+            or f"evaluation-item:{item.item_id}" not in receipt.references
+        ):
+            raise SkillEvaluationValidationError(
+                "A Skill application receipt no longer matches the frozen evaluation item.",
+                code="skill_application_receipt_mismatch",
+            )
+
+
 skill_creator_evaluation_service = SkillCreatorEvaluationService(
     skill_creator_session_store,
     get_skill_draft_store(),
@@ -19464,6 +19616,8 @@ skill_creator_evaluation_service = SkillCreatorEvaluationService(
     preflight=preflight_skill_evaluation,
     actor_id=authoring_service.local_console_actor_id,
     iteration=iterate_skill_creator_from_evaluation,
+    suite_service=skill_creator_evaluation_suite_service,
+    application_receipt_verifier=verify_skill_evaluation_application_receipts,
 )
 configure_skill_creator_evaluation(skill_creator_evaluation_service)
 

--- a/server/skills/creator_api.py
+++ b/server/skills/creator_api.py
@@ -15,6 +15,7 @@ from .creator_evaluation import (
     SkillEvaluationValidationError,
 )
 from .creator_evaluation_service import SkillCreatorEvaluationService
+from .creator_evaluation_suite_service import SkillCreatorEvaluationSuiteService
 from .creator_resource_build_service import SkillCreatorResourceBuildService
 from .creator_resource_service import SkillCreatorResourcePlanningService
 from .creator_service import SkillCreatorService
@@ -44,6 +45,7 @@ except ModuleNotFoundError:
 router = APIRouter(prefix="/api/skills/creator", tags=["skill-creator"])
 _service: SkillCreatorService | None = None
 _evaluation_service: SkillCreatorEvaluationService | None = None
+_evaluation_suite_service: SkillCreatorEvaluationSuiteService | None = None
 _resource_planning_service: SkillCreatorResourcePlanningService | None = None
 _resource_build_service: SkillCreatorResourceBuildService | None = None
 
@@ -210,6 +212,74 @@ class CreatorEvaluationCasesRequest(CreatorEvaluationWriteRequest):
 
 class CreatorEvaluationStartRequest(CreatorEvaluationWriteRequest):
     repetitions: int = Field(default=1, ge=1, le=3)
+    evaluation_suite_revision: int | None = Field(default=None, ge=1)
+    evaluation_suite_digest: str | None = Field(
+        default=None, min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$"
+    )
+
+
+class CreatorEvaluationSuiteCaseInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    case_id: str = Field(min_length=1, max_length=200)
+    role: Literal["normal", "ambiguous", "boundary", "regression"]
+    name: str = Field(min_length=1, max_length=160)
+    prompt: str = Field(min_length=1, max_length=20_000)
+    expected_behavior: str = Field(min_length=1, max_length=4_000)
+    fixtures: list[dict[str, str]] = Field(default_factory=list, max_length=10)
+    assertions: list[dict[str, Any]] = Field(default_factory=list, max_length=20)
+    requirement_ids: list[str] = Field(default_factory=list, max_length=64)
+    required_resource_paths: list[str] = Field(default_factory=list, max_length=20)
+    workflow_step_ids: list[str] = Field(default_factory=list, max_length=64)
+
+
+class CreatorEvaluationSuiteGenerateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_session_revision: int = Field(ge=1)
+    expected_draft_state_revision: int = Field(ge=1)
+    expected_draft_revision: int = Field(ge=1)
+    expected_draft_digest: str = Field(
+        min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$"
+    )
+    expected_suite_revision: int | None = Field(default=None, ge=1)
+    expected_suite_digest: str | None = Field(
+        default=None, min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$"
+    )
+
+
+class CreatorEvaluationSuitePatchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    suite_id: str = Field(min_length=1, max_length=240)
+    expected_session_revision: int = Field(ge=1)
+    expected_draft_state_revision: int = Field(ge=1)
+    expected_draft_revision: int = Field(ge=1)
+    expected_draft_digest: str = Field(
+        min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$"
+    )
+    expected_suite_revision: int = Field(ge=1)
+    expected_suite_digest: str = Field(
+        min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$"
+    )
+    cases: list[CreatorEvaluationSuiteCaseInput] = Field(min_length=3, max_length=12)
+    change_reason: str = Field(default="", max_length=4_000)
+
+
+class CreatorEvaluationSuiteConfirmRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    suite_id: str = Field(min_length=1, max_length=240)
+    expected_session_revision: int = Field(ge=1)
+    expected_draft_state_revision: int = Field(ge=1)
+    expected_draft_revision: int = Field(ge=1)
+    expected_draft_digest: str = Field(
+        min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$"
+    )
+    expected_suite_revision: int = Field(ge=1)
+    expected_suite_digest: str = Field(
+        min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$"
+    )
 
 
 class CreatorEvaluationRunMutationRequest(CreatorEvaluationWriteRequest):
@@ -245,6 +315,7 @@ class CreatorEvaluationIterateRequest(CreatorEvaluationWriteRequest):
 def configure_skill_creator(service: SkillCreatorService | None) -> None:
     global _service
     global _evaluation_service
+    global _evaluation_suite_service
     global _resource_planning_service
     global _resource_build_service
     if service is not _service:
@@ -253,6 +324,11 @@ def configure_skill_creator(service: SkillCreatorService | None) -> None:
             and getattr(_evaluation_service, "creator_service", None) is not service
         ):
             _evaluation_service = None
+        if (
+            _evaluation_suite_service is not None
+            and getattr(_evaluation_suite_service, "creator_service", None) is not service
+        ):
+            _evaluation_suite_service = None
         if (
             _resource_planning_service is not None
             and getattr(_resource_planning_service, "creator_service", None) is not service
@@ -271,6 +347,13 @@ def configure_skill_creator_evaluation(
 ) -> None:
     global _evaluation_service
     _evaluation_service = service
+
+
+def configure_skill_creator_evaluation_suite(
+    service: SkillCreatorEvaluationSuiteService | None,
+) -> None:
+    global _evaluation_suite_service
+    _evaluation_suite_service = service
 
 
 def configure_skill_creator_resource_planning(
@@ -304,6 +387,17 @@ def get_skill_creator_evaluation_service() -> SkillCreatorEvaluationService:
             code="skill_creator_evaluation_unavailable",
         )
     return _evaluation_service
+
+
+def get_skill_creator_evaluation_suite_service() -> SkillCreatorEvaluationSuiteService:
+    get_skill_creator_service()
+    if _evaluation_suite_service is None:
+        raise SkillCreatorValidationError(
+            "Skill Creator evaluation suite is unavailable.",
+            code="skill_creator_evolution_v2_disabled",
+        )
+    _evaluation_suite_service.require_enabled()
+    return _evaluation_suite_service
 
 
 def get_skill_creator_resource_planning_service() -> SkillCreatorResourcePlanningService:
@@ -366,15 +460,24 @@ def _api_error(exc: Exception) -> HTTPException:
                 "model_gateway_unconfigured",
                 "skill_evaluation_sidecar_unavailable",
                 "skill_evaluation_preflight_failed",
+                "skill_application_receipt_unavailable",
+                "skill_application_receipt_store_corrupt",
             }
             else 400
         )
         code = exc.code
+        if code in {
+            "skill_application_receipt_missing",
+            "skill_application_receipt_incomplete",
+            "skill_application_receipt_mismatch",
+        }:
+            status = 409
     elif isinstance(exc, SkillCreatorValidationError):
         code = exc.code
         status = 404 if code in {
             "skill_creator_disabled",
             "skill_creator_resource_authoring_disabled",
+            "skill_creator_evolution_v2_disabled",
         } else 400
         if code == "model_gateway_unconfigured":
             status = 503
@@ -393,6 +496,8 @@ def _api_error(exc: Exception) -> HTTPException:
             "skill_creator_resource_planner_invalid",
             "skill_creator_resource_builder_failed",
             "skill_creator_resource_builder_invalid",
+            "skill_evaluation_suite_generator_failed",
+            "skill_evaluation_suite_generator_invalid",
         }:
             status = 502
         elif code == "skill_creator_proposal_binding_invalid":
@@ -459,6 +564,13 @@ def _session_response(
             and _resource_build_service.enabled
             else None
         ),
+        "evaluation_suite": (
+            _evaluation_suite_service.current_projection(session.session_id)
+            if _evaluation_suite_service is not None
+            and _evaluation_suite_service.enabled
+            and draft is not None
+            else None
+        ),
     }
     return response
 
@@ -482,6 +594,10 @@ async def get_creator_status():
             "resource_build_version": None,
             "resource_builder_available": False,
             "script_sandbox_configured": False,
+            "evaluation_suite_enabled": False,
+            "evaluation_suite_version": None,
+            "evaluation_suite_generator_available": False,
+            "evaluation_suite_store_available": False,
         }
     status = _service.status()
     status["evaluation_available"] = _evaluation_service is not None
@@ -508,6 +624,16 @@ async def get_creator_status():
             "resource_build_version": None,
             "resource_builder_available": False,
             "script_sandbox_configured": False,
+        }
+    )
+    status.update(
+        _evaluation_suite_service.status()
+        if _evaluation_suite_service is not None
+        else {
+            "evaluation_suite_enabled": False,
+            "evaluation_suite_version": None,
+            "evaluation_suite_generator_available": False,
+            "evaluation_suite_store_available": False,
         }
     )
     return status
@@ -1006,6 +1132,88 @@ async def put_creator_evaluation_cases(
         raise _api_error(exc) from exc
 
 
+@router.post("/sessions/{session_id}/evaluation-suite/generate")
+async def generate_creator_evaluation_suite(
+    session_id: str, payload: CreatorEvaluationSuiteGenerateRequest
+):
+    try:
+        creator = get_skill_creator_service()
+        suites = get_skill_creator_evaluation_suite_service()
+        await suites.generate(
+            session_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_draft_state_revision=payload.expected_draft_state_revision,
+            expected_draft_revision=payload.expected_draft_revision,
+            expected_draft_digest=payload.expected_draft_digest.lower(),
+            expected_suite_revision=payload.expected_suite_revision,
+            expected_suite_digest=(
+                payload.expected_suite_digest.lower()
+                if payload.expected_suite_digest is not None
+                else None
+            ),
+        )
+        session, draft = creator.get_session(session_id)
+        response = _session_response(creator, session, draft)
+        response["evaluation_suite"] = suites.current_projection(session_id)
+        return response
+    except (SkillCreatorError, SkillDraftError, SkillEvaluationError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.patch("/sessions/{session_id}/evaluation-suite")
+async def patch_creator_evaluation_suite(
+    session_id: str, payload: CreatorEvaluationSuitePatchRequest
+):
+    try:
+        creator = get_skill_creator_service()
+        suites = get_skill_creator_evaluation_suite_service()
+        await asyncio.to_thread(
+            suites.patch,
+            session_id,
+            suite_id=payload.suite_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_draft_state_revision=payload.expected_draft_state_revision,
+            expected_draft_revision=payload.expected_draft_revision,
+            expected_draft_digest=payload.expected_draft_digest.lower(),
+            expected_suite_revision=payload.expected_suite_revision,
+            expected_suite_digest=payload.expected_suite_digest.lower(),
+            cases=[item.model_dump(mode="python") for item in payload.cases],
+            change_reason=payload.change_reason,
+        )
+        session, draft = creator.get_session(session_id)
+        response = _session_response(creator, session, draft)
+        response["evaluation_suite"] = suites.current_projection(session_id)
+        return response
+    except (SkillCreatorError, SkillDraftError, SkillEvaluationError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.post("/sessions/{session_id}/evaluation-suite/confirm")
+async def confirm_creator_evaluation_suite(
+    session_id: str, payload: CreatorEvaluationSuiteConfirmRequest
+):
+    try:
+        creator = get_skill_creator_service()
+        suites = get_skill_creator_evaluation_suite_service()
+        await asyncio.to_thread(
+            suites.confirm,
+            session_id,
+            suite_id=payload.suite_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_draft_state_revision=payload.expected_draft_state_revision,
+            expected_draft_revision=payload.expected_draft_revision,
+            expected_draft_digest=payload.expected_draft_digest.lower(),
+            expected_suite_revision=payload.expected_suite_revision,
+            expected_suite_digest=payload.expected_suite_digest.lower(),
+        )
+        session, draft = creator.get_session(session_id)
+        response = _session_response(creator, session, draft)
+        response["evaluation_suite"] = suites.current_projection(session_id)
+        return response
+    except (SkillCreatorError, SkillDraftError, SkillEvaluationError) as exc:
+        raise _api_error(exc) from exc
+
+
 @router.post("/sessions/{session_id}/evaluations", status_code=202)
 async def start_creator_evaluation(
     session_id: str, payload: CreatorEvaluationStartRequest
@@ -1019,12 +1227,20 @@ async def start_creator_evaluation(
             expected_revision=payload.expected_revision,
             expected_digest=payload.expected_digest.lower(),
             repetitions=payload.repetitions,
+            evaluation_suite_revision=payload.evaluation_suite_revision,
+            evaluation_suite_digest=(
+                payload.evaluation_suite_digest.lower()
+                if payload.evaluation_suite_digest is not None
+                else None
+            ),
         )
-        case_set = evaluation.evaluation_store.serialize(
-            evaluation.evaluation_store.require_cases(
-                session.session_id, revision=session.cases_revision
+        case_set = None
+        if run.evaluation_suite_id is None:
+            case_set = evaluation.evaluation_store.serialize(
+                evaluation.evaluation_store.require_cases(
+                    session.session_id, revision=session.cases_revision
+                )
             )
-        )
         return _session_response(
             creator, session, draft, case_set=case_set, evaluation_run=run
         )

--- a/server/skills/creator_evaluation.py
+++ b/server/skills/creator_evaluation.py
@@ -97,6 +97,7 @@ class SkillEvaluationCase:
     expected_behavior: str
     fixtures: list[dict[str, str]] = field(default_factory=list)
     assertions: list[dict[str, Any]] = field(default_factory=list)
+    required_resource_paths: list[str] = field(default_factory=list)
     case_fingerprint: str = ""
 
 
@@ -134,6 +135,9 @@ class SkillEvaluationItem:
     usage: dict[str, int] = field(default_factory=dict)
     latency_ms: float = 0.0
     runtime_run_id: str | None = None
+    application_receipt_id: str | None = None
+    application_receipt_revision: int | None = None
+    application_compliance: str | None = None
     error_code: str | None = None
     error: str | None = None
     attempt_history: list[dict[str, Any]] = field(default_factory=list)
@@ -169,6 +173,10 @@ class SkillEvaluationRun:
     items: list[SkillEvaluationItem]
     config: dict[str, Any]
     case_set_revision: int | None = None
+    evaluation_suite_id: str | None = None
+    evaluation_suite_revision: int | None = None
+    evaluation_suite_digest: str | None = None
+    evaluation_suite_version: str | None = None
     status: SkillEvaluationRunStatus = "queued"
     revision: int = 1
     review_state: Literal["pending", "accepted", "revise"] = "pending"
@@ -192,6 +200,9 @@ class SkillEvaluationRunnerResult:
     work_manifest: list[dict[str, Any]] = field(default_factory=list)
     usage: dict[str, int] = field(default_factory=dict)
     runtime_run_id: str | None = None
+    application_receipt_id: str | None = None
+    application_receipt_revision: int | None = None
+    application_compliance: str | None = None
 
 
 class SkillEvaluationRunner(Protocol):
@@ -431,6 +442,10 @@ class SkillEvaluationStore:
         repetitions: int = 1,
         baseline_overlay_id: str | None = None,
         case_set_revision: int | None = None,
+        evaluation_suite_id: str | None = None,
+        evaluation_suite_revision: int | None = None,
+        evaluation_suite_digest: str | None = None,
+        evaluation_suite_version: str | None = None,
         config: Mapping[str, Any] | None = None,
     ) -> SkillEvaluationRun:
         clean_session_id = self._identifier(session_id, "session_id")
@@ -468,10 +483,37 @@ class SkillEvaluationStore:
                     code="skill_evaluation_cases_required",
                 )
             clean_cases = [self.normalize_case(item) for item in cases]
-        if len(clean_cases) != self.REQUIRED_CASE_COUNT:
+        suite_values = (
+            evaluation_suite_id,
+            evaluation_suite_revision,
+            evaluation_suite_digest,
+            evaluation_suite_version,
+        )
+        suite_bound = all(value is not None for value in suite_values)
+        if any(value is not None for value in suite_values) and not suite_bound:
             raise SkillEvaluationValidationError(
-                "Objective Skill evaluation requires exactly three cases.",
-                code="skill_evaluation_three_cases_required",
+                "Evaluation suite binding is incomplete.",
+                code="skill_evaluation_suite_binding_invalid",
+            )
+        if suite_bound and case_set_revision is not None:
+            raise SkillEvaluationValidationError(
+                "An evaluation run cannot bind both a V1 case set and a V2 suite.",
+                code="skill_evaluation_suite_binding_invalid",
+            )
+        if (not suite_bound and len(clean_cases) != self.REQUIRED_CASE_COUNT) or (
+            suite_bound and not self.REQUIRED_CASE_COUNT <= len(clean_cases) <= 12
+        ):
+            raise SkillEvaluationValidationError(
+                (
+                    "A V2 Skill evaluation suite requires three to twelve cases."
+                    if suite_bound
+                    else "Objective Skill evaluation requires exactly three cases."
+                ),
+                code=(
+                    "skill_evaluation_suite_case_limit"
+                    if suite_bound
+                    else "skill_evaluation_three_cases_required"
+                ),
             )
         if len({item.case_id for item in clean_cases}) != len(clean_cases):
             raise SkillEvaluationValidationError(
@@ -545,6 +587,32 @@ class SkillEvaluationStore:
                 config=clean_config,
                 case_set_revision=(
                     bound_case_set.cases_revision if bound_case_set else None
+                ),
+                evaluation_suite_id=(
+                    self._identifier(evaluation_suite_id, "evaluation_suite_id")
+                    if suite_bound
+                    else None
+                ),
+                evaluation_suite_revision=(
+                    self._positive_int(
+                        evaluation_suite_revision, "evaluation_suite_revision"
+                    )
+                    if suite_bound
+                    else None
+                ),
+                evaluation_suite_digest=(
+                    self._digest(evaluation_suite_digest, "evaluation_suite_digest")
+                    if suite_bound
+                    else None
+                ),
+                evaluation_suite_version=(
+                    self._required_text(
+                        evaluation_suite_version,
+                        "evaluation_suite_version",
+                        maximum=120,
+                    )
+                    if suite_bound
+                    else None
                 ),
                 created_at=now,
                 updated_at=now,
@@ -949,6 +1017,23 @@ class SkillEvaluationStore:
         )
         fixtures = cls._normalize_fixtures(source.get("fixtures") or [])
         assertions = cls._normalize_assertions(source.get("assertions") or [])
+        raw_resource_paths = source.get("required_resource_paths") or []
+        if not isinstance(raw_resource_paths, list) or len(raw_resource_paths) > 20:
+            raise SkillEvaluationValidationError(
+                "Evaluation case resource paths are invalid.",
+                code="skill_evaluation_case_resources_invalid",
+            )
+        required_resource_paths: list[str] = []
+        for value in raw_resource_paths:
+            path = cls._relative_path(value, "required resource path")
+            if not path.startswith(("scripts/", "references/", "assets/")):
+                raise SkillEvaluationValidationError(
+                    "Evaluation cases may only require Skill package resources.",
+                    code="skill_evaluation_case_resources_invalid",
+                )
+            if path not in required_resource_paths:
+                required_resource_paths.append(path)
+        required_resource_paths.sort(key=str.casefold)
         fingerprint_payload = {
             "case_id": case_id,
             "name": name,
@@ -957,6 +1042,10 @@ class SkillEvaluationStore:
             "fixtures": fixtures,
             "assertions": assertions,
         }
+        # Preserve the legacy three-case fingerprint when no V2 resource
+        # requirement exists. Old snapshots remain readable byte-for-byte.
+        if required_resource_paths:
+            fingerprint_payload["required_resource_paths"] = required_resource_paths
         fingerprint = hashlib.sha256(
             cls._canonical_json(fingerprint_payload).encode("utf-8")
         ).hexdigest()
@@ -1258,8 +1347,22 @@ class SkillEvaluationStore:
             raise ValueError("invalid review state")
         cases_raw = raw.get("cases")
         items_raw = raw.get("items")
-        if not isinstance(cases_raw, list) or len(cases_raw) != cls.REQUIRED_CASE_COUNT:
-            raise ValueError("run must contain exactly three cases")
+        suite_values = (
+            raw.get("evaluation_suite_id"),
+            raw.get("evaluation_suite_revision"),
+            raw.get("evaluation_suite_digest"),
+            raw.get("evaluation_suite_version"),
+        )
+        suite_bound = all(value is not None for value in suite_values)
+        if any(value is not None for value in suite_values) and not suite_bound:
+            raise ValueError("run evaluation suite binding is incomplete")
+        if suite_bound and raw.get("case_set_revision") is not None:
+            raise ValueError("run cannot bind a case set and evaluation suite")
+        if not isinstance(cases_raw, list) or (
+            (not suite_bound and len(cases_raw) != cls.REQUIRED_CASE_COUNT)
+            or (suite_bound and not cls.REQUIRED_CASE_COUNT <= len(cases_raw) <= 12)
+        ):
+            raise ValueError("run contains an invalid evaluation case count")
         if not isinstance(items_raw, list):
             raise ValueError("run items must be a list")
         cases = [cls.normalize_case(item) for item in cases_raw]
@@ -1303,6 +1406,34 @@ class SkillEvaluationStore:
                 else cls._positive_int(
                     raw.get("case_set_revision"), "case_set_revision"
                 )
+            ),
+            evaluation_suite_id=(
+                cls._identifier(raw.get("evaluation_suite_id"), "evaluation_suite_id")
+                if suite_bound
+                else None
+            ),
+            evaluation_suite_revision=(
+                cls._positive_int(
+                    raw.get("evaluation_suite_revision"), "evaluation_suite_revision"
+                )
+                if suite_bound
+                else None
+            ),
+            evaluation_suite_digest=(
+                cls._digest(
+                    raw.get("evaluation_suite_digest"), "evaluation_suite_digest"
+                )
+                if suite_bound
+                else None
+            ),
+            evaluation_suite_version=(
+                cls._required_text(
+                    raw.get("evaluation_suite_version"),
+                    "evaluation_suite_version",
+                    maximum=120,
+                )
+                if suite_bound
+                else None
             ),
             status=status,  # type: ignore[arg-type]
             revision=cls._positive_int(raw.get("revision"), "revision"),
@@ -1356,6 +1487,21 @@ class SkillEvaluationStore:
         assertion_results = raw.get("assertion_results", [])
         if not isinstance(assertion_results, list):
             raise ValueError("invalid assertion results")
+        receipt_id = cls._optional_identifier(raw.get("application_receipt_id"))
+        receipt_revision = (
+            None
+            if raw.get("application_receipt_revision") is None
+            else cls._positive_int(
+                raw.get("application_receipt_revision"),
+                "application_receipt_revision",
+            )
+        )
+        compliance = cls._optional_text(
+            raw.get("application_compliance"), maximum=40
+        )
+        if any(value is not None for value in (receipt_id, receipt_revision, compliance)):
+            if not receipt_id or receipt_revision is None or compliance != "verified":
+                raise ValueError("invalid Skill application receipt binding")
         return SkillEvaluationItem(
             item_id=cls._identifier(raw.get("item_id"), "item_id"),
             pair_id=cls._identifier(raw.get("pair_id"), "pair_id"),
@@ -1378,6 +1524,9 @@ class SkillEvaluationStore:
             usage=cls._normalize_usage(raw.get("usage") or {}),
             latency_ms=max(0.0, float(raw.get("latency_ms") or 0.0)),
             runtime_run_id=cls._optional_identifier(raw.get("runtime_run_id")),
+            application_receipt_id=receipt_id,
+            application_receipt_revision=receipt_revision,
+            application_compliance=compliance,
             error_code=cls._optional_text(raw.get("error_code"), maximum=120),
             error=cls._optional_text(raw.get("error"), maximum=500),
             attempt_history=copy.deepcopy(history),
@@ -1614,6 +1763,36 @@ class SkillEvaluationStore:
         item.runtime_run_id = cls._optional_identifier(
             result.get("runtime_run_id")
         )
+        item.application_receipt_id = cls._optional_identifier(
+            result.get("application_receipt_id")
+        )
+        item.application_receipt_revision = (
+            None
+            if result.get("application_receipt_revision") is None
+            else cls._positive_int(
+                result.get("application_receipt_revision"),
+                "application_receipt_revision",
+            )
+        )
+        item.application_compliance = cls._optional_text(
+            result.get("application_compliance"), maximum=40
+        )
+        if any(
+            value is not None
+            for value in (
+                item.application_receipt_id,
+                item.application_receipt_revision,
+                item.application_compliance,
+            )
+        ) and (
+            not item.application_receipt_id
+            or item.application_receipt_revision is None
+            or item.application_compliance != "verified"
+        ):
+            raise SkillEvaluationValidationError(
+                "Skill application receipt binding is invalid.",
+                code="skill_application_receipt_invalid",
+            )
         item.error_code = cls._optional_text(result.get("error_code"), maximum=120)
         item.error = cls._optional_text(result.get("error"), maximum=500)
         item.updated_at = time.time()
@@ -1655,6 +1834,9 @@ class SkillEvaluationStore:
             "usage": copy.deepcopy(item.usage),
             "latency_ms": item.latency_ms,
             "runtime_run_id": item.runtime_run_id,
+            "application_receipt_id": item.application_receipt_id,
+            "application_receipt_revision": item.application_receipt_revision,
+            "application_compliance": item.application_compliance,
             "error_code": item.error_code,
             "error": item.error,
             "finished_at": item.updated_at,
@@ -1672,6 +1854,9 @@ class SkillEvaluationStore:
         item.usage = {}
         item.latency_ms = 0.0
         item.runtime_run_id = None
+        item.application_receipt_id = None
+        item.application_receipt_revision = None
+        item.application_compliance = None
         item.error_code = None
         item.error = None
         item.updated_at = time.time()
@@ -1944,6 +2129,32 @@ def normalize_runner_result(
             "Skill evaluation runner must report skill_read.",
             code="skill_evaluation_runner_result_invalid",
         )
+    receipt_id = SkillEvaluationStore._optional_identifier(
+        source.get("application_receipt_id")
+    )
+    receipt_revision = (
+        None
+        if source.get("application_receipt_revision") is None
+        else SkillEvaluationStore._positive_int(
+            source.get("application_receipt_revision"),
+            "application_receipt_revision",
+        )
+    )
+    application_compliance = SkillEvaluationStore._optional_text(
+        source.get("application_compliance"), maximum=40
+    )
+    if any(
+        value is not None
+        for value in (receipt_id, receipt_revision, application_compliance)
+    ) and (
+        not receipt_id
+        or receipt_revision is None
+        or application_compliance != "verified"
+    ):
+        raise SkillEvaluationValidationError(
+            "Skill evaluation runner returned an invalid application receipt.",
+            code="skill_application_receipt_invalid",
+        )
     return SkillEvaluationRunnerResult(
         output=output[:max_output_chars],
         actual_model=actual_model,
@@ -1953,6 +2164,9 @@ def normalize_runner_result(
         runtime_run_id=SkillEvaluationStore._optional_identifier(
             source.get("runtime_run_id")
         ),
+        application_receipt_id=receipt_id,
+        application_receipt_revision=receipt_revision,
+        application_compliance=application_compliance,
     )
 
 
@@ -2134,6 +2348,12 @@ def aggregate_skill_evaluation_report(run: SkillEvaluationRun) -> dict[str, Any]
                 "actual_model_match": actual_model_match,
                 "comparable": comparable,
                 "candidate_skill_read": candidate.skill_read if candidate else None,
+                "candidate_application_receipt_id": (
+                    candidate.application_receipt_id if candidate else None
+                ),
+                "candidate_application_verified": bool(
+                    candidate and candidate.application_compliance == "verified"
+                ),
                 "score_delta": score_delta,
             }
         )
@@ -2154,6 +2374,13 @@ def aggregate_skill_evaluation_report(run: SkillEvaluationRun) -> dict[str, Any]
         for item in run.items
         if item.target == "candidate"
     )
+    application_receipts_verified = bool(run.evaluation_suite_id is None) or all(
+        item.application_compliance == "verified"
+        and bool(item.application_receipt_id)
+        and item.application_receipt_revision is not None
+        for item in run.items
+        if item.target == "candidate"
+    )
     return {
         "run_id": run.run_id,
         "item_count": len(run.items),
@@ -2163,10 +2390,20 @@ def aggregate_skill_evaluation_report(run: SkillEvaluationRun) -> dict[str, Any]
         "pairs": pairs,
         "model_mismatch_count": model_mismatch_count,
         "skill_not_read_count": statuses.get("skill_not_read", 0),
+        "application_receipt_verified_count": sum(
+            item.application_compliance == "verified"
+            for item in run.items
+            if item.target == "candidate"
+        ),
         "assertion_count": len(assertion_results),
         "assertion_passed_count": len(assertion_results) - assertion_failed_count,
         "assertion_failed_count": assertion_failed_count,
-        "eligible_for_accept": all_completed and candidate_read and model_mismatch_count == 0,
+        "eligible_for_accept": (
+            all_completed
+            and candidate_read
+            and application_receipts_verified
+            and model_mismatch_count == 0
+        ),
         "ranker_or_judge_used": False,
     }
 
@@ -2278,6 +2515,20 @@ class SkillEvaluationExecutor:
                     status = "skill_not_read"
                     error_code = "skill_not_read"
                     error = "Candidate did not read the frozen Skill overlay."
+                elif (
+                    item.target == "candidate"
+                    and claimed.evaluation_suite_id is not None
+                    and (
+                        not result.application_receipt_id
+                        or result.application_receipt_revision is None
+                        or result.application_compliance != "verified"
+                    )
+                ):
+                    status = "failed"
+                    error_code = "skill_application_receipt_missing"
+                    error = (
+                        "Candidate did not produce a verified Skill application receipt."
+                    )
                 payload = {
                     "status": status,
                     "output": result.output,
@@ -2286,6 +2537,11 @@ class SkillEvaluationExecutor:
                     "work_manifest": result.work_manifest,
                     "usage": result.usage,
                     "runtime_run_id": result.runtime_run_id,
+                    "application_receipt_id": result.application_receipt_id,
+                    "application_receipt_revision": (
+                        result.application_receipt_revision
+                    ),
+                    "application_compliance": result.application_compliance,
                     "latency_ms": round((time.perf_counter() - started) * 1000, 3),
                     "error_code": error_code,
                     "error": error,

--- a/server/skills/creator_evaluation_runtime.py
+++ b/server/skills/creator_evaluation_runtime.py
@@ -164,10 +164,12 @@ def build_skill_evaluation_workflow_invocation(
     if item.target == "candidate" and overlay is None:
         raise ValueError("Candidate evaluation requires an immutable Skill Overlay.")
     fixture_paths = [f"inputs/{entry['path']}" for entry in case.fixtures]
+    required_resource_paths = list(case.required_resource_paths)
     task_contract = {
         "case_id": case.case_id,
         "prompt": case.prompt,
         "fixture_paths": fixture_paths,
+        "required_skill_resource_paths": required_resource_paths,
         "workspace_contract": {
             "inputs_and_skills_are_read_only": True,
             "write_outputs_under": "work/",
@@ -177,7 +179,8 @@ def build_skill_evaluation_workflow_invocation(
     role_prompt = (
         "You are executing one frozen Skill evaluation case in an offline sandbox. "
         "Always call skill_read with skill_id='evaluation-skill' before solving the "
-        "case. Use skill_stage only when package resources are needed. Read fixtures "
+        "case. Use skill_stage before solving when required_skill_resource_paths is "
+        "non-empty; otherwise stage only when package resources are needed. Read fixtures "
         "only from inputs/. Write generated files only under work/. Do not request "
         "network access, external tools, approval, installation, or additional Skills. "
         "Return only the user-facing result for the case; do not discuss evaluation, "
@@ -315,5 +318,9 @@ def build_skill_evaluation_workflow_invocation(
             "skill_evaluation_overlay_id": overlay.overlay_id if overlay else None,
             "skill_evaluation_workspace_id": workspace_id,
             "skill_evaluation_frozen_digest": run.frozen_digest,
+            "skill_application_policy": (
+                "require_stage" if required_resource_paths else "require_read"
+            ),
+            "skill_application_required_resource_paths": required_resource_paths,
         },
     )

--- a/server/skills/creator_evaluation_service.py
+++ b/server/skills/creator_evaluation_service.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, Mapping, Protocol
 
 from .creator_evaluation import (
     SkillEvaluationConflictError,
+    SkillEvaluationError,
     SkillEvaluationExecutor,
     SkillEvaluationNotFoundError,
     SkillEvaluationRun,
@@ -15,6 +16,8 @@ from .creator_evaluation import (
     SkillEvaluationValidationError,
     aggregate_skill_evaluation_report,
 )
+from .creator_evaluation_suite import SkillEvaluationSuite, SkillEvaluationSuiteStore
+from .creator_evaluation_suite_service import SkillCreatorEvaluationSuiteService
 from .creator_store import (
     CreatorQualityMode,
     SkillCreatorConflictError,
@@ -50,6 +53,10 @@ class SkillEvaluationIteration(Protocol):
     ) -> Any: ...
 
 
+class SkillEvaluationReceiptVerifier(Protocol):
+    def __call__(self, run: SkillEvaluationRun) -> None: ...
+
+
 class SkillCreatorEvaluationService:
     """Cross-store quality gate for one private Skill Creator session.
 
@@ -70,6 +77,8 @@ class SkillCreatorEvaluationService:
         preflight: SkillEvaluationPreflight,
         actor_id: str,
         iteration: SkillEvaluationIteration | None = None,
+        suite_service: SkillCreatorEvaluationSuiteService | None = None,
+        application_receipt_verifier: SkillEvaluationReceiptVerifier | None = None,
     ) -> None:
         clean_actor_id = str(actor_id or "").strip()
         if not clean_actor_id:
@@ -81,6 +90,8 @@ class SkillCreatorEvaluationService:
         self.preflight = preflight
         self.actor_id = clean_actor_id
         self.iteration = iteration
+        self.suite_service = suite_service
+        self.application_receipt_verifier = application_receipt_verifier
 
     def get_projection(
         self, session_id: str
@@ -135,6 +146,15 @@ class SkillCreatorEvaluationService:
             expected_revision=expected_revision,
             expected_digest=expected_digest,
         )
+        if (
+            self.suite_service is not None
+            and self.suite_service.enabled
+            and self.suite_service.suite_store.current_for_session(session.session_id)
+            is not None
+        ):
+            raise SkillCreatorConflictError(
+                "This Creator session uses an evaluation suite; edit the suite instead."
+            )
         if session.active_evaluation_run_id:
             raise SkillCreatorConflictError(
                 "Cancel the active evaluation before changing its cases."
@@ -216,6 +236,8 @@ class SkillCreatorEvaluationService:
         expected_revision: int,
         expected_digest: str,
         repetitions: int = 1,
+        evaluation_suite_revision: int | None = None,
+        evaluation_suite_digest: str | None = None,
     ) -> tuple[SkillCreatorSession, WorkspaceSkillDraft, SkillEvaluationRun]:
         session, draft = self._require_context(
             session_id,
@@ -223,12 +245,41 @@ class SkillCreatorEvaluationService:
             expected_revision=expected_revision,
             expected_digest=expected_digest,
         )
-        case_set = self._require_current_cases(session, draft)
-        if len(case_set.cases) != SkillEvaluationStore.REQUIRED_CASE_COUNT:
-            raise SkillEvaluationValidationError(
-                "Evaluation requires exactly three frozen cases.",
-                code="skill_evaluation_three_cases_required",
+        suite = self._current_v2_suite(session, draft)
+        if (evaluation_suite_revision is None) != (
+            evaluation_suite_digest is None
+        ):
+            raise SkillEvaluationConflictError(
+                "Evaluation suite revision and digest must be supplied together."
             )
+        if suite is not None:
+            if (
+                evaluation_suite_revision is not None
+                and int(evaluation_suite_revision) != suite.suite_revision
+            ) or (
+                evaluation_suite_digest is not None
+                and str(evaluation_suite_digest).lower() != suite.suite_digest
+            ):
+                raise SkillEvaluationConflictError(
+                    "Evaluation suite changed. Reload before starting the evaluation."
+                )
+            cases = SkillEvaluationSuiteStore.to_evaluation_cases(suite)
+            case_set = None
+        else:
+            if (
+                evaluation_suite_revision is not None
+                or evaluation_suite_digest is not None
+            ):
+                raise SkillEvaluationConflictError(
+                    "The requested evaluation suite is unavailable."
+                )
+            case_set = self._require_current_cases(session, draft)
+            if len(case_set.cases) != SkillEvaluationStore.REQUIRED_CASE_COUNT:
+                raise SkillEvaluationValidationError(
+                    "Evaluation requires exactly three frozen cases.",
+                    code="skill_evaluation_three_cases_required",
+                )
+            cases = None
         preflight = await self._run_preflight(draft, "evaluate")
         model_id = str(preflight.model_id or "").strip()
         if not model_id:
@@ -245,7 +296,26 @@ class SkillCreatorEvaluationService:
             expected_revision=expected_revision,
             expected_digest=expected_digest,
         )
-        existing = self._recoverable_run(session, draft, case_set.cases_revision)
+        if suite is not None:
+            refreshed_suite = self._require_v2_suite(session, draft)
+            if (
+                refreshed_suite.suite_id != suite.suite_id
+                or refreshed_suite.suite_revision != suite.suite_revision
+                or not self._same_digest(
+                    refreshed_suite.suite_digest, suite.suite_digest
+                )
+            ):
+                raise SkillEvaluationConflictError(
+                    "Evaluation suite changed during preflight. Reload before starting."
+                )
+            suite = refreshed_suite
+            cases = SkillEvaluationSuiteStore.to_evaluation_cases(suite)
+        existing = self._recoverable_run(
+            session,
+            draft,
+            cases_revision=(case_set.cases_revision if case_set else None),
+            suite=suite,
+        )
         if existing is not None:
             draft = self._begin_or_reuse_draft_run(draft, existing.run_id)
             if session.active_evaluation_run_id != existing.run_id:
@@ -290,7 +360,12 @@ class SkillCreatorEvaluationService:
             frozen_digest=draft.content_digest,
             candidate_overlay_id=candidate.overlay_id,
             baseline_overlay_id=baseline_id,
-            case_set_revision=case_set.cases_revision,
+            cases=cases,
+            case_set_revision=(case_set.cases_revision if case_set else None),
+            evaluation_suite_id=(suite.suite_id if suite else None),
+            evaluation_suite_revision=(suite.suite_revision if suite else None),
+            evaluation_suite_digest=(suite.suite_digest if suite else None),
+            evaluation_suite_version=(suite.version if suite else None),
             model_id=model_id,
             repetitions=repetitions,
             config=dict(preflight.config or {}),
@@ -440,6 +515,7 @@ class SkillCreatorEvaluationService:
                 expected_digest=expected_digest,
                 expected_run_revision=expected_run_revision,
             )
+            self._require_v2_application_receipts(run)
         run = self.evaluation_store.review_run(
             run_id,
             expected_revision=expected_run_revision,
@@ -750,7 +826,8 @@ class SkillCreatorEvaluationService:
         self,
         session: SkillCreatorSession,
         draft: WorkspaceSkillDraft,
-        cases_revision: int,
+        cases_revision: int | None,
+        suite: SkillEvaluationSuite | None = None,
     ) -> SkillEvaluationRun | None:
         for run in self.evaluation_store.list_runs(
             session_id=session.session_id, limit=20
@@ -759,11 +836,47 @@ class SkillCreatorEvaluationService:
                 run.draft_id == draft.draft_id
                 and run.draft_revision == draft.content_revision
                 and self._same_digest(run.frozen_digest, draft.content_digest)
-                and run.case_set_revision == cases_revision
+                and (
+                    (
+                        suite is not None
+                        and run.evaluation_suite_id == suite.suite_id
+                        and run.evaluation_suite_revision == suite.suite_revision
+                        and self._same_digest(
+                            run.evaluation_suite_digest, suite.suite_digest
+                        )
+                    )
+                    or (
+                        suite is None
+                        and run.evaluation_suite_id is None
+                        and run.case_set_revision == cases_revision
+                    )
+                )
                 and run.status in {"queued", "running"}
             ):
                 return run
         return None
+
+    def _current_v2_suite(
+        self, session: SkillCreatorSession, draft: WorkspaceSkillDraft
+    ) -> SkillEvaluationSuite | None:
+        if self.suite_service is None or not self.suite_service.enabled:
+            return None
+        # Enabling Evolution V2 must not silently migrate an existing Creator
+        # session. Only a session with an explicitly generated or migrated
+        # suite enters the V2 evaluation contract.
+        if self.suite_service.suite_store.current_for_session(session.session_id) is None:
+            return None
+        return self._require_v2_suite(session, draft)
+
+    def _require_v2_suite(
+        self, session: SkillCreatorSession, draft: WorkspaceSkillDraft
+    ) -> SkillEvaluationSuite:
+        if self.suite_service is None:
+            raise SkillEvaluationValidationError(
+                "Skill Creator evaluation suite is unavailable.",
+                code="skill_evaluation_suite_unavailable",
+            )
+        return self.suite_service.require_confirmed_current(session, draft)
 
     def _begin_or_reuse_draft_run(
         self, draft: WorkspaceSkillDraft, run_id: str
@@ -793,14 +906,42 @@ class SkillCreatorEvaluationService:
             session_id=session.session_id, limit=20
         )
         current_runs: list[SkillEvaluationRun] = []
+        superseded_v2_acceptance = False
         for run in runs:
+            binding_current = run.case_set_revision == session.cases_revision
+            if run.evaluation_suite_id is not None and self.suite_service is not None:
+                try:
+                    suite = self.suite_service.suite_store.current_for_session(
+                        session.session_id
+                    )
+                    binding_current = bool(
+                        suite is not None
+                        and suite.state == "confirmed"
+                        and suite.suite_id == run.evaluation_suite_id
+                        and suite.suite_revision == run.evaluation_suite_revision
+                        and suite.suite_digest == run.evaluation_suite_digest
+                        and suite.session_id == session.session_id
+                        and suite.draft_id == draft.draft_id
+                        and suite.draft_revision == draft.content_revision
+                        and self._same_digest(suite.draft_digest, draft.content_digest)
+                    )
+                except SkillEvaluationError:
+                    binding_current = False
             if (
                 run.draft_id == draft.draft_id
                 and run.draft_revision == draft.content_revision
                 and self._same_digest(run.frozen_digest, draft.content_digest)
-                and run.case_set_revision == session.cases_revision
+                and binding_current
             ):
                 current_runs.append(run)
+            elif (
+                run.evaluation_suite_id is not None
+                and run.review_state == "accepted"
+                and run.draft_id == draft.draft_id
+                and run.draft_revision == draft.content_revision
+                and self._same_digest(run.frozen_digest, draft.content_digest)
+            ):
+                superseded_v2_acceptance = True
             elif run.status in {"queued", "running"}:
                 self.evaluation_store.mark_stale(
                     run.run_id,
@@ -811,6 +952,7 @@ class SkillCreatorEvaluationService:
             draft = self._begin_or_reuse_draft_run(draft, run.run_id)
         if run is not None and run.review_state == "accepted" and run.reviews:
             self._require_failed_assertion_acknowledgement(run)
+            self._require_v2_application_receipts(run)
             decision = draft.quality_decision
             if not (
                 draft.quality_status == "accepted"
@@ -832,6 +974,8 @@ class SkillCreatorEvaluationService:
             draft = self._mark_outdated_if_needed(draft)
         elif run is not None and run.status in {"failed", "cancelled", "stale"}:
             draft = self._mark_outdated_if_needed(draft)
+        elif run is None and superseded_v2_acceptance:
+            draft = self._mark_outdated_if_needed(draft)
         session = self._project_session(session, draft, run)
         return session, draft, run
 
@@ -852,6 +996,25 @@ class SkillCreatorEvaluationService:
             raise SkillEvaluationStateError(
                 "Accepted failed assertions are missing explicit acknowledgement."
             )
+
+    def _require_v2_application_receipts(self, run: SkillEvaluationRun) -> None:
+        if run.evaluation_suite_id is None:
+            return
+        verifier = self.application_receipt_verifier
+        if verifier is None:
+            raise SkillEvaluationValidationError(
+                "Verified Skill application receipts are unavailable.",
+                code="skill_application_receipt_unavailable",
+            )
+        try:
+            verifier(run)
+        except SkillEvaluationError:
+            raise
+        except Exception as exc:
+            raise SkillEvaluationValidationError(
+                "Verified Skill application receipts are unavailable.",
+                code=getattr(exc, "code", "skill_application_receipt_unavailable"),
+            ) from exc
 
     def _project_session(
         self,

--- a/server/skills/creator_evaluation_suite.py
+++ b/server/skills/creator_evaluation_suite.py
@@ -1,0 +1,1032 @@
+from __future__ import annotations
+
+import contextlib
+import copy
+import hashlib
+import json
+import os
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Literal, Mapping
+
+from .creator_evaluation import (
+    SkillEvaluationCase,
+    SkillEvaluationConflictError,
+    SkillEvaluationNotFoundError,
+    SkillEvaluationStorageError,
+    SkillEvaluationStore,
+    SkillEvaluationValidationError,
+)
+from .package_validation import scan_skill_package_credentials
+
+
+EVALUATION_SUITE_VERSION = "skill-evaluation-suite-v2"
+SuiteState = Literal["draft", "confirmed"]
+SuiteCaseRole = Literal["normal", "ambiguous", "boundary", "regression"]
+SuiteCaseSource = Literal["generated", "user", "migrated"]
+SuiteQualityMode = Literal["objective", "subjective"]
+
+_CORE_ROLES = ("normal", "ambiguous", "boundary")
+_SAFE_ID_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.:@/-"
+)
+_MAX_SUITES_PER_SESSION = 50
+_MAX_SNAPSHOT_BYTES = 32 * 1024 * 1024
+_MAX_REGRESSION_CASES = 9
+_MAX_COVERAGE_IDS = 64
+_MAX_RESOURCE_PATHS = 20
+
+
+@dataclass(frozen=True, slots=True)
+class SkillEvaluationSuiteCase:
+    case_id: str
+    role: SuiteCaseRole
+    source: SuiteCaseSource
+    name: str
+    prompt: str
+    expected_behavior: str
+    fixtures: list[dict[str, str]] = field(default_factory=list)
+    assertions: list[dict[str, Any]] = field(default_factory=list)
+    requirement_ids: tuple[str, ...] = ()
+    required_resource_paths: tuple[str, ...] = ()
+    workflow_step_ids: tuple[str, ...] = ()
+    case_fingerprint: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class SkillEvaluationSuite:
+    suite_id: str
+    version: str
+    suite_revision: int
+    suite_digest: str
+    session_id: str
+    session_revision: int
+    session_definition_digest: str
+    draft_id: str
+    draft_state_revision: int
+    draft_revision: int
+    draft_digest: str
+    quality_mode: SuiteQualityMode
+    state: SuiteState
+    cases: tuple[SkillEvaluationSuiteCase, ...]
+    change_reason: str
+    based_on_revision: int | None = None
+    created_at: float = field(default_factory=time.time)
+
+
+class SkillEvaluationSuiteStore:
+    """Append-only Creator evaluation suites with fail-closed local storage."""
+
+    SCHEMA_VERSION = 1
+
+    def __init__(self, storage_dir: str | Path | None = None) -> None:
+        package_dir = Path(__file__).resolve().parent
+        runtime_dir = os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
+        configured = os.getenv("SKILL_CREATOR_EVALUATION_SUITE_STORAGE_DIR", "").strip()
+        self.storage_dir = Path(
+            storage_dir or configured or runtime_dir or package_dir / "storage"
+        )
+        self.snapshot_path = self.storage_dir / "skill_creator_evaluation_suites.json"
+        self._lock = threading.RLock()
+        self._items: dict[str, list[SkillEvaluationSuite]] = {}
+        self._quarantine: list[dict[str, Any]] = []
+        self._load_error: str | None = None
+        self._load()
+
+    @property
+    def load_error(self) -> str | None:
+        return self._load_error
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "version": EVALUATION_SUITE_VERSION,
+                "available": self._load_error is None,
+                "session_count": len(self._items),
+                "suite_revision_count": sum(len(items) for items in self._items.values()),
+                "quarantine_count": len(self._quarantine),
+                "error_code": (
+                    "skill_evaluation_suite_store_corrupt"
+                    if self._load_error
+                    else None
+                ),
+            }
+
+    def current_for_session(self, session_id: str) -> SkillEvaluationSuite | None:
+        clean_session_id = self._identifier(session_id, "session_id")
+        with self._lock:
+            self._ensure_readable_unlocked()
+            revisions = self._items.get(clean_session_id) or []
+            return copy.deepcopy(revisions[-1]) if revisions else None
+
+    def require(
+        self, suite_id: str, *, revision: int | None = None
+    ) -> SkillEvaluationSuite:
+        clean_suite_id = self._identifier(suite_id, "suite_id")
+        with self._lock:
+            self._ensure_readable_unlocked()
+            for revisions in self._items.values():
+                if not revisions or revisions[0].suite_id != clean_suite_id:
+                    continue
+                if revision is None:
+                    return copy.deepcopy(revisions[-1])
+                clean_revision = self._positive_int(revision, "suite_revision")
+                if clean_revision > len(revisions):
+                    break
+                return copy.deepcopy(revisions[clean_revision - 1])
+        raise SkillEvaluationNotFoundError(
+            f"Skill evaluation suite not found: {clean_suite_id}"
+        )
+
+    def save_generated(
+        self,
+        *,
+        session_id: str,
+        session_revision: int,
+        session_definition_digest: str,
+        draft_id: str,
+        draft_state_revision: int,
+        draft_revision: int,
+        draft_digest: str,
+        quality_mode: SuiteQualityMode,
+        cases: Iterable[Mapping[str, Any]],
+        expected_suite_revision: int | None,
+        expected_suite_digest: str | None,
+        allowed_requirement_ids: Iterable[str],
+        allowed_resource_paths: Iterable[str],
+        allowed_workflow_step_ids: Iterable[str],
+    ) -> SkillEvaluationSuite:
+        normalized = tuple(
+            self.normalize_case(
+                item,
+                forced_source="generated",
+                allowed_requirement_ids=allowed_requirement_ids,
+                allowed_resource_paths=allowed_resource_paths,
+                allowed_workflow_step_ids=allowed_workflow_step_ids,
+            )
+            for item in cases
+        )
+        self._validate_case_set(normalized, allow_regressions=False)
+        return self._append(
+            session_id=session_id,
+            session_revision=session_revision,
+            session_definition_digest=session_definition_digest,
+            draft_id=draft_id,
+            draft_state_revision=draft_state_revision,
+            draft_revision=draft_revision,
+            draft_digest=draft_digest,
+            quality_mode=quality_mode,
+            state="draft",
+            cases=normalized,
+            change_reason="Generated three core evaluation cases.",
+            expected_suite_revision=expected_suite_revision,
+            expected_suite_digest=expected_suite_digest,
+        )
+
+    def migrate_case_set(
+        self,
+        *,
+        session_id: str,
+        session_revision: int,
+        session_definition_digest: str,
+        draft_id: str,
+        draft_state_revision: int,
+        draft_revision: int,
+        draft_digest: str,
+        quality_mode: SuiteQualityMode,
+        cases: Iterable[SkillEvaluationCase | Mapping[str, Any]],
+        allowed_requirement_ids: Iterable[str],
+    ) -> SkillEvaluationSuite:
+        roles = iter(_CORE_ROLES)
+        normalized: list[SkillEvaluationSuiteCase] = []
+        for raw in cases:
+            source = asdict(raw) if isinstance(raw, SkillEvaluationCase) else dict(raw)
+            source.pop("case_fingerprint", None)
+            source["role"] = next(roles, "regression")
+            source["requirement_ids"] = list(allowed_requirement_ids)
+            normalized.append(
+                self.normalize_case(
+                    source,
+                    forced_source="migrated",
+                    allowed_requirement_ids=allowed_requirement_ids,
+                    allowed_resource_paths=(),
+                    allowed_workflow_step_ids=(),
+                )
+            )
+        cases_tuple = tuple(normalized)
+        self._validate_case_set(cases_tuple, allow_regressions=False)
+        return self._append(
+            session_id=session_id,
+            session_revision=session_revision,
+            session_definition_digest=session_definition_digest,
+            draft_id=draft_id,
+            draft_state_revision=draft_state_revision,
+            draft_revision=draft_revision,
+            draft_digest=draft_digest,
+            quality_mode=quality_mode,
+            state="confirmed",
+            cases=cases_tuple,
+            change_reason="Migrated the existing frozen three-case set without a model call.",
+            expected_suite_revision=None,
+            expected_suite_digest=None,
+        )
+
+    def patch(
+        self,
+        suite_id: str,
+        *,
+        expected_suite_revision: int,
+        expected_suite_digest: str,
+        session_revision: int,
+        session_definition_digest: str,
+        draft_state_revision: int,
+        cases: Iterable[Mapping[str, Any]],
+        change_reason: str,
+        allowed_requirement_ids: Iterable[str],
+        allowed_resource_paths: Iterable[str],
+        allowed_workflow_step_ids: Iterable[str],
+    ) -> SkillEvaluationSuite:
+        current, cases_tuple, clean_reason = self._prepare_patch(
+            suite_id,
+            expected_suite_revision=expected_suite_revision,
+            expected_suite_digest=expected_suite_digest,
+            cases=cases,
+            change_reason=change_reason,
+            allowed_requirement_ids=allowed_requirement_ids,
+            allowed_resource_paths=allowed_resource_paths,
+            allowed_workflow_step_ids=allowed_workflow_step_ids,
+        )
+        return self._append(
+            session_id=current.session_id,
+            session_revision=session_revision,
+            session_definition_digest=session_definition_digest,
+            draft_id=current.draft_id,
+            draft_state_revision=draft_state_revision,
+            draft_revision=current.draft_revision,
+            draft_digest=current.draft_digest,
+            quality_mode=current.quality_mode,
+            state="draft",
+            cases=cases_tuple,
+            change_reason=clean_reason,
+            expected_suite_revision=expected_suite_revision,
+            expected_suite_digest=expected_suite_digest,
+            suite_id=current.suite_id,
+        )
+
+    def validate_patch(
+        self,
+        suite_id: str,
+        *,
+        expected_suite_revision: int,
+        expected_suite_digest: str,
+        cases: Iterable[Mapping[str, Any]],
+        change_reason: str,
+        allowed_requirement_ids: Iterable[str],
+        allowed_resource_paths: Iterable[str],
+        allowed_workflow_step_ids: Iterable[str],
+    ) -> None:
+        """Validate a proposed revision without changing the immutable Store."""
+        self._prepare_patch(
+            suite_id,
+            expected_suite_revision=expected_suite_revision,
+            expected_suite_digest=expected_suite_digest,
+            cases=cases,
+            change_reason=change_reason,
+            allowed_requirement_ids=allowed_requirement_ids,
+            allowed_resource_paths=allowed_resource_paths,
+            allowed_workflow_step_ids=allowed_workflow_step_ids,
+        )
+
+    def _prepare_patch(
+        self,
+        suite_id: str,
+        *,
+        expected_suite_revision: int,
+        expected_suite_digest: str,
+        cases: Iterable[Mapping[str, Any]],
+        change_reason: str,
+        allowed_requirement_ids: Iterable[str],
+        allowed_resource_paths: Iterable[str],
+        allowed_workflow_step_ids: Iterable[str],
+    ) -> tuple[SkillEvaluationSuite, tuple[SkillEvaluationSuiteCase, ...], str]:
+        current = self.require(suite_id)
+        self._require_expected(
+            current,
+            expected_revision=expected_suite_revision,
+            expected_digest=expected_suite_digest,
+        )
+        clean_reason = self._text(change_reason, "change_reason", maximum=4_000)
+        if current.state == "confirmed" and not clean_reason:
+            raise SkillEvaluationValidationError(
+                "Changing a confirmed evaluation suite requires a reason.",
+                code="skill_evaluation_suite_change_reason_required",
+            )
+        existing = {item.case_id: item for item in current.cases}
+        normalized: list[SkillEvaluationSuiteCase] = []
+        for raw in cases:
+            source = dict(raw)
+            case_id = str(source.get("case_id") or "").strip()
+            previous = existing.get(case_id)
+            role = str(source.get("role") or "").strip()
+            if previous is not None and role != previous.role:
+                raise SkillEvaluationValidationError(
+                    "An existing evaluation case role cannot be changed.",
+                    code="skill_evaluation_suite_case_role_frozen",
+                )
+            normalized_case = self.normalize_case(
+                source,
+                forced_source=(previous.source if previous else "user"),
+                allowed_requirement_ids=allowed_requirement_ids,
+                allowed_resource_paths=allowed_resource_paths,
+                allowed_workflow_step_ids=allowed_workflow_step_ids,
+            )
+            if (
+                previous is not None
+                and previous.source != "user"
+                and normalized_case.case_fingerprint != previous.case_fingerprint
+            ):
+                normalized_case = self.normalize_case(
+                    source,
+                    forced_source="user",
+                    allowed_requirement_ids=allowed_requirement_ids,
+                    allowed_resource_paths=allowed_resource_paths,
+                    allowed_workflow_step_ids=allowed_workflow_step_ids,
+                )
+            normalized.append(normalized_case)
+        cases_tuple = tuple(normalized)
+        self._validate_case_set(cases_tuple, allow_regressions=True)
+        return current, cases_tuple, clean_reason
+
+    def confirm(
+        self,
+        suite_id: str,
+        *,
+        expected_suite_revision: int,
+        expected_suite_digest: str,
+        session_revision: int,
+        session_definition_digest: str,
+        draft_state_revision: int,
+        allowed_requirement_ids: Iterable[str],
+        allowed_resource_paths: Iterable[str],
+        allowed_workflow_step_ids: Iterable[str],
+    ) -> SkillEvaluationSuite:
+        current = self.require(suite_id)
+        self._require_expected(
+            current,
+            expected_revision=expected_suite_revision,
+            expected_digest=expected_suite_digest,
+        )
+        if current.state == "confirmed":
+            return current
+        cases = tuple(
+            self.normalize_case(
+                asdict(item),
+                forced_source=item.source,
+                allowed_requirement_ids=allowed_requirement_ids,
+                allowed_resource_paths=allowed_resource_paths,
+                allowed_workflow_step_ids=allowed_workflow_step_ids,
+            )
+            for item in current.cases
+        )
+        self._validate_case_set(cases, allow_regressions=True)
+        covered = {value for item in cases for value in item.requirement_ids}
+        missing = sorted(set(allowed_requirement_ids) - covered)
+        if missing:
+            raise SkillEvaluationValidationError(
+                "Evaluation suite does not cover every frozen Creator requirement.",
+                code="skill_evaluation_suite_coverage_incomplete",
+            )
+        return self._append(
+            session_id=current.session_id,
+            session_revision=session_revision,
+            session_definition_digest=session_definition_digest,
+            draft_id=current.draft_id,
+            draft_state_revision=draft_state_revision,
+            draft_revision=current.draft_revision,
+            draft_digest=current.draft_digest,
+            quality_mode=current.quality_mode,
+            state="confirmed",
+            cases=cases,
+            change_reason=current.change_reason,
+            expected_suite_revision=expected_suite_revision,
+            expected_suite_digest=expected_suite_digest,
+            suite_id=current.suite_id,
+        )
+
+    def _append(
+        self,
+        *,
+        session_id: str,
+        session_revision: int,
+        session_definition_digest: str,
+        draft_id: str,
+        draft_state_revision: int,
+        draft_revision: int,
+        draft_digest: str,
+        quality_mode: SuiteQualityMode,
+        state: SuiteState,
+        cases: tuple[SkillEvaluationSuiteCase, ...],
+        change_reason: str,
+        expected_suite_revision: int | None,
+        expected_suite_digest: str | None,
+        suite_id: str | None = None,
+    ) -> SkillEvaluationSuite:
+        clean_session_id = self._identifier(session_id, "session_id")
+        clean_draft_id = self._identifier(draft_id, "draft_id")
+        clean_session_revision = self._positive_int(session_revision, "session_revision")
+        clean_session_definition_digest = self._digest(
+            session_definition_digest, "session_definition_digest"
+        )
+        clean_draft_state_revision = self._positive_int(
+            draft_state_revision, "draft_state_revision"
+        )
+        clean_draft_revision = self._positive_int(draft_revision, "draft_revision")
+        clean_draft_digest = self._digest(draft_digest, "draft_digest")
+        if quality_mode not in {"objective", "subjective"}:
+            raise SkillEvaluationValidationError(
+                "Invalid evaluation suite quality mode.",
+                code="skill_evaluation_suite_invalid",
+            )
+        self._reject_credentials(
+            {"cases": [asdict(item) for item in cases], "change_reason": change_reason}
+        )
+        with self._lock:
+            self._ensure_writable_unlocked()
+            revisions = self._items.get(clean_session_id) or []
+            current = revisions[-1] if revisions else None
+            self._require_expected(
+                current,
+                expected_revision=expected_suite_revision,
+                expected_digest=expected_suite_digest,
+            )
+            if len(revisions) >= _MAX_SUITES_PER_SESSION:
+                raise SkillEvaluationValidationError(
+                    "Evaluation suite revision limit reached.",
+                    code="skill_evaluation_suite_revision_limit",
+                )
+            clean_suite_id = self._identifier(
+                suite_id
+                or (current.suite_id if current else f"skill_eval_suite_{uuid.uuid4().hex}"),
+                "suite_id",
+            )
+            if current is not None and clean_suite_id != current.suite_id:
+                raise SkillEvaluationConflictError("Evaluation suite identity changed.")
+            revision = len(revisions) + 1
+            payload = {
+                "version": EVALUATION_SUITE_VERSION,
+                "suite_id": clean_suite_id,
+                "suite_revision": revision,
+                "session_id": clean_session_id,
+                "session_revision": clean_session_revision,
+                "session_definition_digest": clean_session_definition_digest,
+                "draft_id": clean_draft_id,
+                "draft_state_revision": clean_draft_state_revision,
+                "draft_revision": clean_draft_revision,
+                "draft_digest": clean_draft_digest,
+                "quality_mode": quality_mode,
+                "state": state,
+                "case_fingerprints": [item.case_fingerprint for item in cases],
+                "change_reason": str(change_reason or "").strip(),
+                "based_on_revision": current.suite_revision if current else None,
+            }
+            digest = hashlib.sha256(self._canonical_json(payload).encode("utf-8")).hexdigest()
+            item = SkillEvaluationSuite(
+                suite_id=clean_suite_id,
+                version=EVALUATION_SUITE_VERSION,
+                suite_revision=revision,
+                suite_digest=digest,
+                session_id=clean_session_id,
+                session_revision=clean_session_revision,
+                session_definition_digest=clean_session_definition_digest,
+                draft_id=clean_draft_id,
+                draft_state_revision=clean_draft_state_revision,
+                draft_revision=clean_draft_revision,
+                draft_digest=clean_draft_digest,
+                quality_mode=quality_mode,
+                state=state,
+                cases=cases,
+                change_reason=str(change_reason or "").strip(),
+                based_on_revision=current.suite_revision if current else None,
+            )
+            previous = copy.deepcopy(self._items)
+            self._items.setdefault(clean_session_id, []).append(item)
+            try:
+                self._save_unlocked()
+            except BaseException:
+                self._items = previous
+                raise
+            return copy.deepcopy(item)
+
+    @classmethod
+    def normalize_case(
+        cls,
+        raw: Mapping[str, Any],
+        *,
+        forced_source: SuiteCaseSource,
+        allowed_requirement_ids: Iterable[str],
+        allowed_resource_paths: Iterable[str],
+        allowed_workflow_step_ids: Iterable[str],
+    ) -> SkillEvaluationSuiteCase:
+        if not isinstance(raw, Mapping):
+            raise SkillEvaluationValidationError(
+                "Evaluation suite case must be an object.",
+                code="skill_evaluation_suite_case_invalid",
+            )
+        role = str(raw.get("role") or "").strip()
+        if role not in {*_CORE_ROLES, "regression"}:
+            raise SkillEvaluationValidationError(
+                "Evaluation suite case has an invalid role.",
+                code="skill_evaluation_suite_case_role_invalid",
+            )
+        # ``SkillEvaluationStore`` owns the legacy evaluation-case fingerprint,
+        # while Suite cases have a wider fingerprint that also covers role,
+        # provenance, and coverage.  Never feed the Suite fingerprint into the
+        # legacy normalizer: the two domains are deliberately incompatible.
+        legacy_case = dict(raw)
+        legacy_case.pop("case_fingerprint", None)
+        base = SkillEvaluationStore.normalize_case(legacy_case)
+        requirement_ids = cls._identifier_list(
+            raw.get("requirement_ids") or (),
+            field_name="requirement_ids",
+            maximum=_MAX_COVERAGE_IDS,
+            allowed=set(allowed_requirement_ids),
+        )
+        resource_paths = cls._resource_paths(
+            raw.get("required_resource_paths") or (),
+            allowed=set(allowed_resource_paths),
+        )
+        workflow_step_ids = cls._identifier_list(
+            raw.get("workflow_step_ids") or (),
+            field_name="workflow_step_ids",
+            maximum=_MAX_COVERAGE_IDS,
+            allowed=set(allowed_workflow_step_ids),
+        )
+        payload = {
+            "case_id": base.case_id,
+            "role": role,
+            "source": forced_source,
+            "name": base.name,
+            "prompt": base.prompt,
+            "expected_behavior": base.expected_behavior,
+            "fixtures": base.fixtures,
+            "assertions": base.assertions,
+            "requirement_ids": list(requirement_ids),
+            "required_resource_paths": list(resource_paths),
+            "workflow_step_ids": list(workflow_step_ids),
+        }
+        fingerprint = hashlib.sha256(cls._canonical_json(payload).encode("utf-8")).hexdigest()
+        supplied = raw.get("case_fingerprint")
+        if supplied and str(supplied).lower() != fingerprint:
+            raise SkillEvaluationConflictError(
+                "Evaluation suite case fingerprint does not match its content."
+            )
+        return SkillEvaluationSuiteCase(
+            case_id=base.case_id,
+            role=role,  # type: ignore[arg-type]
+            source=forced_source,
+            name=base.name,
+            prompt=base.prompt,
+            expected_behavior=base.expected_behavior,
+            fixtures=base.fixtures,
+            assertions=base.assertions,
+            requirement_ids=requirement_ids,
+            required_resource_paths=resource_paths,
+            workflow_step_ids=workflow_step_ids,
+            case_fingerprint=fingerprint,
+        )
+
+    @staticmethod
+    def to_evaluation_cases(
+        suite: SkillEvaluationSuite,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "case_id": item.case_id,
+                "name": item.name,
+                "prompt": item.prompt,
+                "expected_behavior": item.expected_behavior,
+                "fixtures": copy.deepcopy(item.fixtures),
+                "assertions": copy.deepcopy(item.assertions),
+                "required_resource_paths": list(item.required_resource_paths),
+            }
+            for item in suite.cases
+        ]
+
+    @staticmethod
+    def serialize(item: SkillEvaluationSuite) -> dict[str, Any]:
+        return asdict(item)
+
+    @staticmethod
+    def serialize_case(item: SkillEvaluationSuiteCase) -> dict[str, Any]:
+        return asdict(item)
+
+    @classmethod
+    def _validate_case_set(
+        cls,
+        cases: tuple[SkillEvaluationSuiteCase, ...],
+        *,
+        allow_regressions: bool,
+    ) -> None:
+        if len({item.case_id for item in cases}) != len(cases):
+            raise SkillEvaluationValidationError(
+                "Evaluation suite case IDs must be unique.",
+                code="skill_evaluation_suite_case_duplicate",
+            )
+        roles = [item.role for item in cases]
+        for role in _CORE_ROLES:
+            if roles.count(role) != 1:
+                raise SkillEvaluationValidationError(
+                    "Evaluation suite requires exactly one normal, ambiguous, and boundary case.",
+                    code="skill_evaluation_suite_core_roles_required",
+                )
+        regressions = [item for item in cases if item.role == "regression"]
+        if not allow_regressions and regressions:
+            raise SkillEvaluationValidationError(
+                "The Creator model cannot add regression cases.",
+                code="skill_evaluation_suite_model_regression_forbidden",
+            )
+        if len(regressions) > _MAX_REGRESSION_CASES:
+            raise SkillEvaluationValidationError(
+                "Evaluation suite supports at most nine regression cases.",
+                code="skill_evaluation_suite_regression_limit",
+            )
+        if any(item.role == "regression" and item.source == "generated" for item in cases):
+            raise SkillEvaluationValidationError(
+                "Regression cases require explicit user confirmation.",
+                code="skill_evaluation_suite_regression_confirmation_required",
+            )
+        if len(cases) > 3 + _MAX_REGRESSION_CASES:
+            raise SkillEvaluationValidationError(
+                "Evaluation suite contains too many cases.",
+                code="skill_evaluation_suite_case_limit",
+            )
+
+    @staticmethod
+    def _require_expected(
+        current: SkillEvaluationSuite | None,
+        *,
+        expected_revision: int | None,
+        expected_digest: str | None,
+    ) -> None:
+        if current is None:
+            if expected_revision is not None or expected_digest is not None:
+                raise SkillEvaluationConflictError(
+                    "Evaluation suite does not exist. Reload before continuing."
+                )
+            return
+        if (
+            expected_revision is None
+            or int(expected_revision) != current.suite_revision
+            or not expected_digest
+            or str(expected_digest).lower() != current.suite_digest
+        ):
+            raise SkillEvaluationConflictError(
+                "Evaluation suite changed. Reload before continuing."
+            )
+
+    def _load(self) -> None:
+        if not self.snapshot_path.exists():
+            return
+        try:
+            raw_bytes = self.snapshot_path.read_bytes()
+            if len(raw_bytes) > _MAX_SNAPSHOT_BYTES:
+                raise ValueError("snapshot too large")
+            payload = json.loads(raw_bytes.decode("utf-8"))
+            if not isinstance(payload, dict) or payload.get("schema_version") != self.SCHEMA_VERSION:
+                raise ValueError("invalid suite snapshot")
+            sessions = payload.get("sessions")
+            if not isinstance(sessions, dict):
+                raise ValueError("invalid suite index")
+            quarantine = payload.get("quarantine") or []
+            if not isinstance(quarantine, list):
+                raise ValueError("invalid suite quarantine")
+        except Exception as exc:
+            self._load_error = f"skill_evaluation_suite_store_corrupt:{type(exc).__name__}"
+            return
+        for session_id, records in sessions.items():
+            try:
+                clean_session_id = self._identifier(session_id, "session_id")
+                if not isinstance(records, list) or len(records) > _MAX_SUITES_PER_SESSION:
+                    raise ValueError("invalid suite revisions")
+                revisions = [self._parse_suite(item) for item in records]
+                if any(item.session_id != clean_session_id for item in revisions):
+                    raise ValueError("suite session mismatch")
+                if [item.suite_revision for item in revisions] != list(
+                    range(1, len(revisions) + 1)
+                ):
+                    raise ValueError("suite revisions are not contiguous")
+                if revisions and len({item.suite_id for item in revisions}) != 1:
+                    raise ValueError("suite identity changed")
+                self._items[clean_session_id] = revisions
+            except Exception:
+                encoded = self._canonical_json(records).encode("utf-8", errors="replace")
+                self._quarantine.append(
+                    {
+                        "code": "skill_evaluation_suite_record_invalid",
+                        "sha256": hashlib.sha256(encoded).hexdigest(),
+                        "size_bytes": len(encoded),
+                    }
+                )
+        for item in quarantine[-200:]:
+            if not isinstance(item, dict):
+                continue
+            digest = str(item.get("sha256") or "").lower()
+            if (
+                item.get("code") == "skill_evaluation_suite_record_invalid"
+                and len(digest) == 64
+                and all(char in "0123456789abcdef" for char in digest)
+            ):
+                self._quarantine.append(
+                    {
+                        "code": "skill_evaluation_suite_record_invalid",
+                        "sha256": digest,
+                        "size_bytes": max(0, int(item.get("size_bytes") or 0)),
+                    }
+                )
+
+    def _save_unlocked(self) -> None:
+        self._ensure_writable_unlocked()
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": self.SCHEMA_VERSION,
+            "version": EVALUATION_SUITE_VERSION,
+            "sessions": {
+                session_id: [asdict(item) for item in revisions]
+                for session_id, revisions in sorted(self._items.items())
+            },
+            "quarantine": list(self._quarantine[-200:]),
+        }
+        content = json.dumps(
+            payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        if len(content) > _MAX_SNAPSHOT_BYTES:
+            raise SkillEvaluationStorageError(
+                "Evaluation suite Store reached its bounded capacity."
+            )
+        temporary = self.snapshot_path.with_name(
+            f".{self.snapshot_path.name}.{uuid.uuid4().hex}.tmp"
+        )
+        try:
+            with temporary.open("xb") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.snapshot_path)
+        finally:
+            with contextlib.suppress(OSError):
+                temporary.unlink()
+
+    @classmethod
+    def _parse_suite(cls, raw: Any) -> SkillEvaluationSuite:
+        if not isinstance(raw, dict):
+            raise ValueError("suite must be an object")
+        if raw.get("version") != EVALUATION_SUITE_VERSION:
+            raise ValueError("unsupported suite version")
+        quality_mode = str(raw.get("quality_mode") or "")
+        state = str(raw.get("state") or "")
+        if quality_mode not in {"objective", "subjective"} or state not in {
+            "draft",
+            "confirmed",
+        }:
+            raise ValueError("invalid suite state")
+        raw_cases = raw.get("cases")
+        if not isinstance(raw_cases, list):
+            raise ValueError("suite cases must be a list")
+        # Persisted cases are verified against their own complete fingerprints.
+        cases: list[SkillEvaluationSuiteCase] = []
+        for value in raw_cases:
+            if not isinstance(value, dict):
+                raise ValueError("invalid suite case")
+            role = str(value.get("role") or "")
+            source = str(value.get("source") or "")
+            if role not in {*_CORE_ROLES, "regression"} or source not in {
+                "generated",
+                "user",
+                "migrated",
+            }:
+                raise ValueError("invalid suite case role or source")
+            legacy_case = dict(value)
+            legacy_case.pop("case_fingerprint", None)
+            base = SkillEvaluationStore.normalize_case(legacy_case)
+            requirement_ids = cls._identifier_list(
+                value.get("requirement_ids") or (),
+                field_name="requirement_ids",
+                maximum=_MAX_COVERAGE_IDS,
+                allowed=None,
+            )
+            resource_paths = cls._resource_paths(
+                value.get("required_resource_paths") or (), allowed=None
+            )
+            step_ids = cls._identifier_list(
+                value.get("workflow_step_ids") or (),
+                field_name="workflow_step_ids",
+                maximum=_MAX_COVERAGE_IDS,
+                allowed=None,
+            )
+            payload = {
+                "case_id": base.case_id,
+                "role": role,
+                "source": source,
+                "name": base.name,
+                "prompt": base.prompt,
+                "expected_behavior": base.expected_behavior,
+                "fixtures": base.fixtures,
+                "assertions": base.assertions,
+                "requirement_ids": list(requirement_ids),
+                "required_resource_paths": list(resource_paths),
+                "workflow_step_ids": list(step_ids),
+            }
+            fingerprint = hashlib.sha256(
+                cls._canonical_json(payload).encode("utf-8")
+            ).hexdigest()
+            if str(value.get("case_fingerprint") or "").lower() != fingerprint:
+                raise ValueError("suite case fingerprint mismatch")
+            cases.append(
+                SkillEvaluationSuiteCase(
+                    case_id=base.case_id,
+                    role=role,  # type: ignore[arg-type]
+                    source=source,  # type: ignore[arg-type]
+                    name=base.name,
+                    prompt=base.prompt,
+                    expected_behavior=base.expected_behavior,
+                    fixtures=base.fixtures,
+                    assertions=base.assertions,
+                    requirement_ids=requirement_ids,
+                    required_resource_paths=resource_paths,
+                    workflow_step_ids=step_ids,
+                    case_fingerprint=fingerprint,
+                )
+            )
+        cases_tuple = tuple(cases)
+        cls._validate_case_set(cases_tuple, allow_regressions=True)
+        item = SkillEvaluationSuite(
+            suite_id=cls._identifier(raw.get("suite_id"), "suite_id"),
+            version=EVALUATION_SUITE_VERSION,
+            suite_revision=cls._positive_int(raw.get("suite_revision"), "suite_revision"),
+            suite_digest=cls._digest(raw.get("suite_digest"), "suite_digest"),
+            session_id=cls._identifier(raw.get("session_id"), "session_id"),
+            session_revision=cls._positive_int(raw.get("session_revision"), "session_revision"),
+            session_definition_digest=cls._digest(
+                raw.get("session_definition_digest"), "session_definition_digest"
+            ),
+            draft_id=cls._identifier(raw.get("draft_id"), "draft_id"),
+            draft_state_revision=cls._positive_int(
+                raw.get("draft_state_revision"), "draft_state_revision"
+            ),
+            draft_revision=cls._positive_int(raw.get("draft_revision"), "draft_revision"),
+            draft_digest=cls._digest(raw.get("draft_digest"), "draft_digest"),
+            quality_mode=quality_mode,  # type: ignore[arg-type]
+            state=state,  # type: ignore[arg-type]
+            cases=cases_tuple,
+            change_reason=str(raw.get("change_reason") or "")[:4_000],
+            based_on_revision=(
+                None
+                if raw.get("based_on_revision") is None
+                else cls._positive_int(raw.get("based_on_revision"), "based_on_revision")
+            ),
+            created_at=max(0.0, float(raw.get("created_at") or 0.0)),
+        )
+        payload = {
+            "version": item.version,
+            "suite_id": item.suite_id,
+            "suite_revision": item.suite_revision,
+            "session_id": item.session_id,
+            "session_revision": item.session_revision,
+            "session_definition_digest": item.session_definition_digest,
+            "draft_id": item.draft_id,
+            "draft_state_revision": item.draft_state_revision,
+            "draft_revision": item.draft_revision,
+            "draft_digest": item.draft_digest,
+            "quality_mode": item.quality_mode,
+            "state": item.state,
+            "case_fingerprints": [case.case_fingerprint for case in item.cases],
+            "change_reason": item.change_reason,
+            "based_on_revision": item.based_on_revision,
+        }
+        expected = hashlib.sha256(cls._canonical_json(payload).encode("utf-8")).hexdigest()
+        if item.suite_digest != expected:
+            raise ValueError("suite digest mismatch")
+        return item
+
+    @staticmethod
+    def _identifier(value: Any, field_name: str) -> str:
+        clean = str(value or "").strip()
+        if (
+            not 1 <= len(clean) <= 240
+            or clean[0] not in _SAFE_ID_CHARS
+            or any(char not in _SAFE_ID_CHARS for char in clean)
+            or any(ord(char) < 32 for char in clean)
+        ):
+            raise SkillEvaluationValidationError(
+                f"Invalid {field_name}.", code="skill_evaluation_suite_invalid"
+            )
+        return clean
+
+    @classmethod
+    def _identifier_list(
+        cls,
+        values: Any,
+        *,
+        field_name: str,
+        maximum: int,
+        allowed: set[str] | None,
+    ) -> tuple[str, ...]:
+        if not isinstance(values, (list, tuple)) or len(values) > maximum:
+            raise SkillEvaluationValidationError(
+                f"Invalid {field_name}.", code="skill_evaluation_suite_invalid"
+            )
+        result = tuple(sorted({cls._identifier(value, field_name) for value in values}))
+        if allowed is not None and not set(result).issubset(allowed):
+            raise SkillEvaluationValidationError(
+                f"Evaluation suite contains unknown {field_name}.",
+                code="skill_evaluation_suite_coverage_invalid",
+            )
+        return result
+
+    @classmethod
+    def _resource_paths(
+        cls, values: Any, *, allowed: set[str] | None
+    ) -> tuple[str, ...]:
+        if not isinstance(values, (list, tuple)) or len(values) > _MAX_RESOURCE_PATHS:
+            raise SkillEvaluationValidationError(
+                "Invalid evaluation resource paths.",
+                code="skill_evaluation_suite_resource_invalid",
+            )
+        result: set[str] = set()
+        for value in values:
+            raw = str(value or "").replace("\\", "/").strip()
+            path = PurePosixPath(raw)
+            if (
+                not raw
+                or path.is_absolute()
+                or ".." in path.parts
+                or raw != path.as_posix()
+                or not raw.startswith(("scripts/", "references/", "assets/"))
+            ):
+                raise SkillEvaluationValidationError(
+                    "Evaluation suite resource path is invalid.",
+                    code="skill_evaluation_suite_resource_invalid",
+                )
+            result.add(raw)
+        if allowed is not None and not result.issubset(allowed):
+            raise SkillEvaluationValidationError(
+                "Evaluation suite references a resource outside the frozen Skill package.",
+                code="skill_evaluation_suite_resource_missing",
+            )
+        return tuple(sorted(result))
+
+    @staticmethod
+    def _positive_int(value: Any, field_name: str) -> int:
+        try:
+            clean = int(value)
+        except (TypeError, ValueError) as exc:
+            raise SkillEvaluationValidationError(f"Invalid {field_name}.") from exc
+        if isinstance(value, bool) or clean < 1:
+            raise SkillEvaluationValidationError(f"Invalid {field_name}.")
+        return clean
+
+    @staticmethod
+    def _digest(value: Any, field_name: str) -> str:
+        clean = str(value or "").strip().lower()
+        if len(clean) != 64 or any(char not in "0123456789abcdef" for char in clean):
+            raise SkillEvaluationValidationError(f"Invalid {field_name}.")
+        return clean
+
+    @staticmethod
+    def _text(value: Any, field_name: str, *, maximum: int) -> str:
+        if not isinstance(value, str) or len(value) > maximum:
+            raise SkillEvaluationValidationError(f"Invalid {field_name}.")
+        return value.strip()
+
+    @staticmethod
+    def _canonical_json(value: Any) -> str:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def _reject_credentials(cls, value: Any) -> None:
+        text = cls._canonical_json(value)
+        if scan_skill_package_credentials(skill_markdown=text):
+            raise SkillEvaluationValidationError(
+                "Blocked credential material was detected in evaluation suite data.",
+                code="skill_evaluation_suite_credentials_blocked",
+            )
+
+    def _ensure_readable_unlocked(self) -> None:
+        if self._load_error:
+            raise SkillEvaluationStorageError(
+                "Skill evaluation suite Store is unavailable."
+            )
+
+    def _ensure_writable_unlocked(self) -> None:
+        self._ensure_readable_unlocked()
+
+
+__all__ = [
+    "EVALUATION_SUITE_VERSION",
+    "SkillEvaluationSuite",
+    "SkillEvaluationSuiteCase",
+    "SkillEvaluationSuiteStore",
+]

--- a/server/skills/creator_evaluation_suite_runtime.py
+++ b/server/skills/creator_evaluation_suite_runtime.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from .creator_evaluation_suite import EVALUATION_SUITE_VERSION
+from .creator_evaluation_suite_service import EvaluationSuiteGenerationRequest
+from .creator_runtime import CREATOR_WORKFLOW_VERSION
+from .creator_store import CREATOR_ASSISTANT_AGENT_ID, SkillCreatorValidationError
+
+
+EVALUATION_SUITE_WORKFLOW_VERSION = "skill-creator-evaluation-suite-planner-v1"
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationSuiteWorkflowInvocation:
+    workflow: dict[str, Any]
+    inputs: dict[str, str]
+    runtime_metadata: dict[str, Any]
+
+
+EvaluationSuiteWorkflowRunner = Callable[
+    [EvaluationSuiteWorkflowInvocation], Awaitable[str]
+]
+
+
+class WorkflowCreatorEvaluationSuiteGenerator:
+    """Generate only the three proposed core cases with a fixed no-tool Agent."""
+
+    def __init__(
+        self,
+        *,
+        model_id: str,
+        model_available: Callable[[], bool],
+        runner: EvaluationSuiteWorkflowRunner,
+    ) -> None:
+        self.model_id = str(model_id or "").strip()
+        self.model_available = model_available
+        self.runner = runner
+
+    def available(self) -> bool:
+        return bool(self.model_id and self.model_available())
+
+    async def generate(
+        self, request: EvaluationSuiteGenerationRequest
+    ) -> dict[str, Any]:
+        invocation = build_evaluation_suite_invocation(request, model_id=self.model_id)
+        output = await self.runner(invocation)
+        payload = parse_evaluation_suite_output(output)
+        if payload.pop("evaluation_suite_version", None) != EVALUATION_SUITE_VERSION:
+            raise SkillCreatorValidationError(
+                "Skill Creator returned an unsupported evaluation suite contract.",
+                code="skill_evaluation_suite_generator_invalid",
+            )
+        return payload
+
+
+def build_evaluation_suite_invocation(
+    request: EvaluationSuiteGenerationRequest,
+    *,
+    model_id: str,
+) -> EvaluationSuiteWorkflowInvocation:
+    session_id = _required_text(request.session.get("session_id"), "session_id")
+    session_revision = _positive_int(
+        request.session.get("session_revision"), "session_revision"
+    )
+    context = {
+        "evaluation_suite_version": EVALUATION_SUITE_VERSION,
+        "definition": {
+            "intent": request.session.get("intent") or "",
+            "positive_examples": list(request.session.get("positive_examples") or []),
+            "near_miss_examples": list(
+                request.session.get("near_miss_examples") or []
+            ),
+            "expected_output": request.session.get("expected_output") or "",
+            "success_criteria": list(request.session.get("success_criteria") or []),
+        },
+        "selected_evidence": list(request.session.get("selected_evidence") or []),
+        "draft": request.draft,
+        "resource_plan": request.resource_plan,
+        "allowed_requirement_ids": list(request.allowed_requirement_ids),
+        "allowed_resource_paths": list(request.allowed_resource_paths),
+        "allowed_workflow_step_ids": list(request.allowed_workflow_step_ids),
+        "case_contract": {
+            "core_roles": ["normal", "ambiguous", "boundary"],
+            "model_may_add_regressions": False,
+            "fixtures_are_utf8_text": True,
+            "assertion_kinds": [
+                "contains",
+                "not_contains",
+                "exact",
+                "json_schema",
+                "file_exists",
+                "file_sha256",
+            ],
+        },
+    }
+    context_text = json.dumps(
+        context, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+    if len(context_text.encode("utf-8")) > 240_000:
+        raise SkillCreatorValidationError(
+            "Skill Creator evaluation suite context is too large.",
+            code="skill_creator_context_too_large",
+        )
+    workflow = {
+        "id": f"skill-evaluation-suite-{session_id}",
+        "title": "Skill Creator evaluation suite design",
+        "nodes": [
+            {
+                "id": "suite-input",
+                "type": "input",
+                "data": {"kind": "input", "variableName": "creator_request"},
+            },
+            {
+                "id": "suite-agent",
+                "type": "workflow_agent",
+                "data": {
+                    "kind": "workflow_agent",
+                    "agentName": CREATOR_ASSISTANT_AGENT_ID,
+                    "modelId": str(model_id or "").strip(),
+                    "agentStrategy": "function_calling",
+                    "rolePrompt": _suite_prompt(),
+                    "taskInput": "{{creator_request}}",
+                    "outputVariable": "evaluation_suite",
+                    "toolMode": "none",
+                    "toolNames": "",
+                    "maxIterations": "1",
+                    "maxToolCalls": "1",
+                    "maxToolConcurrency": "1",
+                    "parallelToolCalls": "false",
+                    "retryOnFailure": "false",
+                    "temperature": "0.1",
+                },
+            },
+            {
+                "id": "suite-output",
+                "type": "output",
+                "data": {"kind": "output", "outputVariable": "evaluation_suite"},
+            },
+        ],
+        "edges": [
+            {"id": "suite-input-agent", "source": "suite-input", "target": "suite-agent"},
+            {"id": "suite-agent-output", "source": "suite-agent", "target": "suite-output"},
+        ],
+    }
+    return EvaluationSuiteWorkflowInvocation(
+        workflow=workflow,
+        inputs={"creator_request": context_text},
+        runtime_metadata={
+            "creator_session_id": session_id,
+            "creator_session_revision": session_revision,
+            "assistant_agent_id": CREATOR_ASSISTANT_AGENT_ID,
+            "creator_workflow_version": CREATOR_WORKFLOW_VERSION,
+            "creator_phase": "evaluation_suite",
+            "evaluation_suite_workflow_version": EVALUATION_SUITE_WORKFLOW_VERSION,
+        },
+    )
+
+
+def parse_evaluation_suite_output(value: Any) -> dict[str, Any]:
+    if not isinstance(value, str):
+        raise SkillCreatorValidationError(
+            "Skill Creator evaluation suite generator returned non-text output.",
+            code="skill_evaluation_suite_generator_invalid",
+        )
+    text = value.strip()
+    try:
+        payload = _decode_versioned_json(text)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise SkillCreatorValidationError(
+            "Skill Creator evaluation suite generator did not return valid JSON.",
+            code="skill_evaluation_suite_generator_invalid",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise SkillCreatorValidationError(
+            "Skill Creator evaluation suite generator must return one JSON object.",
+            code="skill_evaluation_suite_generator_invalid",
+        )
+    return payload
+
+
+def _decode_versioned_json(text: str) -> Any:
+    if not text:
+        raise ValueError("empty evaluation suite output")
+    try:
+        return json.loads(text)
+    except (ValueError, json.JSONDecodeError):
+        pass
+    decoder = json.JSONDecoder()
+    candidates: dict[str, dict[str, Any]] = {}
+    for index, char in enumerate(text):
+        if char != "{":
+            continue
+        try:
+            candidate, _end = decoder.raw_decode(text[index:])
+        except (ValueError, json.JSONDecodeError):
+            continue
+        if not isinstance(candidate, dict):
+            continue
+        if candidate.get("evaluation_suite_version") != EVALUATION_SUITE_VERSION:
+            continue
+        fingerprint = json.dumps(
+            candidate, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+        candidates[fingerprint] = candidate
+    if len(candidates) != 1:
+        raise ValueError("output must contain one versioned suite object")
+    return next(iter(candidates.values()))
+
+
+def _suite_prompt() -> str:
+    return (
+        "You are ModelMirror's fixed private Skill Creator test designer. Produce a reusable "
+        "evaluation suite proposal, not an answer to the Skill task. You have no tools. "
+        "Design exactly three core cases: normal proves the primary workflow, ambiguous "
+        "proves conservative handling of missing or conflicting information, and boundary "
+        "proves the stated non-trigger or failure behavior. Never add regression cases; only "
+        "a user may add or confirm them. Cases must be realistic, mutually distinct, and "
+        "traceable to supplied requirement IDs. Do not invent domain rules or sources. "
+        "Reference only allowed resource paths and workflow step IDs. If a case declares a "
+        "resource, the runtime will require verified skill_stage evidence for that exact path. "
+        "Fixtures are bounded UTF-8 text. Assertions are deterministic evidence for human "
+        "review, never an automatic judge. Return JSON only with no Markdown fences or prose: "
+        '{"evaluation_suite_version":"skill-evaluation-suite-v2","cases":['
+        '{"case_id":"core-normal","role":"normal","name":"Normal task",'
+        '"prompt":"real user request","expected_behavior":"observable behavior",'
+        '"fixtures":[],"assertions":[],"requirement_ids":["intent"],'
+        '"required_resource_paths":[],"workflow_step_ids":["step-id"]},'
+        '{"case_id":"core-ambiguous","role":"ambiguous","name":"Ambiguous task",'
+        '"prompt":"request with missing information","expected_behavior":"safe behavior",'
+        '"fixtures":[],"assertions":[],"requirement_ids":["near_miss:0"],'
+        '"required_resource_paths":[],"workflow_step_ids":["step-id"]},'
+        '{"case_id":"core-boundary","role":"boundary","name":"Boundary task",'
+        '"prompt":"near miss or failure","expected_behavior":"refuse or degrade safely",'
+        '"fixtures":[],"assertions":[],"requirement_ids":["expected_output"],'
+        '"required_resource_paths":[],"workflow_step_ids":["step-id"]}]}. '
+        "The object must contain only evaluation_suite_version and cases."
+    )
+
+
+def _required_text(value: Any, field_name: str) -> str:
+    clean = str(value or "").strip()
+    if not clean:
+        raise SkillCreatorValidationError(
+            f"Evaluation suite generation is missing {field_name}.",
+            code="skill_evaluation_suite_generator_invalid",
+        )
+    return clean
+
+
+def _positive_int(value: Any, field_name: str) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as exc:
+        raise SkillCreatorValidationError(
+            f"Evaluation suite generation has an invalid {field_name}.",
+            code="skill_evaluation_suite_generator_invalid",
+        ) from exc
+    if isinstance(value, bool) or result < 1:
+        raise SkillCreatorValidationError(
+            f"Evaluation suite generation has an invalid {field_name}.",
+            code="skill_evaluation_suite_generator_invalid",
+        )
+    return result
+
+
+__all__ = [
+    "EVALUATION_SUITE_WORKFLOW_VERSION",
+    "EvaluationSuiteWorkflowInvocation",
+    "WorkflowCreatorEvaluationSuiteGenerator",
+    "build_evaluation_suite_invocation",
+    "parse_evaluation_suite_output",
+]

--- a/server/skills/creator_evaluation_suite_service.py
+++ b/server/skills/creator_evaluation_suite_service.py
@@ -1,0 +1,542 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import threading
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping, Protocol
+
+from .creator_evaluation import SkillEvaluationNotFoundError, SkillEvaluationStore
+from .creator_evaluation_suite import SkillEvaluationSuite, SkillEvaluationSuiteStore
+from .creator_quality import build_session_requirement_ids
+from .creator_resource_plan import SkillResourcePlan, SkillResourcePlanStore
+from .creator_service import SkillCreatorService
+from .creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorSession,
+    SkillCreatorValidationError,
+)
+from .draft_store import WorkspaceSkillDraft
+
+
+EVALUATION_SUITE_SERVICE_VERSION = "skill-creator-evaluation-suite-v2"
+_RESOURCE_ROOTS = ("scripts/", "references/", "assets/")
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationSuiteGenerationRequest:
+    session: dict[str, Any]
+    draft: dict[str, Any]
+    resource_plan: dict[str, Any] | None
+    allowed_requirement_ids: tuple[str, ...]
+    allowed_resource_paths: tuple[str, ...]
+    allowed_workflow_step_ids: tuple[str, ...]
+
+
+class EvaluationSuiteGenerator(Protocol):
+    def available(self) -> bool: ...
+
+    async def generate(
+        self, request: EvaluationSuiteGenerationRequest
+    ) -> dict[str, Any]: ...
+
+
+class SkillCreatorEvaluationSuiteService:
+    """Bind immutable suites to the current Creator session and draft facts."""
+
+    VERSION = EVALUATION_SUITE_SERVICE_VERSION
+
+    def __init__(
+        self,
+        creator_service: SkillCreatorService,
+        suite_store: SkillEvaluationSuiteStore,
+        evaluation_store: SkillEvaluationStore,
+        *,
+        resource_plan_store: SkillResourcePlanStore | None = None,
+        generator: EvaluationSuiteGenerator | None = None,
+        enabled: bool | None = None,
+    ) -> None:
+        self.creator_service = creator_service
+        self.suite_store = suite_store
+        self.evaluation_store = evaluation_store
+        self.resource_plan_store = resource_plan_store
+        self.generator = generator
+        self.enabled = (
+            os.getenv("SKILL_CREATOR_EVOLUTION_V2_ENABLED", "false")
+            .strip()
+            .lower()
+            in {"1", "true", "yes", "on"}
+            if enabled is None
+            else bool(enabled)
+        )
+        self._locks_guard = threading.RLock()
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def status(self) -> dict[str, Any]:
+        try:
+            generator_available = bool(self.generator and self.generator.available())
+        except Exception:
+            generator_available = False
+        store_status = self.suite_store.status()
+        return {
+            "evaluation_suite_version": self.VERSION,
+            "evaluation_suite_enabled": self.enabled,
+            "evaluation_suite_generator_available": (
+                self.enabled and generator_available
+            ),
+            "evaluation_suite_store_available": bool(store_status["available"]),
+        }
+
+    def require_enabled(self) -> None:
+        self.creator_service.require_enabled()
+        if not self.enabled:
+            raise SkillCreatorValidationError(
+                "Skill Creator Evolution V2 is disabled.",
+                code="skill_creator_evolution_v2_disabled",
+            )
+
+    def current_projection(self, session_id: str) -> dict[str, Any] | None:
+        self.creator_service.require_enabled()
+        session, draft = self.creator_service.get_session(session_id)
+        current = self.suite_store.current_for_session(session_id)
+        return self._projection(current, session=session, draft=draft)
+
+    async def generate(
+        self,
+        session_id: str,
+        *,
+        expected_session_revision: int,
+        expected_draft_state_revision: int,
+        expected_draft_revision: int,
+        expected_draft_digest: str,
+        expected_suite_revision: int | None,
+        expected_suite_digest: str | None,
+    ) -> SkillEvaluationSuite:
+        self.require_enabled()
+        session, _draft = self._require_context(
+            session_id,
+            expected_session_revision=expected_session_revision,
+            expected_draft_state_revision=expected_draft_state_revision,
+            expected_draft_revision=expected_draft_revision,
+            expected_draft_digest=expected_draft_digest,
+        )
+        async with self._lock(session.session_id):
+            return await self._generate_locked(
+                session.session_id,
+                expected_session_revision=expected_session_revision,
+                expected_draft_state_revision=expected_draft_state_revision,
+                expected_draft_revision=expected_draft_revision,
+                expected_draft_digest=expected_draft_digest,
+                expected_suite_revision=expected_suite_revision,
+                expected_suite_digest=expected_suite_digest,
+            )
+
+    async def _generate_locked(
+        self,
+        session_id: str,
+        **expected: Any,
+    ) -> SkillEvaluationSuite:
+        session, draft = self._require_context(
+            session_id,
+            expected_session_revision=expected["expected_session_revision"],
+            expected_draft_state_revision=expected["expected_draft_state_revision"],
+            expected_draft_revision=expected["expected_draft_revision"],
+            expected_draft_digest=expected["expected_draft_digest"],
+        )
+        self.creator_service._require_ready_for_generation(session)
+        current = self.suite_store.current_for_session(session_id)
+        self._require_expected_suite(
+            current,
+            expected_revision=expected.get("expected_suite_revision"),
+            expected_digest=expected.get("expected_suite_digest"),
+        )
+        if current is not None and current.state == "confirmed" and not self._is_stale(
+            current, session=session, draft=draft
+        ):
+            raise SkillCreatorConflictError(
+                "The current evaluation suite is already confirmed. Edit it with a reason instead."
+            )
+        coverage = self._coverage_context(session, draft)
+
+        # A V1 three-case set is authoritative local data. Its first V2 suite
+        # migration must not spend a model call or reinterpret user-authored cases.
+        if current is None and session.cases_revision > 0:
+            try:
+                legacy = self.evaluation_store.require_cases(
+                    session.session_id, revision=session.cases_revision
+                )
+            except SkillEvaluationNotFoundError:
+                legacy = None
+            if legacy is not None and (
+                legacy.draft_id == draft.draft_id
+                and legacy.draft_revision == draft.content_revision
+                and legacy.content_digest == draft.content_digest
+                and len(legacy.cases) == 3
+            ):
+                return self.suite_store.migrate_case_set(
+                    session_id=session.session_id,
+                    session_revision=session.session_revision,
+                    session_definition_digest=self._session_definition_digest(session),
+                    draft_id=draft.draft_id,
+                    draft_state_revision=draft.revision,
+                    draft_revision=draft.content_revision,
+                    draft_digest=draft.content_digest,
+                    quality_mode=session.quality_mode,
+                    cases=legacy.cases,
+                    allowed_requirement_ids=coverage["requirements"],
+                )
+
+        generator = self.generator
+        try:
+            available = bool(generator and generator.available())
+        except Exception as exc:
+            raise SkillCreatorValidationError(
+                "The Skill Creator evaluation suite generator status is unavailable.",
+                code="skill_evaluation_suite_generator_failed",
+            ) from exc
+        if not available or generator is None:
+            raise SkillCreatorValidationError(
+                "The Skill Creator model gateway is not configured.",
+                code="model_gateway_unconfigured",
+            )
+        request = EvaluationSuiteGenerationRequest(
+            session=asdict(session),
+            draft=self._draft_context(draft),
+            resource_plan=coverage["resource_plan"],
+            allowed_requirement_ids=coverage["requirements"],
+            allowed_resource_paths=coverage["resources"],
+            allowed_workflow_step_ids=coverage["workflow_steps"],
+        )
+        try:
+            payload = await generator.generate(request)
+        except (SkillCreatorConflictError, SkillCreatorValidationError):
+            raise
+        except Exception as exc:
+            raise SkillCreatorValidationError(
+                "The dedicated Skill Creator agent could not design an evaluation suite.",
+                code="skill_evaluation_suite_generator_failed",
+            ) from exc
+        cases = payload.get("cases") if isinstance(payload, Mapping) else None
+        if not isinstance(cases, list):
+            raise SkillCreatorValidationError(
+                "The evaluation suite generator returned an invalid case list.",
+                code="skill_evaluation_suite_generator_invalid",
+            )
+
+        # Freeze only if the session and draft are still the facts shown to the model.
+        session, draft = self._require_context(
+            session_id,
+            expected_session_revision=expected["expected_session_revision"],
+            expected_draft_state_revision=expected["expected_draft_state_revision"],
+            expected_draft_revision=expected["expected_draft_revision"],
+            expected_draft_digest=expected["expected_draft_digest"],
+        )
+        return self.suite_store.save_generated(
+            session_id=session.session_id,
+            session_revision=session.session_revision,
+            session_definition_digest=self._session_definition_digest(session),
+            draft_id=draft.draft_id,
+            draft_state_revision=draft.revision,
+            draft_revision=draft.content_revision,
+            draft_digest=draft.content_digest,
+            quality_mode=session.quality_mode,
+            cases=cases,
+            expected_suite_revision=expected.get("expected_suite_revision"),
+            expected_suite_digest=expected.get("expected_suite_digest"),
+            allowed_requirement_ids=coverage["requirements"],
+            allowed_resource_paths=coverage["resources"],
+            allowed_workflow_step_ids=coverage["workflow_steps"],
+        )
+
+    def patch(
+        self,
+        session_id: str,
+        *,
+        suite_id: str,
+        expected_session_revision: int,
+        expected_draft_state_revision: int,
+        expected_draft_revision: int,
+        expected_draft_digest: str,
+        expected_suite_revision: int,
+        expected_suite_digest: str,
+        cases: list[Mapping[str, Any]],
+        change_reason: str,
+    ) -> SkillEvaluationSuite:
+        self.require_enabled()
+        session, draft = self._require_context(
+            session_id,
+            expected_session_revision=expected_session_revision,
+            expected_draft_state_revision=expected_draft_state_revision,
+            expected_draft_revision=expected_draft_revision,
+            expected_draft_digest=expected_draft_digest,
+        )
+        current = self.suite_store.require(suite_id)
+        self._require_suite_scope(current, session=session, draft=draft)
+        coverage = self._coverage_context(session, draft)
+        self.suite_store.validate_patch(
+            suite_id,
+            expected_suite_revision=expected_suite_revision,
+            expected_suite_digest=expected_suite_digest,
+            cases=cases,
+            change_reason=change_reason,
+            allowed_requirement_ids=coverage["requirements"],
+            allowed_resource_paths=coverage["resources"],
+            allowed_workflow_step_ids=coverage["workflow_steps"],
+        )
+        if current.state == "confirmed" and draft.quality_status not in {
+            "not_evaluated",
+            "outdated",
+        }:
+            draft = self.creator_service.draft_store.mark_quality_outdated(
+                draft.draft_id,
+                expected_revision=draft.revision,
+                expected_digest=draft.content_digest,
+            )
+        return self.suite_store.patch(
+            suite_id,
+            expected_suite_revision=expected_suite_revision,
+            expected_suite_digest=expected_suite_digest,
+            session_revision=session.session_revision,
+            session_definition_digest=self._session_definition_digest(session),
+            draft_state_revision=draft.revision,
+            cases=cases,
+            change_reason=change_reason,
+            allowed_requirement_ids=coverage["requirements"],
+            allowed_resource_paths=coverage["resources"],
+            allowed_workflow_step_ids=coverage["workflow_steps"],
+        )
+
+    def confirm(
+        self,
+        session_id: str,
+        *,
+        suite_id: str,
+        expected_session_revision: int,
+        expected_draft_state_revision: int,
+        expected_draft_revision: int,
+        expected_draft_digest: str,
+        expected_suite_revision: int,
+        expected_suite_digest: str,
+    ) -> SkillEvaluationSuite:
+        self.require_enabled()
+        session, draft = self._require_context(
+            session_id,
+            expected_session_revision=expected_session_revision,
+            expected_draft_state_revision=expected_draft_state_revision,
+            expected_draft_revision=expected_draft_revision,
+            expected_draft_digest=expected_draft_digest,
+        )
+        current = self.suite_store.require(suite_id)
+        self._require_suite_scope(current, session=session, draft=draft)
+        coverage = self._coverage_context(session, draft)
+        return self.suite_store.confirm(
+            suite_id,
+            expected_suite_revision=expected_suite_revision,
+            expected_suite_digest=expected_suite_digest,
+            session_revision=session.session_revision,
+            session_definition_digest=self._session_definition_digest(session),
+            draft_state_revision=draft.revision,
+            allowed_requirement_ids=coverage["requirements"],
+            allowed_resource_paths=coverage["resources"],
+            allowed_workflow_step_ids=coverage["workflow_steps"],
+        )
+
+    def require_confirmed_current(
+        self, session: SkillCreatorSession, draft: WorkspaceSkillDraft
+    ) -> SkillEvaluationSuite:
+        self.require_enabled()
+        current = self.suite_store.current_for_session(session.session_id)
+        if current is None or current.state != "confirmed":
+            raise SkillCreatorValidationError(
+                "Confirm the current evaluation suite before starting a V2 evaluation.",
+                code="skill_evaluation_suite_confirmation_required",
+            )
+        self._require_suite_scope(current, session=session, draft=draft)
+        return current
+
+    @staticmethod
+    def _projection(
+        suite: SkillEvaluationSuite | None,
+        *,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft | None,
+    ) -> dict[str, Any] | None:
+        if suite is None:
+            return None
+        data = SkillEvaluationSuiteStore.serialize(suite)
+        data["stale"] = bool(
+            draft is None
+            or SkillCreatorEvaluationSuiteService._is_stale(
+                suite, session=session, draft=draft
+            )
+        )
+        return data
+
+    def _coverage_context(
+        self, session: SkillCreatorSession, draft: WorkspaceSkillDraft
+    ) -> dict[str, Any]:
+        requirements = build_session_requirement_ids(
+            intent=session.intent,
+            positive_examples=session.positive_examples,
+            near_miss_examples=session.near_miss_examples,
+            expected_output=session.expected_output,
+            success_criteria=session.success_criteria,
+        )
+        resources = tuple(
+            sorted(path for path in draft.files if path.startswith(_RESOURCE_ROOTS))
+        )
+        plan: SkillResourcePlan | None = None
+        if self.resource_plan_store is not None:
+            plan = self.resource_plan_store.current_for_session(session.session_id)
+        steps = tuple(item.step_id for item in plan.workflow_steps) if plan else ()
+        return {
+            "requirements": requirements,
+            "resources": resources,
+            "workflow_steps": steps,
+            "resource_plan": (
+                SkillResourcePlanStore.serialize(plan) if plan is not None else None
+            ),
+        }
+
+    @staticmethod
+    def _draft_context(draft: WorkspaceSkillDraft) -> dict[str, Any]:
+        inventory = []
+        for path, content in sorted(draft.files.items()):
+            if not path.startswith(_RESOURCE_ROOTS):
+                continue
+            encoded = content.encode("utf-8")
+            inventory.append(
+                {
+                    "path": path,
+                    "size_bytes": len(encoded),
+                    "sha256": hashlib.sha256(encoded).hexdigest(),
+                    "kind": path.split("/", 1)[0],
+                }
+            )
+        return {
+            "draft_id": draft.draft_id,
+            "draft_revision": draft.content_revision,
+            "draft_digest": draft.content_digest,
+            "name": draft.name,
+            "description": draft.description,
+            "skill_markdown": draft.skill_markdown[:20_000],
+            "resource_inventory": inventory,
+        }
+
+    def _require_context(
+        self,
+        session_id: str,
+        *,
+        expected_session_revision: int,
+        expected_draft_state_revision: int,
+        expected_draft_revision: int,
+        expected_draft_digest: str,
+    ) -> tuple[SkillCreatorSession, WorkspaceSkillDraft]:
+        session, draft = self.creator_service.get_session(session_id)
+        if draft is None:
+            raise SkillCreatorValidationError(
+                "Create a Skill draft before designing its evaluation suite.",
+                code="skill_creator_draft_required",
+            )
+        if (
+            session.session_revision != int(expected_session_revision)
+            or draft.revision != int(expected_draft_state_revision)
+            or draft.content_revision != int(expected_draft_revision)
+            or draft.content_digest != str(expected_draft_digest or "").lower()
+        ):
+            raise SkillCreatorConflictError(
+                "Creator session or draft changed. Reload before continuing."
+            )
+        if session.active_evaluation_run_id:
+            raise SkillCreatorConflictError(
+                "Cancel the active evaluation before changing its evaluation suite."
+            )
+        return session, draft
+
+    @staticmethod
+    def _require_expected_suite(
+        current: SkillEvaluationSuite | None,
+        *,
+        expected_revision: int | None,
+        expected_digest: str | None,
+    ) -> None:
+        if current is None:
+            if expected_revision is not None or expected_digest is not None:
+                raise SkillCreatorConflictError(
+                    "Evaluation suite changed. Reload before continuing."
+                )
+            return
+        if (
+            expected_revision is None
+            or expected_digest is None
+            or current.suite_revision != int(expected_revision)
+            or current.suite_digest != str(expected_digest).lower()
+        ):
+            raise SkillCreatorConflictError(
+                "Evaluation suite changed. Reload before continuing."
+            )
+
+    @staticmethod
+    def _require_suite_scope(
+        suite: SkillEvaluationSuite,
+        *,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft,
+    ) -> None:
+        if SkillCreatorEvaluationSuiteService._is_stale(
+            suite, session=session, draft=draft
+        ):
+            raise SkillCreatorConflictError(
+                "Evaluation suite no longer matches the current Creator session and draft."
+            )
+
+    @staticmethod
+    def _is_stale(
+        suite: SkillEvaluationSuite,
+        *,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft,
+    ) -> bool:
+        return bool(
+            suite.session_id != session.session_id
+            or suite.session_definition_digest
+            != SkillCreatorEvaluationSuiteService._session_definition_digest(session)
+            or suite.draft_id != draft.draft_id
+            or suite.draft_revision != draft.content_revision
+            or suite.draft_digest != draft.content_digest
+            or suite.quality_mode != session.quality_mode
+        )
+
+    @staticmethod
+    def _session_definition_digest(session: SkillCreatorSession) -> str:
+        payload = {
+            "intent": session.intent,
+            "positive_examples": list(session.positive_examples),
+            "near_miss_examples": list(session.near_miss_examples),
+            "expected_output": session.expected_output,
+            "success_criteria": list(session.success_criteria),
+            "evidence_preview_fingerprint": session.evidence_preview_fingerprint,
+            "selected_evidence": list(session.selected_evidence),
+        }
+        encoded = json.dumps(
+            payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def _lock(self, session_id: str) -> asyncio.Lock:
+        with self._locks_guard:
+            lock = self._locks.get(session_id)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[session_id] = lock
+            return lock
+
+
+__all__ = [
+    "EVALUATION_SUITE_SERVICE_VERSION",
+    "EvaluationSuiteGenerationRequest",
+    "EvaluationSuiteGenerator",
+    "SkillCreatorEvaluationSuiteService",
+]

--- a/server/tests/test_skill_application_receipts.py
+++ b/server/tests/test_skill_application_receipts.py
@@ -17,6 +17,7 @@ from server.skills.application_receipts import (
     SkillApplicationScope,
     build_application_contract,
 )
+from server.skills.creator_evaluation import SkillEvaluationValidationError
 from server.xpert_runtime.sandbox_store import SandboxWorkspace
 from server.xpert_runtime.sandbox_toolset import SandboxToolsetProvider
 from server.xpert_runtime.toolset import RuntimeToolCall
@@ -613,6 +614,65 @@ def test_main_observer_records_sanitized_failed_application(tmp_path, monkeypatc
     persisted = receipt_store.snapshot_path.read_text(encoding="utf-8")
     assert "arguments" not in persisted
     assert "output" not in persisted
+
+
+def test_creator_v2_accept_verifier_rechecks_protected_receipt(
+    tmp_path, monkeypatch
+):
+    import server.main as main
+
+    store = SkillApplicationReceiptStore(tmp_path)
+    package_digest = _digest("evaluation package")
+    content_digest = _digest("skill markdown")
+    contract = build_application_contract(
+        skill_id="evaluation-skill",
+        source_kind="evaluation_overlay",
+        version_id="skill_eval_overlay_one",
+        content_digest=package_digest,
+        policy="require_read",
+    )
+    receipt = store.observe(
+        contract,
+        SkillApplicationScope(
+            run_id="runtime_eval_one",
+            task_id="task_eval_one",
+            node_id="evaluation-agent",
+            runtime_kind="skill_evaluation",
+        ),
+        method="skill_read",
+        resource_paths=["SKILL.md"],
+        resource_digests={"SKILL.md": content_digest},
+        expected_resource_digests={"SKILL.md": content_digest},
+        tool_name="skill_read",
+    )
+    assert receipt is not None and receipt.compliance_status == "verified"
+    receipt = store.protect(
+        receipt.receipt_id,
+        reference_id="evaluation-item:skill_eval_item_one",
+    )
+    monkeypatch.setattr(main, "skill_application_receipt_store", store)
+    item = SimpleNamespace(
+        item_id="skill_eval_item_one",
+        case_id="case-one",
+        target="candidate",
+        runtime_run_id="runtime_eval_one",
+        overlay_id="skill_eval_overlay_one",
+        application_receipt_id=receipt.receipt_id,
+        application_receipt_revision=receipt.revision,
+    )
+    run = SimpleNamespace(
+        evaluation_suite_id="skill_eval_suite_one",
+        frozen_digest=package_digest,
+        cases=[SimpleNamespace(case_id="case-one", required_resource_paths=())],
+        items=[item],
+    )
+
+    main.verify_skill_evaluation_application_receipts(run)
+
+    item.application_receipt_revision -= 1
+    with pytest.raises(SkillEvaluationValidationError) as captured:
+        main.verify_skill_evaluation_application_receipts(run)
+    assert captured.value.code == "skill_application_receipt_mismatch"
 
 
 def test_enforce_mode_propagates_receipt_failures(monkeypatch):

--- a/server/tests/test_skill_creator_evaluation.py
+++ b/server/tests/test_skill_creator_evaluation.py
@@ -206,6 +206,131 @@ def test_store_freezes_three_case_paired_matrix_and_round_trips(tmp_path: Path) 
     assert restored.baseline_overlay_id == run.baseline_overlay_id
 
 
+def test_v2_suite_freezes_up_to_twelve_cases_and_application_receipts(tmp_path: Path) -> None:
+    store = SkillEvaluationStore(tmp_path)
+    candidate = _overlay(store)
+    cases = [
+        {
+            **_case(index),
+            "required_resource_paths": (
+                ["references/guide.md"] if index == 1 else []
+            ),
+        }
+        for index in range(1, 13)
+    ]
+    run = store.create_run(
+        session_id="session-one",
+        draft_id="draft-one",
+        draft_revision=2,
+        frozen_digest=DIGEST,
+        candidate_overlay_id=candidate.overlay_id,
+        cases=cases,
+        model_id="provider/model-one",
+        repetitions=3,
+        evaluation_suite_id="skill_eval_suite_one",
+        evaluation_suite_revision=2,
+        evaluation_suite_digest="c" * 64,
+        evaluation_suite_version="skill-evaluation-suite-v2",
+    )
+    assert len(run.cases) == 12
+    assert len(run.items) == 72
+    assert run.cases[0].required_resource_paths == ["references/guide.md"]
+
+    restored = SkillEvaluationStore(tmp_path).require_run(run.run_id)
+    assert restored.evaluation_suite_id == "skill_eval_suite_one"
+    assert len(restored.items) == 72
+
+    with pytest.raises(SkillEvaluationValidationError) as captured:
+        store.create_run(
+            session_id="session-one",
+            draft_id="draft-one",
+            draft_revision=2,
+            frozen_digest=DIGEST,
+            candidate_overlay_id=candidate.overlay_id,
+            cases=cases,
+            model_id="provider/model-one",
+            evaluation_suite_id="skill_eval_suite_incomplete",
+        )
+    assert captured.value.code == "skill_evaluation_suite_binding_invalid"
+
+
+@pytest.mark.asyncio
+async def test_v2_candidate_requires_verified_application_receipt(tmp_path: Path) -> None:
+    async def runner(run, item, case, overlay):
+        return {
+            "output": "done",
+            "actual_model": "provider/model-one",
+            "skill_read": True,
+            "work_manifest": [],
+            **(
+                {
+                    "application_receipt_id": f"skillappreceipt_{item.item_id}",
+                    "application_receipt_revision": 2,
+                    "application_compliance": "verified",
+                }
+                if item.target == "candidate"
+                else {}
+            ),
+        }
+
+    store = SkillEvaluationStore(tmp_path)
+    candidate = _overlay(store)
+    run = store.create_run(
+        session_id="session-one",
+        draft_id="draft-one",
+        draft_revision=2,
+        frozen_digest=DIGEST,
+        candidate_overlay_id=candidate.overlay_id,
+        cases=[_case(index) for index in range(1, 4)],
+        model_id="provider/model-one",
+        evaluation_suite_id="skill_eval_suite_one",
+        evaluation_suite_revision=1,
+        evaluation_suite_digest="c" * 64,
+        evaluation_suite_version="skill-evaluation-suite-v2",
+    )
+    executor = SkillEvaluationExecutor(store, runner=runner)
+    assert await executor.execute_next() is True
+    completed = store.require_run(run.run_id)
+    assert completed.report["eligible_for_accept"] is True
+    assert completed.report["application_receipt_verified_count"] == 3
+    assert all(
+        item.application_compliance == "verified"
+        for item in completed.items
+        if item.target == "candidate"
+    )
+
+    async def missing_receipt_runner(run, item, case, overlay):
+        return {
+            "output": "done",
+            "actual_model": "provider/model-one",
+            "skill_read": True,
+            "work_manifest": [],
+        }
+
+    second = store.create_run(
+        session_id="session-one",
+        draft_id="draft-one",
+        draft_revision=2,
+        frozen_digest=DIGEST,
+        candidate_overlay_id=candidate.overlay_id,
+        cases=[_case(index) for index in range(1, 4)],
+        model_id="provider/model-one",
+        evaluation_suite_id="skill_eval_suite_two",
+        evaluation_suite_revision=1,
+        evaluation_suite_digest="d" * 64,
+        evaluation_suite_version="skill-evaluation-suite-v2",
+    )
+    missing_executor = SkillEvaluationExecutor(store, runner=missing_receipt_runner)
+    assert await missing_executor.execute_next() is True
+    rejected = store.require_run(second.run_id)
+    assert rejected.report["eligible_for_accept"] is False
+    assert all(
+        item.error_code == "skill_application_receipt_missing"
+        for item in rejected.items
+        if item.target == "candidate"
+    )
+
+
 def test_case_sets_are_private_immutable_revisions_and_bind_runs(tmp_path: Path) -> None:
     store = SkillEvaluationStore(tmp_path)
     candidate = _overlay(store)

--- a/server/tests/test_skill_creator_evaluation_api.py
+++ b/server/tests/test_skill_creator_evaluation_api.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 
 from server.skills import creator_api
 from server.skills.creator_evaluation import (
+    SkillEvaluationConflictError,
     SkillEvaluationExecutor,
     SkillEvaluationRunnerResult,
     SkillEvaluationStore,
@@ -15,6 +16,10 @@ from server.skills.creator_evaluation import (
 )
 from server.skills.creator_evaluation_service import (
     SkillCreatorEvaluationService,
+)
+from server.skills.creator_evaluation_suite import SkillEvaluationSuiteStore
+from server.skills.creator_evaluation_suite_service import (
+    SkillCreatorEvaluationSuiteService,
 )
 from server.skills.creator_service import SkillCreatorService
 from server.skills.creator_store import (
@@ -112,8 +117,16 @@ def _services(tmp_path: Path):
     )
     session = session_store.create(
         intent="Turn note review into a reusable Skill.",
+        positive_examples=["Review these completed meeting notes."],
+        near_miss_examples=["Rewrite this paragraph without extracting actions."],
         expected_output="A traceable action report.",
         success_criteria=["No invented owners"],
+    )
+    session = session_store.set_evidence(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        preview_fingerprint="a" * 64,
+        selected_evidence=[],
     )
     draft = draft_store.create_creator_draft(
         creator_session_id=session.session_id,
@@ -146,6 +159,42 @@ def _services(tmp_path: Path):
     return creator, evaluation, executor, session, draft
 
 
+def _suite_case(role: str, *, regression: bool = False) -> dict:
+    case = _case({"normal": 1, "ambiguous": 2, "boundary": 3}.get(role, 4))
+    case.update(
+        {
+            "case_id": f"case-{role}",
+            "role": role,
+            "requirement_ids": [
+                "intent",
+                "positive_example:0",
+                "near_miss:0",
+                "expected_output",
+                "success_criterion:0",
+            ],
+            "required_resource_paths": [],
+            "workflow_step_ids": [],
+        }
+    )
+    if regression:
+        case["name"] = "Confirmed regression case"
+    return case
+
+
+class _SuiteGenerator:
+    def available(self) -> bool:
+        return True
+
+    async def generate(self, _request):
+        return {
+            "cases": [
+                _suite_case("normal"),
+                _suite_case("ambiguous"),
+                _suite_case("boundary"),
+            ]
+        }
+
+
 def _write_context(session, draft) -> dict:
     return {
         "expected_session_revision": session.session_revision,
@@ -172,7 +221,12 @@ def test_evaluation_service_cannot_bypass_disabled_creator(tmp_path: Path) -> No
 
 @pytest.mark.parametrize(
     "code",
-    ["model_gateway_unconfigured", "skill_evaluation_sidecar_unavailable"],
+    [
+        "model_gateway_unconfigured",
+        "skill_evaluation_sidecar_unavailable",
+        "skill_application_receipt_unavailable",
+        "skill_application_receipt_store_corrupt",
+    ],
 )
 def test_preflight_dependencies_are_reported_as_service_unavailable(code: str) -> None:
     response = creator_api._api_error(
@@ -180,6 +234,23 @@ def test_preflight_dependencies_are_reported_as_service_unavailable(code: str) -
     )
 
     assert response.status_code == 503
+    assert response.detail["code"] == code
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "skill_application_receipt_missing",
+        "skill_application_receipt_incomplete",
+        "skill_application_receipt_mismatch",
+    ],
+)
+def test_stale_application_evidence_is_a_structured_conflict(code: str) -> None:
+    response = creator_api._api_error(
+        SkillEvaluationValidationError("application evidence changed", code=code)
+    )
+
+    assert response.status_code == 409
     assert response.detail["code"] == code
 
 
@@ -280,6 +351,392 @@ async def test_objective_three_case_evaluation_accepts_only_current_digest(
     assert draft.quality_decision.actor_kind == "local_console"
     assert draft.quality_decision.content_digest == draft.content_digest
     assert session.quality_status == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_enabling_suite_service_does_not_silently_migrate_legacy_session(
+    tmp_path: Path,
+) -> None:
+    creator, evaluation, _, session, draft = _services(tmp_path)
+    suites = SkillCreatorEvaluationSuiteService(
+        creator,
+        SkillEvaluationSuiteStore(tmp_path / "suites"),
+        evaluation.evaluation_store,
+        generator=_SuiteGenerator(),
+        enabled=True,
+    )
+    evaluation.suite_service = suites
+    session, draft, _ = evaluation.save_cases(
+        session.session_id,
+        **_write_context(session, draft),
+        quality_mode="objective",
+        cases=[_case(1), _case(2), _case(3)],
+    )
+
+    session, draft, run = await evaluation.start_evaluation(
+        session.session_id, **_write_context(session, draft)
+    )
+
+    assert run.evaluation_suite_id is None
+    assert run.case_set_revision == 1
+    assert suites.suite_store.current_for_session(session.session_id) is None
+
+
+@pytest.mark.asyncio
+async def test_v2_accept_rechecks_authoritative_application_receipts(
+    tmp_path: Path,
+) -> None:
+    creator, evaluation, executor, session, draft = _services(tmp_path)
+    suites = SkillCreatorEvaluationSuiteService(
+        creator,
+        SkillEvaluationSuiteStore(tmp_path / "suites"),
+        evaluation.evaluation_store,
+        generator=_SuiteGenerator(),
+        enabled=True,
+    )
+    evaluation.suite_service = suites
+    generated = await suites.generate(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        expected_draft_state_revision=draft.revision,
+        expected_draft_revision=draft.content_revision,
+        expected_draft_digest=draft.content_digest,
+        expected_suite_revision=None,
+        expected_suite_digest=None,
+    )
+    suite = suites.confirm(
+        session.session_id,
+        suite_id=generated.suite_id,
+        expected_session_revision=session.session_revision,
+        expected_draft_state_revision=draft.revision,
+        expected_draft_revision=draft.content_revision,
+        expected_draft_digest=draft.content_digest,
+        expected_suite_revision=generated.suite_revision,
+        expected_suite_digest=generated.suite_digest,
+    )
+
+    async def receipt_runner(run, item, case, overlay):
+        del case, overlay
+        return SkillEvaluationRunnerResult(
+            output="ok - Alice owns follow-up.",
+            actual_model=run.model_id,
+            skill_read=item.target == "candidate",
+            application_receipt_id=(
+                f"skillappreceipt_{item.item_id}"
+                if item.target == "candidate"
+                else None
+            ),
+            application_receipt_revision=(
+                1 if item.target == "candidate" else None
+            ),
+            application_compliance=(
+                "verified" if item.target == "candidate" else None
+            ),
+        )
+
+    executor.runner = receipt_runner
+    session, draft, run = await evaluation.start_evaluation(
+        session.session_id,
+        **_write_context(session, draft),
+        evaluation_suite_revision=suite.suite_revision,
+        evaluation_suite_digest=suite.suite_digest,
+    )
+    assert await executor.execute_next() is True
+    session, draft, _, run = evaluation.get_projection(session.session_id)
+    assert run is not None and run.report["eligible_for_accept"] is True
+
+    with pytest.raises(SkillEvaluationValidationError) as unavailable:
+        await evaluation.review(
+            run.run_id,
+            **_write_context(session, draft),
+            expected_run_revision=run.revision,
+            expected_review_revision=run.feedback_revision,
+            decision="accept",
+            reason="Reviewed paired outputs and application evidence.",
+        )
+    assert unavailable.value.code == "skill_application_receipt_unavailable"
+    assert evaluation.evaluation_store.require_run(run.run_id).review_state == "pending"
+
+    evaluation.application_receipt_verifier = lambda _run: None
+    session, draft, run = await evaluation.review(
+        run.run_id,
+        **_write_context(session, draft),
+        expected_run_revision=run.revision,
+        expected_review_revision=run.feedback_revision,
+        decision="accept",
+        reason="Reviewed paired outputs and application evidence.",
+    )
+    assert run.review_state == "accepted"
+    assert draft.quality_status == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_confirmed_suite_change_invalidates_acceptance_and_recovers_interrupted_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    creator, evaluation, executor, session, draft = _services(tmp_path)
+    suites = SkillCreatorEvaluationSuiteService(
+        creator,
+        SkillEvaluationSuiteStore(tmp_path / "suites"),
+        evaluation.evaluation_store,
+        generator=_SuiteGenerator(),
+        enabled=True,
+    )
+    evaluation.suite_service = suites
+    generated = await suites.generate(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        expected_draft_state_revision=draft.revision,
+        expected_draft_revision=draft.content_revision,
+        expected_draft_digest=draft.content_digest,
+        expected_suite_revision=None,
+        expected_suite_digest=None,
+    )
+    suite = suites.confirm(
+        session.session_id,
+        suite_id=generated.suite_id,
+        expected_session_revision=session.session_revision,
+        expected_draft_state_revision=draft.revision,
+        expected_draft_revision=draft.content_revision,
+        expected_draft_digest=draft.content_digest,
+        expected_suite_revision=generated.suite_revision,
+        expected_suite_digest=generated.suite_digest,
+    )
+
+    async def receipt_runner(run, item, case, overlay):
+        del case, overlay
+        return SkillEvaluationRunnerResult(
+            output="ok - Alice owns follow-up.",
+            actual_model=run.model_id,
+            skill_read=item.target == "candidate",
+            application_receipt_id=(
+                f"skillappreceipt_{item.item_id}"
+                if item.target == "candidate"
+                else None
+            ),
+            application_receipt_revision=(
+                1 if item.target == "candidate" else None
+            ),
+            application_compliance=(
+                "verified" if item.target == "candidate" else None
+            ),
+        )
+
+    executor.runner = receipt_runner
+    evaluation.application_receipt_verifier = lambda _run: None
+    session, draft, run = await evaluation.start_evaluation(
+        session.session_id,
+        **_write_context(session, draft),
+        evaluation_suite_revision=suite.suite_revision,
+        evaluation_suite_digest=suite.suite_digest,
+    )
+    assert await executor.execute_next() is True
+    session, draft, _, run = evaluation.get_projection(session.session_id)
+    assert run is not None
+    session, draft, run = await evaluation.review(
+        run.run_id,
+        **_write_context(session, draft),
+        expected_run_revision=run.revision,
+        expected_review_revision=run.feedback_revision,
+        decision="accept",
+        reason="Reviewed paired outputs and verified application evidence.",
+    )
+    assert draft.quality_status == "accepted"
+
+    original_suite_save = suites.suite_store._save_unlocked
+
+    def fail_suite_write():
+        raise OSError("simulated disk failure")
+
+    changed_cases = [
+        SkillEvaluationSuiteStore.serialize_case(item) for item in suite.cases
+    ]
+    changed_cases[0]["prompt"] = "Review the notes and call out every missing owner."
+    changed_cases[0].pop("case_fingerprint", None)
+    monkeypatch.setattr(suites.suite_store, "_save_unlocked", fail_suite_write)
+    with pytest.raises(OSError, match="simulated disk failure"):
+        suites.patch(
+            session.session_id,
+            suite_id=suite.suite_id,
+            expected_session_revision=session.session_revision,
+            expected_draft_state_revision=draft.revision,
+            expected_draft_revision=draft.content_revision,
+            expected_draft_digest=draft.content_digest,
+            expected_suite_revision=suite.suite_revision,
+            expected_suite_digest=suite.suite_digest,
+            cases=changed_cases,
+            change_reason="Preserve a newly observed ownership failure.",
+        )
+    monkeypatch.setattr(suites.suite_store, "_save_unlocked", original_suite_save)
+    assert creator.draft_store.require(draft.draft_id).quality_status == "outdated"
+    assert suites.suite_store.require(suite.suite_id).suite_revision == suite.suite_revision
+
+    # The immutable Suite did not change, so projection recovery may safely replay
+    # the still-current accepted run.
+    session, draft, _, replayed_run = evaluation.get_projection(session.session_id)
+    assert replayed_run is not None and replayed_run.run_id == run.run_id
+    assert draft.quality_status == "accepted"
+
+    # Simulate a snapshot written by an older build that crashed before it could
+    # invalidate the Draft Store. Reconciliation must fail closed on the newer Suite.
+    allowed_requirements = {
+        value for item in suite.cases for value in item.requirement_ids
+    }
+    allowed_resources = {
+        value for item in suite.cases for value in item.required_resource_paths
+    }
+    allowed_steps = {
+        value for item in suite.cases for value in item.workflow_step_ids
+    }
+    suites.suite_store.patch(
+        suite.suite_id,
+        expected_suite_revision=suite.suite_revision,
+        expected_suite_digest=suite.suite_digest,
+        session_revision=session.session_revision,
+        session_definition_digest=suites._session_definition_digest(session),
+        draft_state_revision=draft.revision,
+        cases=changed_cases,
+        change_reason="Simulate an interrupted older cross-Store write.",
+        allowed_requirement_ids=allowed_requirements,
+        allowed_resource_paths=allowed_resources,
+        allowed_workflow_step_ids=allowed_steps,
+    )
+
+    recovered_session, recovered_draft, _, recovered_run = evaluation.get_projection(
+        session.session_id
+    )
+    assert recovered_run is None
+    assert recovered_draft.quality_status == "outdated"
+    assert recovered_session.quality_status == "outdated"
+    assert recovered_session.review_state == "none"
+
+
+@pytest.mark.asyncio
+async def test_active_v2_evaluation_blocks_suite_mutation(tmp_path: Path) -> None:
+    creator, evaluation, _, session, draft = _services(tmp_path)
+    suites = SkillCreatorEvaluationSuiteService(
+        creator,
+        SkillEvaluationSuiteStore(tmp_path / "suites"),
+        evaluation.evaluation_store,
+        generator=_SuiteGenerator(),
+        enabled=True,
+    )
+    evaluation.suite_service = suites
+    generated = await suites.generate(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        expected_draft_state_revision=draft.revision,
+        expected_draft_revision=draft.content_revision,
+        expected_draft_digest=draft.content_digest,
+        expected_suite_revision=None,
+        expected_suite_digest=None,
+    )
+    suite = suites.confirm(
+        session.session_id,
+        suite_id=generated.suite_id,
+        expected_session_revision=session.session_revision,
+        expected_draft_state_revision=draft.revision,
+        expected_draft_revision=draft.content_revision,
+        expected_draft_digest=draft.content_digest,
+        expected_suite_revision=generated.suite_revision,
+        expected_suite_digest=generated.suite_digest,
+    )
+    session, draft, _ = await evaluation.start_evaluation(
+        session.session_id,
+        **_write_context(session, draft),
+        evaluation_suite_revision=suite.suite_revision,
+        evaluation_suite_digest=suite.suite_digest,
+    )
+
+    with pytest.raises(SkillCreatorConflictError, match="Cancel the active evaluation"):
+        suites.patch(
+            session.session_id,
+            suite_id=suite.suite_id,
+            expected_session_revision=session.session_revision,
+            expected_draft_state_revision=draft.revision,
+            expected_draft_revision=draft.content_revision,
+            expected_draft_digest=draft.content_digest,
+            expected_suite_revision=suite.suite_revision,
+            expected_suite_digest=suite.suite_digest,
+            cases=[
+                SkillEvaluationSuiteStore.serialize_case(item)
+                for item in suite.cases
+            ],
+            change_reason="This edit must wait until the active run is cancelled.",
+        )
+
+
+@pytest.mark.asyncio
+async def test_suite_change_during_preflight_creates_no_stale_run(
+    tmp_path: Path,
+) -> None:
+    creator, evaluation, _, session, draft = _services(tmp_path)
+    suites = SkillCreatorEvaluationSuiteService(
+        creator,
+        SkillEvaluationSuiteStore(tmp_path / "suites"),
+        evaluation.evaluation_store,
+        generator=_SuiteGenerator(),
+        enabled=True,
+    )
+    evaluation.suite_service = suites
+    generated = await suites.generate(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        expected_draft_state_revision=draft.revision,
+        expected_draft_revision=draft.content_revision,
+        expected_draft_digest=draft.content_digest,
+        expected_suite_revision=None,
+        expected_suite_digest=None,
+    )
+    suite = suites.confirm(
+        session.session_id,
+        suite_id=generated.suite_id,
+        expected_session_revision=session.session_revision,
+        expected_draft_state_revision=draft.revision,
+        expected_draft_revision=draft.content_revision,
+        expected_draft_digest=draft.content_digest,
+        expected_suite_revision=generated.suite_revision,
+        expected_suite_digest=generated.suite_digest,
+    )
+
+    async def mutate_suite_during_preflight(_draft, purpose):
+        assert purpose == "evaluate"
+        revised = suites.patch(
+            session.session_id,
+            suite_id=suite.suite_id,
+            expected_session_revision=session.session_revision,
+            expected_draft_state_revision=draft.revision,
+            expected_draft_revision=draft.content_revision,
+            expected_draft_digest=draft.content_digest,
+            expected_suite_revision=suite.suite_revision,
+            expected_suite_digest=suite.suite_digest,
+            cases=[
+                SkillEvaluationSuiteStore.serialize_case(item)
+                for item in suite.cases
+            ],
+            change_reason="Adjust the frozen suite while preflight is pending.",
+        )
+        suites.confirm(
+            session.session_id,
+            suite_id=revised.suite_id,
+            expected_session_revision=session.session_revision,
+            expected_draft_state_revision=draft.revision,
+            expected_draft_revision=draft.content_revision,
+            expected_draft_digest=draft.content_digest,
+            expected_suite_revision=revised.suite_revision,
+            expected_suite_digest=revised.suite_digest,
+        )
+        return {"model_id": "test/model", "config": {}}
+
+    evaluation.preflight = mutate_suite_during_preflight
+    with pytest.raises(SkillEvaluationConflictError, match="during preflight"):
+        await evaluation.start_evaluation(
+            session.session_id,
+            **_write_context(session, draft),
+            evaluation_suite_revision=suite.suite_revision,
+            evaluation_suite_digest=suite.suite_digest,
+        )
+    assert evaluation.evaluation_store.list_runs(session_id=session.session_id) == []
 
 
 @pytest.mark.asyncio
@@ -468,6 +925,133 @@ async def test_creator_evaluation_api_exposes_cases_run_and_structured_conflict(
     finally:
         creator_api.configure_skill_creator(previous_creator)
         creator_api.configure_skill_creator_evaluation(previous_evaluation)
+
+
+@pytest.mark.asyncio
+async def test_evaluation_suite_api_generates_user_regression_confirms_and_starts_v2(
+    tmp_path: Path,
+) -> None:
+    creator, evaluation, _, session, draft = _services(tmp_path)
+    suites = SkillCreatorEvaluationSuiteService(
+        creator,
+        SkillEvaluationSuiteStore(tmp_path / "suites"),
+        evaluation.evaluation_store,
+        generator=_SuiteGenerator(),
+        enabled=True,
+    )
+    evaluation.suite_service = suites
+    app = FastAPI()
+    app.include_router(creator_api.router)
+    previous_creator = creator_api._service
+    previous_evaluation = creator_api._evaluation_service
+    previous_suites = creator_api._evaluation_suite_service
+    creator_api.configure_skill_creator(creator)
+    creator_api.configure_skill_creator_evaluation(evaluation)
+    creator_api.configure_skill_creator_evaluation_suite(suites)
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            expected = {
+                "expected_session_revision": session.session_revision,
+                "expected_draft_state_revision": draft.revision,
+                "expected_draft_revision": draft.content_revision,
+                "expected_draft_digest": draft.content_digest,
+            }
+            generated = await client.post(
+                f"/api/skills/creator/sessions/{session.session_id}/evaluation-suite/generate",
+                json=expected,
+            )
+            assert generated.status_code == 200, generated.text
+            suite = generated.json()["evaluation_suite"]
+            assert suite["state"] == "draft"
+            assert [item["role"] for item in suite["cases"]] == [
+                "normal",
+                "ambiguous",
+                "boundary",
+            ]
+
+            legacy_write = await client.put(
+                f"/api/skills/creator/sessions/{session.session_id}/cases",
+                json={
+                    **_write_context(session, draft),
+                    "quality_mode": "objective",
+                    "cases": [_case(1), _case(2), _case(3)],
+                },
+            )
+            assert legacy_write.status_code == 409
+            assert legacy_write.json()["detail"]["code"] == "skill_creator_conflict"
+
+            editable_cases = [
+                {
+                    key: value
+                    for key, value in item.items()
+                    if key
+                    in {
+                        "case_id",
+                        "role",
+                        "name",
+                        "prompt",
+                        "expected_behavior",
+                        "fixtures",
+                        "assertions",
+                        "requirement_ids",
+                        "required_resource_paths",
+                        "workflow_step_ids",
+                    }
+                }
+                for item in suite["cases"]
+            ]
+            editable_cases.append(_suite_case("regression", regression=True))
+            patched = await client.patch(
+                f"/api/skills/creator/sessions/{session.session_id}/evaluation-suite",
+                json={
+                    **expected,
+                    "suite_id": suite["suite_id"],
+                    "expected_suite_revision": suite["suite_revision"],
+                    "expected_suite_digest": suite["suite_digest"],
+                    "cases": editable_cases,
+                    "change_reason": "Preserve a failure the user explicitly observed.",
+                },
+            )
+            assert patched.status_code == 200, patched.text
+            suite = patched.json()["evaluation_suite"]
+            assert len(suite["cases"]) == 4
+            assert suite["cases"][-1]["source"] == "user"
+
+            confirmed = await client.post(
+                f"/api/skills/creator/sessions/{session.session_id}/evaluation-suite/confirm",
+                json={
+                    **expected,
+                    "suite_id": suite["suite_id"],
+                    "expected_suite_revision": suite["suite_revision"],
+                    "expected_suite_digest": suite["suite_digest"],
+                },
+            )
+            assert confirmed.status_code == 200, confirmed.text
+            suite = confirmed.json()["evaluation_suite"]
+            assert suite["state"] == "confirmed"
+
+            started = await client.post(
+                f"/api/skills/creator/sessions/{session.session_id}/evaluations",
+                json={
+                    **_write_context(session, draft),
+                    "evaluation_suite_revision": suite["suite_revision"],
+                    "evaluation_suite_digest": suite["suite_digest"],
+                    "repetitions": 1,
+                },
+            )
+            assert started.status_code == 202, started.text
+            run = started.json()["evaluation_run"]
+            assert run["evaluation_suite_id"] == suite["suite_id"]
+            assert len(run["items"]) == 8
+            assert started.json()["cases"] == []
+            assert started.json()["evaluation_suite"]["stale"] is False
+    finally:
+        creator_api.configure_skill_creator(previous_creator)
+        creator_api.configure_skill_creator_evaluation(previous_evaluation)
+        creator_api.configure_skill_creator_evaluation_suite(previous_suites)
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_skill_creator_evaluation_suite.py
+++ b/server/tests/test_skill_creator_evaluation_suite.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from server.skills.creator_evaluation import (
+    SkillEvaluationConflictError,
+    SkillEvaluationStorageError,
+    SkillEvaluationValidationError,
+)
+from server.skills.creator_evaluation_suite import SkillEvaluationSuiteStore
+
+
+DIGEST = "a" * 64
+SESSION_DEFINITION_DIGEST = "d" * 64
+REQUIREMENTS = ("intent", "expected_output", "success_criterion:0")
+
+
+def _case(
+    role: str,
+    index: int,
+    *,
+    source: str | None = None,
+    requirement_ids: tuple[str, ...] = REQUIREMENTS,
+    resources: tuple[str, ...] = (),
+) -> dict:
+    value = {
+        "case_id": f"case-{index}",
+        "role": role,
+        "name": f"Case {index}",
+        "prompt": f"Complete scenario {index} without inventing facts.",
+        "expected_behavior": "Return a bounded and verifiable result.",
+        "fixtures": [],
+        "assertions": [{"kind": "contains", "value": "done"}],
+        "requirement_ids": list(requirement_ids),
+        "required_resource_paths": list(resources),
+        "workflow_step_ids": ["step-1"],
+    }
+    if source:
+        value["source"] = source
+    return value
+
+
+def _core_cases() -> list[dict]:
+    return [
+        _case("normal", 1),
+        _case("ambiguous", 2),
+        _case("boundary", 3),
+    ]
+
+
+def _generated(store: SkillEvaluationSuiteStore, session_id: str = "session-one"):
+    return store.save_generated(
+        session_id=session_id,
+        session_revision=3,
+        session_definition_digest=SESSION_DEFINITION_DIGEST,
+        draft_id=f"draft-{session_id}",
+        draft_state_revision=2,
+        draft_revision=1,
+        draft_digest=DIGEST,
+        quality_mode="objective",
+        cases=_core_cases(),
+        expected_suite_revision=None,
+        expected_suite_digest=None,
+        allowed_requirement_ids=REQUIREMENTS,
+        allowed_resource_paths=("references/rules.md",),
+        allowed_workflow_step_ids=("step-1",),
+    )
+
+
+def test_generated_suite_requires_exact_core_roles_and_round_trips(tmp_path: Path) -> None:
+    store = SkillEvaluationSuiteStore(tmp_path)
+    suite = _generated(store)
+
+    assert suite.suite_revision == 1
+    assert suite.state == "draft"
+    assert [case.role for case in suite.cases] == ["normal", "ambiguous", "boundary"]
+    assert all(case.source == "generated" for case in suite.cases)
+    assert len({case.case_fingerprint for case in suite.cases}) == 3
+
+    restored = SkillEvaluationSuiteStore(tmp_path).require(suite.suite_id)
+    assert restored == suite
+
+    invalid = _core_cases()
+    invalid[-1]["role"] = "normal"
+    with pytest.raises(SkillEvaluationValidationError) as captured:
+        store.save_generated(
+            session_id="session-two",
+            session_revision=1,
+            session_definition_digest=SESSION_DEFINITION_DIGEST,
+            draft_id="draft-two",
+            draft_state_revision=1,
+            draft_revision=1,
+            draft_digest=DIGEST,
+            quality_mode="objective",
+            cases=invalid,
+            expected_suite_revision=None,
+            expected_suite_digest=None,
+            allowed_requirement_ids=REQUIREMENTS,
+            allowed_resource_paths=(),
+            allowed_workflow_step_ids=("step-1",),
+        )
+    assert captured.value.code == "skill_evaluation_suite_core_roles_required"
+
+
+def test_only_user_patch_can_add_regression_and_confirm_coverage(tmp_path: Path) -> None:
+    store = SkillEvaluationSuiteStore(tmp_path)
+    suite = _generated(store)
+
+    model_cases = _core_cases() + [_case("regression", 4)]
+    with pytest.raises(SkillEvaluationValidationError) as model_error:
+        store.save_generated(
+            session_id="session-two",
+            session_revision=1,
+            session_definition_digest=SESSION_DEFINITION_DIGEST,
+            draft_id="draft-two",
+            draft_state_revision=1,
+            draft_revision=1,
+            draft_digest=DIGEST,
+            quality_mode="objective",
+            cases=model_cases,
+            expected_suite_revision=None,
+            expected_suite_digest=None,
+            allowed_requirement_ids=REQUIREMENTS,
+            allowed_resource_paths=(),
+            allowed_workflow_step_ids=("step-1",),
+        )
+    assert model_error.value.code == "skill_evaluation_suite_model_regression_forbidden"
+
+    edited_cases = [
+        SkillEvaluationSuiteStore.serialize_case(item) for item in suite.cases
+    ]
+    edited_cases[0].pop("case_fingerprint")
+    edited_cases[0]["prompt"] = "A user-refined normal scenario."
+    patched = store.patch(
+        suite.suite_id,
+        expected_suite_revision=suite.suite_revision,
+        expected_suite_digest=suite.suite_digest,
+        session_revision=4,
+        session_definition_digest=SESSION_DEFINITION_DIGEST,
+        draft_state_revision=2,
+        cases=[*edited_cases, _case("regression", 4)],
+        change_reason="Add a user-confirmed failure as a regression case.",
+        allowed_requirement_ids=REQUIREMENTS,
+        allowed_resource_paths=("references/rules.md",),
+        allowed_workflow_step_ids=("step-1",),
+    )
+    assert patched.suite_revision == 2
+    assert patched.cases[0].source == "user"
+    assert patched.cases[-1].source == "user"
+
+    confirmed = store.confirm(
+        patched.suite_id,
+        expected_suite_revision=patched.suite_revision,
+        expected_suite_digest=patched.suite_digest,
+        session_revision=5,
+        session_definition_digest=SESSION_DEFINITION_DIGEST,
+        draft_state_revision=2,
+        allowed_requirement_ids=REQUIREMENTS,
+        allowed_resource_paths=("references/rules.md",),
+        allowed_workflow_step_ids=("step-1",),
+    )
+    assert confirmed.state == "confirmed"
+    assert confirmed.suite_revision == 3
+
+    changed = [SkillEvaluationSuiteStore.serialize_case(case) for case in confirmed.cases]
+    changed[0]["prompt"] = "Use the updated normal scenario."
+    with pytest.raises(SkillEvaluationValidationError) as reason_error:
+        store.patch(
+            confirmed.suite_id,
+            expected_suite_revision=confirmed.suite_revision,
+            expected_suite_digest=confirmed.suite_digest,
+            session_revision=6,
+            session_definition_digest=SESSION_DEFINITION_DIGEST,
+            draft_state_revision=2,
+            cases=changed,
+            change_reason="",
+            allowed_requirement_ids=REQUIREMENTS,
+            allowed_resource_paths=("references/rules.md",),
+            allowed_workflow_step_ids=("step-1",),
+        )
+    assert reason_error.value.code == "skill_evaluation_suite_change_reason_required"
+
+
+def test_confirm_rejects_missing_or_unknown_frozen_coverage(tmp_path: Path) -> None:
+    store = SkillEvaluationSuiteStore(tmp_path)
+    cases = _core_cases()
+    for case in cases:
+        case["requirement_ids"] = ["intent"]
+    suite = store.save_generated(
+        session_id="session-one",
+        session_revision=1,
+        session_definition_digest=SESSION_DEFINITION_DIGEST,
+        draft_id="draft-one",
+        draft_state_revision=1,
+        draft_revision=1,
+        draft_digest=DIGEST,
+        quality_mode="objective",
+        cases=cases,
+        expected_suite_revision=None,
+        expected_suite_digest=None,
+        allowed_requirement_ids=REQUIREMENTS,
+        allowed_resource_paths=(),
+        allowed_workflow_step_ids=("step-1",),
+    )
+    with pytest.raises(SkillEvaluationValidationError) as missing:
+        store.confirm(
+            suite.suite_id,
+            expected_suite_revision=1,
+            expected_suite_digest=suite.suite_digest,
+            session_revision=2,
+            session_definition_digest=SESSION_DEFINITION_DIGEST,
+            draft_state_revision=1,
+            allowed_requirement_ids=REQUIREMENTS,
+            allowed_resource_paths=(),
+            allowed_workflow_step_ids=("step-1",),
+        )
+    assert missing.value.code == "skill_evaluation_suite_coverage_incomplete"
+
+    unknown = _core_cases()
+    unknown[0]["requirement_ids"] = ["unknown-requirement"]
+    with pytest.raises(SkillEvaluationValidationError) as invalid:
+        store.save_generated(
+            session_id="session-two",
+            session_revision=1,
+            session_definition_digest=SESSION_DEFINITION_DIGEST,
+            draft_id="draft-two",
+            draft_state_revision=1,
+            draft_revision=1,
+            draft_digest=DIGEST,
+            quality_mode="objective",
+            cases=unknown,
+            expected_suite_revision=None,
+            expected_suite_digest=None,
+            allowed_requirement_ids=REQUIREMENTS,
+            allowed_resource_paths=(),
+            allowed_workflow_step_ids=("step-1",),
+        )
+    assert invalid.value.code == "skill_evaluation_suite_coverage_invalid"
+
+
+def test_legacy_three_cases_migrate_without_model_and_conflicts_are_immutable(
+    tmp_path: Path,
+) -> None:
+    store = SkillEvaluationSuiteStore(tmp_path)
+    legacy_cases = [
+        {
+            key: value
+            for key, value in case.items()
+            if key not in {"role", "requirement_ids", "required_resource_paths", "workflow_step_ids"}
+        }
+        for case in _core_cases()
+    ]
+    migrated = store.migrate_case_set(
+        session_id="session-one",
+        session_revision=3,
+        session_definition_digest=SESSION_DEFINITION_DIGEST,
+        draft_id="draft-one",
+        draft_state_revision=2,
+        draft_revision=1,
+        draft_digest=DIGEST,
+        quality_mode="objective",
+        cases=legacy_cases,
+        allowed_requirement_ids=REQUIREMENTS,
+    )
+    assert migrated.state == "confirmed"
+    assert migrated.suite_revision == 1
+    assert all(case.source == "migrated" for case in migrated.cases)
+
+    with pytest.raises(SkillEvaluationConflictError):
+        store.patch(
+            migrated.suite_id,
+            expected_suite_revision=1,
+            expected_suite_digest="b" * 64,
+            session_revision=4,
+            session_definition_digest=SESSION_DEFINITION_DIGEST,
+            draft_state_revision=2,
+            cases=[SkillEvaluationSuiteStore.serialize_case(case) for case in migrated.cases],
+            change_reason="Retain the same cases.",
+            allowed_requirement_ids=REQUIREMENTS,
+            allowed_resource_paths=(),
+            allowed_workflow_step_ids=(),
+        )
+
+
+def test_secrets_are_blocked_and_snapshot_corruption_fails_closed(tmp_path: Path) -> None:
+    store = SkillEvaluationSuiteStore(tmp_path)
+    cases = _core_cases()
+    cases[0]["prompt"] = "Use token " + "sk-" + ("A" * 40)
+    with pytest.raises(SkillEvaluationValidationError) as secret_error:
+        store.save_generated(
+            session_id="session-secret",
+            session_revision=1,
+            session_definition_digest=SESSION_DEFINITION_DIGEST,
+            draft_id="draft-secret",
+            draft_state_revision=1,
+            draft_revision=1,
+            draft_digest=DIGEST,
+            quality_mode="objective",
+            cases=cases,
+            expected_suite_revision=None,
+            expected_suite_digest=None,
+            allowed_requirement_ids=REQUIREMENTS,
+            allowed_resource_paths=(),
+            allowed_workflow_step_ids=("step-1",),
+        )
+    assert secret_error.value.code == "skill_evaluation_suite_credentials_blocked"
+    assert not store.snapshot_path.exists()
+
+    store.snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+    store.snapshot_path.write_text("{broken", encoding="utf-8")
+    damaged = SkillEvaluationSuiteStore(tmp_path)
+    assert damaged.status()["available"] is False
+    with pytest.raises(SkillEvaluationStorageError):
+        damaged.current_for_session("session-one")
+
+
+def test_single_session_corruption_is_quarantined_without_losing_healthy_record(
+    tmp_path: Path,
+) -> None:
+    store = SkillEvaluationSuiteStore(tmp_path)
+    broken = _generated(store, "session-broken")
+    healthy = _generated(store, "session-healthy")
+    payload = json.loads(store.snapshot_path.read_text(encoding="utf-8"))
+    payload["sessions"]["session-broken"][0]["cases"][0]["case_fingerprint"] = "0" * 64
+    store.snapshot_path.write_text(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")),
+        encoding="utf-8",
+    )
+
+    restored = SkillEvaluationSuiteStore(tmp_path)
+    assert restored.status()["available"] is True
+    assert restored.status()["quarantine_count"] == 1
+    assert restored.current_for_session("session-broken") is None
+    assert restored.require(healthy.suite_id).session_id == "session-healthy"
+    assert broken.suite_id != healthy.suite_id

--- a/server/tests/test_skill_creator_evaluation_suite_service.py
+++ b/server/tests/test_skill_creator_evaluation_suite_service.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from server.skills.creator_evaluation import SkillEvaluationStore
+from server.skills.creator_evaluation_suite import (
+    EVALUATION_SUITE_VERSION,
+    SkillEvaluationSuiteStore,
+)
+from server.skills.creator_evaluation_suite_runtime import (
+    EVALUATION_SUITE_WORKFLOW_VERSION,
+    WorkflowCreatorEvaluationSuiteGenerator,
+    build_evaluation_suite_invocation,
+    parse_evaluation_suite_output,
+)
+from server.skills.creator_evaluation_suite_service import (
+    EvaluationSuiteGenerationRequest,
+    SkillCreatorEvaluationSuiteService,
+)
+from server.skills.creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorSession,
+    SkillCreatorValidationError,
+)
+from server.skills.draft_store import WorkspaceSkillDraft
+
+
+DIGEST = "a" * 64
+
+
+def _core_cases() -> list[dict]:
+    return [
+        {
+            "case_id": f"core-{role}",
+            "role": role,
+            "name": f"{role.title()} case",
+            "prompt": f"Exercise the {role} behavior.",
+            "expected_behavior": "Return a safe and observable result.",
+            "fixtures": [],
+            "assertions": [],
+            "requirement_ids": [
+                "intent",
+                "positive_example:0",
+                "near_miss:0",
+                "expected_output",
+                "success_criterion:0",
+            ],
+            "required_resource_paths": [],
+            "workflow_step_ids": [],
+        }
+        for role in ("normal", "ambiguous", "boundary")
+    ]
+
+
+class _CreatorService:
+    def __init__(self) -> None:
+        self.session = SkillCreatorSession(
+            session_id="session-one",
+            session_revision=4,
+            draft_state_revision=2,
+            intent="Summarize an incident without inventing facts.",
+            positive_examples=["Turn a timeline into an incident review."],
+            near_miss_examples=["Only rewrite prose; no incident review is needed."],
+            expected_output="A structured incident review.",
+            success_criteria=["Unknown root causes remain explicitly unknown."],
+            evidence_confirmed=True,
+            draft_id="draft-one",
+            current_revision=1,
+            current_digest=DIGEST,
+            quality_mode="objective",
+            state="designing_tests",
+        )
+        self.draft = WorkspaceSkillDraft(
+            draft_id="draft-one",
+            name="incident-review",
+            slug="incident-review",
+            description="Create incident reviews when a timeline is supplied.",
+            skill_markdown=(
+                "---\nname: incident-review\ndescription: Create incident reviews.\n---\n"
+                "# Incident review\n\n## Workflow\n\n1. Read facts.\n2. Order facts.\n"
+                "3. Mark gaps.\n4. Render output.\n"
+            ),
+            files={"references/policy.md": "# Policy\n\nNever invent a root cause.\n"},
+            revision=2,
+            content_revision=1,
+            content_digest=DIGEST,
+            creator_session_id="session-one",
+            quality_required=True,
+        )
+
+    def require_enabled(self) -> None:
+        return None
+
+    def get_session(self, session_id: str):
+        assert session_id == self.session.session_id
+        return self.session, self.draft
+
+    @staticmethod
+    def _require_ready_for_generation(_session: SkillCreatorSession) -> None:
+        return None
+
+
+class _Generator:
+    def __init__(self, creator: _CreatorService, *, mutate: bool = False) -> None:
+        self.creator = creator
+        self.mutate = mutate
+        self.calls: list[EvaluationSuiteGenerationRequest] = []
+
+    def available(self) -> bool:
+        return True
+
+    async def generate(self, request: EvaluationSuiteGenerationRequest) -> dict:
+        self.calls.append(request)
+        if self.mutate:
+            self.creator.session.session_revision += 1
+        return {"cases": _core_cases()}
+
+
+def _service(tmp_path: Path, *, generator=None, enabled: bool = True):
+    creator = _CreatorService()
+    suite_store = SkillEvaluationSuiteStore(tmp_path / "suite")
+    evaluation_store = SkillEvaluationStore(tmp_path / "evaluation")
+    return (
+        creator,
+        suite_store,
+        evaluation_store,
+        SkillCreatorEvaluationSuiteService(
+            creator,  # type: ignore[arg-type]
+            suite_store,
+            evaluation_store,
+            generator=generator,
+            enabled=enabled,
+        ),
+    )
+
+
+def _expected(creator: _CreatorService) -> dict:
+    return {
+        "expected_session_revision": creator.session.session_revision,
+        "expected_draft_state_revision": creator.draft.revision,
+        "expected_draft_revision": creator.draft.content_revision,
+        "expected_draft_digest": creator.draft.content_digest,
+        "expected_suite_revision": None,
+        "expected_suite_digest": None,
+    }
+
+
+def test_fixed_generator_contract_is_no_tool_and_parses_one_versioned_object() -> None:
+    request = EvaluationSuiteGenerationRequest(
+        session={"session_id": "session-one", "session_revision": 4},
+        draft={"draft_id": "draft-one"},
+        resource_plan=None,
+        allowed_requirement_ids=("intent",),
+        allowed_resource_paths=(),
+        allowed_workflow_step_ids=(),
+    )
+    invocation = build_evaluation_suite_invocation(request, model_id="provider/model")
+    agent = invocation.workflow["nodes"][1]["data"]
+    assert agent["toolMode"] == "none"
+    assert agent["temperature"] == "0.1"
+    assert invocation.runtime_metadata["evaluation_suite_workflow_version"] == (
+        EVALUATION_SUITE_WORKFLOW_VERSION
+    )
+    context = json.loads(invocation.inputs["creator_request"])
+    assert context["case_contract"]["model_may_add_regressions"] is False
+
+    payload = {"evaluation_suite_version": EVALUATION_SUITE_VERSION, "cases": []}
+    parsed = parse_evaluation_suite_output(
+        "Here is the result:\n```json\n" + json.dumps(payload) + "\n```"
+    )
+    assert parsed == payload
+    with pytest.raises(SkillCreatorValidationError):
+        parse_evaluation_suite_output(
+            json.dumps(payload) + "\n" + json.dumps({**payload, "cases": [{}]})
+        )
+
+
+def test_suite_runtime_uses_dedicated_budget_and_temperature() -> None:
+    import server.main as main_module
+
+    request = EvaluationSuiteGenerationRequest(
+        session={"session_id": "session-one", "session_revision": 4},
+        draft={"draft_id": "draft-one"},
+        resource_plan=None,
+        allowed_requirement_ids=("intent",),
+        allowed_resource_paths=(),
+        allowed_workflow_step_ids=(),
+    )
+    metadata = build_evaluation_suite_invocation(
+        request, model_id="provider/model"
+    ).runtime_metadata
+
+    assert (
+        main_module.workflow_agent_token_budget(metadata)
+        == main_module.SKILL_CREATOR_EVALUATION_SUITE_MAX_TOKENS
+    )
+    assert main_module.workflow_agent_temperature(metadata) == 0.1
+    assert (
+        main_module.workflow_agent_temperature(
+            {**metadata, "creator_workflow_version": "untrusted"}
+        )
+        == 0.7
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_freezes_model_cases_and_confirm_requires_current_facts(
+    tmp_path: Path,
+) -> None:
+    creator = _CreatorService()
+    generator = _Generator(creator)
+    suite_store = SkillEvaluationSuiteStore(tmp_path / "suite")
+    service = SkillCreatorEvaluationSuiteService(
+        creator,  # type: ignore[arg-type]
+        suite_store,
+        SkillEvaluationStore(tmp_path / "evaluation"),
+        generator=generator,
+        enabled=True,
+    )
+    generated = await service.generate(creator.session.session_id, **_expected(creator))
+    assert generated.state == "draft"
+    assert len(generator.calls) == 1
+    assert generator.calls[0].allowed_requirement_ids == (
+        "intent",
+        "positive_example:0",
+        "near_miss:0",
+        "expected_output",
+        "success_criterion:0",
+    )
+    assert generator.calls[0].allowed_resource_paths == ("references/policy.md",)
+
+    confirmed = service.confirm(
+        creator.session.session_id,
+        suite_id=generated.suite_id,
+        expected_session_revision=creator.session.session_revision,
+        expected_draft_state_revision=creator.draft.revision,
+        expected_draft_revision=creator.draft.content_revision,
+        expected_draft_digest=creator.draft.content_digest,
+        expected_suite_revision=generated.suite_revision,
+        expected_suite_digest=generated.suite_digest,
+    )
+    assert confirmed.state == "confirmed"
+    assert service.current_projection(creator.session.session_id)["stale"] is False
+
+    creator.session.session_revision += 1
+    creator.draft.revision += 1
+    assert service.current_projection(creator.session.session_id)["stale"] is False
+
+    creator.session.intent = "Changed intent invalidates the frozen suite."
+    assert service.current_projection(creator.session.session_id)["stale"] is True
+    creator.session.intent = "Summarize an incident without inventing facts."
+
+    creator.draft.content_digest = "b" * 64
+    assert service.current_projection(creator.session.session_id)["stale"] is True
+
+
+@pytest.mark.asyncio
+async def test_existing_v1_cases_migrate_without_calling_model(tmp_path: Path) -> None:
+    creator, suite_store, evaluation_store, _ = _service(tmp_path)
+    legacy = evaluation_store.save_cases(
+        session_id=creator.session.session_id,
+        draft_id=creator.draft.draft_id,
+        draft_revision=creator.draft.content_revision,
+        content_digest=creator.draft.content_digest,
+        expected_revision=0,
+        cases=[
+            {
+                key: value
+                for key, value in case.items()
+                if key
+                not in {
+                    "role",
+                    "requirement_ids",
+                    "required_resource_paths",
+                    "workflow_step_ids",
+                }
+            }
+            for case in _core_cases()
+        ],
+        quality_mode="objective",
+    )
+    creator.session.cases_revision = legacy.cases_revision
+    generator = _Generator(creator)
+    service = SkillCreatorEvaluationSuiteService(
+        creator,  # type: ignore[arg-type]
+        suite_store,
+        evaluation_store,
+        generator=generator,
+        enabled=True,
+    )
+    migrated = await service.generate(creator.session.session_id, **_expected(creator))
+    assert migrated.state == "confirmed"
+    assert all(case.source == "migrated" for case in migrated.cases)
+    assert generator.calls == []
+
+
+@pytest.mark.asyncio
+async def test_generation_discards_stale_model_result_and_flag_fails_closed(
+    tmp_path: Path,
+) -> None:
+    creator = _CreatorService()
+    generator = _Generator(creator, mutate=True)
+    suite_store = SkillEvaluationSuiteStore(tmp_path / "suite")
+    service = SkillCreatorEvaluationSuiteService(
+        creator,  # type: ignore[arg-type]
+        suite_store,
+        SkillEvaluationStore(tmp_path / "evaluation"),
+        generator=generator,
+        enabled=True,
+    )
+    with pytest.raises(SkillCreatorConflictError):
+        await service.generate(creator.session.session_id, **_expected(creator))
+    assert suite_store.current_for_session(creator.session.session_id) is None
+
+    disabled = SkillCreatorEvaluationSuiteService(
+        creator,  # type: ignore[arg-type]
+        suite_store,
+        SkillEvaluationStore(tmp_path / "disabled-evaluation"),
+        generator=generator,
+        enabled=False,
+    )
+    with pytest.raises(SkillCreatorValidationError) as captured:
+        await disabled.generate(
+            creator.session.session_id,
+            expected_session_revision=creator.session.session_revision,
+            expected_draft_state_revision=creator.draft.revision,
+            expected_draft_revision=creator.draft.content_revision,
+            expected_draft_digest=creator.draft.content_digest,
+            expected_suite_revision=None,
+            expected_suite_digest=None,
+        )
+    assert captured.value.code == "skill_creator_evolution_v2_disabled"
+
+
+@pytest.mark.asyncio
+async def test_workflow_generator_rejects_wrong_version_before_store_write() -> None:
+    request = EvaluationSuiteGenerationRequest(
+        session={"session_id": "session-one", "session_revision": 4},
+        draft={"draft_id": "draft-one"},
+        resource_plan=None,
+        allowed_requirement_ids=("intent",),
+        allowed_resource_paths=(),
+        allowed_workflow_step_ids=(),
+    )
+
+    async def runner(_invocation):
+        return json.dumps({"evaluation_suite_version": "old", "cases": []})
+
+    generator = WorkflowCreatorEvaluationSuiteGenerator(
+        model_id="provider/model", model_available=lambda: True, runner=runner
+    )
+    with pytest.raises(SkillCreatorValidationError) as captured:
+        await generator.generate(request)
+    assert captured.value.code == "skill_evaluation_suite_generator_invalid"

--- a/server/tests/test_skill_evaluation_runtime.py
+++ b/server/tests/test_skill_evaluation_runtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from server.sandbox_sidecar.engine import SandboxEngine
@@ -210,7 +212,7 @@ def _overlay() -> SkillEvaluationOverlay:
     )
 
 
-def _case() -> SkillEvaluationCase:
+def _case(*, resources: list[str] | None = None) -> SkillEvaluationCase:
     return SkillEvaluationCase(
         case_id="case_runtime",
         name="Runtime case",
@@ -218,6 +220,7 @@ def _case() -> SkillEvaluationCase:
         expected_behavior="Return a short summary.",
         fixtures=[{"path": "note.txt", "content": "Frozen note."}],
         assertions=[],
+        required_resource_paths=resources or [],
         case_fingerprint="c" * 64,
     )
 
@@ -276,6 +279,21 @@ def test_fixed_workflow_keeps_case_inputs_identical_and_expectations_hidden():
     assert agent["data"]["toolMode"] == "none"
     assert left.runtime_metadata["skill_evaluation_overlay_id"] is None
     assert right.runtime_metadata["skill_evaluation_overlay_id"] == _overlay().overlay_id
+
+
+def test_v2_resource_case_freezes_stage_policy_and_exact_paths():
+    run, _baseline, candidate = _run_and_items()
+    case = _case(resources=["references/guide.md"])
+    invocation = build_skill_evaluation_workflow_invocation(
+        run, candidate, case, _overlay(), workspace_id="ws_candidate"
+    )
+    request = json.loads(invocation.inputs["evaluation_request"])
+
+    assert request["required_skill_resource_paths"] == ["references/guide.md"]
+    assert invocation.runtime_metadata["skill_application_policy"] == "require_stage"
+    assert invocation.runtime_metadata[
+        "skill_application_required_resource_paths"
+    ] == ["references/guide.md"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add immutable, revisioned Skill Evaluation Suites with three fixed core roles and up to nine user-confirmed regression cases
- add fixed Creator generation, edit, confirmation, legacy three-case migration, and Suite-bound evaluation APIs
- require authoritative Skill Application Receipts for V2 candidate items during execution, acceptance, and crash recovery
- fail closed when a confirmed Suite changes: invalidate old quality state before publishing the new revision and reconcile interrupted cross-Store writes
- keep `SKILL_CREATOR_EVOLUTION_V2_ENABLED=false` by default so legacy Creator behavior remains unchanged

## Validation

- `python -m pytest -q -p no:cacheprovider server/tests -k "skill_creator or skill_evaluation or skill_application_receipt"` — 266 passed
- Runtime Router / Workflow Agent / Skill integration / install-upgrade regression set — 49 passed
- `git diff --check origin/main...HEAD`
- tests ran in isolated, network-disabled, read-only one-off containers; shared Docker stack was not changed

## Scope

This is PR 2 of Skill Creator Evaluation & Evolution V2. It does not enable evolution by default, add a Judge model, modify the final Skill package contract, or add frontend workflow changes reserved for later PRs.