### PR TITLE
Skill Creator 中间件 V2：可信交接基础

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -28,6 +28,8 @@ EXPERT_TEAM_AGENCY_HITL_ENABLED=0
 # 私有控制台 Skill Creator V1 默认开启；公共 Xpert App 始终禁用。
 # 设为 false 并重启 Server 可同时关闭 Creator API 与界面入口。
 SKILL_CREATOR_V2_ENABLED=true
+# Workflow Skill Creator V2 handoff remains opt-in until its canvas experience ships.
+SKILL_CREATOR_MIDDLEWARE_V2_ENABLED=false
 # 资源化 Creator 已具备规划、分段构建和脚本离线实测；PR 3 工作台完成前默认关闭。
 SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED=true
 # 私有 Creator 默认启用可复用套件、资源级进化和跨版本回归；设为 false 可回退旧三例流程。

--- a/server/main.py
+++ b/server/main.py
@@ -236,6 +236,12 @@ try:
         TrustedCreatorSourceProvider,
         WorkflowCreatorGenerationExecutor,
     )
+    from server.skills.creator_handoff import (
+        SKILL_CREATOR_HANDOFF_ROLE_INSTRUCTION,
+        SkillCreatorHandoffError,
+        SkillCreatorHandoffRequest,
+        SkillCreatorHandoffService,
+    )
     from server.skills.creator_resource_plan import SkillResourcePlanStore
     from server.skills.creator_resource_build import SkillResourceBuildStore
     from server.skills.creator_resource_build_runtime import (
@@ -327,6 +333,12 @@ except ModuleNotFoundError:
         CreatorWorkflowInvocation,
         TrustedCreatorSourceProvider,
         WorkflowCreatorGenerationExecutor,
+    )
+    from skills.creator_handoff import (
+        SKILL_CREATOR_HANDOFF_ROLE_INSTRUCTION,
+        SkillCreatorHandoffError,
+        SkillCreatorHandoffRequest,
+        SkillCreatorHandoffService,
     )
     from skills.creator_resource_plan import SkillResourcePlanStore
     from skills.creator_resource_build import SkillResourceBuildStore
@@ -772,6 +784,7 @@ try:
         middleware_config_schema,
         middleware_spec,
         middleware_spec_from_node,
+        skill_creator_authoring_mode,
         register_todo_toolset_capability,
         register_sandbox_toolset_capability,
         register_browser_toolset_capability,
@@ -890,6 +903,7 @@ except ModuleNotFoundError:
         middleware_config_schema,
         middleware_spec,
         middleware_spec_from_node,
+        skill_creator_authoring_mode,
         register_todo_toolset_capability,
         register_sandbox_toolset_capability,
         register_browser_toolset_capability,
@@ -1612,6 +1626,7 @@ skill_creator_service = SkillCreatorService(
     authoring_service,
     source_provider=skill_creator_source_provider,
 )
+skill_creator_handoff_service = SkillCreatorHandoffService(skill_creator_service)
 skill_creator_resource_plan_store = SkillResourcePlanStore(
     storage_dir=AGENT_TASK_STORAGE_DIR or None
 )
@@ -7936,6 +7951,30 @@ def _trusted_workflow_execution_source_kind(
     return None
 
 
+def _skill_creator_handoff_node_ids(workflow: WorkflowPayload) -> list[str]:
+    nodes_by_id = {node.id: node for node in workflow.nodes}
+    result: list[str] = []
+    for edge in workflow.edges:
+        if str(edge.targetHandle or "").strip() != "middleware":
+            continue
+        middleware_node = nodes_by_id.get(edge.source)
+        target_node = nodes_by_id.get(edge.target)
+        if (
+            middleware_node is None
+            or target_node is None
+            or workflow_node_kind(middleware_node) != "runtime_middleware"
+            or workflow_node_kind(target_node) != "workflow_agent"
+            or str(middleware_node.data.get("runtimeMiddlewareId") or "").strip()
+            != "skill_creator"
+        ):
+            continue
+        config = middleware_node.data.get("runtimeMiddlewareConfig")
+        clean_config = config if isinstance(config, dict) else {}
+        if skill_creator_authoring_mode(clean_config) == "creator_handoff":
+            result.append(middleware_node.id)
+    return sorted(result)
+
+
 async def _run_workflow_response(
     payload: WorkflowRunRequest,
     request: Request | None,
@@ -7951,6 +7990,14 @@ async def _run_workflow_response(
     runtime_trigger_event: dict[str, Any] | None = None,
     runtime_task_id: str | None = None,
 ):
+    explicit_creator_handoff_node_ids = _skill_creator_handoff_node_ids(
+        payload.workflow
+    )
+    if len(explicit_creator_handoff_node_ids) > 1:
+        return JSONResponse(
+            status_code=422,
+            content={"error": "skill_creator_multiple_handoffs"},
+        )
     trusted_source_kind = runtime_execution_source_kind or (
         _trusted_workflow_execution_source_kind(
             request,
@@ -8167,6 +8214,11 @@ async def _run_workflow_response(
             if str(edge.targetHandle or "").strip() == "middleware"
         ],
         "agent_resume_state": dict(resume_state.get("agent_state") or {}),
+        "skill_creator_handoff_request": (
+            dict(resume_state.get("skill_creator_handoff_request") or {})
+            if isinstance(resume_state.get("skill_creator_handoff_request"), dict)
+            else None
+        ),
         "resolved_approval": (
             asdict(resolved_approval) if resolved_approval is not None else None
         ),
@@ -13743,6 +13795,19 @@ async def _run_workflow_response(
                         skill_creator_spec = middleware_spec(
                             agent_specs, "skill_creator"
                         )
+                        skill_creator_mode = (
+                            skill_creator_authoring_mode(skill_creator_spec.config)
+                            if skill_creator_spec is not None
+                            else None
+                        )
+                        if skill_creator_mode not in {
+                            None,
+                            "legacy_proposal",
+                            "creator_handoff",
+                        }:
+                            raise ValueError(
+                                "Invalid Skill Creator middleware authoring mode."
+                            )
                         ralph_spec = middleware_spec(agent_specs, "ralph_loop")
                         knowledge_writer_spec = middleware_spec(
                             agent_specs, "knowledge_writer"
@@ -13767,7 +13832,22 @@ async def _run_workflow_response(
                         )
                         automation_enabled = scheduler_spec is not None
                         xpert_authoring_enabled = xpert_authoring_spec is not None
-                        skill_creator_enabled = skill_creator_spec is not None
+                        skill_creator_handoff_enabled = bool(
+                            skill_creator_spec is not None
+                            and skill_creator_mode == "creator_handoff"
+                        )
+                        if skill_creator_handoff_enabled and (
+                            skill_creator_spec.binding != "agent"
+                            or skill_creator_spec.node_id
+                            not in explicit_creator_handoff_node_ids
+                        ):
+                            raise RuntimeMiddlewareFatalError(
+                                "skill_creator_handoff_unavailable"
+                            )
+                        skill_creator_enabled = bool(
+                            skill_creator_spec is not None
+                            and skill_creator_mode == "legacy_proposal"
+                        )
                         selector_spec = middleware_spec(
                             agent_specs,
                             "llm_tool_selector",
@@ -13837,6 +13917,7 @@ async def _run_workflow_response(
                         ).strip()
                         if prompt_suffix:
                             task_input = f"{task_input}\n\n{prompt_suffix}".strip()
+                        handoff_task_input = task_input
                         system_prompt_spec = middleware_spec(
                             agent_specs,
                             "system_prompt_injector",
@@ -13881,6 +13962,11 @@ async def _run_workflow_response(
                                         for item in todo_items
                                     ]
                                 )
+                            ).strip()
+                        if skill_creator_handoff_enabled:
+                            role_prompt = (
+                                f"{role_prompt}\n\n"
+                                f"{SKILL_CREATOR_HANDOFF_ROLE_INSTRUCTION}"
                             ).strip()
                         tool_mode = str(node.data.get("toolMode") or "none").strip()
                         agent_strategy = str(
@@ -15455,6 +15541,11 @@ async def _run_workflow_response(
                             output = ""
                         else:
                             variables[output_variable] = output
+                        if success and skill_creator_handoff_enabled:
+                            task_state["skill_creator_handoff_request"] = {
+                                "node_id": skill_creator_spec.node_id,
+                                "intent": handoff_task_input,
+                            }
                         if (
                             success
                             and output.strip()
@@ -16838,6 +16929,64 @@ async def _run_workflow_response(
                 yield sse_payload(cancellation_event())
                 return
 
+            handoff_event: dict[str, Any] | None = None
+            raw_handoff = task_state.get("skill_creator_handoff_request")
+            if isinstance(raw_handoff, dict):
+                handoff_request = SkillCreatorHandoffRequest(
+                    node_id=str(raw_handoff.get("node_id") or ""),
+                    intent=str(raw_handoff.get("intent") or ""),
+                )
+                if completed_execution.source_kind != "workflow_classic":
+                    handoff_event = skill_creator_handoff_service.failed_event(
+                        task_id=task_id,
+                        run_id=workflow_run.run_id,
+                        node_id=handoff_request.node_id,
+                        error_code="skill_creator_handoff_unavailable",
+                    )
+                else:
+                    try:
+                        handoff_session = await asyncio.to_thread(
+                            skill_creator_handoff_service.create_or_get,
+                            task_id=task_id,
+                            run_id=workflow_run.run_id,
+                            request=handoff_request,
+                        )
+                        handoff_event = skill_creator_handoff_service.ready_event(
+                            task_id=task_id,
+                            run_id=workflow_run.run_id,
+                            node_id=handoff_request.node_id,
+                            session_id=handoff_session.session_id,
+                        )
+                    except SkillCreatorHandoffError as exc:
+                        handoff_event = skill_creator_handoff_service.failed_event(
+                            task_id=task_id,
+                            run_id=workflow_run.run_id,
+                            node_id=handoff_request.node_id,
+                            error_code=exc.code,
+                        )
+                        logger.warning(
+                            "Skill Creator handoff failed task_id=%s node_id=%s code=%s",
+                            task_id,
+                            handoff_request.node_id,
+                            exc.code,
+                        )
+                try:
+                    workflow_execution_store.append_event(task_id, handoff_event)
+                except Exception:
+                    logger.exception(
+                        "Failed to persist Skill Creator handoff event "
+                        "task_id=%s node_id=%s",
+                        task_id,
+                        handoff_request.node_id,
+                    )
+                    handoff_event = skill_creator_handoff_service.failed_event(
+                        task_id=task_id,
+                        run_id=workflow_run.run_id,
+                        node_id=handoff_request.node_id,
+                        error_code="skill_creator_handoff_failed",
+                    )
+                yield sse_payload(handoff_event)
+
             yield sse_payload(
                 {
                     "event": "workflow_end",
@@ -16895,6 +17044,13 @@ async def _run_workflow_response(
                 "executed": sorted(executed),
                 "final_output": final_output,
                 "agent_state": dict(interrupt.continuation.get("agent_state") or {}),
+                "skill_creator_handoff_request": (
+                    dict(task_state.get("skill_creator_handoff_request") or {})
+                    if isinstance(
+                        task_state.get("skill_creator_handoff_request"), dict
+                    )
+                    else None
+                ),
                 "runtime_context": {
                     "system_prompt": workflow_runtime_context.get("system_prompt"),
                     "override_system_prompt": workflow_runtime_context.get(

--- a/server/skills/creator_handoff.py
+++ b/server/skills/creator_handoff.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from .creator_service import SkillCreatorService
+from .creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorSession,
+    SkillCreatorStorageError,
+    SkillCreatorValidationError,
+)
+
+
+SKILL_CREATOR_HANDOFF_VERSION = "skill-creator-middleware-handoff-v1"
+SKILL_CREATOR_HANDOFF_ROLE_INSTRUCTION = """
+You are preparing a concise requirement analysis for a Skill Creator handoff.
+Clarify only the intended use, expected inputs, expected output, boundaries, and
+missing information. Do not write SKILL.md, resource files, tool calls,
+installation steps, or an authoring proposal. Finish the user's workflow task
+normally; ModelMirror will create the Creator session only after the workflow
+has completed successfully.
+""".strip()
+
+_HANDOFF_ERROR_CODES = {
+    "skill_creator_handoff_unavailable",
+    "skill_creator_handoff_conflict",
+    "skill_creator_handoff_failed",
+}
+
+
+class SkillCreatorHandoffError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        safe_code = (
+            code
+            if code in _HANDOFF_ERROR_CODES
+            else "skill_creator_handoff_failed"
+        )
+        super().__init__(safe_code)
+        self.code = safe_code
+
+
+@dataclass(frozen=True, slots=True)
+class SkillCreatorHandoffRequest:
+    node_id: str
+    intent: str
+
+
+class SkillCreatorHandoffService:
+    """Bridge a completed classic workflow to one trusted Creator session."""
+
+    def __init__(
+        self,
+        creator_service: SkillCreatorService,
+        *,
+        enabled: bool | None = None,
+    ) -> None:
+        self.creator_service = creator_service
+        self.enabled = (
+            os.getenv("SKILL_CREATOR_MIDDLEWARE_V2_ENABLED", "false")
+            .strip()
+            .lower()
+            in {"1", "true", "yes", "on"}
+            if enabled is None
+            else bool(enabled)
+        )
+
+    def create_or_get(
+        self,
+        *,
+        task_id: str,
+        run_id: str,
+        request: SkillCreatorHandoffRequest,
+    ) -> SkillCreatorSession:
+        if not self.enabled or not self.creator_service.enabled:
+            raise SkillCreatorHandoffError("skill_creator_handoff_unavailable")
+        clean_task_id = str(task_id or "").strip()
+        clean_run_id = str(run_id or "").strip()
+        clean_node_id = str(request.node_id or "").strip()
+        clean_intent = str(request.intent or "").strip()
+        if not clean_task_id or not clean_run_id or not clean_node_id or not clean_intent:
+            raise SkillCreatorHandoffError("skill_creator_handoff_failed")
+        try:
+            return self.creator_service.create_or_get_workflow_handoff(
+                source_task_id=clean_task_id,
+                source_run_id=clean_run_id,
+                intent=clean_intent,
+                positive_examples=[clean_intent],
+                near_miss_examples=[
+                    "与上述目标无关的闲聊、通用改写或其他任务。"
+                ],
+                expected_output=(
+                    "直接完成上述任务；缺少必要信息时明确列出待确认项，不编造事实。"
+                ),
+                success_criteria=[
+                    "结果直接解决用户提出的任务。",
+                    "只使用已有信息，缺失内容明确标记为待确认。",
+                ],
+            )
+        except SkillCreatorConflictError as exc:
+            raise SkillCreatorHandoffError(
+                "skill_creator_handoff_conflict"
+            ) from exc
+        except SkillCreatorStorageError as exc:
+            raise SkillCreatorHandoffError("skill_creator_handoff_failed") from exc
+        except SkillCreatorValidationError as exc:
+            unavailable_codes = {
+                "skill_creator_disabled",
+                "skill_creator_source_unavailable",
+            }
+            code = (
+                "skill_creator_handoff_unavailable"
+                if exc.code in unavailable_codes
+                else "skill_creator_handoff_failed"
+            )
+            raise SkillCreatorHandoffError(code) from exc
+        except Exception as exc:
+            raise SkillCreatorHandoffError("skill_creator_handoff_failed") from exc
+
+    @staticmethod
+    def ready_event(
+        *,
+        task_id: str,
+        run_id: str,
+        node_id: str,
+        session_id: str,
+    ) -> dict[str, Any]:
+        return {
+            "event": "skill_creator_handoff",
+            "status": "ready",
+            "task_id": str(task_id),
+            "run_id": str(run_id),
+            "node_id": str(node_id),
+            "session_id": str(session_id),
+        }
+
+    @staticmethod
+    def failed_event(
+        *,
+        task_id: str,
+        run_id: str,
+        node_id: str,
+        error_code: str,
+    ) -> dict[str, Any]:
+        safe_code = (
+            error_code
+            if error_code in _HANDOFF_ERROR_CODES
+            else "skill_creator_handoff_failed"
+        )
+        return {
+            "event": "skill_creator_handoff",
+            "status": "failed",
+            "task_id": str(task_id),
+            "run_id": str(run_id),
+            "node_id": str(node_id),
+            "error_code": safe_code,
+        }

--- a/server/skills/creator_service.py
+++ b/server/skills/creator_service.py
@@ -199,6 +199,20 @@ class SkillCreatorService:
                     source_message_id=source_message_id,
                 )
             )
+            return self.session_store.create_or_get_run_capture(
+                intent=intent,
+                positive_examples=positive_examples,
+                near_miss_examples=near_miss_examples,
+                expected_output=expected_output,
+                success_criteria=success_criteria,
+                source_kind=source_kind,
+                source_task_id=str(source_task_id or ""),
+                source_run_id=str(source_run_id or ""),
+                source_xpert_id=source_xpert_id,
+                source_conversation_id=source_conversation_id,
+                source_message_id=source_message_id,
+                authoring_flow=authoring_flow,
+            )
         return self.session_store.create(
             mode=mode,
             intent=intent,
@@ -213,6 +227,41 @@ class SkillCreatorService:
             source_conversation_id=source_conversation_id,
             source_message_id=source_message_id,
             authoring_flow=authoring_flow,
+        )
+
+    def create_or_get_workflow_handoff(
+        self,
+        *,
+        source_task_id: str,
+        source_run_id: str,
+        intent: str,
+        positive_examples: list[str],
+        near_miss_examples: list[str],
+        expected_output: str,
+        success_criteria: list[str],
+    ) -> SkillCreatorSession:
+        """Create the unique Creator session owned by a completed workflow run."""
+
+        self.require_enabled()
+        if self.source_provider is None:
+            raise SkillCreatorValidationError(
+                "Trusted runtime sources are not configured.",
+                code="skill_creator_source_unavailable",
+            )
+        source = CreatorSourceDescriptor(
+            source_kind="workflow_classic",
+            source_task_id=str(source_task_id or ""),
+            source_run_id=str(source_run_id or ""),
+        )
+        self.source_provider.validate_source(source)
+        return self.session_store.create_or_get_workflow_handoff(
+            intent=intent,
+            positive_examples=positive_examples,
+            near_miss_examples=near_miss_examples,
+            expected_output=expected_output,
+            success_criteria=success_criteria,
+            source_task_id=source.source_task_id,
+            source_run_id=source.source_run_id,
         )
 
     def list_sessions(self, *, limit: int) -> list[SkillCreatorSession]:

--- a/server/skills/creator_store.py
+++ b/server/skills/creator_store.py
@@ -135,6 +135,168 @@ class SkillCreatorSessionStore:
         source_message_id: str | None = None,
         authoring_flow: CreatorAuthoringFlow = "legacy",
     ) -> SkillCreatorSession:
+        session = self._new_session(
+            mode=mode,
+            intent=intent,
+            positive_examples=positive_examples,
+            near_miss_examples=near_miss_examples,
+            expected_output=expected_output,
+            success_criteria=success_criteria,
+            source_kind=source_kind,
+            source_task_id=source_task_id,
+            source_run_id=source_run_id,
+            source_xpert_id=source_xpert_id,
+            source_conversation_id=source_conversation_id,
+            source_message_id=source_message_id,
+            authoring_flow=authoring_flow,
+        )
+        with self._lock:
+            self._insert_unlocked(session)
+        return self._copy(session)
+
+    def create_or_get_workflow_handoff(
+        self,
+        *,
+        intent: str,
+        positive_examples: list[str],
+        near_miss_examples: list[str],
+        expected_output: str,
+        success_criteria: list[str],
+        source_task_id: str,
+        source_run_id: str,
+    ) -> SkillCreatorSession:
+        """Atomically create one resource-authoring session per trusted run.
+
+        A pristine run-capture session may win a narrow race with the automatic
+        handoff. In that case it is hydrated in place. Any edited or otherwise
+        divergent session fails closed instead of silently changing ownership.
+        """
+
+        candidate = self._new_session(
+            mode="run",
+            intent=intent,
+            positive_examples=positive_examples,
+            near_miss_examples=near_miss_examples,
+            expected_output=expected_output,
+            success_criteria=success_criteria,
+            source_kind="workflow_classic",
+            source_task_id=source_task_id,
+            source_run_id=source_run_id,
+            authoring_flow="resource",
+        )
+        with self._lock:
+            self._ensure_writable_unlocked()
+            matches = [
+                item
+                for item in self._items.values()
+                if item.source_kind == "workflow_classic"
+                and item.source_task_id == candidate.source_task_id
+                and item.source_run_id == candidate.source_run_id
+            ]
+            if len(matches) > 1:
+                raise SkillCreatorConflictError(
+                    "Multiple Creator sessions match this workflow execution."
+                )
+            if matches:
+                existing = matches[0]
+                if self._handoff_definition_matches(existing, candidate):
+                    return self._copy(existing)
+                if self._is_pristine_run_capture(existing):
+                    previous = self._copy(existing)
+                    existing.authoring_flow = "resource"
+                    existing.intent = candidate.intent
+                    existing.positive_examples = candidate.positive_examples
+                    existing.near_miss_examples = candidate.near_miss_examples
+                    existing.expected_output = candidate.expected_output
+                    existing.success_criteria = candidate.success_criteria
+                    existing.state = self._derive_state(existing)
+                    existing.session_revision += 1
+                    existing.updated_at = time.time()
+                    try:
+                        self._save_unlocked()
+                    except BaseException:
+                        self._items[existing.session_id] = previous
+                        raise
+                    return self._copy(existing)
+                raise SkillCreatorConflictError(
+                    "Creator workflow handoff conflicts with an existing session."
+                )
+            self._insert_unlocked(candidate)
+            return self._copy(candidate)
+
+    def create_or_get_run_capture(
+        self,
+        *,
+        intent: str = "",
+        positive_examples: list[str] | None = None,
+        near_miss_examples: list[str] | None = None,
+        expected_output: str = "",
+        success_criteria: list[str] | None = None,
+        source_kind: CreatorSourceKind,
+        source_task_id: str,
+        source_run_id: str,
+        source_xpert_id: str | None = None,
+        source_conversation_id: str | None = None,
+        source_message_id: str | None = None,
+        authoring_flow: CreatorAuthoringFlow = "legacy",
+    ) -> SkillCreatorSession:
+        """Make the existing completed-run capture API idempotent by source."""
+
+        candidate = self._new_session(
+            mode="run",
+            intent=intent,
+            positive_examples=positive_examples,
+            near_miss_examples=near_miss_examples,
+            expected_output=expected_output,
+            success_criteria=success_criteria,
+            source_kind=source_kind,
+            source_task_id=source_task_id,
+            source_run_id=source_run_id,
+            source_xpert_id=source_xpert_id,
+            source_conversation_id=source_conversation_id,
+            source_message_id=source_message_id,
+            authoring_flow=authoring_flow,
+        )
+        with self._lock:
+            self._ensure_writable_unlocked()
+            matches = [
+                item
+                for item in self._items.values()
+                if self._source_matches(item, candidate)
+            ]
+            if len(matches) > 1:
+                raise SkillCreatorConflictError(
+                    "Multiple Creator sessions match this runtime source."
+                )
+            if matches:
+                existing = matches[0]
+                if self._is_empty_definition(candidate) or self._definitions_match(
+                    existing, candidate
+                ):
+                    return self._copy(existing)
+                raise SkillCreatorConflictError(
+                    "Creator runtime source is already bound to another definition."
+                )
+            self._insert_unlocked(candidate)
+            return self._copy(candidate)
+
+    def _new_session(
+        self,
+        *,
+        mode: CreatorMode,
+        intent: str,
+        positive_examples: list[str] | None,
+        near_miss_examples: list[str] | None,
+        expected_output: str,
+        success_criteria: list[str] | None,
+        source_kind: CreatorSourceKind,
+        source_task_id: str | None,
+        source_run_id: str | None,
+        source_xpert_id: str | None = None,
+        source_conversation_id: str | None = None,
+        source_message_id: str | None = None,
+        authoring_flow: CreatorAuthoringFlow = "legacy",
+    ) -> SkillCreatorSession:
         session = SkillCreatorSession(
             session_id=f"skillcreator_{uuid.uuid4().hex}",
             mode=self._mode(mode),
@@ -164,20 +326,91 @@ class SkillCreatorSessionStore:
         self._validate_source(session)
         self._reject_credentials(session)
         session.state = self._derive_state(session)
-        with self._lock:
-            self._ensure_writable_unlocked()
-            if len(self._items) >= self.MAX_SESSIONS:
-                raise SkillCreatorValidationError(
-                    "Skill Creator session limit reached.",
-                    code="skill_creator_session_limit",
-                )
-            self._items[session.session_id] = session
-            try:
-                self._save_unlocked()
-            except BaseException:
-                self._items.pop(session.session_id, None)
-                raise
-        return self._copy(session)
+        return session
+
+    def _insert_unlocked(self, session: SkillCreatorSession) -> None:
+        self._ensure_writable_unlocked()
+        if len(self._items) >= self.MAX_SESSIONS:
+            raise SkillCreatorValidationError(
+                "Skill Creator session limit reached.",
+                code="skill_creator_session_limit",
+            )
+        self._items[session.session_id] = session
+        try:
+            self._save_unlocked()
+        except BaseException:
+            self._items.pop(session.session_id, None)
+            raise
+
+    @staticmethod
+    def _handoff_definition_matches(
+        existing: SkillCreatorSession,
+        candidate: SkillCreatorSession,
+    ) -> bool:
+        return (
+            existing.mode == "run"
+            and existing.authoring_flow == "resource"
+            and existing.intent == candidate.intent
+            and existing.positive_examples == candidate.positive_examples
+            and existing.near_miss_examples == candidate.near_miss_examples
+            and existing.expected_output == candidate.expected_output
+            and existing.success_criteria == candidate.success_criteria
+        )
+
+    @staticmethod
+    def _definitions_match(
+        existing: SkillCreatorSession,
+        candidate: SkillCreatorSession,
+    ) -> bool:
+        return (
+            existing.intent == candidate.intent
+            and existing.positive_examples == candidate.positive_examples
+            and existing.near_miss_examples == candidate.near_miss_examples
+            and existing.expected_output == candidate.expected_output
+            and existing.success_criteria == candidate.success_criteria
+        )
+
+    @staticmethod
+    def _is_empty_definition(item: SkillCreatorSession) -> bool:
+        return not any(
+            (
+                item.intent,
+                item.positive_examples,
+                item.near_miss_examples,
+                item.expected_output,
+                item.success_criteria,
+            )
+        )
+
+    @staticmethod
+    def _source_matches(
+        existing: SkillCreatorSession,
+        candidate: SkillCreatorSession,
+    ) -> bool:
+        return (
+            existing.mode == "run"
+            and existing.source_kind == candidate.source_kind
+            and existing.source_task_id == candidate.source_task_id
+            and existing.source_run_id == candidate.source_run_id
+            and existing.source_xpert_id == candidate.source_xpert_id
+            and existing.source_conversation_id == candidate.source_conversation_id
+            and existing.source_message_id == candidate.source_message_id
+        )
+
+    @staticmethod
+    def _is_pristine_run_capture(item: SkillCreatorSession) -> bool:
+        return (
+            item.mode == "run"
+            and item.session_revision == 1
+            and not item.intent
+            and not item.positive_examples
+            and not item.near_miss_examples
+            and not item.expected_output
+            and not item.success_criteria
+            and not item.evidence_confirmed
+            and not item.proposal_id
+            and not item.draft_id
+        )
 
     def activate_resource_authoring(
         self,

--- a/server/tests/test_skill_creator_middleware_handoff.py
+++ b/server/tests/test_skill_creator_middleware_handoff.py
@@ -1,0 +1,951 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+import server.main as main_module
+from server.skills.creator_handoff import (
+    SKILL_CREATOR_HANDOFF_ROLE_INSTRUCTION,
+    SkillCreatorHandoffError,
+    SkillCreatorHandoffRequest,
+    SkillCreatorHandoffService,
+)
+from server.skills.creator_resource_plan import SkillResourcePlanStore
+from server.skills.creator_resource_service import (
+    SkillCreatorResourcePlanningService,
+)
+from server.skills.creator_runtime import TrustedCreatorSourceProvider
+from server.skills.creator_service import SkillCreatorService
+from server.skills.creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorSessionStore,
+)
+from server.xpert_runtime import WorkflowExecutionStore
+
+
+def _events(body: str) -> list[dict]:
+    return [
+        json.loads(line.removeprefix("data: "))
+        for line in body.splitlines()
+        if line.startswith("data: ")
+    ]
+
+
+def _workflow() -> dict:
+    return {
+        "id": "creator-handoff-contract",
+        "title": "Creator handoff contract",
+        "nodes": [
+            {
+                "id": "input",
+                "type": "input",
+                "data": {"kind": "input", "variableName": "user_input"},
+            },
+            {
+                "id": "agent",
+                "type": "workflow_agent",
+                "data": {
+                    "kind": "workflow_agent",
+                    "agentName": "requirements-analyst",
+                    "modelId": "test/model",
+                    "rolePrompt": "分析用户需求。",
+                    "taskInput": "请分析：{{user_input}}",
+                    "toolMode": "none",
+                    "outputVariable": "analysis",
+                },
+            },
+            {
+                "id": "creator",
+                "type": "runtime_middleware",
+                "data": {
+                    "kind": "runtime_middleware",
+                    "runtimeMiddlewareId": "skill_creator",
+                    "runtimeMiddlewareKind": "runtime_middleware.skill_creator",
+                    "runtimeMiddlewareConfig": {
+                        "authoring_mode": "creator_handoff"
+                    },
+                },
+            },
+            {
+                "id": "output",
+                "type": "output",
+                "data": {"kind": "output", "outputVariable": "analysis"},
+            },
+        ],
+        "edges": [
+            {"id": "e1", "source": "input", "target": "agent"},
+            {
+                "id": "bind-creator",
+                "source": "creator",
+                "target": "agent",
+                "sourceHandle": "middleware-binding",
+                "targetHandle": "middleware",
+            },
+            {"id": "e2", "source": "agent", "target": "output"},
+        ],
+    }
+
+
+def _plugin_handoff_workflow() -> dict:
+    workflow = _workflow()
+    workflow["id"] = "creator-plugin-handoff-contract"
+    workflow["nodes"] = [
+        node for node in workflow["nodes"] if node["id"] != "creator"
+    ]
+    workflow["edges"] = [
+        edge for edge in workflow["edges"] if edge["id"] != "bind-creator"
+    ]
+    next(
+        node for node in workflow["nodes"] if node["id"] == "agent"
+    )["data"]["toolMode"] = "mcp_tools"
+    workflow["nodes"].append(
+        {
+            "id": "plugin",
+            "type": "plugin_resource",
+            "data": {
+                "kind": "plugin_resource",
+                "pluginId": "plugin-creator-attack",
+                "versionPolicy": "latest",
+            },
+        }
+    )
+    workflow["edges"].append(
+        {
+            "id": "bind-plugin",
+            "source": "plugin",
+            "target": "agent",
+            "sourceHandle": "plugin-binding",
+            "targetHandle": "plugin",
+        }
+    )
+    return workflow
+
+
+def _conditional_handoff_workflow() -> dict:
+    workflow = _workflow()
+    workflow["id"] = "creator-conditional-handoff-contract"
+    workflow["nodes"].insert(
+        1,
+        {
+            "id": "route",
+            "type": "multi_route",
+            "data": {
+                "kind": "multi_route",
+                "inputVariable": "user_input",
+                "routes": [
+                    {
+                        "id": "route_1",
+                        "label": "create skill",
+                        "operator": "contains",
+                        "valueType": "text",
+                        "value": "create skill",
+                    },
+                    {
+                        "id": "route_2",
+                        "label": "archive only",
+                        "operator": "contains",
+                        "valueType": "text",
+                        "value": "archive only",
+                    }
+                ],
+            },
+        },
+    )
+    workflow["nodes"].insert(
+        -1,
+        {
+            "id": "fallback",
+            "type": "variable_assign",
+            "data": {
+                "kind": "variable_assign",
+                "variableName": "analysis",
+                "template": "No Skill handoff was requested.",
+            },
+        },
+    )
+    workflow["edges"] = [
+        {"id": "e-input-route", "source": "input", "target": "route"},
+        {
+            "id": "e-route-agent",
+            "source": "route",
+            "sourceHandle": "route_1",
+            "target": "agent",
+        },
+        {
+            "id": "e-route-fallback",
+            "source": "route",
+            "sourceHandle": "default",
+            "target": "fallback",
+        },
+        {
+            "id": "e-route-archive",
+            "source": "route",
+            "sourceHandle": "route_2",
+            "target": "fallback",
+        },
+        {
+            "id": "bind-creator",
+            "source": "creator",
+            "target": "agent",
+            "sourceHandle": "middleware-binding",
+            "targetHandle": "middleware",
+        },
+        {"id": "e-agent-output", "source": "agent", "target": "output"},
+        {
+            "id": "e-fallback-output",
+            "source": "fallback",
+            "target": "output",
+        },
+    ]
+    return workflow
+
+
+def _failing_handoff_workflow() -> dict:
+    workflow = _workflow()
+    workflow["id"] = "creator-failing-handoff-contract"
+    workflow["nodes"] = [
+        node for node in workflow["nodes"] if node["id"] != "output"
+    ]
+    workflow["nodes"].append(
+        {
+            "id": "stop",
+            "type": "terminate_error",
+            "data": {
+                "kind": "terminate_error",
+                "errorCode": "HANDOFF_WORKFLOW_FAILED",
+                "message": "The workflow failed after requirements analysis.",
+            },
+        }
+    )
+    workflow["edges"] = [
+        edge for edge in workflow["edges"] if edge["id"] != "e2"
+    ]
+    workflow["edges"].append(
+        {"id": "e-agent-stop", "source": "agent", "target": "stop"}
+    )
+    return workflow
+
+
+def test_handoff_store_is_idempotent_and_hydrates_pristine_capture(
+    tmp_path: Path,
+) -> None:
+    store = SkillCreatorSessionStore(tmp_path / "creator-sessions")
+    captured = store.create(
+        mode="run",
+        source_kind="workflow_classic",
+        source_task_id="task-1",
+        source_run_id="run-1",
+    )
+
+    values = {
+        "intent": "把事故记录整理成复盘。",
+        "positive_examples": ["把事故记录整理成复盘。"],
+        "near_miss_examples": ["只改写一句话。"],
+        "expected_output": "结构化复盘。",
+        "success_criteria": ["不编造事实。"],
+        "source_task_id": "task-1",
+        "source_run_id": "run-1",
+    }
+    hydrated = store.create_or_get_workflow_handoff(**values)
+    repeated = store.create_or_get_workflow_handoff(**values)
+
+    assert hydrated.session_id == captured.session_id == repeated.session_id
+    assert hydrated.authoring_flow == "resource"
+    assert hydrated.intent == values["intent"]
+    assert hydrated.session_revision == 2
+    assert len(store.list()) == 1
+
+    reloaded = SkillCreatorSessionStore(tmp_path / "creator-sessions")
+    after_restart = reloaded.create_or_get_workflow_handoff(**values)
+    manual_capture = reloaded.create_or_get_run_capture(
+        source_kind="workflow_classic",
+        source_task_id="task-1",
+        source_run_id="run-1",
+    )
+    assert after_restart.session_id == hydrated.session_id
+    assert manual_capture.session_id == hydrated.session_id
+    assert len(reloaded.list()) == 1
+
+
+def test_handoff_store_rejects_an_edited_source_conflict(tmp_path: Path) -> None:
+    store = SkillCreatorSessionStore(tmp_path / "creator-conflict")
+    captured = store.create(
+        mode="run",
+        source_kind="workflow_classic",
+        source_task_id="task-2",
+        source_run_id="run-2",
+    )
+    store.update_definition(
+        captured.session_id,
+        expected_session_revision=captured.session_revision,
+        changes={"intent": "用户已经编辑过的需求"},
+    )
+
+    with pytest.raises(SkillCreatorConflictError):
+        store.create_or_get_workflow_handoff(
+            intent="自动交接的另一份需求",
+            positive_examples=["自动交接的另一份需求"],
+            near_miss_examples=["无关任务"],
+            expected_output="结果",
+            success_criteria=["不编造"],
+            source_task_id="task-2",
+            source_run_id="run-2",
+        )
+    assert len(store.list()) == 1
+
+
+def test_handoff_fails_closed_for_untrusted_state_and_secret_input(
+    tmp_path: Path,
+) -> None:
+    execution_store = WorkflowExecutionStore(tmp_path / "guard-executions")
+    execution_store.create(
+        task_id="task-guard",
+        run_id="run-guard",
+        run_type="workflow",
+        source_kind="workflow_classic",
+        workflow={"id": "guard", "nodes": [], "edges": []},
+        inputs={"user_input": "prepare a reusable report"},
+    )
+    session_store = SkillCreatorSessionStore(tmp_path / "guard-creator")
+    creator = SkillCreatorService(
+        session_store,
+        main_module.get_skill_draft_store(),
+        main_module.authoring_service,
+        source_provider=TrustedCreatorSourceProvider(
+            execution_store, main_module.xpert_context_store
+        ),
+        enabled=True,
+    )
+    handoff = SkillCreatorHandoffService(creator, enabled=True)
+    request = SkillCreatorHandoffRequest(
+        node_id="creator",
+        intent="prepare a reusable report",
+    )
+
+    with pytest.raises(SkillCreatorHandoffError) as pending:
+        handoff.create_or_get(
+            task_id="task-guard",
+            run_id="run-guard",
+            request=request,
+        )
+    assert pending.value.code == "skill_creator_handoff_failed"
+    assert session_store.list() == []
+
+    execution_store.complete("task-guard", result="completed")
+    with pytest.raises(SkillCreatorHandoffError) as secret:
+        handoff.create_or_get(
+            task_id="task-guard",
+            run_id="run-guard",
+            request=SkillCreatorHandoffRequest(
+                node_id="creator",
+                intent="prepare report with API_KEY=super-secret-value",
+            ),
+        )
+    assert secret.value.code == "skill_creator_handoff_failed"
+    assert session_store.list() == []
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_rejects_duplicate_handoff_bindings() -> None:
+    workflow = _workflow()
+    workflow["edges"].append(
+        {
+            "id": "bind-creator-again",
+            "source": "creator",
+            "target": "agent",
+            "sourceHandle": "middleware-binding",
+            "targetHandle": "middleware",
+        }
+    )
+    transport = httpx.ASGITransport(app=main_module.app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/workflow/run",
+            json={"workflow": workflow, "inputs": {"user_input": "test"}},
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {"error": "skill_creator_multiple_handoffs"}
+
+
+@pytest.mark.asyncio
+async def test_unselected_handoff_agent_does_not_create_a_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    execution_store = WorkflowExecutionStore(tmp_path / "conditional-executions")
+    session_store = SkillCreatorSessionStore(tmp_path / "conditional-creator")
+    creator = SkillCreatorService(
+        session_store,
+        main_module.get_skill_draft_store(),
+        main_module.authoring_service,
+        source_provider=TrustedCreatorSourceProvider(
+            execution_store, main_module.xpert_context_store
+        ),
+        enabled=True,
+    )
+
+    async def unexpected_stream(*_args, **_kwargs):
+        raise AssertionError("The unselected workflow Agent must not run.")
+        yield "unreachable"
+
+    monkeypatch.setattr(main_module, "workflow_execution_store", execution_store)
+    monkeypatch.setattr(
+        main_module,
+        "skill_creator_handoff_service",
+        SkillCreatorHandoffService(creator, enabled=True),
+    )
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", False)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "stream_workflow_llm_text", unexpected_stream)
+    main_module.request_windows.clear()
+
+    transport = httpx.ASGITransport(app=main_module.app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/workflow/run",
+            json={
+                "workflow": _conditional_handoff_workflow(),
+                "inputs": {"user_input": "return the fallback result"},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    events = _events(response.text)
+    assert any(item.get("event") == "workflow_end" for item in events)
+    assert not any(
+        item.get("event") == "skill_creator_handoff" for item in events
+    )
+    assert session_store.list() == []
+    persisted = execution_store.list_items(limit=1)[0]
+    assert persisted.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_failed_workflow_does_not_create_a_handoff_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    execution_store = WorkflowExecutionStore(tmp_path / "failed-executions")
+    session_store = SkillCreatorSessionStore(tmp_path / "failed-creator")
+    creator = SkillCreatorService(
+        session_store,
+        main_module.get_skill_draft_store(),
+        main_module.authoring_service,
+        source_provider=TrustedCreatorSourceProvider(
+            execution_store, main_module.xpert_context_store
+        ),
+        enabled=True,
+    )
+
+    async def fake_stream(*_args, **_kwargs):
+        yield "Requirements analysis completed before the downstream failure."
+
+    monkeypatch.setattr(main_module, "workflow_execution_store", execution_store)
+    monkeypatch.setattr(
+        main_module,
+        "skill_creator_handoff_service",
+        SkillCreatorHandoffService(creator, enabled=True),
+    )
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", False)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "stream_workflow_llm_text", fake_stream)
+    main_module.request_windows.clear()
+
+    transport = httpx.ASGITransport(app=main_module.app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/workflow/run",
+            json={
+                "workflow": _failing_handoff_workflow(),
+                "inputs": {"user_input": "create skill from this process"},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    events = _events(response.text)
+    error = next(item for item in events if item.get("event") == "error")
+    assert error["code"] == "HANDOFF_WORKFLOW_FAILED"
+    assert not any(item.get("event") == "workflow_end" for item in events)
+    assert not any(
+        item.get("event") == "skill_creator_handoff" for item in events
+    )
+    assert session_store.list() == []
+    persisted = execution_store.list_items(limit=1)[0]
+    assert persisted.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_workflow_does_not_create_a_handoff_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class CancelOnCompleteStore(WorkflowExecutionStore):
+        def complete(self, task_id: str, *, result: str):
+            self.cancel(task_id, error="cancelled_by_user")
+            return self.require(task_id)
+
+    execution_store = CancelOnCompleteStore(tmp_path / "cancelled-executions")
+    session_store = SkillCreatorSessionStore(tmp_path / "cancelled-creator")
+    creator = SkillCreatorService(
+        session_store,
+        main_module.get_skill_draft_store(),
+        main_module.authoring_service,
+        source_provider=TrustedCreatorSourceProvider(
+            execution_store, main_module.xpert_context_store
+        ),
+        enabled=True,
+    )
+
+    async def fake_stream(*_args, **_kwargs):
+        yield "Requirements analysis completed before cancellation won the race."
+
+    monkeypatch.setattr(main_module, "workflow_execution_store", execution_store)
+    monkeypatch.setattr(
+        main_module,
+        "skill_creator_handoff_service",
+        SkillCreatorHandoffService(creator, enabled=True),
+    )
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", False)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "stream_workflow_llm_text", fake_stream)
+    main_module.request_windows.clear()
+
+    transport = httpx.ASGITransport(app=main_module.app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/workflow/run",
+            json={
+                "workflow": _workflow(),
+                "inputs": {"user_input": "create skill from this process"},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    events = _events(response.text)
+    assert any(item.get("event") == "workflow_cancelled" for item in events)
+    assert not any(item.get("event") == "workflow_end" for item in events)
+    assert not any(
+        item.get("event") == "skill_creator_handoff" for item in events
+    )
+    assert session_store.list() == []
+    persisted = execution_store.list_items(limit=1)[0]
+    assert persisted.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_completed_v2_middleware_creates_one_session_without_proposal_tools(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    execution_store = WorkflowExecutionStore(tmp_path / "executions")
+    session_store = SkillCreatorSessionStore(tmp_path / "creator")
+    source_provider = TrustedCreatorSourceProvider(
+        execution_store,
+        main_module.xpert_context_store,
+    )
+    creator = SkillCreatorService(
+        session_store,
+        main_module.get_skill_draft_store(),
+        main_module.authoring_service,
+        source_provider=source_provider,
+        enabled=True,
+    )
+    handoff = SkillCreatorHandoffService(creator, enabled=True)
+    captured: dict[str, str] = {}
+    model_calls = 0
+
+    async def fake_stream(
+        _model_id: str,
+        prompt: str,
+        *,
+        system_prompt: str | None = None,
+    ):
+        nonlocal model_calls
+        model_calls += 1
+        captured["prompt"] = prompt
+        captured["system_prompt"] = str(system_prompt or "")
+        yield "用途、输入、输出、边界和缺失信息已整理。"
+
+    monkeypatch.setattr(main_module, "workflow_execution_store", execution_store)
+    monkeypatch.setattr(main_module, "skill_creator_handoff_service", handoff)
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", False)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "stream_workflow_llm_text", fake_stream)
+    main_module.request_windows.clear()
+    before = {
+        item.proposal_id for item in main_module.authoring_proposal_store.list(limit=500)
+    }
+
+    transport = httpx.ASGITransport(app=main_module.app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/workflow/run",
+            json={
+                "workflow": _workflow(),
+                "inputs": {"user_input": "把客服处理经验沉淀成 Skill"},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    events = _events(response.text)
+    handoff_event = next(
+        item for item in events if item.get("event") == "skill_creator_handoff"
+    )
+    workflow_end = next(item for item in events if item.get("event") == "workflow_end")
+    assert events.index(handoff_event) < events.index(workflow_end)
+    assert handoff_event["status"] == "ready"
+    assert handoff_event["node_id"] == "creator"
+    assert set(handoff_event) == {
+        "event",
+        "status",
+        "task_id",
+        "run_id",
+        "node_id",
+        "session_id",
+    }
+    session = session_store.require(handoff_event["session_id"])
+    assert session.source_kind == "workflow_classic"
+    assert session.source_task_id == handoff_event["task_id"]
+    assert session.source_run_id == handoff_event["run_id"]
+    assert session.authoring_flow == "resource"
+    assert session.intent == "请分析：把客服处理经验沉淀成 Skill"
+    assert session.evidence_confirmed is False
+    assert session.state == "selecting_evidence"
+    assert model_calls == 1
+    assert captured["prompt"] == session.intent
+    assert SKILL_CREATOR_HANDOFF_ROLE_INSTRUCTION in captured["system_prompt"]
+    after = {
+        item.proposal_id for item in main_module.authoring_proposal_store.list(limit=500)
+    }
+    assert after == before
+    persisted = execution_store.require(handoff_event["task_id"])
+    assert persisted.status == "completed"
+    persisted_handoff = next(
+        item for item in persisted.events
+        if item.get("event") == "skill_creator_handoff"
+    )
+    assert {
+        key: value for key, value in persisted_handoff.items() if key != "sequence"
+    } == handoff_event
+
+    preview = creator.preview_source(session.session_id)
+    session = creator.select_evidence(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        preview_fingerprint=preview.fingerprint,
+        candidate_ids=[],
+    )
+
+    class Planner:
+        def available(self) -> bool:
+            return True
+
+        async def plan(self, _request):
+            return {
+                "skill_name": "customer-support-playbook",
+                "skill_description": (
+                    "Turn a repeated customer-support process into a bounded workflow."
+                ),
+                "workflow_steps": [
+                    {
+                        "id": "analyze",
+                        "instruction": "Confirm the request and missing information.",
+                    },
+                    {
+                        "id": "structure",
+                        "instruction": "Structure the reusable workflow and boundaries.",
+                    },
+                    {
+                        "id": "deliver",
+                        "instruction": "Produce the documented support workflow.",
+                    },
+                    {
+                        "id": "verify",
+                        "instruction": "Verify the output contract and safe fallback.",
+                    },
+                ],
+                "output_contract": ["Return a reusable support workflow."],
+                "failure_modes": ["Do not invent missing policy details."],
+                "resources": [],
+                "clarifications": [],
+            }
+
+    planning = SkillCreatorResourcePlanningService(
+        creator,
+        SkillResourcePlanStore(tmp_path / "handoff-plans"),
+        planner=Planner(),
+        enabled=True,
+    )
+    plan = await planning.generate(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        expected_plan_revision=None,
+        expected_plan_digest=None,
+    )
+    assert plan.state == "ready"
+    confirmed = planning.confirm(
+        session.session_id,
+        plan_id=plan.plan_id,
+        expected_session_revision=session.session_revision,
+        expected_plan_revision=plan.revision,
+        expected_plan_digest=plan.digest,
+    )
+    assert confirmed.state == "confirmed"
+
+
+@pytest.mark.asyncio
+async def test_handoff_event_store_failure_preserves_completed_workflow(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    execution_store = WorkflowExecutionStore(tmp_path / "event-failure-executions")
+    session_store = SkillCreatorSessionStore(tmp_path / "event-failure-creator")
+    creator = SkillCreatorService(
+        session_store,
+        main_module.get_skill_draft_store(),
+        main_module.authoring_service,
+        source_provider=TrustedCreatorSourceProvider(
+            execution_store, main_module.xpert_context_store
+        ),
+        enabled=True,
+    )
+
+    async def fake_stream(*_args, **_kwargs):
+        yield "analysis completed"
+
+    append_event = execution_store.append_event
+
+    def fail_handoff_event(task_id: str, event: dict):
+        if event.get("event") == "skill_creator_handoff":
+            raise OSError("simulated handoff event store failure")
+        return append_event(task_id, event)
+
+    monkeypatch.setattr(main_module, "workflow_execution_store", execution_store)
+    monkeypatch.setattr(
+        main_module,
+        "skill_creator_handoff_service",
+        SkillCreatorHandoffService(creator, enabled=True),
+    )
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", False)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "stream_workflow_llm_text", fake_stream)
+    monkeypatch.setattr(execution_store, "append_event", fail_handoff_event)
+    main_module.request_windows.clear()
+
+    transport = httpx.ASGITransport(
+        app=main_module.app,
+        raise_app_exceptions=False,
+    )
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/workflow/run",
+            json={"workflow": _workflow(), "inputs": {"user_input": "test"}},
+        )
+
+    assert response.status_code == 200
+    events = _events(response.text)
+    failed = next(
+        item for item in events if item.get("event") == "skill_creator_handoff"
+    )
+    assert failed["status"] == "failed"
+    assert failed["error_code"] == "skill_creator_handoff_failed"
+    assert "session_id" not in failed
+    assert any(item.get("event") == "workflow_end" for item in events)
+    executions = execution_store.list_items(limit=10)
+    assert len(executions) == 1 and executions[0].status == "completed"
+    assert len(session_store.list()) == 1
+
+
+@pytest.mark.asyncio
+async def test_plugin_preset_cannot_inject_creator_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    execution_store = WorkflowExecutionStore(tmp_path / "plugin-executions")
+    session_store = SkillCreatorSessionStore(tmp_path / "plugin-creator")
+    creator = SkillCreatorService(
+        session_store,
+        main_module.get_skill_draft_store(),
+        main_module.authoring_service,
+        source_provider=TrustedCreatorSourceProvider(
+            execution_store, main_module.xpert_context_store
+        ),
+        enabled=True,
+    )
+    plugin = SimpleNamespace(
+        id="plugin-creator-attack",
+        status="published",
+        published_version=1,
+    )
+    version = SimpleNamespace(
+        version=1,
+        skills=[],
+        installed_skill_ids=[],
+        toolsets=[],
+        middleware_presets=[
+            SimpleNamespace(
+                middleware_id="skill_creator",
+                priority=100,
+                config={"authoring_mode": "creator_handoff"},
+            )
+        ],
+    )
+    plugin_store = SimpleNamespace(
+        get_plugin=lambda _plugin_id: plugin,
+        get_version=lambda _plugin_id, _version: version,
+    )
+
+    async def fake_collect(*_args, **_kwargs):
+        return "analysis completed"
+
+    monkeypatch.setattr(main_module, "workflow_execution_store", execution_store)
+    monkeypatch.setattr(
+        main_module,
+        "skill_creator_handoff_service",
+        SkillCreatorHandoffService(creator, enabled=True),
+    )
+    monkeypatch.setattr(main_module, "get_plugin_store", lambda: plugin_store)
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", False)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "collect_chat_completion_text", fake_collect)
+    main_module.request_windows.clear()
+
+    transport = httpx.ASGITransport(app=main_module.app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/workflow/run",
+            json={
+                "workflow": _plugin_handoff_workflow(),
+                "inputs": {"user_input": "test"},
+            },
+        )
+
+    assert response.status_code == 200
+    events = _events(response.text)
+    assert any(
+        item.get("event") == "error"
+        and item.get("message") == "skill_creator_handoff_unavailable"
+        for item in events
+    )
+    assert not any(item.get("event") == "skill_creator_handoff" for item in events)
+    assert any(item.get("event") == "workflow_end" for item in events)
+    assert session_store.list() == []
+
+
+@pytest.mark.asyncio
+async def test_disabled_handoff_emits_failure_without_changing_workflow_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    execution_store = WorkflowExecutionStore(tmp_path / "disabled-executions")
+    session_store = SkillCreatorSessionStore(tmp_path / "disabled-creator")
+    creator = SkillCreatorService(
+        session_store,
+        main_module.get_skill_draft_store(),
+        main_module.authoring_service,
+        source_provider=TrustedCreatorSourceProvider(
+            execution_store, main_module.xpert_context_store
+        ),
+        enabled=True,
+    )
+
+    async def fake_stream(*_args, **_kwargs):
+        yield "analysis completed"
+
+    monkeypatch.setattr(main_module, "workflow_execution_store", execution_store)
+    monkeypatch.setattr(
+        main_module,
+        "skill_creator_handoff_service",
+        SkillCreatorHandoffService(creator, enabled=False),
+    )
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", False)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "stream_workflow_llm_text", fake_stream)
+    main_module.request_windows.clear()
+
+    transport = httpx.ASGITransport(app=main_module.app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/workflow/run",
+            json={"workflow": _workflow(), "inputs": {"user_input": "test"}},
+        )
+
+    events = _events(response.text)
+    failed = next(
+        item for item in events if item.get("event") == "skill_creator_handoff"
+    )
+    assert failed == {
+        "event": "skill_creator_handoff",
+        "status": "failed",
+        "task_id": failed["task_id"],
+        "run_id": failed["run_id"],
+        "node_id": "creator",
+        "error_code": "skill_creator_handoff_unavailable",
+    }
+    assert any(item.get("event") == "workflow_end" for item in events)
+    persisted = execution_store.require(failed["task_id"])
+    assert persisted.status == "completed"
+    persisted_failure = next(
+        item for item in persisted.events
+        if item.get("event") == "skill_creator_handoff"
+    )
+    assert persisted_failure["error_code"] == "skill_creator_handoff_unavailable"
+    assert "session_id" not in persisted_failure
+    assert session_store.list() == []

--- a/server/tests/test_workflow_native_validate.py
+++ b/server/tests/test_workflow_native_validate.py
@@ -1806,6 +1806,114 @@ async def test_authoring_middleware_requires_runtime_tool_mode_and_scoped_ids(
 
 
 @pytest.mark.asyncio
+async def test_creator_handoff_does_not_require_runtime_tool_mode(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = middleware_binding_workflow()
+    middleware = workflow["nodes"][-1]
+    middleware["id"] = "creator-handoff"
+    middleware["data"].update(
+        {
+            "runtimeMiddlewareId": "skill_creator",
+            "runtimeMiddlewareKind": "runtime_middleware.skill_creator",
+            "runtimeMiddlewareConfig": {
+                "authoring_mode": "creator_handoff"
+            },
+        }
+    )
+    workflow["edges"][-1]["source"] = "creator-handoff"
+
+    result = await validate(client, workflow)
+
+    assert result["valid"] is True, result["issues"]
+    assert "authoring_requires_runtime_tool_mode" not in issue_codes(result)
+    assert "skill_creator_legacy_middleware" not in issue_codes(result)
+
+
+@pytest.mark.asyncio
+async def test_creator_handoff_rejects_multiple_bindings_and_warns_for_legacy(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = middleware_binding_workflow()
+    middleware = workflow["nodes"][-1]
+    middleware["id"] = "legacy-creator"
+    middleware["data"].update(
+        {
+            "runtimeMiddlewareId": "skill_creator",
+            "runtimeMiddlewareKind": "runtime_middleware.skill_creator",
+            "runtimeMiddlewareConfig": {},
+        }
+    )
+    workflow["edges"][-1]["source"] = "legacy-creator"
+    workflow["nodes"][1]["data"]["toolMode"] = "mcp_tools"
+    legacy = await validate(client, workflow)
+    assert legacy["valid"] is True, legacy["issues"]
+    assert "skill_creator_legacy_middleware" in issue_codes(legacy)
+
+    middleware["data"]["runtimeMiddlewareConfig"] = {
+        "authoring_mode": "creator_handoff"
+    }
+    second = {
+        "id": "creator-handoff-2",
+        "type": "runtime_middleware",
+        "data": {
+            "kind": "runtime_middleware",
+            "runtimeMiddlewareId": "skill_creator",
+            "runtimeMiddlewareKind": "runtime_middleware.skill_creator",
+            "runtimeMiddlewareConfig": {
+                "authoring_mode": "creator_handoff"
+            },
+        },
+    }
+    workflow["nodes"].append(second)
+    workflow["edges"].append(
+        {
+            "id": "bind-second-creator",
+            "source": "creator-handoff-2",
+            "target": workflow["nodes"][1]["id"],
+            "sourceHandle": "middleware-binding",
+            "targetHandle": "middleware",
+        }
+    )
+
+    multiple = await validate(client, workflow)
+    assert "skill_creator_multiple_handoffs" in issue_codes(multiple)
+    assert multiple["valid"] is False
+
+    workflow["nodes"].remove(second)
+    workflow["edges"][-1]["source"] = "legacy-creator"
+    workflow["nodes"].append(
+        {
+            "id": "workflow_agent_2",
+            "type": "workflow_agent",
+            "data": {
+                "kind": "workflow_agent",
+                "agentName": "second-agent",
+                "modelId": "openai/gpt-4o-mini",
+                "rolePrompt": "Answer accurately.",
+                "taskInput": "{{agent_output}}",
+                "toolMode": "none",
+                "outputVariable": "second_output",
+            },
+        }
+    )
+    workflow["nodes"][2]["data"]["outputVariable"] = "second_output"
+    workflow["edges"][1]["source"] = "workflow_agent_2"
+    workflow["edges"].insert(
+        1,
+        {
+            "id": "agent-to-agent-2",
+            "source": "workflow_agent",
+            "target": "workflow_agent_2",
+        },
+    )
+    workflow["edges"][-1]["target"] = "workflow_agent_2"
+    duplicate_binding = await validate(client, workflow)
+    assert "skill_creator_multiple_handoffs" in issue_codes(duplicate_binding)
+    assert duplicate_binding["valid"] is False
+
+
+@pytest.mark.asyncio
 async def test_automation_middleware_configuration_is_validated(
     client: httpx.AsyncClient,
 ) -> None:

--- a/server/tests/test_xpert_runtime_middleware_registry.py
+++ b/server/tests/test_xpert_runtime_middleware_registry.py
@@ -4,6 +4,7 @@ from server.xpert_runtime import (
     RuntimeMiddlewareNode,
     RuntimeMiddlewareRegistry,
     register_builtin_middleware_nodes,
+    skill_creator_authoring_mode,
 )
 
 
@@ -60,8 +61,21 @@ def test_registry_list_returns_builtin_nodes() -> None:
     assert authoring is not None and skill_creator is not None
     assert authoring.requires_tool_mode == "mcp_tools"
     assert skill_creator.requires_tool_mode == "mcp_tools"
+    assert skill_creator.metadata["supported_authoring_modes"] == [
+        "legacy_proposal",
+        "creator_handoff",
+    ]
     assert {"xpert_authoring", "skill_creator"}.issubset(
         registry.app_forbidden_ids()
+    )
+
+
+def test_skill_creator_authoring_mode_defaults_legacy_for_saved_nodes() -> None:
+    assert skill_creator_authoring_mode(None) == "legacy_proposal"
+    assert skill_creator_authoring_mode({}) == "legacy_proposal"
+    assert (
+        skill_creator_authoring_mode({"authoring_mode": "creator_handoff"})
+        == "creator_handoff"
     )
 
 

--- a/server/workflow_native/validate.py
+++ b/server/workflow_native/validate.py
@@ -3342,6 +3342,33 @@ def validate_node_configuration(
                         node_id=node.id,
                     )
                 )
+        if middleware_id == "skill_creator":
+            authoring_mode = str(config.get("authoring_mode") or "").strip()
+            if authoring_mode and authoring_mode not in {
+                "legacy_proposal",
+                "creator_handoff",
+            }:
+                issues.append(
+                    ValidationIssue(
+                        code="invalid_skill_creator_authoring_mode",
+                        message=(
+                            "skill_creator authoring_mode must be "
+                            "legacy_proposal or creator_handoff."
+                        ),
+                        node_id=node.id,
+                    )
+                )
+            if authoring_mode != "creator_handoff":
+                issues.append(
+                    ValidationIssue(
+                        code="skill_creator_legacy_middleware",
+                        message=(
+                            "This Skill Creator middleware uses the legacy proposal path."
+                        ),
+                        severity="warning",
+                        node_id=node.id,
+                    )
+                )
         if middleware_id in {"xpert_authoring", "skill_creator"}:
             allowed_key = (
                 "allowed_xpert_ids"
@@ -4666,6 +4693,27 @@ def validate_automation_middleware_bindings(
         if source is not None and kinds_by_id.get(source.id) == "runtime_middleware":
             bound_by_agent[edge.target].append(source)
 
+    creator_handoffs: list[str] = []
+    for middleware_nodes in bound_by_agent.values():
+        for middleware_node in middleware_nodes:
+            if (
+                str(middleware_node.data.get("runtimeMiddlewareId") or "")
+                != "skill_creator"
+            ):
+                continue
+            raw_config = middleware_node.data.get("runtimeMiddlewareConfig")
+            config = raw_config if isinstance(raw_config, dict) else {}
+            if str(config.get("authoring_mode") or "").strip() == "creator_handoff":
+                creator_handoffs.append(middleware_node.id)
+    if len(creator_handoffs) > 1:
+        issues.append(
+            ValidationIssue(
+                code="skill_creator_multiple_handoffs",
+                message="A workflow can bind at most one Creator V2 handoff.",
+                node_id=sorted(creator_handoffs)[1],
+            )
+        )
+
     for agent_id, middleware_nodes in bound_by_agent.items():
         agent = nodes_by_id.get(agent_id)
         tool_mode = str((agent.data if agent else {}).get("toolMode") or "none")
@@ -4673,7 +4721,8 @@ def validate_automation_middleware_bindings(
             middleware_id = str(
                 middleware_node.data.get("runtimeMiddlewareId") or ""
             )
-            config = middleware_node.data.get("runtimeMiddlewareConfig") or {}
+            raw_config = middleware_node.data.get("runtimeMiddlewareConfig")
+            config = raw_config if isinstance(raw_config, dict) else {}
             if middleware_id == "scheduler" and tool_mode != "mcp_tools":
                 issues.append(
                     ValidationIssue(
@@ -4682,8 +4731,14 @@ def validate_automation_middleware_bindings(
                         node_id=middleware_node.id,
                     )
                 )
+            creator_handoff = bool(
+                middleware_id == "skill_creator"
+                and str(config.get("authoring_mode") or "").strip()
+                == "creator_handoff"
+            )
             if (
                 middleware_id in {"xpert_authoring", "skill_creator"}
+                and not creator_handoff
                 and tool_mode != "mcp_tools"
             ):
                 issues.append(

--- a/server/xpert_runtime/__init__.py
+++ b/server/xpert_runtime/__init__.py
@@ -88,8 +88,10 @@ from .middleware_registry import (
     RuntimeMiddlewareField,
     RuntimeMiddlewareNode,
     RuntimeMiddlewareRegistry,
+    SKILL_CREATOR_AUTHORING_MODES,
     register_builtin_middleware_nodes,
     runtime_middleware_registry,
+    skill_creator_authoring_mode,
 )
 from .memory_toolset import MemoryToolsetProvider, register_memory_toolset_capability
 from .file_memory_middleware import build_xpert_file_memory_middleware
@@ -364,6 +366,7 @@ __all__ = [
     "ToolAuditStatus",
     "ToolsetProvider",
     "ToolPermissionPolicy",
+    "SKILL_CREATOR_AUTHORING_MODES",
     "register_builtin_middleware_nodes",
     "register_builtin_workflow_nodes",
     "register_mcp_toolset_capability",
@@ -383,6 +386,7 @@ __all__ = [
     "middleware_config_schema",
     "middleware_spec",
     "middleware_spec_from_node",
+    "skill_creator_authoring_mode",
     "select_runtime_tools",
     "todo_planning_instruction",
     "validate_structured_output",

--- a/server/xpert_runtime/execution_store.py
+++ b/server/xpert_runtime/execution_store.py
@@ -517,6 +517,8 @@ class WorkflowExecutionStore:
             "request_id",
             "request_status",
             "host_id",
+            "session_id",
+            "error_code",
             "tool_name",
             "status",
             "candidate_id",
@@ -552,6 +554,9 @@ class WorkflowExecutionStore:
                 }
             )
         clean = {key: value for key, value in event.items() if key in allowed}
+        for key in ("session_id", "error_code"):
+            if key in clean:
+                clean[key] = str(clean[key] or "")[:200]
         for key in ("message", "final_output"):
             if key in clean:
                 clean[key] = str(clean[key] or "")[:200_000]

--- a/server/xpert_runtime/middleware_registry.py
+++ b/server/xpert_runtime/middleware_registry.py
@@ -5,6 +5,14 @@ from typing import Any, Literal
 
 
 FieldType = Literal["text", "textarea", "select", "boolean", "number", "json"]
+SKILL_CREATOR_AUTHORING_MODES = {"legacy_proposal", "creator_handoff"}
+
+
+def skill_creator_authoring_mode(config: dict[str, Any] | None) -> str:
+    """Return the backward-compatible authoring mode for Skill Creator nodes."""
+
+    value = str((config or {}).get("authoring_mode") or "").strip()
+    return value or "legacy_proposal"
 
 
 @dataclass(slots=True)
@@ -197,6 +205,10 @@ def register_builtin_middleware_nodes(
                 "real_execution": True,
                 "app_forbidden": True,
                 "proposal_only": True,
+                "supported_authoring_modes": [
+                    "legacy_proposal",
+                    "creator_handoff",
+                ],
             },
             requires_tool_mode="mcp_tools",
             app_policy="forbidden",


### PR DESCRIPTION
## Summary

- add the opt-in Skill Creator middleware V2 handoff contract while preserving legacy nodes
- create one idempotent Creator resource-authoring session only after a trusted classic workflow completes
- keep proposal tools, planner execution, approval, and installation outside the workflow Agent
- emit persisted, redacted ready or failed handoff events with stable error codes
- reject duplicate handoffs and implicit/plugin-injected handoff modes

## Safety and compatibility

- SKILL_CREATOR_MIDDLEWARE_V2_ENABLED remains false by default
- legacy Skill Creator middleware behavior remains available with an explicit warning
- public Xpert Apps remain unable to use the middleware
- failed or cancelled workflows and unselected conditional branches do not create sessions
- event persistence failures preserve the completed workflow result

## Validation

- PR1 focused contract suite: 126 passed
- Creator, Workflow, Plugin, Legacy, and Skill regression suite: 362 passed
- git diff --check passed
- no frontend or shared-stack changes

## Rollback

Set SKILL_CREATOR_MIDDLEWARE_V2_ENABLED=false. Legacy workflows and standalone Creator sessions remain unchanged.
