### PR TITLE
fix: 收尾智能体工作流入口转换

### DIFF
--- a/client/src/components/workflow/WorkflowEditor.conversion.test.tsx
+++ b/client/src/components/workflow/WorkflowEditor.conversion.test.tsx
@@ -1,0 +1,298 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type WorkflowDefinition, type WorkflowNodeKind } from "../../types/workflow";
+import WorkflowEditor from "./WorkflowEditor";
+import { type WorkflowNodeRegistryResponse } from "./workflowNodeRegistry";
+
+let registryAvailable = true;
+let staticValidation = {
+  valid: true,
+  issues: [] as Array<Record<string, unknown>>,
+  order: ["entry", "agent", "output"],
+  node_count: 3,
+  edge_count: 2,
+};
+
+function registry(): WorkflowNodeRegistryResponse {
+  const kinds: WorkflowNodeKind[] = [
+    "input",
+    "workflow_call_entry",
+    "workflow_agent",
+    "output",
+  ];
+  return {
+    version: "xpert-workflow-node-registry-v4",
+    contract_version: 3,
+    contract_checksum: "a".repeat(64),
+    tabs: [],
+    sections: [
+      {
+        id: "logic",
+        label: "test",
+        description: "test",
+        items: kinds.map((kind) => ({
+          kind: kind as Exclude<WorkflowNodeKind, "runtime_middleware">,
+          icon: "T",
+          title: kind,
+          description: kind,
+          enabled: true,
+          contract: {
+            kind: kind as Exclude<WorkflowNodeKind, "runtime_middleware">,
+            contract_status: "complete",
+            config_schema: {},
+            ports: [],
+            edge: {},
+            execution: {},
+            availability: {
+              xpert:
+                kind === "workflow_call_entry"
+                  ? { state: "deny", message: "denied" }
+                  : { state: "allow" },
+            },
+            resources: [],
+            planner: {},
+            contract_version: 3,
+            checksum: "b".repeat(64),
+            compiler_checksum: "c".repeat(64),
+          },
+        })),
+      },
+    ],
+    knowledge_pipeline: { items: [], placeholders: [] },
+  };
+}
+
+function invalidXpertDraft(): WorkflowDefinition {
+  return {
+    id: "xpert-invalid",
+    title: "Invalid Xpert",
+    updatedAt: "2026-08-20T00:00:00.000Z",
+    variables: [
+      {
+        id: "user-input",
+        name: "user_input",
+        kind: "input",
+        valueType: "text",
+      },
+    ],
+    nodes: [
+      {
+        id: "entry",
+        type: "workflowNode",
+        position: { x: 10, y: 20 },
+        data: {
+          kind: "workflow_call_entry",
+          title: "子流程入口",
+          description: "",
+          eventVariable: "call_event",
+        },
+      },
+      {
+        id: "agent",
+        type: "workflowNode",
+        position: { x: 300, y: 20 },
+        data: {
+          kind: "workflow_agent",
+          title: "Agent",
+          description: "",
+          modelId: "test-model",
+          rolePrompt: "Help",
+          taskInput: "{{user_input}}",
+          outputVariable: "agent_output",
+        },
+      },
+      {
+        id: "output",
+        type: "workflowNode",
+        position: { x: 600, y: 20 },
+        data: {
+          kind: "output",
+          title: "Output",
+          description: "",
+          outputVariable: "agent_output",
+        },
+      },
+    ],
+    edges: [
+      { id: "entry-agent", source: "entry", target: "agent" },
+      { id: "agent-output", source: "agent", target: "output" },
+    ],
+  };
+}
+
+function ordinaryWorkflow(): WorkflowDefinition {
+  const definition = invalidXpertDraft();
+  definition.id = "classic-local";
+  definition.variables = [];
+  definition.nodes[0] = {
+    ...definition.nodes[0],
+    data: {
+      kind: "input",
+      title: "Input",
+      description: "",
+      variableName: "user_input",
+    },
+  };
+  return definition;
+}
+
+function jsonResponse(value: unknown) {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("WorkflowEditor Xpert entry repair", () => {
+  beforeEach(() => {
+    registryAvailable = true;
+    staticValidation = {
+      valid: true,
+      issues: [],
+      order: ["entry", "agent", "output"],
+      node_count: 3,
+      edge_count: 2,
+    };
+    class TestResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: RequestInfo | URL) => {
+        const url = String(request);
+        if (url === "/api/workflow/node-registry") {
+          return Promise.resolve(
+            registryAvailable
+              ? jsonResponse(registry())
+              : new Response("unavailable", { status: 503 }),
+          );
+        }
+        if (url === "/api/workflow-native/validate") {
+          return Promise.resolve(jsonResponse(staticValidation));
+        }
+        if (url === "/api/runtime/middleware-nodes") return Promise.resolve(jsonResponse([]));
+        if (url.startsWith("/api/xperts")) {
+          return Promise.resolve(jsonResponse({ items: [], total: 0, version: "test" }));
+        }
+        if (url === "/api/runtime/client-hosts") return Promise.resolve(jsonResponse({ hosts: [] }));
+        if (url === "/api/skills/installed") return Promise.resolve(jsonResponse({ skills: [] }));
+        if (url === "/api/workflow/vision-capabilities") {
+          return Promise.resolve(jsonResponse({ models: [] }));
+        }
+        return Promise.resolve(jsonResponse([]));
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("repairs only the Xpert copy, supports undo, and saves explicitly", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const source = invalidXpertDraft();
+    const sourceSnapshot = structuredClone(source);
+    render(
+      <MemoryRouter>
+        <WorkflowEditor
+          initialDefinition={source}
+          onSave={onSave}
+          saveLabel="保存测试草稿"
+          workflowId="xpert-invalid"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("独立工作流入口需要转换")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "转换为智能体输入" }));
+    await waitFor(() =>
+      expect(screen.queryByText("独立工作流入口需要转换")).not.toBeInTheDocument(),
+    );
+
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+    expect(await screen.findByText("独立工作流入口需要转换")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "转换为智能体输入" }));
+    fireEvent.click(screen.getByRole("button", { name: "保存测试草稿" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce());
+    const saved = onSave.mock.calls[0][0] as WorkflowDefinition;
+    expect(saved.nodes[0]).toMatchObject({
+      id: "entry",
+      position: { x: 10, y: 20 },
+      data: { kind: "input", variableName: "user_input" },
+    });
+    expect(saved.edges).toEqual(source.edges);
+    expect(saved.variables).toEqual([]);
+    expect(source).toEqual(sourceSnapshot);
+  });
+
+  it("fails closed when Registry is unavailable", async () => {
+    registryAvailable = false;
+    render(
+      <MemoryRouter>
+        <WorkflowEditor
+          initialDefinition={ordinaryWorkflow()}
+          workflowId="classic-local"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText(
+        "节点 Registry 暂不可用，已暂停智能体转换与入口修复。",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "转为智能体草稿" }),
+    ).toBeDisabled();
+    const fetchMock = vi.mocked(fetch);
+    expect(
+      fetchMock.mock.calls.some(
+        ([request, init]) =>
+          String(request) === "/api/xperts" && init?.method === "POST",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not create an Xpert when static validation rejects the converted graph", async () => {
+    staticValidation = {
+      valid: false,
+      issues: [
+        {
+          code: "test_invalid",
+          message: "bad graph",
+          severity: "error",
+          node_id: "agent",
+        },
+      ],
+      order: [],
+      node_count: 3,
+      edge_count: 2,
+    };
+    render(
+      <MemoryRouter>
+        <WorkflowEditor
+          initialDefinition={ordinaryWorkflow()}
+          workflowId="classic-local"
+        />
+      </MemoryRouter>,
+    );
+
+    const convert = screen.getByRole("button", { name: "转为智能体草稿" });
+    await waitFor(() => expect(convert).toBeEnabled());
+    fireEvent.click(convert);
+    expect(await screen.findByText("• agent：bad graph")).toBeInTheDocument();
+    const fetchMock = vi.mocked(fetch);
+    expect(
+      fetchMock.mock.calls.some(
+        ([request, init]) =>
+          String(request) === "/api/xperts" && init?.method === "POST",
+      ),
+    ).toBe(false);
+  });
+});

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -82,6 +82,12 @@ import {
   planWorkflowVariableRename,
   type WorkflowVariableRenamePlan,
 } from "./workflowVariables";
+import {
+  analyzeXpertWorkflowConversion,
+  INDEPENDENT_DEPLOYMENT_NODE_KINDS,
+  validateXpertConversionGraph,
+  type XpertConversionAnalysis,
+} from "./workflowXpertConversion";
 import TrustedSkillSelect, {
   type TrustSelectableSkill,
 } from "../skill-trust/TrustedSkillSelect";
@@ -4335,16 +4341,6 @@ interface WorkflowCanvasProps {
 
 type WorkflowWorkspaceTab = "config" | "run";
 
-const INDEPENDENT_DEPLOYMENT_NODE_KINDS = new Set<WorkflowNodeKind>([
-  "scheduled_start",
-  "http_event_entry",
-  "failure_event_entry",
-  "workflow_call_entry",
-  "invoke_workflow",
-  "http_event_reply",
-  "suspend_wait",
-]);
-
 interface WorkflowFileInputFocusRequest {
   requestId: number;
   variableName: string;
@@ -4376,6 +4372,12 @@ function WorkflowCanvas({
   const [errorNotice, setErrorNotice] = useState("");
   const [isSaving, setIsSaving] = useState(false);
   const [isConverting, setIsConverting] = useState(false);
+  const [xpertRegistry, setXpertRegistry] =
+    useState<WorkflowNodeRegistryResponse | null>(null);
+  const [xpertRegistryError, setXpertRegistryError] = useState("");
+  const [conversionReview, setConversionReview] =
+    useState<XpertConversionAnalysis | null>(null);
+  const [conversionInputVariable, setConversionInputVariable] = useState("");
   const [projectRevision, setProjectRevision] = useState<number | null>(null);
   const [activeDeployment, setActiveDeployment] =
     useState<WorkflowDeploymentSummary | null>(null);
@@ -4419,6 +4421,26 @@ function WorkflowCanvas({
   >([]);
   const { screenToFlowPosition, fitView } = useReactFlow();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchWorkflowNodeRegistry()
+      .then((registry) => {
+        if (cancelled) return;
+        setXpertRegistry(registry);
+        setXpertRegistryError("");
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setXpertRegistry(null);
+        setXpertRegistryError(
+          "节点 Registry 暂不可用，已暂停智能体转换与入口修复。",
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (onSave || !workflowId.startsWith("wf_")) return;
@@ -4526,6 +4548,21 @@ function WorkflowCanvas({
     }),
     [edges, nodes, title, variables, workflowId],
   );
+  const xpertEntryRepair = useMemo(() => {
+    if (
+      !onSave ||
+      !xpertRegistry ||
+      nodes.some((node) => node.data.kind === "input") ||
+      !nodes.some((node) => node.data.kind === "workflow_call_entry")
+    ) {
+      return null;
+    }
+    return analyzeXpertWorkflowConversion(
+      definition,
+      xpertRegistry,
+      conversionInputVariable || undefined,
+    );
+  }, [conversionInputVariable, definition, nodes, onSave, xpertRegistry]);
 
   const selectedNode = useMemo(
     () => nodes.find((node) => node.id === selectedNodeId) ?? null,
@@ -5146,22 +5183,50 @@ function WorkflowCanvas({
     }
   }
 
-  async function convertToXpertDraft() {
+  async function convertToXpertDraft(selectedInputVariable?: string) {
     if (onSave || isConverting) return;
+    if (!xpertRegistry) {
+      setErrorNotice(
+        xpertRegistryError || "节点 Registry 正在加载，请稍后再试。",
+      );
+      return;
+    }
     const currentDefinition = stripRunStatus({
       ...definition,
       updatedAt: new Date().toISOString(),
     });
+    const analysis = analyzeXpertWorkflowConversion(
+      currentDefinition,
+      xpertRegistry,
+      selectedInputVariable,
+    );
+    setConversionInputVariable(analysis.selectedInputVariable);
+    if (analysis.status !== "ready" || !analysis.definition) {
+      setConversionReview(analysis);
+      return;
+    }
+    setConversionReview(null);
+
     setIsConverting(true);
     try {
-      const inputVariable =
-        currentDefinition.nodes
-          .find((node) => node.data.kind === "input")
-          ?.data.variableName?.trim() || "user_input";
-      const outputVariable =
-        currentDefinition.nodes
-          .find((node) => node.data.kind === "output")
-          ?.data.outputVariable?.trim() || "agent_output";
+      const staticValidation = await validateXpertConversionGraph(
+        analysis.definition,
+      );
+      if (!staticValidation.valid) {
+        const blockers = staticValidation.issues
+          .filter((issue) => issue.severity === "error")
+          .map((issue) =>
+            `${issue.node_id ? `${issue.node_id}：` : ""}${issue.message}`,
+          );
+        setConversionReview({
+          ...analysis,
+          status: "blocked",
+          blockers:
+            blockers.length > 0 ? blockers : ["静态图校验未通过。"],
+          definition: null,
+        });
+        return;
+      }
       const created = await createXpert({
         name: title.trim() || "未命名智能体",
         description: "由经典工作流草稿转换。",
@@ -5170,21 +5235,41 @@ function WorkflowCanvas({
       await updateXpert(created.id, {
         draft: {
           ...created.draft,
-          workflow: toXpertDraftWorkflow(currentDefinition),
-          input_variable: inputVariable,
-          output_variable: outputVariable,
+          workflow: toXpertDraftWorkflow(analysis.definition),
+          input_variable: analysis.selectedInputVariable,
+          output_variable: analysis.outputVariable,
         },
       });
       saveStoredWorkflow(currentDefinition);
+      setConversionReview(null);
       navigate(`/agents/studio/${created.id}`);
     } catch (error) {
-      setSaveNotice(
+      setErrorNotice(
         error instanceof Error ? error.message : "转换智能体草稿失败，请稍后重试",
       );
-      window.setTimeout(() => setSaveNotice(""), 2600);
     } finally {
       setIsConverting(false);
     }
+  }
+
+  function repairXpertEntry() {
+    if (!onSave || !xpertRegistry || !xpertEntryRepair || isConverting) return;
+    const selectedInput =
+      conversionInputVariable || xpertEntryRepair.selectedInputVariable;
+    const analysis = analyzeXpertWorkflowConversion(
+      definition,
+      xpertRegistry,
+      selectedInput,
+    );
+    if (analysis.status !== "ready" || !analysis.definition) return;
+    commitHistory();
+    setNodes(analysis.definition.nodes);
+    setVariables(analysis.definition.variables ?? []);
+    setSelectedNodeId(analysis.convertedEntryNodeId);
+    setConversionInputVariable("");
+    setErrorNotice("");
+    setSaveNotice("入口已转换；请显式保存智能体草稿");
+    window.setTimeout(() => setSaveNotice(""), 2600);
   }
 
   function onDrop(event: React.DragEvent<HTMLDivElement>) {
@@ -5433,8 +5518,13 @@ function WorkflowCanvas({
             {!onSave ? (
               <button
                 className="rounded-md border border-cyan-300/30 bg-cyan-300/10 px-3 py-1.5 text-xs font-semibold text-cyan-100 transition hover:bg-cyan-300/20 disabled:opacity-50"
-                disabled={isConverting}
+                disabled={isConverting || !xpertRegistry}
                 onClick={() => void convertToXpertDraft()}
+                title={
+                  !xpertRegistry
+                    ? xpertRegistryError || "节点 Registry 正在加载"
+                    : undefined
+                }
                 type="button"
               >
                 {isConverting ? "转换中..." : "转为智能体草稿"}
@@ -5450,6 +5540,157 @@ function WorkflowCanvas({
             </button>
           </div>
         </div>
+
+        {xpertRegistryError ? (
+          <div
+            aria-live="polite"
+            className="border-b border-amber-300/20 bg-amber-300/[0.08] px-4 py-2 text-xs text-amber-100"
+          >
+            {xpertRegistryError}
+          </div>
+        ) : null}
+
+        {!onSave && conversionReview ? (
+          <div
+            aria-live="polite"
+            className={`border-b px-4 py-3 ${
+              conversionReview.status === "blocked"
+                ? "border-rose-300/20 bg-rose-400/[0.08]"
+                : "border-cyan-300/20 bg-cyan-300/[0.08]"
+            }`}
+          >
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-white">
+                  {conversionReview.status === "selection_required"
+                    ? "选择智能体输入"
+                    : "暂时不能转为智能体草稿"}
+                </p>
+                {conversionReview.status === "selection_required" ? (
+                  <p className="mt-1 text-xs leading-5 text-slate-300">
+                    子流程有多个输入候选。请选择智能体每次对话接收的主输入。
+                  </p>
+                ) : (
+                  <ul className="mt-1 space-y-1 text-xs leading-5 text-rose-100">
+                    {conversionReview.blockers.map((blocker) => (
+                      <li key={blocker}>• {blocker}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+              <div className="flex shrink-0 flex-wrap items-center gap-2">
+                {conversionReview.inputCandidates.length > 1 ? (
+                  <select
+                    aria-label="智能体主输入"
+                    className="rounded-md border border-white/15 bg-slate-950 px-2.5 py-1.5 text-xs text-white outline-none focus:border-cyan-300/60"
+                    onChange={(event) =>
+                      setConversionInputVariable(event.target.value)
+                    }
+                    value={
+                      conversionInputVariable ||
+                      conversionReview.selectedInputVariable
+                    }
+                  >
+                    {conversionReview.inputCandidates.map((candidate) => (
+                      <option key={candidate} value={candidate}>
+                        {candidate}
+                      </option>
+                    ))}
+                  </select>
+                ) : null}
+                {conversionReview.status === "selection_required" ||
+                (conversionReview.status === "blocked" &&
+                  conversionReview.inputCandidates.length > 1) ? (
+                  <button
+                    className="rounded-md bg-cyan-300 px-3 py-1.5 text-xs font-semibold text-slate-950 transition hover:bg-cyan-200 disabled:opacity-50"
+                    disabled={isConverting}
+                    onClick={() =>
+                      void convertToXpertDraft(
+                        conversionInputVariable ||
+                          conversionReview.selectedInputVariable,
+                      )
+                    }
+                    type="button"
+                  >
+                    {conversionReview.status === "selection_required"
+                      ? "继续转换"
+                      : "重新检查"}
+                  </button>
+                ) : null}
+                <button
+                  className="rounded-md border border-white/15 px-3 py-1.5 text-xs text-slate-300 transition hover:bg-white/10 hover:text-white"
+                  onClick={() => setConversionReview(null)}
+                  type="button"
+                >
+                  关闭
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        {onSave && xpertEntryRepair ? (
+          <div
+            aria-live="polite"
+            className={`border-b px-4 py-3 ${
+              xpertEntryRepair.status === "blocked"
+                ? "border-rose-300/20 bg-rose-400/[0.08]"
+                : "border-amber-300/20 bg-amber-300/[0.08]"
+            }`}
+          >
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-white">
+                  独立工作流入口需要转换
+                </p>
+                {xpertEntryRepair.status === "blocked" ? (
+                  <ul className="mt-1 space-y-1 text-xs leading-5 text-rose-100">
+                    {xpertEntryRepair.blockers.map((blocker) => (
+                      <li key={blocker}>• {blocker}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="mt-1 text-xs leading-5 text-slate-300">
+                    只修改当前智能体草稿的入口；原独立工作流不会变化。修改可撤销，仍需显式保存。
+                  </p>
+                )}
+              </div>
+              {xpertEntryRepair.status !== "blocked" ||
+              xpertEntryRepair.inputCandidates.length > 1 ? (
+                <div className="flex shrink-0 flex-wrap items-center gap-2">
+                  {xpertEntryRepair.inputCandidates.length > 1 ? (
+                    <select
+                      aria-label="修复后的智能体主输入"
+                      className="rounded-md border border-white/15 bg-slate-950 px-2.5 py-1.5 text-xs text-white outline-none focus:border-amber-300/60"
+                      onChange={(event) =>
+                        setConversionInputVariable(event.target.value)
+                      }
+                      value={
+                        conversionInputVariable ||
+                        xpertEntryRepair.selectedInputVariable
+                      }
+                    >
+                      {xpertEntryRepair.inputCandidates.map((candidate) => (
+                        <option key={candidate} value={candidate}>
+                          {candidate}
+                        </option>
+                      ))}
+                    </select>
+                  ) : null}
+                  {xpertEntryRepair.status !== "blocked" ? (
+                    <button
+                      className="rounded-md bg-amber-300 px-3 py-1.5 text-xs font-semibold text-slate-950 transition hover:bg-amber-200"
+                      onClick={repairXpertEntry}
+                      type="button"
+                    >
+                      转换为智能体输入
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
 
         {oneTimeWebhookKey ? (
           <div className="absolute inset-0 z-50 flex items-center justify-center bg-slate-950/80 p-6">

--- a/client/src/components/workflow/workflowXpertConversion.test.ts
+++ b/client/src/components/workflow/workflowXpertConversion.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type WorkflowDefinition,
+  type WorkflowNode,
+  type WorkflowNodeKind,
+  type WorkflowVariableDeclaration,
+} from "../../types/workflow";
+import { type WorkflowNodeRegistryResponse } from "./workflowNodeRegistry";
+import {
+  analyzeXpertWorkflowConversion,
+  validateXpertConversionGraph,
+} from "./workflowXpertConversion";
+
+function node(
+  id: string,
+  kind: WorkflowNodeKind,
+  data: Record<string, unknown> = {},
+  position = { x: 0, y: 0 },
+): WorkflowNode {
+  return {
+    id,
+    type: "workflowNode",
+    position,
+    data: {
+      kind,
+      title: id,
+      description: `${id} description`,
+      ...data,
+    },
+  };
+}
+
+function registry(
+  kinds: WorkflowNodeKind[],
+  denied: WorkflowNodeKind[] = ["workflow_call_entry"],
+): WorkflowNodeRegistryResponse {
+  return {
+    version: "xpert-workflow-node-registry-v4",
+    contract_version: 3,
+    contract_checksum: "a".repeat(64),
+    tabs: [],
+    sections: [
+      {
+        id: "logic",
+        label: "test",
+        description: "test",
+        items: kinds.map((kind) => ({
+          kind: kind as Exclude<WorkflowNodeKind, "runtime_middleware">,
+          icon: "T",
+          title: kind,
+          description: kind,
+          enabled: true,
+          contract: {
+            kind: kind as Exclude<WorkflowNodeKind, "runtime_middleware">,
+            contract_status: "complete",
+            config_schema: {},
+            ports: [],
+            edge: {},
+            execution: {},
+            availability: {
+              xpert: denied.includes(kind)
+                ? {
+                    state: "deny",
+                    code: "deployment_node_xpert_forbidden",
+                    message: "独立部署节点不能进入智能体。",
+                  }
+                : { state: "allow" },
+            },
+            resources: [],
+            planner: {},
+            contract_version: 3,
+            checksum: "b".repeat(64),
+            compiler_checksum: "c".repeat(64),
+          },
+        })),
+      },
+    ],
+    knowledge_pipeline: { items: [], placeholders: [] },
+  };
+}
+
+function callableDefinition(
+  variables: WorkflowVariableDeclaration[] = [
+    {
+      id: "message",
+      name: "user_input",
+      kind: "input",
+      valueType: "text",
+    },
+  ],
+): WorkflowDefinition {
+  return {
+    id: "wf-callable",
+    title: "Callable",
+    updatedAt: "2026-08-20T00:00:00.000Z",
+    variables,
+    nodes: [
+      node(
+        "entry",
+        "workflow_call_entry",
+        { eventVariable: "call_event" },
+        { x: 20, y: 40 },
+      ),
+      node("agent", "workflow_agent", {
+        modelId: "test-model",
+        rolePrompt: "Help",
+        taskInput: "{{user_input}}",
+        outputVariable: "agent_output",
+      }),
+      node("output", "output", { outputVariable: "agent_output" }),
+    ],
+    edges: [
+      { id: "entry-agent", source: "entry", target: "agent" },
+      { id: "agent-output", source: "agent", target: "output" },
+    ],
+  };
+}
+
+const baseRegistryKinds: WorkflowNodeKind[] = [
+  "input",
+  "workflow_call_entry",
+  "workflow_agent",
+  "output",
+];
+
+describe("analyzeXpertWorkflowConversion", () => {
+  it("converts a sole callable entry in an isolated copy and preserves graph identity", () => {
+    const source = callableDefinition();
+    const snapshot = structuredClone(source);
+    const analysis = analyzeXpertWorkflowConversion(
+      source,
+      registry(baseRegistryKinds),
+    );
+
+    expect(analysis.status).toBe("ready");
+    expect(analysis.selectedInputVariable).toBe("user_input");
+    expect(analysis.outputVariable).toBe("agent_output");
+    expect(analysis.definition?.nodes[0]).toMatchObject({
+      id: "entry",
+      position: { x: 20, y: 40 },
+      data: { kind: "input", variableName: "user_input" },
+    });
+    expect(analysis.definition?.edges).toEqual(source.edges);
+    expect(analysis.definition?.variables).toEqual([]);
+    expect(source).toEqual(snapshot);
+    expect(analysis.definition).not.toBe(source);
+  });
+
+  it("prefers user_input but requires a choice when multiple candidates exist", () => {
+    const source = callableDefinition([
+      {
+        id: "message",
+        name: "message",
+        kind: "input",
+        valueType: "text",
+      },
+      {
+        id: "user-input",
+        name: "user_input",
+        kind: "input",
+        valueType: "text",
+        defaultValue: "fallback",
+      },
+    ]);
+    const analysis = analyzeXpertWorkflowConversion(
+      source,
+      registry(baseRegistryKinds),
+    );
+    expect(analysis.status).toBe("selection_required");
+    expect(analysis.selectedInputVariable).toBe("user_input");
+    expect(analysis.inputCandidates).toEqual(["user_input", "message"]);
+
+    const selected = analyzeXpertWorkflowConversion(
+      source,
+      registry(baseRegistryKinds),
+      "message",
+    );
+    expect(selected.status).toBe("ready");
+    expect(selected.definition?.variables).toEqual([
+      expect.objectContaining({ name: "user_input", defaultValue: "fallback" }),
+    ]);
+  });
+
+  it("blocks conversion when the call context variable is referenced", () => {
+    const source = callableDefinition();
+    source.nodes[1].data.taskInput = "Handle {{call_event}} for {{user_input}}";
+    const analysis = analyzeXpertWorkflowConversion(
+      source,
+      registry(baseRegistryKinds),
+    );
+    expect(analysis.status).toBe("blocked");
+    expect(analysis.blockers.join(" ")).toContain("call_event");
+    expect(analysis.blockers.join(" ")).toContain("改变语义");
+  });
+
+  it("blocks multiple callable entries instead of choosing one silently", () => {
+    const source = callableDefinition();
+    source.nodes.splice(
+      1,
+      0,
+      node("entry-2", "workflow_call_entry", { eventVariable: "call_event_2" }),
+    );
+    const analysis = analyzeXpertWorkflowConversion(
+      source,
+      registry(baseRegistryKinds),
+    );
+    expect(analysis.status).toBe("blocked");
+    expect(analysis.blockers).toContain(
+      "工作流包含多个子流程入口，无法确定要转换的入口。",
+    );
+  });
+
+  it("blocks a selected input when another required input has no default", () => {
+    const source = callableDefinition([
+      {
+        id: "message",
+        name: "message",
+        kind: "input",
+        valueType: "text",
+      },
+      {
+        id: "count",
+        name: "count",
+        kind: "input",
+        valueType: "number",
+      },
+    ]);
+    const analysis = analyzeXpertWorkflowConversion(
+      source,
+      registry(baseRegistryKinds),
+      "message",
+    );
+    expect(analysis.status).toBe("blocked");
+    expect(analysis.blockers).toContain("其他必填输入没有默认值：count。");
+  });
+
+  it.each([
+    "scheduled_start",
+    "http_event_entry",
+    "failure_event_entry",
+    "invoke_workflow",
+    "http_event_reply",
+    "suspend_wait",
+  ] satisfies WorkflowNodeKind[])("blocks independent node %s before Xpert creation", (kind) => {
+    const source = callableDefinition();
+    source.nodes[0] = node("input", "input", { variableName: "user_input" });
+    source.nodes.splice(2, 0, node("forbidden", kind));
+    source.edges = [];
+    const analysis = analyzeXpertWorkflowConversion(
+      source,
+      registry([...baseRegistryKinds, kind], [kind]),
+    );
+    expect(analysis.status).toBe("blocked");
+    expect(analysis.blockers.join(" ")).toContain("独立发布运行面");
+  });
+
+  it("keeps an ordinary single-input workflow unchanged", () => {
+    const source = callableDefinition([]);
+    source.nodes[0] = node(
+      "input",
+      "input",
+      { variableName: "user_input" },
+      { x: 20, y: 40 },
+    );
+    const analysis = analyzeXpertWorkflowConversion(
+      source,
+      registry(baseRegistryKinds, []),
+    );
+    expect(analysis.status).toBe("ready");
+    expect(analysis.convertedEntryNodeId).toBeNull();
+    expect(analysis.definition).toEqual(source);
+    expect(analysis.definition).not.toBe(source);
+  });
+
+  it("fails closed when Registry cannot prove a node's Xpert availability", () => {
+    const analysis = analyzeXpertWorkflowConversion(
+      callableDefinition(),
+      registry(["input", "workflow_call_entry", "output"]),
+    );
+    expect(analysis.status).toBe("blocked");
+    expect(analysis.blockers.join(" ")).toContain("Registry 未提供");
+  });
+});
+
+describe("validateXpertConversionGraph", () => {
+  it("sends the converted copy to the static validator", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          valid: true,
+          issues: [],
+          order: ["entry", "agent", "output"],
+          node_count: 3,
+          edge_count: 2,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const result = await validateXpertConversionGraph(callableDefinition());
+    expect(result.valid).toBe(true);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0];
+    const payload = JSON.parse(String(init.body));
+    expect(payload.workflow).toMatchObject({
+      source: "classic",
+      version: "xpert-conversion-v1",
+      id: "wf-callable",
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it("honors the Xpert-injected history variable without hiding other errors", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          valid: false,
+          issues: [
+            {
+              code: "missing_workflow_agent_template_variable",
+              message:
+                "Workflow agent taskInput references undefined variable 'conversation_history'.",
+              severity: "error",
+              node_id: "agent",
+            },
+            {
+              code: "unrelated_error",
+              message: "Keep this error.",
+              severity: "error",
+              node_id: "agent",
+            },
+          ],
+          order: [],
+          node_count: 3,
+          edge_count: 2,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const result = await validateXpertConversionGraph(callableDefinition());
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.code)).toEqual(["unrelated_error"]);
+    vi.unstubAllGlobals();
+  });
+});

--- a/client/src/components/workflow/workflowXpertConversion.ts
+++ b/client/src/components/workflow/workflowXpertConversion.ts
@@ -1,0 +1,346 @@
+import {
+  type WorkflowDefinition,
+  type WorkflowNode,
+  type WorkflowNodeKind,
+} from "../../types/workflow";
+import {
+  type NativeValidateResponse,
+  type NativeWorkflowDefinition,
+} from "../../types/workflow-native";
+import {
+  type WorkflowNodeRegistryResponse,
+  type WorkflowPaletteItem,
+} from "./workflowNodeRegistry";
+import { analyzeWorkflowVariables } from "./workflowVariables";
+
+export const INDEPENDENT_DEPLOYMENT_NODE_KINDS = new Set<WorkflowNodeKind>([
+  "scheduled_start",
+  "http_event_entry",
+  "failure_event_entry",
+  "workflow_call_entry",
+  "invoke_workflow",
+  "http_event_reply",
+  "suspend_wait",
+]);
+
+export interface XpertConversionAnalysis {
+  status: "ready" | "selection_required" | "blocked";
+  blockers: string[];
+  inputCandidates: string[];
+  selectedInputVariable: string;
+  outputVariable: string;
+  convertedEntryNodeId: string | null;
+  definition: WorkflowDefinition | null;
+}
+
+function cloneDefinition(definition: WorkflowDefinition): WorkflowDefinition {
+  return structuredClone(definition);
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function containsTemplateVariable(value: unknown, variableName: string): boolean {
+  if (typeof value === "string") {
+    const escaped = variableName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`{{\\s*${escaped}\\s*}}`).test(value);
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => containsTemplateVariable(item, variableName));
+  }
+  if (value && typeof value === "object") {
+    return Object.values(value).some((item) =>
+      containsTemplateVariable(item, variableName),
+    );
+  }
+  return false;
+}
+
+function registryItems(registry: WorkflowNodeRegistryResponse): WorkflowPaletteItem[] {
+  return [
+    ...registry.sections.flatMap((section) => section.items),
+    ...registry.knowledge_pipeline.items,
+  ];
+}
+
+function xpertAvailabilityState(item: WorkflowPaletteItem): string {
+  const xpert = item.contract?.availability.xpert;
+  if (!xpert || typeof xpert !== "object" || Array.isArray(xpert)) return "";
+  const state = (xpert as Record<string, unknown>).state;
+  return typeof state === "string" ? state : "";
+}
+
+function xpertAvailabilityMessage(item: WorkflowPaletteItem): string {
+  const xpert = item.contract?.availability.xpert;
+  if (!xpert || typeof xpert !== "object" || Array.isArray(xpert)) return "";
+  const message = (xpert as Record<string, unknown>).message;
+  return typeof message === "string" ? message.trim() : "";
+}
+
+function availabilityBlockers(
+  nodes: WorkflowNode[],
+  registry: WorkflowNodeRegistryResponse,
+  convertibleEntryId: string | null,
+): string[] {
+  const items = new Map(registryItems(registry).map((item) => [item.kind, item]));
+  const blockers: string[] = [];
+  for (const node of nodes) {
+    if (node.id === convertibleEntryId) continue;
+    const item = items.get(node.data.kind as WorkflowPaletteItem["kind"]);
+    if (!item || item.enabled === false || !item.contract) {
+      blockers.push(
+        `${node.data.title || node.id}：Registry 未提供可用的 Xpert 节点合同。`,
+      );
+      continue;
+    }
+    if (xpertAvailabilityState(item) !== "allow") {
+      const independentMessage = INDEPENDENT_DEPLOYMENT_NODE_KINDS.has(
+        node.data.kind,
+      )
+        ? "该节点属于独立发布运行面，不能进入智能体工作流。"
+        : "";
+      blockers.push(
+        `${node.data.title || node.id}：${
+          independentMessage ||
+          xpertAvailabilityMessage(item) ||
+          "该节点不能用于智能体工作流。"
+        }`,
+      );
+    }
+  }
+  return blockers;
+}
+
+function initialResult(): XpertConversionAnalysis {
+  return {
+    status: "blocked",
+    blockers: [],
+    inputCandidates: [],
+    selectedInputVariable: "",
+    outputVariable: "",
+    convertedEntryNodeId: null,
+    definition: null,
+  };
+}
+
+/**
+ * Analyze a classic workflow without mutating it. A callable entry is replaced only in
+ * the returned Xpert copy; the matching global input declaration is removed because the
+ * input node becomes that variable's producer.
+ */
+export function analyzeXpertWorkflowConversion(
+  definition: WorkflowDefinition,
+  registry: WorkflowNodeRegistryResponse,
+  selectedInputVariable?: string,
+): XpertConversionAnalysis {
+  const result = initialResult();
+  const inputNodes = definition.nodes.filter((node) => node.data.kind === "input");
+  const callEntries = definition.nodes.filter(
+    (node) => node.data.kind === "workflow_call_entry",
+  );
+  const outputNodes = definition.nodes.filter((node) => node.data.kind === "output");
+  const agentNodes = definition.nodes.filter(
+    (node) => node.data.kind === "workflow_agent",
+  );
+
+  if (inputNodes.length > 1) {
+    result.blockers.push("工作流包含多个普通入口；智能体只能保留一个入口。");
+  }
+  if (callEntries.length > 1) {
+    result.blockers.push("工作流包含多个子流程入口，无法确定要转换的入口。");
+  }
+  if (inputNodes.length === 1 && callEntries.length > 0) {
+    result.blockers.push("普通入口与子流程入口同时存在，无法自动转换。");
+  }
+  if (outputNodes.length !== 1) {
+    result.blockers.push("智能体草稿必须恰好包含一个输出节点。");
+  } else {
+    result.outputVariable = text(outputNodes[0].data.outputVariable);
+    if (!result.outputVariable) {
+      result.blockers.push("输出节点尚未选择最终输出变量。");
+    }
+  }
+  if (agentNodes.length === 0) {
+    result.blockers.push("智能体草稿至少需要一个工作流智能体节点。");
+  }
+
+  let convertedEntry: WorkflowNode | null = null;
+  if (inputNodes.length === 0) {
+    if (callEntries.length !== 1) {
+      result.blockers.push("没有可转换的唯一子流程入口。");
+    } else {
+      convertedEntry = callEntries[0];
+      result.convertedEntryNodeId = convertedEntry.id;
+      const eventVariable = text(convertedEntry.data.eventVariable) || "call_event";
+      const eventDescriptor = analyzeWorkflowVariables(
+        definition.nodes,
+        definition.edges,
+        null,
+        definition.variables ?? [],
+      ).find((variable) => variable.name === eventVariable);
+      if ((eventDescriptor?.references.length ?? 0) > 0) {
+        result.blockers.push(
+          `子流程调用上下文变量 ${eventVariable} 已被下游引用，转换会改变语义。`,
+        );
+      }
+    }
+  }
+
+  result.blockers.push(
+    ...availabilityBlockers(definition.nodes, registry, convertedEntry?.id ?? null),
+  );
+
+  if (inputNodes.length === 1) {
+    result.selectedInputVariable = text(inputNodes[0].data.variableName);
+    if (!result.selectedInputVariable) {
+      result.blockers.push("普通入口尚未声明输入变量。");
+    }
+    result.blockers = unique(result.blockers);
+    if (result.blockers.length > 0) return result;
+    result.status = "ready";
+    result.definition = cloneDefinition(definition);
+    return result;
+  }
+
+  if (!convertedEntry) {
+    result.blockers = unique(result.blockers);
+    return result;
+  }
+
+  const declaredInputs = unique(
+    (definition.variables ?? [])
+      .filter((variable) => variable.kind === "input")
+      .map((variable) => variable.name.trim()),
+  );
+  const userInputReferenced = definition.nodes.some((node) =>
+    containsTemplateVariable(node.data, "user_input"),
+  );
+  result.inputCandidates = unique([
+    ...(declaredInputs.includes("user_input") || userInputReferenced
+      ? ["user_input"]
+      : []),
+    ...declaredInputs,
+  ]);
+  if (result.inputCandidates.length === 0) {
+    result.inputCandidates = ["user_input"];
+  }
+
+  const explicitSelection = text(selectedInputVariable);
+  result.selectedInputVariable =
+    explicitSelection ||
+    (result.inputCandidates.includes("user_input")
+      ? "user_input"
+      : result.inputCandidates[0]);
+
+  if (
+    explicitSelection &&
+    !result.inputCandidates.includes(result.selectedInputVariable)
+  ) {
+    result.blockers.push("所选智能体输入不在可转换的输入候选中。");
+  }
+
+  if (result.inputCandidates.length > 1 && !explicitSelection) {
+    result.blockers = unique(result.blockers);
+    if (result.blockers.length > 0) return result;
+    result.status = "selection_required";
+    return result;
+  }
+
+  const otherRequiredInputs = (definition.variables ?? []).filter(
+    (variable) =>
+      variable.kind === "input" &&
+      variable.name !== result.selectedInputVariable &&
+      variable.defaultValue === undefined,
+  );
+  if (otherRequiredInputs.length > 0) {
+    result.blockers.push(
+      `其他必填输入没有默认值：${otherRequiredInputs
+        .map((variable) => variable.name)
+        .join("、")}。`,
+    );
+  }
+
+  result.blockers = unique(result.blockers);
+  if (result.blockers.length > 0) return result;
+
+  const converted = cloneDefinition(definition);
+  converted.nodes = converted.nodes.map((node) =>
+    node.id === convertedEntry?.id
+      ? {
+          ...node,
+          data: {
+            kind: "input",
+            title: "智能体输入",
+            description: "接收用户发给智能体的任务。",
+            variableName: result.selectedInputVariable,
+          },
+        }
+      : node,
+  );
+  converted.variables = (converted.variables ?? []).filter(
+    (variable) =>
+      !(
+        variable.kind === "input" &&
+        variable.name === result.selectedInputVariable
+      ),
+  );
+  result.status = "ready";
+  result.definition = converted;
+  return result;
+}
+
+function toNativeDefinition(
+  definition: WorkflowDefinition,
+): NativeWorkflowDefinition {
+  return {
+    id: definition.id,
+    title: definition.title,
+    updatedAt: definition.updatedAt,
+    version: "xpert-conversion-v1",
+    source: "classic",
+    variables: definition.variables ?? [],
+    nodes: definition.nodes,
+    edges: definition.edges,
+  };
+}
+
+async function responseMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { detail?: unknown };
+    if (typeof body.detail === "string") return body.detail;
+  } catch {
+    // Preserve the stable fallback below when an intermediary returns non-JSON.
+  }
+  return `静态图校验不可用（HTTP ${response.status}）。`;
+}
+
+export async function validateXpertConversionGraph(
+  definition: WorkflowDefinition,
+  historyVariable = "conversation_history",
+): Promise<NativeValidateResponse> {
+  const response = await fetch("/api/workflow-native/validate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ workflow: toNativeDefinition(definition) }),
+  });
+  if (!response.ok) throw new Error(await responseMessage(response));
+  const result = (await response.json()) as NativeValidateResponse;
+  const injectedHistoryReference = `variable '${historyVariable}'`;
+  const issues = result.issues.filter(
+    (issue) =>
+      !(
+        issue.code.endsWith("template_variable") &&
+        issue.message.includes(injectedHistoryReference)
+      ),
+  );
+  return {
+    ...result,
+    issues,
+    valid: !issues.some((issue) => issue.severity === "error"),
+  };
+}

--- a/client/src/pages/XpertStudioPage.tsx
+++ b/client/src/pages/XpertStudioPage.tsx
@@ -20,6 +20,7 @@ import {
   updateXpert,
   validateXpert,
 } from "../utils/xpertApi";
+import { consolidateXpertValidation } from "../utils/xpertValidation";
 
 function splitTags(value: string) {
   return value.split(/[,\n]/).map((item) => item.trim()).filter(Boolean);
@@ -140,10 +141,16 @@ export default function XpertStudioPage() {
 
   async function saveWorkflow(definition: WorkflowDefinition) {
     if (!xpert) return;
+    const inputNode = definition.nodes.find((node) => node.data.kind === "input");
+    const outputNode = definition.nodes.find((node) => node.data.kind === "output");
+    const inputVariable = String(inputNode?.data.variableName ?? "").trim();
+    const outputVariable = String(outputNode?.data.outputVariable ?? "").trim();
     const updated = await updateXpert(xpert.id, {
       draft: {
         ...xpert.draft,
         workflow: toXpertDraftWorkflow(definition),
+        input_variable: inputVariable || xpert.draft.input_variable,
+        output_variable: outputVariable || xpert.draft.output_variable,
       },
     });
     setXpert(updated);
@@ -156,7 +163,13 @@ export default function XpertStudioPage() {
     setError("");
     try {
       const result = await validateXpert(xpert.id);
-      setValidation(result);
+      setValidation(
+        consolidateXpertValidation(
+          result,
+          xpert.draft.workflow,
+          xpert.draft.input_variable,
+        ),
+      );
       setNotice(result.valid ? "发布预检通过" : "发布预检发现问题");
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "发布预检失败");
@@ -171,7 +184,13 @@ export default function XpertStudioPage() {
     setError("");
     try {
       const result = await validateXpert(xpert.id);
-      setValidation(result);
+      setValidation(
+        consolidateXpertValidation(
+          result,
+          xpert.draft.workflow,
+          xpert.draft.input_variable,
+        ),
+      );
       if (!result.valid) {
         setNotice("请先修复预检问题");
         return;

--- a/client/src/utils/xpertValidation.test.ts
+++ b/client/src/utils/xpertValidation.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type XpertValidationResult,
+  type XpertWorkflowDefinition,
+} from "../types/xpert";
+import { consolidateXpertValidation } from "./xpertValidation";
+
+function callableWorkflow(): XpertWorkflowDefinition {
+  return {
+    id: "xpert-draft",
+    title: "Draft",
+    source: "classic",
+    version: "xpert-draft-v1",
+    nodes: [
+      {
+        id: "entry",
+        type: "workflow_call_entry",
+        data: {
+          kind: "workflow_call_entry",
+          title: "子流程入口",
+          description: "",
+          eventVariable: "call_event",
+        },
+      },
+      {
+        id: "agent",
+        type: "workflow_agent",
+        data: {
+          kind: "workflow_agent",
+          title: "Agent",
+          description: "",
+          taskInput: "{{user_input}}",
+        },
+      },
+    ],
+    edges: [],
+  };
+}
+
+function noisyResult(): XpertValidationResult {
+  return {
+    valid: false,
+    order: [],
+    node_count: 2,
+    edge_count: 0,
+    issues: [
+      {
+        code: "missing_workflow_agent_template_variable",
+        message: "workflow_agent taskInput references undefined variable 'user_input'.",
+        severity: "error",
+        node_id: "agent",
+      },
+      {
+        code: "xpert_input_contract",
+        message: "Published Xpert requires exactly one input node.",
+        severity: "error",
+      },
+      {
+        code: "deployment_node_xpert_forbidden",
+        message: "Independent deployment nodes are unavailable in Xpert workflows.",
+        severity: "error",
+        node_id: "entry",
+      },
+      {
+        code: "unrelated",
+        message: "Keep this problem.",
+        severity: "error",
+        node_id: "agent",
+      },
+    ],
+  };
+}
+
+describe("consolidateXpertValidation", () => {
+  it("replaces derived entry symptoms with one actionable issue", () => {
+    const consolidated = consolidateXpertValidation(
+      noisyResult(),
+      callableWorkflow(),
+      "user_input",
+    );
+    expect(consolidated.issues.map((issue) => issue.code)).toEqual([
+      "xpert_entry_conversion_required",
+      "unrelated",
+    ]);
+    expect(consolidated.issues[0]).toMatchObject({
+      node_id: "entry",
+      message: expect.stringContaining("转换为智能体输入"),
+    });
+  });
+
+  it("does not hide errors when another independent deployment node exists", () => {
+    const workflow = callableWorkflow();
+    workflow.nodes.push({
+      id: "wait",
+      type: "suspend_wait",
+      data: {
+        kind: "suspend_wait",
+        title: "挂起等待",
+        description: "",
+      },
+    });
+    expect(
+      consolidateXpertValidation(noisyResult(), workflow, "user_input").issues,
+    ).toEqual(noisyResult().issues);
+  });
+
+  it("does not claim entry-only repair when call context is referenced", () => {
+    const workflow = callableWorkflow();
+    workflow.nodes[1].data.taskInput = "Handle {{call_event}}";
+    expect(
+      consolidateXpertValidation(noisyResult(), workflow, "user_input").issues,
+    ).toEqual(noisyResult().issues);
+  });
+
+  it("only hides the undefined variable matching the Xpert input contract", () => {
+    const result = noisyResult();
+    result.issues.push({
+      code: "missing_workflow_agent_template_variable",
+      message: "workflow_agent taskInput references undefined variable 'other_input'.",
+      severity: "error",
+      node_id: "agent",
+    });
+    const consolidated = consolidateXpertValidation(
+      result,
+      callableWorkflow(),
+      "user_input",
+    );
+    expect(consolidated.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: expect.stringContaining("other_input"),
+        }),
+      ]),
+    );
+  });
+});

--- a/client/src/utils/xpertValidation.ts
+++ b/client/src/utils/xpertValidation.ts
@@ -1,0 +1,102 @@
+import {
+  type XpertValidationIssue,
+  type XpertValidationResult,
+  type XpertWorkflowDefinition,
+} from "../types/xpert";
+import { type WorkflowNodeKind } from "../types/workflow";
+import { INDEPENDENT_DEPLOYMENT_NODE_KINDS } from "../components/workflow/workflowXpertConversion";
+import { analyzeWorkflowVariables } from "../components/workflow/workflowVariables";
+
+const DERIVED_ENTRY_ISSUE_CODES = new Set([
+  "xpert_input_contract",
+  "missing_input_node",
+]);
+
+/** Collapse the three symptoms of an unconverted callable entry into one action. */
+export function consolidateXpertValidation(
+  result: XpertValidationResult,
+  workflow: XpertWorkflowDefinition,
+  inputVariable: string,
+): XpertValidationResult {
+  const inputNodes = workflow.nodes.filter(
+    (node) => (node.data.kind || node.type) === "input",
+  );
+  const callEntries = workflow.nodes.filter(
+    (node) => (node.data.kind || node.type) === "workflow_call_entry",
+  );
+  const otherDeploymentNodes = workflow.nodes.filter((node) => {
+    const kind = (node.data.kind || node.type) as WorkflowNodeKind;
+    return (
+      kind !== "workflow_call_entry" &&
+      INDEPENDENT_DEPLOYMENT_NODE_KINDS.has(kind)
+    );
+  });
+  if (
+    inputNodes.length !== 0 ||
+    callEntries.length !== 1 ||
+    otherDeploymentNodes.length > 0
+  ) {
+    return result;
+  }
+
+  const callEventVariable = String(
+    callEntries[0].data.eventVariable || "call_event",
+  ).trim();
+  const variableInventory = analyzeWorkflowVariables(
+    workflow.nodes.map((node) => ({
+      ...node,
+      type: "workflowNode" as const,
+      position: node.position ?? { x: 0, y: 0 },
+    })),
+    workflow.edges,
+    null,
+    workflow.variables ?? [],
+  );
+  if (
+    (variableInventory.find((variable) => variable.name === callEventVariable)
+      ?.references.length ?? 0) > 0 ||
+    (workflow.variables ?? []).some(
+      (variable) =>
+        variable.kind === "input" &&
+        variable.name !== inputVariable &&
+        variable.defaultValue === undefined,
+    )
+  ) {
+    return result;
+  }
+
+  const callEntryId = callEntries[0].id;
+  const inputReference = `variable '${inputVariable}'`;
+  let replaced = false;
+  const retained: XpertValidationIssue[] = [];
+  for (const issue of result.issues) {
+    const isInputContract = DERIVED_ENTRY_ISSUE_CODES.has(issue.code);
+    const isEntryPolicy =
+      issue.code === "deployment_node_xpert_forbidden" &&
+      issue.node_id === callEntryId;
+    const isUndefinedTaskInput =
+      issue.code === "missing_workflow_agent_template_variable" &&
+      issue.message.includes(inputReference);
+    if (isInputContract || isEntryPolicy || isUndefinedTaskInput) {
+      replaced = true;
+      continue;
+    }
+    retained.push(issue);
+  }
+  if (!replaced) return result;
+
+  return {
+    ...result,
+    valid: false,
+    issues: [
+      {
+        code: "xpert_entry_conversion_required",
+        message:
+          "该草稿仍使用子流程入口。请在画布中将它转换为智能体输入，然后保存草稿。",
+        severity: "error",
+        node_id: callEntryId,
+      },
+      ...retained,
+    ],
+  };
+}


### PR DESCRIPTION
## 摘要

- 将仅含 workflow_call_entry 的独立工作流非破坏性转换为合法 Xpert 草稿入口
- 转换仅作用于新建或当前 Xpert 副本，保留原节点 ID、位置和连线
- 增加输入候选选择、Registry 失效关闭、静态校验和不兼容节点拦截
- 为存量无效 Xpert 草稿提供可撤销、显式保存的入口修复条
- 合并入口派生预检错误，保留服务端发布拒绝策略

## 验证

- 前端完整测试：86 files / 438 tests passed
- 前端构建通过
- Xpert 发布测试：9 passed
- NodeContract、native validate、能力审计：121 passed
- Agency Worker 相关回归：70 passed
- git diff --check 通过
- 人工独立预览完成创建、修复、撤销、保存与发布预检闭环

## 边界

- 不修改 NodeContract、Registry checksum、能力矩阵、Store 或后端 API
- R1/R1.5 独立部署节点仍不得直接进入 Xpert 发布版本
- 后端全量中的独立性能门槛在容器环境测得 13.833ms，阈值为 10ms；未发现与本 PR 源码变更相关