### PR TITLE
feature: 增加 Skill Creator 资源级进化

### DIFF
--- a/docs/SKILL_EXPERIENCE_AUDIT.md
+++ b/docs/SKILL_EXPERIENCE_AUDIT.md
@@ -143,6 +143,8 @@ node scripts/audit-skill-experience.mjs
 
 `SKILL_CREATOR_EVOLUTION_V2_ENABLED=true` 时，可显式把旧三例无模型迁移为不可变评测套件，或由固定 Creator Agent 生成“正常、歧义/信息不足、边界/失败”三个核心案例。用户确认的失败案例最多追加 9 条回归案例；模型不得自行写入回归集。V2 run 冻结套件 revision/digest，Candidate 每项必须持有与 Overlay、资源路径和实际 `skill_read`/`skill_stage` 一致的 verified 应用凭据；人工接受和崩溃恢复时都会重新核对权威凭据 Store。该开关在跨版本回归治理完成前默认关闭，旧会话不会被静默迁移。
 
+反馈驱动的资源级进化沿用同一开关并保持默认关闭。用户把 V2 评测结论设为 `revise` 后，固定 Creator Agent 只能读取冻结的 run/review、套件摘要、断言状态、应用凭据结论和当前资源计划，不接收旧模型输出或任意客户端反馈正文。Agent 先生成不可变 Evolution Plan，按案例绑定失败类型、需求、资源/章节和证据 item；最多提出 5 个澄清问题。只有本地用户修改并确认计划后，服务端才将其转换为新的 Resource Plan revision，并复用现有 Resource Build 选择性重建受影响的 `references/`、`scripts/` 或 `assets/`。未变化资源保持 `keep`，脚本测试凭据按内容 digest 复用；变化脚本必须重新离线实测。全部资源再次确认后才重新生成最终 `SKILL.md` 并形成普通 update proposal；新草稿 digest 会使旧评测过期，且不会自动接受或安装。开关开启时旧的一次性 `/iterate` 捷径返回 `skill_creator_evolution_plan_required`，关闭时保留既有流程作为回退。
+
 资源化创作在行为质量门之前增加了“澄清 → 资源计划 → 用户确认 → 逐资源生成与验证 → 最终 `SKILL.md` → 提案确认”的阶段：
 
 - 根据任务重复性与确定性，主动判断是否应生成 `scripts/`，并要求脚本具有清晰入口、失败行为、语法检查和实际测试证据；不为凑目录生成脆弱脚本。

--- a/server/main.py
+++ b/server/main.py
@@ -221,6 +221,7 @@ try:
         configure_skill_creator,
         configure_skill_creator_evaluation,
         configure_skill_creator_evaluation_suite,
+        configure_skill_creator_evolution,
         configure_skill_creator_resource_build,
         configure_skill_creator_resource_planning,
         router as skill_creator_router,
@@ -278,6 +279,12 @@ try:
     from server.skills.creator_evaluation_suite_service import (
         SkillCreatorEvaluationSuiteService,
     )
+    from server.skills.creator_evolution import SkillEvolutionPlanStore
+    from server.skills.creator_evolution_runtime import (
+        EvolutionWorkflowInvocation,
+        WorkflowCreatorEvolutionPlanner,
+    )
+    from server.skills.creator_evolution_service import SkillCreatorEvolutionService
     from server.skills.creator_service import (
         SkillCreatorService,
         configure_creator_generation_executor,
@@ -306,6 +313,7 @@ except ModuleNotFoundError:
         configure_skill_creator,
         configure_skill_creator_evaluation,
         configure_skill_creator_evaluation_suite,
+        configure_skill_creator_evolution,
         configure_skill_creator_resource_build,
         configure_skill_creator_resource_planning,
         router as skill_creator_router,
@@ -357,6 +365,12 @@ except ModuleNotFoundError:
     from skills.creator_evaluation_suite_service import (
         SkillCreatorEvaluationSuiteService,
     )
+    from skills.creator_evolution import SkillEvolutionPlanStore
+    from skills.creator_evolution_runtime import (
+        EvolutionWorkflowInvocation,
+        WorkflowCreatorEvolutionPlanner,
+    )
+    from skills.creator_evolution_service import SkillCreatorEvolutionService
     from skills.creator_service import (
         SkillCreatorService,
         configure_creator_generation_executor,
@@ -1056,9 +1070,11 @@ SKILL_CREATOR_AGENT_MAX_TOKENS = 12_288
 SKILL_CREATOR_RESOURCE_PLANNER_MAX_TOKENS = 8_192
 SKILL_CREATOR_RESOURCE_BUILDER_MAX_TOKENS = 8_192
 SKILL_CREATOR_EVALUATION_SUITE_MAX_TOKENS = 8_192
+SKILL_CREATOR_EVOLUTION_MAX_TOKENS = 8_192
 SKILL_CREATOR_RESOURCE_PLANNER_TEMPERATURE = 0.1
 SKILL_CREATOR_RESOURCE_BUILDER_TEMPERATURE = 0.1
 SKILL_CREATOR_EVALUATION_SUITE_TEMPERATURE = 0.1
+SKILL_CREATOR_EVOLUTION_TEMPERATURE = 0.1
 SKILL_EVALUATION_AGENT_MAX_TOKENS = 4_096
 AGENT_TASK_STORAGE_DIR = os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
 
@@ -1087,6 +1103,8 @@ def workflow_agent_token_budget(runtime_metadata: dict[str, Any] | None) -> int:
             return SKILL_CREATOR_RESOURCE_BUILDER_MAX_TOKENS
         if metadata.get("creator_phase") == "evaluation_suite":
             return SKILL_CREATOR_EVALUATION_SUITE_MAX_TOKENS
+        if metadata.get("creator_phase") == "resource_evolution":
+            return SKILL_CREATOR_EVOLUTION_MAX_TOKENS
         return SKILL_CREATOR_AGENT_MAX_TOKENS
     metadata = dict(runtime_metadata or {})
     if is_trusted_skill_evaluation_metadata(metadata):
@@ -1104,6 +1122,8 @@ def workflow_agent_temperature(runtime_metadata: dict[str, Any] | None) -> float
             return SKILL_CREATOR_RESOURCE_BUILDER_TEMPERATURE
         if phase == "evaluation_suite":
             return SKILL_CREATOR_EVALUATION_SUITE_TEMPERATURE
+        if phase == "resource_evolution":
+            return SKILL_CREATOR_EVOLUTION_TEMPERATURE
     return skill_evaluation_model_temperature(metadata, default=0.7)
 
 
@@ -1558,6 +1578,17 @@ skill_creator_evaluation_suite_service = SkillCreatorEvaluationSuiteService(
     skill_evaluation_store,
     resource_plan_store=skill_creator_resource_plan_store,
 )
+skill_creator_evolution_store = SkillEvolutionPlanStore(
+    storage_dir=AGENT_TASK_STORAGE_DIR or None
+)
+skill_creator_evolution_service = SkillCreatorEvolutionService(
+    skill_creator_service,
+    skill_creator_evolution_store,
+    skill_evaluation_store,
+    skill_creator_evaluation_suite_store,
+    skill_creator_resource_planning_service,
+    resource_build_store=skill_creator_resource_build_store,
+)
 workflow_xpert_authoring_provider = AuthoringToolsetProvider(
     authoring_service, "xpert"
 )
@@ -1569,6 +1600,7 @@ configure_skill_creator(skill_creator_service)
 configure_skill_creator_resource_planning(skill_creator_resource_planning_service)
 configure_skill_creator_resource_build(skill_creator_resource_build_service)
 configure_skill_creator_evaluation_suite(skill_creator_evaluation_suite_service)
+configure_skill_creator_evolution(skill_creator_evolution_service)
 runtime_capabilities.register(
     "mcp_tools",
     workflow_mcp_provider,
@@ -17291,6 +17323,44 @@ skill_creator_evaluation_suite_generator = WorkflowCreatorEvaluationSuiteGenerat
 skill_creator_evaluation_suite_service.generator = (
     skill_creator_evaluation_suite_generator
 )
+
+
+async def run_skill_creator_evolution_planning(
+    invocation: EvolutionWorkflowInvocation,
+) -> str:
+    payload = WorkflowRunRequest.model_validate(
+        {"workflow": invocation.workflow, "inputs": invocation.inputs}
+    )
+    session_id = str(
+        invocation.runtime_metadata.get("creator_session_id") or ""
+    ).strip()
+    response = await _run_workflow_response(
+        payload,
+        None,
+        runtime_run_type="workflow",
+        runtime_source_id=session_id,
+        runtime_metadata=dict(invocation.runtime_metadata),
+    )
+    final_event = await consume_workflow_stream(response)
+    if final_event.get("event") in {
+        "runtime_approval_pending",
+        "client_tool_waiting",
+    }:
+        raise RuntimeError(
+            "The dedicated Skill evolution planner cannot pause for tools."
+        )
+    output = str(final_event.get("final_output") or "").strip()
+    if not output:
+        raise RuntimeError("The Skill evolution planner returned no plan.")
+    return output
+
+
+skill_creator_evolution_planner = WorkflowCreatorEvolutionPlanner(
+    model_id=TEXT_FALLBACK_MODEL,
+    model_available=lambda: bool(get_llm_gateway_config()[0]),
+    runner=run_skill_creator_evolution_planning,
+)
+skill_creator_evolution_service.planner = skill_creator_evolution_planner
 
 
 async def execute_external_xpert_resource(

--- a/server/skills/creator_api.py
+++ b/server/skills/creator_api.py
@@ -16,6 +16,7 @@ from .creator_evaluation import (
 )
 from .creator_evaluation_service import SkillCreatorEvaluationService
 from .creator_evaluation_suite_service import SkillCreatorEvaluationSuiteService
+from .creator_evolution_service import SkillCreatorEvolutionService
 from .creator_resource_build_service import SkillCreatorResourceBuildService
 from .creator_resource_service import SkillCreatorResourcePlanningService
 from .creator_service import SkillCreatorService
@@ -48,6 +49,7 @@ _evaluation_service: SkillCreatorEvaluationService | None = None
 _evaluation_suite_service: SkillCreatorEvaluationSuiteService | None = None
 _resource_planning_service: SkillCreatorResourcePlanningService | None = None
 _resource_build_service: SkillCreatorResourceBuildService | None = None
+_evolution_service: SkillCreatorEvolutionService | None = None
 
 
 class CreatorSessionCreateRequest(BaseModel):
@@ -312,12 +314,49 @@ class CreatorEvaluationIterateRequest(CreatorEvaluationWriteRequest):
     expected_review_revision: int = Field(ge=0)
 
 
+class CreatorEvolutionGenerateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    evaluation_run_id: str = Field(min_length=1, max_length=200)
+    expected_session_revision: int = Field(ge=1)
+    expected_draft_state_revision: int = Field(ge=1)
+    expected_draft_revision: int = Field(ge=1)
+    expected_draft_digest: str = Field(min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$")
+    expected_review_revision: int = Field(ge=1)
+    expected_run_revision: int = Field(ge=1)
+    expected_resource_plan_revision: int = Field(ge=1)
+    expected_resource_plan_digest: str = Field(min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$")
+    expected_evolution_revision: int | None = Field(default=None, ge=1)
+    expected_evolution_digest: str | None = Field(default=None, min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$")
+
+
+class CreatorEvolutionWriteRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    plan_id: str = Field(min_length=1, max_length=200)
+    expected_session_revision: int = Field(ge=1)
+    expected_draft_state_revision: int = Field(ge=1)
+    expected_draft_revision: int = Field(ge=1)
+    expected_draft_digest: str = Field(min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$")
+    expected_plan_revision: int = Field(ge=1)
+    expected_plan_digest: str = Field(min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$")
+
+
+class CreatorEvolutionAnswersRequest(CreatorEvolutionWriteRequest):
+    answers: dict[str, str] = Field(max_length=5)
+
+
+class CreatorEvolutionPatchRequest(CreatorEvolutionWriteRequest):
+    changes: dict[str, Any]
+
+
 def configure_skill_creator(service: SkillCreatorService | None) -> None:
     global _service
     global _evaluation_service
     global _evaluation_suite_service
     global _resource_planning_service
     global _resource_build_service
+    global _evolution_service
     if service is not _service:
         if (
             _evaluation_service is not None
@@ -339,6 +378,11 @@ def configure_skill_creator(service: SkillCreatorService | None) -> None:
             and getattr(_resource_build_service, "creator_service", None) is not service
         ):
             _resource_build_service = None
+        if (
+            _evolution_service is not None
+            and getattr(_evolution_service, "creator_service", None) is not service
+        ):
+            _evolution_service = None
     _service = service
 
 
@@ -354,6 +398,11 @@ def configure_skill_creator_evaluation_suite(
 ) -> None:
     global _evaluation_suite_service
     _evaluation_suite_service = service
+
+
+def configure_skill_creator_evolution(service: SkillCreatorEvolutionService | None) -> None:
+    global _evolution_service
+    _evolution_service = service
 
 
 def configure_skill_creator_resource_planning(
@@ -420,6 +469,17 @@ def get_skill_creator_resource_build_service() -> SkillCreatorResourceBuildServi
         )
     _resource_build_service.require_enabled()
     return _resource_build_service
+
+
+def get_skill_creator_evolution_service() -> SkillCreatorEvolutionService:
+    get_skill_creator_service()
+    if _evolution_service is None:
+        raise SkillCreatorValidationError(
+            "Skill Creator evolution planning is unavailable.",
+            code="skill_creator_evolution_v2_disabled",
+        )
+    _evolution_service.require_enabled()
+    return _evolution_service
 
 
 def _api_error(exc: Exception) -> HTTPException:
@@ -498,8 +558,12 @@ def _api_error(exc: Exception) -> HTTPException:
             "skill_creator_resource_builder_invalid",
             "skill_evaluation_suite_generator_failed",
             "skill_evaluation_suite_generator_invalid",
+            "skill_creator_evolution_planner_failed",
+            "skill_creator_evolution_planner_invalid",
         }:
             status = 502
+        elif code == "skill_creator_evolution_plan_required":
+            status = 409
         elif code == "skill_creator_proposal_binding_invalid":
             status = 409
     elif isinstance(exc, SkillDraftValidationError):
@@ -571,8 +635,21 @@ def _session_response(
             and draft is not None
             else None
         ),
+        "evolution_plan": _evolution_projection(session.session_id),
     }
     return response
+
+
+def _evolution_projection(session_id: str) -> dict[str, Any] | None:
+    if _evolution_service is None or not _evolution_service.enabled:
+        return None
+    try:
+        return _evolution_service.current_projection(session_id)
+    except SkillCreatorStorageError:
+        return {
+            "available": False,
+            "code": "skill_creator_storage_unavailable",
+        }
 
 
 @router.get("/status")
@@ -598,6 +675,10 @@ async def get_creator_status():
             "evaluation_suite_version": None,
             "evaluation_suite_generator_available": False,
             "evaluation_suite_store_available": False,
+            "evolution_enabled": False,
+            "evolution_version": None,
+            "evolution_planner_available": False,
+            "evolution_store_available": False,
         }
     status = _service.status()
     status["evaluation_available"] = _evaluation_service is not None
@@ -614,6 +695,16 @@ async def get_creator_status():
             "resource_authoring_enabled": False,
             "resource_authoring_version": None,
             "resource_planner_available": False,
+        }
+    )
+    status.update(
+        _evolution_service.status()
+        if _evolution_service is not None
+        else {
+            "evolution_enabled": False,
+            "evolution_version": None,
+            "evolution_planner_available": False,
+            "evolution_store_available": False,
         }
     )
     status.update(
@@ -1372,11 +1463,133 @@ async def waive_creator_evaluation(
         raise _api_error(exc) from exc
 
 
+@router.post("/sessions/{session_id}/evolution-plan/generate")
+async def generate_creator_evolution_plan(
+    session_id: str, payload: CreatorEvolutionGenerateRequest
+):
+    try:
+        if (payload.expected_evolution_revision is None) != (
+            payload.expected_evolution_digest is None
+        ):
+            raise SkillCreatorValidationError(
+                "Expected evolution revision and digest must be provided together.",
+                code="skill_creator_evolution_plan_invalid",
+            )
+        evolution = get_skill_creator_evolution_service()
+        plan = await evolution.generate(
+            session_id,
+            evaluation_run_id=payload.evaluation_run_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_draft_state_revision=payload.expected_draft_state_revision,
+            expected_draft_revision=payload.expected_draft_revision,
+            expected_draft_digest=payload.expected_draft_digest.lower(),
+            expected_review_revision=payload.expected_review_revision,
+            expected_run_revision=payload.expected_run_revision,
+            expected_resource_plan_revision=payload.expected_resource_plan_revision,
+            expected_resource_plan_digest=payload.expected_resource_plan_digest.lower(),
+            expected_evolution_revision=payload.expected_evolution_revision,
+            expected_evolution_digest=(
+                payload.expected_evolution_digest.lower()
+                if payload.expected_evolution_digest
+                else None
+            ),
+        )
+        return {
+            "version": evolution.VERSION,
+            "evolution_plan": evolution.evolution_store.serialize(plan),
+        }
+    except (SkillCreatorError, SkillDraftError, SkillEvaluationError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.put("/sessions/{session_id}/evolution-plan/answers")
+async def answer_creator_evolution_plan(
+    session_id: str, payload: CreatorEvolutionAnswersRequest
+):
+    try:
+        evolution = get_skill_creator_evolution_service()
+        plan = await asyncio.to_thread(
+            evolution.save_answers,
+            session_id,
+            plan_id=payload.plan_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_draft_state_revision=payload.expected_draft_state_revision,
+            expected_draft_revision=payload.expected_draft_revision,
+            expected_draft_digest=payload.expected_draft_digest.lower(),
+            expected_plan_revision=payload.expected_plan_revision,
+            expected_plan_digest=payload.expected_plan_digest.lower(),
+            answers=payload.answers,
+        )
+        return {
+            "version": evolution.VERSION,
+            "evolution_plan": evolution.evolution_store.serialize(plan),
+        }
+    except (SkillCreatorError, SkillDraftError, SkillEvaluationError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.patch("/sessions/{session_id}/evolution-plan")
+async def patch_creator_evolution_plan(
+    session_id: str, payload: CreatorEvolutionPatchRequest
+):
+    try:
+        evolution = get_skill_creator_evolution_service()
+        plan = await asyncio.to_thread(
+            evolution.patch,
+            session_id,
+            plan_id=payload.plan_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_draft_state_revision=payload.expected_draft_state_revision,
+            expected_draft_revision=payload.expected_draft_revision,
+            expected_draft_digest=payload.expected_draft_digest.lower(),
+            expected_plan_revision=payload.expected_plan_revision,
+            expected_plan_digest=payload.expected_plan_digest.lower(),
+            changes=payload.changes,
+        )
+        return {
+            "version": evolution.VERSION,
+            "evolution_plan": evolution.evolution_store.serialize(plan),
+        }
+    except (SkillCreatorError, SkillDraftError, SkillEvaluationError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.post("/sessions/{session_id}/evolution-plan/confirm")
+async def confirm_creator_evolution_plan(
+    session_id: str, payload: CreatorEvolutionWriteRequest
+):
+    try:
+        evolution = get_skill_creator_evolution_service()
+        plan, resource_plan = await asyncio.to_thread(
+            evolution.confirm,
+            session_id,
+            plan_id=payload.plan_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_draft_state_revision=payload.expected_draft_state_revision,
+            expected_draft_revision=payload.expected_draft_revision,
+            expected_draft_digest=payload.expected_draft_digest.lower(),
+            expected_plan_revision=payload.expected_plan_revision,
+            expected_plan_digest=payload.expected_plan_digest.lower(),
+        )
+        return {
+            "version": evolution.VERSION,
+            "evolution_plan": evolution.evolution_store.serialize(plan),
+            "resource_plan": evolution.resource_plan_store.serialize(resource_plan),
+        }
+    except (SkillCreatorError, SkillDraftError, SkillEvaluationError) as exc:
+        raise _api_error(exc) from exc
+
+
 @router.post("/sessions/{session_id}/iterate")
 async def iterate_creator_skill(
     session_id: str, payload: CreatorEvaluationIterateRequest
 ):
     try:
+        if _evolution_service is not None and _evolution_service.enabled:
+            raise SkillCreatorValidationError(
+                "Confirm a Skill evolution plan before rebuilding resources.",
+                code="skill_creator_evolution_plan_required",
+            )
         evaluation = get_skill_creator_evaluation_service()
         proposal = await evaluation.iterate(
             session_id,

--- a/server/skills/creator_evolution.py
+++ b/server/skills/creator_evolution.py
@@ -1,0 +1,908 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import re
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal, Mapping
+
+from .creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorNotFoundError,
+    SkillCreatorStorageError,
+    SkillCreatorValidationError,
+)
+from .package_validation import scan_skill_package_credentials
+
+
+EVOLUTION_PLAN_VERSION = "skill-evolution-plan-v1"
+EvolutionPlanState = Literal["needs_input", "needs_regeneration", "ready", "confirmed", "stale"]
+EvolutionActionKind = Literal["keep", "update", "create", "delete"]
+EvolutionResourceKind = Literal["script", "reference", "asset"]
+
+_RESOURCE_ROOTS = {"script": "scripts", "reference": "references", "asset": "assets"}
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,199}$")
+
+
+@dataclass(frozen=True, slots=True)
+class SkillEvolutionQuestion:
+    question_id: str
+    question: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class SkillEvolutionDiagnosis:
+    case_id: str
+    evidence_item_ids: tuple[str, ...]
+    failure_types: tuple[str, ...]
+    requirement_ids: tuple[str, ...]
+    resource_ids: tuple[str, ...]
+    sections: tuple[str, ...]
+    summary: str
+
+
+@dataclass(frozen=True, slots=True)
+class SkillEvolutionAction:
+    action_id: str
+    action: EvolutionActionKind
+    resource_id: str
+    kind: EvolutionResourceKind
+    path: str
+    purpose: str
+    source_ids: tuple[str, ...]
+    used_by_steps: tuple[str, ...]
+    depends_on: tuple[str, ...]
+    acceptance_checks: tuple[str, ...]
+    related_case_ids: tuple[str, ...]
+    expected_improvement: str
+    non_regression_case_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SkillEvolutionPlan:
+    plan_id: str
+    version: str
+    revision: int
+    digest: str
+    state: EvolutionPlanState
+    session_id: str
+    session_revision: int
+    draft_id: str
+    draft_state_revision: int
+    draft_revision: int
+    draft_digest: str
+    evaluation_run_id: str
+    evaluation_run_revision: int
+    review_id: str
+    review_revision: int
+    suite_id: str
+    suite_revision: int
+    suite_digest: str
+    resource_plan_id: str
+    resource_plan_revision: int
+    resource_plan_digest: str
+    diagnoses: tuple[SkillEvolutionDiagnosis, ...]
+    actions: tuple[SkillEvolutionAction, ...]
+    workflow_steps: tuple[dict[str, str], ...]
+    output_contract: tuple[str, ...]
+    failure_modes: tuple[str, ...]
+    expected_improvements: tuple[str, ...]
+    acceptance_criteria: tuple[str, ...]
+    non_goals: tuple[str, ...]
+    overfitting_risks: tuple[str, ...]
+    clarifications: tuple[SkillEvolutionQuestion, ...] = ()
+    clarification_answers: dict[str, str] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+
+class SkillEvolutionPlanStore:
+    """Append-only, fail-closed evolution plans bound to frozen review facts."""
+
+    SCHEMA_VERSION = 1
+    MAX_PLANS = 500
+    MAX_REVISIONS = 40
+    MAX_ACTIONS = 20
+    MAX_ANSWER_BYTES = 32 * 1024
+    MAX_ANSWERS_BYTES = 128 * 1024
+
+    def __init__(self, storage_dir: str | Path | None = None) -> None:
+        package_dir = Path(__file__).resolve().parent
+        runtime_dir = os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
+        configured = os.getenv("SKILL_CREATOR_EVOLUTION_STORAGE_DIR", "").strip()
+        self.storage_dir = Path(storage_dir or configured or runtime_dir or package_dir / "storage")
+        self.snapshot_path = self.storage_dir / "skill_creator_evolution_plans.json"
+        self._lock = threading.RLock()
+        self._items: dict[str, list[SkillEvolutionPlan]] = {}
+        self._session_index: dict[str, str] = {}
+        self._quarantine: list[dict[str, Any]] = []
+        self._load_error: str | None = None
+        self._load()
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "available": self._load_error is None,
+                "plan_count": len(self._items),
+                "quarantine_count": len(self._quarantine),
+            }
+
+    def current_for_session(self, session_id: str) -> SkillEvolutionPlan | None:
+        clean = self._identifier(session_id, "session_id")
+        with self._lock:
+            self._ensure_readable_unlocked()
+            plan_id = self._session_index.get(clean)
+            return copy.deepcopy(self._items[plan_id][-1]) if plan_id else None
+
+    def require(self, plan_id: str, revision: int | None = None) -> SkillEvolutionPlan:
+        clean = self._identifier(plan_id, "plan_id")
+        with self._lock:
+            self._ensure_readable_unlocked()
+            revisions = self._items.get(clean)
+            if not revisions:
+                raise SkillCreatorNotFoundError(f"Evolution plan not found: {clean}")
+            if revision is None:
+                return copy.deepcopy(revisions[-1])
+            for item in revisions:
+                if item.revision == int(revision):
+                    return copy.deepcopy(item)
+        raise SkillCreatorNotFoundError(f"Evolution plan revision not found: {clean}@{revision}")
+
+    def save_generated(
+        self,
+        *,
+        bindings: Mapping[str, Any],
+        payload: Mapping[str, Any],
+        allowed_case_ids: set[str],
+        allowed_item_ids: set[str],
+        allowed_requirement_ids: set[str],
+        allowed_resources: Mapping[str, Mapping[str, str]],
+        allowed_source_ids: set[str],
+        allowed_step_ids: set[str],
+        expected_plan_revision: int | None,
+        expected_plan_digest: str | None,
+    ) -> SkillEvolutionPlan:
+        clean_bindings = self._bindings(bindings)
+        normalized = self._normalize_payload(
+            payload,
+            allowed_case_ids=allowed_case_ids,
+            allowed_item_ids=allowed_item_ids,
+            allowed_requirement_ids=allowed_requirement_ids,
+            allowed_resources=allowed_resources,
+            allowed_source_ids=allowed_source_ids,
+            allowed_step_ids=allowed_step_ids,
+        )
+        with self._lock:
+            self._ensure_writable_unlocked()
+            current = self._current_unlocked(clean_bindings["session_id"])
+            self._require_expected(current, expected_plan_revision, expected_plan_digest)
+            if current is None and len(self._items) >= self.MAX_PLANS:
+                raise SkillCreatorValidationError(
+                    "Skill evolution plan limit reached.", code="skill_creator_evolution_plan_limit"
+                )
+            if current is not None and current.state == "confirmed" and self._same_bindings(current, clean_bindings):
+                raise SkillCreatorConflictError(
+                    "A confirmed evolution plan cannot be regenerated for the same review."
+                )
+            plan_id = current.plan_id if current else f"skillevo_{uuid.uuid4().hex}"
+            revision = current.revision + 1 if current else 1
+            now = time.time()
+            item = self._build(
+                plan_id=plan_id,
+                version=EVOLUTION_PLAN_VERSION,
+                revision=revision,
+                state="needs_input" if normalized["clarifications"] else "ready",
+                clarification_answers=(
+                    dict(current.clarification_answers)
+                    if current is not None and self._same_bindings(current, clean_bindings)
+                    else {}
+                ),
+                created_at=(current.created_at if current else now),
+                updated_at=now,
+                **clean_bindings,
+                **normalized,
+            )
+            return self._append_unlocked(item)
+
+    def save_answers(
+        self,
+        plan_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+        answers: Mapping[str, Any],
+    ) -> SkillEvolutionPlan:
+        with self._lock:
+            current = self._require_current_unlocked(plan_id, expected_revision, expected_digest)
+            if current.state != "needs_input":
+                raise SkillCreatorConflictError("This evolution plan is not waiting for answers.")
+            question_ids = {item.question_id for item in current.clarifications}
+            if set(answers) != question_ids:
+                raise SkillCreatorValidationError(
+                    "Answer every current evolution question exactly once.",
+                    code="skill_creator_evolution_answers_incomplete",
+                )
+            clean_answers = {
+                self._identifier(key, "question_id"): self._required_text(value, "answer", self.MAX_ANSWER_BYTES)
+                for key, value in answers.items()
+            }
+            if sum(len(value.encode("utf-8")) for value in clean_answers.values()) > self.MAX_ANSWERS_BYTES:
+                raise SkillCreatorValidationError(
+                    "Skill evolution answers are too large.", code="skill_creator_evolution_answers_too_large"
+                )
+            self._reject_credentials(clean_answers)
+            return self._append_unlocked(
+                self._replace(
+                    current,
+                    revision=current.revision + 1,
+                    state="needs_regeneration",
+                    clarification_answers=clean_answers,
+                    updated_at=time.time(),
+                )
+            )
+
+    def patch(
+        self,
+        plan_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+        changes: Mapping[str, Any],
+        allowed_case_ids: set[str],
+        allowed_item_ids: set[str],
+        allowed_requirement_ids: set[str],
+        allowed_resources: Mapping[str, Mapping[str, str]],
+        allowed_source_ids: set[str],
+        allowed_step_ids: set[str],
+    ) -> SkillEvolutionPlan:
+        allowed = {
+            "actions", "workflow_steps", "output_contract", "failure_modes",
+            "expected_improvements", "acceptance_criteria", "non_goals", "overfitting_risks",
+        }
+        unknown = sorted(set(changes) - allowed)
+        if unknown:
+            raise SkillCreatorValidationError(
+                "Unsupported evolution plan fields: " + ", ".join(unknown),
+                code="skill_creator_evolution_plan_invalid",
+            )
+        with self._lock:
+            current = self._require_current_unlocked(plan_id, expected_revision, expected_digest)
+            if current.state != "ready":
+                raise SkillCreatorConflictError("Only a ready evolution plan can be edited.")
+            payload = {
+                "diagnoses": [asdict(item) for item in current.diagnoses],
+                "actions": [asdict(item) for item in current.actions],
+                "workflow_steps": list(current.workflow_steps),
+                "output_contract": list(current.output_contract),
+                "failure_modes": list(current.failure_modes),
+                "expected_improvements": list(current.expected_improvements),
+                "acceptance_criteria": list(current.acceptance_criteria),
+                "non_goals": list(current.non_goals),
+                "overfitting_risks": list(current.overfitting_risks),
+                "clarifications": [],
+            }
+            payload.update(dict(changes))
+            normalized = self._normalize_payload(
+                payload,
+                allowed_case_ids=allowed_case_ids,
+                allowed_item_ids=allowed_item_ids,
+                allowed_requirement_ids=allowed_requirement_ids,
+                allowed_resources=allowed_resources,
+                allowed_source_ids=allowed_source_ids,
+                allowed_step_ids=allowed_step_ids,
+            )
+            return self._append_unlocked(
+                self._replace(
+                    current,
+                    revision=current.revision + 1,
+                    state="ready",
+                    updated_at=time.time(),
+                    **normalized,
+                )
+            )
+
+    def confirm(self, plan_id: str, *, expected_revision: int, expected_digest: str) -> SkillEvolutionPlan:
+        with self._lock:
+            current = self._require_current_unlocked(plan_id, expected_revision, expected_digest)
+            if current.state != "ready":
+                raise SkillCreatorConflictError("Only a ready evolution plan can be confirmed.")
+            return self._append_unlocked(
+                self._replace(
+                    current,
+                    revision=current.revision + 1,
+                    state="confirmed",
+                    updated_at=time.time(),
+                )
+            )
+
+    def mark_stale(
+        self,
+        plan_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+    ) -> SkillEvolutionPlan:
+        with self._lock:
+            current = self._require_current_unlocked(
+                plan_id,
+                expected_revision,
+                expected_digest,
+            )
+            if current.state == "stale":
+                return copy.deepcopy(current)
+            return self._append_unlocked(
+                self._replace(current, revision=current.revision + 1, state="stale", updated_at=time.time())
+            )
+
+    @staticmethod
+    def serialize(item: SkillEvolutionPlan) -> dict[str, Any]:
+        return asdict(item)
+
+    def _normalize_payload(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        allowed_case_ids: set[str],
+        allowed_item_ids: set[str],
+        allowed_requirement_ids: set[str],
+        allowed_resources: Mapping[str, Mapping[str, str]],
+        allowed_source_ids: set[str],
+        allowed_step_ids: set[str],
+    ) -> dict[str, Any]:
+        if not isinstance(payload, Mapping):
+            raise SkillCreatorValidationError(
+                "Skill evolution planner returned an invalid object.", code="skill_creator_evolution_plan_invalid"
+            )
+        diagnoses = self._diagnoses(
+            payload.get("diagnoses"), allowed_case_ids, allowed_item_ids,
+            allowed_requirement_ids, set(allowed_resources),
+        )
+        workflow_steps = self._workflow_steps(payload.get("workflow_steps"), allowed_step_ids)
+        step_ids = {item["step_id"] for item in workflow_steps}
+        actions = self._actions(
+            payload.get("actions"), allowed_case_ids, allowed_resources,
+            allowed_source_ids, step_ids,
+        )
+        normalized = {
+            "diagnoses": diagnoses,
+            "actions": actions,
+            "workflow_steps": workflow_steps,
+            "output_contract": self._text_list(payload.get("output_contract"), "output_contract", 20, 2_000, minimum=1),
+            "failure_modes": self._text_list(payload.get("failure_modes"), "failure_modes", 20, 2_000, minimum=1),
+            "expected_improvements": self._text_list(payload.get("expected_improvements"), "expected_improvements", 20, 2_000, minimum=1),
+            "acceptance_criteria": self._text_list(payload.get("acceptance_criteria"), "acceptance_criteria", 30, 2_000, minimum=1),
+            "non_goals": self._text_list(payload.get("non_goals"), "non_goals", 20, 2_000),
+            "overfitting_risks": self._text_list(payload.get("overfitting_risks"), "overfitting_risks", 20, 2_000, minimum=1),
+            "clarifications": self._questions(payload.get("clarifications", [])),
+        }
+        self._reject_credentials(normalized)
+        return normalized
+
+    def _diagnoses(
+        self, value: Any, allowed_cases: set[str], allowed_items: set[str],
+        allowed_requirements: set[str], allowed_resources: set[str],
+    ) -> tuple[SkillEvolutionDiagnosis, ...]:
+        if not isinstance(value, list) or not value or len(value) > 12:
+            raise SkillCreatorValidationError("Evolution plan requires one to twelve diagnoses.", code="skill_creator_evolution_plan_invalid")
+        result: list[SkillEvolutionDiagnosis] = []
+        seen: set[str] = set()
+        for raw in value:
+            if not isinstance(raw, Mapping):
+                raise SkillCreatorValidationError("Invalid evolution diagnosis.", code="skill_creator_evolution_plan_invalid")
+            case_id = self._identifier(raw.get("case_id"), "case_id")
+            if case_id not in allowed_cases or case_id in seen:
+                raise SkillCreatorValidationError("Evolution diagnosis references an unknown or duplicate case.", code="skill_creator_evolution_evidence_invalid")
+            seen.add(case_id)
+            item_ids = self._identifier_list(raw.get("evidence_item_ids"), "evidence_item_ids", 18, allowed_items, minimum=1)
+            result.append(SkillEvolutionDiagnosis(
+                case_id=case_id,
+                evidence_item_ids=item_ids,
+                failure_types=self._identifier_list(raw.get("failure_types"), "failure_types", 8, None, minimum=1),
+                requirement_ids=self._identifier_list(raw.get("requirement_ids", []), "requirement_ids", 30, allowed_requirements),
+                resource_ids=self._identifier_list(raw.get("resource_ids", []), "resource_ids", 20, allowed_resources),
+                sections=self._text_list(raw.get("sections", []), "sections", 20, 300),
+                summary=self._required_text(raw.get("summary"), "diagnosis summary", 2_000),
+            ))
+        return tuple(result)
+
+    def _actions(
+        self, value: Any, allowed_cases: set[str], allowed_resources: Mapping[str, Mapping[str, str]],
+        allowed_source_ids: set[str], allowed_step_ids: set[str],
+    ) -> tuple[SkillEvolutionAction, ...]:
+        if not isinstance(value, list) or len(value) > self.MAX_ACTIONS:
+            raise SkillCreatorValidationError("Invalid evolution resource actions.", code="skill_creator_evolution_plan_invalid")
+        resolved: list[tuple[Mapping[str, Any], str, str, str, str]] = []
+        all_resource_ids = set(allowed_resources)
+        for index, raw in enumerate(value):
+            if not isinstance(raw, Mapping):
+                raise SkillCreatorValidationError("Invalid evolution resource action.", code="skill_creator_evolution_plan_invalid")
+            action = str(raw.get("action") or "").strip().lower()
+            if action not in {"keep", "update", "create", "delete"}:
+                raise SkillCreatorValidationError("Invalid evolution resource action.", code="skill_creator_evolution_plan_invalid")
+            if action == "create":
+                kind = str(raw.get("kind") or "").strip().lower()
+                if kind not in _RESOURCE_ROOTS:
+                    raise SkillCreatorValidationError("Invalid evolution resource kind.", code="skill_creator_evolution_plan_invalid")
+                path = self._resource_path(raw.get("path"), kind)
+                resource_id = self._resource_id(kind, path)
+                if resource_id in all_resource_ids:
+                    raise SkillCreatorValidationError("A create action cannot target an existing resource.", code="skill_creator_evolution_resource_invalid")
+                all_resource_ids.add(resource_id)
+            else:
+                resource_id = self._identifier(raw.get("resource_id"), "resource_id")
+                frozen = allowed_resources.get(resource_id)
+                if frozen is None:
+                    raise SkillCreatorValidationError("Evolution action references an unknown resource.", code="skill_creator_evolution_resource_invalid")
+                kind = str(frozen.get("kind") or "")
+                path = str(frozen.get("path") or "")
+                if raw.get("path") not in {None, "", path} or raw.get("kind") not in {None, "", kind}:
+                    raise SkillCreatorValidationError("Existing resource identity is server-controlled.", code="skill_creator_evolution_resource_invalid")
+            action_id = self._identifier(raw.get("action_id") or f"evolution-action-{index + 1}", "action_id")
+            resolved.append((raw, action, resource_id, kind, path))
+        result: list[SkillEvolutionAction] = []
+        seen_ids: set[str] = set()
+        seen_paths: set[str] = set()
+        covered_existing: set[str] = set()
+        deleted_resource_ids = {
+            resource_id
+            for _raw, action, resource_id, _kind, _path in resolved
+            if action == "delete"
+        }
+        for index, (raw, action, resource_id, kind, path) in enumerate(resolved):
+            if action != "create":
+                covered_existing.add(resource_id)
+            action_id = self._identifier(raw.get("action_id") or f"evolution-action-{index + 1}", "action_id")
+            if action_id in seen_ids or path.casefold() in seen_paths:
+                raise SkillCreatorValidationError("Evolution actions must have unique IDs and paths.", code="skill_creator_evolution_resource_invalid")
+            seen_ids.add(action_id)
+            seen_paths.add(path.casefold())
+            depends_on = self._identifier_list(
+                raw.get("depends_on", []),
+                "depends_on",
+                20,
+                all_resource_ids - {resource_id},
+            )
+            if (action == "delete" and depends_on) or (
+                action != "delete" and deleted_resource_ids.intersection(depends_on)
+            ):
+                raise SkillCreatorValidationError(
+                    "Active resources cannot depend on a resource scheduled for deletion.",
+                    code="skill_creator_evolution_resource_invalid",
+                )
+            result.append(SkillEvolutionAction(
+                action_id=action_id,
+                action=action,  # type: ignore[arg-type]
+                resource_id=resource_id,
+                kind=kind,  # type: ignore[arg-type]
+                path=path,
+                purpose=self._required_text(raw.get("purpose"), "resource purpose", 2_000),
+                source_ids=self._identifier_list(raw.get("source_ids", []), "source_ids", 30, allowed_source_ids),
+                used_by_steps=self._identifier_list(raw.get("used_by_steps", []), "used_by_steps", 20, allowed_step_ids),
+                depends_on=depends_on,
+                acceptance_checks=self._text_list(raw.get("acceptance_checks"), "acceptance_checks", 20, 1_000, minimum=1),
+                related_case_ids=self._identifier_list(raw.get("related_case_ids"), "related_case_ids", 12, allowed_cases, minimum=1),
+                expected_improvement=self._required_text(raw.get("expected_improvement"), "expected_improvement", 2_000),
+                non_regression_case_ids=self._identifier_list(raw.get("non_regression_case_ids", []), "non_regression_case_ids", 12, allowed_cases),
+            ))
+        missing = set(allowed_resources) - covered_existing
+        if missing:
+            raise SkillCreatorValidationError("Evolution plan must account for every existing resource.", code="skill_creator_evolution_resource_incomplete")
+        return tuple(result)
+
+    def _workflow_steps(self, value: Any, allowed_step_ids: set[str]) -> tuple[dict[str, str], ...]:
+        if not isinstance(value, list) or not 4 <= len(value) <= 10:
+            raise SkillCreatorValidationError("Evolution workflow must contain four to ten steps.", code="skill_creator_evolution_plan_invalid")
+        result: list[dict[str, str]] = []
+        seen: set[str] = set()
+        for index, raw in enumerate(value):
+            if not isinstance(raw, Mapping):
+                raise SkillCreatorValidationError("Invalid evolution workflow step.", code="skill_creator_evolution_plan_invalid")
+            step_id = self._identifier(raw.get("step_id") or raw.get("id") or f"step-{index + 1}", "step_id")
+            if step_id in seen:
+                raise SkillCreatorValidationError("Evolution workflow step IDs must be unique.", code="skill_creator_evolution_plan_invalid")
+            seen.add(step_id)
+            result.append({"step_id": step_id, "instruction": self._required_text(raw.get("instruction") or raw.get("description"), "workflow instruction", 2_000)})
+        # Existing IDs may be retained, replaced, or augmented; the server still
+        # freezes all resource references against the IDs in this result.
+        _ = allowed_step_ids
+        return tuple(result)
+
+    def _questions(self, value: Any) -> tuple[SkillEvolutionQuestion, ...]:
+        if not isinstance(value, list) or len(value) > 5:
+            raise SkillCreatorValidationError("Evolution planner may ask at most five questions.", code="skill_creator_evolution_plan_invalid")
+        result: list[SkillEvolutionQuestion] = []
+        seen: set[str] = set()
+        for raw in value:
+            if not isinstance(raw, Mapping):
+                raise SkillCreatorValidationError("Invalid evolution clarification.", code="skill_creator_evolution_plan_invalid")
+            question_id = self._identifier(raw.get("question_id") or raw.get("id"), "question_id")
+            if question_id in seen:
+                raise SkillCreatorValidationError("Evolution question IDs must be unique.", code="skill_creator_evolution_plan_invalid")
+            seen.add(question_id)
+            result.append(SkillEvolutionQuestion(
+                question_id=question_id,
+                question=self._required_text(raw.get("question"), "question", 2_000),
+                reason=self._required_text(raw.get("reason"), "reason", 1_000),
+            ))
+        return tuple(result)
+
+    def _bindings(self, value: Mapping[str, Any]) -> dict[str, Any]:
+        fields = {
+            "session_id": self._identifier(value.get("session_id"), "session_id"),
+            "session_revision": self._positive_int(value.get("session_revision"), "session_revision"),
+            "draft_id": self._identifier(value.get("draft_id"), "draft_id"),
+            "draft_state_revision": self._positive_int(value.get("draft_state_revision"), "draft_state_revision"),
+            "draft_revision": self._positive_int(value.get("draft_revision"), "draft_revision"),
+            "draft_digest": self._digest(value.get("draft_digest"), "draft_digest"),
+            "evaluation_run_id": self._identifier(value.get("evaluation_run_id"), "evaluation_run_id"),
+            "evaluation_run_revision": self._positive_int(value.get("evaluation_run_revision"), "evaluation_run_revision"),
+            "review_id": self._identifier(value.get("review_id"), "review_id"),
+            "review_revision": self._positive_int(value.get("review_revision"), "review_revision"),
+            "suite_id": self._identifier(value.get("suite_id"), "suite_id"),
+            "suite_revision": self._positive_int(value.get("suite_revision"), "suite_revision"),
+            "suite_digest": self._digest(value.get("suite_digest"), "suite_digest"),
+            "resource_plan_id": self._identifier(value.get("resource_plan_id"), "resource_plan_id"),
+            "resource_plan_revision": self._positive_int(value.get("resource_plan_revision"), "resource_plan_revision"),
+            "resource_plan_digest": self._digest(value.get("resource_plan_digest"), "resource_plan_digest"),
+        }
+        return fields
+
+    @staticmethod
+    def _same_bindings(item: SkillEvolutionPlan, bindings: Mapping[str, Any]) -> bool:
+        return all(getattr(item, key) == value for key, value in bindings.items())
+
+    def _build(self, **values: Any) -> SkillEvolutionPlan:
+        digest_values = {key: value for key, value in values.items() if key not in {"digest", "created_at", "updated_at"}}
+        digest = hashlib.sha256(self._canonical_json(self._jsonable(digest_values)).encode("utf-8")).hexdigest()
+        return SkillEvolutionPlan(digest=digest, **values)
+
+    def _replace(self, current: SkillEvolutionPlan, **changes: Any) -> SkillEvolutionPlan:
+        values = asdict(current)
+        values.pop("digest", None)
+        values.update(changes)
+        values["diagnoses"] = tuple(
+            item if isinstance(item, SkillEvolutionDiagnosis) else SkillEvolutionDiagnosis(**item)
+            for item in values["diagnoses"]
+        )
+        values["actions"] = tuple(
+            item if isinstance(item, SkillEvolutionAction) else SkillEvolutionAction(**item)
+            for item in values["actions"]
+        )
+        values["clarifications"] = tuple(
+            item if isinstance(item, SkillEvolutionQuestion) else SkillEvolutionQuestion(**item)
+            for item in values["clarifications"]
+        )
+        values["workflow_steps"] = tuple(values["workflow_steps"])
+        for key in ("output_contract", "failure_modes", "expected_improvements", "acceptance_criteria", "non_goals", "overfitting_risks"):
+            values[key] = tuple(values[key])
+        return self._build(**values)
+
+    def _append_unlocked(self, item: SkillEvolutionPlan) -> SkillEvolutionPlan:
+        revisions = self._items.setdefault(item.plan_id, [])
+        if revisions and item.revision != revisions[-1].revision + 1:
+            raise SkillCreatorConflictError("Evolution plan revision is not sequential.")
+        if len(revisions) >= self.MAX_REVISIONS:
+            raise SkillCreatorValidationError("Evolution plan revision limit reached.", code="skill_creator_evolution_plan_limit")
+        previous_index = self._session_index.get(item.session_id)
+        revisions.append(item)
+        self._session_index[item.session_id] = item.plan_id
+        try:
+            self._save_unlocked()
+        except BaseException:
+            revisions.pop()
+            if not revisions:
+                self._items.pop(item.plan_id, None)
+            if previous_index is None:
+                self._session_index.pop(item.session_id, None)
+            else:
+                self._session_index[item.session_id] = previous_index
+            raise
+        return copy.deepcopy(item)
+
+    def _require_current_unlocked(
+        self, plan_id: str, expected_revision: int | None, expected_digest: str | None,
+        *, require_expected: bool = True,
+    ) -> SkillEvolutionPlan:
+        self._ensure_writable_unlocked()
+        clean = self._identifier(plan_id, "plan_id")
+        revisions = self._items.get(clean)
+        if not revisions:
+            raise SkillCreatorNotFoundError(f"Evolution plan not found: {clean}")
+        current = revisions[-1]
+        if require_expected:
+            self._require_expected(current, expected_revision, expected_digest)
+        return current
+
+    @staticmethod
+    def _require_expected(current: SkillEvolutionPlan | None, revision: int | None, digest: str | None) -> None:
+        if current is None:
+            if revision is not None or digest is not None:
+                raise SkillCreatorConflictError("Evolution plan changed. Reload before continuing.")
+            return
+        if revision is None or digest is None or current.revision != int(revision) or current.digest != str(digest).lower():
+            raise SkillCreatorConflictError("Evolution plan changed. Reload before continuing.")
+
+    def _current_unlocked(self, session_id: str) -> SkillEvolutionPlan | None:
+        plan_id = self._session_index.get(session_id)
+        return self._items[plan_id][-1] if plan_id else None
+
+    def _load(self) -> None:
+        with self._lock:
+            if not self.snapshot_path.exists():
+                return
+            try:
+                raw = json.loads(self.snapshot_path.read_text(encoding="utf-8"))
+                if not isinstance(raw, dict) or raw.get("schema_version") != self.SCHEMA_VERSION or not isinstance(raw.get("items"), list):
+                    raise ValueError("unsupported snapshot structure")
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+                self._load_error = f"skill_evolution_store_corrupt: {str(exc)[:300]}"
+                return
+            quarantine = raw.get("quarantine", [])
+            if isinstance(quarantine, list):
+                self._quarantine = [dict(item) for item in quarantine if isinstance(item, dict)][: self.MAX_PLANS]
+            sanitized = False
+            for index, record in enumerate(raw["items"]):
+                try:
+                    item = self._decode(record)
+                    revisions = self._items.get(item.plan_id)
+                    if revisions is None:
+                        if item.revision != 1:
+                            raise ValueError("evolution revision history must start at one")
+                    elif item.revision != revisions[-1].revision + 1:
+                        raise ValueError("non-sequential evolution revision")
+                    existing = self._session_index.get(item.session_id)
+                    if existing not in {None, item.plan_id}:
+                        raise ValueError("multiple evolution plans for one session")
+                    if revisions is None:
+                        revisions = []
+                        self._items[item.plan_id] = revisions
+                    revisions.append(item)
+                    self._session_index[item.session_id] = item.plan_id
+                except Exception:
+                    self._quarantine.append(self._quarantine_record(record, index))
+                    sanitized = True
+            if sanitized:
+                try:
+                    self._save_unlocked()
+                except OSError as exc:
+                    self._load_error = f"skill_evolution_store_sanitize_failed: {str(exc)[:300]}"
+
+    def _decode(self, record: Any) -> SkillEvolutionPlan:
+        if not isinstance(record, dict):
+            raise TypeError("evolution record must be an object")
+        values = dict(record)
+        diagnoses = []
+        for raw in values.get("diagnoses", []):
+            item = dict(raw)
+            for key in ("evidence_item_ids", "failure_types", "requirement_ids", "resource_ids", "sections"):
+                item[key] = tuple(item.get(key, []))
+            diagnoses.append(SkillEvolutionDiagnosis(**item))
+        values["diagnoses"] = tuple(diagnoses)
+        actions = []
+        for raw in values.get("actions", []):
+            item = dict(raw)
+            for key in (
+                "source_ids",
+                "used_by_steps",
+                "depends_on",
+                "acceptance_checks",
+                "related_case_ids",
+                "non_regression_case_ids",
+            ):
+                item[key] = tuple(item.get(key, []))
+            actions.append(SkillEvolutionAction(**item))
+        values["actions"] = tuple(actions)
+        values["clarifications"] = tuple(SkillEvolutionQuestion(**item) for item in values.get("clarifications", []))
+        values["workflow_steps"] = tuple(values.get("workflow_steps", []))
+        for key in ("output_contract", "failure_modes", "expected_improvements", "acceptance_criteria", "non_goals", "overfitting_risks"):
+            values[key] = tuple(values.get(key, []))
+        item = SkillEvolutionPlan(**values)
+        if item.version != EVOLUTION_PLAN_VERSION or item.state not in {"needs_input", "needs_regeneration", "ready", "confirmed", "stale"}:
+            raise ValueError("unsupported evolution plan")
+        rebuilt = self._build(**{key: value for key, value in asdict(item).items() if key != "digest"})
+        if rebuilt.digest != item.digest:
+            raise ValueError("evolution plan digest mismatch")
+        self._validate_decoded_payload(item)
+        self._reject_credentials(asdict(item))
+        return item
+
+    def _validate_decoded_payload(self, item: SkillEvolutionPlan) -> None:
+        case_ids = {
+            case_id
+            for diagnosis in item.diagnoses
+            for case_id in (diagnosis.case_id,)
+        } | {
+            case_id
+            for action in item.actions
+            for case_id in (*action.related_case_ids, *action.non_regression_case_ids)
+        }
+        item_ids = {
+            item_id
+            for diagnosis in item.diagnoses
+            for item_id in diagnosis.evidence_item_ids
+        }
+        requirement_ids = {
+            requirement_id
+            for diagnosis in item.diagnoses
+            for requirement_id in diagnosis.requirement_ids
+        }
+        existing_resources = {
+            action.resource_id: {"kind": action.kind, "path": action.path}
+            for action in item.actions
+            if action.action != "create"
+        }
+        source_ids = {
+            source_id
+            for action in item.actions
+            for source_id in action.source_ids
+        }
+        step_ids = {
+            str(step.get("step_id") or "")
+            for step in item.workflow_steps
+            if isinstance(step, Mapping)
+        }
+        normalized = self._normalize_payload(
+            {
+                "diagnoses": [asdict(value) for value in item.diagnoses],
+                "actions": [asdict(value) for value in item.actions],
+                "workflow_steps": list(item.workflow_steps),
+                "output_contract": list(item.output_contract),
+                "failure_modes": list(item.failure_modes),
+                "expected_improvements": list(item.expected_improvements),
+                "acceptance_criteria": list(item.acceptance_criteria),
+                "non_goals": list(item.non_goals),
+                "overfitting_risks": list(item.overfitting_risks),
+                "clarifications": [asdict(value) for value in item.clarifications],
+            },
+            allowed_case_ids=case_ids,
+            allowed_item_ids=item_ids,
+            allowed_requirement_ids=requirement_ids,
+            allowed_resources=existing_resources,
+            allowed_source_ids=source_ids,
+            allowed_step_ids=step_ids,
+        )
+        for field_name, value in normalized.items():
+            if value != getattr(item, field_name):
+                raise ValueError(f"evolution plan {field_name} is not canonical")
+
+    def _save_unlocked(self) -> None:
+        self._ensure_writable_unlocked()
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        temporary = self.snapshot_path.with_name(f"{self.snapshot_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+        payload = {
+            "schema_version": self.SCHEMA_VERSION,
+            "items": [asdict(item) for plan_id in sorted(self._items) for item in self._items[plan_id]],
+            "quarantine": list(self._quarantine),
+        }
+        encoded = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+        try:
+            with temporary.open("xb") as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.snapshot_path)
+        finally:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _quarantine_record(record: Any, index: int) -> dict[str, Any]:
+        encoded = json.dumps(record, ensure_ascii=False, sort_keys=True, default=str).encode("utf-8")
+        return {"index": index, "sha256": hashlib.sha256(encoded).hexdigest(), "size_bytes": len(encoded), "code": "invalid_evolution_plan"}
+
+    @staticmethod
+    def _jsonable(value: Any) -> Any:
+        if hasattr(value, "__dataclass_fields__"):
+            return asdict(value)
+        if isinstance(value, tuple):
+            return [SkillEvolutionPlanStore._jsonable(item) for item in value]
+        if isinstance(value, list):
+            return [SkillEvolutionPlanStore._jsonable(item) for item in value]
+        if isinstance(value, dict):
+            return {str(key): SkillEvolutionPlanStore._jsonable(item) for key, item in value.items()}
+        return value
+
+    @staticmethod
+    def _canonical_json(value: Any) -> str:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+    @staticmethod
+    def _required_text(value: Any, field_name: str, maximum: int) -> str:
+        if not isinstance(value, str):
+            raise SkillCreatorValidationError(f"Invalid {field_name}.", code="skill_creator_evolution_plan_invalid")
+        clean = value.strip()
+        if not clean or len(clean.encode("utf-8")) > maximum:
+            raise SkillCreatorValidationError(f"Invalid {field_name}.", code="skill_creator_evolution_plan_invalid")
+        return clean
+
+    @classmethod
+    def _text_list(cls, value: Any, field_name: str, maximum_items: int, maximum_bytes: int, *, minimum: int = 0) -> tuple[str, ...]:
+        if not isinstance(value, (list, tuple)) or not minimum <= len(value) <= maximum_items:
+            raise SkillCreatorValidationError(f"Invalid {field_name}.", code="skill_creator_evolution_plan_invalid")
+        return tuple(cls._required_text(item, field_name, maximum_bytes) for item in value)
+
+    @staticmethod
+    def _identifier(value: Any, field_name: str) -> str:
+        clean = str(value or "").strip()
+        if not _ID_RE.fullmatch(clean):
+            raise SkillCreatorValidationError(f"Invalid {field_name}.", code="skill_creator_evolution_plan_invalid")
+        return clean
+
+    @classmethod
+    def _identifier_list(cls, value: Any, field_name: str, maximum: int, allowed: set[str] | None, *, minimum: int = 0) -> tuple[str, ...]:
+        if not isinstance(value, (list, tuple)) or not minimum <= len(value) <= maximum:
+            raise SkillCreatorValidationError(f"Invalid {field_name}.", code="skill_creator_evolution_plan_invalid")
+        result = tuple(dict.fromkeys(cls._identifier(item, field_name) for item in value))
+        if len(result) != len(value) or (allowed is not None and not set(result).issubset(allowed)):
+            raise SkillCreatorValidationError(f"Unknown or duplicate {field_name}.", code="skill_creator_evolution_evidence_invalid")
+        return result
+
+    @staticmethod
+    def _positive_int(value: Any, field_name: str) -> int:
+        try:
+            result = int(value)
+        except (TypeError, ValueError) as exc:
+            raise SkillCreatorValidationError(f"Invalid {field_name}.") from exc
+        if isinstance(value, bool) or result < 1:
+            raise SkillCreatorValidationError(f"Invalid {field_name}.")
+        return result
+
+    @staticmethod
+    def _digest(value: Any, field_name: str) -> str:
+        clean = str(value or "").strip().lower()
+        if not re.fullmatch(r"[a-f0-9]{64}", clean):
+            raise SkillCreatorValidationError(f"Invalid {field_name}.", code="skill_creator_evolution_plan_invalid")
+        return clean
+
+    @staticmethod
+    def _resource_path(value: Any, kind: str) -> str:
+        raw = str(value or "").replace("\\", "/").strip()
+        path = PurePosixPath(raw)
+        if (
+            not raw or path.is_absolute() or ".." in path.parts or raw != path.as_posix()
+            or len(raw) > 240 or not raw.startswith(f"{_RESOURCE_ROOTS[kind]}/")
+        ):
+            raise SkillCreatorValidationError("Invalid evolution resource path.", code="skill_creator_evolution_resource_invalid")
+        if kind == "script" and path.suffix.lower() not in {".py", ".js"}:
+            raise SkillCreatorValidationError("Evolution scripts must use Python or JavaScript.", code="skill_creator_evolution_resource_invalid")
+        if kind in {"reference", "asset"} and path.suffix.lower() not in {".md", ".txt", ".json", ".yaml", ".yml", ".csv"}:
+            raise SkillCreatorValidationError("Evolution resources must be supported UTF-8 text files.", code="skill_creator_evolution_resource_invalid")
+        return raw
+
+    @staticmethod
+    def _resource_id(kind: str, path: str) -> str:
+        return "skillres_" + hashlib.sha256(f"{kind}\0{path}".encode("utf-8")).hexdigest()[:16]
+
+    @classmethod
+    def _reject_credentials(cls, value: Any) -> None:
+        if scan_skill_package_credentials(skill_markdown=cls._canonical_json(cls._jsonable(value))):
+            raise SkillCreatorValidationError(
+                "Blocked credential material was detected in evolution plan data.",
+                code="skill_creator_evolution_credentials_blocked",
+            )
+
+    def _ensure_readable_unlocked(self) -> None:
+        if self._load_error:
+            raise SkillCreatorStorageError("Skill evolution plan Store is unavailable.")
+
+    def _ensure_writable_unlocked(self) -> None:
+        self._ensure_readable_unlocked()
+
+
+__all__ = [
+    "EVOLUTION_PLAN_VERSION",
+    "SkillEvolutionAction",
+    "SkillEvolutionDiagnosis",
+    "SkillEvolutionPlan",
+    "SkillEvolutionPlanStore",
+    "SkillEvolutionQuestion",
+]

--- a/server/skills/creator_evolution_runtime.py
+++ b/server/skills/creator_evolution_runtime.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from .creator_evolution import EVOLUTION_PLAN_VERSION
+from .creator_evolution_service import EvolutionGenerationRequest
+from .creator_runtime import CREATOR_WORKFLOW_VERSION
+from .creator_store import CREATOR_ASSISTANT_AGENT_ID, SkillCreatorValidationError
+
+
+EVOLUTION_WORKFLOW_VERSION = "skill-creator-resource-evolution-planner-v1"
+
+
+@dataclass(frozen=True, slots=True)
+class EvolutionWorkflowInvocation:
+    workflow: dict[str, Any]
+    inputs: dict[str, str]
+    runtime_metadata: dict[str, Any]
+
+
+EvolutionWorkflowRunner = Callable[[EvolutionWorkflowInvocation], Awaitable[str]]
+
+
+class WorkflowCreatorEvolutionPlanner:
+    def __init__(self, *, model_id: str, model_available: Callable[[], bool], runner: EvolutionWorkflowRunner) -> None:
+        self.model_id = str(model_id or "").strip()
+        self.model_available = model_available
+        self.runner = runner
+
+    def available(self) -> bool:
+        return bool(self.model_id and self.model_available())
+
+    async def generate(self, request: EvolutionGenerationRequest) -> dict[str, Any]:
+        invocation = build_evolution_invocation(request, model_id=self.model_id)
+        output = await self.runner(invocation)
+        payload = parse_evolution_output(output)
+        if payload.pop("evolution_plan_version", None) != EVOLUTION_PLAN_VERSION:
+            raise SkillCreatorValidationError(
+                "Skill Creator returned an unsupported evolution plan contract.",
+                code="skill_creator_evolution_planner_invalid",
+            )
+        return payload
+
+
+def build_evolution_invocation(request: EvolutionGenerationRequest, *, model_id: str) -> EvolutionWorkflowInvocation:
+    session_id = str(request.session.get("session_id") or "").strip()
+    if not session_id:
+        raise SkillCreatorValidationError("Evolution planning is missing session_id.", code="skill_creator_evolution_planner_invalid")
+    context = {
+        "evolution_plan_version": EVOLUTION_PLAN_VERSION,
+        "session": request.session,
+        "draft": request.draft,
+        "evaluation": request.evaluation,
+        "review": request.review,
+        "suite": request.suite,
+        "resource_plan": request.resource_plan,
+        "previous_evolution_plan": request.current_plan,
+        "allowed": {
+            "case_ids": list(request.allowed_case_ids),
+            "item_ids": list(request.allowed_item_ids),
+            "requirement_ids": list(request.allowed_requirement_ids),
+            "resource_ids": list(request.allowed_resource_ids),
+            "source_ids": list(request.allowed_source_ids),
+            "workflow_step_ids": list(request.allowed_step_ids),
+        },
+        "limits": {"clarification_questions": 5, "resource_actions": 20},
+    }
+    context_text = json.dumps(context, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    if len(context_text.encode("utf-8")) > 240_000:
+        raise SkillCreatorValidationError("Skill evolution context is too large.", code="skill_creator_context_too_large")
+    workflow = {
+        "id": f"skill-evolution-{session_id}",
+        "title": "Skill Creator resource evolution planning",
+        "nodes": [
+            {"id": "evolution-input", "type": "input", "data": {"kind": "input", "variableName": "creator_request"}},
+            {
+                "id": "evolution-agent",
+                "type": "workflow_agent",
+                "data": {
+                    "kind": "workflow_agent",
+                    "agentName": CREATOR_ASSISTANT_AGENT_ID,
+                    "modelId": str(model_id or "").strip(),
+                    "agentStrategy": "function_calling",
+                    "rolePrompt": _evolution_prompt(),
+                    "taskInput": "{{creator_request}}",
+                    "outputVariable": "evolution_plan",
+                    "toolMode": "none",
+                    "toolNames": "",
+                    "maxIterations": "1",
+                    "maxToolCalls": "1",
+                    "maxToolConcurrency": "1",
+                    "parallelToolCalls": "false",
+                    "retryOnFailure": "false",
+                    "temperature": "0.1",
+                },
+            },
+            {"id": "evolution-output", "type": "output", "data": {"kind": "output", "outputVariable": "evolution_plan"}},
+        ],
+        "edges": [
+            {"id": "evolution-input-agent", "source": "evolution-input", "target": "evolution-agent"},
+            {"id": "evolution-agent-output", "source": "evolution-agent", "target": "evolution-output"},
+        ],
+    }
+    return EvolutionWorkflowInvocation(
+        workflow=workflow,
+        inputs={"creator_request": context_text},
+        runtime_metadata={
+            "creator_session_id": session_id,
+            "creator_session_revision": request.session.get("session_revision"),
+            "assistant_agent_id": CREATOR_ASSISTANT_AGENT_ID,
+            "creator_workflow_version": CREATOR_WORKFLOW_VERSION,
+            "creator_phase": "resource_evolution",
+            "evolution_workflow_version": EVOLUTION_WORKFLOW_VERSION,
+        },
+    )
+
+
+def parse_evolution_output(value: Any) -> dict[str, Any]:
+    if not isinstance(value, str):
+        raise SkillCreatorValidationError("Skill evolution planner returned non-text output.", code="skill_creator_evolution_planner_invalid")
+    text = value.strip()
+    try:
+        payload = _decode_versioned_json(text)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise SkillCreatorValidationError("Skill evolution planner did not return valid JSON.", code="skill_creator_evolution_planner_invalid") from exc
+    if not isinstance(payload, dict):
+        raise SkillCreatorValidationError("Skill evolution planner must return one JSON object.", code="skill_creator_evolution_planner_invalid")
+    return payload
+
+
+def _decode_versioned_json(text: str) -> Any:
+    if not text:
+        raise ValueError("empty evolution output")
+    try:
+        return json.loads(text)
+    except (ValueError, json.JSONDecodeError):
+        pass
+    decoder = json.JSONDecoder()
+    candidates: dict[str, dict[str, Any]] = {}
+    for index, char in enumerate(text):
+        if char != "{":
+            continue
+        try:
+            candidate, _ = decoder.raw_decode(text[index:])
+        except (ValueError, json.JSONDecodeError):
+            continue
+        if isinstance(candidate, dict) and candidate.get("evolution_plan_version") == EVOLUTION_PLAN_VERSION:
+            candidates[json.dumps(candidate, ensure_ascii=False, sort_keys=True, separators=(",", ":"))] = candidate
+    if len(candidates) != 1:
+        raise ValueError("output must contain one versioned evolution object")
+    return next(iter(candidates.values()))
+
+
+def _evolution_prompt() -> str:
+    return (
+        "You are ModelMirror's fixed private Skill evolution planner. Diagnose only from the "
+        "server-frozen evaluation item IDs, deterministic assertion status, confirmed suite, "
+        "review feedback, and current resource plan. Never quote or reconstruct old model output. "
+        "Plan the smallest change that can address the reviewed failures without overfitting. "
+        "Account for every existing resource exactly once with keep, update, or delete; create a "
+        "new resource only when an independently reusable script, reference, or UTF-8 asset is "
+        "necessary. Preserve unaffected resources. Keep unchanged scripts so their digest-bound "
+        "test receipts can be reused. Identify affected requirements, sections, evidence item IDs, "
+        "expected improvements, non-regression cases, acceptance criteria, non-goals, and overfit "
+        "risks. If evidence is insufficient, ask at most five concrete questions and do not invent "
+        "domain rules. Return exactly one JSON object and no prose or Markdown. The object must use "
+        'evolution_plan_version="skill-evolution-plan-v1" and contain diagnoses, actions, '
+        "workflow_steps, output_contract, failure_modes, expected_improvements, acceptance_criteria, "
+        "non_goals, overfitting_risks, and clarifications. Existing resource actions must name only "
+        "allowed resource_id values; their path and kind are server-controlled. Create actions omit "
+        "resource_id and use a safe path under scripts/, references/, or assets/. Every action includes "
+        "purpose, source_ids, used_by_steps, depends_on, acceptance_checks, related_case_ids, "
+        "expected_improvement, and non_regression_case_ids."
+    )
+
+
+__all__ = [
+    "EVOLUTION_WORKFLOW_VERSION",
+    "EvolutionWorkflowInvocation",
+    "WorkflowCreatorEvolutionPlanner",
+    "build_evolution_invocation",
+    "parse_evolution_output",
+]

--- a/server/skills/creator_evolution_service.py
+++ b/server/skills/creator_evolution_service.py
@@ -1,0 +1,848 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import threading
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping, Protocol
+
+from .creator_evaluation import SkillEvaluationRun, SkillEvaluationStore
+from .creator_evaluation_suite import SkillEvaluationSuite, SkillEvaluationSuiteStore
+from .creator_evolution import SkillEvolutionPlan, SkillEvolutionPlanStore
+from .creator_resource_plan import SkillResourcePlan, SkillResourcePlanStore
+from .creator_resource_build import SkillResourceBuildStore
+from .creator_resource_service import SkillCreatorResourcePlanningService
+from .creator_service import SkillCreatorService
+from .creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorNotFoundError,
+    SkillCreatorSession,
+    SkillCreatorValidationError,
+)
+from .draft_store import WorkspaceSkillDraft
+from .package_validation import compute_package_digest
+
+
+EVOLUTION_SERVICE_VERSION = "skill-creator-resource-evolution-v1"
+
+
+@dataclass(frozen=True, slots=True)
+class EvolutionGenerationRequest:
+    session: dict[str, Any]
+    draft: dict[str, Any]
+    evaluation: dict[str, Any]
+    review: dict[str, Any]
+    suite: dict[str, Any]
+    resource_plan: dict[str, Any]
+    current_plan: dict[str, Any] | None
+    allowed_case_ids: tuple[str, ...]
+    allowed_item_ids: tuple[str, ...]
+    allowed_requirement_ids: tuple[str, ...]
+    allowed_resource_ids: tuple[str, ...]
+    allowed_source_ids: tuple[str, ...]
+    allowed_step_ids: tuple[str, ...]
+
+
+class EvolutionPlanner(Protocol):
+    def available(self) -> bool: ...
+
+    async def generate(self, request: EvolutionGenerationRequest) -> dict[str, Any]: ...
+
+
+class SkillCreatorEvolutionService:
+    """Turn one frozen revise review into a user-confirmed resource revision."""
+
+    VERSION = EVOLUTION_SERVICE_VERSION
+
+    def __init__(
+        self,
+        creator_service: SkillCreatorService,
+        evolution_store: SkillEvolutionPlanStore,
+        evaluation_store: SkillEvaluationStore,
+        suite_store: SkillEvaluationSuiteStore,
+        resource_planning_service: SkillCreatorResourcePlanningService,
+        *,
+        resource_build_store: SkillResourceBuildStore | None = None,
+        planner: EvolutionPlanner | None = None,
+        enabled: bool | None = None,
+    ) -> None:
+        self.creator_service = creator_service
+        self.evolution_store = evolution_store
+        self.evaluation_store = evaluation_store
+        self.suite_store = suite_store
+        self.resource_planning_service = resource_planning_service
+        self.resource_plan_store = resource_planning_service.plan_store
+        self.resource_build_store = resource_build_store
+        self.planner = planner
+        self.enabled = (
+            os.getenv("SKILL_CREATOR_EVOLUTION_V2_ENABLED", "false").strip().lower()
+            in {"1", "true", "yes", "on"}
+            if enabled is None
+            else bool(enabled)
+        )
+        self._locks_guard = threading.RLock()
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def status(self) -> dict[str, Any]:
+        try:
+            planner_available = bool(self.planner and self.planner.available())
+        except Exception:
+            planner_available = False
+        store_status = self.evolution_store.status()
+        return {
+            "evolution_version": self.VERSION,
+            "evolution_enabled": self.enabled,
+            "evolution_planner_available": self.enabled and planner_available,
+            "evolution_store_available": bool(store_status["available"]),
+        }
+
+    def require_enabled(self) -> None:
+        self.creator_service.require_enabled()
+        self.resource_planning_service.require_enabled()
+        if not self.enabled:
+            raise SkillCreatorValidationError(
+                "Skill Creator Evolution V2 is disabled.",
+                code="skill_creator_evolution_v2_disabled",
+            )
+
+    def current_projection(self, session_id: str) -> dict[str, Any] | None:
+        self.creator_service.require_enabled()
+        session, draft = self.creator_service.get_session(session_id)
+        current = self.evolution_store.current_for_session(session_id)
+        if current is None:
+            return None
+        stale = draft is None or self._is_stale(current, session=session, draft=draft)
+        if not stale and draft is not None:
+            try:
+                self._facts_for_plan(current, session=session, draft=draft)
+            except (SkillCreatorConflictError, SkillCreatorNotFoundError, SkillCreatorValidationError):
+                stale = True
+        if stale and current.state != "stale":
+            try:
+                current = self.evolution_store.mark_stale(
+                    current.plan_id,
+                    expected_revision=current.revision,
+                    expected_digest=current.digest,
+                )
+            except SkillCreatorConflictError:
+                latest = self.evolution_store.current_for_session(session_id)
+                if latest is not None:
+                    current = latest
+                    stale = draft is None or self._is_stale(
+                        current,
+                        session=session,
+                        draft=draft,
+                    )
+        result = self.evolution_store.serialize(current)
+        result["stale"] = stale
+        result["resource_plan"] = self._materialized_resource_projection(current)
+        return result
+
+    async def generate(
+        self,
+        session_id: str,
+        *,
+        evaluation_run_id: str,
+        expected_session_revision: int,
+        expected_draft_state_revision: int,
+        expected_draft_revision: int,
+        expected_draft_digest: str,
+        expected_review_revision: int,
+        expected_run_revision: int,
+        expected_resource_plan_revision: int,
+        expected_resource_plan_digest: str,
+        expected_evolution_revision: int | None,
+        expected_evolution_digest: str | None,
+    ) -> SkillEvolutionPlan:
+        self.require_enabled()
+        # Validate existence before allocating a per-session lock. The Session
+        # Store already bounds real sessions, while arbitrary missing IDs must
+        # not grow the in-memory lock table.
+        self.creator_service.get_session(session_id)
+        async with self._lock(session_id):
+            facts = self._require_facts(
+                session_id,
+                evaluation_run_id=evaluation_run_id,
+                expected_session_revision=expected_session_revision,
+                expected_draft_state_revision=expected_draft_state_revision,
+                expected_draft_revision=expected_draft_revision,
+                expected_draft_digest=expected_draft_digest,
+                expected_review_revision=expected_review_revision,
+                expected_run_revision=expected_run_revision,
+                expected_resource_plan_revision=expected_resource_plan_revision,
+                expected_resource_plan_digest=expected_resource_plan_digest,
+            )
+            planner = self.planner
+            try:
+                available = bool(planner and planner.available())
+            except Exception as exc:
+                raise SkillCreatorValidationError(
+                    "Skill evolution planner status is unavailable.",
+                    code="skill_creator_evolution_planner_failed",
+                ) from exc
+            if not available or planner is None:
+                raise SkillCreatorValidationError(
+                    "The Skill Creator model gateway is not configured.",
+                    code="model_gateway_unconfigured",
+                )
+            request = self._generation_request(*facts)
+            try:
+                payload = await planner.generate(request)
+            except SkillCreatorValidationError:
+                raise
+            except Exception as exc:
+                raise SkillCreatorValidationError(
+                    "The Skill evolution planner failed.",
+                    code="skill_creator_evolution_planner_failed",
+                ) from exc
+            facts = self._require_facts(
+                session_id,
+                evaluation_run_id=evaluation_run_id,
+                expected_session_revision=expected_session_revision,
+                expected_draft_state_revision=expected_draft_state_revision,
+                expected_draft_revision=expected_draft_revision,
+                expected_draft_digest=expected_draft_digest,
+                expected_review_revision=expected_review_revision,
+                expected_run_revision=expected_run_revision,
+                expected_resource_plan_revision=expected_resource_plan_revision,
+                expected_resource_plan_digest=expected_resource_plan_digest,
+            )
+            session, draft, run, suite, resource_plan = facts
+            self._require_payload_evidence_links(payload, run)
+            return self.evolution_store.save_generated(
+                bindings=self._bindings(session, draft, run, suite, resource_plan),
+                payload=payload,
+                **self._allowed(request, resource_plan),
+                expected_plan_revision=expected_evolution_revision,
+                expected_plan_digest=expected_evolution_digest,
+            )
+
+    def save_answers(
+        self,
+        session_id: str,
+        *,
+        plan_id: str,
+        expected_session_revision: int,
+        expected_draft_state_revision: int,
+        expected_draft_revision: int,
+        expected_draft_digest: str,
+        expected_plan_revision: int,
+        expected_plan_digest: str,
+        answers: Mapping[str, Any],
+    ) -> SkillEvolutionPlan:
+        self.require_enabled()
+        session, draft = self._require_context(
+            session_id,
+            expected_session_revision,
+            expected_draft_state_revision,
+            expected_draft_revision,
+            expected_draft_digest,
+        )
+        current = self.evolution_store.require(plan_id)
+        self._require_plan_scope(current, session=session, draft=draft)
+        self._facts_for_plan(current, session=session, draft=draft)
+        return self.evolution_store.save_answers(
+            plan_id,
+            expected_revision=expected_plan_revision,
+            expected_digest=expected_plan_digest,
+            answers=answers,
+        )
+
+    def patch(
+        self,
+        session_id: str,
+        *,
+        plan_id: str,
+        expected_session_revision: int,
+        expected_draft_state_revision: int,
+        expected_draft_revision: int,
+        expected_draft_digest: str,
+        expected_plan_revision: int,
+        expected_plan_digest: str,
+        changes: Mapping[str, Any],
+    ) -> SkillEvolutionPlan:
+        self.require_enabled()
+        session, draft = self._require_context(
+            session_id,
+            expected_session_revision,
+            expected_draft_state_revision,
+            expected_draft_revision,
+            expected_draft_digest,
+        )
+        current = self.evolution_store.require(plan_id)
+        self._require_plan_scope(current, session=session, draft=draft)
+        facts = self._facts_for_plan(current, session=session, draft=draft)
+        request = self._generation_request(*facts)
+        resource_plan = facts[-1]
+        return self.evolution_store.patch(
+            plan_id,
+            expected_revision=expected_plan_revision,
+            expected_digest=expected_plan_digest,
+            changes=changes,
+            **self._allowed(request, resource_plan),
+        )
+
+    def confirm(
+        self,
+        session_id: str,
+        *,
+        plan_id: str,
+        expected_session_revision: int,
+        expected_draft_state_revision: int,
+        expected_draft_revision: int,
+        expected_draft_digest: str,
+        expected_plan_revision: int,
+        expected_plan_digest: str,
+    ) -> tuple[SkillEvolutionPlan, SkillResourcePlan]:
+        self.require_enabled()
+        session, draft = self._require_context(
+            session_id,
+            expected_session_revision,
+            expected_draft_state_revision,
+            expected_draft_revision,
+            expected_draft_digest,
+        )
+        current = self.evolution_store.require(plan_id)
+        self._require_plan_scope(current, session=session, draft=draft)
+        self._facts_for_plan(current, session=session, draft=draft)
+        if current.revision == expected_plan_revision + 1 and current.state == "confirmed":
+            previous = self.evolution_store.require(plan_id, expected_plan_revision)
+            if previous.digest != str(expected_plan_digest).lower():
+                raise SkillCreatorConflictError("Evolution plan changed. Reload before continuing.")
+            confirmed = current
+        else:
+            confirmed = self.evolution_store.confirm(
+                plan_id,
+                expected_revision=expected_plan_revision,
+                expected_digest=expected_plan_digest,
+            )
+        resource_plan = self._materialize_resource_plan(confirmed, session=session, draft=draft)
+        return confirmed, resource_plan
+
+    def _require_facts(
+        self,
+        session_id: str,
+        *,
+        evaluation_run_id: str,
+        expected_session_revision: int,
+        expected_draft_state_revision: int,
+        expected_draft_revision: int,
+        expected_draft_digest: str,
+        expected_review_revision: int,
+        expected_run_revision: int,
+        expected_resource_plan_revision: int,
+        expected_resource_plan_digest: str,
+    ) -> tuple[SkillCreatorSession, WorkspaceSkillDraft, SkillEvaluationRun, SkillEvaluationSuite, SkillResourcePlan]:
+        session, draft = self._require_context(
+            session_id,
+            expected_session_revision,
+            expected_draft_state_revision,
+            expected_draft_revision,
+            expected_draft_digest,
+        )
+        run = self.evaluation_store.require_run(evaluation_run_id)
+        if (
+            run.revision != int(expected_run_revision)
+            or
+            run.session_id != session.session_id
+            or run.draft_id != draft.draft_id
+            or run.draft_revision != draft.content_revision
+            or run.frozen_digest != draft.content_digest
+            or run.review_state != "revise"
+            or not run.reviews
+            or run.reviews[-1].review_revision != int(expected_review_revision)
+        ):
+            raise SkillCreatorConflictError(
+                "Only the current draft's frozen revise review can create an evolution plan."
+            )
+        review = run.reviews[-1]
+        if not (review.reason or review.feedback).strip():
+            raise SkillCreatorValidationError(
+                "Revision feedback is required before planning evolution.",
+                code="skill_evaluation_feedback_required",
+            )
+        if not run.evaluation_suite_id or not run.evaluation_suite_revision or not run.evaluation_suite_digest:
+            raise SkillCreatorValidationError(
+                "Migrate and confirm a V2 evaluation suite before planning evolution.",
+                code="skill_creator_evolution_suite_required",
+            )
+        suite = self.suite_store.require(run.evaluation_suite_id, revision=run.evaluation_suite_revision)
+        if (
+            suite.suite_digest != run.evaluation_suite_digest
+            or suite.session_id != session.session_id
+            or suite.draft_id != draft.draft_id
+            or suite.draft_revision != draft.content_revision
+            or suite.draft_digest != draft.content_digest
+            or suite.state != "confirmed"
+        ):
+            raise SkillCreatorConflictError("The evaluation suite no longer matches the frozen review.")
+        resource_plan = self.resource_plan_store.current_for_session(session.session_id)
+        if (
+            resource_plan is None
+            or resource_plan.revision != int(expected_resource_plan_revision)
+            or resource_plan.digest != str(expected_resource_plan_digest).lower()
+            or resource_plan.state != "confirmed"
+            or not self._resource_plan_produced_draft(
+                resource_plan, session=session, draft=draft
+            )
+        ):
+            raise SkillCreatorConflictError(
+                "The confirmed resource plan no longer matches the evaluated draft."
+            )
+        return session, draft, run, suite, resource_plan
+
+    def _resource_plan_produced_draft(
+        self,
+        plan: SkillResourcePlan,
+        *,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft,
+    ) -> bool:
+        if (
+            plan.session_id == session.session_id
+            and plan.draft_id == draft.draft_id
+            and plan.draft_revision == draft.revision
+            and plan.draft_digest == draft.content_digest
+        ):
+            return True
+        if self.resource_build_store is None or not draft.source_proposal_id:
+            return False
+        build = self.resource_build_store.current_for_session(session.session_id)
+        if (
+            build is None
+            or build.plan_id != plan.plan_id
+            or build.plan_revision != plan.revision
+            or build.plan_digest != plan.digest
+            or build.proposal_id != draft.source_proposal_id
+            or build.state != "accepted"
+            or build.phase != "proposal"
+            or not build.skill_markdown
+        ):
+            return False
+        files = {
+            item.path: item.content
+            for item in build.resources
+            if item.action != "delete" and item.content is not None
+        }
+        files.update(
+            {
+                path: content
+                for path, content in draft.files.items()
+                if path.startswith("agents/")
+            }
+        )
+        try:
+            built_digest = compute_package_digest(build.skill_markdown, files)
+        except (TypeError, ValueError):
+            return False
+        return built_digest == draft.content_digest
+
+    def _facts_for_plan(
+        self,
+        plan: SkillEvolutionPlan,
+        *,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft,
+    ) -> tuple[SkillCreatorSession, WorkspaceSkillDraft, SkillEvaluationRun, SkillEvaluationSuite, SkillResourcePlan]:
+        run = self.evaluation_store.require_run(plan.evaluation_run_id)
+        suite = self.suite_store.require(plan.suite_id, revision=plan.suite_revision)
+        resource_plan = self.resource_plan_store.require(plan.resource_plan_id, plan.resource_plan_revision)
+        review = run.reviews[-1] if run.reviews else None
+        if (
+            run.revision != plan.evaluation_run_revision
+            or run.session_id != session.session_id
+            or run.draft_id != draft.draft_id
+            or run.draft_revision != draft.content_revision
+            or run.frozen_digest != draft.content_digest
+            or run.status != "completed"
+            or run.review_state != "revise"
+            or review is None
+            or review.review_id != plan.review_id
+            or review.review_revision != plan.review_revision
+            or suite.suite_digest != plan.suite_digest
+            or suite.session_id != session.session_id
+            or suite.draft_id != draft.draft_id
+            or suite.draft_revision != draft.content_revision
+            or suite.draft_digest != draft.content_digest
+            or suite.state != "confirmed"
+            or resource_plan.digest != plan.resource_plan_digest
+            or resource_plan.session_id != session.session_id
+            or resource_plan.state != "confirmed"
+            or not self._resource_plan_produced_draft(
+                resource_plan,
+                session=session,
+                draft=draft,
+            )
+        ):
+            raise SkillCreatorConflictError("Frozen evolution evidence changed unexpectedly.")
+        self._require_plan_evidence_links(plan, run)
+        return session, draft, run, suite, resource_plan
+
+    def _generation_request(
+        self,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft,
+        run: SkillEvaluationRun,
+        suite: SkillEvaluationSuite,
+        resource_plan: SkillResourcePlan,
+    ) -> EvolutionGenerationRequest:
+        current = self.evolution_store.current_for_session(session.session_id)
+        item_projection = []
+        for item in run.items:
+            if item.target != "candidate":
+                continue
+            item_projection.append({
+                "item_id": item.item_id,
+                "case_id": item.case_id,
+                "status": item.status,
+                "error_code": item.error_code,
+                "assertion_results": [
+                    {
+                        "assertion_id": str(result.get("assertion_id") or result.get("id") or "")[:200],
+                        "passed": result.get("passed") is True,
+                        "code": str(result.get("code") or "")[:200],
+                    }
+                    for result in item.assertion_results[:30]
+                    if isinstance(result, Mapping)
+                ],
+                "application_compliance": item.application_compliance,
+            })
+        review = run.reviews[-1]
+        return EvolutionGenerationRequest(
+            session={
+                "session_id": session.session_id,
+                "session_revision": session.session_revision,
+                "intent": session.intent,
+                "expected_output": session.expected_output,
+                "success_criteria": list(session.success_criteria),
+            },
+            draft={
+                "draft_id": draft.draft_id,
+                "draft_state_revision": draft.revision,
+                "draft_revision": draft.content_revision,
+                "draft_digest": draft.content_digest,
+                "name": draft.name,
+                "description": draft.description,
+                "skill_markdown_headings": self._markdown_headings(draft.skill_markdown),
+                "resource_inventory": [
+                    {"path": path, "sha256": hashlib.sha256(content.encode("utf-8")).hexdigest()}
+                    for path, content in sorted(draft.files.items())
+                    if path.startswith(("scripts/", "references/", "assets/"))
+                ],
+            },
+            evaluation={
+                "run_id": run.run_id,
+                "run_revision": run.revision,
+                "items": item_projection,
+            },
+            review={
+                "review_id": review.review_id,
+                "review_revision": review.review_revision,
+                "reason": review.reason,
+                "feedback": review.feedback,
+            },
+            suite={
+                "suite_id": suite.suite_id,
+                "suite_revision": suite.suite_revision,
+                "suite_digest": suite.suite_digest,
+                "cases": [
+                    {
+                        "case_id": case.case_id,
+                        "role": case.role,
+                        "name": case.name,
+                        "expected_behavior": case.expected_behavior,
+                        "requirement_ids": list(case.requirement_ids),
+                        "required_resource_paths": list(case.required_resource_paths),
+                        "workflow_step_ids": list(case.workflow_step_ids),
+                    }
+                    for case in suite.cases
+                ],
+            },
+            resource_plan=SkillResourcePlanStore.serialize(resource_plan),
+            current_plan=(self.evolution_store.serialize(current) if current else None),
+            allowed_case_ids=tuple(case.case_id for case in suite.cases),
+            allowed_item_ids=tuple(item["item_id"] for item in item_projection),
+            allowed_requirement_ids=tuple(sorted({item for case in suite.cases for item in case.requirement_ids})),
+            allowed_resource_ids=tuple(item.resource_id for item in resource_plan.resources),
+            allowed_source_ids=tuple(sorted(self.resource_planning_service._source_ids(session))),
+            allowed_step_ids=tuple(item.step_id for item in resource_plan.workflow_steps),
+        )
+
+    @staticmethod
+    def _allowed(request: EvolutionGenerationRequest, resource_plan: SkillResourcePlan) -> dict[str, Any]:
+        return {
+            "allowed_case_ids": set(request.allowed_case_ids),
+            "allowed_item_ids": set(request.allowed_item_ids),
+            "allowed_requirement_ids": set(request.allowed_requirement_ids),
+            "allowed_resources": {
+                item.resource_id: {"kind": item.kind, "path": item.path}
+                for item in resource_plan.resources
+            },
+            "allowed_source_ids": set(request.allowed_source_ids),
+            "allowed_step_ids": set(request.allowed_step_ids),
+        }
+
+    @staticmethod
+    def _candidate_item_cases(run: SkillEvaluationRun) -> dict[str, str]:
+        return {
+            item.item_id: item.case_id
+            for item in run.items
+            if item.target == "candidate"
+        }
+
+    @classmethod
+    def _require_payload_evidence_links(
+        cls,
+        payload: Any,
+        run: SkillEvaluationRun,
+    ) -> None:
+        if not isinstance(payload, Mapping):
+            return
+        diagnoses = payload.get("diagnoses")
+        if not isinstance(diagnoses, list):
+            return
+        item_cases = cls._candidate_item_cases(run)
+        for diagnosis in diagnoses:
+            if not isinstance(diagnosis, Mapping):
+                continue
+            case_id = str(diagnosis.get("case_id") or "").strip()
+            item_ids = diagnosis.get("evidence_item_ids")
+            if not isinstance(item_ids, list):
+                continue
+            if any(
+                item_cases.get(str(item_id or "").strip()) not in {None, case_id}
+                for item_id in item_ids
+            ):
+                raise SkillCreatorValidationError(
+                    "Evolution evidence items must belong to the diagnosed case.",
+                    code="skill_creator_evolution_evidence_invalid",
+                )
+
+    @classmethod
+    def _require_plan_evidence_links(
+        cls,
+        plan: SkillEvolutionPlan,
+        run: SkillEvaluationRun,
+    ) -> None:
+        item_cases = cls._candidate_item_cases(run)
+        if any(
+            item_cases.get(item_id) != diagnosis.case_id
+            for diagnosis in plan.diagnoses
+            for item_id in diagnosis.evidence_item_ids
+        ):
+            raise SkillCreatorValidationError(
+                "Evolution evidence items no longer match the diagnosed case.",
+                code="skill_creator_evolution_evidence_invalid",
+            )
+
+    @staticmethod
+    def _bindings(
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft,
+        run: SkillEvaluationRun,
+        suite: SkillEvaluationSuite,
+        resource_plan: SkillResourcePlan,
+    ) -> dict[str, Any]:
+        review = run.reviews[-1]
+        return {
+            "session_id": session.session_id,
+            "session_revision": session.session_revision,
+            "draft_id": draft.draft_id,
+            "draft_state_revision": draft.revision,
+            "draft_revision": draft.content_revision,
+            "draft_digest": draft.content_digest,
+            "evaluation_run_id": run.run_id,
+            "evaluation_run_revision": run.revision,
+            "review_id": review.review_id,
+            "review_revision": review.review_revision,
+            "suite_id": suite.suite_id,
+            "suite_revision": suite.suite_revision,
+            "suite_digest": suite.suite_digest,
+            "resource_plan_id": resource_plan.plan_id,
+            "resource_plan_revision": resource_plan.revision,
+            "resource_plan_digest": resource_plan.digest,
+        }
+
+    def _materialize_resource_plan(
+        self,
+        evolution: SkillEvolutionPlan,
+        *,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft,
+    ) -> SkillResourcePlan:
+        source = self.resource_plan_store.require(
+            evolution.resource_plan_id, evolution.resource_plan_revision
+        )
+        if source.digest != evolution.resource_plan_digest:
+            raise SkillCreatorConflictError("The source resource plan no longer matches evolution evidence.")
+        payload = self._resource_plan_payload(evolution, source)
+        ready = self.resource_plan_store.save_evolution_revision(
+            source_plan_id=source.plan_id,
+            source_revision=source.revision,
+            source_digest=source.digest,
+            session_revision=session.session_revision,
+            draft_id=draft.draft_id,
+            draft_revision=draft.revision,
+            draft_digest=draft.content_digest,
+            payload=payload,
+            allowed_source_ids=self.resource_planning_service._source_ids(session),
+        )
+        return self.resource_plan_store.confirm(
+            ready.plan_id,
+            expected_revision=ready.revision,
+            expected_digest=ready.digest,
+            session_revision=session.session_revision,
+            draft_revision=draft.revision,
+            draft_digest=draft.content_digest,
+        ) if ready.state == "ready" else ready
+
+    def _materialized_resource_projection(self, evolution: SkillEvolutionPlan) -> dict[str, Any] | None:
+        if evolution.state != "confirmed":
+            return None
+        try:
+            source = self.resource_plan_store.require(
+                evolution.resource_plan_id,
+                evolution.resource_plan_revision,
+            )
+        except (SkillCreatorConflictError, SkillCreatorNotFoundError, SkillCreatorValidationError):
+            return None
+        for revision in (source.revision + 2, source.revision + 1):
+            try:
+                candidate = self.resource_plan_store.require(source.plan_id, revision)
+            except SkillCreatorNotFoundError:
+                continue
+            if self._resource_plan_matches_evolution(candidate, evolution=evolution, source=source):
+                return SkillResourcePlanStore.serialize(candidate)
+        return None
+
+    @staticmethod
+    def _resource_plan_payload(
+        evolution: SkillEvolutionPlan,
+        source: SkillResourcePlan,
+    ) -> dict[str, Any]:
+        path_by_id = {item.resource_id: item.path for item in evolution.actions}
+        source_by_id = {item.resource_id: item for item in source.resources}
+        resources = []
+        for action in evolution.actions:
+            source_item = source_by_id.get(action.resource_id)
+            resources.append({
+                "resource_id": action.resource_id,
+                "kind": action.kind,
+                "action": action.action,
+                "generation_cost": source_item.generation_cost if source_item is not None else "medium",
+                "path": action.path,
+                "purpose": action.purpose,
+                "source_ids": list(action.source_ids),
+                "used_by_steps": list(action.used_by_steps),
+                "depends_on": [path_by_id[item] for item in action.depends_on],
+                "acceptance_checks": list(action.acceptance_checks),
+            })
+        return {
+            "skill_name": source.skill_name,
+            "skill_description": source.skill_description,
+            "workflow_steps": list(evolution.workflow_steps),
+            "output_contract": list(evolution.output_contract),
+            "failure_modes": list(evolution.failure_modes),
+            "resources": resources,
+        }
+
+    @staticmethod
+    def _resource_plan_matches_evolution(
+        candidate: SkillResourcePlan,
+        *,
+        evolution: SkillEvolutionPlan,
+        source: SkillResourcePlan,
+    ) -> bool:
+        if (
+            candidate.plan_id != source.plan_id
+            or candidate.revision not in {source.revision + 1, source.revision + 2}
+            or candidate.state not in {"ready", "confirmed"}
+            or candidate.session_id != evolution.session_id
+            or candidate.session_revision != evolution.session_revision
+            or candidate.draft_id != evolution.draft_id
+            or candidate.draft_revision != evolution.draft_state_revision
+            or candidate.draft_digest != evolution.draft_digest
+            or candidate.skill_name != source.skill_name
+            or candidate.skill_description != source.skill_description
+            or tuple((item.step_id, item.instruction) for item in candidate.workflow_steps)
+            != tuple((item["step_id"], item["instruction"]) for item in evolution.workflow_steps)
+            or tuple(candidate.output_contract) != tuple(evolution.output_contract)
+            or tuple(candidate.failure_modes) != tuple(evolution.failure_modes)
+            or len(candidate.resources) != len(evolution.actions)
+        ):
+            return False
+        source_by_id = {item.resource_id: item for item in source.resources}
+        for actual, expected in zip(candidate.resources, evolution.actions):
+            source_item = source_by_id.get(expected.resource_id)
+            expected_cost = source_item.generation_cost if source_item is not None else "medium"
+            if (
+                actual.resource_id != expected.resource_id
+                or actual.kind != expected.kind
+                or actual.action != expected.action
+                or actual.generation_cost != expected_cost
+                or actual.path != expected.path
+                or actual.purpose != expected.purpose
+                or tuple(actual.source_ids) != tuple(expected.source_ids)
+                or tuple(actual.used_by_steps) != tuple(expected.used_by_steps)
+                or tuple(actual.depends_on) != tuple(expected.depends_on)
+                or tuple(actual.acceptance_checks) != tuple(expected.acceptance_checks)
+            ):
+                return False
+        return True
+
+    def _require_context(
+        self,
+        session_id: str,
+        expected_session_revision: int,
+        expected_draft_state_revision: int,
+        expected_draft_revision: int,
+        expected_draft_digest: str,
+    ) -> tuple[SkillCreatorSession, WorkspaceSkillDraft]:
+        session, draft = self.creator_service.get_session(session_id)
+        if draft is None:
+            raise SkillCreatorValidationError("Create a Skill draft before planning evolution.", code="skill_creator_draft_required")
+        if (
+            session.session_revision != int(expected_session_revision)
+            or draft.revision != int(expected_draft_state_revision)
+            or draft.content_revision != int(expected_draft_revision)
+            or draft.content_digest != str(expected_draft_digest).lower()
+        ):
+            raise SkillCreatorConflictError("Creator session or draft changed. Reload before continuing.")
+        return session, draft
+
+    @staticmethod
+    def _require_plan_scope(plan: SkillEvolutionPlan, *, session: SkillCreatorSession, draft: WorkspaceSkillDraft) -> None:
+        if SkillCreatorEvolutionService._is_stale(plan, session=session, draft=draft):
+            raise SkillCreatorConflictError("Evolution plan no longer matches the current session and draft.")
+
+    @staticmethod
+    def _is_stale(plan: SkillEvolutionPlan, *, session: SkillCreatorSession, draft: WorkspaceSkillDraft) -> bool:
+        return bool(
+            plan.session_id != session.session_id
+            or plan.session_revision != session.session_revision
+            or plan.draft_id != draft.draft_id
+            or plan.draft_state_revision != draft.revision
+            or plan.draft_revision != draft.content_revision
+            or plan.draft_digest != draft.content_digest
+        )
+
+    @staticmethod
+    def _markdown_headings(markdown: str) -> list[str]:
+        return [line.lstrip("#").strip()[:300] for line in markdown.splitlines() if line.startswith("#")][:80]
+
+    def _lock(self, session_id: str) -> asyncio.Lock:
+        with self._locks_guard:
+            lock = self._locks.get(session_id)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[session_id] = lock
+            return lock
+
+
+__all__ = [
+    "EVOLUTION_SERVICE_VERSION",
+    "EvolutionGenerationRequest",
+    "EvolutionPlanner",
+    "SkillCreatorEvolutionService",
+]

--- a/server/skills/creator_resource_plan.py
+++ b/server/skills/creator_resource_plan.py
@@ -401,9 +401,106 @@ class SkillResourcePlanStore:
             )
             return self._append_unlocked(item)
 
+    def save_evolution_revision(
+        self,
+        *,
+        source_plan_id: str,
+        source_revision: int,
+        source_digest: str,
+        session_revision: int,
+        draft_id: str,
+        draft_revision: int,
+        draft_digest: str,
+        payload: dict[str, Any],
+        allowed_source_ids: set[str],
+    ) -> SkillResourcePlan:
+        """Create one server-owned revision rebound to the reviewed session facts.
+
+        Public plan editing deliberately retains the original bindings. Evolution is
+        the only flow allowed to rebind an immutable plan after an evaluation review
+        advances the Creator session revision. The operation is idempotent across a
+        crash between this Store and the Evolution Store.
+        """
+
+        clean_plan_id = self._required_text(source_plan_id, "source_plan_id", 200)
+        clean_source_digest = self._optional_digest(source_digest, "source_digest")
+        normalized = self._normalize_payload(
+            {**dict(payload), "clarifications": []},
+            allowed_source_ids=allowed_source_ids,
+        )
+        clean_bindings = {
+            "session_revision": self._positive_int(session_revision, "session_revision"),
+            "draft_id": self._optional_text(draft_id, 200),
+            "draft_revision": self._positive_int(draft_revision, "draft_revision"),
+            "draft_digest": self._optional_digest(draft_digest, "draft_digest"),
+        }
+        with self._lock:
+            self._ensure_writable_unlocked()
+            revisions = self._plans.get(clean_plan_id)
+            if not revisions or int(source_revision) < 1 or int(source_revision) > len(revisions):
+                raise SkillCreatorNotFoundError(
+                    f"Resource plan revision not found: {clean_plan_id}@{source_revision}"
+                )
+            source = revisions[int(source_revision) - 1]
+            if source.digest != clean_source_digest or source.state != "confirmed":
+                raise SkillCreatorConflictError(
+                    "The source resource plan changed before evolution was confirmed."
+                )
+            current = revisions[-1]
+            if current.revision > source.revision:
+                if self._matches_evolution_revision(
+                    current,
+                    source=source,
+                    normalized=normalized,
+                    bindings=clean_bindings,
+                ):
+                    return self._copy(current)
+                raise SkillCreatorConflictError(
+                    "A different resource plan revision already superseded this evolution source."
+                )
+            if current.revision != source.revision:
+                raise SkillCreatorConflictError("Resource plan revision is no longer current.")
+            item = self._build_plan(
+                plan_id=source.plan_id,
+                session_id=source.session_id,
+                revision=source.revision + 1,
+                state="ready",
+                clarification_answers={},
+                created_at=source.created_at,
+                updated_at=time.time(),
+                **clean_bindings,
+                **normalized,
+            )
+            return self._append_unlocked(item)
+
     @staticmethod
     def serialize(item: SkillResourcePlan) -> dict[str, Any]:
         return asdict(item)
+
+    @staticmethod
+    def _matches_evolution_revision(
+        current: SkillResourcePlan,
+        *,
+        source: SkillResourcePlan,
+        normalized: dict[str, Any],
+        bindings: dict[str, Any],
+    ) -> bool:
+        if current.revision not in {source.revision + 1, source.revision + 2}:
+            return False
+        if current.state not in {"ready", "confirmed"}:
+            return False
+        return bool(
+            current.session_revision == bindings["session_revision"]
+            and current.draft_id == bindings["draft_id"]
+            and current.draft_revision == bindings["draft_revision"]
+            and current.draft_digest == bindings["draft_digest"]
+            and current.skill_name == normalized["skill_name"]
+            and current.skill_description == normalized["skill_description"]
+            and current.workflow_steps == normalized["workflow_steps"]
+            and current.output_contract == normalized["output_contract"]
+            and current.failure_modes == normalized["failure_modes"]
+            and current.resources == normalized["resources"]
+        )
 
     def _normalize_payload(
         self, payload: dict[str, Any], *, allowed_source_ids: set[str]

--- a/server/tests/test_skill_creator_evolution.py
+++ b/server/tests/test_skill_creator_evolution.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+import pytest
+
+from server.skills.creator_evolution import SkillEvolutionPlanStore
+from server.skills.creator_resource_plan import SkillResourcePlanStore
+from server.skills.creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorStorageError,
+    SkillCreatorValidationError,
+)
+
+
+HEX_A = "a" * 64
+HEX_B = "b" * 64
+HEX_C = "c" * 64
+HEX_D = "d" * 64
+
+
+def _bindings() -> dict[str, object]:
+    return {
+        "session_id": "skillcreator_test",
+        "session_revision": 7,
+        "draft_id": "skilldraft_test",
+        "draft_state_revision": 5,
+        "draft_revision": 3,
+        "draft_digest": HEX_A,
+        "evaluation_run_id": "skill_eval_run_test",
+        "evaluation_run_revision": 11,
+        "review_id": "skill_eval_review_test",
+        "review_revision": 1,
+        "suite_id": "skill_eval_suite_test",
+        "suite_revision": 2,
+        "suite_digest": HEX_B,
+        "resource_plan_id": "skillplan_test",
+        "resource_plan_revision": 4,
+        "resource_plan_digest": HEX_C,
+    }
+
+
+def _payload(*, questions: bool = False) -> dict[str, object]:
+    return {
+        "diagnoses": [
+            {
+                "case_id": "core-normal",
+                "evidence_item_ids": ["skill_eval_item_candidate"],
+                "failure_types": ["assertion_failure"],
+                "requirement_ids": ["intent"],
+                "resource_ids": ["skillres_existing"],
+                "sections": ["Workflow"],
+                "summary": "The deterministic normalization step was not applied.",
+            }
+        ],
+        "actions": [
+            {
+                "action_id": "update-normalizer",
+                "action": "update",
+                "resource_id": "skillres_existing",
+                "purpose": "Normalize the input deterministically.",
+                "source_ids": ["intent"],
+                "used_by_steps": ["normalize"],
+                "depends_on": [],
+                "acceptance_checks": ["The CLI exits non-zero for invalid input."],
+                "related_case_ids": ["core-normal"],
+                "expected_improvement": "The failed normalization assertion passes.",
+                "non_regression_case_ids": ["core-boundary"],
+            }
+        ],
+        "workflow_steps": [
+            {"step_id": "inspect", "instruction": "Inspect the supplied records."},
+            {"step_id": "normalize", "instruction": "Run the deterministic normalizer."},
+            {"step_id": "verify", "instruction": "Verify every normalized field."},
+            {"step_id": "render", "instruction": "Render the required report."},
+        ],
+        "output_contract": ["Return the fixed report fields."],
+        "failure_modes": ["Stop with a bounded error when input is invalid."],
+        "expected_improvements": ["Normalization becomes deterministic."],
+        "acceptance_criteria": ["The normal case assertion passes without regressing the boundary case."],
+        "non_goals": ["Do not invent missing domain data."],
+        "overfitting_risks": ["Do not hard-code the frozen case values."],
+        "clarifications": (
+            [
+                {
+                    "question_id": "missing-rule",
+                    "question": "Which normalization table is authoritative?",
+                    "reason": "The frozen evidence does not identify one.",
+                }
+            ]
+            if questions
+            else []
+        ),
+    }
+
+
+def _allowed() -> dict[str, object]:
+    return {
+        "allowed_case_ids": {"core-normal", "core-boundary"},
+        "allowed_item_ids": {"skill_eval_item_candidate"},
+        "allowed_requirement_ids": {"intent"},
+        "allowed_resources": {
+            "skillres_existing": {"kind": "script", "path": "scripts/normalize.py"}
+        },
+        "allowed_source_ids": {"intent"},
+        "allowed_step_ids": {"inspect", "normalize", "verify", "render"},
+    }
+
+
+def test_evolution_plan_is_append_only_and_answers_require_regeneration(tmp_path) -> None:
+    store = SkillEvolutionPlanStore(tmp_path)
+    waiting = store.save_generated(
+        bindings=_bindings(),
+        payload=_payload(questions=True),
+        expected_plan_revision=None,
+        expected_plan_digest=None,
+        **_allowed(),
+    )
+    assert waiting.state == "needs_input"
+    answered = store.save_answers(
+        waiting.plan_id,
+        expected_revision=waiting.revision,
+        expected_digest=waiting.digest,
+        answers={"missing-rule": "Use the table in the confirmed reference."},
+    )
+    assert answered.revision == 2
+    assert answered.state == "needs_regeneration"
+
+    regenerated = store.save_generated(
+        bindings=_bindings(),
+        payload=_payload(),
+        expected_plan_revision=answered.revision,
+        expected_plan_digest=answered.digest,
+        **_allowed(),
+    )
+    confirmed = store.confirm(
+        regenerated.plan_id,
+        expected_revision=regenerated.revision,
+        expected_digest=regenerated.digest,
+    )
+    assert confirmed.state == "confirmed"
+    assert SkillEvolutionPlanStore(tmp_path).require(confirmed.plan_id).digest == confirmed.digest
+
+
+def test_evolution_plan_rejects_unfrozen_evidence_paths_and_credentials(tmp_path) -> None:
+    store = SkillEvolutionPlanStore(tmp_path)
+    wrong_path = _payload()
+    wrong_path["actions"][0]["path"] = "scripts/other.py"  # type: ignore[index]
+    with pytest.raises(SkillCreatorValidationError) as exc_info:
+        store.save_generated(
+            bindings=_bindings(), payload=wrong_path,
+            expected_plan_revision=None, expected_plan_digest=None, **_allowed()
+        )
+    assert exc_info.value.code == "skill_creator_evolution_resource_invalid"
+
+    secret = _payload()
+    secret["expected_improvements"] = ["api_key = 'sk-" + "live-secret-value-1234567890'"]
+    with pytest.raises(SkillCreatorValidationError) as exc_info:
+        store.save_generated(
+            bindings=_bindings(), payload=secret,
+            expected_plan_revision=None, expected_plan_digest=None, **_allowed()
+        )
+    assert exc_info.value.code == "skill_creator_evolution_credentials_blocked"
+    assert not store.snapshot_path.exists()
+
+
+def test_evolution_plan_patch_preserves_server_minted_create_resources(tmp_path) -> None:
+    store = SkillEvolutionPlanStore(tmp_path)
+    payload = _payload()
+    payload["actions"].append(  # type: ignore[union-attr]
+        {
+            "action_id": "create-template",
+            "action": "create",
+            "kind": "asset",
+            "path": "assets/report-template.md",
+            "purpose": "Provide the stable report skeleton.",
+            "source_ids": ["intent"],
+            "used_by_steps": ["render"],
+            "depends_on": ["skillres_existing"],
+            "acceptance_checks": ["The template contains every output field."],
+            "related_case_ids": ["core-normal"],
+            "expected_improvement": "Output fields remain stable.",
+            "non_regression_case_ids": ["core-boundary"],
+        }
+    )
+    generated = store.save_generated(
+        bindings=_bindings(), payload=payload,
+        expected_plan_revision=None, expected_plan_digest=None, **_allowed()
+    )
+    created = next(item for item in generated.actions if item.action == "create")
+    assert created.resource_id.startswith("skillres_")
+    patched = store.patch(
+        generated.plan_id,
+        expected_revision=generated.revision,
+        expected_digest=generated.digest,
+        changes={"non_goals": ["Do not add network access."]},
+        **_allowed(),
+    )
+    assert next(item for item in patched.actions if item.action == "create").resource_id == created.resource_id
+
+
+def test_evolution_plan_rejects_dependencies_on_deleted_resources(tmp_path) -> None:
+    store = SkillEvolutionPlanStore(tmp_path)
+    payload = _payload()
+    payload["actions"][0]["action"] = "delete"  # type: ignore[index]
+    payload["actions"].append(  # type: ignore[union-attr]
+        {
+            "action_id": "update-policy",
+            "action": "update",
+            "resource_id": "skillres_policy",
+            "purpose": "Keep the policy aligned with the workflow.",
+            "source_ids": ["intent"],
+            "used_by_steps": ["verify"],
+            "depends_on": ["skillres_existing"],
+            "acceptance_checks": ["The policy remains directly readable."],
+            "related_case_ids": ["core-normal"],
+            "expected_improvement": "The policy matches the corrected workflow.",
+            "non_regression_case_ids": ["core-boundary"],
+        }
+    )
+    allowed = _allowed()
+    allowed["allowed_resources"] = {
+        "skillres_existing": {"kind": "script", "path": "scripts/normalize.py"},
+        "skillres_policy": {"kind": "reference", "path": "references/policy.md"},
+    }
+
+    with pytest.raises(SkillCreatorValidationError) as exc_info:
+        store.save_generated(
+            bindings=_bindings(),
+            payload=payload,
+            expected_plan_revision=None,
+            expected_plan_digest=None,
+            **allowed,
+        )
+
+    assert exc_info.value.code == "skill_creator_evolution_resource_invalid"
+    assert not store.snapshot_path.exists()
+
+
+def test_mark_stale_is_bound_to_the_exact_plan_revision(tmp_path) -> None:
+    store = SkillEvolutionPlanStore(tmp_path)
+    first = store.save_generated(
+        bindings=_bindings(), payload=_payload(),
+        expected_plan_revision=None, expected_plan_digest=None, **_allowed()
+    )
+    second = store.patch(
+        first.plan_id,
+        expected_revision=first.revision,
+        expected_digest=first.digest,
+        changes={"non_goals": ["Do not add network access."]},
+        **_allowed(),
+    )
+
+    with pytest.raises(SkillCreatorConflictError):
+        store.mark_stale(
+            first.plan_id,
+            expected_revision=first.revision,
+            expected_digest=first.digest,
+        )
+
+    assert store.require(second.plan_id).digest == second.digest
+    assert store.require(second.plan_id).state == "ready"
+
+
+def test_evolution_store_quarantines_one_record_and_top_level_corruption_fails_closed(tmp_path) -> None:
+    store = SkillEvolutionPlanStore(tmp_path)
+    item = store.save_generated(
+        bindings=_bindings(), payload=_payload(),
+        expected_plan_revision=None, expected_plan_digest=None, **_allowed()
+    )
+    snapshot = json.loads(store.snapshot_path.read_text(encoding="utf-8"))
+    snapshot["items"].append({"plan_id": "broken", "secret": "must-not-be-copied"})
+    store.snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+    recovered = SkillEvolutionPlanStore(tmp_path)
+    assert recovered.require(item.plan_id).digest == item.digest
+    persisted = store.snapshot_path.read_text(encoding="utf-8")
+    assert "must-not-be-copied" not in persisted
+    assert recovered.status()["quarantine_count"] == 1
+
+    store.snapshot_path.write_text("{not-json", encoding="utf-8")
+    failed = SkillEvolutionPlanStore(tmp_path)
+    with pytest.raises(SkillCreatorStorageError):
+        failed.current_for_session("skillcreator_test")
+    assert store.snapshot_path.read_text(encoding="utf-8") == "{not-json"
+
+
+def test_evolution_store_quarantines_revision_history_without_revision_one(tmp_path) -> None:
+    store = SkillEvolutionPlanStore(tmp_path)
+    first = store.save_generated(
+        bindings=_bindings(), payload=_payload(),
+        expected_plan_revision=None, expected_plan_digest=None, **_allowed()
+    )
+    second = store.patch(
+        first.plan_id,
+        expected_revision=first.revision,
+        expected_digest=first.digest,
+        changes={"non_goals": ["Do not add network access."]},
+        **_allowed(),
+    )
+    snapshot = json.loads(store.snapshot_path.read_text(encoding="utf-8"))
+    snapshot["items"] = [item for item in snapshot["items"] if item["revision"] == second.revision]
+    store.snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+    recovered = SkillEvolutionPlanStore(tmp_path)
+    assert recovered.current_for_session("skillcreator_test") is None
+    assert recovered.status()["plan_count"] == 0
+    assert recovered.status()["quarantine_count"] == 1
+
+
+def test_evolution_store_revalidates_self_consistent_record_shape(tmp_path) -> None:
+    store = SkillEvolutionPlanStore(tmp_path)
+    item = store.save_generated(
+        bindings=_bindings(), payload=_payload(),
+        expected_plan_revision=None, expected_plan_digest=None, **_allowed()
+    )
+    values = asdict(item)
+    values.pop("digest")
+    values["workflow_steps"][0].pop("instruction")
+    tampered = store._build(**values)
+    snapshot = json.loads(store.snapshot_path.read_text(encoding="utf-8"))
+    snapshot["items"] = [asdict(tampered)]
+    store.snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+    recovered = SkillEvolutionPlanStore(tmp_path)
+    assert recovered.current_for_session("skillcreator_test") is None
+    assert recovered.status()["quarantine_count"] == 1
+
+
+def _resource_payload() -> dict[str, object]:
+    return {
+        "skill_name": "incident-review",
+        "skill_description": "Create a structured incident review when requested.",
+        "workflow_steps": [
+            {"step_id": "inspect", "instruction": "Inspect the input."},
+            {"step_id": "normalize", "instruction": "Normalize the facts."},
+            {"step_id": "verify", "instruction": "Verify the facts."},
+            {"step_id": "render", "instruction": "Render the report."},
+        ],
+        "output_contract": ["Return the fixed report."],
+        "failure_modes": ["Mark missing facts as unknown."],
+        "resources": [
+            {
+                "kind": "script",
+                "action": "update",
+                "generation_cost": "medium",
+                "path": "scripts/normalize.py",
+                "purpose": "Normalize facts.",
+                "source_ids": ["intent"],
+                "used_by_steps": ["normalize"],
+                "depends_on": [],
+                "acceptance_checks": ["Exit non-zero on invalid input."],
+            }
+        ],
+    }
+
+
+def test_resource_plan_evolution_rebind_is_idempotent(tmp_path) -> None:
+    store = SkillResourcePlanStore(tmp_path)
+    generated = store.save_generated(
+        session_id="skillcreator_test",
+        session_revision=1,
+        draft_id="skilldraft_test",
+        draft_revision=2,
+        draft_digest=HEX_D,
+        payload=_resource_payload(),
+        allowed_source_ids={"intent"},
+    )
+    source = store.confirm(
+        generated.plan_id,
+        expected_revision=generated.revision,
+        expected_digest=generated.digest,
+        session_revision=1,
+        draft_revision=2,
+        draft_digest=HEX_D,
+    )
+    ready = store.save_evolution_revision(
+        source_plan_id=source.plan_id,
+        source_revision=source.revision,
+        source_digest=source.digest,
+        session_revision=3,
+        draft_id="skilldraft_test",
+        draft_revision=2,
+        draft_digest=HEX_D,
+        payload=_resource_payload(),
+        allowed_source_ids={"intent"},
+    )
+    confirmed = store.confirm(
+        ready.plan_id,
+        expected_revision=ready.revision,
+        expected_digest=ready.digest,
+        session_revision=3,
+        draft_revision=2,
+        draft_digest=HEX_D,
+    )
+    replay = store.save_evolution_revision(
+        source_plan_id=source.plan_id,
+        source_revision=source.revision,
+        source_digest=source.digest,
+        session_revision=3,
+        draft_id="skilldraft_test",
+        draft_revision=2,
+        draft_digest=HEX_D,
+        payload=_resource_payload(),
+        allowed_source_ids={"intent"},
+    )
+    assert replay.revision == confirmed.revision
+    assert replay.digest == confirmed.digest

--- a/server/tests/test_skill_creator_evolution_api.py
+++ b/server/tests/test_skill_creator_evolution_api.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from server.skills import creator_api
+
+
+class _Store:
+    @staticmethod
+    def serialize(item):
+        return dict(item)
+
+
+class _EvolutionService:
+    VERSION = "skill-creator-resource-evolution-v1"
+    enabled = True
+
+    def __init__(self) -> None:
+        self.evolution_store = _Store()
+        self.resource_plan_store = _Store()
+        self.calls: list[str] = []
+
+    def require_enabled(self) -> None:
+        return None
+
+    def status(self):
+        return {
+            "evolution_enabled": self.enabled,
+            "evolution_version": self.VERSION,
+            "evolution_planner_available": True,
+            "evolution_store_available": True,
+        }
+
+    async def generate(self, *_args, **_kwargs):
+        self.calls.append("generate")
+        return {"plan_id": "skillevo_api", "revision": 1, "digest": "a" * 64}
+
+    def save_answers(self, *_args, **_kwargs):
+        self.calls.append("answers")
+        return {"plan_id": "skillevo_api", "revision": 2, "digest": "b" * 64}
+
+    def patch(self, *_args, **_kwargs):
+        self.calls.append("patch")
+        return {"plan_id": "skillevo_api", "revision": 3, "digest": "c" * 64}
+
+    def confirm(self, *_args, **_kwargs):
+        self.calls.append("confirm")
+        return (
+            {"plan_id": "skillevo_api", "revision": 4, "digest": "d" * 64},
+            {"plan_id": "skillplan_api", "revision": 6, "digest": "e" * 64},
+        )
+
+
+@pytest.mark.asyncio
+async def test_evolution_routes_use_frozen_revision_and_digest_contracts() -> None:
+    previous_creator = creator_api._service
+    previous_evolution = creator_api._evolution_service
+    creator = SimpleNamespace(require_enabled=lambda: None)
+    evolution = _EvolutionService()
+    app = FastAPI()
+    app.include_router(creator_api.router)
+    try:
+        creator_api.configure_skill_creator(creator)
+        creator_api.configure_skill_creator_evolution(evolution)  # type: ignore[arg-type]
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            generated = await client.post(
+                "/api/skills/creator/sessions/session-api/evolution-plan/generate",
+                json={
+                    "evaluation_run_id": "skill_eval_run_api",
+                    "expected_session_revision": 7,
+                    "expected_draft_state_revision": 5,
+                    "expected_draft_revision": 3,
+                    "expected_draft_digest": "f" * 64,
+                    "expected_review_revision": 1,
+                    "expected_run_revision": 9,
+                    "expected_resource_plan_revision": 4,
+                    "expected_resource_plan_digest": "9" * 64,
+                    "expected_evolution_revision": None,
+                    "expected_evolution_digest": None,
+                },
+            )
+            assert generated.status_code == 200, generated.text
+            base = {
+                "plan_id": "skillevo_api",
+                "expected_session_revision": 7,
+                "expected_draft_state_revision": 5,
+                "expected_draft_revision": 3,
+                "expected_draft_digest": "f" * 64,
+                "expected_plan_revision": 1,
+                "expected_plan_digest": "a" * 64,
+            }
+            answered = await client.put(
+                "/api/skills/creator/sessions/session-api/evolution-plan/answers",
+                json={**base, "answers": {"question-one": "Use the confirmed policy."}},
+            )
+            assert answered.status_code == 200, answered.text
+            patched = await client.patch(
+                "/api/skills/creator/sessions/session-api/evolution-plan",
+                json={**base, "changes": {"non_goals": ["Do not add network access."]}},
+            )
+            assert patched.status_code == 200, patched.text
+            confirmed = await client.post(
+                "/api/skills/creator/sessions/session-api/evolution-plan/confirm",
+                json=base,
+            )
+            assert confirmed.status_code == 200, confirmed.text
+            assert confirmed.json()["resource_plan"]["plan_id"] == "skillplan_api"
+        assert evolution.calls == ["generate", "answers", "patch", "confirm"]
+    finally:
+        creator_api.configure_skill_creator(previous_creator)
+        creator_api.configure_skill_creator_evolution(previous_evolution)
+
+
+@pytest.mark.asyncio
+async def test_iterate_is_only_blocked_when_evolution_v2_is_enabled() -> None:
+    previous_creator = creator_api._service
+    previous_evolution = creator_api._evolution_service
+    creator = SimpleNamespace(require_enabled=lambda: None)
+    evolution = _EvolutionService()
+    app = FastAPI()
+    app.include_router(creator_api.router)
+    try:
+        creator_api.configure_skill_creator(creator)
+        creator_api.configure_skill_creator_evolution(evolution)  # type: ignore[arg-type]
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/api/skills/creator/sessions/session-api/iterate",
+                json={
+                    "evaluation_run_id": "skill_eval_run_api",
+                    "expected_session_revision": 7,
+                    "expected_revision": 5,
+                    "expected_digest": "f" * 64,
+                    "expected_review_revision": 1,
+                },
+            )
+            assert response.status_code == 409, response.text
+            assert response.json()["detail"]["code"] == "skill_creator_evolution_plan_required"
+            evolution.enabled = False
+            fallback = await client.post(
+                "/api/skills/creator/sessions/session-api/iterate",
+                json={
+                    "evaluation_run_id": "skill_eval_run_api",
+                    "expected_session_revision": 7,
+                    "expected_revision": 5,
+                    "expected_digest": "f" * 64,
+                    "expected_review_revision": 1,
+                },
+            )
+            assert fallback.status_code == 400, fallback.text
+            assert fallback.json()["detail"]["code"] != "skill_creator_evolution_plan_required"
+    finally:
+        creator_api.configure_skill_creator(previous_creator)
+        creator_api.configure_skill_creator_evolution(previous_evolution)

--- a/server/tests/test_skill_creator_evolution_service.py
+++ b/server/tests/test_skill_creator_evolution_service.py
@@ -1,0 +1,608 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from server.skills.creator_evaluation import (
+    SkillEvaluationItem,
+    SkillEvaluationReview,
+    SkillEvaluationRun,
+)
+from server.skills.creator_evaluation_suite import (
+    EVALUATION_SUITE_VERSION,
+    SkillEvaluationSuite,
+    SkillEvaluationSuiteCase,
+)
+from server.skills.creator_evolution import EVOLUTION_PLAN_VERSION, SkillEvolutionPlanStore
+from server.skills.creator_evolution_runtime import (
+    EVOLUTION_WORKFLOW_VERSION,
+    WorkflowCreatorEvolutionPlanner,
+    build_evolution_invocation,
+    parse_evolution_output,
+)
+from server.skills.creator_evolution_service import (
+    EvolutionGenerationRequest,
+    SkillCreatorEvolutionService,
+)
+from server.skills.creator_resource_plan import SkillResourcePlanStore
+from server.skills.creator_resource_service import SkillCreatorResourcePlanningService
+from server.skills.creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorNotFoundError,
+    SkillCreatorSession,
+    SkillCreatorValidationError,
+)
+from server.skills.draft_store import WorkspaceSkillDraft
+from server.skills.package_validation import compute_package_digest
+
+
+DRAFT_DIGEST = "a" * 64
+SUITE_DIGEST = "b" * 64
+
+
+class _CreatorService:
+    def __init__(self) -> None:
+        self.session = SkillCreatorSession(
+            session_id="session-one",
+            session_revision=7,
+            draft_state_revision=5,
+            intent="Normalize incident facts and create a bounded review.",
+            positive_examples=["Create a review from an incident timeline."],
+            near_miss_examples=["Only rewrite this paragraph."],
+            expected_output="A structured incident review.",
+            success_criteria=["Unknown root causes stay unknown."],
+            evidence_confirmed=True,
+            draft_id="draft-one",
+            current_revision=3,
+            current_digest=DRAFT_DIGEST,
+            quality_mode="objective",
+            state="iterating",
+        )
+        self.draft = WorkspaceSkillDraft(
+            draft_id="draft-one",
+            name="incident-review",
+            slug="incident-review",
+            description="Create incident reviews from supplied facts.",
+            skill_markdown=(
+                "---\nname: incident-review\ndescription: Create incident reviews.\n---\n"
+                "# Incident Review\n\n## Workflow\n\n1. Inspect.\n2. Normalize.\n"
+                "3. Verify.\n4. Render.\n\n## Output contract\n\nReturn fields.\n"
+                "## Failure behavior\n\nMark unknown facts.\n"
+            ),
+            files={
+                "scripts/normalize.py": "print('normalized')\n",
+                "references/policy.md": "# Policy\n\nDo not invent facts.\n",
+            },
+            revision=5,
+            content_revision=3,
+            content_digest=DRAFT_DIGEST,
+            creator_session_id="session-one",
+            quality_required=True,
+        )
+
+    def require_enabled(self) -> None:
+        return None
+
+    def get_session(self, session_id: str):
+        assert session_id == self.session.session_id
+        return self.session, self.draft
+
+
+class _EvaluationStore:
+    def __init__(self, run: SkillEvaluationRun) -> None:
+        self.run = run
+
+    def require_run(self, run_id: str) -> SkillEvaluationRun:
+        assert run_id == self.run.run_id
+        return self.run
+
+
+class _SuiteStore:
+    def __init__(self, suite: SkillEvaluationSuite) -> None:
+        self.suite = suite
+
+    def require(self, suite_id: str, *, revision: int | None = None) -> SkillEvaluationSuite:
+        assert suite_id == self.suite.suite_id
+        assert revision in {None, self.suite.suite_revision}
+        return self.suite
+
+
+class _Planner:
+    def __init__(self) -> None:
+        self.calls: list[EvolutionGenerationRequest] = []
+
+    def available(self) -> bool:
+        return True
+
+    async def generate(self, request: EvolutionGenerationRequest) -> dict:
+        self.calls.append(request)
+        script_id, reference_id = request.allowed_resource_ids
+        return {
+            "diagnoses": [
+                {
+                    "case_id": "core-normal",
+                    "evidence_item_ids": ["item-candidate"],
+                    "failure_types": ["assertion_failure"],
+                    "requirement_ids": ["intent"],
+                    "resource_ids": [script_id],
+                    "sections": ["Workflow"],
+                    "summary": "Normalization failed its deterministic assertion.",
+                }
+            ],
+            "actions": [
+                {
+                    "action_id": "update-script",
+                    "action": "update",
+                    "resource_id": script_id,
+                    "purpose": "Normalize incident facts deterministically.",
+                    "source_ids": ["intent"],
+                    "used_by_steps": ["normalize"],
+                    "depends_on": [],
+                    "acceptance_checks": ["Pass the frozen normal case."],
+                    "related_case_ids": ["core-normal"],
+                    "expected_improvement": "The deterministic assertion passes.",
+                    "non_regression_case_ids": ["core-boundary"],
+                },
+                {
+                    "action_id": "keep-policy",
+                    "action": "keep",
+                    "resource_id": reference_id,
+                    "purpose": "Preserve the existing fact policy.",
+                    "source_ids": ["intent"],
+                    "used_by_steps": ["verify"],
+                    "depends_on": [],
+                    "acceptance_checks": ["Unknown root causes stay unknown."],
+                    "related_case_ids": ["core-normal"],
+                    "expected_improvement": "No change; retain the safety boundary.",
+                    "non_regression_case_ids": ["core-boundary"],
+                },
+            ],
+            "workflow_steps": [
+                {"step_id": "inspect", "instruction": "Inspect supplied facts."},
+                {"step_id": "normalize", "instruction": "Run the deterministic normalizer."},
+                {"step_id": "verify", "instruction": "Verify facts against policy."},
+                {"step_id": "render", "instruction": "Render the output contract."},
+            ],
+            "output_contract": ["Return the structured incident review fields."],
+            "failure_modes": ["Mark missing facts as unknown and stop on invalid input."],
+            "expected_improvements": ["The failed normal case becomes deterministic."],
+            "acceptance_criteria": ["Normal passes and boundary does not regress."],
+            "non_goals": ["Do not add domain facts."],
+            "overfitting_risks": ["Do not hard-code the frozen timeline."],
+            "clarifications": [],
+        }
+
+
+class _MutatingPlanner(_Planner):
+    def __init__(self, creator: _CreatorService) -> None:
+        super().__init__()
+        self.creator = creator
+
+    async def generate(self, request: EvolutionGenerationRequest) -> dict:
+        payload = await super().generate(request)
+        self.creator.session = replace(
+            self.creator.session,
+            session_revision=self.creator.session.session_revision + 1,
+        )
+        return payload
+
+
+class _CrossCasePlanner(_Planner):
+    async def generate(self, request: EvolutionGenerationRequest) -> dict:
+        payload = await super().generate(request)
+        payload["diagnoses"][0]["case_id"] = "core-boundary"
+        return payload
+
+
+def _suite() -> SkillEvaluationSuite:
+    cases = (
+        SkillEvaluationSuiteCase(
+            case_id="core-normal", role="normal", source="generated",
+            name="Normal", prompt="Create a review.", expected_behavior="Return fields.",
+            requirement_ids=("intent",), workflow_step_ids=("normalize",), case_fingerprint="c" * 64,
+        ),
+        SkillEvaluationSuiteCase(
+            case_id="core-ambiguous", role="ambiguous", source="generated",
+            name="Ambiguous", prompt="Create a review with missing facts.", expected_behavior="Mark gaps.",
+            requirement_ids=("expected_output",), workflow_step_ids=("verify",), case_fingerprint="d" * 64,
+        ),
+        SkillEvaluationSuiteCase(
+            case_id="core-boundary", role="boundary", source="generated",
+            name="Boundary", prompt="Only rewrite prose.", expected_behavior="Do not trigger.",
+            requirement_ids=("near_miss:0",), workflow_step_ids=("inspect",), case_fingerprint="e" * 64,
+        ),
+    )
+    return SkillEvaluationSuite(
+        suite_id="skill_eval_suite_one",
+        version=EVALUATION_SUITE_VERSION,
+        suite_revision=1,
+        suite_digest=SUITE_DIGEST,
+        session_id="session-one",
+        session_revision=6,
+        session_definition_digest="f" * 64,
+        draft_id="draft-one",
+        draft_state_revision=4,
+        draft_revision=3,
+        draft_digest=DRAFT_DIGEST,
+        quality_mode="objective",
+        state="confirmed",
+        cases=cases,
+        change_reason="Initial suite",
+    )
+
+
+def _run(suite: SkillEvaluationSuite) -> SkillEvaluationRun:
+    review = SkillEvaluationReview(
+        review_id="skill_eval_review_one",
+        review_revision=1,
+        decision="revise",
+        reason="Fix normalization without weakening the unknown-fact boundary.",
+        feedback_revision=1,
+        feedback="The normal case failed the deterministic normalization assertion.",
+        actor_kind="local_console",
+    )
+    return SkillEvaluationRun(
+        run_id="skill_eval_run_one",
+        session_id="session-one",
+        draft_id="draft-one",
+        draft_revision=3,
+        frozen_digest=DRAFT_DIGEST,
+        baseline_overlay_id=None,
+        candidate_overlay_id="overlay-one",
+        model_id="provider/model",
+        repetitions=1,
+        cases=[],
+        items=[
+            SkillEvaluationItem(
+                item_id="item-candidate", pair_id="pair-one", case_id="core-normal",
+                target="candidate", repetition=1, overlay_id="overlay-one", status="completed",
+                assertion_results=[{"assertion_id": "normalized", "passed": False, "code": "contains_failed"}],
+                application_compliance="verified",
+            )
+        ],
+        config={},
+        evaluation_suite_id=suite.suite_id,
+        evaluation_suite_revision=suite.suite_revision,
+        evaluation_suite_digest=suite.suite_digest,
+        evaluation_suite_version=suite.version,
+        status="completed",
+        revision=9,
+        review_state="revise",
+        feedback=review.feedback,
+        feedback_revision=1,
+        reviews=[review],
+    )
+
+
+def _resource_plan(store: SkillResourcePlanStore):
+    generated = store.save_generated(
+        session_id="session-one", session_revision=4, draft_id="draft-one",
+        draft_revision=5, draft_digest=DRAFT_DIGEST,
+        payload={
+            "skill_name": "incident-review",
+            "skill_description": "Create incident reviews from supplied facts.",
+            "workflow_steps": [
+                {"step_id": "inspect", "instruction": "Inspect supplied facts."},
+                {"step_id": "normalize", "instruction": "Normalize the facts."},
+                {"step_id": "verify", "instruction": "Verify facts against policy."},
+                {"step_id": "render", "instruction": "Render the output."},
+            ],
+            "output_contract": ["Return the structured fields."],
+            "failure_modes": ["Mark missing facts as unknown."],
+            "resources": [
+                {
+                    "kind": "script", "action": "update", "generation_cost": "medium",
+                    "path": "scripts/normalize.py", "purpose": "Normalize facts.",
+                    "source_ids": ["intent"], "used_by_steps": ["normalize"],
+                    "depends_on": [], "acceptance_checks": ["Exit non-zero on invalid input."],
+                },
+                {
+                    "kind": "reference", "action": "update", "generation_cost": "low",
+                    "path": "references/policy.md", "purpose": "Define the no-invention policy.",
+                    "source_ids": ["intent"], "used_by_steps": ["verify"],
+                    "depends_on": [], "acceptance_checks": ["Unknown facts remain unknown."],
+                },
+            ],
+        },
+        allowed_source_ids={"intent", "expected_output", "near_miss:0", "success_criterion:0"},
+    )
+    return store.confirm(
+        generated.plan_id, expected_revision=generated.revision,
+        expected_digest=generated.digest, session_revision=4,
+        draft_revision=5, draft_digest=DRAFT_DIGEST,
+    )
+
+
+def _service(tmp_path: Path):
+    creator = _CreatorService()
+    resource_store = SkillResourcePlanStore(tmp_path / "resources")
+    resource_plan = _resource_plan(resource_store)
+    suite = _suite()
+    run = _run(suite)
+    planner = _Planner()
+    planning = SkillCreatorResourcePlanningService(
+        creator, resource_store, enabled=True  # type: ignore[arg-type]
+    )
+    service = SkillCreatorEvolutionService(
+        creator,  # type: ignore[arg-type]
+        SkillEvolutionPlanStore(tmp_path / "evolution"),
+        _EvaluationStore(run),  # type: ignore[arg-type]
+        _SuiteStore(suite),  # type: ignore[arg-type]
+        planning,
+        planner=planner,
+        enabled=True,
+    )
+    return creator, resource_plan, suite, run, planner, service
+
+
+def _expected(creator: _CreatorService, resource_plan) -> dict:
+    return {
+        "evaluation_run_id": "skill_eval_run_one",
+        "expected_session_revision": creator.session.session_revision,
+        "expected_draft_state_revision": creator.draft.revision,
+        "expected_draft_revision": creator.draft.content_revision,
+        "expected_draft_digest": creator.draft.content_digest,
+        "expected_review_revision": 1,
+        "expected_run_revision": 9,
+        "expected_resource_plan_revision": resource_plan.revision,
+        "expected_resource_plan_digest": resource_plan.digest,
+        "expected_evolution_revision": None,
+        "expected_evolution_digest": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_generate_uses_frozen_evidence_without_model_outputs_and_confirm_rebinds_resource_plan(tmp_path: Path) -> None:
+    creator, resource_plan, _suite_value, _run_value, planner, service = _service(tmp_path)
+    generated = await service.generate("session-one", **_expected(creator, resource_plan))
+    assert generated.state == "ready"
+    assert len(planner.calls) == 1
+    request = planner.calls[0]
+    assert "output" not in json.dumps(request.evaluation)
+    assert request.review["feedback"].startswith("The normal case")
+
+    confirmed, evolved_resource_plan = service.confirm(
+        "session-one",
+        plan_id=generated.plan_id,
+        expected_session_revision=creator.session.session_revision,
+        expected_draft_state_revision=creator.draft.revision,
+        expected_draft_revision=creator.draft.content_revision,
+        expected_draft_digest=creator.draft.content_digest,
+        expected_plan_revision=generated.revision,
+        expected_plan_digest=generated.digest,
+    )
+    assert confirmed.state == "confirmed"
+    assert evolved_resource_plan.state == "confirmed"
+    assert evolved_resource_plan.session_revision == creator.session.session_revision
+    actions = {item.path: item.action for item in evolved_resource_plan.resources}
+    assert actions == {"scripts/normalize.py": "update", "references/policy.md": "keep"}
+
+    replay, replay_resource = service.confirm(
+        "session-one",
+        plan_id=generated.plan_id,
+        expected_session_revision=creator.session.session_revision,
+        expected_draft_state_revision=creator.draft.revision,
+        expected_draft_revision=creator.draft.content_revision,
+        expected_draft_digest=creator.draft.content_digest,
+        expected_plan_revision=generated.revision,
+        expected_plan_digest=generated.digest,
+    )
+    assert replay.digest == confirmed.digest
+    assert replay_resource.digest == evolved_resource_plan.digest
+
+
+@pytest.mark.asyncio
+async def test_generate_rejects_stale_review_and_resource_plan(tmp_path: Path) -> None:
+    creator, resource_plan, _suite_value, run, _planner, service = _service(tmp_path)
+    run.reviews[-1] = replace(run.reviews[-1], review_revision=2)
+    with pytest.raises(SkillCreatorConflictError):
+        await service.generate("session-one", **_expected(creator, resource_plan))
+
+
+@pytest.mark.asyncio
+async def test_generate_revalidates_session_after_model_call_without_orphan_plan(tmp_path: Path) -> None:
+    creator, resource_plan, _suite_value, _run_value, _planner, service = _service(tmp_path)
+    service.planner = _MutatingPlanner(creator)
+
+    with pytest.raises(SkillCreatorConflictError):
+        await service.generate("session-one", **_expected(creator, resource_plan))
+
+    assert service.evolution_store.current_for_session("session-one") is None
+
+
+@pytest.mark.asyncio
+async def test_confirm_revalidates_frozen_run_revision(tmp_path: Path) -> None:
+    creator, resource_plan, _suite_value, run, _planner, service = _service(tmp_path)
+    generated = await service.generate("session-one", **_expected(creator, resource_plan))
+    run.revision += 1
+
+    with pytest.raises(SkillCreatorConflictError):
+        service.confirm(
+            "session-one",
+            plan_id=generated.plan_id,
+            expected_session_revision=creator.session.session_revision,
+            expected_draft_state_revision=creator.draft.revision,
+            expected_draft_revision=creator.draft.content_revision,
+            expected_draft_digest=creator.draft.content_digest,
+            expected_plan_revision=generated.revision,
+            expected_plan_digest=generated.digest,
+        )
+
+    assert service.evolution_store.require(generated.plan_id).state == "ready"
+
+
+@pytest.mark.asyncio
+async def test_confirm_crash_retry_cannot_cross_creator_sessions(tmp_path: Path) -> None:
+    creator, resource_plan, _suite_value, _run_value, _planner, service = _service(tmp_path)
+    generated = await service.generate("session-one", **_expected(creator, resource_plan))
+    service.evolution_store.confirm(
+        generated.plan_id,
+        expected_revision=generated.revision,
+        expected_digest=generated.digest,
+    )
+    creator.session = replace(creator.session, session_id="session-two")
+    creator.draft = replace(
+        creator.draft,
+        draft_id="draft-two",
+        creator_session_id="session-two",
+    )
+
+    with pytest.raises(SkillCreatorConflictError):
+        service.confirm(
+            "session-two",
+            plan_id=generated.plan_id,
+            expected_session_revision=creator.session.session_revision,
+            expected_draft_state_revision=creator.draft.revision,
+            expected_draft_revision=creator.draft.content_revision,
+            expected_draft_digest=creator.draft.content_digest,
+            expected_plan_revision=generated.revision,
+            expected_plan_digest=generated.digest,
+        )
+
+
+@pytest.mark.asyncio
+async def test_generate_rejects_evidence_item_from_another_case(tmp_path: Path) -> None:
+    creator, resource_plan, _suite_value, _run_value, _planner, service = _service(tmp_path)
+    service.planner = _CrossCasePlanner()
+
+    with pytest.raises(SkillCreatorValidationError) as exc_info:
+        await service.generate("session-one", **_expected(creator, resource_plan))
+
+    assert exc_info.value.code == "skill_creator_evolution_evidence_invalid"
+    assert service.evolution_store.current_for_session("session-one") is None
+
+
+@pytest.mark.asyncio
+async def test_projection_keeps_exact_materialized_plan_after_later_revision(tmp_path: Path) -> None:
+    creator, resource_plan, _suite_value, _run_value, _planner, service = _service(tmp_path)
+    generated = await service.generate("session-one", **_expected(creator, resource_plan))
+    confirmed, materialized = service.confirm(
+        "session-one",
+        plan_id=generated.plan_id,
+        expected_session_revision=creator.session.session_revision,
+        expected_draft_state_revision=creator.draft.revision,
+        expected_draft_revision=creator.draft.content_revision,
+        expected_draft_digest=creator.draft.content_digest,
+        expected_plan_revision=generated.revision,
+        expected_plan_digest=generated.digest,
+    )
+    unrelated = service.resource_plan_store.patch(
+        materialized.plan_id,
+        expected_revision=materialized.revision,
+        expected_digest=materialized.digest,
+        changes={"skill_description": "A later unrelated resource plan."},
+        allowed_source_ids={"intent", "expected_output", "near_miss:0", "success_criterion:0"},
+    )
+    service.resource_plan_store.confirm(
+        unrelated.plan_id,
+        expected_revision=unrelated.revision,
+        expected_digest=unrelated.digest,
+        session_revision=unrelated.session_revision,
+        draft_revision=unrelated.draft_revision,
+        draft_digest=unrelated.draft_digest,
+    )
+
+    projection = service.current_projection("session-one")
+    assert projection is not None
+    assert projection["resource_plan"]["revision"] == materialized.revision
+    assert projection["resource_plan"]["digest"] == materialized.digest
+    assert projection["digest"] == confirmed.digest
+
+
+@pytest.mark.asyncio
+async def test_missing_sessions_do_not_allocate_generation_locks(tmp_path: Path) -> None:
+    creator, resource_plan, _suite_value, _run_value, _planner, service = _service(tmp_path)
+
+    def missing_session(_session_id: str):
+        raise SkillCreatorNotFoundError("missing")
+
+    creator.get_session = missing_session  # type: ignore[method-assign]
+    with pytest.raises(SkillCreatorNotFoundError):
+        await service.generate("missing-session", **_expected(creator, resource_plan))
+
+    assert "missing-session" not in service._locks
+
+
+def test_evolution_runtime_is_no_tool_and_parses_one_versioned_object() -> None:
+    request = EvolutionGenerationRequest(
+        session={"session_id": "session-one", "session_revision": 7},
+        draft={}, evaluation={}, review={}, suite={}, resource_plan={}, current_plan=None,
+        allowed_case_ids=(), allowed_item_ids=(), allowed_requirement_ids=(),
+        allowed_resource_ids=(), allowed_source_ids=(), allowed_step_ids=(),
+    )
+    invocation = build_evolution_invocation(request, model_id="provider/model")
+    agent = invocation.workflow["nodes"][1]["data"]
+    assert agent["toolMode"] == "none"
+    assert agent["temperature"] == "0.1"
+    assert invocation.runtime_metadata["evolution_workflow_version"] == EVOLUTION_WORKFLOW_VERSION
+    payload = {"evolution_plan_version": EVOLUTION_PLAN_VERSION, "diagnoses": []}
+    assert parse_evolution_output("Result:\n```json\n" + json.dumps(payload) + "\n```") == payload
+    with pytest.raises(SkillCreatorValidationError):
+        parse_evolution_output(json.dumps(payload) + json.dumps({**payload, "actions": []}))
+
+
+def test_post_build_draft_accepts_only_the_exact_proposal_and_recomputed_package(tmp_path: Path) -> None:
+    creator, resource_plan, suite, run, _planner, _service_value = _service(tmp_path)
+    creator.draft.source_proposal_id = "proposal-from-build"
+    creator.draft.content_digest = compute_package_digest(
+        creator.draft.skill_markdown, creator.draft.files
+    )
+    build = SimpleNamespace(
+        plan_id=resource_plan.plan_id,
+        plan_revision=resource_plan.revision,
+        plan_digest=resource_plan.digest,
+        proposal_id="proposal-from-build",
+        state="accepted",
+        phase="proposal",
+        skill_markdown=creator.draft.skill_markdown,
+        resources=[
+            SimpleNamespace(action="update", path=path, content=content)
+            for path, content in creator.draft.files.items()
+            if path.startswith(("scripts/", "references/", "assets/"))
+        ],
+    )
+    planning = SkillCreatorResourcePlanningService(
+        creator, _service_value.resource_plan_store, enabled=True  # type: ignore[arg-type]
+    )
+    service = SkillCreatorEvolutionService(
+        creator,  # type: ignore[arg-type]
+        SkillEvolutionPlanStore(tmp_path / "post-build-evolution"),
+        _EvaluationStore(run),  # type: ignore[arg-type]
+        _SuiteStore(suite),  # type: ignore[arg-type]
+        planning,
+        resource_build_store=SimpleNamespace(
+            current_for_session=lambda _session_id: build
+        ),  # type: ignore[arg-type]
+        enabled=True,
+    )
+    assert service._resource_plan_produced_draft(
+        resource_plan, session=creator.session, draft=creator.draft
+    )
+    build.resources[0].content = "print('tampered')\n"
+    assert not service._resource_plan_produced_draft(
+        resource_plan, session=creator.session, draft=creator.draft
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_evolution_planner_strips_version_before_store_payload() -> None:
+    payload = {"evolution_plan_version": EVOLUTION_PLAN_VERSION, "diagnoses": []}
+    planner = WorkflowCreatorEvolutionPlanner(
+        model_id="provider/model", model_available=lambda: True,
+        runner=lambda _invocation: _async_value(json.dumps(payload)),
+    )
+    request = EvolutionGenerationRequest(
+        session={"session_id": "session-one", "session_revision": 7},
+        draft={}, evaluation={}, review={}, suite={}, resource_plan={}, current_plan=None,
+        allowed_case_ids=(), allowed_item_ids=(), allowed_requirement_ids=(),
+        allowed_resource_ids=(), allowed_source_ids=(), allowed_step_ids=(),
+    )
+    assert await planner.generate(request) == {"diagnoses": []}
+
+
+async def _async_value(value: str) -> str:
+    return value


### PR DESCRIPTION
## Summary

- 新增不可变 SkillEvolutionPlan，冻结评测 run、review、suite、草稿与资源计划证据，并支持澄清、编辑和确认。
- 将已确认的进化计划转换为新的 Resource Plan revision，选择性复用未变化资源并继续走既有 Resource Build 与普通 update proposal。
- V2 开启时阻止旧的一次性 iterate 绕过进化计划；功能开关默认关闭，旧会话与既有流程保持兼容。
- 按待证伪方式补齐并发、崩溃恢复、跨会话重放、证据归属、删除依赖、投影漂移、锁表增长、stale 并发和损坏快照隔离门禁。

## Validation

- PR3 专项：22 passed。
- Creator、资源规划/构建、评测套件与三例评测广回归：222 passed。
- Skill 安装、Runtime Router、Authoring、工作区与 Meta Planner 跨模块回归：51 passed。
- git diff --check、路径白名单和新增行敏感信息扫描通过。

## Safety and scope

- 仅包含 Creator 资源级进化后端、API、资源计划转换、测试和体验审计文档。
- 无前端变化，不修改 Sandbox 协议或镜像，不触碰共享 Docker。
- SKILL_CREATOR_EVOLUTION_V2_ENABLED 默认关闭；回退时可直接关闭该开关并保留 Store 数据。