### PR TITLE
feature: 完善 Skill Creator 跨版本回归与体验

### DIFF
--- a/client/src/components/skill-creator/SkillCreatorFinish.tsx
+++ b/client/src/components/skill-creator/SkillCreatorFinish.tsx
@@ -1,12 +1,17 @@
-import { Check, Download, LoaderCircle, RefreshCw, ShieldCheck, Sparkles } from "lucide-react";
-import { useState } from "react";
+import { Check, Download, History, LoaderCircle, RefreshCw, Save, ShieldCheck, Sparkles } from "lucide-react";
+import { useEffect, useState } from "react";
 import {
+  answerSkillCreatorEvolutionPlan,
+  confirmSkillCreatorEvolutionPlan,
+  generateSkillCreatorEvolutionPlan,
   installSkillCreatorDraft,
   iterateSkillCreatorDraft,
+  updateSkillCreatorEvolutionPlan,
   type SkillCreatorDraft,
   type SkillCreatorProposal,
   type SkillCreatorSession,
   type SkillEvaluationRun,
+  type SkillEvolutionPlan,
 } from "../../utils/skillCreatorApi";
 
 export default function SkillCreatorFinish({
@@ -16,6 +21,7 @@ export default function SkillCreatorFinish({
   proposal,
   onProposal,
   onReload,
+  onGoToBuild,
   onError,
   onNotice,
 }: {
@@ -25,15 +31,25 @@ export default function SkillCreatorFinish({
   proposal: SkillCreatorProposal | null;
   onProposal: (proposal: SkillCreatorProposal, session?: SkillCreatorSession) => Promise<void> | void;
   onReload: () => Promise<void>;
+  onGoToBuild?: () => void;
   onError: (error: unknown, fallback: string) => void;
   onNotice: (message: string) => void;
 }) {
   const [busy, setBusy] = useState("");
+  const [evolutionPlan, setEvolutionPlan] = useState<SkillEvolutionPlan | null>(
+    session.evolution_plan && "plan_id" in session.evolution_plan ? session.evolution_plan : null,
+  );
+  const [answers, setAnswers] = useState<Record<string, string>>({});
   const qualityStatus = session.quality_status ?? draft.quality_status ?? "not_evaluated";
   const installState = session.install_state ?? draft.install_state ?? "not_installed";
   const accepted = qualityStatus === "accepted";
   const waived = qualityStatus === "eval_waived";
   const canInstall = (accepted || waived) && session.current_digest === draft.content_digest && installState !== "current";
+  const evolutionEnabled = Boolean(session.regression_governance?.enabled);
+
+  useEffect(() => {
+    setEvolutionPlan(session.evolution_plan && "plan_id" in session.evolution_plan ? session.evolution_plan : null);
+  }, [session.evolution_plan]);
 
   async function iterate() {
     if (!run) return;
@@ -44,6 +60,65 @@ export default function SkillCreatorFinish({
       onNotice("生成助手已根据已保存反馈提交更新提案。批准后会形成新 revision，并使旧评测过期。");
     } catch (error) {
       onError(error, "改进提案生成失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function generateEvolutionPlan() {
+    if (!run) return;
+    setBusy("evolution-generate");
+    try {
+      const next = await generateSkillCreatorEvolutionPlan(session, draft, run);
+      setEvolutionPlan(next);
+      setAnswers(next.clarification_answers ?? {});
+      onNotice(next.state === "needs_input" ? "进化计划需要补充少量信息。" : "资源级进化计划已生成，请检查后确认。");
+    } catch (error) {
+      onError(error, "进化计划生成失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function saveEvolutionAnswers() {
+    if (!evolutionPlan) return;
+    setBusy("evolution-answers");
+    try {
+      const next = await answerSkillCreatorEvolutionPlan(session, draft, evolutionPlan, answers);
+      setEvolutionPlan(next);
+      onNotice("澄清答案已冻结；请重新生成计划以应用答案。");
+    } catch (error) {
+      onError(error, "进化计划答案保存失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function saveEvolutionActions() {
+    if (!evolutionPlan) return;
+    setBusy("evolution-save");
+    try {
+      const next = await updateSkillCreatorEvolutionPlan(session, draft, evolutionPlan, { actions: evolutionPlan.actions });
+      setEvolutionPlan(next);
+      onNotice("进化动作已保存为新的不可变 revision。");
+    } catch (error) {
+      onError(error, "进化动作保存失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function confirmEvolution() {
+    if (!evolutionPlan) return;
+    setBusy("evolution-confirm");
+    try {
+      const result = await confirmSkillCreatorEvolutionPlan(session, draft, evolutionPlan);
+      setEvolutionPlan(result.evolution_plan);
+      await onReload();
+      onGoToBuild?.();
+      onNotice("改进方案已确认。接下来只重新生成需要变化的内容。");
+    } catch (error) {
+      onError(error, "进化计划确认失败。");
     } finally {
       setBusy("");
     }
@@ -69,35 +144,84 @@ export default function SkillCreatorFinish({
         <div className="flex items-start gap-3">
           <RefreshCw aria-hidden="true" className="mt-0.5 shrink-0 text-brand-100" size={20} />
           <div>
-            <h2 className="text-lg font-semibold text-white" id="creator-iteration-heading">根据真实结果迭代</h2>
-            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">改进助手只读取已保存、已绑定本次 run 与 digest 的人工反馈。生成结果仍是类型化提案，需要你检查 diff 并批准。</p>
+            <h2 className="text-lg font-semibold text-white" id="creator-iteration-heading">按你的反馈继续改进</h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">AI 只根据你刚保存的反馈找出需要变化的内容。它会先给出改进方案，得到确认后才重新生成。</p>
           </div>
         </div>
         {session.review_state === "revise" ? (
           <div className="mt-5 rounded-lg bg-amber-300/[0.07] p-4">
-            <p className="text-xs font-semibold text-amber-100">当前评审：需要修改</p>
+            <p className="text-xs font-semibold text-amber-100">你选择了：还要修改</p>
             <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-amber-50/85">{session.review_feedback || run?.reviews?.at(-1)?.feedback || "反馈已保存在评测记录中。"}</p>
-            <button className="mt-4 inline-flex items-center gap-2 rounded-md bg-brand-200 px-4 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-white disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500" disabled={!run || Boolean(busy) || proposal?.status === "pending"} onClick={() => void iterate()} type="button">
-              {busy === "iterate" ? <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" size={15} /> : <Sparkles aria-hidden="true" size={15} />}
-              {proposal?.status === "pending" ? "更新提案待评审" : busy === "iterate" ? "正在生成…" : "根据反馈生成改进提案"}
-            </button>
+            {evolutionEnabled ? (
+              <div className="mt-4 space-y-4">
+                {!evolutionPlan ? (
+                  <button className="inline-flex min-h-11 items-center gap-2 rounded-md bg-brand-200 px-4 py-2.5 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={!run || !session.resource_plan || Boolean(busy)} onClick={() => void generateEvolutionPlan()} type="button"><Sparkles aria-hidden="true" size={15} />{busy === "evolution-generate" ? "正在分析问题…" : "生成改进方案"}</button>
+                ) : (
+                  <div className="space-y-4 rounded-lg border border-white/10 bg-black/10 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p className="text-sm font-semibold text-white">AI 建议这样修改</p>
+                      <span className="rounded-full bg-white/[0.06] px-2.5 py-1 text-xs text-slate-300">方案 {evolutionPlan.revision}</span>
+                    </div>
+                    {evolutionPlan.diagnoses.length ? <ul className="space-y-2 text-sm leading-6 text-slate-300">{evolutionPlan.diagnoses.map((diagnosis) => <li className="rounded-md bg-white/[0.035] p-3" key={`${diagnosis.case_id}-${diagnosis.summary}`}><span className="font-semibold text-white">{diagnosis.case_id}</span>：{diagnosis.summary}</li>)}</ul> : null}
+                    {evolutionPlan.clarifications.length && evolutionPlan.state === "needs_input" ? (
+                      <div className="space-y-3">{evolutionPlan.clarifications.map((question) => <label className="block" key={question.question_id}><span className="text-xs font-semibold text-amber-100">{question.question}</span><span className="mt-1 block text-xs text-slate-500">{question.reason}</span><textarea className="mt-2 min-h-20 w-full rounded-md border border-white/10 bg-ink-950/70 px-3 py-2 text-sm text-white" maxLength={4_000} onChange={(event) => setAnswers((current) => ({ ...current, [question.question_id]: event.target.value }))} value={answers[question.question_id] ?? ""} /></label>)}<button className="inline-flex items-center gap-2 rounded-md border border-white/15 px-3 py-2 text-sm font-semibold text-white disabled:opacity-40" disabled={evolutionPlan.clarifications.some((question) => !answers[question.question_id]?.trim()) || Boolean(busy)} onClick={() => void saveEvolutionAnswers()} type="button"><Save aria-hidden="true" size={14} />保存全部答案</button></div>
+                    ) : null}
+                    {evolutionPlan.actions.length ? (
+                      <div className="space-y-2">{evolutionPlan.actions.map((action, index) => <div className="grid gap-3 rounded-md bg-white/[0.035] p-3 sm:grid-cols-[120px_minmax(0,1fr)]" key={action.action_id}><select className="rounded-md border border-white/10 bg-ink-950 px-2 py-2 text-sm text-white" disabled={evolutionPlan.state !== "ready"} onChange={(event) => setEvolutionPlan((current) => current ? { ...current, actions: current.actions.map((item, currentIndex) => currentIndex === index ? { ...item, action: event.target.value as typeof item.action } : item) } : current)} value={action.action}><option value="keep">保留</option><option value="update">更新</option><option value="create">新增</option><option value="delete">删除</option></select><div className="min-w-0"><p className="break-all font-mono text-xs text-white">{action.path}</p><p className="mt-1 text-xs leading-5 text-slate-400">{action.expected_improvement}</p></div></div>)}</div>
+                    ) : null}
+                    {evolutionPlan.overfitting_risks.length ? <div className="rounded-md bg-rose-300/[0.07] p-3 text-xs leading-5 text-rose-50"><span className="font-semibold">需要留意：</span>{evolutionPlan.overfitting_risks.join("；")}</div> : null}
+                    <div className="flex flex-wrap gap-2">
+                      {evolutionPlan.state === "ready" ? <><button className="inline-flex min-h-11 items-center gap-2 rounded-md border border-white/15 px-3 py-2 text-sm font-semibold text-white disabled:opacity-40" disabled={Boolean(busy)} onClick={() => void saveEvolutionActions()} type="button"><Save aria-hidden="true" size={14} />保存调整</button><button className="inline-flex min-h-11 items-center gap-2 rounded-md bg-emerald-300 px-3 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={Boolean(busy)} onClick={() => void confirmEvolution()} type="button"><Check aria-hidden="true" size={14} />确认方案并继续生成</button></> : null}
+                      {evolutionPlan.state === "needs_regeneration" ? <button className="inline-flex items-center gap-2 rounded-md bg-brand-200 px-3 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={Boolean(busy)} onClick={() => void generateEvolutionPlan()} type="button"><RefreshCw aria-hidden="true" size={14} />根据答案重新生成</button> : null}
+                      {evolutionPlan.state === "confirmed" ? <span className="inline-flex items-center gap-2 text-sm font-semibold text-emerald-100"><Check aria-hidden="true" size={14} />已转换为资源计划，返回资源构建阶段继续</span> : null}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <button className="mt-4 inline-flex items-center gap-2 rounded-md bg-brand-200 px-4 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-white disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500" disabled={!run || Boolean(busy) || proposal?.status === "pending"} onClick={() => void iterate()} type="button">
+                {busy === "iterate" ? <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" size={15} /> : <Sparkles aria-hidden="true" size={15} />}
+                {proposal?.status === "pending" ? "更新提案待评审" : busy === "iterate" ? "正在生成…" : "根据反馈生成改进提案"}
+              </button>
+            )}
           </div>
         ) : (
           <p className="mt-5 rounded-lg bg-white/[0.025] p-4 text-sm leading-6 text-slate-400">评审选择“需要修改”后，可在这里生成下一版提案。任何内容修改都会让旧评测变为过期。</p>
         )}
+        {session.resource_build ? (
+          <div className="mt-4 rounded-lg border border-white/10 bg-white/[0.025] p-4">
+            <p className="text-xs font-semibold text-slate-300">内容生成进度</p>
+            <p className="mt-2 text-sm text-slate-400">已确认 {session.resource_build.resources.filter((item) => item.state === "accepted").length}/{session.resource_build.resources.length} 项辅助内容；最终使用说明 {session.resource_build.skill_markdown_digest ? "已生成" : "待生成"}。</p>
+          </div>
+        ) : null}
       </section>
+
+      {session.regression_governance ? (
+        <details className="rounded-lg border border-white/10 bg-surface-900/80 p-5 sm:p-6">
+          <summary className="cursor-pointer text-sm font-semibold text-slate-300">查看版本与评测历史</summary>
+        <section className="mt-5" aria-labelledby="creator-history-heading">
+          <div className="flex items-start gap-3">
+            <History aria-hidden="true" className="mt-0.5 shrink-0 text-brand-100" size={20} />
+            <div><h2 className="text-lg font-semibold text-white" id="creator-history-heading">版本与评测历史</h2><p className="mt-2 text-sm leading-6 text-slate-400">历史记录不会被覆盖，只有当前版本的接受结果可以用于安装。</p></div>
+          </div>
+          <div className="mt-5 grid gap-3 lg:grid-cols-2">
+            <div className="rounded-lg bg-white/[0.025] p-4"><h3 className="text-sm font-semibold text-white">草稿 revision</h3><ul className="mt-3 space-y-2">{session.regression_governance.revisions.slice().reverse().map((item) => <li className="flex flex-wrap items-center justify-between gap-2 text-xs text-slate-400" key={item.revision}><span>revision {item.revision} · {item.content_digest.slice(0, 12)}…</span><span>{item.is_current ? "当前" : item.is_previous ? "进化前" : item.is_installed ? "已安装基线" : "历史"}</span></li>)}</ul></div>
+            <div className="rounded-lg bg-white/[0.025] p-4"><h3 className="text-sm font-semibold text-white">最近评测</h3><ul className="mt-3 space-y-2">{session.regression_governance.runs.slice(0, 8).map((item) => <li className="text-xs leading-5 text-slate-400" key={item.run_id}><span className="font-mono text-slate-300">{item.run_id.slice(0, 18)}…</span> · rev {item.draft_revision} · {item.target_count} 侧 · {item.status}{item.comparison_counts ? ` · 改善 ${item.comparison_counts.improved ?? 0} / 退化 ${item.comparison_counts.regressed ?? 0}` : ""}</li>)}</ul></div>
+          </div>
+        </section></details>
+      ) : null}
 
       <section className={`rounded-lg p-5 sm:p-6 ${waived ? "border border-amber-300/25 bg-amber-300/[0.055]" : accepted || installState === "current" ? "border border-emerald-300/20 bg-emerald-300/[0.045]" : "border border-white/10 bg-surface-900/80"}`} aria-labelledby="creator-install-heading">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex items-start gap-3">
             <ShieldCheck aria-hidden="true" className={`mt-0.5 shrink-0 ${waived ? "text-amber-100" : accepted || installState === "current" ? "text-emerald-100" : "text-slate-500"}`} size={22} />
             <div>
-              <h2 className="text-lg font-semibold text-white" id="creator-install-heading">质量门与正式安装</h2>
+              <h2 className="text-lg font-semibold text-white" id="creator-install-heading">最后一步：安装</h2>
               <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">
                 {installState === "current"
                   ? "当前摘要已安装。后续编辑只会生成新 revision，不会静默替换已安装版本。"
                   : accepted
-                    ? "当前摘要的三个对照用例已经人工接受。安装仍是一次独立的全局写入。"
+                    ? "当前摘要的全部核心与回归用例已经人工接受。安装仍是一次独立的全局写入。"
                     : waived
                       ? "当前摘要记录了人工评测豁免。它没有获得行为对照结论，安装前请再次确认风险。"
                       : "当前摘要尚未获得有效的评测接受或人工豁免，不能安装。"}
@@ -114,7 +238,7 @@ export default function SkillCreatorFinish({
         ) : null}
 
         <div className="mt-5 flex flex-col gap-3 border-t border-white/10 pt-5 sm:flex-row sm:items-center sm:justify-between">
-          <p className="break-all font-mono text-xs text-slate-500">revision {draft.revision} · {draft.content_digest}</p>
+          <details className="text-xs text-slate-500"><summary className="cursor-pointer">查看版本信息</summary><p className="mt-2 break-all font-mono">版本 {draft.revision} · {draft.content_digest}</p></details>
           {installState === "current" ? (
             <span className="inline-flex items-center gap-2 text-sm font-semibold text-emerald-100"><Check aria-hidden="true" size={16} />已安装为 {session.installed_skill_id || draft.installed_skill_id || draft.name}</span>
           ) : (

--- a/client/src/components/skill-creator/SkillEvaluationDesigner.tsx
+++ b/client/src/components/skill-creator/SkillEvaluationDesigner.tsx
@@ -1,8 +1,11 @@
-import { AlertTriangle, FilePlus2, FlaskConical, Plus, Save, ShieldAlert, Trash2 } from "lucide-react";
+import { AlertTriangle, Check, FilePlus2, FlaskConical, Plus, Save, ShieldAlert, Sparkles, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import {
+  confirmSkillCreatorEvaluationSuite,
+  generateSkillCreatorEvaluationSuite,
   saveSkillCreatorEvaluationCases,
   startSkillCreatorEvaluation,
+  updateSkillCreatorEvaluationSuite,
   updateSkillCreatorSession,
   waiveSkillCreatorEvaluation,
   type SkillCreatorDraft,
@@ -10,9 +13,17 @@ import {
   type SkillCreatorSession,
   type SkillEvaluationAssertion,
   type SkillEvaluationAssertionKind,
-  type SkillEvaluationCase,
   type SkillEvaluationRun,
+  type SkillEvaluationSuiteCase,
 } from "../../utils/skillCreatorApi";
+
+const CORE_ROLES = ["normal", "ambiguous", "boundary"] as const;
+const ROLE_LABELS = {
+  normal: "正常任务",
+  ambiguous: "歧义 / 信息不足",
+  boundary: "边界 / 失败",
+  regression: "用户确认回归",
+} as const;
 
 const ASSERTION_LABELS: Record<SkillEvaluationAssertionKind, string> = {
   exact_match: "输出完全等于",
@@ -23,7 +34,7 @@ const ASSERTION_LABELS: Record<SkillEvaluationAssertionKind, string> = {
   file_sha256: "文件摘要匹配",
 };
 
-function emptyCase(index: number, session: SkillCreatorSession): SkillEvaluationCase {
+function emptyCase(index: number, session: SkillCreatorSession): SkillEvaluationSuiteCase {
   return {
     case_id: `draft-case-${index + 1}`,
     name: `用例 ${index + 1}`,
@@ -31,11 +42,26 @@ function emptyCase(index: number, session: SkillCreatorSession): SkillEvaluation
     expected_behavior: session.success_criteria[index] ?? session.expected_output ?? "",
     fixtures: [],
     assertions: [],
+    role: CORE_ROLES[index] ?? "regression",
+    source: "user",
+    requirement_ids: [],
+    required_resource_paths: [],
+    workflow_step_ids: [],
   };
 }
 
 function initialCases(session: SkillCreatorSession) {
-  if (session.evaluation_cases?.length === 3) return session.evaluation_cases;
+  if (session.evaluation_suite?.cases.length) return session.evaluation_suite.cases;
+  if (session.evaluation_cases?.length === 3) {
+    return session.evaluation_cases.map((item, index) => ({
+      ...item,
+      role: CORE_ROLES[index] ?? "normal",
+      source: "migrated" as const,
+      requirement_ids: [],
+      required_resource_paths: [],
+      workflow_step_ids: [],
+    }));
+  }
   return [0, 1, 2].map((index) => emptyCase(index, session));
 }
 
@@ -48,8 +74,10 @@ function assertionComplete(assertion: SkillEvaluationAssertion) {
   return Boolean(assertion.value?.trim());
 }
 
-function casesComplete(cases: SkillEvaluationCase[]) {
-  return cases.length === 3 && cases.every((item) =>
+function casesComplete(cases: SkillEvaluationSuiteCase[], useSuite: boolean) {
+  const coreComplete = !useSuite || CORE_ROLES.every((role) => cases.filter((item) => item.role === role).length === 1);
+  const regressionCount = cases.filter((item) => item.role === "regression").length;
+  return coreComplete && regressionCount <= 9 && cases.length >= 3 && cases.length <= (useSuite ? 12 : 3) && cases.every((item) =>
     item.name.trim() &&
     item.prompt.trim() &&
     item.expected_behavior.trim() &&
@@ -64,8 +92,8 @@ function CaseEditor({
   onChange,
 }: {
   index: number;
-  value: SkillEvaluationCase;
-  onChange: (value: SkillEvaluationCase) => void;
+  value: SkillEvaluationSuiteCase;
+  onChange: (value: SkillEvaluationSuiteCase) => void;
 }) {
   function updateAssertion(assertionIndex: number, patch: Partial<SkillEvaluationAssertion>) {
     onChange({
@@ -81,8 +109,18 @@ function CaseEditor({
           <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-brand-300/10 text-sm font-semibold text-brand-100">{index + 1}</span>
           <h3 className="text-base font-semibold text-white" id={`evaluation-case-${index}`}>{value.name || `用例 ${index + 1}`}</h3>
         </div>
-        <span className="text-xs text-slate-500">baseline 与 with-skill 使用完全相同的输入</span>
+        <span className="rounded-full bg-white/[0.055] px-2.5 py-1 text-xs font-semibold text-slate-300">{ROLE_LABELS[value.role]}</span>
       </div>
+      {value.requirement_ids.length || value.required_resource_paths.length || value.workflow_step_ids.length ? (
+        <details className="mt-3 rounded-md bg-white/[0.025] p-3 text-xs text-slate-400">
+          <summary className="cursor-pointer font-semibold text-slate-300">查看 coverage 与资源要求</summary>
+          <div className="mt-2 space-y-1">
+            {value.requirement_ids.length ? <p>需求：{value.requirement_ids.join("、")}</p> : null}
+            {value.workflow_step_ids.length ? <p>步骤：{value.workflow_step_ids.join("、")}</p> : null}
+            {value.required_resource_paths.length ? <p className="break-all">必须暂存：{value.required_resource_paths.join("、")}</p> : null}
+          </div>
+        </details>
+      ) : null}
 
       <div className="mt-4 grid gap-4 lg:grid-cols-2">
         <label className="block">
@@ -116,11 +154,13 @@ function CaseEditor({
         </label>
       </div>
 
+      <details className="mt-5 rounded-lg border border-white/10 bg-white/[0.02] p-4">
+        <summary className="cursor-pointer text-sm font-semibold text-slate-300">添加文件或自动检查（可选）</summary>
       <section className="mt-5" aria-label={`${value.name || `用例 ${index + 1}`} 的文本夹具`}>
         <div className="flex flex-wrap items-center justify-between gap-2">
           <div>
-            <h4 className="text-sm font-semibold text-white">UTF-8 文本夹具</h4>
-            <p className="mt-1 text-xs text-slate-500">最多 10 个，运行时以只读方式放入 inputs/。</p>
+            <h4 className="text-sm font-semibold text-white">测试时要附带的文本文件</h4>
+            <p className="mt-1 text-xs text-slate-500">只有任务确实依赖文件时才需要添加。</p>
           </div>
           <button
             className="inline-flex items-center gap-2 rounded-md border border-white/10 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-white/[0.055] disabled:opacity-40"
@@ -128,7 +168,7 @@ function CaseEditor({
             onClick={() => onChange({ ...value, fixtures: [...value.fixtures, { path: `fixture-${value.fixtures.length + 1}.txt`, content: "" }] })}
             type="button"
           >
-            <FilePlus2 aria-hidden="true" size={14} /> 添加夹具
+            <FilePlus2 aria-hidden="true" size={14} /> 添加测试文件
           </button>
         </div>
         <div className="mt-3 space-y-3">
@@ -167,14 +207,14 @@ function CaseEditor({
       <section className="mt-5" aria-label={`${value.name || `用例 ${index + 1}`} 的确定性断言`}>
         <div className="flex flex-wrap items-center justify-between gap-2">
           <div>
-            <h4 className="text-sm font-semibold text-white">确定性断言（可选）</h4>
-            <p className="mt-1 text-xs text-slate-500">断言用于辅助评审，最终结论仍由你确认。</p>
+            <h4 className="text-sm font-semibold text-white">自动检查规则</h4>
+            <p className="mt-1 text-xs text-slate-500">可自动检查是否包含关键内容；最终结论仍由你确认。</p>
           </div>
           <button
             className="inline-flex items-center gap-2 rounded-md border border-white/10 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-white/[0.055]"
             onClick={() => onChange({ ...value, assertions: [...value.assertions, { kind: "contains", value: "" }] })}
             type="button"
-          ><Plus aria-hidden="true" size={14} /> 添加断言</button>
+          ><Plus aria-hidden="true" size={14} /> 添加检查</button>
         </div>
         <div className="mt-3 space-y-2">
           {value.assertions.map((assertion, assertionIndex) => (
@@ -222,6 +262,7 @@ function CaseEditor({
           ))}
         </div>
       </section>
+      </details>
     </article>
   );
 }
@@ -233,6 +274,7 @@ export default function SkillEvaluationDesigner({
   onRunStarted,
   onError,
   onNotice,
+  suiteEnabled = false,
 }: {
   session: SkillCreatorSession;
   draft: SkillCreatorDraft;
@@ -240,24 +282,39 @@ export default function SkillEvaluationDesigner({
   onRunStarted: (run: SkillEvaluationRun) => void;
   onError: (error: unknown, fallback: string) => void;
   onNotice: (message: string) => void;
+  suiteEnabled?: boolean;
 }) {
   const [mode, setMode] = useState<SkillCreatorQualityMode>(session.quality_mode ?? "objective");
-  const [cases, setCases] = useState<SkillEvaluationCase[]>(() => initialCases(session));
+  const [cases, setCases] = useState<SkillEvaluationSuiteCase[]>(() => initialCases(session));
   const [repetitions, setRepetitions] = useState(session.evaluation_repetitions ?? 1);
-  const [savedSignature, setSavedSignature] = useState(() => JSON.stringify(session.evaluation_cases ?? []));
+  const [savedSignature, setSavedSignature] = useState(() => JSON.stringify(initialCases(session)));
+  const [changeReason, setChangeReason] = useState("");
   const [busy, setBusy] = useState("");
   const [waiverReason, setWaiverReason] = useState("");
   const [waiverConfirmed, setWaiverConfirmed] = useState(false);
 
   useEffect(() => {
+    if (session.evaluation_suite?.cases.length) {
+      setCases(session.evaluation_suite.cases);
+      setSavedSignature(JSON.stringify(session.evaluation_suite.cases));
+      setChangeReason("");
+      return;
+    }
     if (!session.evaluation_cases?.length) return;
-    setCases(session.evaluation_cases);
-    setSavedSignature(JSON.stringify(session.evaluation_cases));
-  }, [session.cases_revision, session.evaluation_cases]);
+    const legacyCases = initialCases(session);
+    setCases(legacyCases);
+    setSavedSignature(JSON.stringify(legacyCases));
+  }, [session.cases_revision, session.evaluation_cases, session.evaluation_suite]);
 
-  const complete = useMemo(() => casesComplete(cases), [cases]);
+  const useSuite = Boolean(session.evaluation_suite);
+  const mustUseSuite = suiteEnabled && !useSuite && !session.cases_revision;
+  const suiteConfirmed = session.evaluation_suite?.state === "confirmed" && !session.evaluation_suite.stale;
+  const complete = useMemo(() => casesComplete(cases, useSuite), [cases, useSuite]);
   const dirty = JSON.stringify(cases) !== savedSignature || mode !== (session.quality_mode ?? "objective");
-  const canEvaluate = complete && !dirty && Boolean(session.cases_revision);
+  const canEvaluate = complete && !dirty && (useSuite ? suiteConfirmed : Boolean(session.cases_revision));
+  const maxRepetitions = session.regression_governance?.max_repetitions ?? 3;
+  const targetCount = session.regression_governance?.target_count ?? 2;
+  const estimatedCalls = cases.length * targetCount * repetitions;
 
   async function saveCases() {
     setBusy("save");
@@ -269,15 +326,58 @@ export default function SkillEvaluationDesigner({
           quality_mode: mode,
         });
       }
-      const updated = await saveSkillCreatorEvaluationCases(current, draft, cases);
+      const updated = current.evaluation_suite
+        ? await updateSkillCreatorEvaluationSuite(current, draft, cases, changeReason)
+        : await saveSkillCreatorEvaluationCases(current, draft, cases);
       await onSessionChange(updated);
-      setSavedSignature(JSON.stringify(updated.evaluation_cases ?? cases));
-      onNotice("三个真实用例已保存，并绑定当前草稿摘要。");
+      setSavedSignature(JSON.stringify(updated.evaluation_suite?.cases ?? updated.evaluation_cases ?? cases));
+      setChangeReason("");
+      onNotice(current.evaluation_suite ? "测试套件新 revision 已保存，确认后才能运行。" : "三个真实用例已保存，并绑定当前草稿摘要。");
     } catch (error) {
       onError(error, "测试用例保存失败。");
     } finally {
       setBusy("");
     }
+  }
+
+  async function generateSuite() {
+    setBusy("suite-generate");
+    try {
+      const updated = await generateSkillCreatorEvaluationSuite(session, draft);
+      await onSessionChange(updated);
+      onNotice(session.cases_revision ? "旧三例已无模型迁移为套件 revision 1。" : "测试设计助手已生成三类核心用例草案，请检查后确认。 ");
+    } catch (error) {
+      onError(error, "测试套件生成失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function confirmSuite() {
+    setBusy("suite-confirm");
+    try {
+      const updated = await confirmSkillCreatorEvaluationSuite(session, draft);
+      await onSessionChange(updated);
+      setSavedSignature(JSON.stringify(updated.evaluation_suite?.cases ?? cases));
+      onNotice("测试套件已冻结；后续修改会形成新 revision 并使旧评测过期。");
+    } catch (error) {
+      onError(error, "测试套件确认失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  function addRegressionCase() {
+    const nextIndex = cases.length;
+    setCases((current) => [...current, {
+      ...emptyCase(nextIndex, session),
+      case_id: `user-regression-${crypto.randomUUID()}`,
+      name: `回归案例 ${current.filter((item) => item.role === "regression").length + 1}`,
+      prompt: "",
+      expected_behavior: "",
+      role: "regression",
+      source: "user",
+    }]);
   }
 
   async function startEvaluation() {
@@ -322,16 +422,35 @@ export default function SkillEvaluationDesigner({
           <div>
             <div className="flex items-center gap-3">
               <FlaskConical aria-hidden="true" className="text-brand-100" size={20} />
-              <h2 className="text-xl font-semibold text-white" id="creator-test-design-heading">设计三个真实用例</h2>
+              <h2 className="text-xl font-semibold text-white" id="creator-test-design-heading">用三个真实任务试一试</h2>
             </div>
-            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">每个用例都会在相同模型、提示、预算和文本夹具下分别运行 baseline 与 with-skill。只有 Skill Overlay 不同。</p>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">AI 会准备“正常使用、信息不足、明显不适用”三类任务。你只需检查任务和期望结果是否真实；文件与自动检查都是可选的高级设置。</p>
           </div>
           <label className="flex items-center gap-3 text-sm text-slate-300">
             <span className="font-semibold">每侧重复</span>
             <select className="rounded-md border border-white/10 bg-ink-950 px-3 py-2 text-white" onChange={(event) => setRepetitions(Number(event.target.value))} value={repetitions}>
-              {[1, 2, 3].map((value) => <option key={value} value={value}>{value} 次</option>)}
+              {[1, 2, 3].filter((value) => value <= maxRepetitions).map((value) => <option key={value} value={value}>{value} 次</option>)}
             </select>
           </label>
+        </div>
+
+        <div className="mt-5 rounded-lg border border-brand-300/20 bg-brand-300/[0.055] p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold text-white">{useSuite ? "三类任务已准备" : "还没有测试任务"}</p>
+              <p className="mt-1 text-xs leading-5 text-slate-400">{suiteConfirmed ? "当前测试已确认，可以开始运行。" : useSuite ? "请检查并保存当前修改。" : "让 AI 先生成三类任务草案，你可以再修改。"}</p>
+            </div>
+            {!useSuite ? (
+              <button className="inline-flex min-h-11 items-center justify-center gap-2 rounded-md bg-brand-200 px-4 py-2.5 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={Boolean(busy)} onClick={() => void generateSuite()} type="button"><Sparkles aria-hidden="true" size={15} />{busy === "suite-generate" ? "正在准备…" : session.cases_revision ? "沿用已有测试" : "让 AI 准备三个任务"}</button>
+            ) : suiteConfirmed ? (
+              <span className="inline-flex items-center gap-2 text-sm font-semibold text-emerald-100"><Check aria-hidden="true" size={15} />已冻结</span>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                <button className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 px-4 py-2.5 text-sm font-semibold text-white disabled:opacity-40" disabled={dirty || Boolean(busy)} onClick={() => void generateSuite()} type="button"><Sparkles aria-hidden="true" size={15} />{busy === "suite-generate" ? "正在重新生成…" : "重新生成套件"}</button>
+                <button className="inline-flex items-center justify-center gap-2 rounded-md bg-emerald-300 px-4 py-2.5 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={dirty || !complete || Boolean(busy)} onClick={() => void confirmSuite()} type="button"><Check aria-hidden="true" size={15} />{busy === "suite-confirm" ? "正在确认…" : "确认当前套件"}</button>
+              </div>
+            )}
+          </div>
         </div>
 
         <fieldset className="mt-5 border-y border-white/10 py-4">
@@ -340,7 +459,7 @@ export default function SkillEvaluationDesigner({
             <label className={`cursor-pointer rounded-lg p-4 ${mode === "objective" ? "bg-brand-300/10 ring-1 ring-brand-300/40" : "bg-white/[0.025] ring-1 ring-white/10"}`}>
               <input checked={mode === "objective"} className="accent-cyan-300" name="quality-mode" onChange={() => setMode("objective")} type="radio" />
               <span className="ml-3 text-sm font-semibold text-white">客观任务（默认）</span>
-              <span className="mt-2 block text-xs leading-5 text-slate-400">必须运行当前摘要对应的三个对照用例，完成后由你评审。</span>
+              <span className="mt-2 block text-xs leading-5 text-slate-400">必须运行当前摘要对应的全部核心与回归案例，完成后由你评审。</span>
             </label>
             <label className={`cursor-pointer rounded-lg p-4 ${mode === "subjective" ? "bg-amber-300/[0.08] ring-1 ring-amber-300/30" : "bg-white/[0.025] ring-1 ring-white/10"}`}>
               <input checked={mode === "subjective"} className="accent-amber-300" name="quality-mode" onChange={() => setMode("subjective")} type="radio" />
@@ -352,22 +471,39 @@ export default function SkillEvaluationDesigner({
 
         <div className="mt-6">
           {cases.map((item, index) => (
-            <CaseEditor key={item.case_id || index} index={index} onChange={(next) => setCases((current) => current.map((entry, currentIndex) => currentIndex === index ? next : entry))} value={item} />
+            <div className="relative" key={item.case_id || index}>
+              {useSuite && item.role === "regression" ? (
+                <button aria-label={`删除 ${item.name}`} className="absolute right-0 top-6 z-10 inline-flex items-center gap-1 rounded-md border border-rose-300/20 px-2 py-1 text-xs text-rose-100" onClick={() => setCases((current) => current.filter((_, currentIndex) => currentIndex !== index))} type="button"><Trash2 aria-hidden="true" size={12} />删除回归</button>
+              ) : null}
+              <CaseEditor index={index} onChange={(next) => setCases((current) => current.map((entry, currentIndex) => currentIndex === index ? next : entry))} value={item} />
+            </div>
           ))}
         </div>
+
+        {useSuite ? (
+          <div className="space-y-4 border-t border-white/10 pt-5">
+            <button className="inline-flex items-center gap-2 rounded-md border border-white/15 px-3 py-2 text-sm font-semibold text-white disabled:opacity-40" disabled={cases.filter((item) => item.role === "regression").length >= 9 || Boolean(busy)} onClick={addRegressionCase} type="button"><Plus aria-hidden="true" size={14} />加入用户确认的回归案例</button>
+            {dirty && session.evaluation_suite ? (
+              <label className="block">
+                <span className="text-xs font-semibold text-slate-300">套件修改原因</span>
+                <textarea className="mt-2 min-h-20 w-full rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2.5 text-sm text-white" maxLength={4_000} onChange={(event) => setChangeReason(event.target.value)} placeholder="说明新增、删除或改写案例的原因；历史 revision 不会被覆盖。" value={changeReason} />
+              </label>
+            ) : null}
+          </div>
+        ) : null}
 
         {!complete ? (
           <div className="flex items-start gap-3 rounded-lg bg-amber-300/[0.08] p-4 text-sm leading-6 text-amber-100" role="status">
             <AlertTriangle aria-hidden="true" className="mt-0.5 shrink-0" size={17} />
-            三个用例都必须填写名称、真实提示和期望行为。夹具路径不得使用绝对路径或 ..，已添加的断言也必须完整。
+            三类核心用例和所有回归案例都必须填写名称、真实提示和期望行为。夹具路径不得使用绝对路径或 ..，已添加的断言也必须完整。
           </div>
         ) : null}
 
         <div className="mt-5 flex flex-col gap-3 border-t border-white/10 pt-5 sm:flex-row sm:items-center sm:justify-between">
-          <p className="text-xs leading-5 text-slate-500">保存后，测试集与草稿 revision {draft.revision}、{draft.content_digest.slice(0, 12)}… 绑定。</p>
+          <p className="text-xs leading-5 text-slate-500">这次会运行约 {estimatedCalls} 次，用相同设置比较“未使用 Skill”和“使用当前 Skill”的结果。</p>
           <div className="flex flex-wrap gap-2">
-            <button className="inline-flex items-center gap-2 rounded-md border border-white/15 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-white/[0.055] disabled:cursor-not-allowed disabled:opacity-40" disabled={!complete || Boolean(busy)} onClick={() => void saveCases()} type="button"><Save aria-hidden="true" size={15} />{busy === "save" ? "正在保存…" : "保存三个用例"}</button>
-            <button className="inline-flex items-center gap-2 rounded-md bg-hire-300 px-4 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500" disabled={!canEvaluate || Boolean(busy)} onClick={() => void startEvaluation()} type="button"><FlaskConical aria-hidden="true" size={15} />{busy === "start" ? "正在启动…" : "开始对照评测"}</button>
+            <button className="inline-flex min-h-11 items-center gap-2 rounded-md border border-white/15 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-white/[0.055] disabled:cursor-not-allowed disabled:opacity-40" disabled={mustUseSuite || !complete || (useSuite && dirty && !changeReason.trim()) || Boolean(busy)} onClick={() => void saveCases()} type="button"><Save aria-hidden="true" size={15} />{busy === "save" ? "正在保存…" : mustUseSuite ? "先准备三个任务" : "保存测试任务"}</button>
+            <button className="inline-flex min-h-11 items-center gap-2 rounded-md bg-hire-300 px-4 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500" disabled={!canEvaluate || Boolean(busy)} onClick={() => void startEvaluation()} type="button"><FlaskConical aria-hidden="true" size={15} />{busy === "start" ? "正在启动…" : "开始试用对比"}</button>
           </div>
         </div>
       </section>

--- a/client/src/components/skill-creator/SkillEvaluationFlow.test.tsx
+++ b/client/src/components/skill-creator/SkillEvaluationFlow.test.tsx
@@ -6,6 +6,9 @@ import type {
   SkillCreatorSession,
   SkillEvaluationCase,
   SkillEvaluationRun,
+  SkillEvaluationSuite,
+  SkillEvolutionPlan,
+  SkillResourcePlan,
 } from "../../utils/skillCreatorApi";
 import SkillEvaluationDesigner from "./SkillEvaluationDesigner";
 import SkillEvaluationReview from "./SkillEvaluationReview";
@@ -69,6 +72,27 @@ const session: SkillCreatorSession = {
   updated_at: 2,
 };
 
+const evaluationSuite: SkillEvaluationSuite = {
+  suite_id: "suite-1",
+  version: "skill-evaluation-suite-v2",
+  suite_revision: 2,
+  suite_digest: "b".repeat(64),
+  session_id: session.session_id,
+  draft_id: draft.draft_id,
+  draft_revision: draft.revision,
+  draft_digest: draft.content_digest,
+  quality_mode: "objective",
+  state: "confirmed",
+  cases: evaluationCases.map((item, index) => ({
+    ...item,
+    role: (["normal", "ambiguous", "boundary"] as const)[index],
+    source: "user",
+    requirement_ids: [],
+    required_resource_paths: [],
+    workflow_step_ids: [],
+  })),
+};
+
 function evaluationRun(candidateRead: boolean, errorCode?: string): SkillEvaluationRun {
   return {
     run_id: "eval-1",
@@ -116,6 +140,41 @@ afterEach(() => {
 });
 
 describe("Skill Creator evaluation flow", () => {
+  it("can replace an unconfirmed generated suite instead of stranding it", async () => {
+    const draftSuite = { ...evaluationSuite, state: "draft" as const };
+    const suiteSession = { ...session, cases_revision: 0, evaluation_suite: draftSuite };
+    const regenerated = {
+      ...suiteSession,
+      evaluation_suite: { ...draftSuite, suite_revision: 3, suite_digest: "c".repeat(64) },
+    };
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) => (
+      jsonResponse({ session: regenerated })
+    ));
+    vi.stubGlobal("fetch", fetchMock);
+    const onSessionChange = vi.fn();
+
+    render(
+      <SkillEvaluationDesigner
+        draft={draft}
+        onError={vi.fn()}
+        onNotice={vi.fn()}
+        onRunStarted={vi.fn()}
+        onSessionChange={onSessionChange}
+        session={suiteSession}
+        suiteEnabled
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "重新生成套件" }));
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/evaluation-suite/generate");
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toMatchObject({
+      expected_suite_revision: 2,
+      expected_suite_digest: evaluationSuite.suite_digest,
+    });
+    expect(onSessionChange).toHaveBeenCalledWith(regenerated);
+  });
+
   it("keeps objective evaluation at exactly three cases and starts a paired run", async () => {
     const run = evaluationRun(true);
     const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) => jsonResponse({
@@ -142,7 +201,7 @@ describe("Skill Creator evaluation flow", () => {
     for (const number of [1, 2, 3]) {
       expect(screen.getByRole("heading", { name: `真实用例 ${number}` })).toBeVisible();
     }
-    await userEvent.click(screen.getByRole("button", { name: "开始对照评测" }));
+    await userEvent.click(screen.getByRole("button", { name: "开始试用对比" }));
 
     expect(started).toHaveBeenCalledWith(run);
     const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
@@ -191,6 +250,38 @@ describe("Skill Creator evaluation flow", () => {
     });
   });
 
+  it("starts a confirmed suite with its frozen revision and projected call budget", async () => {
+    const run = { ...evaluationRun(true), evaluation_suite_id: evaluationSuite.suite_id, evaluation_suite_revision: evaluationSuite.suite_revision, evaluation_suite_digest: evaluationSuite.suite_digest };
+    const suiteSession: SkillCreatorSession = {
+      ...session,
+      evaluation_suite: evaluationSuite,
+      regression_governance: {
+        version: "skill-creator-regression-v1",
+        enabled: true,
+        max_items: 72,
+        case_count: 3,
+        target_count: 3,
+        estimated_model_calls: 9,
+        max_repetitions: 3,
+        previous_revision: 1,
+        previous_digest: "c".repeat(64),
+        revisions: [],
+        runs: [],
+      },
+    };
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) => jsonResponse({ session: suiteSession, draft, evaluation_suite: evaluationSuite, evaluation_run: run }));
+    vi.stubGlobal("fetch", fetchMock);
+    const started = vi.fn();
+
+    render(<SkillEvaluationDesigner draft={draft} onError={vi.fn()} onNotice={vi.fn()} onRunStarted={started} onSessionChange={vi.fn()} session={suiteSession} />);
+
+    expect(screen.getByText(/这次会运行约 9 次/)).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "开始试用对比" }));
+    expect(started).toHaveBeenCalledWith(run);
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body).toMatchObject({ evaluation_suite_revision: 2, evaluation_suite_digest: evaluationSuite.suite_digest });
+  });
+
   it("fails closed when Candidate did not read the Skill or Sandbox is unavailable", () => {
     render(
       <SkillEvaluationReview
@@ -204,8 +295,8 @@ describe("Skill Creator evaluation flow", () => {
       />,
     );
 
-    expect(screen.getAllByText("Sandbox sidecar 不可用，评测已失败关闭。").length).toBeGreaterThan(0);
-    expect(screen.getByRole("button", { name: "接受当前评测" })).toBeDisabled();
+    expect(screen.getAllByText("隔离运行环境暂不可用，本次试用已安全停止。").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "效果可以，继续" })).toBeDisabled();
   });
 
   it("fails closed on unresolved tool control and never presents unknown usage as zero", () => {
@@ -232,11 +323,11 @@ describe("Skill Creator evaluation flow", () => {
       />,
     );
 
-    expect(screen.getAllByText("模型返回了未执行的工具决策，结果已失败关闭。").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("模型给出了工具指令但没有真正执行，本次结果已作废。").length).toBeGreaterThan(0);
     expect(screen.getAllByText("42 tokens").length).toBeGreaterThan(0);
     expect(screen.getAllByText("token 用量未提供").length).toBeGreaterThan(0);
     expect(screen.queryByText("0 tokens")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "接受当前评测" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "效果可以，继续" })).toBeDisabled();
   });
 
   it("refreshes the session projection when polling first reaches a terminal run", async () => {
@@ -284,7 +375,7 @@ describe("Skill Creator evaluation flow", () => {
       />,
     );
 
-    const accept = screen.getByRole("button", { name: "接受当前评测" });
+    const accept = screen.getByRole("button", { name: "效果可以，继续" });
     expect(accept).toBeEnabled();
     await userEvent.click(accept);
 
@@ -294,6 +385,54 @@ describe("Skill Creator evaluation flow", () => {
       expected_review_revision: 0,
       expected_digest: draft.content_digest,
     });
+  });
+
+  it("requires item-level acknowledgement before accepting a three-side regression", async () => {
+    const base = evaluationRun(true);
+    const previousItems = evaluationCases.map((evaluationCase) => ({
+      item_id: `${evaluationCase.case_id}-previous`,
+      pair_id: evaluationCase.case_id,
+      case_id: evaluationCase.case_id,
+      target: "previous" as const,
+      repetition: 1,
+      status: "completed" as const,
+      output: "带页码的上一版摘要",
+      actual_model: "real-model-v1",
+      skill_read: true,
+    }));
+    const regressionItemId = "case-2-candidate";
+    const run: SkillEvaluationRun = {
+      ...base,
+      previous_overlay_id: "overlay-previous",
+      items: [...base.items, ...previousItems],
+      report: {
+        eligible_for_accept: true,
+        regression_item_ids: [regressionItemId],
+        comparison_counts: { regressed: 1, improved: 0, flat: 2, inconclusive: 0 },
+        pairs: evaluationCases.map((item, index) => ({
+          pair_id: item.case_id,
+          case_id: item.case_id,
+          repetition: 1,
+          classification: index === 1 ? "regressed" as const : "flat" as const,
+          candidate_item_id: `${item.case_id}-candidate`,
+          previous_item_id: `${item.case_id}-previous`,
+        })),
+      },
+    };
+    const accepted = { ...run, revision: 3, review_state: "accepted" as const };
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) => jsonResponse({ evaluation_run: accepted, session: { ...session, review_state: "accepted" }, draft }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillEvaluationReview draft={draft} onError={vi.fn()} onNotice={vi.fn()} onRunChange={vi.fn()} onSessionRefresh={vi.fn()} run={run} session={session} />);
+
+    const accept = screen.getByRole("button", { name: "效果可以，继续" });
+    expect(accept).toBeDisabled();
+    await userEvent.type(screen.getByLabelText("你观察到了什么？"), "该退化是已知格式变化，仍保留事实完整性。 ");
+    await userEvent.click(screen.getByRole("checkbox", { name: /真实用例 2/ }));
+    expect(accept).toBeEnabled();
+    await userEvent.click(accept);
+    const body = JSON.parse(String(fetchMock.mock.calls.at(-1)?.[1]?.body));
+    expect(body.acknowledged_regression_item_ids).toEqual([regressionItemId]);
   });
 
   it("freezes saved feedback before submitting a revise decision", async () => {
@@ -319,8 +458,8 @@ describe("Skill Creator evaluation flow", () => {
       />,
     );
 
-    await userEvent.type(screen.getByLabelText("反馈与判断依据"), "第二个用例缺少失败处理");
-    await userEvent.click(screen.getByRole("button", { name: "需要修改" }));
+    await userEvent.type(screen.getByLabelText("你观察到了什么？"), "第二个用例缺少失败处理");
+    await userEvent.click(screen.getByRole("button", { name: "还要修改" }));
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const feedbackBody = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
@@ -364,5 +503,164 @@ describe("Skill Creator evaluation flow", () => {
       "/api/skills/drafts/draft-1/install",
       expect.objectContaining({ method: "POST" }),
     );
+  });
+
+  it("turns a revise decision into a confirmed resource evolution plan", async () => {
+    const resourcePlan: SkillResourcePlan = {
+      plan_id: "resource-plan-1",
+      session_id: session.session_id,
+      revision: 2,
+      digest: "c".repeat(64),
+      state: "confirmed",
+      session_revision: session.session_revision,
+      draft_id: draft.draft_id,
+      draft_revision: draft.revision,
+      draft_digest: draft.content_digest,
+      skill_name: draft.name,
+      skill_description: draft.description,
+      workflow_steps: [{ step_id: "step-1", instruction: "Read the reference." }],
+      output_contract: ["Return a cited summary."],
+      failure_modes: ["Ask for missing pages."],
+      resources: [{
+        resource_id: "reference-1",
+        spec_digest: "d".repeat(64),
+        kind: "reference",
+        action: "keep",
+        generation_cost: "low",
+        path: "references/rules.md",
+        purpose: "Keep citation rules.",
+        source_ids: [],
+        used_by_steps: ["step-1"],
+        depends_on: [],
+        acceptance_checks: ["Contains page citation rules."],
+      }],
+      clarifications: [],
+      clarification_answers: {},
+      created_at: 1,
+      updated_at: 2,
+    };
+    const stateAdvancedDraft = { ...draft, revision: draft.revision + 1 };
+    const plan: SkillEvolutionPlan = {
+      plan_id: "evolution-plan-1",
+      version: "skill-evolution-plan-v1",
+      revision: 1,
+      digest: "e".repeat(64),
+      state: "ready",
+      session_id: session.session_id,
+      draft_id: draft.draft_id,
+      draft_revision: stateAdvancedDraft.content_revision,
+      draft_digest: draft.content_digest,
+      evaluation_run_id: "eval-1",
+      evaluation_run_revision: 2,
+      review_revision: 1,
+      suite_id: evaluationSuite.suite_id,
+      suite_revision: evaluationSuite.suite_revision,
+      suite_digest: evaluationSuite.suite_digest,
+      diagnoses: [{
+        case_id: "case-2",
+        evidence_item_ids: ["case-2-candidate"],
+        failure_types: ["assertion_failed"],
+        requirement_ids: ["success_criterion:0"],
+        resource_ids: ["reference-1"],
+        sections: ["Workflow"],
+        summary: "页码引用在歧义输入中丢失。",
+      }],
+      actions: [{
+        action_id: "action-1",
+        action: "update",
+        resource_id: "reference-1",
+        kind: "reference",
+        path: "references/rules.md",
+        purpose: "Clarify fallback citation behavior.",
+        source_ids: [],
+        used_by_steps: ["step-1"],
+        depends_on: [],
+        acceptance_checks: ["Ambiguous input retains page markers."],
+        related_case_ids: ["case-2"],
+        expected_improvement: "保留歧义输入中的页码。",
+        non_regression_case_ids: ["case-1", "case-3"],
+      }],
+      expected_improvements: ["Fix case-2 without changing case-1."],
+      acceptance_criteria: ["All confirmed suite cases complete."],
+      non_goals: ["Do not change the output language."],
+      overfitting_risks: ["Do not special-case the fixture wording."],
+      clarifications: [],
+      clarification_answers: {},
+    };
+    const confirmedPlan = { ...plan, revision: 2, state: "confirmed" as const };
+    const revisedSession: SkillCreatorSession = {
+      ...session,
+      draft_state_revision: stateAdvancedDraft.revision,
+      current_revision: stateAdvancedDraft.content_revision,
+      draft: stateAdvancedDraft,
+      review_state: "revise",
+      review_revision: 2,
+      review_feedback: "歧义输入丢失页码引用。",
+      resource_plan: resourcePlan,
+      evaluation_suite: evaluationSuite,
+      regression_governance: {
+        version: "skill-creator-regression-v1",
+        enabled: true,
+        max_items: 72,
+        case_count: 3,
+        target_count: 2,
+        estimated_model_calls: 6,
+        max_repetitions: 3,
+        revisions: [],
+        runs: [],
+      },
+    };
+    const run = {
+      ...evaluationRun(true),
+      review_state: "revise" as const,
+      review_revision: undefined,
+      reviews: [{
+        review_id: "review-1",
+        review_revision: 1,
+        decision: "revise" as const,
+        reason: "歧义输入丢失页码引用。",
+        feedback_revision: 1,
+        feedback: "歧义输入丢失页码引用。",
+        actor_kind: "local_console",
+        acknowledge_failed_assertions: false,
+        created_at: 3,
+      }],
+    };
+    const fetchMock = vi.fn((input: RequestInfo | URL, _init?: RequestInit) => {
+      if (String(input).endsWith("/evolution-plan/confirm")) {
+        return jsonResponse({ evolution_plan: confirmedPlan, resource_plan: resourcePlan });
+      }
+      return jsonResponse({ evolution_plan: plan });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const onReload = vi.fn();
+
+    render(
+      <SkillCreatorFinish
+        draft={stateAdvancedDraft}
+        onError={vi.fn()}
+        onNotice={vi.fn()}
+        onProposal={vi.fn()}
+        onReload={onReload}
+        proposal={null}
+        run={run}
+        session={revisedSession}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "生成改进方案" }));
+    expect(await screen.findByText(/页码引用在歧义输入中丢失/)).toBeVisible();
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toMatchObject({
+      expected_draft_state_revision: stateAdvancedDraft.revision,
+      expected_draft_revision: stateAdvancedDraft.content_revision,
+      expected_draft_digest: stateAdvancedDraft.content_digest,
+      expected_review_revision: 1,
+    });
+    await userEvent.click(screen.getByRole("button", { name: "确认方案并继续生成" }));
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      `/api/skills/creator/sessions/${session.session_id}/evolution-plan/confirm`,
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(onReload).toHaveBeenCalledOnce();
   });
 });

--- a/client/src/components/skill-creator/SkillEvaluationReview.tsx
+++ b/client/src/components/skill-creator/SkillEvaluationReview.tsx
@@ -17,14 +17,14 @@ import {
 const TERMINAL = new Set(["completed", "failed", "cancelled", "stale"]);
 
 const ERROR_LABELS: Record<string, string> = {
-  skill_not_read: "Candidate 未读取 Skill，本次结果不能用于质量门。",
-  model_gateway_unconfigured: "模型网关缺少 Key，无法执行评测。",
-  sandbox_unavailable: "Sandbox sidecar 不可用，评测已失败关闭。",
-  evaluation_stale: "草稿或用例已变化，本次评测已过期。",
-  model_mismatch: "两侧实际模型不一致，结果不可比较。",
-  tool_not_allowed: "运行尝试调用评测范围外的工具，已被阻断。",
-  network_not_allowed: "运行尝试访问网络，已被离线 Sandbox 阻断。",
-  skill_evaluation_unresolved_tool_call: "模型返回了未执行的工具决策，结果已失败关闭。",
+  skill_not_read: "本次运行没有实际使用 Skill，结果不能用于最终判断。",
+  model_gateway_unconfigured: "模型服务尚未配置，无法开始试用。",
+  sandbox_unavailable: "隔离运行环境暂不可用，本次试用已安全停止。",
+  evaluation_stale: "Skill 或测试任务已经变化，本次结果仅供查看。",
+  model_mismatch: "对比两侧使用了不同模型，结果不可直接比较。",
+  tool_not_allowed: "运行尝试使用未允许的工具，已安全停止。",
+  network_not_allowed: "运行尝试访问网络，已被离线环境阻止。",
+  skill_evaluation_unresolved_tool_call: "模型给出了工具指令但没有真正执行，本次结果已作废。",
 };
 
 function statusLabel(status: SkillEvaluationRun["status"]) {
@@ -54,7 +54,24 @@ function assertionLabel(assertion: SkillEvaluationAssertion) {
   return `${assertion.path ?? "文件"} SHA-256 匹配`;
 }
 
-function ItemResult({ item, target }: { item?: SkillEvaluationItem; target: "baseline" | "candidate" }) {
+function assertionMessage(value?: string | null) {
+  if (!value) return "";
+  const translations: Record<string, string> = {
+    "Output did not contain the required text.": "输出缺少要求的内容。",
+    "Output contained the required text.": "输出包含要求的内容。",
+    "Output contained the forbidden text.": "输出包含了不应出现的内容。",
+    "Output excluded the forbidden text.": "输出未包含禁用内容。",
+  };
+  return translations[value] ?? value;
+}
+
+function targetLabel(target: SkillEvaluationItem["target"]) {
+  if (target === "baseline") return "未使用 Skill";
+  if (target === "previous") return "改进前";
+  return "当前 Skill";
+}
+
+function ItemResult({ item, target }: { item?: SkillEvaluationItem; target: SkillEvaluationItem["target"] }) {
   if (!item) {
     return <div className="grid min-h-48 place-items-center rounded-lg bg-white/[0.025] text-sm text-slate-500">尚无结果</div>;
   }
@@ -67,15 +84,15 @@ function ItemResult({ item, target }: { item?: SkillEvaluationItem; target: "bas
       : null
   );
   return (
-    <article className="min-w-0 rounded-lg bg-white/[0.025] p-4" aria-label={target === "candidate" ? "with-skill 结果" : "baseline 结果"}>
+    <article className="min-w-0 rounded-lg bg-white/[0.025] p-4" aria-label={`${targetLabel(target)} 结果`}>
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <h4 className="text-sm font-semibold text-white">{target === "candidate" ? "With Skill" : "Baseline"}</h4>
+        <h4 className="text-sm font-semibold text-white">{targetLabel(target)}</h4>
         <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${item.status === "completed" ? "bg-emerald-300/10 text-emerald-100" : item.status === "failed" || item.status === "skill_not_read" ? "bg-rose-300/10 text-rose-100" : "bg-white/[0.055] text-slate-300"}`}>{itemStatusLabel(item.status)}</span>
       </div>
-      {target === "candidate" ? (
+      {target !== "baseline" ? (
         <p className={`mt-3 flex items-center gap-2 text-xs font-semibold ${item.skill_read ? "text-emerald-100" : "text-rose-100"}`}>
           {item.skill_read ? <Check aria-hidden="true" size={13} /> : <X aria-hidden="true" size={13} />}
-          {item.skill_read ? "已通过受信任 Overlay 读取 Skill" : "未读取 Skill"}
+          {item.skill_read ? "已确认实际使用 Skill" : "没有实际使用 Skill"}
         </p>
       ) : null}
       {errorText ? <p className="mt-3 rounded-md bg-rose-300/10 p-3 text-xs leading-5 text-rose-50" role="alert">{errorText}</p> : null}
@@ -85,7 +102,7 @@ function ItemResult({ item, target }: { item?: SkillEvaluationItem; target: "bas
           {assertionResults.map((assertion, index) => (
             <li className={`flex items-start gap-2 text-xs leading-5 ${assertion.passed === false ? "text-rose-100" : assertion.passed ? "text-emerald-100" : "text-slate-400"}`} key={`${assertion.kind}-${index}`}>
               {assertion.passed === false ? <X aria-hidden="true" className="mt-1 shrink-0" size={12} /> : <Check aria-hidden="true" className="mt-1 shrink-0" size={12} />}
-              <span>{assertionLabel(assertion)}{assertion.message || assertion.reason ? `：${assertion.message ?? assertion.reason}` : ""}</span>
+              <span>{assertionLabel(assertion)}{assertion.message || assertion.reason ? `：${assertionMessage(assertion.message ?? assertion.reason)}` : ""}</span>
             </li>
           ))}
         </ul>
@@ -104,30 +121,38 @@ function ItemResult({ item, target }: { item?: SkillEvaluationItem; target: "bas
           </ul>
         </details>
       ) : null}
-      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-slate-500">
-        <span>{item.latency_ms != null ? `${(item.latency_ms / 1000).toFixed(1)} 秒` : "耗时待记录"}</span>
-        <span>{tokenCount != null && tokenCount > 0 ? `${tokenCount} tokens` : "token 用量未提供"}</span>
-        <span>{item.actual_model || "实际模型待记录"}</span>
-      </div>
+      <details className="mt-3 text-[11px] text-slate-500"><summary className="cursor-pointer">查看运行信息</summary><div className="mt-2 flex flex-wrap gap-x-4 gap-y-1"><span>{item.latency_ms != null ? `${(item.latency_ms / 1000).toFixed(1)} 秒` : "耗时待记录"}</span><span>{tokenCount != null && tokenCount > 0 ? `${tokenCount} tokens` : "token 用量未提供"}</span><span>{item.actual_model || "实际模型待记录"}</span></div></details>
     </article>
   );
 }
 
-function CaseComparison({ evaluationCase, items, onRetry, retrying, canRetry }: { evaluationCase: SkillEvaluationCase; items: SkillEvaluationItem[]; onRetry: () => void; retrying: boolean; canRetry: boolean }) {
-  const [mobileTarget, setMobileTarget] = useState<"baseline" | "candidate">("candidate");
+function CaseComparison({ evaluationCase, items, comparisons, onRetry, retrying, canRetry }: {
+  evaluationCase: SkillEvaluationCase;
+  items: SkillEvaluationItem[];
+  comparisons: NonNullable<SkillEvaluationRun["report"]>["pairs"];
+  onRetry: () => void;
+  retrying: boolean;
+  canRetry: boolean;
+}) {
+  const [mobileTarget, setMobileTarget] = useState<SkillEvaluationItem["target"]>("candidate");
   const [requestedRepetition, setRequestedRepetition] = useState<number | null>(null);
   const repetitions = [...new Set(items.map((item) => item.repetition))].sort((a, b) => a - b);
   const selectedRepetition = requestedRepetition != null && repetitions.includes(requestedRepetition)
     ? requestedRepetition
     : repetitions.at(-1) ?? 1;
   const baseline = items.find((item) => item.target === "baseline" && item.repetition === selectedRepetition);
+  const previous = items.find((item) => item.target === "previous" && item.repetition === selectedRepetition);
   const candidate = items.find((item) => item.target === "candidate" && item.repetition === selectedRepetition);
+  const targets: SkillEvaluationItem["target"][] = previous ? ["baseline", "previous", "candidate"] : ["baseline", "candidate"];
+  const comparison = comparisons?.find((item) => item.case_id === evaluationCase.case_id && item.repetition === selectedRepetition);
+  const comparisonLabels = { regressed: "出现退化", improved: "已改善", flat: "结果持平", inconclusive: "证据不足" } as const;
   return (
     <section className="border-t border-white/10 py-6 first:border-t-0 first:pt-0" aria-labelledby={`result-${evaluationCase.case_id}`}>
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h3 className="text-base font-semibold text-white" id={`result-${evaluationCase.case_id}`}>{evaluationCase.name}</h3>
           <p className="mt-1 max-w-3xl text-xs leading-5 text-slate-400">{evaluationCase.expected_behavior}</p>
+          {comparison ? <span className={`mt-2 inline-flex rounded-full px-2.5 py-1 text-[11px] font-semibold ${comparison.classification === "regressed" ? "bg-rose-300/10 text-rose-100" : comparison.classification === "improved" ? "bg-emerald-300/10 text-emerald-100" : "bg-white/[0.055] text-slate-300"}`}>{comparisonLabels[comparison.classification]}</span> : null}
           {repetitions.length > 1 ? (
             <div className="mt-2 flex flex-wrap items-center gap-1" aria-label={`${evaluationCase.name} 重复运行`}>
               <span className="mr-1 text-[11px] text-slate-500">重复运行</span>
@@ -139,17 +164,18 @@ function CaseComparison({ evaluationCase, items, onRetry, retrying, canRetry }: 
         </div>
         <button className="inline-flex shrink-0 items-center gap-2 rounded-md border border-white/10 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-white/[0.055] disabled:opacity-40" disabled={!canRetry || retrying} onClick={onRetry} type="button"><RefreshCw aria-hidden="true" className={retrying ? "animate-spin motion-reduce:animate-none" : ""} size={13} />重跑此用例</button>
       </div>
-      <div className="mt-4 grid grid-cols-2 gap-1 rounded-md bg-white/[0.045] p-1 sm:hidden" role="tablist" aria-label={`${evaluationCase.name} 结果视图`}>
-        {(["baseline", "candidate"] as const).map((target) => (
-          <button aria-selected={mobileTarget === target} className={`rounded px-3 py-2 text-xs font-semibold ${mobileTarget === target ? "bg-surface-800 text-white" : "text-slate-400"}`} key={target} onClick={() => setMobileTarget(target)} role="tab" type="button">{target === "baseline" ? "Baseline" : "With Skill"}</button>
+      <div className={`mt-4 grid gap-1 rounded-md bg-white/[0.045] p-1 sm:hidden ${targets.length === 3 ? "grid-cols-3" : "grid-cols-2"}`} role="tablist" aria-label={`${evaluationCase.name} 结果视图`}>
+        {targets.map((target) => (
+          <button aria-selected={mobileTarget === target} className={`min-h-11 rounded px-2 py-2 text-xs font-semibold ${mobileTarget === target ? "bg-surface-800 text-white" : "text-slate-400"}`} key={target} onClick={() => setMobileTarget(target)} role="tab" type="button">{targetLabel(target)}</button>
         ))}
       </div>
-      <div className="mt-3 hidden gap-3 sm:grid sm:grid-cols-2">
+      <div className={`mt-3 hidden gap-3 sm:grid ${previous ? "sm:grid-cols-3" : "sm:grid-cols-2"}`}>
         <ItemResult item={baseline} target="baseline" />
+        {previous ? <ItemResult item={previous} target="previous" /> : null}
         <ItemResult item={candidate} target="candidate" />
       </div>
       <div className="mt-3 sm:hidden">
-        <ItemResult item={mobileTarget === "baseline" ? baseline : candidate} target={mobileTarget} />
+        <ItemResult item={mobileTarget === "baseline" ? baseline : mobileTarget === "previous" ? previous : candidate} target={mobileTarget} />
       </div>
     </section>
   );
@@ -175,6 +201,9 @@ export default function SkillEvaluationReview({
   const [busy, setBusy] = useState("");
   const [feedback, setFeedback] = useState(session.review_feedback ?? run.feedback ?? run.reviews?.at(-1)?.feedback ?? "");
   const [failedAcknowledged, setFailedAcknowledged] = useState(false);
+  const [acknowledgedRegressionIds, setAcknowledgedRegressionIds] = useState<Set<string>>(
+    () => new Set(run.reviews?.at(-1)?.acknowledged_regression_item_ids ?? []),
+  );
 
   useEffect(() => {
     if (TERMINAL.has(run.status)) return;
@@ -190,17 +219,20 @@ export default function SkillEvaluationReview({
   }, [onError, onRunChange, onSessionRefresh, run.run_id, run.status]);
 
   const completedItems = run.items.filter((item) => item.status === "completed").length;
-  const failedAssertions = run.items.some((item) => (item.assertion_results ?? item.assertions)?.some((assertion) => assertion.passed === false));
+  const failedAssertions = run.items.filter((item) => item.target === "candidate").some((item) => (item.assertion_results ?? item.assertions)?.some((assertion) => assertion.passed === false));
   const candidateItems = run.items.filter((item) => item.target === "candidate");
   const candidateRead = candidateItems.length > 0 && candidateItems.every((item) => item.status === "completed" && item.skill_read === true);
   const actualModels = new Set(run.items.flatMap((item) => item.actual_model ? [item.actual_model] : []));
   const digestMatches = run.frozen_digest.toLowerCase() === draft.content_digest.toLowerCase();
-  const expectedItemCount = run.cases.length * 2 * Math.max(run.repetitions, 1);
+  const targetCount = run.previous_overlay_id ? 3 : 2;
+  const expectedItemCount = run.cases.length * targetCount * Math.max(run.repetitions, 1);
   const allItemsComplete = run.items.length === expectedItemCount && run.items.every((item) => item.status === "completed" && !item.error_code);
   const modelIdentityComplete = run.items.length > 0 && run.items.every((item) => Boolean(item.actual_model)) && actualModels.size === 1;
-  const comparable = run.status === "completed" && run.cases.length === 3 && allItemsComplete && candidateRead && modelIdentityComplete && digestMatches;
+  const comparable = run.status === "completed" && run.cases.length >= 3 && allItemsComplete && candidateRead && modelIdentityComplete && digestMatches && run.report?.eligible_for_accept !== false;
+  const regressionIds = run.report?.regression_item_ids ?? [];
+  const regressionsAcknowledged = regressionIds.every((itemId) => acknowledgedRegressionIds.has(itemId));
   const reviewPending = (run.review_state ?? "pending") === "pending" && !["accepted", "revise", "waived"].includes(session.review_state ?? "none");
-  const canAccept = reviewPending && comparable && (!failedAssertions || failedAcknowledged);
+  const canAccept = reviewPending && comparable && regressionsAcknowledged && (!regressionIds.length || Boolean(feedback.trim())) && (!failedAssertions || failedAcknowledged);
   const runError = run.error_code ? ERROR_LABELS[run.error_code] ?? run.error ?? run.error_code : run.error;
 
   async function cancel() {
@@ -259,8 +291,11 @@ export default function SkillEvaluationReview({
       }
       const result = await submitSkillCreatorEvaluationReview(currentSession, draft, currentRun, decision, {
         feedback,
-        reason: decision === "accept" && failedAssertions ? "人工检查后接受断言失败项" : undefined,
+        reason: decision === "accept" && (failedAssertions || regressionIds.length)
+          ? feedback.trim() || "人工检查后接受断言失败项"
+          : undefined,
         confirm_failed_assertions: failedAcknowledged,
+        acknowledged_regression_item_ids: [...acknowledgedRegressionIds].sort(),
       });
       onRunChange(result.run);
       await onSessionRefresh();
@@ -278,10 +313,10 @@ export default function SkillEvaluationReview({
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <div className="flex flex-wrap items-center gap-3">
-              <h2 className="text-xl font-semibold text-white" id="creator-evaluation-results-heading">Baseline 与 With Skill</h2>
+              <h2 className="text-xl font-semibold text-white" id="creator-evaluation-results-heading">看看 Skill 是否真的更好用</h2>
               <span className={`rounded-full px-3 py-1 text-xs font-semibold ${run.status === "completed" ? "bg-emerald-300/10 text-emerald-100" : run.status === "failed" || run.status === "stale" ? "bg-rose-300/10 text-rose-100" : "bg-brand-300/10 text-brand-100"}`}>{statusLabel(run.status)}</span>
             </div>
-            <p className="mt-2 text-sm leading-6 text-slate-400">运行 {run.run_id} · revision {run.revision} · {run.model_id || "默认文本模型"}</p>
+            <p className="mt-2 text-sm leading-6 text-slate-400">同一批任务、同一个模型，比较未使用 Skill、改进前和当前版本的结果。</p>
           </div>
           <div className="flex flex-wrap gap-2">
             {!TERMINAL.has(run.status) ? <button className="inline-flex items-center gap-2 rounded-md border border-rose-300/20 px-3 py-2 text-xs font-semibold text-rose-100 disabled:opacity-40" disabled={Boolean(busy)} onClick={() => void cancel()} type="button"><Square aria-hidden="true" size={12} />取消评测</button> : null}
@@ -290,21 +325,22 @@ export default function SkillEvaluationReview({
         </div>
 
         <div className="mt-5 grid gap-3 sm:grid-cols-3">
-          <div className="rounded-lg bg-white/[0.025] p-4"><p className="text-xs text-slate-500">完成项</p><p className="mt-2 text-lg font-semibold text-white">{completedItems}/{run.items.length}</p></div>
-          <div className="rounded-lg bg-white/[0.025] p-4"><p className="text-xs text-slate-500">Candidate 读取 Skill</p><p className={`mt-2 text-sm font-semibold ${candidateRead ? "text-emerald-100" : "text-amber-100"}`}>{candidateRead ? "全部已读取" : "尚未满足"}</p></div>
-          <div className="rounded-lg bg-white/[0.025] p-4"><p className="text-xs text-slate-500">冻结摘要</p><p className={`mt-2 font-mono text-xs font-semibold ${digestMatches ? "text-slate-200" : "text-rose-100"}`}>{run.frozen_digest.slice(0, 12)}…</p></div>
+          <div className="rounded-lg bg-white/[0.025] p-4"><p className="text-xs text-slate-500">运行进度</p><p className="mt-2 text-lg font-semibold text-white">{completedItems}/{run.items.length}</p></div>
+          <div className="rounded-lg bg-white/[0.025] p-4"><p className="text-xs text-slate-500">是否真的使用了 Skill</p><p className={`mt-2 text-sm font-semibold ${candidateRead ? "text-emerald-100" : "text-amber-100"}`}>{candidateRead ? "全部确认" : "尚未满足"}</p></div>
+          <div className="rounded-lg bg-white/[0.025] p-4"><p className="text-xs text-slate-500">结果是否可比较</p><p className={`mt-2 text-sm font-semibold ${digestMatches && modelIdentityComplete ? "text-emerald-100" : "text-rose-100"}`}>{digestMatches && modelIdentityComplete ? "可以比较" : "需要重试"}</p></div>
         </div>
 
         {!TERMINAL.has(run.status) ? (
           <p className="mt-5 flex items-center gap-2 text-sm text-brand-100" role="status"><LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" size={16} />评测在服务端继续运行，页面每 2 秒刷新一次。</p>
         ) : null}
         {runError ? <p className="mt-5 rounded-lg bg-rose-300/10 p-4 text-sm leading-6 text-rose-50" role="alert">{runError}</p> : null}
-        {!digestMatches ? <p className="mt-5 rounded-lg bg-rose-300/10 p-4 text-sm leading-6 text-rose-50" role="alert">草稿摘要已变化，本次结果只可查看，不能接受。请返回测试设计并重新运行三个用例。</p> : null}
+        {!digestMatches ? <p className="mt-5 rounded-lg bg-rose-300/10 p-4 text-sm leading-6 text-rose-50" role="alert">草稿摘要已变化，本次结果只可查看，不能接受。请返回测试设计并重新运行当前套件。</p> : null}
 
         <div className="mt-6">
           {run.cases.map((evaluationCase) => (
             <CaseComparison
               evaluationCase={evaluationCase}
+              comparisons={run.report?.pairs}
               canRetry={reviewPending && TERMINAL.has(run.status)}
               items={run.items.filter((item) => item.case_id === evaluationCase.case_id)}
               key={evaluationCase.case_id}
@@ -316,10 +352,10 @@ export default function SkillEvaluationReview({
       </section>
 
       <section className="rounded-lg border border-white/10 bg-surface-900/80 p-5 sm:p-6" aria-labelledby="creator-human-review-heading">
-        <h2 className="text-lg font-semibold text-white" id="creator-human-review-heading">人工评审</h2>
-        <p className="mt-2 text-sm leading-6 text-slate-400">比较三组结果后接受当前 Skill，或记录需要修改的具体问题。系统不会用额外 Judge 模型替你做结论。</p>
+        <h2 className="text-lg font-semibold text-white" id="creator-human-review-heading">告诉我们你的判断</h2>
+        <p className="mt-2 text-sm leading-6 text-slate-400">结果符合预期就继续；有问题就指出哪一项需要改。系统不会用另一个模型替你做最终决定。</p>
         <label className="mt-4 block" htmlFor="creator-review-feedback">
-          <span className="text-xs font-semibold text-slate-300">反馈与判断依据</span>
+          <span className="text-xs font-semibold text-slate-300">你观察到了什么？</span>
           <textarea className="mt-2 min-h-28 w-full resize-y rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2.5 text-sm leading-6 text-white focus:border-brand-300/50 focus:outline-none" id="creator-review-feedback" maxLength={4_000} onChange={(event) => setFeedback(event.target.value)} placeholder="指出哪一个用例、哪一处行为需要保留或修改。选择“需要修改”时必填。" value={feedback} />
         </label>
         {failedAssertions ? (
@@ -328,13 +364,35 @@ export default function SkillEvaluationReview({
             存在失败断言。我已逐项检查，并理解接受会以人工判断覆盖这些辅助断言。
           </label>
         ) : null}
+        {regressionIds.length ? (
+          <fieldset className="mt-4 rounded-lg border border-rose-300/20 bg-rose-300/[0.055] p-4">
+            <legend className="px-1 text-sm font-semibold text-rose-100">逐项确认新增退化</legend>
+            <p className="mt-1 text-xs leading-5 text-rose-50/75">以下 candidate 相比 previous 新增失败。必须逐项确认并在反馈中说明理由，不能静默忽略。</p>
+            <div className="mt-3 space-y-2">
+              {regressionIds.map((itemId) => {
+                const item = run.items.find((candidate) => candidate.item_id === itemId);
+                const caseName = run.cases.find((candidate) => candidate.case_id === item?.case_id)?.name ?? itemId;
+                return (
+                  <label className="flex items-start gap-3 text-sm leading-6 text-rose-50" key={itemId}>
+                    <input checked={acknowledgedRegressionIds.has(itemId)} className="mt-1 h-4 w-4 accent-rose-300" onChange={(event) => setAcknowledgedRegressionIds((current) => {
+                      const next = new Set(current);
+                      if (event.target.checked) next.add(itemId); else next.delete(itemId);
+                      return next;
+                    })} type="checkbox" />
+                    <span>{caseName} · 第 {item?.repetition ?? 1} 次</span>
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+        ) : null}
         {!comparable ? (
-          <p className="mt-4 flex items-start gap-2 text-sm leading-6 text-amber-100"><AlertCircle aria-hidden="true" className="mt-1 shrink-0" size={15} />只有当前摘要的三组配对全部完成、Candidate 均读取 Skill 且实际模型一致时，才能接受。</p>
+          <p className="mt-4 flex items-start gap-2 text-sm leading-6 text-amber-100"><AlertCircle aria-hidden="true" className="mt-1 shrink-0" size={15} />只有当前摘要的全部目标与用例完成、应用凭据可信且实际模型一致时，才能接受。</p>
         ) : null}
         <div className="mt-5 flex flex-wrap justify-end gap-2 border-t border-white/10 pt-5">
           <button className="inline-flex items-center gap-2 rounded-md border border-white/15 px-4 py-2.5 text-sm font-semibold text-white disabled:opacity-40" disabled={!reviewPending || Boolean(busy)} onClick={() => void saveFeedback()} type="button"><Save aria-hidden="true" size={14} />{busy === "feedback" ? "正在保存…" : reviewPending ? "保存反馈" : "评审已冻结"}</button>
-          <button className="inline-flex items-center gap-2 rounded-md border border-amber-300/25 bg-amber-300/[0.08] px-4 py-2.5 text-sm font-semibold text-amber-50 disabled:opacity-40" disabled={!reviewPending || !feedback.trim() || !TERMINAL.has(run.status) || Boolean(busy)} onClick={() => void review("revise")} type="button"><Clock3 aria-hidden="true" size={14} />需要修改</button>
-          <button className="inline-flex items-center gap-2 rounded-md bg-emerald-300 px-4 py-2.5 text-sm font-semibold text-ink-950 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500" disabled={!canAccept || Boolean(busy)} onClick={() => void review("accept")} type="button"><Check aria-hidden="true" size={15} />接受当前评测</button>
+          <button className="inline-flex min-h-11 items-center gap-2 rounded-md border border-amber-300/25 bg-amber-300/[0.08] px-4 py-2.5 text-sm font-semibold text-amber-50 disabled:opacity-40" disabled={!reviewPending || !feedback.trim() || !TERMINAL.has(run.status) || Boolean(busy)} onClick={() => void review("revise")} type="button"><Clock3 aria-hidden="true" size={14} />还要修改</button>
+          <button className="inline-flex min-h-11 items-center gap-2 rounded-md bg-emerald-300 px-4 py-2.5 text-sm font-semibold text-ink-950 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500" disabled={!canAccept || Boolean(busy)} onClick={() => void review("accept")} type="button"><Check aria-hidden="true" size={15} />效果可以，继续</button>
         </div>
       </section>
     </div>

--- a/client/src/components/skill-creator/SkillResourceBuildPanel.test.tsx
+++ b/client/src/components/skill-creator/SkillResourceBuildPanel.test.tsx
@@ -124,13 +124,16 @@ describe("SkillResourceBuildPanel", () => {
     const started = { ...build, state: "planned" as const, phase: "resources" as const };
     const fetchMock = vi.fn<
       (_input: RequestInfo | URL, _init?: RequestInit) => Promise<Response>
-    >((_input, _init) => jsonResponse({ resource_build: started }, 201));
+    >((input, _init) => String(input).endsWith("/next")
+      ? jsonResponse({ resource_build: build })
+      : jsonResponse({ resource_build: started }, 201));
     vi.stubGlobal("fetch", fetchMock);
 
     render(<SkillResourceBuildPanel onProposal={vi.fn()} onSessionRefresh={vi.fn()} session={baseSession} status={status} />);
-    await userEvent.click(screen.getByRole("button", { name: "创建资源构建" }));
+    await userEvent.click(screen.getByRole("button", { name: "开始生成内容" }));
 
-    expect(await screen.findByRole("heading", { name: "资源构建工作台" })).toBeVisible();
+    expect(await screen.findByRole("heading", { name: "逐项生成内容" })).toBeVisible();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     const [url, init] = fetchMock.mock.calls[0];
     expect(String(url).endsWith("/resource-build")).toBe(true);
     expect(JSON.parse(String(init?.body))).toMatchObject({
@@ -139,6 +142,50 @@ describe("SkillResourceBuildPanel", () => {
       expected_plan_revision: plan.revision,
       expected_plan_digest: plan.digest,
     });
+  });
+
+  it("offers a replacement build when the retained build belongs to an older plan", async () => {
+    const currentPlan = { ...plan, revision: 4, digest: "4".repeat(64) };
+    const replacement = {
+      ...build,
+      build_id: "build_2",
+      revision: 1,
+      digest: "5".repeat(64),
+      state: "planned" as const,
+      plan_revision: currentPlan.revision,
+      plan_digest: currentPlan.digest,
+    };
+    const refresh = vi.fn();
+    const fetchMock = vi.fn<
+      (_input: RequestInfo | URL, _init?: RequestInit) => Promise<Response>
+    >((input, _init) => String(input).endsWith("/next")
+      ? jsonResponse({ resource_build: { ...replacement, state: "awaiting_review", resources: build.resources } })
+      : jsonResponse({ resource_build: replacement }, 201));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillResourceBuildPanel
+      onProposal={vi.fn()}
+      onSessionRefresh={refresh}
+      session={{
+        ...baseSession,
+        resource_plan: currentPlan,
+        resource_build: { ...build, state: "stale", stale: true },
+      }}
+      status={status}
+    />);
+
+    expect(screen.getByText(/旧版本仍会只读保留/)).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "按新方案开始生成" }));
+
+    expect(await screen.findByRole("heading", { name: "逐项生成内容" })).toBeVisible();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url).endsWith("/resource-build")).toBe(true);
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      plan_id: currentPlan.plan_id,
+      expected_plan_revision: currentPlan.revision,
+      expected_plan_digest: currentPlan.digest,
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   it("saves a complete direct edit as a new server revision", async () => {

--- a/client/src/components/skill-creator/SkillResourceBuildPanel.tsx
+++ b/client/src/components/skill-creator/SkillResourceBuildPanel.tsx
@@ -171,7 +171,22 @@ export default function SkillResourceBuildPanel({
   }
 
   async function start() {
-    await run("start", () => startSkillCreatorResourceBuild(session), "资源构建已创建，可以按依赖顺序生成。 ");
+    setBusy("start");
+    setError("");
+    setNotice("");
+    try {
+      const started = await startSkillCreatorResourceBuild(session);
+      setBuild(started);
+      const generated = await advanceSkillCreatorResourceBuild(session, started);
+      update(generated, generated.phase === "skill_markdown"
+        ? "辅助内容已准备好，正在整理最终说明。"
+        : "第一项内容已经生成并通过基础检查，请确认是否符合需要。");
+      await onSessionRefresh();
+    } catch (caught) {
+      setError(errorMessage(caught, "资源生成启动失败。"));
+    } finally {
+      setBusy("");
+    }
   }
 
   async function next() {
@@ -238,17 +253,31 @@ export default function SkillResourceBuildPanel({
     );
   }
 
-  if (!build) {
+  const buildMatchesCurrentPlan = Boolean(build
+    && !build.stale
+    && build.state !== "stale"
+    && build.plan_id === session.resource_plan.plan_id
+    && build.plan_revision === session.resource_plan.revision
+    && build.plan_digest === session.resource_plan.digest);
+
+  if (!build || !buildMatchesCurrentPlan) {
     return (
       <section className="rounded-lg border border-white/10 bg-surface-900/80 p-5 sm:p-6" aria-labelledby="resource-build-start-heading">
-        <h2 className="text-xl font-semibold text-white" id="resource-build-start-heading">按确认计划构建 Skill</h2>
-        <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">服务端固定路径和依赖顺序，每次只生成一个完整资源。内部可分段，但只在组装、校验和脚本实测完成后请求一次确认。</p>
+        <h2 className="text-xl font-semibold text-white" id="resource-build-start-heading">
+          {build ? "按新方案重新生成" : "准备生成内容"}
+        </h2>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">点击后会立即生成第一项内容。每项完成基础检查后只请你确认一次，不会用内部生成片段反复打扰。</p>
+        {build ? (
+          <p className="mt-3 rounded-md border border-amber-300/25 bg-amber-300/10 px-4 py-3 text-xs leading-5 text-amber-50">
+            旧版本仍会只读保留；这次会严格按你刚确认的新方案重新生成。
+          </p>
+        ) : null}
         <div className="mt-5 flex flex-wrap items-center gap-3">
           <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2.5 text-sm font-semibold text-ink-950 disabled:cursor-not-allowed disabled:opacity-40" disabled={!builderReady || Boolean(busy)} onClick={() => void start()} type="button">
             {busy === "start" ? <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" size={16} /> : <Play aria-hidden="true" size={16} />}
-            {busy === "start" ? "正在创建构建…" : "创建资源构建"}
+            {busy === "start" ? "正在生成第一项…" : build ? "按新方案开始生成" : "开始生成内容"}
           </button>
-          <span className="text-xs text-slate-500">{session.resource_plan.resources.length} 个附加资源，随后生成 SKILL.md</span>
+          <span className="text-xs text-slate-500">共 {session.resource_plan.resources.length} 项辅助内容，最后自动整理完整使用说明</span>
         </div>
         {!builderReady ? <p className="mt-3 text-xs text-amber-200">模型网关不可用，当前只能查看已保存计划，不能开始生成。</p> : null}
       </section>
@@ -263,13 +292,12 @@ export default function SkillResourceBuildPanel({
       <div className="border-y border-white/10 py-5">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
-            <h2 className="text-xl font-semibold text-white" id="resource-build-heading">资源构建工作台</h2>
-            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">{activeTarget ? `当前目标：${activeTarget}` : "所有附加资源已完成，准备最终文档。"}</p>
+            <h2 className="text-xl font-semibold text-white" id="resource-build-heading">逐项生成内容</h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">{activeTarget ? `正在处理：${activeTarget}` : "辅助内容已完成，准备整理最终使用说明。"}</p>
           </div>
           <div className="flex flex-wrap gap-2 text-xs">
-            <span className="rounded-full bg-white/[0.055] px-3 py-1.5 text-slate-300">build r{build.revision}</span>
-            <span className="rounded-full bg-brand-300/10 px-3 py-1.5 text-brand-100">{acceptedCount}/{totalCount} 资源已确认</span>
-            <span className="rounded-full bg-white/[0.055] px-3 py-1.5 text-slate-400">{Math.ceil(generatedBytes / 1024)} KiB / 160 KiB</span>
+            <span className="rounded-full bg-brand-300/10 px-3 py-1.5 text-brand-100">已确认 {acceptedCount}/{totalCount}</span>
+            <details className="relative"><summary className="cursor-pointer list-none rounded-full bg-white/[0.055] px-3 py-1.5 text-slate-400">技术信息</summary><div className="absolute right-0 z-10 mt-2 w-48 rounded-lg border border-white/10 bg-ink-950 p-3 text-right shadow-xl"><p>构建版本 {build.revision}</p><p className="mt-1">{Math.ceil(generatedBytes / 1024)} KiB / 160 KiB</p></div></details>
           </div>
         </div>
         <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-white/[0.06]" aria-label={`资源确认进度 ${acceptedCount}/${totalCount}`}>

--- a/client/src/components/skill-creator/SkillResourcePlanPanel.test.tsx
+++ b/client/src/components/skill-creator/SkillResourcePlanPanel.test.tsx
@@ -101,7 +101,7 @@ describe("SkillResourcePlanPanel", () => {
     const onSession = vi.fn();
 
     render(<SkillResourcePlanPanel onSession={onSession} session={emptySession} status={status} />);
-    await userEvent.click(screen.getByRole("button", { name: "生成资源计划" }));
+    await userEvent.click(screen.getByRole("button", { name: "让 AI 生成方案" }));
 
     await waitFor(() => expect(onSession).toHaveBeenCalledWith(plannedSession));
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -122,7 +122,7 @@ describe("SkillResourcePlanPanel", () => {
 
     render(<SkillResourcePlanPanel onSession={vi.fn()} session={session} status={status} />);
     await userEvent.click(screen.getByRole("button", { name: "移除资源" }));
-    await userEvent.click(screen.getByRole("button", { name: "保存计划修改" }));
+    await userEvent.click(screen.getByRole("button", { name: "保存我的调整" }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
@@ -146,7 +146,7 @@ describe("SkillResourcePlanPanel", () => {
     render(<SkillResourcePlanPanel onSession={vi.fn()} session={zeroResourceSession} status={status} />);
     await userEvent.click(screen.getByRole("button", { name: "添加必要资源" }));
     await userEvent.selectOptions(screen.getByRole("combobox", { name: "资源 1 类型" }), "asset");
-    await userEvent.click(screen.getByRole("button", { name: "保存计划修改" }));
+    await userEvent.click(screen.getByRole("button", { name: "保存我的调整" }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));

--- a/client/src/components/skill-creator/SkillResourcePlanPanel.tsx
+++ b/client/src/components/skill-creator/SkillResourcePlanPanel.tsx
@@ -229,17 +229,13 @@ export default function SkillResourcePlanPanel({ session, status, onSession }: P
         <div>
           <div className="flex items-center gap-2 text-brand-100">
             <Sparkles aria-hidden="true" size={17} />
-            <h3 className="text-base font-semibold" id="creator-resource-plan-heading">资源规划</h3>
+            <h3 className="text-base font-semibold" id="creator-resource-plan-heading">AI 给出的制作方案</h3>
           </div>
           <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-300">
-            先决定哪些步骤需要脚本、参考资料或输出模板。规划阶段不会写草稿，也不会为了显得完整而强行增加文件。
+            AI 会先决定是否真的需要脚本、参考资料或输出模板。简单任务可以不增加任何文件，复杂任务才会拆分。
           </p>
         </div>
-        {plan ? (
-          <span className="rounded-full border border-white/10 bg-ink-950/55 px-3 py-1 text-xs text-slate-300">
-            plan r{plan.revision} · {plan.digest.slice(0, 10)}
-          </span>
-        ) : null}
+        {plan ? <span className="rounded-full border border-white/10 bg-ink-950/55 px-3 py-1 text-xs text-slate-300">方案 {plan.revision}</span> : null}
       </div>
 
       {error ? <p className="mt-4 rounded-md border border-red-400/25 bg-red-400/10 px-3 py-2 text-sm text-red-100" role="alert">{error}</p> : null}
@@ -250,7 +246,7 @@ export default function SkillResourcePlanPanel({ session, status, onSession }: P
           <p className="text-sm text-slate-300">
             {legacyFlow
               ? "这是旧版 Creator 会话。现有提案和草稿保持可读；只有你主动进入资源规划后，才切换到逐资源生成流程。"
-              : "素材确认后，让固定 Creator 助手只生成一份可编辑计划，不生成任何文件。"}
+              : "先让 AI 给出一份可编辑方案。此时不会生成文件，也不会安装任何内容。"}
           </p>
           <button
             className="mt-4 inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:opacity-40"
@@ -259,7 +255,7 @@ export default function SkillResourcePlanPanel({ session, status, onSession }: P
             type="button"
           >
             {busy === "generate" ? <LoaderCircle className="animate-spin" aria-hidden="true" size={16} /> : <Sparkles aria-hidden="true" size={16} />}
-            {busy === "generate" ? "正在分析需求…" : legacyFlow ? "进入资源规划并生成计划" : "生成资源计划"}
+            {busy === "generate" ? "正在理解需求…" : legacyFlow ? "切换到新流程并生成方案" : "让 AI 生成方案"}
           </button>
           {plannerUnavailable ? <p className="mt-3 text-xs text-amber-200">模型网关未配置，暂时不能生成资源计划。</p> : null}
         </div>
@@ -305,6 +301,23 @@ export default function SkillResourcePlanPanel({ session, status, onSession }: P
 
       {plan && !plan.stale && (plan.state === "ready" || plan.state === "confirmed") ? (
         <div className="mt-5 space-y-5">
+          <div className="rounded-lg border border-white/10 bg-ink-950/45 p-4 sm:p-5">
+            <p className="text-xs font-semibold text-brand-100">AI 的理解</p>
+            <h4 className="mt-2 text-base font-semibold text-white">{skillName || "待命名 Skill"}</h4>
+            <p className="mt-2 text-sm leading-6 text-slate-300">{skillDescription}</p>
+            <div className="mt-4 grid gap-2 sm:grid-cols-2">
+              {resources.length ? resources.map((item) => (
+                <div className="rounded-md bg-white/[0.035] p-3" key={item.resource_id}>
+                  <p className="text-xs font-semibold text-white">{KIND_LABELS[item.kind]} · {item.action === "create" ? "新增" : ACTION_LABELS[item.action]}</p>
+                  <p className="mt-1 text-xs leading-5 text-slate-400">{item.purpose}</p>
+                </div>
+              )) : <p className="text-sm text-emerald-100">这个任务不需要额外资源，保持简单即可。</p>}
+            </div>
+          </div>
+
+          <details className="rounded-lg border border-white/10 bg-white/[0.02] p-4">
+            <summary className="cursor-pointer text-sm font-semibold text-slate-300">调整技术细节（可选）</summary>
+            <div className="mt-5 space-y-5">
           <div className="grid gap-4 lg:grid-cols-2">
             <label className="block">
               <span className="text-xs font-semibold text-slate-300">Skill ID</span>
@@ -366,16 +379,18 @@ export default function SkillResourcePlanPanel({ session, status, onSession }: P
               })}
             </div>
           </div>
+            </div>
+          </details>
 
           {plan.state === "confirmed" ? (
             <div className="rounded-md border border-emerald-300/20 bg-emerald-300/[0.08] p-4">
-              <p className="flex items-center gap-2 text-sm font-semibold text-emerald-100"><CheckCircle2 aria-hidden="true" size={17} />资源计划已确认</p>
-              <p className="mt-1 text-xs leading-5 text-emerald-100/75">路径、来源和生成顺序已经冻结。当前阶段不会提前写入草稿或安装目录。</p>
+              <p className="flex items-center gap-2 text-sm font-semibold text-emerald-100"><CheckCircle2 aria-hidden="true" size={17} />方案已确认</p>
+              <p className="mt-1 text-xs leading-5 text-emerald-100/75">下一步会按这个方案逐项生成，仍不会自动安装。</p>
             </div>
           ) : (
             <div className="flex flex-wrap justify-end gap-3 border-t border-white/10 pt-4">
-              <button className="min-h-11 rounded-full border border-white/15 px-5 py-2 text-sm font-semibold text-white disabled:opacity-40" disabled={!planDirty || Boolean(busy)} onClick={() => void savePlan()} type="button">{busy === "save" ? "正在保存…" : "保存计划修改"}</button>
-              <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={planDirty || Boolean(busy)} onClick={() => void confirmPlan()} type="button"><CheckCircle2 aria-hidden="true" size={16} />{busy === "confirm" ? "正在确认…" : "确认并冻结资源计划"}</button>
+              <button className="min-h-11 rounded-full border border-white/15 px-5 py-2 text-sm font-semibold text-white disabled:opacity-40" disabled={!planDirty || Boolean(busy)} onClick={() => void savePlan()} type="button">{busy === "save" ? "正在保存…" : "保存我的调整"}</button>
+              <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={planDirty || Boolean(busy)} onClick={() => void confirmPlan()} type="button"><CheckCircle2 aria-hidden="true" size={16} />{busy === "confirm" ? "正在确认…" : "方案没问题，开始生成"}</button>
             </div>
           )}
         </div>

--- a/client/src/pages/SkillCreatorIndexPage.tsx
+++ b/client/src/pages/SkillCreatorIndexPage.tsx
@@ -180,11 +180,11 @@ export default function SkillCreatorIndexPage() {
                   <span className="text-sm font-semibold">Skill Creator</span>
                 </div>
                 <h1 className="mt-4 text-3xl font-semibold text-white sm:text-4xl">
-                  把可复用的做法写成 Skill
+                  说一句需求，让 AI 帮你做成 Skill
                 </h1>
                 <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300 sm:text-base">
                   {status.resource_authoring_enabled
-                    ? "先明确用途和触发条件，再确认素材、冻结资源计划。规划阶段不会生成文件或提案。"
+                    ? "不需要先懂触发条件、测试夹具或文件结构。AI 会先理解并给出方案，只有在信息不足时才追问。"
                     : "先明确用途和触发条件，再确认素材、审阅文件。模型只能提交类型化提案，批准后仍只是待评测草稿。"}
                 </p>
               </div>
@@ -220,12 +220,12 @@ export default function SkillCreatorIndexPage() {
                 <div>
                   <h2 className="text-xl font-semibold text-white">创建新 Skill</h2>
                   <p className="mt-1 text-sm leading-6 text-slate-400">
-                    可以先写一句目标，进入工作台后再补充示例和成功标准。
+                    像向同事交代任务一样写一句话就够了。
                   </p>
                 </div>
               </div>
               <label className="mt-6 block" htmlFor="creator-intent">
-                <span className="text-sm font-semibold text-slate-200">想沉淀什么做法</span>
+                <span className="text-sm font-semibold text-slate-200">你希望它帮你完成什么？</span>
                 <textarea
                   className="mt-2 min-h-32 w-full resize-y rounded-lg border border-white/10 bg-ink-950/75 px-4 py-3 text-sm leading-6 text-white placeholder:text-slate-400 focus:border-brand-300/60 focus:outline-none"
                   id="creator-intent"
@@ -243,7 +243,7 @@ export default function SkillCreatorIndexPage() {
                   onClick={() => void createSession()}
                   type="button"
                 >
-                  {creating ? "正在创建…" : "进入工作台"}
+                  {creating ? "正在准备…" : "开始创建"}
                   <ArrowRight aria-hidden="true" size={16} />
                 </button>
               </div>
@@ -252,18 +252,13 @@ export default function SkillCreatorIndexPage() {
             <aside className="rounded-lg border border-white/10 bg-white/[0.035] p-5 sm:p-6">
               <div className="flex items-center gap-3">
                 <FileText aria-hidden="true" className="text-hire-200" size={20} />
-                <h2 className="text-base font-semibold text-white">完整 Creator V1 闭环</h2>
+                <h2 className="text-base font-semibold text-white">你只负责做决定</h2>
               </div>
               <ol className="mt-5 space-y-4 text-sm">
                 {[
-                  ["定义用途", "写清触发场景、正向示例和近似反例。"],
-                  status.resource_authoring_enabled
-                    ? ["素材与资源计划", "确认来源，必要时回答澄清问题，再冻结脚本、参考资料和模板计划。"]
-                    : ["确认素材", "逐项选择脱敏后的运行证据，也可从零开始。"],
-                  ["编辑草稿", "检查 SKILL.md 和 UTF-8 文本资源。"],
-                  ["设计测试", "为当前摘要准备恰好 3 个真实用例。"],
-                  ["对照评审", "隔离比较 Baseline 与使用 Skill 的结果。"],
-                  ["迭代与安装", "人工接受或豁免后，再单独确认全局安装。"],
+                  ["AI 先给方案", "复杂任务才拆资源，简单任务保持简单。"],
+                  ["用真实任务试用", "同一条件下比较使用前后的结果。"],
+                  ["你确认后才安装", "生成、改进和安装都不会偷偷发生。"],
                 ].map(([title, detail], index) => (
                   <li className="flex gap-3" key={title}>
                     <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-hire-300 text-xs font-bold text-ink-950">

--- a/client/src/pages/SkillCreatorPages.test.tsx
+++ b/client/src/pages/SkillCreatorPages.test.tsx
@@ -142,8 +142,10 @@ describe("Skill Creator pages", () => {
     );
 
     expect(await screen.findByText("分析竞品 PDF 并保留页码")).toBeVisible();
-    fireEvent.change(screen.getByLabelText("想沉淀什么做法"), { target: { value: "新目标" } });
-    await userEvent.click(screen.getByRole("button", { name: /进入工作台/ }));
+    expect(screen.getByText(/AI 先给方案/)).toBeVisible();
+    expect(screen.getByText(/用真实任务试用/)).toBeVisible();
+    fireEvent.change(screen.getByLabelText("你希望它帮你完成什么？"), { target: { value: "新目标" } });
+    await userEvent.click(screen.getByRole("button", { name: /开始创建/ }));
 
     expect(await screen.findByText("studio destination")).toBeVisible();
     const createCall = fetchMock.mock.calls.find(([input, init]) =>
@@ -222,8 +224,8 @@ describe("Skill Creator pages", () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByRole("heading", { name: "分析竞品 PDF 并保留页码" })).toBeVisible();
-    await userEvent.click(screen.getByRole("button", { name: "第 2 步：确认素材" }));
+    expect(await screen.findByRole("heading", { name: "把你的做法变成可复用的 Skill" })).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "第 2 步：确认方案" }));
     expect(screen.getByText("模型网关未配置 Key。")).toBeVisible();
     expect(screen.getByRole("button", { name: "生成可评测初稿" })).toBeDisabled();
 
@@ -233,8 +235,8 @@ describe("Skill Creator pages", () => {
       "比较 PDF 并保留证据页码。用于竞品分析，不用于仅做文字转换。",
     );
     expect(screen.getByRole("button", { name: "创建结构化手工模板" })).toBeDisabled();
-    await userEvent.click(screen.getByRole("button", { name: "确认无需运行素材" }));
-    expect(await screen.findByText("已确认无需运行素材")).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "确认并继续" }));
+    expect(await screen.findByText(/已确认不导入运行素材/)).toBeVisible();
     const evidenceCall = fetchMock.mock.calls.find(([input, init]) =>
       String(input).endsWith("/evidence") && (init as RequestInit | undefined)?.method === "PUT",
     );
@@ -291,8 +293,8 @@ describe("Skill Creator pages", () => {
       </MemoryRouter>,
     );
 
-    await screen.findByRole("heading", { name: "分析竞品 PDF 并保留页码" });
-    await userEvent.click(screen.getByRole("button", { name: "第 2 步：确认素材" }));
+    await screen.findByRole("heading", { name: "把你的做法变成可复用的 Skill" });
+    await userEvent.click(screen.getByRole("button", { name: "第 2 步：确认方案" }));
 
     expect(screen.getByRole("heading", { name: "AI 生成准备度" })).toBeVisible();
     expect(screen.getByText("5/6 项已完成")).toBeVisible();
@@ -353,8 +355,8 @@ describe("Skill Creator pages", () => {
       </MemoryRouter>,
     );
 
-    await screen.findByRole("heading", { name: "分析竞品 PDF 并保留页码" });
-    await userEvent.click(screen.getByRole("button", { name: "第 2 步：确认素材" }));
+    await screen.findByRole("heading", { name: "把你的做法变成可复用的 Skill" });
+    await userEvent.click(screen.getByRole("button", { name: "第 2 步：确认方案" }));
     await userEvent.click(screen.getByRole("button", { name: "读取脱敏素材候选" }));
 
     expect(await screen.findByRole("checkbox", { name: /默认目标/ })).not.toBeChecked();
@@ -406,7 +408,7 @@ describe("Skill Creator pages", () => {
 
     await screen.findByRole("button", { name: "保存草稿" });
     expect(screen.getByRole("button", { name: "生成可评测更新初稿" })).toBeEnabled();
-    await userEvent.click(screen.getByRole("button", { name: "第 2 步：确认素材" }));
+    await userEvent.click(screen.getByRole("button", { name: "第 2 步：确认方案" }));
     expect(screen.getByText("该提案没有写入草稿。你可以保留当前草稿并重新生成提案。")).toBeVisible();
 
     const generateButton = screen.getByRole("button", { name: "生成可评测更新初稿" });
@@ -536,16 +538,16 @@ describe("Skill Creator pages", () => {
     expect(confirm).toHaveBeenCalledTimes(1);
     expect(historyGo).toHaveBeenCalledWith(1);
 
-    await userEvent.click(screen.getByRole("button", { name: "第 2 步：确认素材" }));
+    await userEvent.click(screen.getByRole("button", { name: "第 2 步：确认方案" }));
     expect(screen.getByRole("button", { name: "保存草稿" })).toBeVisible();
     expect(confirm).toHaveBeenCalledTimes(2);
 
-    await userEvent.click(screen.getByRole("link", { name: "Creator 会话" }));
+    await userEvent.click(screen.getByRole("link", { name: "返回我的 Skill" }));
     expect(screen.queryByText("Creator session list")).not.toBeInTheDocument();
     expect(confirm).toHaveBeenCalledTimes(3);
 
     confirm.mockReturnValue(true);
-    await userEvent.click(screen.getByRole("link", { name: "Creator 会话" }));
+    await userEvent.click(screen.getByRole("link", { name: "返回我的 Skill" }));
     expect(await screen.findByText("Creator session list")).toBeVisible();
   });
 
@@ -601,10 +603,225 @@ describe("Skill Creator pages", () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByRole("heading", { name: "Baseline 与 With Skill" })).toBeVisible();
+    expect(await screen.findByRole("heading", { name: "看看 Skill 是否真的更好用" })).toBeVisible();
     expect(screen.getByText("当前步骤 5/6")).toBeVisible();
     expect(screen.getByText("展开全部步骤")).toBeVisible();
-    expect(screen.getByRole("button", { name: "第 4 步：设计测试" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "第 6 步：迭代与安装" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "第 4 步：试一试" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "第 6 步：改进并安装" })).toBeEnabled();
+  });
+
+  it("refreshes a stale Creator session when its browser tab regains focus", async () => {
+    const staleSession: SkillCreatorSession = {
+      ...baseSession,
+      draft_id: draft.draft_id,
+      draft,
+      current_revision: draft.revision,
+      current_digest: draft.content_digest,
+      state: "iterating",
+      review_state: "none",
+      review_revision: 0,
+    };
+    const revisedSession: SkillCreatorSession = {
+      ...staleSession,
+      session_revision: staleSession.session_revision + 1,
+      review_state: "revise",
+      review_revision: 1,
+      regression_governance: {
+        version: "skill-creator-regression-v1",
+        enabled: true,
+        max_items: 72,
+        case_count: 3,
+        target_count: 2,
+        estimated_model_calls: 6,
+        max_repetitions: 3,
+        previous_revision: null,
+        previous_digest: null,
+        evolution_history_available: true,
+        revisions: [],
+        runs: [],
+      },
+    };
+    let sessionReads = 0;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/skills/creator/status") return jsonResponse(status);
+      if (url === "/api/skills/creator/sessions/creator_1" && !init?.method) {
+        sessionReads += 1;
+        return jsonResponse({
+          session: sessionReads === 1 ? staleSession : revisedSession,
+          draft,
+          regression_governance: sessionReads === 1 ? null : revisedSession.regression_governance,
+        });
+      }
+      return jsonResponse({ detail: `not found: ${url}` }, 404);
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/skills/create/creator_1"]}>
+        <Routes><Route element={<SkillCreatorStudioPage />} path="/skills/create/:sessionId" /></Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/选择“需要修改”后|选择“还要修改”后/)).toBeVisible();
+    window.dispatchEvent(new Event("focus"));
+
+    expect(await screen.findByRole("button", { name: "生成改进方案" })).toBeVisible();
+    expect(sessionReads).toBeGreaterThanOrEqual(2);
+  });
+
+  it("keeps the resource step active while starting a replacement build", async () => {
+    const plan = {
+      plan_id: "plan-current",
+      session_id: baseSession.session_id,
+      revision: 2,
+      digest: "p".repeat(64),
+      state: "confirmed" as const,
+      session_revision: 7,
+      draft_id: draft.draft_id,
+      draft_revision: draft.content_revision,
+      draft_digest: draft.content_digest,
+      skill_name: draft.name,
+      skill_description: draft.description,
+      workflow_steps: [{ step_id: "step-1", instruction: "读取规则并生成报告" }],
+      output_contract: ["返回带页码的中文报告"],
+      failure_modes: ["资料不足时明确说明"],
+      resources: [{
+        resource_id: "resource-1",
+        spec_digest: "s".repeat(64),
+        kind: "reference" as const,
+        action: "update" as const,
+        generation_cost: "low" as const,
+        path: "references/rules.md",
+        purpose: "保存核对规则",
+        source_ids: [],
+        used_by_steps: ["step-1"],
+        depends_on: [],
+        acceptance_checks: ["包含页码规则"],
+      }],
+      clarifications: [],
+      clarification_answers: {},
+      created_at: 1,
+      updated_at: 2,
+    };
+    const staleBuild = {
+      build_id: "build-old",
+      session_id: baseSession.session_id,
+      revision: 1,
+      digest: "b".repeat(64),
+      state: "stale" as const,
+      phase: "resources" as const,
+      session_revision: 7,
+      plan_id: "plan-old",
+      plan_revision: 1,
+      plan_digest: "o".repeat(64),
+      draft_id: draft.draft_id,
+      draft_revision: draft.content_revision,
+      draft_digest: draft.content_digest,
+      skill_name: draft.name,
+      skill_description: draft.description,
+      workflow_steps: plan.workflow_steps,
+      output_contract: plan.output_contract,
+      failure_modes: plan.failure_modes,
+      resources: [],
+      current_resource_id: null,
+      skill_chunks: [],
+      skill_markdown: null,
+      skill_markdown_digest: null,
+      skill_attempt: 0,
+      skill_repair_count: 0,
+      skill_validation_issues: [],
+      skill_feedback: "",
+      requirement_coverage: [],
+      stale: true,
+      created_at: 1,
+      updated_at: 2,
+    };
+    const startedBuild = {
+      ...staleBuild,
+      build_id: "build-new",
+      revision: 1,
+      digest: "n".repeat(64),
+      state: "planned" as const,
+      plan_id: plan.plan_id,
+      plan_revision: plan.revision,
+      plan_digest: plan.digest,
+      stale: false,
+      resources: [{
+        ...plan.resources[0],
+        state: "planned" as const,
+        attempt: 0,
+        repair_count: 0,
+        chunks: [],
+        content: null,
+        content_digest: null,
+        base_content: null,
+        base_digest: null,
+        script_tests: [],
+        script_receipt: null,
+        validation_issues: [],
+        feedback: "",
+      }],
+      current_resource_id: "resource-1",
+    };
+    const generatedBuild = {
+      ...startedBuild,
+      revision: 2,
+      digest: "g".repeat(64),
+      state: "awaiting_review" as const,
+      resources: [{
+        ...startedBuild.resources[0],
+        state: "awaiting_review" as const,
+        attempt: 1,
+        content: "# 核对规则\n",
+        content_digest: "c".repeat(64),
+      }],
+    };
+    const resourceSession: SkillCreatorSession = {
+      ...baseSession,
+      session_revision: 7,
+      authoring_flow: "resource",
+      draft_id: draft.draft_id,
+      draft,
+      current_revision: draft.content_revision,
+      current_digest: draft.content_digest,
+      state: "iterating",
+      review_state: "revise",
+      review_revision: 1,
+      resource_plan: plan,
+      resource_build: staleBuild,
+    };
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/skills/creator/status") return jsonResponse({
+        ...status,
+        resource_authoring_enabled: true,
+        resource_builder_available: true,
+      });
+      if (url === "/api/skills/creator/sessions/creator_1" && !init?.method) {
+        return jsonResponse({ session: resourceSession, draft, resource_plan: plan, resource_build: staleBuild });
+      }
+      if (url.endsWith("/resource-build") && init?.method === "POST") return jsonResponse({ resource_build: startedBuild });
+      if (url.endsWith("/resource-builds/build-new/next") && init?.method === "POST") return jsonResponse({ resource_build: generatedBuild });
+      return jsonResponse({ detail: `not found: ${url}` }, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <MemoryRouter initialEntries={["/skills/create/creator_1"]}>
+        <Routes><Route element={<SkillCreatorStudioPage />} path="/skills/create/:sessionId" /></Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("当前步骤 6/6")).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "第 3 步：生成内容" }));
+    await userEvent.click(screen.getByRole("button", { name: "按新方案开始生成" }));
+
+    expect(await screen.findByRole("heading", { name: "逐项生成内容" })).toBeVisible();
+    expect(screen.getByText("当前步骤 3/6")).toBeVisible();
+    expect(screen.queryByRole("heading", { name: "按你的反馈继续改进" })).not.toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/skills/creator/resource-builds/build-new/next",
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 });

--- a/client/src/pages/SkillCreatorStudioPage.tsx
+++ b/client/src/pages/SkillCreatorStudioPage.tsx
@@ -50,12 +50,12 @@ import {
 } from "../utils/skillCreatorApi";
 
 const LEGACY_STEPS = [
-  { title: "定义用途", detail: "触发条件与成功标准", icon: Lightbulb },
-  { title: "确认素材", detail: "选择证据并生成草稿", icon: ClipboardCheck },
-  { title: "编辑草稿", detail: "文件、规范与安全", icon: FileEdit },
-  { title: "设计测试", detail: "三个真实用例", icon: FlaskConical },
-  { title: "评审结果", detail: "Baseline 对照", icon: ShieldCheck },
-  { title: "迭代与安装", detail: "反馈、质量门与安装", icon: Sparkles },
+  { title: "说出需求", detail: "一句话也可以", icon: Lightbulb },
+  { title: "确认方案", detail: "让 AI 先规划", icon: ClipboardCheck },
+  { title: "生成内容", detail: "逐项检查结果", icon: FileEdit },
+  { title: "试一试", detail: "准备真实任务", icon: FlaskConical },
+  { title: "对比结果", detail: "判断是否更好", icon: ShieldCheck },
+  { title: "改进并安装", detail: "做最后决定", icon: Sparkles },
 ] as const;
 
 type CreatorStep = {
@@ -66,11 +66,15 @@ type CreatorStep = {
 
 const RESOURCE_STEPS: readonly CreatorStep[] = LEGACY_STEPS.map((step, index) => (
   index === 1
-    ? { ...step, title: "素材与资源计划", detail: "确认素材并规划可复用资源" }
+    ? { ...step, title: "确认方案", detail: "素材与资源计划" }
     : index === 2
-      ? { ...step, title: "构建资源", detail: "逐项生成、实测并确认完整文件" }
+      ? { ...step, title: "生成内容", detail: "资源与最终说明" }
     : step
 ));
+
+type HydrateOptions = {
+  preserveActiveStep?: boolean;
+};
 
 const EVIDENCE_LABELS: Record<SkillCreatorEvidenceCandidate["kind"], string> = {
   intent_summary: "目标摘要",
@@ -174,7 +178,7 @@ function StepRail({
           </ol>
         </details>
       </div>
-      <ol className="hidden grid-cols-6 gap-2 lg:grid">
+      <ol className="hidden grid-cols-6 overflow-hidden rounded-lg border border-white/10 bg-surface-900/70 lg:grid">
         {steps.map((step, index) => {
           const Icon = step.icon;
           const inaccessible = !availableSteps[index];
@@ -184,12 +188,12 @@ function StepRail({
               <button
                 aria-label={`第 ${index + 1} 步：${step.title}`}
                 aria-current={current ? "step" : undefined}
-                className={`flex min-h-20 w-full items-start gap-3 rounded-lg border px-3 py-3 text-left transition ${
+                className={`flex min-h-16 w-full items-center gap-2 border-r border-white/10 px-3 py-3 text-left transition last:border-r-0 ${
                   current
-                    ? "border-hire-300/50 bg-hire-300/10 text-white"
+                    ? "bg-hire-300/10 text-white"
                     : inaccessible
-                      ? "border-white/[0.06] bg-white/[0.025] text-slate-600"
-                      : "border-white/10 bg-surface-900/70 text-slate-300 hover:bg-white/[0.055]"
+                      ? "bg-white/[0.015] text-slate-600"
+                      : "text-slate-300 hover:bg-white/[0.055]"
                 }`}
                 disabled={inaccessible}
                 onClick={() => onSelect(index)}
@@ -198,10 +202,7 @@ function StepRail({
                 <span className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md ${current ? "bg-hire-300 text-ink-950" : "bg-white/[0.055]"}`}>
                   {inaccessible ? <LockKeyhole aria-hidden="true" size={13} /> : <Icon aria-hidden="true" size={14} />}
                 </span>
-                <span className="min-w-0">
-                  <span className="block text-xs font-semibold">{index + 1}. {step.title}</span>
-                  <span className="mt-1 block text-[11px] leading-4 opacity-75">{step.detail}</span>
-                </span>
+                <span className="min-w-0 text-xs font-semibold">{step.title}</span>
               </button>
             </li>
           );
@@ -227,6 +228,7 @@ export default function SkillCreatorStudioPage() {
   const [nearMissExamples, setNearMissExamples] = useState("");
   const [expectedOutput, setExpectedOutput] = useState("");
   const [successCriteria, setSuccessCriteria] = useState("");
+  const [definitionMode, setDefinitionMode] = useState<"simple" | "advanced">("simple");
   const [rootName, setRootName] = useState("");
   const [manualDescription, setManualDescription] = useState("");
   const [loading, setLoading] = useState(true);
@@ -246,7 +248,7 @@ export default function SkillCreatorStudioPage() {
     setSuccessCriteria(joinLines(value.success_criteria ?? []));
   }, []);
 
-  const hydrate = useCallback(async (value: SkillCreatorSession) => {
+  const hydrate = useCallback(async (value: SkillCreatorSession, options: HydrateOptions = {}) => {
     let hydratedDraft = value.draft ?? null;
     let hydratedProposal = value.proposal ?? null;
     if (!hydratedDraft && value.draft_id) {
@@ -290,15 +292,17 @@ export default function SkillCreatorStudioPage() {
       value.quality_status === "accepted" || value.quality_status === "eval_waived"
     ) restoredStep = 5;
     if (hydratedProposal?.status === "pending" && value.review_state !== "revise") restoredStep = resourceFlow ? 2 : 1;
-    setActiveStep((current) => Math.max(current, restoredStep));
+    if (!options.preserveActiveStep) {
+      setActiveStep((current) => Math.max(current, restoredStep));
+    }
   }, [syncSessionForm]);
 
-  const loadSession = useCallback(async () => {
+  const loadSession = useCallback(async (options: HydrateOptions = {}) => {
     if (!sessionId || !status?.enabled) return;
     setLoading(true);
     setError("");
     try {
-      await hydrate(await readSkillCreatorSession(sessionId));
+      await hydrate(await readSkillCreatorSession(sessionId), options);
     } catch (caught) {
       setError(caught instanceof SkillCreatorApiError ? caught.message : "Creator 会话加载失败。");
     } finally {
@@ -307,11 +311,25 @@ export default function SkillCreatorStudioPage() {
   }, [hydrate, sessionId, status?.enabled]);
 
   useEffect(() => {
-    if (status?.enabled) void loadSession();
-    else if (status && !status.enabled) setLoading(false);
+    if (!status?.enabled) {
+      if (status) setLoading(false);
+      return;
+    }
+    const refreshVisibleSession = () => {
+      if (document.visibilityState === "visible") void loadSession();
+    };
+    void loadSession();
+    window.addEventListener("focus", refreshVisibleSession);
+    document.addEventListener("visibilitychange", refreshVisibleSession);
+    return () => {
+      window.removeEventListener("focus", refreshVisibleSession);
+      document.removeEventListener("visibilitychange", refreshVisibleSession);
+    };
   }, [loadSession, status]);
 
-  const intentComplete = Boolean(intent.trim() && positiveExamples.trim() && expectedOutput.trim() && successCriteria.trim());
+  const intentComplete = definitionMode === "simple"
+    ? Boolean(intent.trim())
+    : Boolean(intent.trim() && positiveExamples.trim() && nearMissExamples.trim() && expectedOutput.trim() && successCriteria.trim());
   const generationReadiness = useMemo<GenerationReadinessItem[]>(() => [
     { id: "intent", label: "用途与触发条件", ready: Boolean(intent.trim()), missing: "用途" },
     { id: "positive", label: "正向示例", ready: Boolean(positiveExamples.trim()), missing: "正向示例" },
@@ -331,19 +349,36 @@ export default function SkillCreatorStudioPage() {
     setError("");
     setNotice("");
     try {
-      const updated = await updateSkillCreatorSession(session.session_id, {
+      const quickPositiveExamples = splitLines(positiveExamples).length
+        ? splitLines(positiveExamples)
+        : [intent.trim()];
+      const quickNearMissExamples = splitLines(nearMissExamples).length
+        ? splitLines(nearMissExamples)
+        : ["与上述目标无关的闲聊、通用改写或其他任务。"];
+      const quickExpectedOutput = expectedOutput.trim()
+        || "直接完成上述任务；缺少必要信息时明确列出待确认项，不编造事实。";
+      const quickSuccessCriteria = splitLines(successCriteria).length
+        ? splitLines(successCriteria)
+        : ["结果直接解决用户提出的任务。", "只使用已有信息，缺失内容明确标记为待确认。"];
+      let updated = await updateSkillCreatorSession(session.session_id, {
         expected_session_revision: session.session_revision,
         intent: intent.trim(),
-        positive_examples: splitLines(positiveExamples),
-        near_miss_examples: splitLines(nearMissExamples),
-        expected_output: expectedOutput.trim(),
-        success_criteria: splitLines(successCriteria),
+        positive_examples: definitionMode === "simple" ? quickPositiveExamples : splitLines(positiveExamples),
+        near_miss_examples: definitionMode === "simple" ? quickNearMissExamples : splitLines(nearMissExamples),
+        expected_output: definitionMode === "simple" ? quickExpectedOutput : expectedOutput.trim(),
+        success_criteria: definitionMode === "simple" ? quickSuccessCriteria : splitLines(successCriteria),
       });
-      await hydrate(updated);
+      if (updated.mode === "blank" && !updated.evidence_confirmed) {
+        const preview = await previewSkillCreatorSource(updated);
+        updated = await selectSkillCreatorEvidence(updated, preview, []);
+        setSourcePreview(preview);
+        setSelectedEvidence(new Set());
+      }
+      await hydrate(updated, { preserveActiveStep: true });
       setActiveStep(1);
       setNotice(status?.resource_authoring_enabled
-        ? "用途与示例已保存。下一步确认素材并生成资源计划。"
-        : "用途与示例已保存。下一步确认素材并生成草稿。");
+        ? "需求已保存。接下来让 AI 给出方案；需要补充信息时，它会明确提问。"
+        : "需求已保存。接下来确认 AI 的理解并生成草稿。");
     } catch (caught) {
       handleError(caught, "用途保存失败。");
     } finally {
@@ -602,8 +637,13 @@ export default function SkillCreatorStudioPage() {
   ], [draft, evaluationRun, evaluationTerminal, qualityStatus, resourceFlow, session?.resource_build, session?.resource_plan?.state, session?.review_state]);
 
   async function acceptHydratedSession(value: SkillCreatorSession) {
-    await hydrate(value);
+    await hydrate(value, { preserveActiveStep: true });
   }
+
+  const refreshSessionInPlace = useCallback(
+    () => loadSession({ preserveActiveStep: true }),
+    [loadSession],
+  );
 
   function evaluationError(caught: unknown, fallback: string) {
     setError("");
@@ -627,13 +667,9 @@ export default function SkillCreatorStudioPage() {
       <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
         <Link className="inline-flex items-center gap-2 text-sm font-semibold text-slate-300 transition hover:text-white" to="/skills/create">
           <ArrowLeft aria-hidden="true" size={16} />
-          Creator 会话
+          返回我的 Skill
         </Link>
-        {session ? (
-          <span className="max-w-full truncate rounded-full border border-white/10 bg-white/[0.045] px-3 py-1.5 font-mono text-xs text-slate-400">
-            {session.session_id} · r{session.session_revision}
-          </span>
-        ) : null}
+        {session ? <span className="text-xs text-slate-500">自动保存到本机</span> : null}
       </div>
 
       {statusLoading || loading ? (
@@ -669,15 +705,13 @@ export default function SkillCreatorStudioPage() {
           <header className="mb-5 flex flex-col gap-4 border-y border-white/10 py-5 sm:flex-row sm:items-end sm:justify-between">
             <div className="min-w-0">
               <p className="text-sm font-semibold text-brand-100">Skill Creator 工作台</p>
-              <h1 className="mt-2 max-w-4xl text-2xl font-semibold text-white sm:text-3xl">
-                {session.intent || "未命名 Skill 会话"}
-              </h1>
-              <p className="mt-2 text-sm text-slate-400">当前阶段：{currentStep.title}。所有写入均绑定 revision 与内容摘要。</p>
+              <h1 className="mt-2 max-w-4xl text-2xl font-semibold text-white sm:text-3xl">把你的做法变成可复用的 Skill</h1>
+              <p className="mt-2 line-clamp-2 max-w-4xl text-sm leading-6 text-slate-400">{session.intent || "先用一句话说出你希望它完成的任务。"}</p>
             </div>
             <div className="flex shrink-0 items-center gap-2 text-xs">
               <span className="rounded-full bg-white/[0.055] px-3 py-1.5 text-slate-300">{session.mode === "run" ? "运行沉淀" : "从零创建"}</span>
               <span className={`rounded-full px-3 py-1.5 font-semibold ${installState === "current" ? "bg-emerald-300/10 text-emerald-100" : qualityStatus === "accepted" ? "bg-emerald-300/10 text-emerald-100" : qualityStatus === "eval_waived" ? "bg-amber-300/10 text-amber-100" : qualityStatus === "running" ? "bg-brand-300/10 text-brand-100" : "bg-white/[0.055] text-slate-400"}`}>
-                {installState === "current" ? "已安装当前版本" : qualityStatus === "accepted" ? "评测已接受" : qualityStatus === "eval_waived" ? "人工豁免" : qualityStatus === "running" ? "评测中" : "不可安装"}
+                {installState === "current" ? "已安装" : qualityStatus === "accepted" ? "可以安装" : qualityStatus === "eval_waived" ? "已人工确认" : qualityStatus === "running" ? "正在试用" : "制作中"}
               </span>
             </div>
           </header>
@@ -693,45 +727,46 @@ export default function SkillCreatorStudioPage() {
 
           {activeStep === 0 ? (
             <section className="mt-5 rounded-lg border border-white/10 bg-surface-900/80 p-5 sm:p-6" aria-labelledby="creator-intent-heading">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                  <h2 className="text-xl font-semibold text-white" id="creator-intent-heading">定义用途与边界</h2>
-                  <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">用真实任务描述 Skill 应在何时触发、哪些相似请求不应触发，以及什么结果才算成功。</p>
-                </div>
-                <span className={`w-fit rounded-full px-3 py-1.5 text-xs font-semibold ${intentComplete ? "bg-emerald-300/10 text-emerald-100" : "bg-amber-300/10 text-amber-100"}`}>
-                  {intentComplete ? "定义完整" : "需要补充"}
-                </span>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-brand-100">第 1 步 · 从一句话开始</p>
+                <h2 className="mt-2 text-xl font-semibold text-white sm:text-2xl" id="creator-intent-heading">你希望这个 Skill 帮你做什么？</h2>
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">像向同事交代任务一样描述即可。AI 会补全使用场景、边界和验收方式；信息不足时再向你提问。</p>
               </div>
-              <div className="mt-6 grid gap-5 lg:grid-cols-2">
-                <label className="block lg:col-span-2" htmlFor="creator-studio-intent">
-                  <span className="text-sm font-semibold text-slate-200">用途与触发条件</span>
-                  <textarea className="mt-2 min-h-28 w-full resize-y rounded-lg border border-white/10 bg-ink-950/75 px-4 py-3 text-sm leading-6 text-white placeholder:text-slate-400 focus:border-brand-300/50 focus:outline-none" id="creator-studio-intent" maxLength={2000} onChange={(event) => setIntent(event.target.value)} placeholder="这个 Skill 解决什么任务？用户通常会怎样提出需求？" value={intent} />
-                </label>
+              <div className="mt-5 inline-flex rounded-lg border border-white/10 bg-ink-950/55 p-1" aria-label="需求填写方式" role="group">
+                <button aria-pressed={definitionMode === "simple"} className={`min-h-11 rounded-md px-4 text-sm font-semibold ${definitionMode === "simple" ? "bg-brand-200 text-ink-950" : "text-slate-300"}`} onClick={() => setDefinitionMode("simple")} type="button">一句话开始</button>
+                <button aria-pressed={definitionMode === "advanced"} className={`min-h-11 rounded-md px-4 text-sm font-semibold ${definitionMode === "advanced" ? "bg-brand-200 text-ink-950" : "text-slate-300"}`} onClick={() => setDefinitionMode("advanced")} type="button">我想详细设置</button>
+              </div>
+              <label className="mt-5 block" htmlFor="creator-studio-intent">
+                <span className="sr-only">一句话描述需求</span>
+                <textarea className="min-h-36 w-full resize-y rounded-lg border border-white/10 bg-ink-950/75 px-4 py-4 text-base leading-7 text-white placeholder:text-slate-400 focus:border-brand-300/50 focus:outline-none" id="creator-studio-intent" maxLength={2000} onChange={(event) => setIntent(event.target.value)} placeholder="例如：把零散的事故记录整理成清楚、可信的中文复盘，缺少的信息要标出来，不要猜。" value={intent} />
+              </label>
+
+              {definitionMode === "advanced" ? <div className="mt-6 grid gap-5 rounded-lg border border-white/10 bg-white/[0.02] p-4 lg:grid-cols-2">
                 <label className="block" htmlFor="creator-positive-examples">
-                  <span className="text-sm font-semibold text-slate-200">正向示例</span>
-                  <span className="mt-1 block text-xs text-slate-500">每行一个真实需求。</span>
+                  <span className="text-sm font-semibold text-slate-200">哪些请求应该使用它？</span>
+                  <span className="mt-1 block text-xs text-slate-500">每行一个例子。</span>
                   <textarea className="mt-2 min-h-36 w-full resize-y rounded-lg border border-white/10 bg-ink-950/75 px-4 py-3 text-sm leading-6 text-white placeholder:text-slate-400 focus:border-brand-300/50 focus:outline-none" id="creator-positive-examples" onChange={(event) => setPositiveExamples(event.target.value)} placeholder={"分析这份竞品 PDF 并列出证据页码\n把两个版本的定价差异整理成表格"} value={positiveExamples} />
                 </label>
                 <label className="block" htmlFor="creator-near-miss-examples">
-                  <span className="text-sm font-semibold text-slate-200">近似反例</span>
-                  <span className="mt-1 block text-xs text-slate-500">每行一个不应触发的相似请求，AI 生成前必须填写。</span>
+                  <span className="text-sm font-semibold text-slate-200">哪些相似请求不该使用它？</span>
+                  <span className="mt-1 block text-xs text-slate-500">帮助 AI 不要在错误场景出现。</span>
                   <textarea className="mt-2 min-h-36 w-full resize-y rounded-lg border border-white/10 bg-ink-950/75 px-4 py-3 text-sm leading-6 text-white placeholder:text-slate-400 focus:border-brand-300/50 focus:outline-none" id="creator-near-miss-examples" onChange={(event) => setNearMissExamples(event.target.value)} placeholder="只把 PDF 转成纯文本，不需要竞品分析" value={nearMissExamples} />
                 </label>
                 <label className="block" htmlFor="creator-expected-output">
-                  <span className="text-sm font-semibold text-slate-200">预期输出</span>
+                  <span className="text-sm font-semibold text-slate-200">你希望拿到什么结果？</span>
                   <textarea className="mt-2 min-h-28 w-full resize-y rounded-lg border border-white/10 bg-ink-950/75 px-4 py-3 text-sm leading-6 text-white placeholder:text-slate-400 focus:border-brand-300/50 focus:outline-none" id="creator-expected-output" maxLength={2000} onChange={(event) => setExpectedOutput(event.target.value)} placeholder="说明交付格式、语言、必要字段和证据要求。" value={expectedOutput} />
                 </label>
                 <label className="block" htmlFor="creator-success-criteria">
-                  <span className="text-sm font-semibold text-slate-200">成功标准</span>
-                  <span className="mt-1 block text-xs text-slate-500">每行一项可检查标准。</span>
+                  <span className="text-sm font-semibold text-slate-200">怎样算完成得好？</span>
+                  <span className="mt-1 block text-xs text-slate-500">每行写一项最重要的要求。</span>
                   <textarea className="mt-2 min-h-28 w-full resize-y rounded-lg border border-white/10 bg-ink-950/75 px-4 py-3 text-sm leading-6 text-white placeholder:text-slate-400 focus:border-brand-300/50 focus:outline-none" id="creator-success-criteria" onChange={(event) => setSuccessCriteria(event.target.value)} placeholder={"每项结论包含页码\n价格字段保留币种和计费周期"} value={successCriteria} />
                 </label>
-              </div>
+              </div> : null}
               <div className="mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-white/10 pt-5">
-                <p className="text-xs text-slate-500">可先保存四项基础定义；AI 生成还要求近似反例与素材确认齐备。</p>
+                <p className="max-w-xl text-xs leading-5 text-slate-500">一句话模式会补上通用边界与“不得编造”要求；你仍会在下一步确认 AI 的具体方案。</p>
                 <button className="inline-flex items-center gap-2 rounded-full bg-hire-300 px-5 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500" disabled={!intentComplete || Boolean(busy)} onClick={() => void saveIntent()} type="button">
-                  <Save aria-hidden="true" size={15} />
-                  {busy === "intent" ? "正在保存…" : "保存并确认素材"}
+                  <ArrowRight aria-hidden="true" size={15} />
+                  {busy === "intent" ? "正在准备…" : "继续，让 AI 完善"}
                 </button>
               </div>
             </section>
@@ -739,7 +774,7 @@ export default function SkillCreatorStudioPage() {
 
           {activeStep === 1 ? (
             <div className="mt-5 space-y-5">
-              <section className="rounded-lg border border-white/10 bg-surface-900/80 p-5 sm:p-6" aria-labelledby="creator-evidence-heading">
+              {session.mode !== "blank" && session.source_kind ? <section className="rounded-lg border border-white/10 bg-surface-900/80 p-5 sm:p-6" aria-labelledby="creator-evidence-heading">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                   <div>
                     <h2 className="text-xl font-semibold text-white" id="creator-evidence-heading">确认用于草稿的素材</h2>
@@ -748,20 +783,7 @@ export default function SkillCreatorStudioPage() {
                   <span className="w-fit rounded-full bg-white/[0.055] px-3 py-1.5 text-xs font-semibold text-slate-300">已选 {session.selected_evidence.length} 项</span>
                 </div>
 
-                {session.mode === "blank" || !session.source_kind ? (
-                  <div className="mt-5 rounded-lg border border-dashed border-white/15 px-5 py-7 text-center">
-                    <p className="text-sm font-semibold text-white">本会话从零创建</p>
-                    <p className="mt-2 text-sm text-slate-400">没有运行记录需要导入，生成助手将只使用第一步的用途、示例和成功标准。</p>
-                    {session.evidence_confirmed ? (
-                      <p className="mt-4 text-sm font-semibold text-emerald-100">已确认无需运行素材</p>
-                    ) : (
-                      <button className="mt-5 inline-flex items-center gap-2 rounded-full border border-brand-300/30 bg-brand-300/10 px-4 py-2.5 text-sm font-semibold text-brand-100 transition hover:bg-brand-300/20 disabled:cursor-wait disabled:opacity-50" disabled={busy === "evidence"} onClick={() => void confirmBlankEvidence()} type="button">
-                        <ClipboardCheck aria-hidden="true" size={16} />
-                        {busy === "evidence" ? "正在确认…" : "确认无需运行素材"}
-                      </button>
-                    )}
-                  </div>
-                ) : sourcePreview ? (
+                {sourcePreview ? (
                   <div className="mt-5">
                     <div className="grid gap-3 lg:grid-cols-2">
                       {sourcePreview.candidates.map((candidate) => (
@@ -786,7 +808,13 @@ export default function SkillCreatorStudioPage() {
                     {busy === "preview" ? "正在生成脱敏预览…" : "读取脱敏素材候选"}
                   </button>
                 )}
-              </section>
+              </section> : (
+                <section className="rounded-lg border border-emerald-300/15 bg-emerald-300/[0.04] px-5 py-4" aria-label="素材状态">
+                  <p className="text-sm font-semibold text-emerald-100"><Check aria-hidden="true" className="mr-2 inline" size={15} />从零开始，无需导入历史运行记录</p>
+                  <p className="mt-1 text-xs leading-5 text-slate-400">AI 只会使用你刚才填写的需求；如果需要权威资料，会在方案阶段明确询问。</p>
+                  {!session.evidence_confirmed ? <button className="mt-3 inline-flex min-h-11 items-center gap-2 rounded-full border border-emerald-200/25 px-4 py-2 text-sm font-semibold text-emerald-100 disabled:opacity-40" disabled={busy === "evidence"} onClick={() => void confirmBlankEvidence()} type="button"><ClipboardCheck aria-hidden="true" size={15} />{busy === "evidence" ? "正在确认…" : "确认并继续"}</button> : null}
+                </section>
+              )}
 
               {status.resource_authoring_enabled ? (
                 <SkillResourcePlanPanel onSession={acceptHydratedSession} session={session} status={status} />
@@ -861,7 +889,7 @@ export default function SkillCreatorStudioPage() {
                   setProposal(nextProposal);
                   setNotice("最终资源包已形成标准提案，请检查全包差异后批准写入草稿。");
                 }}
-                onSessionRefresh={loadSession}
+                onSessionRefresh={refreshSessionInPlace}
                 session={session}
                 status={status}
               />
@@ -930,6 +958,7 @@ export default function SkillCreatorStudioPage() {
               }}
               onSessionChange={acceptHydratedSession}
               session={session}
+              suiteEnabled={status.evaluation_suite_enabled === true}
             />
           ) : null}
 
@@ -939,7 +968,7 @@ export default function SkillCreatorStudioPage() {
               onError={evaluationError}
               onNotice={evaluationNotice}
               onRunChange={setEvaluationRun}
-              onSessionRefresh={loadSession}
+              onSessionRefresh={refreshSessionInPlace}
               run={evaluationRun}
               session={session}
             />
@@ -973,7 +1002,8 @@ export default function SkillCreatorStudioPage() {
                 onError={evaluationError}
                 onNotice={evaluationNotice}
                 onProposal={acceptIterationProposal}
-                onReload={loadSession}
+                onReload={refreshSessionInPlace}
+                onGoToBuild={() => setActiveStep(2)}
                 proposal={proposal}
                 run={evaluationRun}
                 session={session}

--- a/client/src/utils/skillCreatorApi.test.ts
+++ b/client/src/utils/skillCreatorApi.test.ts
@@ -4,6 +4,8 @@ import {
   copySkillCreatorSession,
   createSkillCreatorSession,
   generateSkillCreatorProposal,
+  confirmSkillCreatorEvaluationSuite,
+  generateSkillCreatorEvaluationSuite,
   retrySkillCreatorEvaluation,
   saveSkillCreatorEvaluationCases,
   saveSkillCreatorDraft,
@@ -14,6 +16,7 @@ import {
   type SkillCreatorSession,
   type SkillEvaluationCase,
   type SkillEvaluationRun,
+  type SkillEvaluationSuite,
 } from "./skillCreatorApi";
 
 function jsonResponse(payload: unknown, status = 200) {
@@ -289,6 +292,7 @@ describe("skillCreatorApi", () => {
     await submitSkillCreatorEvaluationReview(session, draft, evaluationRun, "accept", {
       feedback: "三组结果均改善",
       confirm_failed_assertions: true,
+      acknowledged_regression_item_ids: ["candidate-case-2"],
     });
 
     const retryBody = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
@@ -305,7 +309,48 @@ describe("skillCreatorApi", () => {
       expected_run_revision: 4,
       expected_review_revision: 2,
       acknowledge_failed_assertions: true,
+      acknowledged_regression_item_ids: ["candidate-case-2"],
     });
     expect(reviewBody).not.toHaveProperty("feedback");
+  });
+
+  it("binds suite generation and confirmation to immutable session and draft facts", async () => {
+    const stateAdvancedDraft = { ...draft, revision: draft.revision + 1 };
+    const suite: SkillEvaluationSuite = {
+      suite_id: "suite-1",
+      version: "skill-evaluation-suite-v2",
+      suite_revision: 1,
+      suite_digest: "d".repeat(64),
+      session_id: session.session_id,
+      draft_id: draft.draft_id,
+      draft_revision: stateAdvancedDraft.content_revision,
+      draft_digest: draft.content_digest,
+      quality_mode: "objective",
+      state: "draft",
+      cases: [],
+    };
+    const fetchMock = vi.fn((input: RequestInfo | URL, _init?: RequestInit) => jsonResponse({
+      session: { ...session, evaluation_suite: suite },
+      draft: stateAdvancedDraft,
+      evaluation_suite: String(input).endsWith("/confirm") ? { ...suite, state: "confirmed" } : suite,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generated = await generateSkillCreatorEvaluationSuite(session, stateAdvancedDraft);
+    await confirmSkillCreatorEvaluationSuite(generated, stateAdvancedDraft);
+
+    const generateBody = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(generateBody).toMatchObject({
+      expected_session_revision: session.session_revision,
+      expected_draft_state_revision: session.draft_state_revision,
+      expected_draft_revision: stateAdvancedDraft.content_revision,
+      expected_draft_digest: draft.content_digest,
+    });
+    const confirmBody = JSON.parse(String(fetchMock.mock.calls[1][1]?.body));
+    expect(confirmBody).toMatchObject({
+      suite_id: suite.suite_id,
+      expected_suite_revision: suite.suite_revision,
+      expected_suite_digest: suite.suite_digest,
+    });
   });
 });

--- a/client/src/utils/skillCreatorApi.ts
+++ b/client/src/utils/skillCreatorApi.ts
@@ -70,6 +70,35 @@ export interface SkillEvaluationCase {
   assertions: SkillEvaluationAssertion[];
 }
 
+export type SkillEvaluationSuiteRole = "normal" | "ambiguous" | "boundary" | "regression";
+
+export interface SkillEvaluationSuiteCase extends SkillEvaluationCase {
+  role: SkillEvaluationSuiteRole;
+  source: "generated" | "migrated" | "user";
+  requirement_ids: string[];
+  required_resource_paths: string[];
+  workflow_step_ids: string[];
+  case_fingerprint?: string;
+}
+
+export interface SkillEvaluationSuite {
+  suite_id: string;
+  version: string;
+  suite_revision: number;
+  suite_digest: string;
+  session_id: string;
+  draft_id: string;
+  draft_revision: number;
+  draft_digest: string;
+  quality_mode: SkillCreatorQualityMode;
+  state: "draft" | "confirmed";
+  cases: SkillEvaluationSuiteCase[];
+  change_reason?: string;
+  based_on_revision?: number | null;
+  stale?: boolean;
+  created_at?: number;
+}
+
 export interface SkillEvaluationUsage {
   prompt_tokens?: number | null;
   completion_tokens?: number | null;
@@ -104,7 +133,7 @@ export interface SkillEvaluationItem {
   item_id: string;
   pair_id?: string | null;
   case_id: string;
-  target: "baseline" | "candidate";
+  target: "baseline" | "previous" | "candidate";
   repetition: number;
   status: SkillEvaluationItemStatus;
   attempts?: number;
@@ -127,6 +156,7 @@ export interface SkillEvaluationReview {
   decision: "accept" | "revise";
   feedback?: string | null;
   reason?: string | null;
+  acknowledged_regression_item_ids?: string[];
   actor_kind?: string;
   created_at?: number;
 }
@@ -140,6 +170,26 @@ export interface SkillEvaluationReport {
   candidate_usage?: SkillEvaluationUsage | null;
   baseline_latency_ms?: number | null;
   candidate_latency_ms?: number | null;
+  previous_usage?: SkillEvaluationUsage | null;
+  previous_latency_ms?: number | null;
+  candidate_assertion_failed_count?: number;
+  eligible_for_accept?: boolean;
+  application_receipt_verified_count?: number;
+  model_mismatch_count?: number;
+  regression_item_ids?: string[];
+  comparison_reference?: "baseline" | "previous";
+  comparison_counts?: Record<"regressed" | "improved" | "flat" | "inconclusive", number>;
+  pairs?: Array<{
+    pair_id: string;
+    case_id: string;
+    repetition: number;
+    baseline_item_id?: string | null;
+    previous_item_id?: string | null;
+    candidate_item_id?: string | null;
+    classification: "regressed" | "improved" | "flat" | "inconclusive";
+    new_failure_indices?: number[];
+    fixed_failure_indices?: number[];
+  }>;
 }
 
 export interface SkillEvaluationRun {
@@ -149,10 +199,14 @@ export interface SkillEvaluationRun {
   revision: number;
   frozen_digest: string;
   baseline_overlay_id?: string | null;
+  previous_overlay_id?: string | null;
   candidate_overlay_id?: string | null;
   model_id: string;
   repetitions: number;
   case_set_revision?: number | null;
+  evaluation_suite_id?: string | null;
+  evaluation_suite_revision?: number | null;
+  evaluation_suite_digest?: string | null;
   cases: SkillEvaluationCase[];
   items: SkillEvaluationItem[];
   report?: SkillEvaluationReport | null;
@@ -166,6 +220,106 @@ export interface SkillEvaluationRun {
   error?: string | null;
   created_at?: number;
   updated_at?: number;
+}
+
+export interface SkillEvolutionQuestion {
+  question_id: string;
+  question: string;
+  reason: string;
+}
+
+export interface SkillEvolutionDiagnosis {
+  case_id: string;
+  evidence_item_ids: string[];
+  failure_types: string[];
+  requirement_ids: string[];
+  resource_ids: string[];
+  sections: string[];
+  summary: string;
+}
+
+export interface SkillEvolutionAction {
+  action_id: string;
+  action: "keep" | "update" | "create" | "delete";
+  resource_id: string;
+  kind: "script" | "reference" | "asset";
+  path: string;
+  purpose: string;
+  source_ids: string[];
+  used_by_steps: string[];
+  depends_on: string[];
+  acceptance_checks: string[];
+  related_case_ids: string[];
+  expected_improvement: string;
+  non_regression_case_ids: string[];
+}
+
+export interface SkillEvolutionPlan {
+  plan_id: string;
+  version: string;
+  revision: number;
+  digest: string;
+  state: "needs_input" | "needs_regeneration" | "ready" | "confirmed" | "stale";
+  session_id: string;
+  draft_id: string;
+  draft_revision: number;
+  draft_digest: string;
+  evaluation_run_id: string;
+  evaluation_run_revision: number;
+  review_revision: number;
+  suite_id: string;
+  suite_revision: number;
+  suite_digest: string;
+  diagnoses: SkillEvolutionDiagnosis[];
+  actions: SkillEvolutionAction[];
+  expected_improvements: string[];
+  acceptance_criteria: string[];
+  non_goals: string[];
+  overfitting_risks: string[];
+  clarifications: SkillEvolutionQuestion[];
+  clarification_answers: Record<string, string>;
+  created_at?: number;
+  updated_at?: number;
+}
+
+export interface SkillUnavailableProjection {
+  available: false;
+  code: string;
+}
+
+export interface SkillRegressionGovernance {
+  version: string;
+  enabled: boolean;
+  max_items: number;
+  case_count: number;
+  target_count: 2 | 3;
+  estimated_model_calls: number;
+  max_repetitions: number;
+  previous_revision?: number | null;
+  previous_digest?: string | null;
+  evolution_history_available?: boolean;
+  revisions: Array<{
+    revision: number;
+    content_digest: string;
+    source_proposal_id?: string | null;
+    created_at?: number;
+    is_current: boolean;
+    is_installed: boolean;
+    is_previous: boolean;
+  }>;
+  runs: Array<{
+    run_id: string;
+    draft_revision: number;
+    frozen_digest: string;
+    status: SkillEvaluationRunStatus;
+    review_state?: string | null;
+    suite_revision?: number | null;
+    target_count: 2 | 3;
+    item_count: number;
+    comparison_counts?: Record<string, number>;
+    created_at?: number;
+    completed_at?: number | null;
+  }>;
 }
 
 export interface SkillCreatorQualityDecision {
@@ -517,6 +671,9 @@ export interface SkillCreatorSession {
   draft?: SkillCreatorDraft | null;
   resource_plan?: SkillResourcePlan | null;
   resource_build?: SkillResourceBuild | null;
+  evaluation_suite?: SkillEvaluationSuite | null;
+  evolution_plan?: SkillEvolutionPlan | SkillUnavailableProjection | null;
+  regression_governance?: SkillRegressionGovernance | null;
   created_at: number;
   updated_at: number;
 }
@@ -536,6 +693,13 @@ export interface SkillCreatorStatus {
   resource_build_version?: string | null;
   resource_builder_available?: boolean;
   script_sandbox_configured?: boolean;
+  evaluation_suite_enabled?: boolean;
+  evaluation_suite_version?: string | null;
+  evaluation_suite_generator_available?: boolean;
+  evaluation_suite_store_available?: boolean;
+  evolution_enabled?: boolean;
+  evolution_version?: string | null;
+  evolution_planner_available?: boolean;
 }
 
 export interface SkillCreatorListResponse {
@@ -627,6 +791,9 @@ function unwrapSession(
         evaluation_run?: SkillEvaluationRun | null;
         resource_plan?: SkillResourcePlan | null;
         resource_build?: SkillResourceBuild | null;
+        evaluation_suite?: SkillEvaluationSuite | null;
+        evolution_plan?: SkillEvolutionPlan | SkillUnavailableProjection | null;
+        regression_governance?: SkillRegressionGovernance | null;
       },
 ): SkillCreatorSession {
   if (!("session" in payload)) return payload;
@@ -639,6 +806,9 @@ function unwrapSession(
     evaluation_run: payload.evaluation_run ?? payload.session.evaluation_run,
     resource_plan: payload.resource_plan ?? payload.session.resource_plan,
     resource_build: payload.resource_build ?? payload.session.resource_build,
+    evaluation_suite: payload.evaluation_suite ?? payload.session.evaluation_suite,
+    evolution_plan: payload.evolution_plan ?? payload.session.evolution_plan,
+    regression_governance: payload.regression_governance ?? payload.session.regression_governance,
   };
 }
 
@@ -742,6 +912,95 @@ export async function saveSkillCreatorEvaluationCases(
   ));
 }
 
+function suiteOptimisticPayload(session: SkillCreatorSession, draft: SkillCreatorDraft) {
+  return {
+    expected_session_revision: session.session_revision,
+    expected_draft_state_revision: session.draft_state_revision,
+    expected_draft_revision: draft.content_revision,
+    expected_draft_digest: draft.content_digest,
+  };
+}
+
+function suiteCasePayload(evaluationCase: SkillEvaluationSuiteCase) {
+  return {
+    case_id: evaluationCase.case_id,
+    role: evaluationCase.role,
+    name: evaluationCase.name,
+    prompt: evaluationCase.prompt,
+    expected_behavior: evaluationCase.expected_behavior,
+    fixtures: evaluationCase.fixtures,
+    assertions: evaluationCase.assertions,
+    requirement_ids: evaluationCase.requirement_ids,
+    required_resource_paths: evaluationCase.required_resource_paths,
+    workflow_step_ids: evaluationCase.workflow_step_ids,
+  };
+}
+
+export async function generateSkillCreatorEvaluationSuite(
+  session: SkillCreatorSession,
+  draft: SkillCreatorDraft,
+) {
+  const suite = session.evaluation_suite;
+  return unwrapSession(await request<SkillCreatorSession | {
+    session: SkillCreatorSession;
+    draft?: SkillCreatorDraft;
+    evaluation_suite?: SkillEvaluationSuite | null;
+  }>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/evaluation-suite/generate`,
+    jsonRequest("POST", {
+      ...suiteOptimisticPayload(session, draft),
+      expected_suite_revision: suite?.suite_revision,
+      expected_suite_digest: suite?.suite_digest,
+    }),
+  ));
+}
+
+export async function updateSkillCreatorEvaluationSuite(
+  session: SkillCreatorSession,
+  draft: SkillCreatorDraft,
+  cases: SkillEvaluationSuiteCase[],
+  changeReason: string,
+) {
+  const suite = session.evaluation_suite;
+  if (!suite) throw new Error("Evaluation suite is not available.");
+  return unwrapSession(await request<SkillCreatorSession | {
+    session: SkillCreatorSession;
+    draft?: SkillCreatorDraft;
+    evaluation_suite?: SkillEvaluationSuite | null;
+  }>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/evaluation-suite`,
+    jsonRequest("PATCH", {
+      ...suiteOptimisticPayload(session, draft),
+      suite_id: suite.suite_id,
+      expected_suite_revision: suite.suite_revision,
+      expected_suite_digest: suite.suite_digest,
+      cases: cases.map(suiteCasePayload),
+      change_reason: changeReason.trim(),
+    }),
+  ));
+}
+
+export async function confirmSkillCreatorEvaluationSuite(
+  session: SkillCreatorSession,
+  draft: SkillCreatorDraft,
+) {
+  const suite = session.evaluation_suite;
+  if (!suite) throw new Error("Evaluation suite is not available.");
+  return unwrapSession(await request<SkillCreatorSession | {
+    session: SkillCreatorSession;
+    draft?: SkillCreatorDraft;
+    evaluation_suite?: SkillEvaluationSuite | null;
+  }>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/evaluation-suite/confirm`,
+    jsonRequest("POST", {
+      ...suiteOptimisticPayload(session, draft),
+      suite_id: suite.suite_id,
+      expected_suite_revision: suite.suite_revision,
+      expected_suite_digest: suite.suite_digest,
+    }),
+  ));
+}
+
 export async function startSkillCreatorEvaluation(
   session: SkillCreatorSession,
   draft: SkillCreatorDraft,
@@ -756,6 +1015,12 @@ export async function startSkillCreatorEvaluation(
     jsonRequest("POST", {
       ...optimisticPayload(session, draft),
       repetitions,
+      evaluation_suite_revision: session.evaluation_suite?.state === "confirmed"
+        ? session.evaluation_suite.suite_revision
+        : undefined,
+      evaluation_suite_digest: session.evaluation_suite?.state === "confirmed"
+        ? session.evaluation_suite.suite_digest
+        : undefined,
     }),
   );
   return {
@@ -837,7 +1102,12 @@ export async function submitSkillCreatorEvaluationReview(
   draft: SkillCreatorDraft,
   run: SkillEvaluationRun,
   decision: "accept" | "revise",
-  payload: { feedback?: string; reason?: string; confirm_failed_assertions?: boolean },
+  payload: {
+    feedback?: string;
+    reason?: string;
+    confirm_failed_assertions?: boolean;
+    acknowledged_regression_item_ids?: string[];
+  },
 ) {
   const result = await request<
     SkillEvaluationRun |
@@ -852,6 +1122,7 @@ export async function submitSkillCreatorEvaluationReview(
       decision,
       reason: payload.reason?.trim() || undefined,
       acknowledge_failed_assertions: payload.confirm_failed_assertions ?? false,
+      acknowledged_regression_item_ids: payload.acknowledged_regression_item_ids ?? [],
     }),
   );
   return {
@@ -881,6 +1152,95 @@ export async function iterateSkillCreatorDraft(
     proposal: result.proposal,
     session: result.session ?? await readSkillCreatorSession(session.session_id),
   };
+}
+
+function evolutionOptimisticPayload(
+  session: SkillCreatorSession,
+  draft: SkillCreatorDraft,
+  plan: SkillEvolutionPlan,
+) {
+  return {
+    plan_id: plan.plan_id,
+    expected_session_revision: session.session_revision,
+    expected_draft_state_revision: session.draft_state_revision,
+    expected_draft_revision: draft.content_revision,
+    expected_draft_digest: draft.content_digest,
+    expected_plan_revision: plan.revision,
+    expected_plan_digest: plan.digest,
+  };
+}
+
+export async function generateSkillCreatorEvolutionPlan(
+  session: SkillCreatorSession,
+  draft: SkillCreatorDraft,
+  run: SkillEvaluationRun,
+) {
+  const resourcePlan = session.resource_plan;
+  if (!resourcePlan) throw new Error("Resource plan is not available.");
+  const evolution = session.evolution_plan && "plan_id" in session.evolution_plan
+    ? session.evolution_plan
+    : null;
+  const result = await request<{ evolution_plan: SkillEvolutionPlan }>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/evolution-plan/generate`,
+    jsonRequest("POST", {
+      evaluation_run_id: run.run_id,
+      expected_session_revision: session.session_revision,
+      expected_draft_state_revision: session.draft_state_revision,
+      expected_draft_revision: draft.content_revision,
+      expected_draft_digest: draft.content_digest,
+      expected_review_revision:
+        run.reviews?.at(-1)?.review_revision ?? run.review_revision ?? session.review_revision ?? 0,
+      expected_run_revision: run.revision,
+      expected_resource_plan_revision: resourcePlan.revision,
+      expected_resource_plan_digest: resourcePlan.digest,
+      expected_evolution_revision: evolution?.revision,
+      expected_evolution_digest: evolution?.digest,
+    }),
+  );
+  return result.evolution_plan;
+}
+
+export async function answerSkillCreatorEvolutionPlan(
+  session: SkillCreatorSession,
+  draft: SkillCreatorDraft,
+  plan: SkillEvolutionPlan,
+  answers: Record<string, string>,
+) {
+  const result = await request<{ evolution_plan: SkillEvolutionPlan }>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/evolution-plan/answers`,
+    jsonRequest("PUT", {
+      ...evolutionOptimisticPayload(session, draft, plan),
+      answers,
+    }),
+  );
+  return result.evolution_plan;
+}
+
+export async function updateSkillCreatorEvolutionPlan(
+  session: SkillCreatorSession,
+  draft: SkillCreatorDraft,
+  plan: SkillEvolutionPlan,
+  changes: Record<string, unknown>,
+) {
+  const result = await request<{ evolution_plan: SkillEvolutionPlan }>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/evolution-plan`,
+    jsonRequest("PATCH", {
+      ...evolutionOptimisticPayload(session, draft, plan),
+      changes,
+    }),
+  );
+  return result.evolution_plan;
+}
+
+export async function confirmSkillCreatorEvolutionPlan(
+  session: SkillCreatorSession,
+  draft: SkillCreatorDraft,
+  plan: SkillEvolutionPlan,
+) {
+  return request<{ evolution_plan: SkillEvolutionPlan; resource_plan: SkillResourcePlan }>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/evolution-plan/confirm`,
+    jsonRequest("POST", evolutionOptimisticPayload(session, draft, plan)),
+  );
 }
 
 export async function waiveSkillCreatorEvaluation(

--- a/docs/SKILL_EXPERIENCE_AUDIT.md
+++ b/docs/SKILL_EXPERIENCE_AUDIT.md
@@ -137,13 +137,13 @@ node scripts/audit-skill-experience.mjs
 
 ### 4.3 通过 skill-creator 创建 Skill
 
-当前实现：Creator V1 已完成“意图定义 → 可信素材 → 不可变草稿 → 三个真实用例 → baseline/with-skill 隔离对照 → 人工反馈与迭代 → 质量门 → 单独安装确认”核心闭环。`SKILL_CREATOR_V2_ENABLED` 默认开启私有控制台；公共 Xpert App 不提供 Creator 入口、Creator 工具或可信素材来源。
+当前实现：Creator V2 已完成“意图定义 → 可信素材 → 不可变草稿 → 可复用评测套件 → baseline/previous/candidate 隔离对照 → 人工反馈 → 资源级进化 → 跨版本回归 → 质量门 → 单独安装确认”核心闭环。`SKILL_CREATOR_V2_ENABLED` 默认开启私有控制台；公共 Xpert App 不提供 Creator 入口、Creator 工具或可信素材来源。
 
-评测合同：客观 Skill 必须完成与当前 digest 绑定的恰好 3 个用例；主观创作类 Skill 可运行同一三例，或由本地控制台填写原因并二次确认豁免。新 Skill 的 baseline 不加载 Skill；升级 Skill 的 baseline 固定为会话开始时已安装的 digest；Candidate 使用当前不可变 Overlay。两侧使用同一实际模型与参数，只开放 `skill_read`、`skill_stage` 和固定离线 Sandbox；不开放网络、MCP、浏览器、安装或 HITL。接受或豁免均不会自动安装，当前 digest 仍需单独确认全局安装。
+评测合同：客观 Skill 必须完成与当前 digest 绑定的三个核心角色及全部用户确认回归案例；主观创作类 Skill 可运行同一套件，或由本地控制台填写原因并二次确认豁免。新 Skill 的 baseline 不加载 Skill；升级 Skill 的 baseline 固定为会话开始时已安装的 digest；进化后再加入 previous（进化前 revision）与当前 Candidate。所有目标使用同一套件、实际模型与参数，只开放 `skill_read`、`skill_stage` 和固定离线 Sandbox；不开放网络、MCP、浏览器、安装或 HITL。单次最多 72 个 item，新增退化必须逐项确认并填写原因。接受或豁免均不会自动安装，当前 digest 仍需单独确认全局安装。
 
-`SKILL_CREATOR_EVOLUTION_V2_ENABLED=true` 时，可显式把旧三例无模型迁移为不可变评测套件，或由固定 Creator Agent 生成“正常、歧义/信息不足、边界/失败”三个核心案例。用户确认的失败案例最多追加 9 条回归案例；模型不得自行写入回归集。V2 run 冻结套件 revision/digest，Candidate 每项必须持有与 Overlay、资源路径和实际 `skill_read`/`skill_stage` 一致的 verified 应用凭据；人工接受和崩溃恢复时都会重新核对权威凭据 Store。该开关在跨版本回归治理完成前默认关闭，旧会话不会被静默迁移。
+`SKILL_CREATOR_EVOLUTION_V2_ENABLED=true` 默认用于私有控制台：旧三例可由用户显式、无模型迁移为不可变评测套件，新 Session 则由固定 Creator Agent 生成“正常、歧义/信息不足、边界/失败”三个核心案例。用户确认的失败案例最多追加 9 条回归案例；模型不得自行写入回归集。V2 run 冻结套件 revision/digest，所有加载 Overlay 的目标都必须持有与版本、资源路径和实际 `skill_read`/`skill_stage` 一致的 verified 应用凭据；人工接受和崩溃恢复时都会重新核对权威凭据 Store。关闭开关立即回退旧流程，旧会话不会被静默迁移或删除。
 
-反馈驱动的资源级进化沿用同一开关并保持默认关闭。用户把 V2 评测结论设为 `revise` 后，固定 Creator Agent 只能读取冻结的 run/review、套件摘要、断言状态、应用凭据结论和当前资源计划，不接收旧模型输出或任意客户端反馈正文。Agent 先生成不可变 Evolution Plan，按案例绑定失败类型、需求、资源/章节和证据 item；最多提出 5 个澄清问题。只有本地用户修改并确认计划后，服务端才将其转换为新的 Resource Plan revision，并复用现有 Resource Build 选择性重建受影响的 `references/`、`scripts/` 或 `assets/`。未变化资源保持 `keep`，脚本测试凭据按内容 digest 复用；变化脚本必须重新离线实测。全部资源再次确认后才重新生成最终 `SKILL.md` 并形成普通 update proposal；新草稿 digest 会使旧评测过期，且不会自动接受或安装。开关开启时旧的一次性 `/iterate` 捷径返回 `skill_creator_evolution_plan_required`，关闭时保留既有流程作为回退。
+反馈驱动的资源级进化沿用同一默认开启的开关。用户把 V2 评测结论设为 `revise` 后，固定 Creator Agent 只能读取冻结的 run/review、套件摘要、断言状态、应用凭据结论和当前资源计划，不接收旧模型输出或任意客户端反馈正文。Agent 先生成不可变 Evolution Plan，按案例绑定失败类型、需求、资源/章节和证据 item；最多提出 5 个澄清问题。只有本地用户修改并确认计划后，服务端才将其转换为新的 Resource Plan revision，并复用现有 Resource Build 选择性重建受影响的 `references/`、`scripts/` 或 `assets/`。未变化资源保持 `keep`，脚本测试凭据按内容 digest 复用；变化脚本必须重新离线实测。全部资源再次确认后才重新生成最终 `SKILL.md` 并形成普通 update proposal；新草稿 digest 会使旧评测过期，下一轮以同一套件比较 previous 与 Candidate，且不会自动接受或安装。开关开启时旧的一次性 `/iterate` 捷径返回 `skill_creator_evolution_plan_required`，关闭时保留既有流程作为回退。
 
 资源化创作在行为质量门之前增加了“澄清 → 资源计划 → 用户确认 → 逐资源生成与验证 → 最终 `SKILL.md` → 提案确认”的阶段：
 

--- a/docs/SKILL_INTEGRATION.md
+++ b/docs/SKILL_INTEGRATION.md
@@ -249,7 +249,7 @@ curl -X DELETE http://localhost:8000/api/skills/anthropics-skills-skills-pdf
 - 父级组合包显示“安装技能包”；成员集合显示“成员可安装”和“查看成员”，详情支持本地名称/路径搜索、每页 50 项分页、成员逐项安装，以及按顺序调用现有接口的“一键安装全部成员”。该操作会跳过已安装成员并在首个失败处停止，不使用整仓安装或新增后端批量协议。
 - `已安装`：调用 `/api/skills/installed`，展示本地已安装 Skill、来源摘要、信任凭据、Router 状态和卸载按钮。本地导入项可回到精确 import 记录查看原始包摘要和扫描结论。
 - `本地导入`：懒加载私有 Import Store 摘要；`/skills/import` 接受单个 ZIP 或文件夹，完成确定性扫描、风险确认、安装或同源替换，不执行包内脚本、不调用模型或网络。
-- `工作区草稿`、`待审提案`：保留通用创作与审批入口；默认开启的私有 `/skills/create` 提供 Creator V1 工作台。新 Session 先确认资源计划，再按需生成和验证 `scripts/`、`references/`、可选 `assets/`，最后评审 `SKILL.md`；简单 Skill 可以不生成附加资源。Creator 草稿仍须完成当前摘要的三例隔离对照评测，或仅对主观创作类记录明确人工豁免。质量门通过后仍需独立确认安装，评测不会自动安装。详细边界见 [Skill 体验治理与候选能力审计](./SKILL_EXPERIENCE_AUDIT.md#43-通过-skill-creator-创建-skill)。
+- `工作区草稿`、`待审提案`：保留通用创作与审批入口；默认开启的私有 `/skills/create` 提供 Creator V2 工作台。新 Session 先确认资源计划，再按需生成和验证 `scripts/`、`references/`、可选 `assets/`，最后评审 `SKILL.md`；简单 Skill 可以不生成附加资源。客观 Skill 使用固定三类核心案例和最多 9 条用户确认回归案例，并在进化后以 baseline / previous / candidate 三侧复跑；主观创作类仍可记录明确人工豁免。新增退化必须逐项确认并说明原因，质量门通过后仍需独立确认安装，评测不会自动安装。详细边界见 [Skill 体验治理与候选能力审计](./SKILL_EXPERIENCE_AUDIT.md#43-通过-skill-creator-创建-skill)。
 
 社区资源卡片同时显示原始来源与收录索引。安装第三方条目只会复制目录，不会在安装阶段自动执行脚本；用户仍需在激活前检查依赖、外部服务和凭据要求。
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -30,8 +30,8 @@ EXPERT_TEAM_AGENCY_HITL_ENABLED=0
 SKILL_CREATOR_V2_ENABLED=true
 # 资源化 Creator 已具备规划、分段构建和脚本离线实测；PR 3 工作台完成前默认关闭。
 SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED=true
-# 可复用评测套件与进化流程在最终治理轮完成前保持显式启用。
-SKILL_CREATOR_EVOLUTION_V2_ENABLED=false
+# 私有 Creator 默认启用可复用套件、资源级进化和跨版本回归；设为 false 可回退旧三例流程。
+SKILL_CREATOR_EVOLUTION_V2_ENABLED=true
 # 第三方 Git Skill 信任门默认 enforce：确定恶意或不可安装内容会被阻断；
 # 其余风险需确认精确凭据，可疑项不进入 Agent Router。可切回 audit 或 off 即时回退。
 SKILL_TRUST_GATE_MODE=enforce

--- a/server/main.py
+++ b/server/main.py
@@ -20007,7 +20007,7 @@ async def run_skill_evaluation_item(
         child = completed[0]
         actual_model = require_skill_evaluation_actual_model(child.metadata)
         application_receipt = None
-        if item.target == "candidate" and run.evaluation_suite_id is not None:
+        if item.overlay_id is not None and run.evaluation_suite_id is not None:
             expected_policy = (
                 "require_stage" if case.required_resource_paths else "require_read"
             )
@@ -20141,7 +20141,7 @@ def verify_skill_evaluation_application_receipts(run: Any) -> None:
         return
     cases = {case.case_id: case for case in run.cases}
     for item in run.items:
-        if item.target != "candidate":
+        if item.overlay_id is None:
             continue
         try:
             receipt = skill_application_receipt_store.require_verified(
@@ -20153,6 +20153,11 @@ def verify_skill_evaluation_application_receipts(run: Any) -> None:
                 code=exc.code,
             ) from exc
         case = cases[item.case_id]
+        expected_content_digest = (
+            run.frozen_digest
+            if item.target == "candidate"
+            else skill_evaluation_store.require_overlay(item.overlay_id).content_digest
+        )
         expected_policy = (
             "require_stage" if case.required_resource_paths else "require_read"
         )
@@ -20162,7 +20167,7 @@ def verify_skill_evaluation_application_receipts(run: Any) -> None:
             or receipt.skill_id != "evaluation-skill"
             or receipt.source_kind != "evaluation_overlay"
             or receipt.version_id != item.overlay_id
-            or receipt.content_digest != run.frozen_digest
+            or receipt.content_digest != expected_content_digest
             or receipt.policy != expected_policy
             or tuple(receipt.required_resource_paths)
             != tuple(case.required_resource_paths)
@@ -20183,6 +20188,7 @@ skill_creator_evaluation_service = SkillCreatorEvaluationService(
     actor_id=authoring_service.local_console_actor_id,
     iteration=iterate_skill_creator_from_evaluation,
     suite_service=skill_creator_evaluation_suite_service,
+    evolution_store=skill_creator_evolution_store,
     application_receipt_verifier=verify_skill_evaluation_application_receipts,
 )
 configure_skill_creator_evaluation(skill_creator_evaluation_service)

--- a/server/skills/creator_api.py
+++ b/server/skills/creator_api.py
@@ -302,6 +302,9 @@ class CreatorEvaluationReviewRequest(CreatorEvaluationRunMutationRequest):
     decision: Literal["accept", "revise"]
     reason: str = Field(default="", max_length=4_000)
     acknowledge_failed_assertions: bool = False
+    acknowledged_regression_item_ids: list[str] = Field(
+        default_factory=list, max_length=36
+    )
 
 
 class CreatorEvaluationWaiveRequest(CreatorEvaluationWriteRequest):
@@ -636,6 +639,11 @@ def _session_response(
             else None
         ),
         "evolution_plan": _evolution_projection(session.session_id),
+        "regression_governance": (
+            _evaluation_service.governance_projection(session, draft)
+            if _evaluation_service is not None and draft is not None
+            else None
+        ),
     }
     return response
 
@@ -1437,6 +1445,9 @@ async def review_creator_evaluation(
             decision=payload.decision,
             reason=payload.reason,
             acknowledge_failed_assertions=payload.acknowledge_failed_assertions,
+            acknowledged_regression_item_ids=(
+                payload.acknowledged_regression_item_ids
+            ),
         )
         return _session_response(creator, session, draft, evaluation_run=run)
     except (SkillCreatorError, SkillDraftError, SkillEvaluationError) as exc:

--- a/server/skills/creator_evaluation.py
+++ b/server/skills/creator_evaluation.py
@@ -21,7 +21,7 @@ from jsonschema import Draft202012Validator
 from .package_validation import compute_package_digest, scan_skill_package_credentials
 
 
-SkillEvaluationTarget = Literal["baseline", "candidate"]
+SkillEvaluationTarget = Literal["baseline", "previous", "candidate"]
 SkillEvaluationRunStatus = Literal[
     "queued",
     "running",
@@ -155,6 +155,7 @@ class SkillEvaluationReview:
     feedback: str
     actor_kind: str
     acknowledge_failed_assertions: bool = False
+    acknowledged_regression_item_ids: tuple[str, ...] = ()
     created_at: float = field(default_factory=time.time)
 
 
@@ -172,6 +173,7 @@ class SkillEvaluationRun:
     cases: list[SkillEvaluationCase]
     items: list[SkillEvaluationItem]
     config: dict[str, Any]
+    previous_overlay_id: str | None = None
     case_set_revision: int | None = None
     evaluation_suite_id: str | None = None
     evaluation_suite_revision: int | None = None
@@ -234,6 +236,7 @@ class SkillEvaluationStore:
     MAX_PACKAGE_BYTES = 4 * 1024 * 1024
     MAX_FIXTURE_BYTES = 256 * 1024
     MAX_OUTPUT_CHARS = 50_000
+    MAX_RUN_ITEMS = 72
 
     def __init__(self, storage_dir: str | Path | None = None) -> None:
         package_dir = Path(__file__).resolve().parent
@@ -441,6 +444,7 @@ class SkillEvaluationStore:
         model_id: str,
         repetitions: int = 1,
         baseline_overlay_id: str | None = None,
+        previous_overlay_id: str | None = None,
         case_set_revision: int | None = None,
         evaluation_suite_id: str | None = None,
         evaluation_suite_revision: int | None = None,
@@ -543,6 +547,31 @@ class SkillEvaluationStore:
                     raise SkillEvaluationConflictError(
                         "Baseline and candidate overlays must belong to the same draft."
                     )
+            previous_overlay: SkillEvaluationOverlay | None = None
+            if previous_overlay_id is not None:
+                previous_overlay = self._overlay_unlocked(previous_overlay_id)
+                if previous_overlay.draft_id != clean_draft_id:
+                    raise SkillEvaluationConflictError(
+                        "Previous and candidate overlays must belong to the same draft."
+                    )
+                if previous_overlay.draft_revision >= candidate.draft_revision:
+                    raise SkillEvaluationConflictError(
+                        "Previous overlay must precede the candidate draft revision."
+                    )
+                if previous_overlay.content_digest == candidate.content_digest:
+                    raise SkillEvaluationConflictError(
+                        "Previous and candidate overlays must have different digests."
+                    )
+            target_count = 3 if previous_overlay is not None else 2
+            item_count = len(clean_cases) * clean_repetitions * target_count
+            if item_count > self.MAX_RUN_ITEMS:
+                raise SkillEvaluationValidationError(
+                    (
+                        f"Evaluation would create {item_count} items; "
+                        f"the maximum is {self.MAX_RUN_ITEMS}."
+                    ),
+                    code="skill_evaluation_item_budget_exceeded",
+                )
             run_id = f"skill_eval_run_{uuid.uuid4().hex}"
             now = time.time()
             items: list[SkillEvaluationItem] = []
@@ -552,10 +581,13 @@ class SkillEvaluationStore:
                     pair_id = "skill_eval_pair_" + hashlib.sha256(
                         pair_key.encode("utf-8")
                     ).hexdigest()[:24]
-                    for target, target_overlay_id in (
+                    targets: list[tuple[SkillEvaluationTarget, str | None]] = [
                         ("baseline", baseline.overlay_id if baseline else None),
-                        ("candidate", candidate.overlay_id),
-                    ):
+                    ]
+                    if previous_overlay is not None:
+                        targets.append(("previous", previous_overlay.overlay_id))
+                    targets.append(("candidate", candidate.overlay_id))
+                    for target, target_overlay_id in targets:
                         item_key = f"{pair_key}:{target}"
                         item_id = "skill_eval_item_" + hashlib.sha256(
                             item_key.encode("utf-8")
@@ -585,6 +617,9 @@ class SkillEvaluationStore:
                 cases=clean_cases,
                 items=items,
                 config=clean_config,
+                previous_overlay_id=(
+                    previous_overlay.overlay_id if previous_overlay else None
+                ),
                 case_set_revision=(
                     bound_case_set.cases_revision if bound_case_set else None
                 ),
@@ -674,13 +709,17 @@ class SkillEvaluationStore:
             claimed: list[list[SkillEvaluationItem]] = []
             previous = self._snapshot_unlocked()
             now = time.time()
+            expected_pair_size = 3 if run.previous_overlay_id is not None else 2
             for pair in grouped.values():
-                if len(pair) != 2 or any(item.status == "running" for item in pair):
+                if len(pair) != expected_pair_size or any(
+                    item.status == "running" for item in pair
+                ):
                     continue
                 pending = [item for item in pair if item.status == "pending"]
                 if not pending:
                     continue
-                pair.sort(key=lambda item: 0 if item.target == "baseline" else 1)
+                order = {"baseline": 0, "previous": 1, "candidate": 2}
+                pair.sort(key=lambda item: order[item.target])
                 for item in pending:
                     item.status = "running"
                     item.attempts += 1
@@ -880,6 +919,7 @@ class SkillEvaluationStore:
         reason: str,
         actor_kind: str = "local_console",
         acknowledge_failed_assertions: bool = False,
+        acknowledged_regression_item_ids: list[str] | tuple[str, ...] = (),
     ) -> SkillEvaluationRun:
         with self._lock:
             self._ensure_writable_unlocked()
@@ -915,12 +955,38 @@ class SkillEvaluationStore:
                     code="skill_evaluation_feedback_required",
                 )
             report = aggregate_skill_evaluation_report(run)
+            governance_enabled = (
+                run.config.get("regression_governance_version")
+                == "skill-creator-regression-v1"
+            )
+            required_regression_ids = (
+                {
+                    self._identifier(item, "regression_item_id")
+                    for item in report.get("regression_item_ids") or []
+                }
+                if governance_enabled
+                else set()
+            )
+            acknowledged_regression_ids = {
+                self._identifier(item, "acknowledged_regression_item_id")
+                for item in acknowledged_regression_item_ids
+            }
             if decision == "accept":
                 if not bool(report.get("eligible_for_accept")):
                     raise SkillEvaluationStateError(
                         "Evaluation is not eligible for acceptance."
                     )
-                if int(report.get("assertion_failed_count") or 0):
+                if required_regression_ids != acknowledged_regression_ids:
+                    raise SkillEvaluationValidationError(
+                        "Every regressed candidate item requires explicit acknowledgement.",
+                        code="skill_evaluation_regressions_unacknowledged",
+                    )
+                if required_regression_ids and not clean_reason:
+                    raise SkillEvaluationValidationError(
+                        "Accepting regressions requires a reason.",
+                        code="skill_evaluation_accept_reason_required",
+                    )
+                if int(report.get("candidate_assertion_failed_count") or 0):
                     if not bool(acknowledge_failed_assertions):
                         raise SkillEvaluationValidationError(
                             "Accepting failed assertions requires explicit acknowledgement.",
@@ -944,6 +1010,11 @@ class SkillEvaluationStore:
                 ),
                 acknowledge_failed_assertions=(
                     bool(acknowledge_failed_assertions) if decision == "accept" else False
+                ),
+                acknowledged_regression_item_ids=(
+                    tuple(sorted(acknowledged_regression_ids))
+                    if decision == "accept"
+                    else ()
                 ),
             )
             run.reviews.append(review)
@@ -1132,6 +1203,11 @@ class SkillEvaluationStore:
                     and run.baseline_overlay_id not in self._overlays
                 ):
                     raise ValueError("baseline overlay unavailable")
+                if (
+                    run.previous_overlay_id is not None
+                    and run.previous_overlay_id not in self._overlays
+                ):
+                    raise ValueError("previous overlay unavailable")
                 if run.case_set_revision is not None:
                     revisions = self._case_sets.get(run.session_id) or []
                     if run.case_set_revision > len(revisions):
@@ -1370,7 +1446,17 @@ class SkillEvaluationStore:
             raw.get("repetitions"), "repetitions", minimum=1, maximum=3
         )
         items = [cls._parse_item(item) for item in items_raw]
-        cls._validate_item_matrix(cases, items, repetitions)
+        previous_overlay_id = cls._optional_identifier(
+            raw.get("previous_overlay_id")
+        )
+        cls._validate_item_matrix(
+            cases,
+            items,
+            repetitions,
+            include_previous=previous_overlay_id is not None,
+        )
+        if len(items) > cls.MAX_RUN_ITEMS:
+            raise ValueError("evaluation item budget exceeded")
         reviews_raw = raw.get("reviews", [])
         if not isinstance(reviews_raw, list):
             raise ValueError("run reviews must be a list")
@@ -1400,6 +1486,7 @@ class SkillEvaluationStore:
             cases=cases,
             items=items,
             config=cls._normalize_config(raw.get("config") or {}),
+            previous_overlay_id=previous_overlay_id,
             case_set_revision=(
                 None
                 if raw.get("case_set_revision") is None
@@ -1452,15 +1539,23 @@ class SkillEvaluationStore:
             completed_at=cls._optional_timestamp(raw.get("completed_at")),
         )
         if run.review_state == "accepted" and run.reviews:
+            report = aggregate_skill_evaluation_report(run)
             failed_assertions = int(
-                aggregate_skill_evaluation_report(run).get(
-                    "assertion_failed_count"
-                )
-                or 0
+                report.get("candidate_assertion_failed_count") or 0
             )
             if failed_assertions and not run.reviews[-1].acknowledge_failed_assertions:
                 raise ValueError(
                     "accepted review is missing failed-assertion acknowledgement"
+                )
+            regression_ids = (
+                set(report.get("regression_item_ids") or [])
+                if run.config.get("regression_governance_version")
+                == "skill-creator-regression-v1"
+                else set()
+            )
+            if regression_ids != set(run.reviews[-1].acknowledged_regression_item_ids):
+                raise ValueError(
+                    "accepted review is missing regression acknowledgements"
                 )
         return run
 
@@ -1469,7 +1564,7 @@ class SkillEvaluationStore:
         if not isinstance(raw, dict):
             raise ValueError("item must be an object")
         target = str(raw.get("target") or "")
-        if target not in {"baseline", "candidate"}:
+        if target not in {"baseline", "previous", "candidate"}:
             raise ValueError("invalid item target")
         status = str(raw.get("status") or "")
         if status not in {
@@ -1544,6 +1639,15 @@ class SkillEvaluationStore:
         acknowledgement = raw.get("acknowledge_failed_assertions", False)
         if not isinstance(acknowledgement, bool):
             raise ValueError("invalid failed-assertion acknowledgement")
+        regression_ids_raw = raw.get("acknowledged_regression_item_ids", [])
+        if not isinstance(regression_ids_raw, list) or len(regression_ids_raw) > 36:
+            raise ValueError("invalid regression acknowledgement list")
+        regression_ids = tuple(
+            cls._identifier(item, "acknowledged_regression_item_id")
+            for item in regression_ids_raw
+        )
+        if len(set(regression_ids)) != len(regression_ids):
+            raise ValueError("duplicate regression acknowledgement")
         return SkillEvaluationReview(
             review_id=cls._identifier(raw.get("review_id"), "review_id"),
             review_revision=cls._positive_int(
@@ -1559,6 +1663,7 @@ class SkillEvaluationStore:
                 raw.get("actor_kind"), "actor_kind", maximum=80
             ),
             acknowledge_failed_assertions=acknowledgement,
+            acknowledged_regression_item_ids=regression_ids,
             created_at=cls._timestamp(raw.get("created_at")),
         )
 
@@ -1568,12 +1673,19 @@ class SkillEvaluationStore:
         cases: list[SkillEvaluationCase],
         items: list[SkillEvaluationItem],
         repetitions: int,
+        *,
+        include_previous: bool = False,
     ) -> None:
+        targets = (
+            ("baseline", "previous", "candidate")
+            if include_previous
+            else ("baseline", "candidate")
+        )
         expected = {
             (case.case_id, repetition, target)
             for case in cases
             for repetition in range(1, repetitions + 1)
-            for target in ("baseline", "candidate")
+            for target in targets
         }
         actual = {(item.case_id, item.repetition, item.target) for item in items}
         if actual != expected or len(actual) != len(items):
@@ -1584,7 +1696,7 @@ class SkillEvaluationStore:
             key = (item.case_id, item.repetition)
             pairs.setdefault(key, set()).add(item.target)
             pair_ids.setdefault(key, set()).add(item.pair_id)
-        if any(value != {"baseline", "candidate"} for value in pairs.values()):
+        if any(value != set(targets) for value in pairs.values()):
             raise ValueError("evaluation targets are not paired")
         if any(len(value) != 1 for value in pair_ids.values()):
             raise ValueError("evaluation pair ids do not match")
@@ -1698,7 +1810,7 @@ class SkillEvaluationStore:
                 "Skill evaluation isolation attestation is invalid.",
                 code="skill_evaluation_isolation_invalid",
             )
-        return {
+        result = {
             "timeout_seconds": cls._bounded_int(
                 raw.get("timeout_seconds", 120),
                 "timeout_seconds",
@@ -1729,6 +1841,33 @@ class SkillEvaluationStore:
             "network_policy": network_policy,
             "landlock_required": True,
         }
+        governance_version = str(raw.get("regression_governance_version") or "")
+        if governance_version:
+            if governance_version != "skill-creator-regression-v1":
+                raise SkillEvaluationValidationError(
+                    "Unsupported Skill regression governance version.",
+                    code="skill_evaluation_config_invalid",
+                )
+            target_count = cls._bounded_int(
+                raw.get("target_count"),
+                "target_count",
+                minimum=2,
+                maximum=3,
+            )
+            estimated_model_calls = cls._bounded_int(
+                raw.get("estimated_model_calls"),
+                "estimated_model_calls",
+                minimum=1,
+                maximum=cls.MAX_RUN_ITEMS,
+            )
+            result.update(
+                {
+                    "regression_governance_version": governance_version,
+                    "target_count": target_count,
+                    "estimated_model_calls": estimated_model_calls,
+                }
+            )
+        return result
 
     @classmethod
     def _apply_item_result(
@@ -2283,8 +2422,13 @@ def evaluate_skill_case(
 
 def aggregate_skill_evaluation_report(run: SkillEvaluationRun) -> dict[str, Any]:
     statuses = Counter(item.status for item in run.items)
+    targets_in_run: tuple[SkillEvaluationTarget, ...] = (
+        ("baseline", "previous", "candidate")
+        if run.previous_overlay_id is not None
+        else ("baseline", "candidate")
+    )
     target_summaries: list[dict[str, Any]] = []
-    for target in ("baseline", "candidate"):
+    for target in targets_in_run:
         items = [item for item in run.items if item.target == target]
         scores = [float(item.score) for item in items if item.score is not None]
         target_summaries.append(
@@ -2315,35 +2459,92 @@ def aggregate_skill_evaluation_report(run: SkillEvaluationRun) -> dict[str, Any]
         grouped.setdefault(item.pair_id, {})[item.target] = item
     pairs: list[dict[str, Any]] = []
     model_mismatch_count = 0
+    comparison_counts: Counter[str] = Counter()
+    regression_item_ids: list[str] = []
     for pair_id, targets in grouped.items():
         baseline = targets.get("baseline")
+        previous = targets.get("previous")
         candidate = targets.get("candidate")
+        required_items = [baseline, candidate]
+        if run.previous_overlay_id is not None:
+            required_items.insert(1, previous)
+        actual_models = {
+            item.actual_model for item in required_items if item and item.actual_model
+        }
         actual_model_match = bool(
-            baseline
-            and candidate
-            and baseline.actual_model
-            and baseline.actual_model == candidate.actual_model
+            all(item is not None and item.actual_model for item in required_items)
+            and len(actual_models) == 1
         )
-        if baseline and candidate and not actual_model_match:
+        if not actual_model_match:
             model_mismatch_count += 1
         comparable = bool(
-            baseline
-            and candidate
-            and baseline.status == "completed"
-            and candidate.status == "completed"
+            all(item is not None and item.status == "completed" for item in required_items)
             and actual_model_match
         )
-        score_delta = None
+        baseline_score_delta = None
+        previous_score_delta = None
         if comparable and baseline.score is not None and candidate.score is not None:
-            score_delta = round(float(candidate.score) - float(baseline.score), 6)
+            baseline_score_delta = round(
+                float(candidate.score) - float(baseline.score), 6
+            )
+        if (
+            comparable
+            and previous is not None
+            and previous.score is not None
+            and candidate.score is not None
+        ):
+            previous_score_delta = round(
+                float(candidate.score) - float(previous.score), 6
+            )
+        reference = previous or baseline
+        classification = "inconclusive"
+        new_failed_assertions: list[int] = []
+        fixed_assertions: list[int] = []
+        if candidate is not None and reference is not None:
+            reference_failed = {
+                index
+                for index, assertion in enumerate(reference.assertion_results)
+                if not bool(assertion.get("passed"))
+            }
+            candidate_failed = {
+                index
+                for index, assertion in enumerate(candidate.assertion_results)
+                if not bool(assertion.get("passed"))
+            }
+            new_failed_assertions = sorted(candidate_failed - reference_failed)
+            fixed_assertions = sorted(reference_failed - candidate_failed)
+            candidate_receipt_missing = bool(
+                run.evaluation_suite_id is not None
+                and candidate.overlay_id is not None
+                and (
+                    candidate.application_compliance != "verified"
+                    or not candidate.application_receipt_id
+                )
+            )
+            if (
+                not actual_model_match
+                or candidate.status != "completed"
+                or candidate_receipt_missing
+                or new_failed_assertions
+            ):
+                classification = "regressed"
+            elif reference.status != "completed" or fixed_assertions:
+                classification = "improved"
+            elif reference.assertion_results or candidate.assertion_results:
+                classification = "flat"
+        comparison_counts[classification] += 1
+        if classification == "regressed" and candidate is not None:
+            regression_item_ids.append(candidate.item_id)
         pairs.append(
             {
                 "pair_id": pair_id,
                 "case_id": baseline.case_id if baseline else candidate.case_id,
                 "repetition": baseline.repetition if baseline else candidate.repetition,
                 "baseline_item_id": baseline.item_id if baseline else None,
+                "previous_item_id": previous.item_id if previous else None,
                 "candidate_item_id": candidate.item_id if candidate else None,
                 "baseline_status": baseline.status if baseline else "missing",
+                "previous_status": previous.status if previous else "not_applicable",
                 "candidate_status": candidate.status if candidate else "missing",
                 "actual_model_match": actual_model_match,
                 "comparable": comparable,
@@ -2354,7 +2555,16 @@ def aggregate_skill_evaluation_report(run: SkillEvaluationRun) -> dict[str, Any]
                 "candidate_application_verified": bool(
                     candidate and candidate.application_compliance == "verified"
                 ),
-                "score_delta": score_delta,
+                "baseline_score_delta": baseline_score_delta,
+                "previous_score_delta": previous_score_delta,
+                "score_delta": (
+                    previous_score_delta
+                    if previous is not None
+                    else baseline_score_delta
+                ),
+                "classification": classification,
+                "new_failed_assertion_indexes": new_failed_assertions,
+                "fixed_assertion_indexes": fixed_assertions,
             }
         )
     pairs.sort(key=lambda item: (str(item["case_id"]), int(item["repetition"])))
@@ -2366,6 +2576,16 @@ def aggregate_skill_evaluation_report(run: SkillEvaluationRun) -> dict[str, Any]
     assertion_failed_count = sum(
         not bool(assertion.get("passed")) for assertion in assertion_results
     )
+    candidate_assertion_results = [
+        assertion
+        for item in run.items
+        if item.target == "candidate"
+        for assertion in item.assertion_results
+    ]
+    candidate_assertion_failed_count = sum(
+        not bool(assertion.get("passed"))
+        for assertion in candidate_assertion_results
+    )
     all_completed = bool(run.items) and all(
         item.status == "completed" for item in run.items
     )
@@ -2374,12 +2594,16 @@ def aggregate_skill_evaluation_report(run: SkillEvaluationRun) -> dict[str, Any]
         for item in run.items
         if item.target == "candidate"
     )
+    receipt_bound_items = [
+        item
+        for item in run.items
+        if item.overlay_id is not None
+    ]
     application_receipts_verified = bool(run.evaluation_suite_id is None) or all(
         item.application_compliance == "verified"
         and bool(item.application_receipt_id)
         and item.application_receipt_revision is not None
-        for item in run.items
-        if item.target == "candidate"
+        for item in receipt_bound_items
     )
     return {
         "run_id": run.run_id,
@@ -2389,15 +2613,20 @@ def aggregate_skill_evaluation_report(run: SkillEvaluationRun) -> dict[str, Any]
         "targets": target_summaries,
         "pairs": pairs,
         "model_mismatch_count": model_mismatch_count,
+        "comparison_counts": dict(sorted(comparison_counts.items())),
+        "regression_item_ids": sorted(set(regression_item_ids)),
+        "comparison_reference": (
+            "previous" if run.previous_overlay_id is not None else "baseline"
+        ),
         "skill_not_read_count": statuses.get("skill_not_read", 0),
         "application_receipt_verified_count": sum(
             item.application_compliance == "verified"
-            for item in run.items
-            if item.target == "candidate"
+            for item in receipt_bound_items
         ),
         "assertion_count": len(assertion_results),
         "assertion_passed_count": len(assertion_results) - assertion_failed_count,
         "assertion_failed_count": assertion_failed_count,
+        "candidate_assertion_failed_count": candidate_assertion_failed_count,
         "eligible_for_accept": (
             all_completed
             and candidate_read
@@ -2511,12 +2740,13 @@ class SkillEvaluationExecutor:
                 )
                 status: SkillEvaluationItemStatus = "completed"
                 error_code = error = None
-                if item.target == "candidate" and not result.skill_read:
+                requires_skill_application = item.overlay_id is not None
+                if requires_skill_application and not result.skill_read:
                     status = "skill_not_read"
                     error_code = "skill_not_read"
-                    error = "Candidate did not read the frozen Skill overlay."
+                    error = "Evaluation target did not read the frozen Skill overlay."
                 elif (
-                    item.target == "candidate"
+                    requires_skill_application
                     and claimed.evaluation_suite_id is not None
                     and (
                         not result.application_receipt_id
@@ -2527,7 +2757,7 @@ class SkillEvaluationExecutor:
                     status = "failed"
                     error_code = "skill_application_receipt_missing"
                     error = (
-                        "Candidate did not produce a verified Skill application receipt."
+                        "Evaluation target did not produce a verified Skill application receipt."
                     )
                 payload = {
                     "status": status,
@@ -2571,7 +2801,8 @@ class SkillEvaluationExecutor:
         async def execute_pair(pair: list[SkillEvaluationItem]) -> None:
             # Stable baseline-then-candidate order avoids cross-side state leakage in
             # adapters while each side still receives an isolated workspace.
-            for item in sorted(pair, key=lambda row: 0 if row.target == "baseline" else 1):
+            order = {"baseline": 0, "previous": 1, "candidate": 2}
+            for item in sorted(pair, key=lambda row: order[row.target]):
                 await execute_item(item)
 
         while True:

--- a/server/skills/creator_evaluation_service.py
+++ b/server/skills/creator_evaluation_service.py
@@ -18,11 +18,13 @@ from .creator_evaluation import (
 )
 from .creator_evaluation_suite import SkillEvaluationSuite, SkillEvaluationSuiteStore
 from .creator_evaluation_suite_service import SkillCreatorEvaluationSuiteService
+from .creator_evolution import SkillEvolutionPlanStore
 from .creator_store import (
     CreatorQualityMode,
     SkillCreatorConflictError,
     SkillCreatorSession,
     SkillCreatorSessionStore,
+    SkillCreatorStorageError,
     SkillCreatorValidationError,
 )
 from .draft_store import WorkspaceSkillDraft, WorkspaceSkillDraftStore
@@ -78,6 +80,7 @@ class SkillCreatorEvaluationService:
         actor_id: str,
         iteration: SkillEvaluationIteration | None = None,
         suite_service: SkillCreatorEvaluationSuiteService | None = None,
+        evolution_store: SkillEvolutionPlanStore | None = None,
         application_receipt_verifier: SkillEvaluationReceiptVerifier | None = None,
     ) -> None:
         clean_actor_id = str(actor_id or "").strip()
@@ -91,6 +94,7 @@ class SkillCreatorEvaluationService:
         self.actor_id = clean_actor_id
         self.iteration = iteration
         self.suite_service = suite_service
+        self.evolution_store = evolution_store
         self.application_receipt_verifier = application_receipt_verifier
 
     def get_projection(
@@ -129,6 +133,114 @@ class SkillCreatorEvaluationService:
         draft = self._require_session_draft(session)
         session, draft, _ = self._reconcile(session, draft)
         return session, draft, self.evaluation_store.require_run(run_id)
+
+    def governance_projection(
+        self,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft,
+    ) -> dict[str, Any]:
+        """Return bounded version history and the next-run budget projection."""
+
+        suite = None
+        if self.suite_service is not None and self.suite_service.enabled:
+            candidate_suite = self.suite_service.suite_store.current_for_session(
+                session.session_id
+            )
+            if (
+                candidate_suite is not None
+                and candidate_suite.state == "confirmed"
+                and candidate_suite.draft_id == draft.draft_id
+                and candidate_suite.draft_revision == draft.content_revision
+                and self._same_digest(
+                    candidate_suite.draft_digest, draft.content_digest
+                )
+            ):
+                suite = candidate_suite
+        previous_revision: int | None = None
+        previous_digest: str | None = None
+        evolution_history_available = True
+        if suite is not None and self.evolution_store is not None:
+            try:
+                evolution = self.evolution_store.current_for_session(
+                    session.session_id
+                )
+            except SkillCreatorStorageError:
+                evolution = None
+                evolution_history_available = False
+            if (
+                evolution is not None
+                and evolution.session_id == session.session_id
+                and evolution.draft_id == draft.draft_id
+                and evolution.draft_revision < draft.content_revision
+                and evolution.state in {"confirmed", "stale"}
+            ):
+                previous_revision = evolution.draft_revision
+                previous_digest = evolution.draft_digest
+        case_count = len(suite.cases) if suite is not None else 3
+        target_count = 3 if previous_revision is not None else 2
+        estimated_model_calls = case_count * target_count
+        max_repetitions = max(
+            1,
+            min(
+                3,
+                SkillEvaluationStore.MAX_RUN_ITEMS
+                // max(1, estimated_model_calls),
+            ),
+        )
+        revisions = []
+        for snapshot in self.draft_store.list_revision_snapshots(draft.draft_id):
+            revisions.append(
+                {
+                    "revision": snapshot.revision,
+                    "content_digest": snapshot.content_digest,
+                    "source_proposal_id": snapshot.source_proposal_id,
+                    "created_at": snapshot.created_at,
+                    "is_current": snapshot.revision == draft.content_revision,
+                    "is_installed": (
+                        snapshot.revision == draft.installed_content_revision
+                        and self._same_digest(
+                            snapshot.content_digest,
+                            draft.installed_content_digest,
+                        )
+                    ),
+                    "is_previous": snapshot.revision == previous_revision,
+                }
+            )
+        runs = []
+        for run in self.evaluation_store.list_runs(
+            session_id=session.session_id, limit=50
+        ):
+            runs.append(
+                {
+                    "run_id": run.run_id,
+                    "draft_revision": run.draft_revision,
+                    "frozen_digest": run.frozen_digest,
+                    "status": run.status,
+                    "review_state": run.review_state,
+                    "suite_revision": run.evaluation_suite_revision,
+                    "target_count": 3 if run.previous_overlay_id else 2,
+                    "item_count": len(run.items),
+                    "comparison_counts": dict(
+                        (run.report or {}).get("comparison_counts") or {}
+                    ),
+                    "created_at": run.created_at,
+                    "completed_at": run.completed_at,
+                }
+            )
+        return {
+            "version": "skill-creator-regression-v1",
+            "enabled": bool(suite is not None),
+            "max_items": SkillEvaluationStore.MAX_RUN_ITEMS,
+            "case_count": case_count,
+            "target_count": target_count,
+            "estimated_model_calls": estimated_model_calls,
+            "max_repetitions": max_repetitions,
+            "previous_revision": previous_revision,
+            "previous_digest": previous_digest,
+            "evolution_history_available": evolution_history_available,
+            "revisions": revisions,
+            "runs": runs,
+        }
 
     def save_cases(
         self,
@@ -328,6 +440,33 @@ class SkillCreatorEvaluationService:
             self.executor.wake()
             return session, draft, existing
 
+        previous_snapshot = None
+        if suite is not None and self.evolution_store is not None:
+            evolution = self.evolution_store.current_for_session(session.session_id)
+            if (
+                evolution is not None
+                and evolution.session_id == session.session_id
+                and evolution.draft_id == draft.draft_id
+                and evolution.draft_revision < draft.content_revision
+                and evolution.state in {"confirmed", "stale"}
+            ):
+                previous_snapshot = self.draft_store.require_revision_snapshot(
+                    draft.draft_id,
+                    revision=evolution.draft_revision,
+                    content_digest=evolution.draft_digest,
+                )
+        case_count = len(cases if cases is not None else case_set.cases)
+        target_count = 3 if previous_snapshot is not None else 2
+        estimated_model_calls = case_count * int(repetitions) * target_count
+        if estimated_model_calls > SkillEvaluationStore.MAX_RUN_ITEMS:
+            raise SkillEvaluationValidationError(
+                (
+                    f"Evaluation would require {estimated_model_calls} model calls; "
+                    f"the maximum is {SkillEvaluationStore.MAX_RUN_ITEMS}."
+                ),
+                code="skill_evaluation_item_budget_exceeded",
+            )
+
         candidate_snapshot = self.draft_store.require_revision_snapshot(
             draft.draft_id,
             revision=draft.content_revision,
@@ -353,6 +492,24 @@ class SkillCreatorEvaluationService:
                 package=baseline.package,
             )
             baseline_id = baseline_overlay.overlay_id
+        previous_id: str | None = None
+        if previous_snapshot is not None:
+            previous_overlay = self.evaluation_store.create_overlay(
+                draft_id=draft.draft_id,
+                draft_revision=previous_snapshot.revision,
+                content_digest=previous_snapshot.content_digest,
+                package=previous_snapshot.package,
+            )
+            previous_id = previous_overlay.overlay_id
+        run_config = dict(preflight.config or {})
+        if suite is not None:
+            run_config.update(
+                {
+                    "regression_governance_version": "skill-creator-regression-v1",
+                    "target_count": target_count,
+                    "estimated_model_calls": estimated_model_calls,
+                }
+            )
         run = self.evaluation_store.create_run(
             session_id=session.session_id,
             draft_id=draft.draft_id,
@@ -360,6 +517,7 @@ class SkillCreatorEvaluationService:
             frozen_digest=draft.content_digest,
             candidate_overlay_id=candidate.overlay_id,
             baseline_overlay_id=baseline_id,
+            previous_overlay_id=previous_id,
             cases=cases,
             case_set_revision=(case_set.cases_revision if case_set else None),
             evaluation_suite_id=(suite.suite_id if suite else None),
@@ -368,7 +526,7 @@ class SkillCreatorEvaluationService:
             evaluation_suite_version=(suite.version if suite else None),
             model_id=model_id,
             repetitions=repetitions,
-            config=dict(preflight.config or {}),
+            config=run_config,
         )
         try:
             draft = self._begin_or_reuse_draft_run(draft, run.run_id)
@@ -486,6 +644,7 @@ class SkillCreatorEvaluationService:
         decision: Literal["accept", "revise"],
         reason: str,
         acknowledge_failed_assertions: bool = False,
+        acknowledged_regression_item_ids: list[str] | tuple[str, ...] = (),
     ) -> tuple[SkillCreatorSession, WorkspaceSkillDraft, SkillEvaluationRun]:
         session, draft, run = self._require_run_context(
             run_id,
@@ -494,7 +653,9 @@ class SkillCreatorEvaluationService:
             expected_digest=expected_digest,
             expected_run_revision=expected_run_revision,
         )
-        failed_assertions = int((run.report or {}).get("assertion_failed_count") or 0)
+        failed_assertions = int(
+            (run.report or {}).get("candidate_assertion_failed_count") or 0
+        )
         if decision == "accept" and failed_assertions:
             if not acknowledge_failed_assertions:
                 raise SkillEvaluationValidationError(
@@ -524,6 +685,7 @@ class SkillCreatorEvaluationService:
             reason=reason,
             actor_kind="local_console",
             acknowledge_failed_assertions=acknowledge_failed_assertions,
+            acknowledged_regression_item_ids=acknowledged_regression_item_ids,
         )
         if decision == "accept":
             self._require_failed_assertion_acknowledgement(run)
@@ -984,7 +1146,10 @@ class SkillCreatorEvaluationService:
         run: SkillEvaluationRun,
     ) -> None:
         failed_assertions = int(
-            aggregate_skill_evaluation_report(run).get("assertion_failed_count") or 0
+            aggregate_skill_evaluation_report(run).get(
+                "candidate_assertion_failed_count"
+            )
+            or 0
         )
         if (
             failed_assertions
@@ -995,6 +1160,22 @@ class SkillCreatorEvaluationService:
         ):
             raise SkillEvaluationStateError(
                 "Accepted failed assertions are missing explicit acknowledgement."
+            )
+        report = aggregate_skill_evaluation_report(run)
+        required_regressions = (
+            set(report.get("regression_item_ids") or [])
+            if run.config.get("regression_governance_version")
+            == "skill-creator-regression-v1"
+            else set()
+        )
+        acknowledged = (
+            set(run.reviews[-1].acknowledged_regression_item_ids)
+            if run.reviews
+            else set()
+        )
+        if required_regressions != acknowledged:
+            raise SkillEvaluationStateError(
+                "Accepted regressions are missing item-level acknowledgement."
             )
 
     def _require_v2_application_receipts(self, run: SkillEvaluationRun) -> None:

--- a/server/skills/creator_evaluation_suite.py
+++ b/server/skills/creator_evaluation_suite.py
@@ -547,6 +547,10 @@ class SkillEvaluationSuiteStore:
         # legacy normalizer: the two domains are deliberately incompatible.
         legacy_case = dict(raw)
         legacy_case.pop("case_fingerprint", None)
+        if isinstance(legacy_case.get("required_resource_paths"), tuple):
+            legacy_case["required_resource_paths"] = list(
+                legacy_case["required_resource_paths"]
+            )
         base = SkillEvaluationStore.normalize_case(legacy_case)
         requirement_ids = cls._identifier_list(
             raw.get("requirement_ids") or (),

--- a/server/skills/creator_evaluation_suite_runtime.py
+++ b/server/skills/creator_evaluation_suite_runtime.py
@@ -82,6 +82,7 @@ def build_evaluation_suite_invocation(
         "allowed_requirement_ids": list(request.allowed_requirement_ids),
         "allowed_resource_paths": list(request.allowed_resource_paths),
         "allowed_workflow_step_ids": list(request.allowed_workflow_step_ids),
+        "coverage_repair": request.coverage_repair,
         "case_contract": {
             "core_roles": ["normal", "ambiguous", "boundary"],
             "model_may_add_regressions": False,
@@ -89,7 +90,7 @@ def build_evaluation_suite_invocation(
             "assertion_kinds": [
                 "contains",
                 "not_contains",
-                "exact",
+                "exact_match",
                 "json_schema",
                 "file_exists",
                 "file_sha256",
@@ -218,7 +219,13 @@ def _suite_prompt() -> str:
         "proves conservative handling of missing or conflicting information, and boundary "
         "proves the stated non-trigger or failure behavior. Never add regression cases; only "
         "a user may add or confirm them. Cases must be realistic, mutually distinct, and "
-        "traceable to supplied requirement IDs. Do not invent domain rules or sources. "
+        "traceable to supplied requirement IDs. The union of requirement_ids across the "
+        "three cases must contain every ID in allowed_requirement_ids exactly as supplied; "
+        "assign an ID only to a case whose prompt and expected behavior genuinely exercise "
+        "that requirement. Do not invent domain rules or sources. "
+        "If coverage_repair is present, return a complete replacement for all three cases. "
+        "Use its missing_requirement_ids and previous_cases to repair both the case content "
+        "and its truthful requirement mapping; do not merely attach unrelated IDs. "
         "Reference only allowed resource paths and workflow step IDs. If a case declares a "
         "resource, the runtime will require verified skill_stage evidence for that exact path. "
         "Fixtures are bounded UTF-8 text. Assertions are deterministic evidence for human "

--- a/server/skills/creator_evaluation_suite_service.py
+++ b/server/skills/creator_evaluation_suite_service.py
@@ -33,6 +33,7 @@ class EvaluationSuiteGenerationRequest:
     allowed_requirement_ids: tuple[str, ...]
     allowed_resource_paths: tuple[str, ...]
     allowed_workflow_step_ids: tuple[str, ...]
+    coverage_repair: dict[str, Any] | None = None
 
 
 class EvaluationSuiteGenerator(Protocol):
@@ -64,7 +65,7 @@ class SkillCreatorEvaluationSuiteService:
         self.resource_plan_store = resource_plan_store
         self.generator = generator
         self.enabled = (
-            os.getenv("SKILL_CREATOR_EVOLUTION_V2_ENABLED", "false")
+            os.getenv("SKILL_CREATOR_EVOLUTION_V2_ENABLED", "true")
             .strip()
             .lower()
             in {"1", "true", "yes", "on"}
@@ -218,11 +219,40 @@ class SkillCreatorEvaluationSuiteService:
                 "The dedicated Skill Creator agent could not design an evaluation suite.",
                 code="skill_evaluation_suite_generator_failed",
             ) from exc
-        cases = payload.get("cases") if isinstance(payload, Mapping) else None
-        if not isinstance(cases, list):
+        cases = self._generated_cases(payload)
+        missing_requirement_ids = self._missing_requirement_ids(
+            cases, coverage["requirements"]
+        )
+        if missing_requirement_ids:
+            repair_request = EvaluationSuiteGenerationRequest(
+                session=request.session,
+                draft=request.draft,
+                resource_plan=request.resource_plan,
+                allowed_requirement_ids=request.allowed_requirement_ids,
+                allowed_resource_paths=request.allowed_resource_paths,
+                allowed_workflow_step_ids=request.allowed_workflow_step_ids,
+                coverage_repair={
+                    "missing_requirement_ids": list(missing_requirement_ids),
+                    "previous_cases": cases,
+                },
+            )
+            try:
+                payload = await generator.generate(repair_request)
+            except (SkillCreatorConflictError, SkillCreatorValidationError):
+                raise
+            except Exception as exc:
+                raise SkillCreatorValidationError(
+                    "The dedicated Skill Creator agent could not repair evaluation suite coverage.",
+                    code="skill_evaluation_suite_generator_failed",
+                ) from exc
+            cases = self._generated_cases(payload)
+            missing_requirement_ids = self._missing_requirement_ids(
+                cases, coverage["requirements"]
+            )
+        if missing_requirement_ids:
             raise SkillCreatorValidationError(
-                "The evaluation suite generator returned an invalid case list.",
-                code="skill_evaluation_suite_generator_invalid",
+                "The evaluation suite generator did not cover every frozen Creator requirement.",
+                code="skill_evaluation_suite_generator_coverage_incomplete",
             )
 
         # Freeze only if the session and draft are still the facts shown to the model.
@@ -248,6 +278,38 @@ class SkillCreatorEvaluationSuiteService:
             allowed_requirement_ids=coverage["requirements"],
             allowed_resource_paths=coverage["resources"],
             allowed_workflow_step_ids=coverage["workflow_steps"],
+        )
+
+    @staticmethod
+    def _generated_cases(payload: Any) -> list[Mapping[str, Any]]:
+        cases = payload.get("cases") if isinstance(payload, Mapping) else None
+        if not isinstance(cases, list) or not all(
+            isinstance(case, Mapping) for case in cases
+        ):
+            raise SkillCreatorValidationError(
+                "The evaluation suite generator returned an invalid case list.",
+                code="skill_evaluation_suite_generator_invalid",
+            )
+        return cases
+
+    @staticmethod
+    def _missing_requirement_ids(
+        cases: list[Mapping[str, Any]], allowed_requirement_ids: tuple[str, ...]
+    ) -> tuple[str, ...]:
+        covered = {
+            requirement_id
+            for case in cases
+            for requirement_id in (
+                case.get("requirement_ids")
+                if isinstance(case.get("requirement_ids"), (list, tuple))
+                else ()
+            )
+            if isinstance(requirement_id, str)
+        }
+        return tuple(
+            requirement_id
+            for requirement_id in allowed_requirement_ids
+            if requirement_id not in covered
         )
 
     def patch(
@@ -377,12 +439,21 @@ class SkillCreatorEvaluationSuiteService:
     def _coverage_context(
         self, session: SkillCreatorSession, draft: WorkspaceSkillDraft
     ) -> dict[str, Any]:
-        requirements = build_session_requirement_ids(
+        creator_requirements = build_session_requirement_ids(
             intent=session.intent,
             positive_examples=session.positive_examples,
             near_miss_examples=session.near_miss_examples,
             expected_output=session.expected_output,
             success_criteria=session.success_criteria,
+        )
+        # Positive examples guide the fixed three-role case designer, but they are
+        # not independent test obligations.  Requiring one frozen coverage ID per
+        # example can make a valid normal/ambiguous/boundary suite impossible to
+        # confirm without inventing extra model-authored regression cases.
+        requirements = tuple(
+            requirement_id
+            for requirement_id in creator_requirements
+            if not requirement_id.startswith("positive_example:")
         )
         resources = tuple(
             sorted(path for path in draft.files if path.startswith(_RESOURCE_ROOTS))

--- a/server/skills/creator_evolution.py
+++ b/server/skills/creator_evolution.py
@@ -22,6 +22,17 @@ from .package_validation import scan_skill_package_credentials
 
 
 EVOLUTION_PLAN_VERSION = "skill-evolution-plan-v1"
+EVOLUTION_FAILURE_TYPES = (
+    "assertion_failure",
+    "runtime_failure",
+    "skill_application_missing",
+    "output_contract_gap",
+    "trigger_boundary_gap",
+    "workflow_gap",
+    "resource_gap",
+    "failure_handling_gap",
+    "overfitting_risk",
+)
 EvolutionPlanState = Literal["needs_input", "needs_regeneration", "ready", "confirmed", "stale"]
 EvolutionActionKind = Literal["keep", "update", "create", "delete"]
 EvolutionResourceKind = Literal["script", "reference", "asset"]
@@ -404,7 +415,13 @@ class SkillEvolutionPlanStore:
             result.append(SkillEvolutionDiagnosis(
                 case_id=case_id,
                 evidence_item_ids=item_ids,
-                failure_types=self._identifier_list(raw.get("failure_types"), "failure_types", 8, None, minimum=1),
+                failure_types=self._identifier_list(
+                    raw.get("failure_types"),
+                    "failure_types",
+                    8,
+                    set(EVOLUTION_FAILURE_TYPES),
+                    minimum=1,
+                ),
                 requirement_ids=self._identifier_list(raw.get("requirement_ids", []), "requirement_ids", 30, allowed_requirements),
                 resource_ids=self._identifier_list(raw.get("resource_ids", []), "resource_ids", 20, allowed_resources),
                 sections=self._text_list(raw.get("sections", []), "sections", 20, 300),
@@ -900,6 +917,7 @@ class SkillEvolutionPlanStore:
 
 __all__ = [
     "EVOLUTION_PLAN_VERSION",
+    "EVOLUTION_FAILURE_TYPES",
     "SkillEvolutionAction",
     "SkillEvolutionDiagnosis",
     "SkillEvolutionPlan",

--- a/server/skills/creator_evolution_runtime.py
+++ b/server/skills/creator_evolution_runtime.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
-from .creator_evolution import EVOLUTION_PLAN_VERSION
+from .creator_evolution import EVOLUTION_FAILURE_TYPES, EVOLUTION_PLAN_VERSION
 from .creator_evolution_service import EvolutionGenerationRequest
 from .creator_runtime import CREATOR_WORKFLOW_VERSION
 from .creator_store import CREATOR_ASSISTANT_AGENT_ID, SkillCreatorValidationError
@@ -48,6 +49,18 @@ def build_evolution_invocation(request: EvolutionGenerationRequest, *, model_id:
     session_id = str(request.session.get("session_id") or "").strip()
     if not session_id:
         raise SkillCreatorValidationError("Evolution planning is missing session_id.", code="skill_creator_evolution_planner_invalid")
+    allowed_cases = set(request.allowed_case_ids)
+    allowed_items = set(request.allowed_item_ids)
+    evidence_items_by_case: dict[str, list[str]] = {}
+    evaluation_items = request.evaluation.get("items")
+    if isinstance(evaluation_items, list):
+        for item in evaluation_items:
+            if not isinstance(item, Mapping):
+                continue
+            case_id = str(item.get("case_id") or "").strip()
+            item_id = str(item.get("item_id") or "").strip()
+            if case_id in allowed_cases and item_id in allowed_items:
+                evidence_items_by_case.setdefault(case_id, []).append(item_id)
     context = {
         "evolution_plan_version": EVOLUTION_PLAN_VERSION,
         "session": request.session,
@@ -57,9 +70,13 @@ def build_evolution_invocation(request: EvolutionGenerationRequest, *, model_id:
         "suite": request.suite,
         "resource_plan": request.resource_plan,
         "previous_evolution_plan": request.current_plan,
+        "repair": request.repair,
+        "output_contract_spec": _output_contract_spec(),
         "allowed": {
             "case_ids": list(request.allowed_case_ids),
             "item_ids": list(request.allowed_item_ids),
+            "evidence_item_ids_by_case": evidence_items_by_case,
+            "failure_types": list(EVOLUTION_FAILURE_TYPES),
             "requirement_ids": list(request.allowed_requirement_ids),
             "resource_ids": list(request.allowed_resource_ids),
             "source_ids": list(request.allowed_source_ids),
@@ -172,8 +189,106 @@ def _evolution_prompt() -> str:
         "allowed resource_id values; their path and kind are server-controlled. Create actions omit "
         "resource_id and use a safe path under scripts/, references/, or assets/. Every action includes "
         "purpose, source_ids, used_by_steps, depends_on, acceptance_checks, related_case_ids, "
-        "expected_improvement, and non_regression_case_ids."
+        "expected_improvement, and non_regression_case_ids. If repair is non-null, return a full "
+        "replacement object that follows its fixed instruction; do not discuss the prior failure. "
+        "Treat output_contract_spec as authoritative: include every required field, respect every "
+        "minItems value, and never return an empty required string. "
+        "For every diagnosis, copy case_id exactly from allowed.case_ids and copy evidence_item_ids "
+        "only from allowed.evidence_item_ids_by_case[case_id]; never invent or abbreviate an ID. "
+        "Every failure_types value must be copied exactly from allowed.failure_types."
     )
+
+
+def _output_contract_spec() -> dict[str, Any]:
+    nonempty_text = {"type": "string", "minLength": 1}
+    string_array = {"type": "array", "items": nonempty_text}
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "evolution_plan_version", "diagnoses", "actions", "workflow_steps",
+            "output_contract", "failure_modes", "expected_improvements",
+            "acceptance_criteria", "non_goals", "overfitting_risks", "clarifications",
+        ],
+        "properties": {
+            "evolution_plan_version": {"const": EVOLUTION_PLAN_VERSION},
+            "diagnoses": {
+                "type": "array", "minItems": 1, "maxItems": 12,
+                "items": {
+                    "type": "object", "additionalProperties": False,
+                    "required": [
+                        "case_id", "evidence_item_ids", "failure_types", "requirement_ids",
+                        "resource_ids", "sections", "summary",
+                    ],
+                    "properties": {
+                        "case_id": nonempty_text,
+                        "evidence_item_ids": {"type": "array", "minItems": 1, "items": nonempty_text},
+                        "failure_types": {"type": "array", "minItems": 1, "items": nonempty_text},
+                        "requirement_ids": string_array,
+                        "resource_ids": string_array,
+                        "sections": string_array,
+                        "summary": nonempty_text,
+                    },
+                },
+            },
+            "actions": {
+                "type": "array", "maxItems": 20,
+                "x-rules": [
+                    "Account for every existing resource exactly once with keep, update, or delete.",
+                    "Create uses kind and path; existing actions use the exact resource_id and omit changed identity.",
+                ],
+                "items": {
+                    "type": "object", "additionalProperties": False,
+                    "required": [
+                        "action_id", "action", "purpose", "source_ids", "used_by_steps",
+                        "depends_on", "acceptance_checks", "related_case_ids",
+                        "expected_improvement", "non_regression_case_ids",
+                    ],
+                    "properties": {
+                        "action_id": nonempty_text,
+                        "action": {"enum": ["keep", "update", "create", "delete"]},
+                        "resource_id": nonempty_text,
+                        "kind": {"enum": ["script", "reference", "asset"]},
+                        "path": nonempty_text,
+                        "purpose": nonempty_text,
+                        "source_ids": string_array,
+                        "used_by_steps": string_array,
+                        "depends_on": string_array,
+                        "acceptance_checks": {"type": "array", "minItems": 1, "items": nonempty_text},
+                        "related_case_ids": {"type": "array", "minItems": 1, "items": nonempty_text},
+                        "expected_improvement": nonempty_text,
+                        "non_regression_case_ids": string_array,
+                    },
+                },
+            },
+            "workflow_steps": {
+                "type": "array", "minItems": 4, "maxItems": 10,
+                "items": {
+                    "type": "object", "additionalProperties": False,
+                    "required": ["step_id", "instruction"],
+                    "properties": {"step_id": nonempty_text, "instruction": nonempty_text},
+                },
+            },
+            "output_contract": {"type": "array", "minItems": 1, "items": nonempty_text},
+            "failure_modes": {"type": "array", "minItems": 1, "items": nonempty_text},
+            "expected_improvements": {"type": "array", "minItems": 1, "items": nonempty_text},
+            "acceptance_criteria": {"type": "array", "minItems": 1, "items": nonempty_text},
+            "non_goals": string_array,
+            "overfitting_risks": {"type": "array", "minItems": 1, "items": nonempty_text},
+            "clarifications": {
+                "type": "array", "maxItems": 5,
+                "items": {
+                    "type": "object", "additionalProperties": False,
+                    "required": ["question_id", "question", "reason"],
+                    "properties": {
+                        "question_id": nonempty_text,
+                        "question": nonempty_text,
+                        "reason": nonempty_text,
+                    },
+                },
+            },
+        },
+    }
 
 
 __all__ = [

--- a/server/skills/creator_evolution_service.py
+++ b/server/skills/creator_evolution_service.py
@@ -4,7 +4,7 @@ import asyncio
 import hashlib
 import os
 import threading
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from typing import Any, Mapping, Protocol
 
 from .creator_evaluation import SkillEvaluationRun, SkillEvaluationStore
@@ -42,6 +42,7 @@ class EvolutionGenerationRequest:
     allowed_resource_ids: tuple[str, ...]
     allowed_source_ids: tuple[str, ...]
     allowed_step_ids: tuple[str, ...]
+    repair: dict[str, Any] | None = None
 
 
 class EvolutionPlanner(Protocol):
@@ -76,7 +77,7 @@ class SkillCreatorEvolutionService:
         self.resource_build_store = resource_build_store
         self.planner = planner
         self.enabled = (
-            os.getenv("SKILL_CREATOR_EVOLUTION_V2_ENABLED", "false").strip().lower()
+            os.getenv("SKILL_CREATOR_EVOLUTION_V2_ENABLED", "true").strip().lower()
             in {"1", "true", "yes", "on"}
             if enabled is None
             else bool(enabled)
@@ -187,36 +188,56 @@ class SkillCreatorEvolutionService:
                     code="model_gateway_unconfigured",
                 )
             request = self._generation_request(*facts)
-            try:
-                payload = await planner.generate(request)
-            except SkillCreatorValidationError:
-                raise
-            except Exception as exc:
-                raise SkillCreatorValidationError(
-                    "The Skill evolution planner failed.",
-                    code="skill_creator_evolution_planner_failed",
-                ) from exc
-            facts = self._require_facts(
-                session_id,
-                evaluation_run_id=evaluation_run_id,
-                expected_session_revision=expected_session_revision,
-                expected_draft_state_revision=expected_draft_state_revision,
-                expected_draft_revision=expected_draft_revision,
-                expected_draft_digest=expected_draft_digest,
-                expected_review_revision=expected_review_revision,
-                expected_run_revision=expected_run_revision,
-                expected_resource_plan_revision=expected_resource_plan_revision,
-                expected_resource_plan_digest=expected_resource_plan_digest,
-            )
-            session, draft, run, suite, resource_plan = facts
-            self._require_payload_evidence_links(payload, run)
-            return self.evolution_store.save_generated(
-                bindings=self._bindings(session, draft, run, suite, resource_plan),
-                payload=payload,
-                **self._allowed(request, resource_plan),
-                expected_plan_revision=expected_evolution_revision,
-                expected_plan_digest=expected_evolution_digest,
-            )
+            for attempt in range(2):
+                try:
+                    payload = await planner.generate(request)
+                except SkillCreatorValidationError:
+                    raise
+                except Exception as exc:
+                    raise SkillCreatorValidationError(
+                        "The Skill evolution planner failed.",
+                        code="skill_creator_evolution_planner_failed",
+                    ) from exc
+                facts = self._require_facts(
+                    session_id,
+                    evaluation_run_id=evaluation_run_id,
+                    expected_session_revision=expected_session_revision,
+                    expected_draft_state_revision=expected_draft_state_revision,
+                    expected_draft_revision=expected_draft_revision,
+                    expected_draft_digest=expected_draft_digest,
+                    expected_review_revision=expected_review_revision,
+                    expected_run_revision=expected_run_revision,
+                    expected_resource_plan_revision=expected_resource_plan_revision,
+                    expected_resource_plan_digest=expected_resource_plan_digest,
+                )
+                session, draft, run, suite, resource_plan = facts
+                try:
+                    self._require_payload_evidence_links(payload, run)
+                    return self.evolution_store.save_generated(
+                        bindings=self._bindings(session, draft, run, suite, resource_plan),
+                        payload=payload,
+                        **self._allowed(request, resource_plan),
+                        expected_plan_revision=expected_evolution_revision,
+                        expected_plan_digest=expected_evolution_digest,
+                    )
+                except SkillCreatorValidationError as exc:
+                    if attempt or exc.code != "skill_creator_evolution_plan_invalid":
+                        raise
+                    request = replace(request, repair={
+                        "attempt": 1,
+                        "error_code": "skill_creator_evolution_plan_invalid",
+                        "instruction": (
+                            "Return the complete contract again. Include one to twelve diagnoses "
+                            "bound only to allowed case, requirement, and resource IDs. For each "
+                            "diagnosis, copy evidence_item_ids exactly from "
+                            "allowed.evidence_item_ids_by_case[case_id]; never invent or abbreviate "
+                            "an ID. Copy each failure_types value exactly from "
+                            "allowed.failure_types. Validate the full replacement against "
+                            "output_contract_spec: include every required field, satisfy minItems, "
+                            "and never return an empty required string."
+                        ),
+                    })
+            raise AssertionError("bounded evolution planning loop exhausted")
 
     def save_answers(
         self,
@@ -415,7 +436,7 @@ class SkillCreatorEvolutionService:
             or build.plan_revision != plan.revision
             or build.plan_digest != plan.digest
             or build.proposal_id != draft.source_proposal_id
-            or build.state != "accepted"
+            or build.state not in {"accepted", "stale"}
             or build.phase != "proposal"
             or not build.skill_markdown
         ):

--- a/server/tests/test_skill_application_receipts.py
+++ b/server/tests/test_skill_application_receipts.py
@@ -17,7 +17,8 @@ from server.skills.application_receipts import (
     SkillApplicationScope,
     build_application_contract,
 )
-from server.skills.creator_evaluation import SkillEvaluationValidationError
+from server.skills.creator_evaluation import SkillEvaluationStore, SkillEvaluationValidationError
+from server.skills.package_validation import compute_package_digest
 from server.xpert_runtime.sandbox_store import SandboxWorkspace
 from server.xpert_runtime.sandbox_toolset import SandboxToolsetProvider
 from server.xpert_runtime.toolset import RuntimeToolCall
@@ -673,6 +674,76 @@ def test_creator_v2_accept_verifier_rechecks_protected_receipt(
     with pytest.raises(SkillEvaluationValidationError) as captured:
         main.verify_skill_evaluation_application_receipts(run)
     assert captured.value.code == "skill_application_receipt_mismatch"
+
+
+def test_creator_v2_verifier_uses_previous_overlay_digest(
+    tmp_path, monkeypatch
+):
+    import server.main as main
+
+    evaluation_store = SkillEvaluationStore(tmp_path / "evaluation")
+    package = {
+        "name": "previous-version",
+        "slug": "previous-version",
+        "description": "Use when verifying a previous Skill version.",
+        "skill_markdown": (
+            "---\nname: previous-version\n"
+            "description: Use when verifying a previous Skill version.\n---\n\n"
+            "# Previous version\n\nRead the frozen previous revision.\n"
+        ),
+        "files": {},
+    }
+    overlay = evaluation_store.create_overlay(
+        draft_id="draft_previous",
+        draft_revision=2,
+        content_digest=compute_package_digest(package["skill_markdown"], package["files"]),
+        package=package,
+    )
+    receipt_store = SkillApplicationReceiptStore(tmp_path / "receipts")
+    contract = build_application_contract(
+        skill_id="evaluation-skill",
+        source_kind="evaluation_overlay",
+        version_id=overlay.overlay_id,
+        content_digest=overlay.content_digest,
+        policy="require_read",
+    )
+    receipt = receipt_store.observe(
+        contract,
+        SkillApplicationScope(
+            run_id="runtime_previous",
+            task_id="task_previous",
+            node_id="evaluation-agent",
+            runtime_kind="skill_evaluation",
+        ),
+        method="skill_read",
+        resource_paths=["SKILL.md"],
+        resource_digests={"SKILL.md": _digest(package["skill_markdown"])},
+        expected_resource_digests={"SKILL.md": _digest(package["skill_markdown"])},
+        tool_name="skill_read",
+    )
+    assert receipt is not None
+    receipt = receipt_store.protect(
+        receipt.receipt_id,
+        reference_id="evaluation-item:item_previous",
+    )
+    monkeypatch.setattr(main, "skill_application_receipt_store", receipt_store)
+    monkeypatch.setattr(main, "skill_evaluation_store", evaluation_store)
+    run = SimpleNamespace(
+        evaluation_suite_id="suite_previous",
+        frozen_digest=_digest("candidate-digest"),
+        cases=[SimpleNamespace(case_id="case-one", required_resource_paths=())],
+        items=[SimpleNamespace(
+            item_id="item_previous",
+            case_id="case-one",
+            target="previous",
+            runtime_run_id="runtime_previous",
+            overlay_id=overlay.overlay_id,
+            application_receipt_id=receipt.receipt_id,
+            application_receipt_revision=receipt.revision,
+        )],
+    )
+
+    main.verify_skill_evaluation_application_receipts(run)
 
 
 def test_enforce_mode_propagates_receipt_failures(monkeypatch):

--- a/server/tests/test_skill_creator_evaluation_api.py
+++ b/server/tests/test_skill_creator_evaluation_api.py
@@ -167,7 +167,6 @@ def _suite_case(role: str, *, regression: bool = False) -> dict:
             "role": role,
             "requirement_ids": [
                 "intent",
-                "positive_example:0",
                 "near_miss:0",
                 "expected_output",
                 "success_criterion:0",

--- a/server/tests/test_skill_creator_evaluation_suite.py
+++ b/server/tests/test_skill_creator_evaluation_suite.py
@@ -105,6 +105,45 @@ def test_generated_suite_requires_exact_core_roles_and_round_trips(tmp_path: Pat
     assert captured.value.code == "skill_evaluation_suite_core_roles_required"
 
 
+def test_confirm_preserves_generated_asset_resource_paths(tmp_path: Path) -> None:
+    store = SkillEvaluationSuiteStore(tmp_path)
+    cases = _core_cases()
+    cases[0]["required_resource_paths"] = ["assets/report_template.md"]
+    suite = store.save_generated(
+        session_id="session-assets",
+        session_revision=3,
+        session_definition_digest=SESSION_DEFINITION_DIGEST,
+        draft_id="draft-assets",
+        draft_state_revision=2,
+        draft_revision=1,
+        draft_digest=DIGEST,
+        quality_mode="objective",
+        cases=cases,
+        expected_suite_revision=None,
+        expected_suite_digest=None,
+        allowed_requirement_ids=REQUIREMENTS,
+        allowed_resource_paths=("assets/report_template.md",),
+        allowed_workflow_step_ids=("step-1",),
+    )
+
+    confirmed = store.confirm(
+        suite.suite_id,
+        expected_suite_revision=suite.suite_revision,
+        expected_suite_digest=suite.suite_digest,
+        session_revision=4,
+        session_definition_digest=SESSION_DEFINITION_DIGEST,
+        draft_state_revision=2,
+        allowed_requirement_ids=REQUIREMENTS,
+        allowed_resource_paths=("assets/report_template.md",),
+        allowed_workflow_step_ids=("step-1",),
+    )
+
+    assert confirmed.state == "confirmed"
+    assert confirmed.cases[0].required_resource_paths == (
+        "assets/report_template.md",
+    )
+
+
 def test_only_user_patch_can_add_regression_and_confirm_coverage(tmp_path: Path) -> None:
     store = SkillEvaluationSuiteStore(tmp_path)
     suite = _generated(store)

--- a/server/tests/test_skill_creator_evaluation_suite_service.py
+++ b/server/tests/test_skill_creator_evaluation_suite_service.py
@@ -43,7 +43,6 @@ def _core_cases() -> list[dict]:
             "assertions": [],
             "requirement_ids": [
                 "intent",
-                "positive_example:0",
                 "near_miss:0",
                 "expected_output",
                 "success_criterion:0",
@@ -119,6 +118,23 @@ class _Generator:
         return {"cases": _core_cases()}
 
 
+class _IncompleteCoverageGenerator(_Generator):
+    async def generate(self, request: EvaluationSuiteGenerationRequest) -> dict:
+        self.calls.append(request)
+        cases = _core_cases()
+        for case in cases:
+            case["requirement_ids"] = ["intent"]
+        return {"cases": cases}
+
+
+class _RepairingCoverageGenerator(_IncompleteCoverageGenerator):
+    async def generate(self, request: EvaluationSuiteGenerationRequest) -> dict:
+        if request.coverage_repair is None:
+            return await super().generate(request)
+        self.calls.append(request)
+        return {"cases": _core_cases()}
+
+
 def _service(tmp_path: Path, *, generator=None, enabled: bool = True):
     creator = _CreatorService()
     suite_store = SkillEvaluationSuiteStore(tmp_path / "suite")
@@ -161,11 +177,14 @@ def test_fixed_generator_contract_is_no_tool_and_parses_one_versioned_object() -
     agent = invocation.workflow["nodes"][1]["data"]
     assert agent["toolMode"] == "none"
     assert agent["temperature"] == "0.1"
+    assert "every ID in allowed_requirement_ids" in agent["rolePrompt"]
     assert invocation.runtime_metadata["evaluation_suite_workflow_version"] == (
         EVALUATION_SUITE_WORKFLOW_VERSION
     )
     context = json.loads(invocation.inputs["creator_request"])
     assert context["case_contract"]["model_may_add_regressions"] is False
+    assert "exact_match" in context["case_contract"]["assertion_kinds"]
+    assert "exact" not in context["case_contract"]["assertion_kinds"]
 
     payload = {"evaluation_suite_version": EVALUATION_SUITE_VERSION, "cases": []}
     parsed = parse_evaluation_suite_output(
@@ -211,6 +230,11 @@ async def test_generate_freezes_model_cases_and_confirm_requires_current_facts(
     tmp_path: Path,
 ) -> None:
     creator = _CreatorService()
+    creator.session.positive_examples = [
+        "Turn a timeline into an incident review.",
+        "Summarize an incident with an unknown root cause.",
+        "Preserve owners while organizing corrective actions.",
+    ]
     generator = _Generator(creator)
     suite_store = SkillEvaluationSuiteStore(tmp_path / "suite")
     service = SkillCreatorEvaluationSuiteService(
@@ -225,7 +249,6 @@ async def test_generate_freezes_model_cases_and_confirm_requires_current_facts(
     assert len(generator.calls) == 1
     assert generator.calls[0].allowed_requirement_ids == (
         "intent",
-        "positive_example:0",
         "near_miss:0",
         "expected_output",
         "success_criterion:0",
@@ -255,6 +278,63 @@ async def test_generate_freezes_model_cases_and_confirm_requires_current_facts(
 
     creator.draft.content_digest = "b" * 64
     assert service.current_projection(creator.session.session_id)["stale"] is True
+
+
+@pytest.mark.asyncio
+async def test_generate_rejects_incomplete_requirement_coverage_before_persisting(
+    tmp_path: Path,
+) -> None:
+    creator = _CreatorService()
+    generator = _IncompleteCoverageGenerator(creator)
+    suite_store = SkillEvaluationSuiteStore(tmp_path / "suite")
+    service = SkillCreatorEvaluationSuiteService(
+        creator,  # type: ignore[arg-type]
+        suite_store,
+        SkillEvaluationStore(tmp_path / "evaluation"),
+        generator=generator,
+        enabled=True,
+    )
+
+    with pytest.raises(SkillCreatorValidationError) as captured:
+        await service.generate(creator.session.session_id, **_expected(creator))
+
+    assert captured.value.code == (
+        "skill_evaluation_suite_generator_coverage_incomplete"
+    )
+    assert len(generator.calls) == 2
+    repair = generator.calls[1].coverage_repair
+    assert repair is not None
+    assert repair["missing_requirement_ids"] == [
+        "near_miss:0",
+        "expected_output",
+        "success_criterion:0",
+    ]
+    assert len(repair["previous_cases"]) == 3
+    assert suite_store.current_for_session(creator.session.session_id) is None
+
+
+@pytest.mark.asyncio
+async def test_generate_repairs_incomplete_coverage_once_before_persisting(
+    tmp_path: Path,
+) -> None:
+    creator = _CreatorService()
+    generator = _RepairingCoverageGenerator(creator)
+    suite_store = SkillEvaluationSuiteStore(tmp_path / "suite")
+    service = SkillCreatorEvaluationSuiteService(
+        creator,  # type: ignore[arg-type]
+        suite_store,
+        SkillEvaluationStore(tmp_path / "evaluation"),
+        generator=generator,
+        enabled=True,
+    )
+
+    suite = await service.generate(creator.session.session_id, **_expected(creator))
+
+    assert suite.state == "draft"
+    assert suite.suite_revision == 1
+    assert len(generator.calls) == 2
+    assert generator.calls[1].coverage_repair is not None
+    assert suite_store.current_for_session(creator.session.session_id) == suite
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_skill_creator_evolution.py
+++ b/server/tests/test_skill_creator_evolution.py
@@ -143,6 +143,21 @@ def test_evolution_plan_is_append_only_and_answers_require_regeneration(tmp_path
     assert SkillEvolutionPlanStore(tmp_path).require(confirmed.plan_id).digest == confirmed.digest
 
 
+def test_evolution_plan_rejects_unversioned_free_text_failure_types(tmp_path) -> None:
+    store = SkillEvolutionPlanStore(tmp_path)
+    payload = _payload()
+    payload["diagnoses"][0]["failure_types"] = ["输出格式不稳定"]
+
+    with pytest.raises(SkillCreatorValidationError):
+        store.save_generated(
+            bindings=_bindings(),
+            payload=payload,
+            expected_plan_revision=None,
+            expected_plan_digest=None,
+            **_allowed(),
+        )
+
+
 def test_evolution_plan_rejects_unfrozen_evidence_paths_and_credentials(tmp_path) -> None:
     store = SkillEvolutionPlanStore(tmp_path)
     wrong_path = _payload()

--- a/server/tests/test_skill_creator_evolution_service.py
+++ b/server/tests/test_skill_creator_evolution_service.py
@@ -198,6 +198,14 @@ class _CrossCasePlanner(_Planner):
         return payload
 
 
+class _RepairingPlanner(_Planner):
+    async def generate(self, request: EvolutionGenerationRequest) -> dict:
+        payload = await super().generate(request)
+        if len(self.calls) == 1:
+            payload["diagnoses"] = []
+        return payload
+
+
 def _suite() -> SkillEvaluationSuite:
     cases = (
         SkillEvaluationSuiteCase(
@@ -415,6 +423,34 @@ async def test_generate_revalidates_session_after_model_call_without_orphan_plan
 
 
 @pytest.mark.asyncio
+async def test_generate_repairs_one_invalid_plan_without_persisting_the_first_attempt(tmp_path: Path) -> None:
+    creator, resource_plan, _suite_value, _run_value, _planner, service = _service(tmp_path)
+    planner = _RepairingPlanner()
+    service.planner = planner
+
+    generated = await service.generate("session-one", **_expected(creator, resource_plan))
+
+    assert generated.state == "ready"
+    assert len(planner.calls) == 2
+    assert planner.calls[0].repair is None
+    assert planner.calls[1].repair == {
+        "attempt": 1,
+        "error_code": "skill_creator_evolution_plan_invalid",
+        "instruction": (
+            "Return the complete contract again. Include one to twelve diagnoses "
+            "bound only to allowed case, requirement, and resource IDs. For each "
+            "diagnosis, copy evidence_item_ids exactly from "
+            "allowed.evidence_item_ids_by_case[case_id]; never invent or abbreviate "
+            "an ID. Copy each failure_types value exactly from "
+            "allowed.failure_types. Validate the full replacement against "
+            "output_contract_spec: include every required field, satisfy minItems, "
+            "and never return an empty required string."
+        ),
+    }
+    assert service.evolution_store.current_for_session("session-one").revision == 1
+
+
+@pytest.mark.asyncio
 async def test_confirm_revalidates_frozen_run_revision(tmp_path: Path) -> None:
     creator, resource_plan, _suite_value, run, _planner, service = _service(tmp_path)
     generated = await service.generate("session-one", **_expected(creator, resource_plan))
@@ -530,8 +566,13 @@ async def test_missing_sessions_do_not_allocate_generation_locks(tmp_path: Path)
 def test_evolution_runtime_is_no_tool_and_parses_one_versioned_object() -> None:
     request = EvolutionGenerationRequest(
         session={"session_id": "session-one", "session_revision": 7},
-        draft={}, evaluation={}, review={}, suite={}, resource_plan={}, current_plan=None,
-        allowed_case_ids=(), allowed_item_ids=(), allowed_requirement_ids=(),
+        draft={},
+        evaluation={"items": [
+            {"item_id": "item-candidate", "case_id": "case-normal"},
+            {"item_id": "item-baseline", "case_id": "case-normal"},
+        ]},
+        review={}, suite={}, resource_plan={}, current_plan=None,
+        allowed_case_ids=("case-normal",), allowed_item_ids=("item-candidate",), allowed_requirement_ids=(),
         allowed_resource_ids=(), allowed_source_ids=(), allowed_step_ids=(),
     )
     invocation = build_evolution_invocation(request, model_id="provider/model")
@@ -539,6 +580,14 @@ def test_evolution_runtime_is_no_tool_and_parses_one_versioned_object() -> None:
     assert agent["toolMode"] == "none"
     assert agent["temperature"] == "0.1"
     assert invocation.runtime_metadata["evolution_workflow_version"] == EVOLUTION_WORKFLOW_VERSION
+    context = json.loads(invocation.inputs["creator_request"])
+    assert context["allowed"]["evidence_item_ids_by_case"] == {
+        "case-normal": ["item-candidate"],
+    }
+    assert "assertion_failure" in context["allowed"]["failure_types"]
+    diagnosis_spec = context["output_contract_spec"]["properties"]["diagnoses"]
+    assert diagnosis_spec["minItems"] == 1
+    assert diagnosis_spec["items"]["properties"]["summary"]["minLength"] == 1
     payload = {"evolution_plan_version": EVOLUTION_PLAN_VERSION, "diagnoses": []}
     assert parse_evolution_output("Result:\n```json\n" + json.dumps(payload) + "\n```") == payload
     with pytest.raises(SkillCreatorValidationError):
@@ -579,6 +628,10 @@ def test_post_build_draft_accepts_only_the_exact_proposal_and_recomputed_package
         ),  # type: ignore[arg-type]
         enabled=True,
     )
+    assert service._resource_plan_produced_draft(
+        resource_plan, session=creator.session, draft=creator.draft
+    )
+    build.state = "stale"
     assert service._resource_plan_produced_draft(
         resource_plan, session=creator.session, draft=creator.draft
     )

--- a/server/tests/test_skill_creator_regression_governance.py
+++ b/server/tests/test_skill_creator_regression_governance.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from server.skills.creator_evaluation import (
+    SkillEvaluationStore,
+    SkillEvaluationValidationError,
+    aggregate_skill_evaluation_report,
+)
+from server.skills.creator_evaluation_service import SkillCreatorEvaluationService
+from server.skills.creator_store import SkillCreatorStorageError
+from server.skills.package_validation import compute_package_digest
+
+
+def _package(label: str) -> dict:
+    markdown = (
+        "---\n"
+        "name: regression-demo\n"
+        "description: Use when a regression comparison is required.\n"
+        "---\n\n"
+        f"# Regression demo\n\n{label}\n"
+    )
+    return {
+        "name": "regression-demo",
+        "slug": "regression-demo",
+        "description": "Use when a regression comparison is required.",
+        "skill_markdown": markdown,
+        "files": {},
+    }
+
+
+def _digest(package: dict) -> str:
+    return compute_package_digest(package["skill_markdown"], package["files"])
+
+
+def _case(index: int) -> dict:
+    return {
+        "case_id": f"case-{index}",
+        "name": f"Case {index}",
+        "prompt": f"Complete case {index}",
+        "expected_behavior": "Return done.",
+        "fixtures": [],
+        "assertions": [{"kind": "contains", "value": "done"}],
+    }
+
+
+def _three_side_run(store: SkillEvaluationStore):
+    baseline_package = _package("baseline")
+    previous_package = _package("previous")
+    candidate_package = _package("candidate")
+    baseline = store.create_overlay(
+        draft_id="draft-one",
+        draft_revision=1,
+        content_digest=_digest(baseline_package),
+        package=baseline_package,
+    )
+    previous = store.create_overlay(
+        draft_id="draft-one",
+        draft_revision=2,
+        content_digest=_digest(previous_package),
+        package=previous_package,
+    )
+    candidate = store.create_overlay(
+        draft_id="draft-one",
+        draft_revision=3,
+        content_digest=_digest(candidate_package),
+        package=candidate_package,
+    )
+    run = store.create_run(
+        session_id="session-one",
+        draft_id="draft-one",
+        draft_revision=3,
+        frozen_digest=candidate.content_digest,
+        baseline_overlay_id=baseline.overlay_id,
+        previous_overlay_id=previous.overlay_id,
+        candidate_overlay_id=candidate.overlay_id,
+        cases=[_case(index) for index in range(1, 4)],
+        model_id="provider/model-one",
+        repetitions=1,
+        config={
+            "regression_governance_version": "skill-creator-regression-v1",
+            "target_count": 3,
+            "estimated_model_calls": 9,
+        },
+    )
+    return run
+
+
+def test_three_side_matrix_is_persisted_and_budgeted(tmp_path: Path) -> None:
+    store = SkillEvaluationStore(tmp_path)
+    run = _three_side_run(store)
+    assert len(run.items) == 9
+    assert {item.target for item in run.items} == {
+        "baseline",
+        "previous",
+        "candidate",
+    }
+    restored = SkillEvaluationStore(tmp_path).require_run(run.run_id)
+    assert restored.previous_overlay_id == run.previous_overlay_id
+    assert len(restored.items) == 9
+
+    cases = [_case(index) for index in range(1, 13)]
+    at_limit = store.create_run(
+        session_id="session-at-limit",
+        draft_id=run.draft_id,
+        draft_revision=run.draft_revision,
+        frozen_digest=run.frozen_digest,
+        baseline_overlay_id=run.baseline_overlay_id,
+        previous_overlay_id=run.previous_overlay_id,
+        candidate_overlay_id=run.candidate_overlay_id,
+        cases=cases,
+        model_id=run.model_id,
+        repetitions=2,
+        evaluation_suite_id="suite-at-limit",
+        evaluation_suite_revision=1,
+        evaluation_suite_digest="b" * 64,
+        evaluation_suite_version="skill-evaluation-suite-v2",
+    )
+    assert len(at_limit.items) == SkillEvaluationStore.MAX_RUN_ITEMS == 72
+    with pytest.raises(SkillEvaluationValidationError) as captured:
+        store.create_run(
+            session_id="session-two",
+            draft_id=run.draft_id,
+            draft_revision=run.draft_revision,
+            frozen_digest=run.frozen_digest,
+            baseline_overlay_id=run.baseline_overlay_id,
+            previous_overlay_id=run.previous_overlay_id,
+            candidate_overlay_id=run.candidate_overlay_id,
+            cases=cases,
+            model_id=run.model_id,
+            repetitions=3,
+            evaluation_suite_id="suite-one",
+            evaluation_suite_revision=1,
+            evaluation_suite_digest="a" * 64,
+            evaluation_suite_version="skill-evaluation-suite-v2",
+        )
+    assert captured.value.code == "skill_evaluation_item_budget_exceeded"
+
+
+def test_governance_projection_survives_unavailable_evolution_history() -> None:
+    suite = SimpleNamespace(
+        state="confirmed",
+        draft_id="draft-one",
+        draft_revision=3,
+        draft_digest="c" * 64,
+        cases=(_case(1), _case(2), _case(3)),
+    )
+
+    class BrokenEvolutionStore:
+        def current_for_session(self, _session_id: str):
+            raise SkillCreatorStorageError("evolution snapshot is unavailable")
+
+    service = object.__new__(SkillCreatorEvaluationService)
+    service.suite_service = SimpleNamespace(
+        enabled=True,
+        suite_store=SimpleNamespace(
+            current_for_session=lambda _session_id: suite,
+        ),
+    )
+    service.evolution_store = BrokenEvolutionStore()
+    service.draft_store = SimpleNamespace(
+        list_revision_snapshots=lambda _draft_id: []
+    )
+    service.evaluation_store = SimpleNamespace(
+        list_runs=lambda *, session_id, limit: [],
+    )
+    session = SimpleNamespace(session_id="session-one")
+    draft = SimpleNamespace(
+        draft_id="draft-one",
+        content_revision=3,
+        content_digest="c" * 64,
+    )
+
+    projection = service.governance_projection(session, draft)
+
+    assert projection["enabled"] is True
+    assert projection["evolution_history_available"] is False
+    assert projection["target_count"] == 2
+    assert projection["previous_revision"] is None
+
+
+def test_regression_classification_and_item_level_override(tmp_path: Path) -> None:
+    store = SkillEvaluationStore(tmp_path)
+    run = _three_side_run(store)
+    store.claim_next_run()
+    while True:
+        pairs = store.claim_pairs(run.run_id, limit_pairs=4)
+        if not pairs:
+            break
+        for pair in pairs:
+            for item in pair:
+                passed = True
+                if item.case_id == "case-1" and item.target == "previous":
+                    passed = False
+                if item.case_id == "case-2" and item.target == "candidate":
+                    passed = False
+                store.record_item_result(
+                    run.run_id,
+                    item.item_id,
+                    result={
+                        "status": "completed",
+                        "output": "done" if passed else "not yet",
+                        "actual_model": "provider/model-one",
+                        "skill_read": True,
+                        "work_manifest": [],
+                        "assertion_results": [
+                            {
+                                "kind": "contains",
+                                "passed": passed,
+                                "score": 1.0 if passed else 0.0,
+                                "reason": "test",
+                            }
+                        ],
+                        "score": 1.0 if passed else 0.0,
+                        "usage": {"model_calls": 1},
+                    },
+                )
+    current = store.require_run(run.run_id)
+    report = aggregate_skill_evaluation_report(current)
+    completed = store.complete_run(run.run_id, report)
+    pairs = {item["case_id"]: item for item in completed.report["pairs"]}
+    assert pairs["case-1"]["classification"] == "improved"
+    assert pairs["case-2"]["classification"] == "regressed"
+    assert pairs["case-3"]["classification"] == "flat"
+    regression_ids = completed.report["regression_item_ids"]
+    assert regression_ids == [pairs["case-2"]["candidate_item_id"]]
+
+    with pytest.raises(SkillEvaluationValidationError) as captured:
+        store.review_run(
+            run.run_id,
+            expected_revision=completed.revision,
+            expected_feedback_revision=0,
+            decision="accept",
+            reason="The known regression is acceptable for this revision.",
+            acknowledge_failed_assertions=True,
+        )
+    assert captured.value.code == "skill_evaluation_regressions_unacknowledged"
+
+    accepted = store.review_run(
+        run.run_id,
+        expected_revision=completed.revision,
+        expected_feedback_revision=0,
+        decision="accept",
+        reason="The known regression is acceptable for this revision.",
+        acknowledge_failed_assertions=True,
+        acknowledged_regression_item_ids=regression_ids,
+    )
+    assert accepted.review_state == "accepted"
+    assert accepted.reviews[-1].acknowledged_regression_item_ids == tuple(
+        regression_ids
+    )


### PR DESCRIPTION
## 增量

- 将 Creator 评测升级为可复用套件与 baseline / previous / candidate 跨版本回归。
- 绑定可信 Skill 应用凭据，缺失、版本漂移或资源使用不一致时失败关闭。
- 接入反馈驱动的进化计划与资源构建，批准新 revision 后旧评测自动过期。
- 重做六步工作台文案与交互：默认一句话创建，复杂字段按需展开；修复刷新误跳第六步及“生成资源”只跳转不执行。

## 验证

- 后端 Creator/评测组合测试：选定 118 项全部覆盖通过；最终 main 接线组 30 passed。
- 前端 Creator 定向 Vitest：39 passed。
- TypeScript app/node 类型检查：通过。
- 前端生产构建：通过（仅既有主包体积警告）。
- 完整前端 Vitest 预检：412 passed；3 个并发超时文件单独复跑 23 passed。
- 独立预览器人工验收通过；390px 页面无横向溢出。
- git diff --check、路径白名单和敏感信息扫描通过。

## 边界

- 未重建或重启共享 Docker，未部署。
- 不加入 LLM Judge、自动安装、自动发布或 Skill 包内 evals/README/user-meta。