### PR TITLE
feature: 统一 Provider Catalog、Readiness 与设置入口

### DIFF
--- a/client/src/components/PromptTemplateLibrary.test.tsx
+++ b/client/src/components/PromptTemplateLibrary.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import PromptTemplateLibrary from "./PromptTemplateLibrary";
@@ -12,10 +12,6 @@ describe("PromptTemplateLibrary", () => {
   afterEach(() => vi.restoreAllMocks());
 
   it("creates a one-shot draft and navigates without sending", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
-      models: [{ profile_id: "openai/gpt-5.6-sol", invocation_id: "openai/gpt-5.6-sol", invocable: true }],
-      routes: [],
-    }), { status: 200 }));
     render(
       <MemoryRouter initialEntries={["/prompts"]}>
         <Routes>
@@ -24,28 +20,26 @@ describe("PromptTemplateLibrary", () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => expect(screen.getByRole("button", { name: /使用前选择/i })).toBeEnabled());
+    expect(screen.getByRole("button", { name: /使用前选择/i })).toBeEnabled();
     fireEvent.click(screen.getByRole("button", { name: /使用前选择/i }));
-    fireEvent.click(screen.getByRole("option", { name: /GPT-5.6 Sol/i }));
+    fireEvent.click(screen.getAllByRole("option", { name: /GPT-5.6 Sol/i })[0]);
     fireEvent.click(screen.getAllByRole("button", { name: "用于对话" })[0]);
     expect(screen.getByText(/\/chat\/openai%2Fgpt-5.6-sol\?prompt_draft=/)).toBeInTheDocument();
-    expect(fetch).toHaveBeenCalledTimes(1);
   }, 15_000);
 
-  it("fails closed when the live catalog is unavailable", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 503 }));
+  it("keeps curated targets selectable without a runtime catalog request", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
     render(<MemoryRouter><PromptTemplateLibrary /></MemoryRouter>);
-    await waitFor(() => expect(screen.getByRole("button", { name: /实时目录不可用/i })).toBeDisabled());
-    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    const trigger = screen.getByRole("button", { name: /使用前选择/i });
+    expect(trigger).toBeEnabled();
+    fireEvent.click(trigger);
+    expect(screen.getAllByRole("option", { name: /GPT-5.6 Sol/i })[0]).toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("closes the model picker with Escape and restores trigger focus", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
-      models: [{ profile_id: "openai/gpt-5.6-sol", invocation_id: "openai/gpt-5.6-sol", invocable: true }],
-      routes: [],
-    }), { status: 200 }));
     render(<MemoryRouter><PromptTemplateLibrary /></MemoryRouter>);
-    const trigger = await screen.findByRole("button", { name: /使用前选择/i });
+    const trigger = screen.getByRole("button", { name: /使用前选择/i });
     fireEvent.click(trigger);
     expect(screen.getByRole("listbox")).toBeInTheDocument();
     fireEvent.keyDown(document, { key: "Escape" });

--- a/client/src/components/PromptTemplateLibrary.tsx
+++ b/client/src/components/PromptTemplateLibrary.tsx
@@ -116,7 +116,7 @@ function TargetModelPicker({ models, available, value, onChange }: TargetModelPi
               </button>
             ))}
             {filteredModels.length === 0 ? (
-              <p className="px-3 py-5 text-center text-sm text-slate-500">没有匹配的可调用模型</p>
+              <p className="px-3 py-5 text-center text-sm text-slate-500">没有匹配的目标模型</p>
             ) : null}
           </div>
           {models.length > filteredModels.length ? (
@@ -134,43 +134,12 @@ export default function PromptTemplateLibrary() {
   const [categoryId, setCategoryId] = useState("all");
   const [targetModelId, setTargetModelId] = useState("");
   const [notice, setNotice] = useState("");
-  const [invocableModelIds, setInvocableModelIds] = useState<Set<string> | null>(null);
 
-  useEffect(() => {
-    const controller = new AbortController();
-    void fetch("/api/models/catalog", { signal: controller.signal })
-      .then(async (response) => {
-        if (!response.ok) throw new Error("catalog unavailable");
-        return await response.json() as {
-          models?: Array<{ profile_id?: string; invocation_id?: string; root?: string | null; invocable?: boolean }>;
-          routes?: Array<{ id?: string; invocable?: boolean }>;
-        };
-      })
-      .then((payload) => {
-        if (controller.signal.aborted) return;
-        const next = new Set<string>();
-        for (const model of payload.models ?? []) {
-          if (!model.invocable) continue;
-          if (model.profile_id) next.add(model.profile_id);
-          if (model.invocation_id) next.add(model.invocation_id);
-          if (model.root) next.add(model.root);
-        }
-        for (const route of payload.routes ?? []) {
-          if (route.invocable && route.id) next.add(route.id);
-        }
-        setInvocableModelIds(next);
-      })
-      .catch(() => {
-        if (!controller.signal.aborted) setInvocableModelIds(null);
-      });
-    return () => controller.abort();
-  }, []);
-
-  const callableModels = useMemo(
+  const selectableModels = useMemo(
     () => chatModelOptions.filter(
-      (model) => model.interaction_status === "ready" && invocableModelIds?.has(model.id),
+      (model) => model.interaction_status === "ready",
     ),
-    [invocableModelIds],
+    [],
   );
   const visibleCategories = useMemo(() => {
     const normalized = query.trim().toLowerCase();
@@ -205,9 +174,9 @@ export default function PromptTemplateLibrary() {
           <span className="sr-only">搜索模板</span>
           <input className="h-12 w-full rounded-xl border border-white/10 bg-[#0a1423] px-4 text-sm text-white outline-none placeholder:text-slate-500 focus:border-[#ffb45e]/60" onChange={(event) => setQuery(event.target.value)} placeholder="搜索模板或使用场景" type="search" value={query} />
         </label>
-        <TargetModelPicker
-          available={invocableModelIds !== null}
-          models={callableModels}
+          <TargetModelPicker
+            available
+            models={selectableModels}
           onChange={(modelId) => {
             setTargetModelId(modelId);
             setNotice("");

--- a/client/src/components/settings/ModelServiceConnections.test.tsx
+++ b/client/src/components/settings/ModelServiceConnections.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ModelServiceConnections from "./ModelServiceConnections";
+
+describe("ModelServiceConnections editing", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("keeps the stored secret when blank and re-tests the edited connection", async () => {
+    const connection = {
+      id: "connection-1",
+      name: "newAPI",
+      kind: "newapi",
+      base_url: "https://provider.example/v1",
+      masked_key: "****cret",
+      scopes: ["chat"],
+      enabled: true,
+      health: "online",
+      model_count: 2,
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === "/api/router/connections" && !init?.method) return new Response(JSON.stringify([connection]), { status: 200 });
+      if (url === "/api/router/connections/connection-1" && init?.method === "PATCH") return new Response(JSON.stringify(connection), { status: 200 });
+      if (url === "/api/router/connections/connection-1/test" && init?.method === "POST") return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      if (url.includes("/certifications")) return new Response(JSON.stringify({ enabled: true, certifications: [] }), { status: 200 });
+      if (url.includes("/canaries")) return new Response(JSON.stringify({ feature_enabled: false, connections: [], runs: [], aggregates: [] }), { status: 200 });
+      return new Response(null, { status: 404 });
+    });
+
+    render(<ModelServiceConnections csrfToken="csrf-test" />);
+    fireEvent.click(await screen.findByRole("button", { name: "编辑" }));
+    fireEvent.change(screen.getByLabelText("连接名称"), { target: { value: "更新后的 newAPI" } });
+    fireEvent.click(screen.getByRole("button", { name: "保存修改并测试" }));
+
+    await waitFor(() => expect(fetchMock.mock.calls.some(([input, init]) => String(input) === "/api/router/connections/connection-1/test" && init?.method === "POST")).toBe(true));
+    const patchCall = fetchMock.mock.calls.find(([input, init]) => String(input) === "/api/router/connections/connection-1" && init?.method === "PATCH");
+    expect(JSON.parse(String(patchCall?.[1]?.body))).toEqual({
+      name: "更新后的 newAPI",
+      base_url: "https://provider.example/v1",
+      scopes: ["chat"],
+    });
+  });
+
+  it("explains why OpenRouter has no billed Chat certification action", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            id: "connection-openrouter",
+            name: "OpenRouter",
+            kind: "openrouter",
+            base_url: "https://openrouter.ai/api/v1",
+            masked_key: "****test",
+            scopes: ["chat", "audio"],
+            enabled: true,
+            health: "online",
+            model_count: 419,
+          },
+        ]),
+        { status: 200 },
+      ),
+    );
+
+    render(<ModelServiceConnections csrfToken="csrf-test" />);
+
+    expect(
+      await screen.findByText(/Chat 契约认证首期仅支持 newAPI/),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "运行 Chat 认证" }),
+    ).toBeNull();
+  });
+});

--- a/client/src/components/settings/ModelServiceConnections.tsx
+++ b/client/src/components/settings/ModelServiceConnections.tsx
@@ -151,11 +151,15 @@ export default function ModelServiceConnections({
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [error, setError] = useState("");
 
   const provider = PROVIDERS[form.kind];
   const canTest = Boolean(
     form.name.trim() && form.base_url.trim() && form.api_key.trim(),
+  );
+  const canSaveEdit = Boolean(
+    editingId && form.name.trim() && form.base_url.trim() && form.scopes.length,
   );
 
   const loadConnections = useCallback(async () => {
@@ -263,6 +267,65 @@ export default function ModelServiceConnections({
     }
   }, [csrfToken, loadConnections, payload, testResult]);
 
+  const beginEdit = useCallback((connection: RouterConnection) => {
+    setEditingId(connection.id);
+    setForm({
+      kind: connection.kind,
+      name: connection.name,
+      base_url: connection.base_url,
+      api_key: "",
+      scopes: scopesForConnection(connection),
+    });
+    setTestResult(null);
+    setError("");
+  }, []);
+
+  const cancelEdit = useCallback(() => {
+    setEditingId(null);
+    setForm(INITIAL_FORM);
+    setTestResult(null);
+    setError("");
+  }, []);
+
+  const saveEditedConnection = useCallback(async () => {
+    if (!editingId || !canSaveEdit) return;
+    setSaving(true);
+    setError("");
+    try {
+      const updatePayload: Record<string, unknown> = {
+        name: form.name.trim(),
+        base_url: form.base_url.trim(),
+        scopes: form.scopes,
+      };
+      if (form.api_key.trim()) updatePayload.api_key = form.api_key;
+      const updated = await fetch(
+        `/api/router/connections/${encodeURIComponent(editingId)}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            "X-ModelMirror-CSRF": csrfToken,
+          },
+          body: JSON.stringify(updatePayload),
+        },
+      );
+      if (!updated.ok) throw new Error(await readError(updated));
+      const tested = await fetch(
+        `/api/router/connections/${encodeURIComponent(editingId)}/test`,
+        { method: "POST", headers: { "X-ModelMirror-CSRF": csrfToken } },
+      );
+      if (!tested.ok) throw new Error(await readError(tested));
+      setEditingId(null);
+      setForm(INITIAL_FORM);
+      await loadConnections();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "连接修改未完成。");
+      await loadConnections();
+    } finally {
+      setSaving(false);
+    }
+  }, [canSaveEdit, csrfToken, editingId, form, loadConnections]);
+
   const testSavedConnection = useCallback(
     async (connectionId: string) => {
       setBusyId(connectionId);
@@ -357,7 +420,8 @@ export default function ModelServiceConnections({
           className="space-y-5 border-b border-white/10 p-5 lg:border-b-0 lg:border-r"
           onSubmit={(event) => {
             event.preventDefault();
-            void testNewConnection();
+            if (editingId) void saveEditedConnection();
+            else void testNewConnection();
           }}
         >
           <label className="block">
@@ -366,6 +430,7 @@ export default function ModelServiceConnections({
             </span>
             <select
               className="w-full rounded-lg border border-white/15 bg-slate-950 px-3 py-2.5 text-sm text-white outline-none transition focus:border-cyan-300/60"
+              disabled={editingId !== null}
               onChange={(event) =>
                 selectProvider(event.target.value as ConnectionKind)
               }
@@ -413,7 +478,7 @@ export default function ModelServiceConnections({
                 autoComplete="new-password"
                 className="w-full rounded-lg border border-white/15 bg-slate-950 px-3 py-2.5 text-sm text-white outline-none transition placeholder:text-slate-500 focus:border-cyan-300/60"
                 onChange={(event) => updateForm({ api_key: event.target.value })}
-                placeholder="仅发送到本机后端"
+                placeholder={editingId ? "留空以保留现有密钥" : "仅发送到本机后端"}
                 type="password"
                 value={form.api_key}
               />
@@ -473,7 +538,7 @@ export default function ModelServiceConnections({
           <div className="flex flex-wrap gap-3">
             <button
               className="inline-flex items-center justify-center gap-2 rounded-full border border-cyan-300/30 bg-cyan-300/10 px-4 py-2 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-300/18 disabled:cursor-not-allowed disabled:opacity-45"
-              disabled={!canTest || testing || saving}
+              disabled={editingId ? !canSaveEdit || saving : !canTest || testing || saving}
               type="submit"
             >
               {testing ? (
@@ -481,16 +546,18 @@ export default function ModelServiceConnections({
               ) : (
                 <Plug className="h-4 w-4" />
               )}
-              测试连接
+              {editingId ? "保存修改并测试" : "测试连接"}
             </button>
-            <button
+            {editingId ? (
+              <button className="rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-slate-200" disabled={saving} onClick={cancelEdit} type="button">取消编辑</button>
+            ) : <button
               className="rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:opacity-45"
               disabled={!testResult?.ok || saving || testing}
               onClick={() => void saveConnection()}
               type="button"
             >
               {saving ? "正在保存" : "保存连接"}
-            </button>
+            </button>}
           </div>
         </form>
 
@@ -570,9 +637,21 @@ export default function ModelServiceConnections({
                           connectionId={connection.id}
                           csrfToken={csrfToken}
                         />
+                      ) : scopesForConnection(connection).includes("chat") ? (
+                        <p className="mt-3 rounded-lg border border-amber-300/15 bg-amber-300/[0.06] px-3 py-2 text-xs leading-5 text-amber-100">
+                          Chat 契约认证首期仅支持 newAPI。此连接当前只提供连通性与目录证据，不会标记为已完成真实 Chat 认证。
+                        </p>
                       ) : null}
                     </div>
                     <div className="flex shrink-0 gap-2">
+                      <button
+                        className="rounded-full border border-white/15 px-3 py-1.5 text-xs font-medium text-slate-200 transition hover:bg-white/[0.07] disabled:opacity-45"
+                        disabled={busyId === connection.id || editingId === connection.id}
+                        onClick={() => beginEdit(connection)}
+                        type="button"
+                      >
+                        编辑
+                      </button>
                       <button
                         className="rounded-full border border-white/15 px-3 py-1.5 text-xs font-medium text-slate-200 transition hover:bg-white/[0.07] disabled:opacity-45"
                         disabled={!connection.enabled || busyId === connection.id}

--- a/client/src/components/settings/ProviderCatalogPanel.tsx
+++ b/client/src/components/settings/ProviderCatalogPanel.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { LoaderCircle, RefreshCw } from "lucide-react";
+
+interface Connection {
+  id: string;
+  name: string;
+  kind: string;
+  enabled: boolean;
+  health: string;
+  model_count: number;
+}
+
+interface Offering {
+  connection_id: string;
+  connection_name: string;
+  model_id: string;
+  operation: string;
+  inventory_status: string;
+  verification_status: string;
+  invocable: boolean;
+  stale: boolean;
+}
+
+async function readError(response: Response) {
+  try {
+    const payload = await response.json();
+    return payload?.detail?.message ?? payload?.detail ?? "目录操作未完成。";
+  } catch {
+    return "目录操作未完成。";
+  }
+}
+
+export default function ProviderCatalogPanel({ csrfToken }: { csrfToken: string }) {
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [offerings, setOfferings] = useState<Offering[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const [connectionsResponse, offeringsResponse] = await Promise.all([
+        fetch("/api/router/connections"),
+        fetch("/api/router/catalog/offerings?limit=100"),
+      ]);
+      if (!connectionsResponse.ok) throw new Error(await readError(connectionsResponse));
+      if (!offeringsResponse.ok) throw new Error(await readError(offeringsResponse));
+      setConnections((await connectionsResponse.json()) as Connection[]);
+      setOfferings(((await offeringsResponse.json()) as { offerings?: Offering[] }).offerings ?? []);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "无法读取 Provider Catalog。");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const offeringsByConnection = useMemo(() => {
+    const grouped = new Map<string, Offering[]>();
+    for (const item of offerings) grouped.set(item.connection_id, [...(grouped.get(item.connection_id) ?? []), item]);
+    return grouped;
+  }, [offerings]);
+
+  const refresh = useCallback(async (connection: Connection) => {
+    setBusyId(connection.id);
+    setError("");
+    setNotice("");
+    try {
+      const response = await fetch(`/api/router/connections/${encodeURIComponent(connection.id)}/catalog/refresh`, {
+        method: "POST",
+        headers: { "X-ModelMirror-CSRF": csrfToken },
+      });
+      if (!response.ok) throw new Error(await readError(response));
+      const payload = await response.json() as { model_count?: number; truncated?: boolean };
+      setNotice(`${connection.name} 已发现 ${payload.model_count ?? 0} 个模型${payload.truncated ? "；结果已截断，旧目录未退休" : ""}。该检查不会发起 Chat。`);
+      await load();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "目录刷新失败。");
+    } finally {
+      setBusyId(null);
+    }
+  }, [csrfToken, load]);
+
+  return (
+    <section className="mb-6 overflow-hidden rounded-lg border border-white/10 bg-ink-950/82 shadow-prism">
+      <div className="border-b border-white/10 bg-white/[0.035] px-5 py-4">
+        <h2 className="text-xl font-semibold text-white">Provider Inventory</h2>
+        <p className="mt-1 text-sm text-slate-400">显式读取模型目录并生成运行时 Inventory；不会认证模型、改变路由或产生 Chat 费用。</p>
+      </div>
+      <div className="space-y-4 p-5">
+        {error ? <p className="rounded-lg border border-rose-300/20 bg-rose-300/10 p-3 text-sm text-rose-100" role="alert">{error}</p> : null}
+        {notice ? <p className="rounded-lg border border-emerald-300/20 bg-emerald-300/10 p-3 text-sm text-emerald-100" role="status">{notice}</p> : null}
+        {loading ? <p className="text-sm text-slate-300"><LoaderCircle className="mr-2 inline h-4 w-4 animate-spin" />正在读取 Inventory…</p> : connections.map((connection) => {
+          const rows = offeringsByConnection.get(connection.id) ?? [];
+          return (
+            <article className="rounded-lg border border-white/10 bg-white/[0.025] p-4" key={connection.id}>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="font-semibold text-white">{connection.name}</p>
+                  <p className="mt-1 text-xs text-slate-400">{connection.kind} · {connection.health} · {rows.length || connection.model_count} 条模型证据</p>
+                </div>
+                <button className="inline-flex items-center justify-center gap-2 rounded-full border border-cyan-300/25 bg-cyan-300/10 px-4 py-2 text-sm font-semibold text-cyan-100 disabled:opacity-45" disabled={busyId !== null} onClick={() => void refresh(connection)} type="button">
+                  <RefreshCw className={`h-4 w-4 ${busyId === connection.id ? "animate-spin" : ""}`} />
+                  {busyId === connection.id ? "正在刷新" : "刷新目录"}
+                </button>
+              </div>
+              {rows.length ? (
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {rows.slice(0, 12).map((row) => <span className="rounded-full border border-white/10 bg-white/[0.045] px-3 py-1 text-xs text-slate-300" key={`${row.model_id}:${row.operation}`}>{row.model_id} · {row.operation} · {row.invocable ? "可调用" : row.verification_status}</span>)}
+                  {rows.length > 12 ? <span className="px-2 py-1 text-xs text-slate-500">另有 {rows.length - 12} 条</span> : null}
+                </div>
+              ) : <p className="mt-3 text-sm text-slate-400">尚无 v14 Inventory；请人工刷新。</p>}
+            </article>
+          );
+        })}
+        {!loading && connections.length === 0 ? <p className="text-sm text-slate-400">请先在上方创建 Provider 连接。</p> : null}
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/settings/ProviderControlPlaneOverview.tsx
+++ b/client/src/components/settings/ProviderControlPlaneOverview.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from "react";
+import { Activity, CircleAlert, Database, Server } from "lucide-react";
+
+interface OperationCount {
+  operation: string;
+  total: number;
+  invocable: number;
+  stale: number;
+  blocked: number;
+}
+
+interface Overview {
+  provider_count: number;
+  online_provider_count: number;
+  discovered_model_count: number;
+  stale_model_count: number;
+  operation_counts: OperationCount[];
+  blocking_reason_codes: string[];
+  default_qualification: "not_evaluated";
+}
+
+interface RuntimeEnvironmentSummary {
+  llm_gateway_configured: boolean;
+  openrouter_configured: boolean;
+  model_gateway_ready: boolean;
+}
+
+const REASON_LABELS: Record<string, string> = {
+  provider_not_configured: "尚未配置 Provider",
+  provider_not_online: "没有已连通的 Provider",
+  catalog_not_available: "尚未生成运行时目录",
+  catalog_contains_stale_evidence: "目录包含过期证据",
+};
+
+const OPERATION_LABELS: Record<string, string> = {
+  chat: "文本 Chat",
+  analyze_image: "图像理解",
+  generate_image: "图像生成",
+  transcribe: "语音转写",
+  synthesize_speech: "语音合成",
+  realtime_voice: "实时语音",
+  analyze_video: "视频理解",
+  generate_video: "视频生成",
+  generate_world: "世界生成",
+};
+
+export default function ProviderControlPlaneOverview() {
+  const [overview, setOverview] = useState<Overview | null>(null);
+  const [error, setError] = useState("");
+  const [runtimeEnvironment, setRuntimeEnvironment] = useState<RuntimeEnvironmentSummary | null>(null);
+  const [runtimeEnvironmentUnavailable, setRuntimeEnvironmentUnavailable] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch("/api/router/control-plane/overview", { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) throw new Error("无法读取统一控制面总览。");
+        return (await response.json()) as Overview;
+      })
+      .then((payload) => {
+        if (!controller.signal.aborted) setOverview(payload);
+      })
+      .catch((reason) => {
+        if (!controller.signal.aborted) {
+          setError(reason instanceof Error ? reason.message : "无法读取统一控制面总览。");
+        }
+      });
+    void fetch("/api/runtime/environment-summary", { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) throw new Error("无法读取普通 Chat 环境路径。");
+        return (await response.json()) as RuntimeEnvironmentSummary;
+      })
+      .then((payload) => {
+        if (!controller.signal.aborted) setRuntimeEnvironment(payload);
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setRuntimeEnvironmentUnavailable(true);
+      });
+    return () => controller.abort();
+  }, []);
+
+  if (error) {
+    return <p className="rounded-lg border border-rose-300/20 bg-rose-300/10 p-4 text-sm text-rose-100" role="alert">{error}</p>;
+  }
+  if (!overview) {
+    return <p className="rounded-lg border border-white/10 bg-ink-950/82 p-5 text-sm text-slate-300">正在汇总 Provider、目录与运行准备度…</p>;
+  }
+
+  const metrics = [
+    { label: "Provider", value: `${overview.online_provider_count}/${overview.provider_count}`, hint: "已连通 / 已配置", icon: Server },
+    { label: "运行时模型", value: overview.discovered_model_count, hint: `${overview.stale_model_count} 个目录证据过期`, icon: Database },
+    { label: "可调用 operation", value: overview.operation_counts.reduce((sum, item) => sum + item.invocable, 0), hint: "按模型与 operation 计数", icon: Activity },
+  ];
+
+  const runtimePath = runtimeEnvironment?.llm_gateway_configured
+    ? { value: "LLM Gateway 已配置", hint: "普通 /api/chat 当前仍读取 LLM_GATEWAY_URL / KEY；R4 不改变该路由。", ready: true }
+    : runtimeEnvironment?.openrouter_configured
+      ? { value: "OpenRouter 环境回退", hint: "普通 /api/chat 当前仍读取 OPENROUTER_API_KEY；R4 不改变该路由。", ready: true }
+      : { value: runtimeEnvironmentUnavailable ? "状态读取失败" : "尚未配置", hint: runtimeEnvironmentUnavailable ? "无法读取脱敏环境状态；Provider 控制面仍可独立使用。" : "受管 Provider 只形成控制面证据，不会在 R4 自动接管 /api/chat；Chat 迁移属于 Round 5。", ready: false };
+
+  return (
+    <div className="space-y-5">
+      <div className="grid gap-4 md:grid-cols-3">
+        {metrics.map(({ label, value, hint, icon: Icon }) => (
+          <article className="rounded-lg border border-white/10 bg-ink-950/82 p-5" key={label}>
+            <div className="flex items-center gap-2 text-hire-100"><Icon className="h-4 w-4" /><span className="text-xs font-semibold uppercase tracking-[0.18em]">{label}</span></div>
+            <p className="mt-3 text-3xl font-semibold text-white">{value}</p>
+            <p className="mt-1 text-xs text-slate-400">{hint}</p>
+          </article>
+        ))}
+      </div>
+
+      <section className={`rounded-lg border p-5 ${runtimePath.ready ? "border-emerald-300/20 bg-emerald-300/10" : "border-amber-300/20 bg-amber-300/10"}`}>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className={`text-xs font-semibold uppercase tracking-[0.18em] ${runtimePath.ready ? "text-emerald-100" : "text-amber-100"}`}>当前普通 Chat 环境路径</p>
+            <h2 className="mt-2 text-lg font-semibold text-white">{runtimePath.value}</h2>
+            <p className="mt-1 text-sm leading-6 text-slate-300">{runtimePath.hint}</p>
+          </div>
+          <span className="rounded-full border border-white/10 bg-white/[0.045] px-3 py-1 text-xs text-slate-200">与受管 Provider 分离</span>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-white/10 bg-ink-950/82 p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-white">逐 operation 准备度</h2>
+            <p className="mt-1 text-sm text-slate-400">可发现、可连接、已认证与可试运行分别计算；本页不触发刷新或模型调用。</p>
+          </div>
+          <span className="rounded-full border border-amber-300/25 bg-amber-300/10 px-3 py-1 text-xs text-amber-100">默认数据面资格未评估</span>
+        </div>
+        {overview.operation_counts.length ? (
+          <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {overview.operation_counts.map((item) => (
+              <div className="rounded-lg border border-white/10 bg-white/[0.035] p-4" key={item.operation}>
+                <p className="font-medium text-white">{OPERATION_LABELS[item.operation] ?? item.operation}</p>
+                <p className="mt-2 text-sm text-slate-300"><span className="text-emerald-200">{item.invocable} 可调用</span> · {item.blocked} 阻塞 · {item.stale} 过期</p>
+              </div>
+            ))}
+          </div>
+        ) : <p className="mt-4 text-sm text-slate-400">人工刷新 Provider 目录后，这里会出现逐 operation 证据。</p>}
+      </section>
+
+      {overview.blocking_reason_codes.length ? (
+        <section className="rounded-lg border border-amber-300/20 bg-amber-300/10 p-5">
+          <div className="flex items-center gap-2 text-amber-100"><CircleAlert className="h-4 w-4" /><h2 className="font-semibold">当前阻塞项</h2></div>
+          <ul className="mt-3 space-y-1 text-sm text-amber-50/80">
+            {overview.blocking_reason_codes.map((reason) => <li key={reason}>• {REASON_LABELS[reason] ?? reason}</li>)}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/components/settings/ProviderControlPlanePanels.test.tsx
+++ b/client/src/components/settings/ProviderControlPlanePanels.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ProviderCatalogPanel from "./ProviderCatalogPanel";
+import ProviderControlPlaneOverview from "./ProviderControlPlaneOverview";
+
+describe("Provider Control Plane panels", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders evidence categories without claiming default qualification", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      if (String(input) === "/api/runtime/environment-summary") {
+        return new Response(JSON.stringify({
+          llm_gateway_configured: false,
+          openrouter_configured: false,
+          model_gateway_ready: false,
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        provider_count: 2,
+        online_provider_count: 1,
+        discovered_model_count: 3,
+        stale_model_count: 1,
+        operation_counts: [{ operation: "chat", total: 3, invocable: 1, stale: 1, blocked: 2 }],
+        blocking_reason_codes: ["catalog_contains_stale_evidence"],
+        default_qualification: "not_evaluated",
+      }), { status: 200 });
+    });
+    render(<ProviderControlPlaneOverview />);
+    expect(await screen.findByText("默认数据面资格未评估")).toBeVisible();
+    expect(await screen.findByText("尚未配置")).toBeVisible();
+    expect(screen.getByText(/受管 Provider 只形成控制面证据/)).toBeVisible();
+    expect(screen.getByText(/1 可调用/)).toBeVisible();
+    expect(screen.getByText("• 目录包含过期证据")).toBeVisible();
+  });
+
+  it("refreshes only the explicit Catalog endpoint and never Chat", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === "/api/router/connections") return new Response(JSON.stringify([{ id: "connection-1", name: "newAPI", kind: "newapi", enabled: true, health: "online", model_count: 0 }]), { status: 200 });
+      if (url.startsWith("/api/router/catalog/offerings")) return new Response(JSON.stringify({ offerings: [] }), { status: 200 });
+      if (url.endsWith("/catalog/refresh") && init?.method === "POST") return new Response(JSON.stringify({ model_count: 2, truncated: false }), { status: 200 });
+      return new Response(null, { status: 404 });
+    });
+    render(<ProviderCatalogPanel csrfToken="csrf-test" />);
+    fireEvent.click(await screen.findByRole("button", { name: "刷新目录" }));
+    expect(await screen.findByText(/已发现 2 个模型/)).toBeVisible();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/router/connections/connection-1/catalog/refresh",
+      expect.objectContaining({ method: "POST", headers: { "X-ModelMirror-CSRF": "csrf-test" } }),
+    );
+    await waitFor(() => expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/api/chat"))).toBe(false));
+  });
+});

--- a/client/src/data/models.refresh.test.ts
+++ b/client/src/data/models.refresh.test.ts
@@ -60,6 +60,7 @@ describe("OpenRouter model refresh", () => {
     expect(counted.filter((model) => model.catalog_status === "live")).toHaveLength(491);
     expect(counted.filter((model) => model.catalog_status === "uncertain")).toHaveLength(55);
     expect(counted.filter((model) => model.catalog_status === "expired")).toHaveLength(6);
+    expect(counted.filter((model) => model.catalog_status !== "expired")).toHaveLength(546);
   });
 
   it("restores V4 Flash ahead of V4 Pro and keeps Seedream in row four", () => {

--- a/client/src/pages/ModelListPage.layout.test.tsx
+++ b/client/src/pages/ModelListPage.layout.test.tsx
@@ -12,10 +12,10 @@ describe("ModelMarketHero", () => {
 
     render(
       <ModelMarketHero
+        adaptedCount={17}
         onsiteCount={24}
         onSearchChange={onSearchChange}
         searchTerm="vision"
-        usableCount={15}
       />,
     );
 
@@ -27,9 +27,10 @@ describe("ModelMarketHero", () => {
     ).toBeInTheDocument();
     const status = screen.getByLabelText("模型市场状态");
     expect(status).toHaveTextContent("24 个模型");
-    expect(status).toHaveTextContent("15 可直接调用");
+    expect(status).toHaveTextContent("17 已适配");
+    expect(status).not.toHaveTextContent("可直接调用");
+    expect(status).not.toHaveTextContent("可调用数待确认");
     expect(status).not.toHaveTextContent("岗位要求");
-    expect(status).not.toHaveTextContent("已适配");
 
     const search = screen.getByRole("searchbox");
     expect(search).toHaveClass("h-12");
@@ -40,20 +41,6 @@ describe("ModelMarketHero", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not report a false zero while realtime invocation status is unavailable", () => {
-    render(
-      <ModelMarketHero
-        onsiteCount={24}
-        onSearchChange={vi.fn()}
-        searchTerm=""
-        usableCount={null}
-      />,
-    );
-
-    const status = screen.getByLabelText("模型市场状态");
-    expect(status).toHaveTextContent("可调用数待确认");
-    expect(status).not.toHaveTextContent("0 可直接调用");
-  });
 });
 
 describe("model market recommendation layout", () => {

--- a/client/src/pages/ModelListPage.tsx
+++ b/client/src/pages/ModelListPage.tsx
@@ -253,21 +253,17 @@ interface GeneralCatalogPayload {
   }>;
 }
 
-interface RuntimeEnvironmentSummary {
-  model_gateway_ready: boolean;
-}
-
 interface ModelMarketHeroProps {
+  adaptedCount: number;
   onsiteCount: number;
   searchTerm: string;
-  usableCount: number | null;
   onSearchChange: (value: string) => void;
 }
 
 export function ModelMarketHero({
+  adaptedCount,
   onsiteCount,
   searchTerm,
-  usableCount,
   onSearchChange,
 }: ModelMarketHeroProps) {
   return (
@@ -296,13 +292,7 @@ export function ModelMarketHero({
         <p aria-label="模型市场状态" className="shrink-0 text-xs text-slate-400">
           <span className="font-semibold text-slate-100">{onsiteCount}</span> 个模型
           <span aria-hidden="true" className="mx-2 text-hire-300/70">/</span>
-          {usableCount === null ? (
-            <span className="font-medium text-cyan-100">可调用数待确认</span>
-          ) : (
-            <>
-              <span className="font-semibold text-cyan-100">{usableCount}</span> 可直接调用
-            </>
-          )}
+          <span className="font-semibold text-cyan-100">{adaptedCount}</span> 已适配
         </p>
       </div>
 
@@ -340,8 +330,6 @@ export default function ModelListPage() {
     useState<GeneralCatalogPayload | null>(null);
   const [fileCapabilities, setFileCapabilities] =
     useState<FileCapabilitiesResponse | null>(null);
-  const [runtimeEnvironment, setRuntimeEnvironment] =
-    useState<RuntimeEnvironmentSummary | null>(null);
 
   useEffect(() => {
     document.title = "模镜 - AI 牛马招聘会";
@@ -429,26 +417,6 @@ export default function ModelListPage() {
       .catch(() => {
         if (!controller.signal.aborted) {
           setGeneralCatalog(null);
-        }
-      });
-
-    void fetch("/api/runtime/environment-summary", {
-      signal: controller.signal,
-    })
-      .then(async (response) => {
-        if (!response.ok) {
-          throw new Error("runtime environment unavailable");
-        }
-        return (await response.json()) as RuntimeEnvironmentSummary;
-      })
-      .then((payload) => {
-        if (!controller.signal.aborted) {
-          setRuntimeEnvironment(payload);
-        }
-      })
-      .catch(() => {
-        if (!controller.signal.aborted) {
-          setRuntimeEnvironment(null);
         }
       });
 
@@ -806,29 +774,11 @@ export default function ModelListPage() {
   const onsiteModels = models.filter(
     (model) => model.catalog_counted,
   );
-  const onsiteFilteredModels = filteredModels.filter(
-    (model) =>
-      model.catalog_counted && model.catalog_status !== "expired",
+  // Public "adapted" means the snapshot is integrated and not expired.
+  // Runtime invocability remains a Provider Control Plane concern.
+  const adaptedModels = onsiteModels.filter(
+    (model) => model.catalog_status !== "expired",
   );
-  const usableFilteredCount = onsiteFilteredModels.filter(
-    (model) =>
-      invocableModelIds.has(model.id) ||
-      (
-        model.active &&
-        runtimeEnvironment?.model_gateway_ready === true &&
-        model.interaction_status === "ready" &&
-        (model.ui_entrypoint === "chat" || model.ui_entrypoint === "rag")
-      ) ||
-      Boolean(confirmedAudioOperations.get(model.id)?.length) ||
-      Boolean(confirmedImageOperations.get(model.id)?.length) ||
-      Boolean(confirmedVideoOperations.get(model.id)?.length),
-  ).length;
-  const usableCountKnown =
-    generalCatalog !== null ||
-    runtimeEnvironment !== null ||
-    videoCatalog !== null ||
-    audioCatalog !== null ||
-    imageCatalog !== null;
   const showFeaturedRecommendations = shouldShowFeaturedRecommendations(
     filters,
     searchTerm,
@@ -872,10 +822,10 @@ export default function ModelListPage() {
       sidebarGridClassName="xl:grid-cols-[230px_minmax(0,1fr)] xl:gap-x-[54px]"
     >
         <ModelMarketHero
+          adaptedCount={adaptedModels.length}
           onsiteCount={onsiteModels.length}
           onSearchChange={setSearchTerm}
           searchTerm={searchTerm}
-          usableCount={usableCountKnown ? usableFilteredCount : null}
         />
 
         <section className="mt-4">

--- a/client/src/pages/SystemSettingsPage.test.tsx
+++ b/client/src/pages/SystemSettingsPage.test.tsx
@@ -1,74 +1,66 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import SystemSettingsPage, { resolveNewApiConsoleUrl } from "./SystemSettingsPage";
 
-vi.mock("../components/PageContainer", () => ({
-  default: ({ children }: { children: ReactNode }) => <main>{children}</main>,
-}));
-vi.mock("../components/settings/ModelServiceConnections", () => ({
-  default: () => <div>connections</div>,
-}));
-vi.mock("../components/settings/MarbleConnectionSettings", () => ({
-  default: () => <div>marble</div>,
-}));
-vi.mock("../components/settings/SmartRoutingSettings", () => ({
-  default: () => <div>routing</div>,
-}));
-vi.mock("../components/settings/ProviderAdminGate", () => ({
-  default: ({
-    children,
-  }: {
-    children: (session: { csrfToken: string }) => ReactNode;
-  }) => <>{children({ csrfToken: "test-csrf" })}</>,
-}));
+const adminState = vi.hoisted(() => ({ unlocked: true }));
+
+vi.mock("../components/PageContainer", () => ({ default: ({ children }: { children: ReactNode }) => <main>{children}</main> }));
+vi.mock("../components/settings/ModelServiceConnections", () => ({ default: () => <div>connections</div> }));
+vi.mock("../components/settings/MarbleConnectionSettings", () => ({ default: () => <div>marble</div> }));
+vi.mock("../components/settings/ProviderCatalogPanel", () => ({ default: () => <div>inventory</div> }));
+vi.mock("../components/settings/ProviderControlPlaneOverview", () => ({ default: () => <div>overview panel</div> }));
+vi.mock("../components/settings/SmartRoutingSettings", () => ({ default: () => <div>routing</div> }));
+vi.mock("../components/settings/ProviderAdminGate", () => ({ default: ({ children }: { children: (session: { csrfToken: string }) => ReactNode }) => adminState.unlocked ? <>{children({ csrfToken: "test-csrf" })}</> : <div>admin locked</div> }));
+
+function renderPage(entry = "/settings") {
+  return render(<MemoryRouter initialEntries={[entry]}><SystemSettingsPage /></MemoryRouter>);
+}
 
 describe("SystemSettingsPage", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
+  afterEach(() => { vi.unstubAllGlobals(); adminState.unlocked = true; });
 
   it("accepts only safe external console URLs", () => {
     expect(resolveNewApiConsoleUrl(undefined)).toBeNull();
     expect(resolveNewApiConsoleUrl("javascript:alert(1)")).toBeNull();
     expect(resolveNewApiConsoleUrl("https://user:secret@example.com")).toBeNull();
     expect(resolveNewApiConsoleUrl("https://example.com/?token=secret")).toBeNull();
-    expect(resolveNewApiConsoleUrl("https://console.example.com/admin")?.host).toBe(
-      "console.example.com",
-    );
+    expect(resolveNewApiConsoleUrl("https://console.example.com/admin")?.host).toBe("console.example.com");
   });
 
-  it("loads a safe runtime management URL without embedding the console", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ newApiWebUrl: "http://127.0.0.1:3000" }),
-      }),
-    );
-
-    render(<SystemSettingsPage />);
+  it("uses URL-backed tabs while preserving every existing settings module", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ newApiWebUrl: "http://127.0.0.1:3000" }) }));
+    renderPage();
+    expect(screen.getByText("overview panel")).toBeVisible();
+    expect(screen.getByText("marble")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: /Provider 与 Catalog/ }));
+    expect(screen.getByText("connections")).toBeVisible();
+    expect(screen.getByText("inventory")).toBeVisible();
     const link = await screen.findByRole("link", { name: "在新窗口管理" });
     expect(link).toHaveAttribute("href", "http://127.0.0.1:3000/");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
-    expect(screen.getByText("外部管理入口已配置")).toBeVisible();
     expect(document.querySelector("iframe")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /路由与实验/ }));
+    expect(screen.getByText("routing")).toBeVisible();
+    expect(screen.getByText("marble")).toBeVisible();
   });
 
-  it("shows an actionable runtime configuration instruction when unset", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ newApiWebUrl: "" }),
-      }),
-    );
+  it("opens the requested section and keeps Marble outside the admin content", () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ newApiWebUrl: "" }) }));
+    renderPage("/settings?section=routing");
+    expect(screen.getByText("routing")).toBeVisible();
+    expect(screen.getByText("marble")).toBeVisible();
+    expect(screen.queryByText("connections")).toBeNull();
+  });
 
-    render(<SystemSettingsPage />);
-    expect(await screen.findByText("外部管理入口未配置")).toBeVisible();
-    expect(screen.getByText(/请在 client 服务环境中配置后重启前端容器/)).toBeVisible();
-    expect(document.querySelector("iframe")).toBeNull();
-    expect(screen.queryByRole("link", { name: "在新窗口管理" })).toBeNull();
+  it("keeps Marble usable when Provider administration is locked", () => {
+    adminState.unlocked = false;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ newApiWebUrl: "" }) }));
+    renderPage("/settings?section=providers");
+    expect(screen.getByText("admin locked")).toBeVisible();
+    expect(screen.getByText("marble")).toBeVisible();
+    expect(screen.queryByText("connections")).toBeNull();
   });
 });

--- a/client/src/pages/SystemSettingsPage.tsx
+++ b/client/src/pages/SystemSettingsPage.tsx
@@ -1,137 +1,87 @@
 import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import PageContainer from "../components/PageContainer";
 import ModelServiceConnections from "../components/settings/ModelServiceConnections";
 import MarbleConnectionSettings from "../components/settings/MarbleConnectionSettings";
-import SmartRoutingSettings from "../components/settings/SmartRoutingSettings";
 import ProviderAdminGate from "../components/settings/ProviderAdminGate";
+import ProviderCatalogPanel from "../components/settings/ProviderCatalogPanel";
+import ProviderControlPlaneOverview from "../components/settings/ProviderControlPlaneOverview";
+import SmartRoutingSettings from "../components/settings/SmartRoutingSettings";
 
-function trimTrailingSlash(value: string) {
-  return value.replace(/\/+$/, "");
-}
+type SettingsSection = "overview" | "providers" | "routing";
+const SECTIONS: Array<{ id: SettingsSection; label: string; description: string }> = [
+  { id: "overview", label: "总览", description: "目录与运行准备度" },
+  { id: "providers", label: "Provider 与 Catalog", description: "连接、Inventory 与认证" },
+  { id: "routing", label: "路由与实验", description: "Native 门禁与 Canary" },
+];
+
+function trimTrailingSlash(value: string) { return value.replace(/\/+$/, ""); }
 
 export function resolveNewApiConsoleUrl(value: string | undefined) {
   const configured = trimTrailingSlash(value?.trim() ?? "");
   if (!configured) return null;
   try {
     const url = new URL(configured);
-    if (
-      !["http:", "https:"].includes(url.protocol) ||
-      url.username ||
-      url.password ||
-      url.search ||
-      url.hash
-    ) {
-      return null;
-    }
+    if (!["http:", "https:"].includes(url.protocol) || url.username || url.password || url.search || url.hash) return null;
     return url;
-  } catch {
-    return null;
-  }
+  } catch { return null; }
 }
 
-type RuntimeConfig = {
-  newApiWebUrl?: string;
-};
+function NewApiExternalConsole({ consoleUrl }: { consoleUrl: URL | null }) {
+  return (
+    <section className="overflow-hidden rounded-lg border border-white/10 bg-ink-950/82 shadow-prism">
+      <div className="flex flex-col gap-3 border-b border-white/10 bg-white/[0.035] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-hire-100">newAPI Gateway</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">外部 newAPI 管理入口</h2>
+          <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-400">ModelMirror 不嵌入或代理 newAPI 管理界面。通过客户端容器环境变量 <code className="mx-1 rounded bg-white/10 px-1 py-0.5">NEWAPI_WEB_URL</code> 配置；该状态不代表网关健康。</p>
+        </div>
+        {consoleUrl ? <a className="inline-flex items-center justify-center rounded-full border border-hire-300/30 bg-hire-300/10 px-4 py-2 text-sm font-semibold text-hire-100" href={consoleUrl.toString()} rel="noopener noreferrer" target="_blank">在新窗口管理</a> : null}
+      </div>
+      <div className="grid gap-4 px-5 py-5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+        <div><p className="text-sm font-semibold text-white">{consoleUrl ? "外部管理入口已配置" : "外部管理入口未配置"}</p><p className="mt-1 text-sm leading-6 text-slate-400">{consoleUrl ? `管理主机：${consoleUrl.host}` : "未设置 NEWAPI_WEB_URL；请在 client 服务环境中配置后重启前端容器。ModelMirror 不会猜测或自动加载本地控制台。"}</p></div>
+        <span className="rounded-full border border-white/10 bg-white/[0.045] px-3 py-1.5 text-xs text-slate-300">{consoleUrl ? "仅外链" : "未配置"}</span>
+      </div>
+    </section>
+  );
+}
 
 export default function SystemSettingsPage() {
-  const buildTimeConsoleUrl = useMemo(
-    () => resolveNewApiConsoleUrl(import.meta.env.VITE_NEWAPI_WEB_URL),
-    [],
-  );
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requested = searchParams.get("section");
+  const section: SettingsSection = SECTIONS.some((item) => item.id === requested) ? requested as SettingsSection : "overview";
+  const buildTimeConsoleUrl = useMemo(() => resolveNewApiConsoleUrl(import.meta.env.VITE_NEWAPI_WEB_URL), []);
   const [consoleUrl, setConsoleUrl] = useState<URL | null>(buildTimeConsoleUrl);
 
-  useEffect(() => {
-    document.title = "模镜 - 系统设置";
-  }, []);
-
+  useEffect(() => { document.title = "模镜 - 系统设置"; }, []);
   useEffect(() => {
     let active = true;
-    void fetch("/runtime-config.json", { cache: "no-store" })
-      .then(async (response) => {
-        if (!response.ok) return null;
-        return (await response.json()) as RuntimeConfig;
-      })
-      .then((config) => {
-        if (!active || !config) return;
-        setConsoleUrl(
-          resolveNewApiConsoleUrl(config.newApiWebUrl) ?? buildTimeConsoleUrl,
-        );
-      })
-      .catch(() => {
-        // Vite development and static-only deployments keep the build-time fallback.
-      });
-    return () => {
-      active = false;
-    };
+    void fetch("/runtime-config.json", { cache: "no-store" }).then(async (response) => response.ok ? await response.json() as { newApiWebUrl?: string } : null).then((config) => {
+      if (active && config) setConsoleUrl(resolveNewApiConsoleUrl(config.newApiWebUrl) ?? buildTimeConsoleUrl);
+    }).catch(() => undefined);
+    return () => { active = false; };
   }, [buildTimeConsoleUrl]);
 
   return (
     <PageContainer activeResource="agents" maxWidthClassName="max-w-[1760px]">
       <header className="mb-6 overflow-hidden rounded-lg border border-hire-300/20 bg-[linear-gradient(135deg,rgba(67,20,7,0.74),rgba(6,9,22,0.92)_52%,rgba(8,51,68,0.48))] p-6 shadow-prism">
         <p className="text-sm font-semibold text-hire-100">系统设置</p>
-        <h1 className="mt-3 text-3xl font-semibold text-white sm:text-4xl">
-          模型服务与智能调度
-        </h1>
-        <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-300">
-          在这里完成模型服务连接、Marble 世界生成、智能调度和上下文优化。
-          日常使用无需理解底层网关；外部数据面与 ModelMirror 控制面保持独立。
-        </p>
+        <h1 className="mt-3 text-3xl font-semibold text-white sm:text-4xl">Model Provider Control Plane</h1>
+        <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-300">统一管理模型发现、运行准备度和路由实验；Catalog 统一不改变各模态数据面，也不代表默认 Provider 已切换。</p>
       </header>
 
-      <MarbleConnectionSettings />
-      <ProviderAdminGate>
-        {({ csrfToken }) => (
-          <>
-            <ModelServiceConnections csrfToken={csrfToken} />
-            <SmartRoutingSettings csrfToken={csrfToken} />
-          </>
-        )}
-      </ProviderAdminGate>
+      <section aria-label="Provider Control Plane" className="mb-8">
+        <nav aria-label="Provider 设置分区" className="mb-5 grid gap-2 rounded-lg border border-white/10 bg-ink-950/82 p-2 md:grid-cols-3">
+          {SECTIONS.map((item) => <button aria-current={section === item.id ? "page" : undefined} className={`rounded-lg px-4 py-3 text-left transition ${section === item.id ? "bg-cyan-300/12 text-cyan-100 ring-1 ring-cyan-300/25" : "text-slate-300 hover:bg-white/[0.045]"}`} key={item.id} onClick={() => setSearchParams({ section: item.id }, { replace: true })} type="button"><span className="block text-sm font-semibold">{item.label}</span><span className="mt-1 block text-xs text-slate-400">{item.description}</span></button>)}
+        </nav>
+        <ProviderAdminGate>
+          {({ csrfToken }) => section === "overview" ? <ProviderControlPlaneOverview /> : section === "providers" ? <div><ModelServiceConnections csrfToken={csrfToken} /><ProviderCatalogPanel csrfToken={csrfToken} /><NewApiExternalConsole consoleUrl={consoleUrl} /></div> : <SmartRoutingSettings csrfToken={csrfToken} />}
+        </ProviderAdminGate>
+      </section>
 
-      <section className="overflow-hidden rounded-lg border border-white/10 bg-ink-950/82 shadow-prism">
-        <div className="flex flex-col gap-3 border-b border-white/10 bg-white/[0.035] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-hire-100">
-              newAPI Gateway
-            </p>
-            <h2 className="mt-2 text-2xl font-semibold text-white">
-              外部 newAPI 管理入口
-            </h2>
-            <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-400">
-              ModelMirror 不嵌入或代理 newAPI 管理界面。通过客户端容器环境变量
-              <code className="mx-1 rounded bg-white/10 px-1 py-0.5">
-                NEWAPI_WEB_URL
-              </code>
-              配置后只需重启前端容器，无需重新构建镜像；该状态不代表网关运行健康。
-            </p>
-          </div>
-          {consoleUrl ? (
-            <a
-              className="inline-flex items-center justify-center rounded-full border border-hire-300/30 bg-hire-300/10 px-4 py-2 text-sm font-semibold text-hire-100 transition hover:bg-hire-300/20"
-              href={consoleUrl.toString()}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              在新窗口管理
-            </a>
-          ) : null}
-        </div>
-
-        <div className="grid gap-4 px-5 py-5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
-          <div>
-            <p className="text-sm font-semibold text-white">
-              {consoleUrl ? "外部管理入口已配置" : "外部管理入口未配置"}
-            </p>
-            <p className="mt-1 text-sm leading-6 text-slate-400">
-              {consoleUrl
-                ? `管理主机：${consoleUrl.host}`
-                : "未设置 NEWAPI_WEB_URL；请在 client 服务环境中配置后重启前端容器。ModelMirror 不会猜测或自动加载本地控制台。"}
-            </p>
-          </div>
-          <span className="rounded-full border border-white/10 bg-white/[0.045] px-3 py-1.5 text-xs text-slate-300">
-            {consoleUrl ? "仅外链" : "未配置"}
-          </span>
-        </div>
+      <section aria-labelledby="other-integrations-title">
+        <div className="mb-3"><p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Provider Control Plane 之外</p><h2 className="mt-1 text-xl font-semibold text-white" id="other-integrations-title">其他集成</h2><p className="mt-1 text-sm text-slate-400">以下设置不受 Provider 管理配对状态影响。</p></div>
+        <MarbleConnectionSettings />
       </section>
     </PageContainer>
   );

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 > **文档范围：Current State。** 本文只描述当前主分支中能够由代码、配置和测试定位的已合并实现。AI Capability Compiler、Router Federation、统一 Capability Graph / Evaluation 与自演进闭环属于[目标架构](./architecture/ai-capability-compiler.md)，不能由本文件中的局部 Router、Runtime 或 Evaluation 入口外推为已经完成的平台能力。
 
-最后更新日期：2026-08-13
+最后更新日期：2026-08-21
 维护人：模镜团队
 
 ## 当前定位
@@ -139,6 +139,26 @@ sequenceDiagram
   A-->>C: 文本/图片事件与 route_receipt
   C-->>U: 合帧渲染与最终强制刷新
 ```
+
+### Model Provider Control Plane
+
+Provider Control Plane 是单租户 `local` 的管理与证据层，不是新的统一数据面。
+SQLite v14 保存租户隔离的 Provider Inventory、逐 operation Offering 与脱敏刷新证据；
+Provider 凭据仍使用既有加密存储。显式目录刷新只发送 `/models` GET，并与连接健康、
+Inventory 和 Offering 在同一事务提交。
+
+`GET /api/models/control-plane-catalog` 将 managed Inventory、static/default、OmniRoute、
+Chat certification、显式 newAPI Canary 和多模态专用目录的已有证据聚合为只读 Readiness。
+该查询不刷新上游、不发起 Chat，也不改变 default、Native 或 Canary 调度。现有普通目录、
+多模态目录和各专用调用 API 保持兼容；统一 Catalog 不代表调用协议、默认 Provider 或
+计费控制面已经统一。
+
+公共 `/models` 与 Prompt 模型选择器仍使用原有静态快照和适配口径，不消费运行时
+`invocable`，也不展示仅由 Provider 发现的模型；运行时 Readiness 只在设置控制面审计。
+普通 `/api/chat` 在 R4 仍使用既有环境配置路径，受管 Provider 的数据面迁移属于 Round 5。
+
+`/settings?section=overview|providers|routing` 共用一份 Provider 管理会话。Marble 等其他
+集成位于该门禁之外；newAPI 管理 UI 继续只通过安全外链访问，不嵌入或代理。
 
 ### 本地知识流水线
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # 部署与运维指南
 
-最后更新日期：2026-08-13
+最后更新日期：2026-08-21
 维护人：模镜团队
 
 ## 支持边界
@@ -96,6 +96,40 @@ docker compose -f docker-compose.yml `
 `127.0.0.1:3000`，并复用 `${MODELMIRROR_DATA_ROOT}/new-api-data`。停止或回退
 ModelMirror 不得删除该目录。newAPI 上游为带附加条款的 AGPLv3 项目；本仓库不
 嵌入或修改其管理 UI，部署者仍需自行完成许可证与业务使用合规审查。
+
+### Provider Control Plane 与 v14 Catalog
+
+Provider 管理面仍需外部注入至少 32 字符的
+`MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET` 和规范凭据主密钥。升级到 SQLite v14
+前，先停止 Server 写入并使用 SQLite Backup API 或等价一致性方式备份 Router 数据库，
+同时保留旧主密钥；不得复制正在写入的数据库文件充当一致性备份。
+
+设置入口为：
+
+```text
+/settings?section=overview
+/settings?section=providers
+/settings?section=routing
+```
+
+管理员在 Provider 页执行“刷新目录”只会对该连接发送一次受 SSRF/DNS pinning 保护的
+模型目录 GET，不会发起 Chat、认证或付费调用。刷新失败或返回截断目录时，最后一次成功
+Inventory 会保留并标记 stale；不要通过删除 Router SQLite 来处理目录异常。
+
+受管 Provider 连接与普通 `/api/chat` 当前使用的环境路径相互独立。R4 不会把设置页中的
+OpenRouter 或 newAPI 连接自动转成 `LLM_GATEWAY_URL/KEY`；迁移属于 Round 5。若公网
+Provider 被报告为受保护网络，先检查容器内 DNS。VPN 的 Fake-IP 模式可能把公网域名解析
+到 `198.18.0.0/15` 等保留地址，安全出口会按设计拒绝；应让容器解析到真实公网地址，
+不得将保留地址加入内网白名单或降低 SSRF 规则。
+
+只读检查可使用：
+
+```bash
+curl -H "Cache-Control: no-cache" "http://localhost:8000/api/models/control-plane-catalog?include_unavailable=true&limit=200"
+```
+
+该接口描述当前发现与 Readiness，不是 liveness、默认 Provider 资格或计费账本。回退旧
+代码时保留 v14 表；旧版本可忽略这些加法表，无需降级或重写数据库。
 
 规则：
 

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -1,8 +1,8 @@
 # Model Provider Control Plane
 
-状态：Round 0–3 建设批准，Round 3 真实额度验收及默认数据面切换未批准
-Round 3 基线：`origin/main@0e0202b313b2378d13d899cf53166665baac6bee`
-更新日期：2026-08-20
+状态：Round 0–3 已合并且 Round 3 真实 Canary 已人工验收；Round 4 候选处于 PR 提交前收尾；默认数据面切换未批准
+Round 4 收尾基线：`origin/main@4f942f73149ea33a81df795b4035c37f9b49fe64`
+更新日期：2026-08-21
 
 ## 决策
 
@@ -31,6 +31,8 @@ Provider Control Plane 的会话、SQLite 或主密钥。它只加入独立外�
   SSE 或路由回执，也不产生影子复制流量。
 - Round 3 只增加用户显式、页面会话级的 `newapi_canary`；默认关闭，不做百分比灰度、
   影子复制、自动切流或默认资格判定。
+- Round 4 统一模型发现、Readiness 投影和 Provider 设置入口，不统一各模态调用协议，
+  不触发自动刷新、自动认证、自动路由或付费请求。
 - newAPI 是否成为强制默认数据面由后续独立决策决定。
 - 任一门禁失败时保留现有静态数据面和 SQLite，不自动迁移或删除数据。
 
@@ -122,11 +124,39 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
   过期认证下的运行保留为明确标记的历史证据，不计入当前成功率。该汇总只覆盖接口返回的
   最近记录，不能解释为全量历史或默认数据面资格。
 - 受管端点与当前静态默认端点相同时标记 `baseline_overlap`；该运行只证明受管路径，不能
-  作为未来默认资格证据。每次真实额度 Canary 仍需单独授权和人工验收。
+  作为未来默认资格证据。Round 3 已在明确额度授权后完成一次真实人工验收；后续每次
+  真实额度 Canary 仍需单独授权和人工验收。
+
+## 统一 Catalog、Readiness 与设置入口
+
+- 内部与公共契约版本为 `modelmirror-provider-catalog-v1`。`CatalogModel`、连接级
+  `ProviderInventoryRecord`、逐 operation 的 `ProviderOffering` 与只读
+  `OperationReadinessProjection` 分离；不得按模型名称推断 operation、价格或兼容性。
+- SQLite v14 加法新增刷新、Inventory 和 Offering 表，所有唯一键包含 `tenant_id`。
+  完整未截断刷新才会退休未再次出现的旧模型；失败或截断只将旧证据标为 stale，
+  不删除最后一次成功目录。遗留 `running` 在重启后变为 `uncertain`，不会重放。
+- `POST /api/router/connections/{id}/catalog/refresh` 只执行显式模型目录 GET。连接健康、
+  Inventory、Offering 与刷新证据在同一事务提交；旧 `/models/refresh` 委托同一服务并
+  保留原有最多 500 个 ID 的响应契约。
+- 公共 `GET /api/models/control-plane-catalog` 按模型、operation 和 access mode 返回
+  目录出现、连接状态、认证、Canary 与专用数据面的聚合证据。响应不包含 tenant、连接
+  ID、Base URL、凭据或内部错误，并设置 `Cache-Control: no-store`。
+- Readiness 是只读现状投影。Chat 认证只证明 Chat；Canary 只增加
+  `newapi_canary` access mode；任一可调用 Offering 可以令 operation 可调用，但冲突、
+  过期与失败证据仍通过稳定 reason code 保留。价格只是带来源的十进制字符串元数据，
+  `billing_authoritative=false`，冲突报价不求平均。
+- `/settings` 使用 `?section=overview|providers|routing` 组织总览、Provider/Catalog 与
+  路由实验。三页签共用管理员会话和 CSRF；Marble 位于控制面之外，即使未配对仍可用。
+  newAPI 管理界面仍只允许安全外链，不嵌入、代理或自动加载。
+- 公共 `/models` 与 Prompt 目标模型选择器继续使用原有静态快照口径，不显示或断言运行时
+  `invocable`，也不插入仅由 Provider 发现的模型。统一 Readiness 仅在设置页审计，避免
+  控制面建设改变既有用户模型浏览与选择体验。
+- R4 受管 Provider 不会自动配置或接管普通 `/api/chat`。当前 default Chat 仍读取
+  `LLM_GATEWAY_URL/KEY` 或 `OPENROUTER_API_KEY`；迁移和 newAPI 默认门禁属于 Round 5。
 
 ## 回退
 
 关闭管理面或回退路由不得删除 Provider SQLite、newAPI 数据目录、旧主密钥或迁移
 备份。将 `MODEL_MIRROR_PROVIDER_CHAT_CANARY_ENABLED=false` 可立即关闭 Round 3 入口；
-代码回退保留 v13 表和脱敏证据，旧版本可忽略新表继续运行。部署回退通过恢复上一版本
+代码回退保留 v14 表和脱敏证据，旧版本可忽略新表继续运行。部署回退通过恢复上一版本
 Compose 与对应显式环境配置完成。

--- a/server/model_router/api.py
+++ b/server/model_router/api.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import os
 import threading
+from typing import Literal
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
 
 try:
     from server.omniroute.catalog import OmniRouteCatalogService
@@ -32,6 +33,11 @@ from .schemas import (
     ProviderChatCanaryAdminResponse,
     ProviderChatCanaryPolicyUpdate,
     ProviderChatCanaryPublicStatus,
+    ProviderCatalogRefreshResponse,
+    ProviderCatalogOfferingsResponse,
+    ProviderControlPlaneOverview,
+    ControlPlaneCatalogResponse,
+    OperationName,
     ProviderModelsRefreshResponse,
     RouterConnection,
     RouterConnectionCreate,
@@ -42,6 +48,8 @@ from .schemas import (
 )
 from .chat_certification import ProviderChatCertificationService
 from .chat_canary import ProviderChatCanaryService
+from .provider_catalog import ProviderCatalogService
+from .control_plane_catalog import ControlPlaneCatalogService
 from .service import (
     ModelRouterService,
     RouterServiceError,
@@ -92,6 +100,28 @@ def get_native_router_engine():
 
         _native_engine = NativeRouterEngine(get_model_router_service())
     return _native_engine
+
+
+def get_control_plane_catalog_service() -> ControlPlaneCatalogService:
+    try:
+        from server.multimodal.api import (
+            get_audio_catalog_service,
+            get_image_catalog_service,
+            get_video_catalog_service,
+        )
+    except ModuleNotFoundError:
+        from multimodal.api import (
+            get_audio_catalog_service,
+            get_image_catalog_service,
+            get_video_catalog_service,
+        )
+    return ControlPlaneCatalogService(
+        get_model_router_service(),
+        general_catalog=get_catalog_coordinator().peek_catalog(),
+        audio_catalog=get_audio_catalog_service().peek_catalog(),
+        image_catalog=get_image_catalog_service().peek_catalog(),
+        video_catalog=get_video_catalog_service().peek_catalog(),
+    )
 
 
 def _raise_public_error(exc: Exception) -> None:
@@ -196,6 +226,22 @@ async def test_saved_connection(
 ) -> ConnectionTestResult:
     try:
         return await get_model_router_service().test_saved_connection(connection_id)
+    except (ProviderEgressError, RouterServiceError, RouterRepositoryError) as exc:
+        _raise_public_error(exc)
+
+
+@router.post(
+    "/connections/{connection_id}/catalog/refresh",
+    response_model=ProviderCatalogRefreshResponse,
+)
+async def refresh_provider_catalog(
+    connection_id: str,
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin_csrf),
+) -> ProviderCatalogRefreshResponse:
+    try:
+        return await ProviderCatalogService(
+            get_model_router_service()
+        ).refresh_connection(connection_id)
     except (ProviderEgressError, RouterServiceError, RouterRepositoryError) as exc:
         _raise_public_error(exc)
 
@@ -320,6 +366,47 @@ def get_status(
         _raise_public_error(exc)
 
 
+@router.get(
+    "/control-plane/overview",
+    response_model=ProviderControlPlaneOverview,
+)
+def get_control_plane_overview(
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin),
+) -> ProviderControlPlaneOverview:
+    try:
+        return get_control_plane_catalog_service().overview()
+    except (RouterServiceError, RouterRepositoryError) as exc:
+        _raise_public_error(exc)
+
+
+@router.get(
+    "/catalog/offerings",
+    response_model=ProviderCatalogOfferingsResponse,
+)
+def get_provider_catalog_offerings(
+    connection_id: str | None = None,
+    model_id: str | None = None,
+    operation: OperationName | None = None,
+    status_filter: Literal["active", "stale", "retired", "invocable"] | None = Query(
+        default=None, alias="status"
+    ),
+    cursor: str | None = None,
+    limit: int = 200,
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin),
+) -> ProviderCatalogOfferingsResponse:
+    try:
+        return get_control_plane_catalog_service().offerings(
+            connection_id=connection_id,
+            model_id=model_id,
+            operation=operation,
+            status=status_filter,
+            cursor=cursor,
+            limit=limit,
+        )
+    except (RouterServiceError, RouterRepositoryError) as exc:
+        _raise_public_error(exc)
+
+
 @router.get("/diagnostics")
 def get_diagnostics(
     _principal: ProviderControlPrincipal = Depends(require_provider_admin),
@@ -362,6 +449,31 @@ async def get_model_catalog() -> ModelCatalogResponse:
 @models_router.get("/router-status", response_model=RouterStatusResponse)
 async def get_public_router_status() -> RouterStatusResponse:
     return await get_catalog_coordinator().get_status()
+
+
+@models_router.get(
+    "/control-plane-catalog",
+    response_model=ControlPlaneCatalogResponse,
+)
+def get_public_control_plane_catalog(
+    response: Response,
+    model_id: str | None = None,
+    operation: OperationName | None = None,
+    include_unavailable: bool = False,
+    cursor: str | None = None,
+    limit: int = 200,
+) -> ControlPlaneCatalogResponse:
+    response.headers["Cache-Control"] = "no-store"
+    try:
+        return get_control_plane_catalog_service().public_catalog(
+            model_id=model_id,
+            operation=operation,
+            include_unavailable=include_unavailable,
+            cursor=cursor,
+            limit=max(1, min(limit, 500)),
+        )
+    except (RouterServiceError, RouterRepositoryError) as exc:
+        _raise_public_error(exc)
 
 
 @models_router.get(

--- a/server/model_router/catalog.py
+++ b/server/model_router/catalog.py
@@ -57,6 +57,22 @@ class NativeCatalogService:
         self._cache: _CacheEntry | None = None
         self._lock = asyncio.Lock()
 
+    def peek_catalog(self) -> ModelCatalogResponse | None:
+        """Return the last bounded native snapshot without provider I/O."""
+        cached = self._cache
+        if cached is None:
+            return None
+        age = time.monotonic() - cached.stored_at
+        if age > STALE_IF_ERROR_SECONDS:
+            return None
+        catalog = cached.catalog.model_copy(deep=True)
+        if age > CATALOG_TTL_SECONDS:
+            catalog.stale = True
+            catalog.router_status = "stale"
+            for model in catalog.models:
+                model.availability = "degraded"
+        return catalog
+
     async def get_catalog(
         self,
         service: ModelRouterService,
@@ -211,6 +227,17 @@ class CatalogCoordinator:
     ) -> None:
         self.sidecar = sidecar
         self.native = native or NativeCatalogService()
+
+    def peek_catalog(self) -> ModelCatalogResponse | None:
+        """Read the selected engine snapshot without starting a refresh."""
+        try:
+            service = get_model_router_service()
+            policy = service.get_policy()
+        except (RouterRepositoryError, RouterServiceError):
+            return self.sidecar.peek_catalog()
+        if policy.engine in {"native", "native_canary"}:
+            return self.native.peek_catalog()
+        return self.sidecar.peek_catalog()
 
     async def get_catalog(self) -> ModelCatalogResponse:
         try:

--- a/server/model_router/chat_certification.py
+++ b/server/model_router/chat_certification.py
@@ -16,6 +16,7 @@ from .provider_chat import (
     ProviderChatTarget,
     ProviderChatTransport,
 )
+from .provider_catalog import ProviderCatalogService
 from .egress import ProviderEgressError
 from .repository import RouterCredentialUnavailable, RouterRepositoryError
 from .schemas import (
@@ -83,19 +84,9 @@ class ProviderChatCertificationService:
         return value.strip().casefold() not in {"0", "false", "no", "off"}
 
     async def refresh_models(self, connection_id: str) -> ProviderModelsRefreshResponse:
-        result, model_ids = await self.router_service.fetch_connection_models(
-            connection_id
-        )
-        unique_ids = list(dict.fromkeys(str(item) for item in model_ids if str(item)))
-        return ProviderModelsRefreshResponse(
-            connection_id=connection_id,
-            ok=result.ok,
-            model_ids=unique_ids[:500],
-            model_count=len(unique_ids),
-            checked_at=result.checked_at,
-            truncated=len(unique_ids) > 500,
-            message=result.message,
-        )
+        return await ProviderCatalogService(
+            self.router_service
+        ).refresh_connection_legacy(connection_id)
 
     def list(self) -> ProviderChatCertificationListResponse:
         rows = {

--- a/server/model_router/control_plane_catalog.py
+++ b/server/model_router/control_plane_catalog.py
@@ -1,0 +1,940 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any, Iterable
+
+from .chat_canary import ProviderChatCanaryService
+from .provider_catalog import PROVIDER_CATALOG_CONTRACT_VERSION
+from .provider_chat import PROVIDER_CHAT_CONTRACT_VERSION
+from .repository import RouterRepositoryError, utc_now
+from .schemas import (
+    ControlPlaneCatalogModel,
+    ControlPlaneCatalogResponse,
+    ControlPlaneOperationCount,
+    OperationReadinessProjection,
+    ProviderCatalogOfferingSummary,
+    ProviderCatalogOfferingsResponse,
+    ProviderCatalogPrice,
+    ProviderControlPlaneOverview,
+    RouterConnection,
+)
+from .service import ModelRouterService, RouterServiceError
+
+
+_VERIFICATION_PRIORITY = {
+    "not_applicable": 0,
+    "failed": 1,
+    "manual_required": 2,
+    "verified": 3,
+    "contract_verified": 4,
+}
+_INTERACTION_PRIORITY = {"disabled": 0, "planned": 1, "ready": 2}
+_SUPPORTED_OPERATIONS = {
+    "chat",
+    "analyze_document",
+    "analyze_image",
+    "generate_image",
+    "transcribe",
+    "synthesize_speech",
+    "generate_audio",
+    "analyze_audio",
+    "realtime_voice",
+    "analyze_video",
+    "generate_video",
+    "generate_world",
+    "embed",
+    "rerank",
+}
+
+
+@dataclass
+class _Evidence:
+    operation: str
+    interaction_status: str
+    availability_status: str
+    verification_status: str
+    invocable: bool
+    access_modes: set[str] = field(default_factory=set)
+    reason_codes: set[str] = field(default_factory=set)
+    observed_at: str | None = None
+    stale: bool = False
+    pricing: list[ProviderCatalogPrice] = field(default_factory=list)
+
+
+@dataclass
+class _ProjectedModel:
+    model_id: str
+    presences: set[str] = field(default_factory=set)
+    operations: dict[str, list[_Evidence]] = field(default_factory=dict)
+
+    def add(self, evidence: _Evidence) -> None:
+        self.operations.setdefault(evidence.operation, []).append(evidence)
+
+
+class ControlPlaneCatalogService:
+    """Side-effect-free Catalog and readiness projection.
+
+    All provider refreshes remain explicit. Optional catalog arguments must be
+    snapshots obtained through ``peek_catalog`` and are never fetched here.
+    """
+
+    def __init__(
+        self,
+        router_service: ModelRouterService,
+        *,
+        general_catalog: object | None = None,
+        audio_catalog: object | None = None,
+        image_catalog: object | None = None,
+        video_catalog: object | None = None,
+    ) -> None:
+        self.router_service = router_service
+        self.repository = router_service.repository
+        self.general_catalog = general_catalog
+        self.audio_catalog = audio_catalog
+        self.image_catalog = image_catalog
+        self.video_catalog = video_catalog
+
+    def public_catalog(
+        self,
+        *,
+        model_id: str | None = None,
+        operation: str | None = None,
+        include_unavailable: bool = False,
+        cursor: str | None = None,
+        limit: int = 200,
+    ) -> ControlPlaneCatalogResponse:
+        projected, revision = self._build_projection()
+        models = self._materialize(projected, operation=operation)
+        self._add_canary_modes(models)
+        if model_id is not None:
+            models = [item for item in models if item.model_id == model_id]
+        if not include_unavailable:
+            models = [
+                item
+                for item in models
+                if any(readiness.invocable for readiness in item.operations)
+            ]
+        offset = self._decode_cursor(cursor, revision)
+        bounded_limit = max(1, min(int(limit), 500))
+        catalog_stale = any(
+            readiness.stale
+            for item in models
+            for readiness in item.operations
+        )
+        page = models[offset : offset + bounded_limit]
+        next_offset = offset + len(page)
+        next_cursor = (
+            self._encode_cursor(revision, next_offset)
+            if next_offset < len(models)
+            else None
+        )
+        return ControlPlaneCatalogResponse(
+            contract_version=PROVIDER_CATALOG_CONTRACT_VERSION,
+            catalog_revision=revision,
+            generated_at=utc_now(),
+            stale=catalog_stale,
+            next_cursor=next_cursor,
+            models=page,
+        )
+
+    def offerings(
+        self,
+        *,
+        connection_id: str | None = None,
+        model_id: str | None = None,
+        operation: str | None = None,
+        status: str | None = None,
+        cursor: str | None = None,
+        limit: int = 200,
+    ) -> ProviderCatalogOfferingsResponse:
+        projected, revision = self._build_projection()
+        del projected
+        offset = self._decode_cursor(cursor, revision)
+        bounded_limit = max(1, min(int(limit), 500))
+        rows = self._all_catalog_offerings(
+            connection_id=connection_id,
+            model_id=model_id,
+            operation=operation,
+        )
+        connections = {item.id: item for item in self.router_service.list_connections()}
+        models = {
+            (str(row["connection_id"]), str(row["model_id"])): row
+            for row in self._all_catalog_models(
+                connection_id=connection_id,
+                model_id=model_id,
+            )
+        }
+        refreshes = {
+            str(row["id"]): row
+            for row in self._catalog_refresh_rows(connections)
+        }
+        certifications = {
+            (str(row["connection_id"]), str(row["requested_model"])): row
+            for row in self.repository.list_latest_chat_certifications_by_model(
+                self.router_service.tenant_id
+            )
+        }
+        summaries: list[ProviderCatalogOfferingSummary] = []
+        for row in rows:
+            connection = connections.get(str(row["connection_id"]))
+            inventory = models.get(
+                (str(row["connection_id"]), str(row["model_id"]))
+            )
+            if connection is None or inventory is None:
+                continue
+            evidence = self._managed_evidence(
+                row,
+                inventory,
+                connection,
+                refreshes.get(str(row["last_refresh_id"])),
+                certifications.get((connection.id, str(row["model_id"]))),
+            )
+            if status is not None:
+                inventory_status = str(inventory["status"])
+                if status != inventory_status and not (
+                    status == "invocable" and evidence.invocable
+                ):
+                    continue
+            summaries.append(
+                ProviderCatalogOfferingSummary(
+                    connection_id=connection.id,
+                    connection_name=connection.name,
+                    provider_kind=connection.kind,
+                    model_id=str(row["model_id"]),
+                    operation=str(row["operation"]),
+                    access_mode=str(row["access_mode"]),
+                    capability_source=str(row["capability_source"]),
+                    inventory_status=str(inventory["status"]),
+                    connection_health=connection.health,
+                    verification_status=evidence.verification_status,
+                    invocable=evidence.invocable,
+                    reason_codes=sorted(evidence.reason_codes),
+                    refresh_id=str(row["last_refresh_id"]),
+                    observed_at=str(row["observed_at"]),
+                    stale=evidence.stale,
+                    pricing=(evidence.pricing[0] if evidence.pricing else None),
+                )
+            )
+        summaries.sort(
+            key=lambda item: (item.model_id, item.operation, item.connection_id)
+        )
+        page = summaries[offset : offset + bounded_limit]
+        next_offset = offset + len(page)
+        return ProviderCatalogOfferingsResponse(
+            contract_version=PROVIDER_CATALOG_CONTRACT_VERSION,
+            next_cursor=(
+                self._encode_cursor(revision, next_offset)
+                if next_offset < len(summaries)
+                else None
+            ),
+            offerings=page,
+        )
+
+    def overview(self) -> ProviderControlPlaneOverview:
+        projected, revision = self._build_projection()
+        models = self._materialize(projected)
+        self._add_canary_modes(models)
+        connections = self.router_service.list_connections()
+        counts: list[ControlPlaneOperationCount] = []
+        operations = sorted(
+            {
+                readiness.operation
+                for item in models
+                for readiness in item.operations
+            }
+        )
+        for operation in operations:
+            rows = [
+                readiness
+                for item in models
+                for readiness in item.operations
+                if readiness.operation == operation
+            ]
+            counts.append(
+                ControlPlaneOperationCount(
+                    operation=operation,
+                    total=len(rows),
+                    invocable=sum(item.invocable for item in rows),
+                    stale=sum(item.stale for item in rows),
+                    blocked=sum(not item.invocable for item in rows),
+                )
+            )
+        blockers: list[str] = []
+        if not connections:
+            blockers.append("provider_not_configured")
+        if connections and not any(item.health == "online" for item in connections):
+            blockers.append("provider_not_online")
+        if not models:
+            blockers.append("catalog_not_available")
+        if any(
+            readiness.stale
+            for item in models
+            for readiness in item.operations
+        ):
+            blockers.append("catalog_contains_stale_evidence")
+        return ProviderControlPlaneOverview(
+            contract_version=PROVIDER_CATALOG_CONTRACT_VERSION,
+            catalog_revision=revision,
+            generated_at=utc_now(),
+            provider_count=len(connections),
+            online_provider_count=sum(
+                item.enabled and item.health == "online" for item in connections
+            ),
+            discovered_model_count=len(models),
+            stale_model_count=sum(
+                item.catalog_presence == "stale" for item in models
+            ),
+            operation_counts=counts,
+            blocking_reason_codes=blockers,
+        )
+
+    def _build_projection(self) -> tuple[dict[str, _ProjectedModel], str]:
+        tenant_id = self.router_service.tenant_id
+        connections = {item.id: item for item in self.router_service.list_connections()}
+        model_rows = self._all_catalog_models()
+        offering_rows = self._all_catalog_offerings()
+        refresh_rows = self._catalog_refresh_rows(connections)
+        refreshes = {str(row["id"]): row for row in refresh_rows}
+        certifications = {
+            (str(row["connection_id"]), str(row["requested_model"])): row
+            for row in self.repository.list_latest_chat_certifications_by_model(
+                tenant_id
+            )
+        }
+        projected: dict[str, _ProjectedModel] = {}
+        inventory = {
+            (str(row["connection_id"]), str(row["model_id"])): row
+            for row in model_rows
+        }
+        for row in model_rows:
+            model = projected.setdefault(
+                str(row["model_id"]), _ProjectedModel(str(row["model_id"]))
+            )
+            model.presences.add(str(row["status"]))
+        for row in offering_rows:
+            connection = connections.get(str(row["connection_id"]))
+            model_row = inventory.get(
+                (str(row["connection_id"]), str(row["model_id"]))
+            )
+            if connection is None or model_row is None:
+                continue
+            model = projected.setdefault(
+                str(row["model_id"]), _ProjectedModel(str(row["model_id"]))
+            )
+            model.add(
+                self._managed_evidence(
+                    row,
+                    model_row,
+                    connection,
+                    refreshes.get(str(row["last_refresh_id"])),
+                    certifications.get((connection.id, str(row["model_id"]))),
+                )
+            )
+        self._add_general_snapshot(projected, self.general_catalog)
+        for catalog in (self.audio_catalog, self.image_catalog, self.video_catalog):
+            self._add_specialized_snapshot(projected, catalog)
+        revision_material = {
+            "refreshes": [
+                [
+                    row.get("id"),
+                    row.get("status"),
+                    row.get("catalog_fingerprint"),
+                    row.get("completed_at"),
+                ]
+                for row in refresh_rows
+            ],
+            "snapshots": [
+                [
+                    getattr(catalog, "source", None),
+                    getattr(catalog, "status", None)
+                    or getattr(catalog, "router_status", None),
+                    getattr(catalog, "synced_at", None),
+                    getattr(catalog, "stale", None),
+                ]
+                for catalog in (
+                    self.general_catalog,
+                    self.audio_catalog,
+                    self.image_catalog,
+                    self.video_catalog,
+                )
+            ],
+            "connections": [
+                [
+                    connection.id,
+                    connection.kind,
+                    connection.enabled,
+                    connection.health,
+                    connection.model_count,
+                    connection.last_checked_at,
+                    connection.updated_at,
+                ]
+                for connection in connections.values()
+            ],
+            "certifications": [
+                [
+                    row.get("id"),
+                    row.get("connection_id"),
+                    row.get("requested_model"),
+                    row.get("connection_fingerprint"),
+                    row.get("status"),
+                    row.get("completed_at"),
+                ]
+                for row in certifications.values()
+            ],
+            "canary": self._canary_revision_material(),
+        }
+        revision = hashlib.sha256(
+            json.dumps(
+                revision_material,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        return projected, revision
+
+    def _all_catalog_models(
+        self,
+        *,
+        connection_id: str | None = None,
+        model_id: str | None = None,
+    ) -> list[dict[str, object]]:
+        rows: list[dict[str, object]] = []
+        offset = 0
+        while True:
+            page = self.repository.list_catalog_models(
+                self.router_service.tenant_id,
+                connection_id=connection_id,
+                model_id=model_id,
+                limit=5_000,
+                offset=offset,
+            )
+            rows.extend(page)
+            if len(page) < 5_000:
+                return rows
+            offset += len(page)
+
+    def _all_catalog_offerings(
+        self,
+        *,
+        connection_id: str | None = None,
+        model_id: str | None = None,
+        operation: str | None = None,
+    ) -> list[dict[str, object]]:
+        rows: list[dict[str, object]] = []
+        offset = 0
+        while True:
+            page = self.repository.list_catalog_offerings(
+                self.router_service.tenant_id,
+                connection_id=connection_id,
+                model_id=model_id,
+                operation=operation,
+                include_stale=True,
+                limit=5_000,
+                offset=offset,
+            )
+            rows.extend(page)
+            if len(page) < 5_000:
+                return rows
+            offset += len(page)
+
+    def _catalog_refresh_rows(
+        self, connections: dict[str, RouterConnection]
+    ) -> list[dict[str, object]]:
+        rows: list[dict[str, object]] = []
+        for connection_id in sorted(connections):
+            rows.extend(
+                self.repository.list_catalog_refreshes(
+                    self.router_service.tenant_id,
+                    connection_id=connection_id,
+                    limit=500,
+                )
+            )
+        return rows
+
+    def _canary_revision_material(self) -> dict[str, object]:
+        policy_reader = getattr(self.repository, "get_chat_canary_policy", None)
+        run_reader = getattr(self.repository, "list_chat_canary_runs", None)
+        policy = (
+            policy_reader(self.router_service.tenant_id)
+            if callable(policy_reader)
+            else None
+        )
+        runs = (
+            run_reader(self.router_service.tenant_id, limit=100)
+            if callable(run_reader)
+            else []
+        )
+        return {
+            "feature_enabled": os.getenv(
+                "MODEL_MIRROR_PROVIDER_CHAT_CANARY_ENABLED", "false"
+            ),
+            "policy": (
+                [
+                    policy.get("connection_id"),
+                    policy.get("enabled"),
+                    policy.get("updated_at"),
+                ]
+                if policy is not None
+                else None
+            ),
+            "runs": [
+                [
+                    row.get("id"),
+                    row.get("connection_id"),
+                    row.get("requested_model"),
+                    row.get("certification_id"),
+                    row.get("status"),
+                    row.get("result_class"),
+                    row.get("error_code"),
+                    row.get("completed_at"),
+                ]
+                for row in runs
+            ],
+        }
+
+    def _managed_evidence(
+        self,
+        offering: dict[str, object],
+        inventory: dict[str, object],
+        connection: RouterConnection,
+        refresh: dict[str, object] | None,
+        certification: dict[str, object] | None,
+    ) -> _Evidence:
+        stale = bool(offering["stale"]) or inventory["status"] != "active"
+        try:
+            current_fingerprint = self.repository.connection_config_fingerprint(
+                self.router_service.tenant_id, connection.id
+            )
+        except RouterRepositoryError:
+            current_fingerprint = None
+            stale = True
+        if (
+            refresh is None
+            or current_fingerprint is None
+            or refresh.get("connection_fingerprint") != current_fingerprint
+        ):
+            stale = True
+        reasons: set[str] = set()
+        if not connection.enabled:
+            availability = "disabled"
+            reasons.add("connection_disabled")
+        elif connection.health == "offline":
+            availability = "upstream_unavailable"
+            reasons.add("connection_offline")
+        elif connection.health == "untested":
+            availability = "needs_configuration"
+            reasons.add("connection_untested")
+        elif stale:
+            availability = "verification_required"
+            reasons.add("catalog_stale")
+        else:
+            availability = "available"
+            reasons.add("managed_catalog_present")
+        verification = "manual_required"
+        if str(offering["operation"]) == "chat" and certification is not None:
+            certification_current = (
+                certification.get("connection_fingerprint") == current_fingerprint
+                and certification.get("contract_version")
+                == PROVIDER_CHAT_CONTRACT_VERSION
+            )
+            status = str(certification.get("status"))
+            if status == "passed" and certification_current:
+                verification = "contract_verified"
+                reasons.add("chat_contract_certified")
+            elif status in {"failed", "uncertain"}:
+                verification = "failed"
+                reasons.add("chat_certification_failed")
+            else:
+                reasons.add("chat_certification_required")
+        elif str(offering["operation"]) == "chat":
+            reasons.add("chat_certification_required")
+        invocable = (
+            connection.enabled
+            and connection.health == "online"
+            and not stale
+            and availability == "available"
+        )
+        price = self._price_from_row(offering, stale=stale)
+        return _Evidence(
+            operation=str(offering["operation"]),
+            interaction_status="ready" if invocable else "planned",
+            availability_status=availability,
+            verification_status=verification,
+            invocable=invocable,
+            access_modes={"native"},
+            reason_codes=reasons,
+            observed_at=str(offering["observed_at"]),
+            stale=stale,
+            pricing=[price] if price is not None else [],
+        )
+
+    @staticmethod
+    def _price_from_row(
+        offering: dict[str, object], *, stale: bool
+    ) -> ProviderCatalogPrice | None:
+        raw = offering.get("pricing_json")
+        if not isinstance(raw, str) or not raw:
+            return None
+        try:
+            payload = json.loads(raw)
+            if not isinstance(payload, dict):
+                return None
+            if stale:
+                payload["status"] = "stale"
+            payload["billing_authoritative"] = False
+            return ProviderCatalogPrice.model_validate(payload)
+        except (ValueError, TypeError):
+            return None
+
+    def _add_general_snapshot(
+        self, projected: dict[str, _ProjectedModel], catalog: object | None
+    ) -> None:
+        if catalog is None:
+            return
+        source = str(getattr(catalog, "source", "bundled"))
+        mode = "omniroute" if source == "omniroute" else (
+            "native" if source == "native" else "default"
+        )
+        stale = bool(getattr(catalog, "stale", False))
+        observed_at = getattr(catalog, "synced_at", None)
+        for candidate in getattr(catalog, "models", []):
+            model_id = str(getattr(candidate, "invocation_id", "")).strip()
+            if not model_id:
+                continue
+            model = projected.setdefault(model_id, _ProjectedModel(model_id))
+            model.presences.add("stale" if stale else "active")
+            invocable = bool(getattr(candidate, "invocable", False)) and not stale
+            raw_interaction = str(getattr(candidate, "interaction_status", "planned"))
+            interaction = (
+                "disabled" if raw_interaction == "unsupported" else raw_interaction
+            )
+            availability_value = str(getattr(candidate, "availability", "offline"))
+            availability = {
+                "live": "available",
+                "degraded": "upstream_unavailable",
+                "offline": "upstream_unavailable",
+                "disabled": "disabled",
+            }.get(availability_value, "verification_required")
+            for operation in getattr(candidate, "operations", ["chat"]):
+                model.add(
+                    _Evidence(
+                        operation=str(operation),
+                        interaction_status=interaction,
+                        availability_status=availability,
+                        verification_status=("verified" if invocable else "not_applicable"),
+                        invocable=invocable,
+                        access_modes={mode},
+                        reason_codes={
+                            "general_catalog_available"
+                            if invocable
+                            else "general_catalog_unavailable"
+                        },
+                        observed_at=observed_at,
+                        stale=stale,
+                    )
+                )
+
+    def _add_specialized_snapshot(
+        self, projected: dict[str, _ProjectedModel], catalog: object | None
+    ) -> None:
+        if catalog is None:
+            return
+        stale = bool(getattr(catalog, "stale", False))
+        observed_at = getattr(catalog, "synced_at", None)
+        for profile in getattr(catalog, "profiles", []):
+            model_id = str(getattr(profile, "model_id", "")).strip()
+            if not model_id:
+                continue
+            model = projected.setdefault(model_id, _ProjectedModel(model_id))
+            model.presences.add("stale" if stale else "active")
+            readiness_rows = list(getattr(profile, "operation_readiness", []))
+            if not readiness_rows:
+                raw_operations = getattr(profile, "operations", None)
+                if not raw_operations:
+                    raw_operation = getattr(profile, "operation", None)
+                    raw_operations = [raw_operation] if raw_operation else []
+                readiness_rows = [
+                    type(
+                        "Readiness",
+                        (),
+                        {
+                            "operation": operation,
+                            "interaction_status": getattr(
+                                profile, "interaction_status", "planned"
+                            ),
+                            "availability_status": (
+                                "available"
+                                if bool(getattr(profile, "invocable", False))
+                                else "verification_required"
+                            ),
+                            "verification_status": "manual_required",
+                        },
+                    )()
+                    for operation in raw_operations
+                ]
+            for readiness in readiness_rows:
+                operation = str(getattr(readiness, "operation", "")).strip()
+                if operation not in _SUPPORTED_OPERATIONS:
+                    # Specialized catalogs may expose provider-specific actions
+                    # (for example voice cloning). Keep those in their native
+                    # catalog until the public control-plane contract defines
+                    # an operation for them.
+                    continue
+                interaction = str(
+                    getattr(readiness, "interaction_status", "planned")
+                )
+                if interaction == "unsupported":
+                    interaction = "disabled"
+                availability = str(
+                    getattr(readiness, "availability_status", "verification_required")
+                )
+                invocable = (
+                    availability == "available"
+                    and interaction == "ready"
+                    and not stale
+                )
+                model.add(
+                    _Evidence(
+                        operation=operation,
+                        interaction_status=interaction,
+                        availability_status=availability,
+                        verification_status=str(
+                            getattr(readiness, "verification_status", "manual_required")
+                        ),
+                        invocable=invocable,
+                        access_modes={"specialized"},
+                        reason_codes={
+                            "specialized_catalog_available"
+                            if invocable
+                            else "specialized_catalog_not_ready"
+                        },
+                        observed_at=observed_at,
+                        stale=stale,
+                        pricing=self._specialized_prices(profile, observed_at, stale),
+                    )
+                )
+
+    @staticmethod
+    def _specialized_prices(
+        profile: object, observed_at: str | None, stale: bool
+    ) -> list[ProviderCatalogPrice]:
+        if observed_at is None:
+            return []
+        result: list[ProviderCatalogPrice] = []
+        for item in getattr(profile, "pricing", []):
+            cost = getattr(item, "cost_usd", None)
+            if cost is None:
+                continue
+            result.append(
+                ProviderCatalogPrice(
+                    currency="USD",
+                    unit=str(getattr(item, "unit", "unknown")),
+                    input_price=None,
+                    output_price=format(Decimal(str(cost)), "f"),
+                    source="specialized_catalog",
+                    observed_at=observed_at,
+                    status="stale" if stale else "reported",
+                    billing_authoritative=False,
+                )
+            )
+        generation_price = getattr(profile, "price_per_generation_usd", None)
+        if generation_price is not None:
+            result.append(
+                ProviderCatalogPrice(
+                    currency="USD",
+                    unit="generation",
+                    output_price=format(Decimal(str(generation_price)), "f"),
+                    source="specialized_catalog",
+                    observed_at=observed_at,
+                    status="stale" if stale else "reported",
+                    billing_authoritative=False,
+                )
+            )
+        return result
+
+    def _materialize(
+        self,
+        projected: dict[str, _ProjectedModel],
+        *,
+        operation: str | None = None,
+    ) -> list[ControlPlaneCatalogModel]:
+        result: list[ControlPlaneCatalogModel] = []
+        for model_id in sorted(projected):
+            model = projected[model_id]
+            readiness: list[OperationReadinessProjection] = []
+            for operation_name in sorted(model.operations):
+                if operation is not None and operation_name != operation:
+                    continue
+                evidence = model.operations[operation_name]
+                invocable = any(item.invocable for item in evidence)
+                interaction = max(
+                    (item.interaction_status for item in evidence),
+                    key=lambda value: _INTERACTION_PRIORITY.get(value, -1),
+                )
+                if invocable:
+                    availability = "available"
+                elif any(item.availability_status == "needs_configuration" for item in evidence):
+                    availability = "needs_configuration"
+                elif any(item.availability_status == "verification_required" for item in evidence):
+                    availability = "verification_required"
+                elif any(item.availability_status == "upstream_unavailable" for item in evidence):
+                    availability = "upstream_unavailable"
+                else:
+                    availability = "disabled"
+                verification = max(
+                    (item.verification_status for item in evidence),
+                    key=lambda value: _VERIFICATION_PRIORITY.get(value, -1),
+                )
+                prices = self._dedupe_prices(
+                    price for item in evidence for price in item.pricing
+                )
+                if len(
+                    {
+                        (price.currency, price.unit, price.input_price, price.output_price)
+                        for price in prices
+                    }
+                ) > 1:
+                    prices = [
+                        price.model_copy(update={"status": "ambiguous"})
+                        for price in prices
+                    ]
+                readiness.append(
+                    OperationReadinessProjection(
+                        operation=operation_name,
+                        interaction_status=interaction,
+                        availability_status=availability,
+                        verification_status=verification,
+                        invocable=invocable,
+                        access_modes=sorted(
+                            {mode for item in evidence for mode in item.access_modes}
+                        ),
+                        reason_codes=sorted(
+                            {reason for item in evidence for reason in item.reason_codes}
+                        ),
+                        observed_at=max(
+                            (
+                                item.observed_at
+                                for item in evidence
+                                if item.observed_at is not None
+                            ),
+                            default=None,
+                        ),
+                        stale=all(item.stale for item in evidence),
+                        pricing=prices,
+                    )
+                )
+            if operation is not None and not readiness:
+                continue
+            presence = (
+                "present"
+                if "active" in model.presences
+                else "stale"
+                if "stale" in model.presences
+                else "retired"
+                if "retired" in model.presences
+                else "unknown"
+            )
+            result.append(
+                ControlPlaneCatalogModel(
+                    model_id=model_id,
+                    catalog_presence=presence,
+                    operations=readiness,
+                )
+            )
+        return result
+
+    def _add_canary_modes(self, models: list[ControlPlaneCatalogModel]) -> None:
+        service = ProviderChatCanaryService(self.router_service)
+        if not service.enabled():
+            return
+        status = service.admin_status(
+            limit=1,
+            default_gateway_url=os.getenv("LLM_GATEWAY_URL"),
+        )
+        if not status.policy_enabled:
+            return
+        available_models = {
+            item.model_id
+            for connection in status.connections
+            for item in connection.models
+            if item.available
+        }
+        for model in models:
+            chat = next(
+                (item for item in model.operations if item.operation == "chat"),
+                None,
+            )
+            if chat is None or model.model_id not in available_models:
+                continue
+            chat.access_modes = sorted(
+                set(chat.access_modes) | {"newapi_canary"}
+            )
+            chat.invocable = True
+            chat.availability_status = "available"
+            chat.reason_codes = sorted(
+                set(chat.reason_codes) | {"newapi_canary_available"}
+            )
+
+    @staticmethod
+    def _dedupe_prices(
+        prices: Iterable[ProviderCatalogPrice],
+    ) -> list[ProviderCatalogPrice]:
+        result: list[ProviderCatalogPrice] = []
+        seen: set[tuple[object, ...]] = set()
+        for price in prices:
+            key = (
+                price.currency,
+                price.unit,
+                price.input_price,
+                price.output_price,
+                price.source,
+                price.observed_at,
+            )
+            if key not in seen:
+                seen.add(key)
+                result.append(price)
+        return result
+
+    @staticmethod
+    def _encode_cursor(revision: str, offset: int) -> str:
+        payload = json.dumps(
+            {"revision": revision, "offset": offset},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+    @staticmethod
+    def _decode_cursor(cursor: str | None, revision: str) -> int:
+        if not cursor:
+            return 0
+        try:
+            padding = "=" * (-len(cursor) % 4)
+            payload = json.loads(
+                base64.urlsafe_b64decode(cursor + padding).decode("utf-8")
+            )
+            offset = int(payload["offset"])
+        except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
+            raise RouterServiceError(
+                "invalid_catalog_cursor",
+                "Catalog cursor is invalid.",
+                status_code=422,
+            ) from exc
+        if payload.get("revision") != revision:
+            raise RouterServiceError(
+                "catalog_cursor_stale",
+                "Catalog changed while paging; restart from the first page.",
+                status_code=409,
+            )
+        if offset < 0:
+            raise RouterServiceError(
+                "invalid_catalog_cursor",
+                "Catalog cursor is invalid.",
+                status_code=422,
+            )
+        return offset

--- a/server/model_router/egress.py
+++ b/server/model_router/egress.py
@@ -295,7 +295,9 @@ class ProviderEgressPolicy:
     def _blocked() -> ProviderEgressError:
         return ProviderEgressError(
             "provider_address_blocked",
-            "模型服务地址指向受保护网络；仅允许公网 HTTPS 或显式内网白名单。",
+            "模型服务地址解析到受保护或保留网络；仅允许公网 HTTPS 或显式内网白名单。"
+            "若这是公网域名，请检查容器 DNS 或 VPN Fake-IP，确保其解析为真实公网地址；"
+            "保留地址不能通过白名单放行。",
         )
 
     @staticmethod

--- a/server/model_router/provider_catalog.py
+++ b/server/model_router/provider_catalog.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from decimal import Decimal, InvalidOperation
+from typing import Iterable
+
+from .egress import ProviderEgressError
+from .repository import RouterRepositoryError, utc_now
+from .schemas import (
+    ProviderCatalogRefreshResponse,
+    ProviderModelsRefreshResponse,
+    RouterConnection,
+)
+from .service import ModelRouterService, RouterServiceError
+
+
+PROVIDER_CATALOG_CONTRACT_VERSION = "modelmirror-provider-catalog-v1"
+MAX_PROVIDER_CATALOG_MODELS = 5_000
+MAX_MODEL_ID_LENGTH = 512
+KNOWN_OPERATIONS = {
+    "chat",
+    "analyze_document",
+    "analyze_image",
+    "generate_image",
+    "transcribe",
+    "synthesize_speech",
+    "generate_audio",
+    "analyze_audio",
+    "realtime_voice",
+    "analyze_video",
+    "generate_video",
+    "generate_world",
+    "embed",
+    "rerank",
+}
+
+
+def _clean_model_id(value: object) -> str | None:
+    model_id = str(value or "").strip()
+    if not model_id or len(model_id) > MAX_MODEL_ID_LENGTH:
+        return None
+    if any(ord(character) < 32 or ord(character) == 127 for character in model_id):
+        return None
+    return model_id
+
+
+def _safe_scalar(value: object, *, limit: int = 512) -> object | None:
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return value[:limit]
+    return None
+
+
+def _decimal_text(value: object) -> str | None:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+    if not parsed.is_finite() or parsed < 0:
+        return None
+    return format(parsed.normalize(), "f")
+
+
+def _reported_pricing(record: dict[str, object], observed_at: str) -> dict[str, object] | None:
+    pricing = record.get("pricing")
+    if not isinstance(pricing, dict):
+        return None
+    currency = pricing.get("currency")
+    unit = pricing.get("unit")
+    if not isinstance(currency, str) or not currency.strip():
+        return None
+    if not isinstance(unit, str) or not unit.strip():
+        return None
+    input_price = _decimal_text(pricing.get("input", pricing.get("prompt")))
+    output_price = _decimal_text(pricing.get("output", pricing.get("completion")))
+    if input_price is None and output_price is None:
+        return None
+    return {
+        "currency": currency.strip()[:16].upper(),
+        "unit": unit.strip()[:64],
+        "input_price": input_price,
+        "output_price": output_price,
+        "source": "provider_catalog",
+        "observed_at": observed_at,
+        "status": "reported",
+        "billing_authoritative": False,
+    }
+
+
+def _declared_operations(record: dict[str, object]) -> set[str]:
+    candidates = record.get("operations")
+    capabilities = record.get("capabilities")
+    if not isinstance(candidates, list) and isinstance(capabilities, dict):
+        candidates = capabilities.get("operations")
+    if not isinstance(candidates, list):
+        return set()
+    return {
+        str(value).strip()
+        for value in candidates
+        if str(value).strip() in KNOWN_OPERATIONS
+    }
+
+
+def normalize_provider_catalog(
+    records: Iterable[dict[str, object]],
+    *,
+    connection: RouterConnection,
+    observed_at: str,
+) -> tuple[list[dict[str, object]], list[dict[str, object]], int, bool]:
+    normalized: dict[str, dict[str, object]] = {}
+    offerings: dict[tuple[str, str, str], dict[str, object]] = {}
+    for record in records:
+        model_id = _clean_model_id(record.get("id"))
+        if model_id is None or model_id in normalized:
+            continue
+        declared = _declared_operations(record)
+        metadata = {
+            key: safe
+            for key in ("object", "owned_by", "created", "name")
+            if (safe := _safe_scalar(record.get(key))) is not None
+        }
+        normalized[model_id] = {
+            "model_id": model_id,
+            "normalized_model_id": model_id.casefold(),
+            "metadata": metadata,
+            "capability_state": (
+                "declared" if declared else "capabilities_unclassified"
+            ),
+        }
+        pricing = _reported_pricing(record, observed_at)
+        operation_sources: dict[str, str] = {
+            operation: "provider_declared" for operation in declared
+        }
+        if "chat" in connection.scopes:
+            operation_sources.setdefault("chat", "connection_scope")
+        for operation, capability_source in operation_sources.items():
+            key = (model_id, operation, "managed")
+            offerings[key] = {
+                "model_id": model_id,
+                "operation": operation,
+                "access_mode": "managed",
+                "capability_source": capability_source,
+                "pricing": pricing,
+                "pricing_source": "provider_catalog" if pricing else None,
+                "pricing_status": "reported" if pricing else "unknown",
+                "pricing_observed_at": observed_at if pricing else None,
+            }
+
+    model_count = len(normalized)
+    truncated = model_count > MAX_PROVIDER_CATALOG_MODELS
+    kept_ids = sorted(normalized)[:MAX_PROVIDER_CATALOG_MODELS]
+    kept_id_set = set(kept_ids)
+    kept = [normalized[model_id] for model_id in kept_ids]
+    kept_offerings = [
+        offering
+        for key, offering in sorted(offerings.items())
+        if key[0] in kept_id_set
+    ]
+    return kept, kept_offerings, model_count, truncated
+
+
+class ProviderCatalogService:
+    def __init__(self, router_service: ModelRouterService) -> None:
+        self.router_service = router_service
+        self.repository = router_service.repository
+
+    async def refresh_connection(
+        self, connection_id: str
+    ) -> ProviderCatalogRefreshResponse:
+        connection = self.repository.get_connection(
+            self.router_service.tenant_id, connection_id
+        )
+        if not connection.enabled:
+            raise RouterServiceError(
+                "connection_disabled",
+                "该模型服务已停用。",
+                status_code=409,
+            )
+        refresh_id = f"catalog_{uuid.uuid4().hex}"
+        fingerprint = self.repository.connection_config_fingerprint(
+            self.router_service.tenant_id, connection_id
+        )
+        try:
+            self.repository.claim_catalog_refresh(
+                self.router_service.tenant_id,
+                refresh_id=refresh_id,
+                connection_id=connection_id,
+                connection_fingerprint=fingerprint,
+            )
+        except RouterRepositoryError as exc:
+            if str(exc) == "provider_catalog_refresh_in_progress":
+                raise RouterServiceError(
+                    "provider_catalog_refresh_in_progress",
+                    "该连接已有目录刷新正在运行。",
+                    status_code=409,
+                ) from exc
+            raise
+
+        try:
+            result, records = await self.router_service.fetch_connection_model_records(
+                connection_id,
+                persist_result=False,
+                require_chat_scope=False,
+            )
+        except ProviderEgressError as exc:
+            checked_at = utc_now()
+            self.repository.fail_catalog_refresh(
+                self.router_service.tenant_id,
+                refresh_id,
+                connection_id=connection_id,
+                error_code=exc.code,
+                health="offline",
+                checked_at=checked_at,
+                error_hint=exc.message,
+            )
+            raise
+        except Exception:
+            self._safe_fail(refresh_id, connection_id, "provider_catalog_request_failed")
+            raise
+
+        if not result.ok:
+            error_code = self.router_service._result_error_code(result)
+            self.repository.fail_catalog_refresh(
+                self.router_service.tenant_id,
+                refresh_id,
+                connection_id=connection_id,
+                error_code=error_code,
+                health=result.health,
+                model_count=result.model_count,
+                checked_at=result.checked_at,
+                error_hint=result.message,
+            )
+            return ProviderCatalogRefreshResponse(
+                contract_version=PROVIDER_CATALOG_CONTRACT_VERSION,
+                refresh_id=refresh_id,
+                connection_id=connection_id,
+                status="failed",
+                model_count=0,
+                checked_at=result.checked_at,
+                error_code=error_code,
+                message=result.message,
+            )
+
+        models, offerings, model_count, truncated = normalize_provider_catalog(
+            records,
+            connection=connection,
+            observed_at=result.checked_at,
+        )
+        if not models:
+            self.repository.fail_catalog_refresh(
+                self.router_service.tenant_id,
+                refresh_id,
+                connection_id=connection_id,
+                error_code="incompatible_catalog",
+                health="offline",
+                model_count=0,
+                checked_at=result.checked_at,
+                error_hint="服务已连接，但模型目录没有可保存的规范模型 ID。",
+            )
+            return ProviderCatalogRefreshResponse(
+                contract_version=PROVIDER_CATALOG_CONTRACT_VERSION,
+                refresh_id=refresh_id,
+                connection_id=connection_id,
+                status="failed",
+                model_count=0,
+                checked_at=result.checked_at,
+                error_code="incompatible_catalog",
+                message="服务已连接，但模型目录没有可保存的规范模型 ID。",
+            )
+
+        fingerprint_payload = {
+            "models": [item["model_id"] for item in models],
+            "offerings": [
+                [item["model_id"], item["operation"], item["access_mode"]]
+                for item in offerings
+            ],
+            "truncated": truncated,
+        }
+        catalog_fingerprint = hashlib.sha256(
+            json.dumps(
+                fingerprint_payload,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        row = self.repository.complete_catalog_refresh(
+            self.router_service.tenant_id,
+            refresh_id,
+            connection_id=connection_id,
+            models=models,
+            offerings=offerings,
+            model_count=model_count,
+            truncated=truncated,
+            catalog_fingerprint=catalog_fingerprint,
+            observed_at=result.checked_at,
+        )
+        return ProviderCatalogRefreshResponse(
+            contract_version=PROVIDER_CATALOG_CONTRACT_VERSION,
+            refresh_id=refresh_id,
+            connection_id=connection_id,
+            status="succeeded",
+            model_ids=[str(item["model_id"]) for item in models[:500]],
+            model_count=model_count,
+            checked_at=result.checked_at,
+            truncated=truncated,
+            catalog_fingerprint=str(row["catalog_fingerprint"]),
+            message=(
+                f"目录刷新成功，保存 {len(models)} 个模型。"
+                + ("目录已截断，未退休未再次出现的旧模型。" if truncated else "")
+            ),
+        )
+
+    async def refresh_connection_legacy(
+        self, connection_id: str
+    ) -> ProviderModelsRefreshResponse:
+        refreshed = await self.refresh_connection(connection_id)
+        return ProviderModelsRefreshResponse(
+            connection_id=connection_id,
+            ok=refreshed.status == "succeeded",
+            model_ids=refreshed.model_ids,
+            model_count=refreshed.model_count,
+            checked_at=refreshed.checked_at,
+            truncated=refreshed.truncated or refreshed.model_count > 500,
+            message=refreshed.message,
+        )
+
+    def _safe_fail(
+        self, refresh_id: str, connection_id: str, error_code: str
+    ) -> None:
+        try:
+            self.repository.fail_catalog_refresh(
+                self.router_service.tenant_id,
+                refresh_id,
+                connection_id=connection_id,
+                error_code=error_code,
+            )
+        except RouterRepositoryError:
+            return

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -28,7 +28,7 @@ from .schemas import (
 )
 
 
-SCHEMA_VERSION = 13
+SCHEMA_VERSION = 14
 DEFAULT_TENANT_ID = "local"
 CANONICAL_MASTER_KEY_ENV = "MODEL_MIRROR_CREDENTIAL_MASTER_KEY"
 LEGACY_MASTER_KEY_ENV = "MODEL_ROUTER_CREDENTIAL_MASTER_KEY"
@@ -370,6 +370,53 @@ class SQLiteRouterRepository:
             completed_at TEXT,
             PRIMARY KEY (tenant_id, id)
         );
+        CREATE TABLE IF NOT EXISTS provider_catalog_refreshes (
+            id TEXT NOT NULL,
+            tenant_id TEXT NOT NULL,
+            connection_id TEXT NOT NULL,
+            connection_fingerprint TEXT NOT NULL,
+            status TEXT NOT NULL,
+            model_count INTEGER NOT NULL DEFAULT 0,
+            truncated INTEGER NOT NULL DEFAULT 0,
+            catalog_fingerprint TEXT,
+            error_code TEXT,
+            started_at TEXT NOT NULL,
+            completed_at TEXT,
+            PRIMARY KEY (tenant_id, id)
+        );
+        CREATE TABLE IF NOT EXISTS provider_catalog_models (
+            tenant_id TEXT NOT NULL,
+            connection_id TEXT NOT NULL,
+            model_id TEXT NOT NULL,
+            normalized_model_id TEXT NOT NULL,
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            capability_state TEXT NOT NULL DEFAULT 'capabilities_unclassified',
+            status TEXT NOT NULL DEFAULT 'active',
+            first_seen_at TEXT NOT NULL,
+            last_seen_at TEXT NOT NULL,
+            retired_at TEXT,
+            last_refresh_id TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, connection_id, model_id)
+        );
+        CREATE TABLE IF NOT EXISTS provider_catalog_offerings (
+            tenant_id TEXT NOT NULL,
+            connection_id TEXT NOT NULL,
+            model_id TEXT NOT NULL,
+            operation TEXT NOT NULL,
+            access_mode TEXT NOT NULL,
+            capability_source TEXT NOT NULL,
+            pricing_json TEXT,
+            pricing_source TEXT,
+            pricing_status TEXT NOT NULL DEFAULT 'unknown',
+            pricing_observed_at TEXT,
+            billing_authoritative INTEGER NOT NULL DEFAULT 0,
+            stale INTEGER NOT NULL DEFAULT 0,
+            observed_at TEXT NOT NULL,
+            last_refresh_id TEXT NOT NULL,
+            PRIMARY KEY (
+                tenant_id, connection_id, model_id, operation, access_mode
+            )
+        );
         CREATE INDEX IF NOT EXISTS idx_router_connections_tenant_enabled
             ON router_connections (tenant_id, enabled);
         CREATE INDEX IF NOT EXISTS idx_router_decisions_tenant_created
@@ -409,6 +456,21 @@ class SQLiteRouterRepository:
             );
         CREATE INDEX IF NOT EXISTS idx_provider_chat_canary_runs_status
             ON provider_chat_canary_runs (tenant_id, status);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_provider_catalog_refreshes_running
+            ON provider_catalog_refreshes (tenant_id, connection_id)
+            WHERE status = 'running';
+        CREATE INDEX IF NOT EXISTS idx_provider_catalog_refreshes_recent
+            ON provider_catalog_refreshes (
+                tenant_id, connection_id, started_at DESC
+            );
+        CREATE INDEX IF NOT EXISTS idx_provider_catalog_models_status
+            ON provider_catalog_models (
+                tenant_id, connection_id, status, model_id
+            );
+        CREATE INDEX IF NOT EXISTS idx_provider_catalog_offerings_lookup
+            ON provider_catalog_offerings (
+                tenant_id, operation, stale, model_id
+            );
         """
         with self._lock, self._connect() as connection:
             previous_schema_version = int(
@@ -610,6 +672,15 @@ class SQLiteRouterRepository:
                 """,
                 (now, now),
             )
+            connection.execute(
+                """
+                UPDATE provider_catalog_refreshes
+                SET status = 'uncertain', error_code = 'server_restarted',
+                    completed_at = ?
+                WHERE status = 'running'
+                """,
+                (now,),
+            )
             connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 
     def create_connection(
@@ -702,14 +773,32 @@ class SQLiteRouterRepository:
                     self._mask(api_key),
                 ]
             )
-        if payload.enabled is not None:
-            updates.extend(["enabled = ?", "health = ?"])
-            values.extend(
+        configuration_changed = any(
+            value is not None
+            for value in (payload.base_url, payload.scopes, payload.api_key)
+        )
+        if configuration_changed:
+            updates.extend(
                 [
-                    int(payload.enabled),
-                    "untested" if payload.enabled else "disabled",
+                    "health = ?",
+                    "model_count = ?",
+                    "last_checked_at = ?",
+                    "last_error_code = ?",
+                    "last_error_hint = ?",
                 ]
             )
+            remains_enabled = (
+                current.enabled if payload.enabled is None else payload.enabled
+            )
+            values.extend(
+                ["untested" if remains_enabled else "disabled", 0, None, None, None]
+            )
+        if payload.enabled is not None:
+            updates.append("enabled = ?")
+            values.append(int(payload.enabled))
+            if not configuration_changed:
+                updates.append("health = ?")
+                values.append("untested" if payload.enabled else "disabled")
         if not updates:
             return current
         updates.append("updated_at = ?")
@@ -776,6 +865,407 @@ class SQLiteRouterRepository:
             separators=(",", ":"),
         )
         return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+    def claim_catalog_refresh(
+        self,
+        tenant_id: str,
+        *,
+        refresh_id: str,
+        connection_id: str,
+        connection_fingerprint: str,
+    ) -> dict[str, object]:
+        clean_tenant = self._tenant_id(tenant_id)
+        self.get_connection(clean_tenant, connection_id)
+        now = utc_now()
+        try:
+            with self._lock, self._connect() as connection:
+                connection.execute(
+                    """
+                    INSERT INTO provider_catalog_refreshes (
+                        id, tenant_id, connection_id, connection_fingerprint,
+                        status, started_at
+                    ) VALUES (?, ?, ?, ?, 'running', ?)
+                    """,
+                    (
+                        refresh_id,
+                        clean_tenant,
+                        connection_id,
+                        connection_fingerprint,
+                        now,
+                    ),
+                )
+                row = connection.execute(
+                    """
+                    SELECT * FROM provider_catalog_refreshes
+                    WHERE tenant_id = ? AND id = ?
+                    """,
+                    (clean_tenant, refresh_id),
+                ).fetchone()
+        except sqlite3.IntegrityError as exc:
+            raise RouterRepositoryError(
+                "provider_catalog_refresh_in_progress"
+            ) from exc
+        return dict(row)
+
+    def complete_catalog_refresh(
+        self,
+        tenant_id: str,
+        refresh_id: str,
+        *,
+        connection_id: str,
+        models: list[dict[str, object]],
+        offerings: list[dict[str, object]],
+        model_count: int,
+        truncated: bool,
+        catalog_fingerprint: str,
+        observed_at: str,
+    ) -> dict[str, object]:
+        clean_tenant = self._tenant_id(tenant_id)
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            running = connection.execute(
+                """
+                SELECT id FROM provider_catalog_refreshes
+                WHERE tenant_id = ? AND id = ? AND connection_id = ?
+                    AND status = 'running'
+                """,
+                (clean_tenant, refresh_id, connection_id),
+            ).fetchone()
+            if running is None:
+                raise RouterRepositoryError("provider_catalog_refresh_not_running")
+
+            if truncated:
+                connection.execute(
+                    """
+                    UPDATE provider_catalog_models
+                    SET status = 'stale'
+                    WHERE tenant_id = ? AND connection_id = ?
+                        AND status IN ('active', 'stale')
+                    """,
+                    (clean_tenant, connection_id),
+                )
+            else:
+                connection.execute(
+                    """
+                    UPDATE provider_catalog_models
+                    SET status = 'retired', retired_at = ?
+                    WHERE tenant_id = ? AND connection_id = ?
+                        AND status IN ('active', 'stale')
+                    """,
+                    (observed_at, clean_tenant, connection_id),
+                )
+            connection.execute(
+                """
+                UPDATE provider_catalog_offerings
+                SET stale = 1
+                WHERE tenant_id = ? AND connection_id = ?
+                """,
+                (clean_tenant, connection_id),
+            )
+
+            for model in models:
+                model_id = str(model["model_id"])
+                metadata = model.get("metadata")
+                connection.execute(
+                    """
+                    INSERT INTO provider_catalog_models (
+                        tenant_id, connection_id, model_id,
+                        normalized_model_id, metadata_json, capability_state,
+                        status, first_seen_at, last_seen_at, retired_at,
+                        last_refresh_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, 'active', ?, ?, NULL, ?)
+                    ON CONFLICT(tenant_id, connection_id, model_id) DO UPDATE SET
+                        normalized_model_id = excluded.normalized_model_id,
+                        metadata_json = excluded.metadata_json,
+                        capability_state = excluded.capability_state,
+                        status = 'active',
+                        last_seen_at = excluded.last_seen_at,
+                        retired_at = NULL,
+                        last_refresh_id = excluded.last_refresh_id
+                    """,
+                    (
+                        clean_tenant,
+                        connection_id,
+                        model_id,
+                        str(model.get("normalized_model_id") or model_id),
+                        json.dumps(
+                            metadata if isinstance(metadata, dict) else {},
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ),
+                        str(
+                            model.get("capability_state")
+                            or "capabilities_unclassified"
+                        ),
+                        observed_at,
+                        observed_at,
+                        refresh_id,
+                    ),
+                )
+
+            for offering in offerings:
+                pricing = offering.get("pricing")
+                connection.execute(
+                    """
+                    INSERT INTO provider_catalog_offerings (
+                        tenant_id, connection_id, model_id, operation,
+                        access_mode, capability_source, pricing_json,
+                        pricing_source, pricing_status, pricing_observed_at,
+                        billing_authoritative, stale, observed_at,
+                        last_refresh_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, ?, ?)
+                    ON CONFLICT(
+                        tenant_id, connection_id, model_id, operation,
+                        access_mode
+                    ) DO UPDATE SET
+                        capability_source = excluded.capability_source,
+                        pricing_json = excluded.pricing_json,
+                        pricing_source = excluded.pricing_source,
+                        pricing_status = excluded.pricing_status,
+                        pricing_observed_at = excluded.pricing_observed_at,
+                        billing_authoritative = 0,
+                        stale = 0,
+                        observed_at = excluded.observed_at,
+                        last_refresh_id = excluded.last_refresh_id
+                    """,
+                    (
+                        clean_tenant,
+                        connection_id,
+                        str(offering["model_id"]),
+                        str(offering["operation"]),
+                        str(offering["access_mode"]),
+                        str(offering["capability_source"]),
+                        (
+                            json.dumps(
+                                pricing,
+                                sort_keys=True,
+                                separators=(",", ":"),
+                            )
+                            if isinstance(pricing, dict)
+                            else None
+                        ),
+                        offering.get("pricing_source"),
+                        str(offering.get("pricing_status") or "unknown"),
+                        offering.get("pricing_observed_at"),
+                        observed_at,
+                        refresh_id,
+                    ),
+                )
+
+            connection.execute(
+                """
+                UPDATE router_connections
+                SET health = 'online', model_count = ?, last_checked_at = ?,
+                    last_error_code = NULL, last_error_hint = NULL,
+                    updated_at = ?
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (
+                    max(0, int(model_count)),
+                    observed_at,
+                    observed_at,
+                    clean_tenant,
+                    connection_id,
+                ),
+            )
+            cursor = connection.execute(
+                """
+                UPDATE provider_catalog_refreshes
+                SET status = 'succeeded', model_count = ?, truncated = ?,
+                    catalog_fingerprint = ?, error_code = NULL,
+                    completed_at = ?
+                WHERE tenant_id = ? AND id = ? AND status = 'running'
+                """,
+                (
+                    max(0, int(model_count)),
+                    int(truncated),
+                    catalog_fingerprint,
+                    now,
+                    clean_tenant,
+                    refresh_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise RouterRepositoryError("provider_catalog_refresh_not_running")
+            row = connection.execute(
+                """
+                SELECT * FROM provider_catalog_refreshes
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (clean_tenant, refresh_id),
+            ).fetchone()
+        return dict(row)
+
+    def fail_catalog_refresh(
+        self,
+        tenant_id: str,
+        refresh_id: str,
+        *,
+        connection_id: str,
+        error_code: str,
+        health: str | None = None,
+        model_count: int = 0,
+        checked_at: str | None = None,
+        error_hint: str | None = None,
+    ) -> dict[str, object]:
+        clean_tenant = self._tenant_id(tenant_id)
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE provider_catalog_refreshes
+                SET status = 'failed', error_code = ?, completed_at = ?
+                WHERE tenant_id = ? AND id = ? AND connection_id = ?
+                    AND status = 'running'
+                """,
+                (error_code, now, clean_tenant, refresh_id, connection_id),
+            )
+            if cursor.rowcount != 1:
+                raise RouterRepositoryError("provider_catalog_refresh_not_running")
+            connection.execute(
+                """
+                UPDATE provider_catalog_models
+                SET status = 'stale'
+                WHERE tenant_id = ? AND connection_id = ? AND status = 'active'
+                """,
+                (clean_tenant, connection_id),
+            )
+            connection.execute(
+                """
+                UPDATE provider_catalog_offerings
+                SET stale = 1
+                WHERE tenant_id = ? AND connection_id = ?
+                """,
+                (clean_tenant, connection_id),
+            )
+            if health is not None and checked_at is not None:
+                connection.execute(
+                    """
+                    UPDATE router_connections
+                    SET health = ?, model_count = ?, last_checked_at = ?,
+                        last_error_code = ?, last_error_hint = ?, updated_at = ?
+                    WHERE tenant_id = ? AND id = ?
+                    """,
+                    (
+                        health,
+                        max(0, int(model_count)),
+                        checked_at,
+                        error_code,
+                        error_hint,
+                        checked_at,
+                        clean_tenant,
+                        connection_id,
+                    ),
+                )
+            row = connection.execute(
+                """
+                SELECT * FROM provider_catalog_refreshes
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (clean_tenant, refresh_id),
+            ).fetchone()
+        return dict(row)
+
+    def list_catalog_refreshes(
+        self,
+        tenant_id: str,
+        *,
+        connection_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, object]]:
+        clean_tenant = self._tenant_id(tenant_id)
+        clauses = ["tenant_id = ?"]
+        values: list[object] = [clean_tenant]
+        if connection_id is not None:
+            clauses.append("connection_id = ?")
+            values.append(connection_id)
+        values.append(max(1, min(int(limit), 500)))
+        with self._lock, self._connect() as connection:
+            rows = connection.execute(
+                f"""
+                SELECT * FROM provider_catalog_refreshes
+                WHERE {" AND ".join(clauses)}
+                ORDER BY started_at DESC, id DESC
+                LIMIT ?
+                """,
+                tuple(values),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def list_catalog_models(
+        self,
+        tenant_id: str,
+        *,
+        connection_id: str | None = None,
+        model_id: str | None = None,
+        status: str | None = None,
+        limit: int = 500,
+        offset: int = 0,
+    ) -> list[dict[str, object]]:
+        clean_tenant = self._tenant_id(tenant_id)
+        clauses = ["tenant_id = ?"]
+        values: list[object] = [clean_tenant]
+        for column, value in (
+            ("connection_id", connection_id),
+            ("model_id", model_id),
+            ("status", status),
+        ):
+            if value is not None:
+                clauses.append(f"{column} = ?")
+                values.append(value)
+        values.extend(
+            [max(1, min(int(limit), 5_000)), max(0, int(offset))]
+        )
+        with self._lock, self._connect() as connection:
+            rows = connection.execute(
+                f"""
+                SELECT * FROM provider_catalog_models
+                WHERE {" AND ".join(clauses)}
+                ORDER BY model_id ASC, connection_id ASC
+                LIMIT ? OFFSET ?
+                """,
+                tuple(values),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def list_catalog_offerings(
+        self,
+        tenant_id: str,
+        *,
+        connection_id: str | None = None,
+        model_id: str | None = None,
+        operation: str | None = None,
+        include_stale: bool = True,
+        limit: int = 500,
+        offset: int = 0,
+    ) -> list[dict[str, object]]:
+        clean_tenant = self._tenant_id(tenant_id)
+        clauses = ["tenant_id = ?"]
+        values: list[object] = [clean_tenant]
+        for column, value in (
+            ("connection_id", connection_id),
+            ("model_id", model_id),
+            ("operation", operation),
+        ):
+            if value is not None:
+                clauses.append(f"{column} = ?")
+                values.append(value)
+        if not include_stale:
+            clauses.append("stale = 0")
+        values.extend(
+            [max(1, min(int(limit), 5_000)), max(0, int(offset))]
+        )
+        with self._lock, self._connect() as connection:
+            rows = connection.execute(
+                f"""
+                SELECT * FROM provider_catalog_offerings
+                WHERE {" AND ".join(clauses)}
+                ORDER BY model_id ASC, operation ASC, connection_id ASC
+                LIMIT ? OFFSET ?
+                """,
+                tuple(values),
+            ).fetchall()
+        return [dict(row) for row in rows]
 
     def claim_chat_certification(
         self,

--- a/server/model_router/schemas.py
+++ b/server/model_router/schemas.py
@@ -33,6 +33,44 @@ ProviderChatCanaryRunStatus = Literal[
     "preflight_fallback",
     "cancelled",
 ]
+ProviderCatalogRefreshStatus = Literal[
+    "running",
+    "succeeded",
+    "failed",
+    "uncertain",
+]
+ProviderCatalogModelStatus = Literal["active", "stale", "retired"]
+OperationName = Literal[
+    "chat",
+    "analyze_document",
+    "analyze_image",
+    "generate_image",
+    "transcribe",
+    "synthesize_speech",
+    "generate_audio",
+    "analyze_audio",
+    "realtime_voice",
+    "analyze_video",
+    "generate_video",
+    "generate_world",
+    "embed",
+    "rerank",
+]
+OperationAvailabilityStatus = Literal[
+    "available",
+    "needs_configuration",
+    "verification_required",
+    "upstream_unavailable",
+    "disabled",
+]
+OperationVerificationStatus = Literal[
+    "verified",
+    "contract_verified",
+    "manual_required",
+    "failed",
+    "not_applicable",
+]
+OperationInteractionStatus = Literal["ready", "planned", "disabled"]
 CONNECTION_SCOPE_ORDER: tuple[ConnectionScope, ...] = (
     "chat",
     "audio",
@@ -179,6 +217,108 @@ class ProviderModelsRefreshResponse(BaseModel):
     checked_at: str
     truncated: bool = False
     message: str
+
+
+class ProviderCatalogPrice(BaseModel):
+    currency: str | None = None
+    unit: str | None = None
+    input_price: str | None = None
+    output_price: str | None = None
+    source: str
+    observed_at: str
+    status: Literal["reported", "verified_source", "ambiguous", "unknown", "stale"]
+    billing_authoritative: Literal[False] = False
+
+
+class ProviderCatalogRefreshResponse(BaseModel):
+    contract_version: Literal["modelmirror-provider-catalog-v1"]
+    refresh_id: str
+    connection_id: str
+    status: ProviderCatalogRefreshStatus
+    model_ids: list[str] = Field(default_factory=list, max_length=500)
+    model_count: int = 0
+    checked_at: str
+    truncated: bool = False
+    catalog_fingerprint: str | None = None
+    error_code: str | None = None
+    message: str
+
+
+class ProviderCatalogOfferingSummary(BaseModel):
+    connection_id: str
+    connection_name: str
+    provider_kind: ConnectionKind
+    model_id: str
+    operation: OperationName
+    access_mode: str
+    capability_source: str
+    inventory_status: ProviderCatalogModelStatus
+    connection_health: ConnectionHealth
+    verification_status: OperationVerificationStatus
+    invocable: bool
+    reason_codes: list[str] = Field(default_factory=list)
+    refresh_id: str
+    observed_at: str
+    stale: bool = False
+    pricing: ProviderCatalogPrice | None = None
+
+
+class ProviderCatalogOfferingsResponse(BaseModel):
+    contract_version: Literal["modelmirror-provider-catalog-v1"]
+    next_cursor: str | None = None
+    offerings: list[ProviderCatalogOfferingSummary] = Field(default_factory=list)
+
+
+class OperationReadinessProjection(BaseModel):
+    operation: OperationName
+    interaction_status: OperationInteractionStatus
+    availability_status: OperationAvailabilityStatus
+    verification_status: OperationVerificationStatus
+    invocable: bool
+    access_modes: list[str] = Field(default_factory=list)
+    reason_codes: list[str] = Field(default_factory=list)
+    observed_at: str | None = None
+    stale: bool = False
+    pricing: list[ProviderCatalogPrice] = Field(default_factory=list)
+
+
+class ControlPlaneCatalogModel(BaseModel):
+    model_id: str
+    catalog_presence: Literal["present", "stale", "retired", "unknown"]
+    display_source: Literal["runtime_discovered", "runtime_and_curated"] = (
+        "runtime_discovered"
+    )
+    operations: list[OperationReadinessProjection] = Field(default_factory=list)
+
+
+class ControlPlaneCatalogResponse(BaseModel):
+    contract_version: Literal["modelmirror-provider-catalog-v1"]
+    catalog_revision: str
+    generated_at: str
+    stale: bool
+    next_cursor: str | None = None
+    models: list[ControlPlaneCatalogModel] = Field(default_factory=list)
+
+
+class ControlPlaneOperationCount(BaseModel):
+    operation: OperationName
+    total: int
+    invocable: int
+    stale: int
+    blocked: int
+
+
+class ProviderControlPlaneOverview(BaseModel):
+    contract_version: Literal["modelmirror-provider-catalog-v1"]
+    catalog_revision: str
+    generated_at: str
+    provider_count: int
+    online_provider_count: int
+    discovered_model_count: int
+    stale_model_count: int
+    operation_counts: list[ControlPlaneOperationCount] = Field(default_factory=list)
+    blocking_reason_codes: list[str] = Field(default_factory=list)
+    default_qualification: Literal["not_evaluated"] = "not_evaluated"
 
 
 class ProviderChatCertificationRequest(BaseModel):

--- a/server/model_router/service.py
+++ b/server/model_router/service.py
@@ -184,7 +184,11 @@ class ModelRouterService:
         return result, model_ids
 
     async def fetch_connection_model_records(
-        self, connection_id: str
+        self,
+        connection_id: str,
+        *,
+        persist_result: bool = True,
+        require_chat_scope: bool = True,
     ) -> tuple[ConnectionTestResult, list[dict[str, object]]]:
         connection = self.repository.get_connection(self.tenant_id, connection_id)
         if not connection.enabled:
@@ -193,14 +197,14 @@ class ModelRouterService:
                 "该模型服务已停用。",
                 status_code=409,
             )
-        if "chat" not in connection.scopes:
+        if require_chat_scope and "chat" not in connection.scopes:
             return self._scope_mismatch_result(connection), []
         api_key = self.repository.resolve_api_key(self.tenant_id, connection_id)
         result, _, records = await self._probe_with_models(
             connection.base_url, api_key
         )
         save_result = getattr(self.repository, "save_test_result", None)
-        if callable(save_result):
+        if persist_result and callable(save_result):
             save_result(
                 self.tenant_id,
                 connection_id,

--- a/server/multimodal/audio_catalog.py
+++ b/server/multimodal/audio_catalog.py
@@ -347,6 +347,19 @@ class AudioCatalogService:
         self._cache: _CachedAudioCatalog | None = None
         self._lock = asyncio.Lock()
 
+    def peek_catalog(self) -> AudioModelCatalogResponse | None:
+        """Return the last bounded snapshot without performing provider I/O."""
+        cached = self._cache
+        if cached is None:
+            return None
+        age = time.monotonic() - cached.stored_at
+        if age > AUDIO_CATALOG_STALE_SECONDS:
+            return None
+        return self._response(
+            cached,
+            stale=age > AUDIO_CATALOG_TTL_SECONDS,
+        )
+
     async def get_catalog(
         self,
         *,

--- a/server/multimodal/image_catalog.py
+++ b/server/multimodal/image_catalog.py
@@ -97,6 +97,19 @@ class ImageCatalogService:
         self._cache: _CachedImageCatalog | None = None
         self._lock = asyncio.Lock()
 
+    def peek_catalog(self) -> ImageModelCatalogResponse | None:
+        """Return the last bounded snapshot without performing provider I/O."""
+        cached = self._cache
+        if cached is None:
+            return None
+        age = time.monotonic() - cached.stored_at
+        if age > IMAGE_CATALOG_STALE_SECONDS:
+            return None
+        return self._response(
+            cached,
+            stale=age > IMAGE_CATALOG_TTL_SECONDS,
+        )
+
     async def get_catalog(
         self,
         *,

--- a/server/multimodal/video_catalog.py
+++ b/server/multimodal/video_catalog.py
@@ -193,6 +193,19 @@ class VideoCatalogService:
         self._cache: _CachedVideoCatalog | None = None
         self._lock = asyncio.Lock()
 
+    def peek_catalog(self) -> VideoModelCatalogResponse | None:
+        """Return the last bounded snapshot without performing provider I/O."""
+        cached = self._cache
+        if cached is None:
+            return None
+        age = time.monotonic() - cached.stored_at
+        if age > VIDEO_CATALOG_STALE_SECONDS:
+            return None
+        return self._response(
+            cached,
+            stale=age > VIDEO_CATALOG_TTL_SECONDS,
+        )
+
     async def get_catalog(self, *, force: bool = False) -> VideoModelCatalogResponse:
         analysis_enabled = self._enabled("MULTIMODAL_VIDEO_ANALYSIS_ENABLED")
         generation_enabled = self._enabled(

--- a/server/omniroute/catalog.py
+++ b/server/omniroute/catalog.py
@@ -283,6 +283,42 @@ class OmniRouteCatalogService:
         self._last_good = None
         self._last_good_monotonic = 0.0
 
+    def peek_catalog(self) -> ModelCatalogResponse | None:
+        """Return configured state or the last bounded snapshot without I/O."""
+        settings = self._settings_factory()
+        if not settings.enabled:
+            return ModelCatalogResponse(
+                source="bundled",
+                router_status="disabled",
+                stale=False,
+                synced_at=None,
+                catalog_version=CATALOG_VERSION,
+                routes=_disabled_routes(),
+            )
+        if not settings.configured:
+            return ModelCatalogResponse(
+                source="bundled",
+                router_status="offline",
+                stale=False,
+                synced_at=None,
+                catalog_version=CATALOG_VERSION,
+                routes=_disabled_routes(),
+            )
+        if self._last_good is None:
+            return None
+        age = time.monotonic() - self._last_good_monotonic
+        if age > settings.stale_ttl_seconds:
+            return None
+        catalog = self._last_good.model_copy(deep=True)
+        if age > settings.catalog_ttl_seconds:
+            catalog.router_status = "stale"
+            catalog.stale = True
+            for model in catalog.models:
+                model.availability = "degraded"
+            for route in catalog.routes:
+                route.availability = "degraded"
+        return catalog
+
     async def get_catalog(self, *, force: bool = False) -> ModelCatalogResponse:
         settings = self._settings_factory()
         if not settings.enabled:

--- a/server/tests/test_control_plane_catalog_api.py
+++ b/server/tests/test_control_plane_catalog_api.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient, MockTransport, Request, Response
+
+from server.model_router.admin_auth import reset_provider_admin_auth
+from server.model_router.api import configure_model_router, models_router, router
+from server.model_router.egress import ProviderEgressPolicy
+from server.model_router.provider_catalog import ProviderCatalogService
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import RouterConnectionCreate
+from server.model_router.service import ModelRouterService
+
+
+PAIRING_SECRET = "provider-admin-test-secret-at-least-32-chars"
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth() -> None:
+    reset_provider_admin_auth()
+    yield
+    reset_provider_admin_auth()
+
+
+async def _app(tmp_path: Path) -> tuple[FastAPI, str]:
+    repository = SQLiteRouterRepository(tmp_path)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="newAPI",
+            kind="newapi",
+            base_url="https://provider.example/v1",
+            api_key="catalog-secret",
+            scopes=["chat"],
+        ),
+    )
+
+    def handler(_request: Request) -> Response:
+        return Response(200, json={"data": [{"id": "provider/model"}]})
+
+    service = ModelRouterService(
+        repository,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=MockTransport(handler), trust_env=False
+        ),
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+    configure_model_router(service)
+    await ProviderCatalogService(service).refresh_connection(connection.id)
+    app = FastAPI()
+    app.include_router(router)
+    app.include_router(models_router)
+    return app, connection.id
+
+
+@pytest.mark.asyncio
+async def test_public_catalog_is_redacted_and_side_effect_free(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_CHAT_CANARY_ENABLED", "false")
+    app, _connection_id = await _app(tmp_path)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://localhost"
+    ) as client:
+        response = await client.get(
+            "/api/models/control-plane-catalog?include_unavailable=true"
+        )
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    payload = response.json()
+    assert payload["contract_version"] == "modelmirror-provider-catalog-v1"
+    assert payload["models"][0]["model_id"] == "provider/model"
+    serialized = response.text
+    assert "catalog-secret" not in serialized
+    assert "provider.example" not in serialized
+    assert "connection_id" not in serialized
+    assert "tenant_id" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_admin_overview_and_offerings_require_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", PAIRING_SECRET)
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_CHAT_CANARY_ENABLED", "false")
+    app, connection_id = await _app(tmp_path)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://localhost"
+    ) as client:
+        assert (await client.get("/api/router/control-plane/overview")).status_code == 401
+        assert (await client.get("/api/router/catalog/offerings")).status_code == 401
+        paired = await client.post(
+            "/api/router/admin/session", json={"pairing_secret": PAIRING_SECRET}
+        )
+        assert paired.status_code == 200
+        overview = await client.get("/api/router/control-plane/overview")
+        offerings = await client.get("/api/router/catalog/offerings")
+        filtered = await client.get(
+            "/api/router/catalog/offerings?status=active&operation=chat"
+        )
+
+    assert overview.status_code == 200
+    assert overview.json()["provider_count"] == 1
+    assert overview.json()["default_qualification"] == "not_evaluated"
+    assert offerings.status_code == 200
+    assert offerings.json()["offerings"][0]["connection_id"] == connection_id
+    assert filtered.status_code == 200
+    assert len(filtered.json()["offerings"]) == 1
+    assert "catalog-secret" not in offerings.text
+    assert "provider.example" not in offerings.text
+
+
+@pytest.mark.asyncio
+async def test_public_catalog_pagination_rejects_stale_cursor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_MIRROR_PROVIDER_CHAT_CANARY_ENABLED", "false")
+    app, _connection_id = await _app(tmp_path)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://localhost"
+    ) as client:
+        first = await client.get(
+            "/api/models/control-plane-catalog?include_unavailable=true&limit=1"
+        )
+        invalid = await client.get(
+            "/api/models/control-plane-catalog?include_unavailable=true&cursor=invalid"
+        )
+
+    assert first.status_code == 200
+    assert invalid.status_code == 422
+    assert invalid.json()["detail"]["code"] == "invalid_catalog_cursor"

--- a/server/tests/test_control_plane_catalog_service.py
+++ b/server/tests/test_control_plane_catalog_service.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from server.model_router.chat_canary import ProviderChatCanaryService
+from server.model_router.control_plane_catalog import ControlPlaneCatalogService
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.service import ModelRouterService
+
+
+def _service(tmp_path, **catalogs) -> ControlPlaneCatalogService:
+    router = ModelRouterService(SQLiteRouterRepository(tmp_path))
+    return ControlPlaneCatalogService(router, **catalogs)
+
+
+def test_canary_only_model_is_included_before_available_filter(
+    tmp_path, monkeypatch
+) -> None:
+    catalog = SimpleNamespace(
+        source="bundled",
+        stale=False,
+        synced_at="2026-08-21T00:00:00+00:00",
+        models=[
+            SimpleNamespace(
+                invocation_id="provider/canary-only",
+                invocable=False,
+                interaction_status="planned",
+                availability="offline",
+                operations=["chat"],
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        ProviderChatCanaryService,
+        "enabled",
+        lambda *_args, **_kwargs: True,
+    )
+    admin_status = Mock(
+        return_value=SimpleNamespace(
+            policy_enabled=True,
+            connections=[
+                SimpleNamespace(
+                    models=[
+                        SimpleNamespace(
+                            model_id="provider/canary-only",
+                            available=True,
+                        )
+                    ]
+                )
+            ],
+        )
+    )
+    monkeypatch.setattr(ProviderChatCanaryService, "admin_status", admin_status)
+
+    service = _service(tmp_path, general_catalog=catalog)
+    response = service.public_catalog()
+
+    assert [item.model_id for item in response.models] == ["provider/canary-only"]
+    readiness = response.models[0].operations[0]
+    assert readiness.invocable is True
+    assert readiness.access_modes == ["default", "newapi_canary"]
+    assert "newapi_canary_available" in readiness.reason_codes
+    overview = service.overview()
+    assert overview.operation_counts[0].invocable == 1
+    assert admin_status.call_count == 2
+
+
+def test_catalog_stale_flag_describes_all_pages_not_only_current_page(tmp_path) -> None:
+    general = SimpleNamespace(
+        source="bundled",
+        stale=False,
+        synced_at="2026-08-21T00:00:00+00:00",
+        models=[
+            SimpleNamespace(
+                invocation_id="a/current",
+                invocable=True,
+                interaction_status="ready",
+                availability="live",
+                operations=["chat"],
+            )
+        ],
+    )
+    image = SimpleNamespace(
+        stale=True,
+        synced_at="2026-08-20T00:00:00+00:00",
+        profiles=[
+            SimpleNamespace(
+                model_id="z/stale",
+                operation_readiness=[
+                    SimpleNamespace(
+                        operation="generate_image",
+                        interaction_status="ready",
+                        availability_status="available",
+                        verification_status="verified",
+                    )
+                ],
+                pricing=[],
+                price_per_generation_usd=None,
+            )
+        ],
+    )
+
+    first_page = _service(
+        tmp_path,
+        general_catalog=general,
+        image_catalog=image,
+    ).public_catalog(include_unavailable=True, limit=1)
+
+    assert first_page.models[0].model_id == "a/current"
+    assert first_page.models[0].operations[0].stale is False
+    assert first_page.stale is True
+    assert first_page.next_cursor is not None
+
+
+def test_internal_projection_reads_beyond_one_repository_page(tmp_path) -> None:
+    service = _service(tmp_path)
+    first = [{"model_id": f"model-{index}"} for index in range(5_000)]
+    final = [{"model_id": "model-5000"}]
+    reader = Mock(side_effect=[first, final])
+    service.repository.list_catalog_models = reader
+
+    rows = service._all_catalog_models()
+
+    assert len(rows) == 5_001
+    assert reader.call_args_list[0].kwargs["offset"] == 0
+    assert reader.call_args_list[1].kwargs["offset"] == 5_000

--- a/server/tests/test_model_catalog_snapshots.py
+++ b/server/tests/test_model_catalog_snapshots.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import time
+
+from server.model_router.catalog import (
+    CATALOG_TTL_SECONDS,
+    CatalogCoordinator,
+    NativeCatalogService,
+    _CacheEntry,
+)
+from server.omniroute.catalog import OmniRouteCatalogService
+from server.omniroute.config import OmniRouteSettings
+from server.omniroute.schemas import ModelCandidate, ModelCatalogResponse
+
+
+def _settings(*, enabled: bool = True, configured: bool = True) -> OmniRouteSettings:
+    return OmniRouteSettings(
+        enabled=enabled,
+        base_url="http://omniroute:20128" if configured else "",
+        api_key="secret" if configured else "",
+        default_router="omniroute",
+        catalog_ttl_seconds=30,
+        stale_ttl_seconds=600,
+    )
+
+
+def _catalog(source: str = "omniroute") -> ModelCatalogResponse:
+    return ModelCatalogResponse(
+        source=source,
+        router_status="online",
+        stale=False,
+        synced_at="2026-08-21T00:00:00+00:00",
+        catalog_version="test",
+        models=[
+            ModelCandidate(
+                profile_id="model",
+                invocation_id="model",
+                name="Model",
+                provider="provider",
+            )
+        ],
+    )
+
+
+def test_omniroute_peek_is_side_effect_free_and_bounded() -> None:
+    calls = 0
+
+    def client_factory(_settings):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("peek must not construct a client")
+
+    service = OmniRouteCatalogService(lambda: _settings(), client_factory)
+    assert service.peek_catalog() is None
+    assert calls == 0
+
+    service._last_good = _catalog()
+    service._last_good_monotonic = time.monotonic() - 60
+    snapshot = service.peek_catalog()
+    assert snapshot is not None and snapshot.stale is True
+    assert snapshot.models[0].availability == "degraded"
+    assert calls == 0
+
+
+def test_disabled_sidecar_peek_reports_configuration_without_io() -> None:
+    service = OmniRouteCatalogService(lambda: _settings(enabled=False))
+    snapshot = service.peek_catalog()
+    assert snapshot is not None
+    assert snapshot.router_status == "disabled"
+    assert snapshot.models == []
+
+
+def test_native_peek_marks_old_cache_stale_without_refresh() -> None:
+    native = NativeCatalogService()
+    native._cache = _CacheEntry(
+        catalog=_catalog("native"),
+        stored_at=time.monotonic() - CATALOG_TTL_SECONDS - 1,
+    )
+    snapshot = native.peek_catalog()
+    assert snapshot is not None
+    assert snapshot.router_status == "stale"
+    assert snapshot.models[0].availability == "degraded"
+
+
+def test_coordinator_peek_uses_selected_sidecar_snapshot(monkeypatch) -> None:
+    sidecar = OmniRouteCatalogService(lambda: _settings(enabled=False))
+    coordinator = CatalogCoordinator(sidecar)
+
+    class Service:
+        @staticmethod
+        def get_policy():
+            return type("Policy", (), {"engine": "sidecar"})()
+
+    monkeypatch.setattr(
+        "server.model_router.catalog.get_model_router_service",
+        lambda: Service(),
+    )
+    assert coordinator.peek_catalog().router_status == "disabled"

--- a/server/tests/test_model_router_egress.py
+++ b/server/tests/test_model_router_egress.py
@@ -36,12 +36,14 @@ async def test_public_https_is_pinned_and_public_http_is_rejected() -> None:
         "https://169.254.169.254/latest/meta-data",
         "https://224.0.0.1/v1",
         "https://0.0.0.0/v1",
+        "https://198.18.0.1/v1",
     ],
 )
 async def test_protected_addresses_fail_closed(url: str) -> None:
     with pytest.raises(ProviderEgressError) as exc_info:
         await ProviderEgressPolicy().authorize(url)
     assert exc_info.value.code == "provider_address_blocked"
+    assert "VPN Fake-IP" in exc_info.value.message
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_multimodal_catalog_snapshots.py
+++ b/server/tests/test_multimodal_catalog_snapshots.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.service import ModelRouterService
+from server.multimodal.audio_catalog import (
+    AUDIO_CATALOG_STALE_SECONDS,
+    AudioCatalogService,
+    AudioChatProfile,
+    _CachedAudioCatalog,
+)
+from server.multimodal.image_catalog import (
+    ImageCatalogService,
+    ImageModelProfile,
+    _CachedImageCatalog,
+)
+from server.multimodal.video_catalog import (
+    VideoCatalogService,
+    VideoModelProfile,
+    _CachedVideoCatalog,
+)
+
+
+def _router(tmp_path: Path) -> ModelRouterService:
+    return ModelRouterService(SQLiteRouterRepository(tmp_path))
+
+
+def test_peek_catalog_never_populates_an_empty_cache(tmp_path: Path) -> None:
+    router = _router(tmp_path)
+    assert AudioCatalogService(router).peek_catalog() is None
+    assert ImageCatalogService(router).peek_catalog() is None
+    assert VideoCatalogService(router).peek_catalog() is None
+
+
+def test_peek_catalog_returns_copied_snapshots_without_provider_io(
+    tmp_path: Path,
+) -> None:
+    router = _router(tmp_path)
+    now = time.monotonic()
+    audio = AudioCatalogService(router)
+    image = ImageCatalogService(router)
+    video = VideoCatalogService(router)
+    audio._cache = _CachedAudioCatalog(
+        [
+            AudioChatProfile(
+                model_id="audio/model",
+                display_name="Audio",
+                provider="openrouter",
+                invocable=True,
+                interaction_status="ready",
+                operations=["transcribe"],
+            )
+        ],
+        "openrouter",
+        "2026-08-21T00:00:00+00:00",
+        now,
+    )
+    image._cache = _CachedImageCatalog(
+        [
+            ImageModelProfile(
+                model_id="image/model",
+                display_name="Image",
+                operation="generate_image",
+            )
+        ],
+        "2026-08-21T00:00:00+00:00",
+        now,
+    )
+    video._cache = _CachedVideoCatalog(
+        [VideoModelProfile(model_id="video/model", operation="generate_video")],
+        "2026-08-21T00:00:00+00:00",
+        now,
+    )
+
+    assert audio.peek_catalog().profiles[0].model_id == "audio/model"
+    assert image.peek_catalog().profiles[0].model_id == "image/model"
+    assert video.peek_catalog().profiles[0].model_id == "video/model"
+
+    copied = image.peek_catalog()
+    copied.profiles.clear()
+    assert image.peek_catalog().profiles[0].model_id == "image/model"
+
+
+def test_peek_catalog_rejects_snapshots_past_stale_window(tmp_path: Path) -> None:
+    service = AudioCatalogService(_router(tmp_path))
+    service._cache = _CachedAudioCatalog(
+        [],
+        "openrouter",
+        "2026-08-21T00:00:00+00:00",
+        time.monotonic() - AUDIO_CATALOG_STALE_SECONDS - 1,
+    )
+    assert service.peek_catalog() is None

--- a/server/tests/test_provider_catalog_repository.py
+++ b/server/tests/test_provider_catalog_repository.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from server.model_router.repository import RouterRepositoryError, SQLiteRouterRepository
+from server.model_router.schemas import RouterConnectionCreate, RouterConnectionUpdate
+
+
+def _connection(repository: SQLiteRouterRepository, tenant_id: str = "local") -> str:
+    return repository.create_connection(
+        tenant_id,
+        RouterConnectionCreate(
+            name="provider",
+            kind="newapi",
+            base_url="https://provider.example/v1",
+            api_key="secret",
+            scopes=["chat"],
+        ),
+    ).id
+
+
+def _claim(repository: SQLiteRouterRepository, connection_id: str, refresh_id: str) -> None:
+    repository.claim_catalog_refresh(
+        "local",
+        refresh_id=refresh_id,
+        connection_id=connection_id,
+        connection_fingerprint=repository.connection_config_fingerprint(
+            "local", connection_id
+        ),
+    )
+
+
+def _complete(
+    repository: SQLiteRouterRepository,
+    connection_id: str,
+    refresh_id: str,
+    model_ids: list[str],
+    *,
+    truncated: bool = False,
+) -> None:
+    repository.complete_catalog_refresh(
+        "local",
+        refresh_id,
+        connection_id=connection_id,
+        models=[
+            {
+                "model_id": model_id,
+                "normalized_model_id": model_id.casefold(),
+                "metadata": {"owned_by": "provider"},
+                "capability_state": "capabilities_unclassified",
+            }
+            for model_id in model_ids
+        ],
+        offerings=[
+            {
+                "model_id": model_id,
+                "operation": "chat",
+                "access_mode": "managed",
+                "capability_source": "connection_scope",
+                "pricing_status": "unknown",
+            }
+            for model_id in model_ids
+        ],
+        model_count=len(model_ids),
+        truncated=truncated,
+        catalog_fingerprint=f"fingerprint-{refresh_id}",
+        observed_at="2026-08-21T00:00:00+00:00",
+    )
+
+
+def test_v13_to_v14_is_additive_and_creates_catalog_tables(tmp_path: Path) -> None:
+    database_path = tmp_path / "router.sqlite3"
+    with sqlite3.connect(database_path) as connection:
+        connection.execute("PRAGMA user_version = 13")
+
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+
+    with sqlite3.connect(database_path) as connection:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 14
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    assert {
+        "provider_catalog_refreshes",
+        "provider_catalog_models",
+        "provider_catalog_offerings",
+    }.issubset(tables)
+    assert repository.list_connections("local") == []
+
+
+def test_refresh_claim_is_atomic_and_restart_marks_it_uncertain(tmp_path: Path) -> None:
+    repository = SQLiteRouterRepository(tmp_path)
+    connection_id = _connection(repository)
+    _claim(repository, connection_id, "refresh-1")
+
+    with pytest.raises(RouterRepositoryError, match="refresh_in_progress"):
+        _claim(repository, connection_id, "refresh-2")
+
+    restarted = SQLiteRouterRepository(tmp_path)
+    rows = restarted.list_catalog_refreshes("local", connection_id=connection_id)
+    assert rows[0]["status"] == "uncertain"
+    assert rows[0]["error_code"] == "server_restarted"
+
+
+def test_complete_refresh_retires_only_after_complete_snapshot(tmp_path: Path) -> None:
+    repository = SQLiteRouterRepository(tmp_path)
+    connection_id = _connection(repository)
+    _claim(repository, connection_id, "refresh-1")
+    _complete(repository, connection_id, "refresh-1", ["model-a", "model-b"])
+
+    _claim(repository, connection_id, "refresh-2")
+    _complete(
+        repository,
+        connection_id,
+        "refresh-2",
+        ["model-a"],
+        truncated=True,
+    )
+    truncated = {
+        row["model_id"]: row["status"]
+        for row in repository.list_catalog_models(
+            "local", connection_id=connection_id
+        )
+    }
+    assert truncated == {"model-a": "active", "model-b": "stale"}
+
+    _claim(repository, connection_id, "refresh-3")
+    _complete(repository, connection_id, "refresh-3", ["model-a"])
+    complete = {
+        row["model_id"]: row["status"]
+        for row in repository.list_catalog_models(
+            "local", connection_id=connection_id
+        )
+    }
+    assert complete == {"model-a": "active", "model-b": "retired"}
+    connection = repository.get_connection("local", connection_id)
+    assert connection.health == "online"
+    assert connection.model_count == 1
+
+
+def test_complete_refresh_rolls_back_inventory_and_health_together(tmp_path: Path) -> None:
+    repository = SQLiteRouterRepository(tmp_path)
+    connection_id = _connection(repository)
+    _claim(repository, connection_id, "refresh-1")
+    _complete(repository, connection_id, "refresh-1", ["model-a"])
+    _claim(repository, connection_id, "refresh-2")
+
+    with pytest.raises(KeyError):
+        repository.complete_catalog_refresh(
+            "local",
+            "refresh-2",
+            connection_id=connection_id,
+            models=[{"model_id": "model-b"}],
+            offerings=[{"operation": "chat"}],
+            model_count=99,
+            truncated=False,
+            catalog_fingerprint="never-committed",
+            observed_at="2026-08-21T01:00:00+00:00",
+        )
+
+    rows = repository.list_catalog_models("local", connection_id=connection_id)
+    assert [(row["model_id"], row["status"]) for row in rows] == [("model-a", "active")]
+    connection = repository.get_connection("local", connection_id)
+    assert connection.health == "online"
+    assert connection.model_count == 1
+
+
+def test_failed_refresh_preserves_rows_as_stale_and_is_tenant_scoped(
+    tmp_path: Path,
+) -> None:
+    repository = SQLiteRouterRepository(tmp_path)
+    connection_id = _connection(repository)
+    _claim(repository, connection_id, "refresh-1")
+    _complete(repository, connection_id, "refresh-1", ["model-a"])
+    _claim(repository, connection_id, "refresh-2")
+
+    repository.fail_catalog_refresh(
+        "local",
+        "refresh-2",
+        connection_id=connection_id,
+        error_code="unreachable",
+    )
+
+    rows = repository.list_catalog_models("local", connection_id=connection_id)
+    assert rows[0]["status"] == "stale"
+    assert repository.list_catalog_models("other") == []
+    offerings = repository.list_catalog_offerings(
+        "local", connection_id=connection_id
+    )
+    assert offerings[0]["stale"] == 1
+
+
+def test_catalog_schema_contains_no_payload_or_secret_columns(tmp_path: Path) -> None:
+    repository = SQLiteRouterRepository(tmp_path)
+    with sqlite3.connect(repository.database_path) as connection:
+        columns = {
+            row[1]
+            for table in (
+                "provider_catalog_refreshes",
+                "provider_catalog_models",
+                "provider_catalog_offerings",
+            )
+            for row in connection.execute(f"PRAGMA table_info({table})").fetchall()
+        }
+    assert not {
+        "api_key",
+        "base_url",
+        "prompt",
+        "response",
+        "response_body",
+        "credential",
+    }.intersection(columns)
+
+
+def test_provider_configuration_edit_invalidates_old_connection_health(tmp_path: Path) -> None:
+    repository = SQLiteRouterRepository(tmp_path)
+    connection_id = _connection(repository)
+    repository.save_test_result(
+        "local",
+        connection_id,
+        health="online",
+        model_count=2,
+        checked_at="2026-08-21T00:00:00+00:00",
+    )
+
+    updated = repository.update_connection(
+        "local",
+        connection_id,
+        RouterConnectionUpdate(base_url="https://changed.example/v1"),
+    )
+
+    assert updated.health == "untested"
+    assert updated.model_count == 0
+    assert updated.last_checked_at is None
+
+
+def test_configuration_edit_with_enabled_field_clears_old_evidence(tmp_path: Path) -> None:
+    repository = SQLiteRouterRepository(tmp_path)
+    connection_id = _connection(repository)
+    repository.save_test_result(
+        "local",
+        connection_id,
+        health="online",
+        model_count=2,
+        checked_at="2026-08-21T00:00:00+00:00",
+    )
+
+    updated = repository.update_connection(
+        "local",
+        connection_id,
+        RouterConnectionUpdate(
+            base_url="https://changed.example/v1",
+            enabled=True,
+        ),
+    )
+
+    assert updated.enabled is True
+    assert updated.health == "untested"
+    assert updated.model_count == 0
+    assert updated.last_checked_at is None

--- a/server/tests/test_provider_catalog_service.py
+++ b/server/tests/test_provider_catalog_service.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from httpx import MockTransport, Request, Response
+
+from server.model_router.egress import ProviderEgressError, ProviderEgressPolicy
+from server.model_router.provider_catalog import (
+    ProviderCatalogService,
+    normalize_provider_catalog,
+)
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import RouterConnectionCreate, RouterConnectionUpdate
+from server.model_router.service import ModelRouterService, RouterServiceError
+
+
+def _service(
+    tmp_path: Path,
+    handler,
+    *,
+    scopes: list[str] | None = None,
+    resolver=lambda _host, _port: ["8.8.8.8"],
+) -> tuple[ProviderCatalogService, SQLiteRouterRepository, str, list[Request]]:
+    requests: list[Request] = []
+
+    def recording_handler(request: Request) -> Response:
+        requests.append(request)
+        return handler(request)
+
+    repository = SQLiteRouterRepository(tmp_path)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="newAPI",
+            kind="newapi",
+            base_url="https://newapi.example/v1",
+            api_key="catalog-secret",
+            scopes=scopes or ["chat"],
+        ),
+    )
+    router_service = ModelRouterService(
+        repository,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=MockTransport(recording_handler),
+            follow_redirects=False,
+            trust_env=False,
+        ),
+        egress_policy=ProviderEgressPolicy(resolver=resolver),
+    )
+    return ProviderCatalogService(router_service), repository, connection.id, requests
+
+
+@pytest.mark.asyncio
+async def test_refresh_persists_normalized_inventory_without_paid_call(
+    tmp_path: Path,
+) -> None:
+    def handler(request: Request) -> Response:
+        return Response(
+            200,
+            json={
+                "data": [
+                    {"id": "provider/model", "owned_by": "provider"},
+                    {"id": "provider/model"},
+                    {"id": "provider/other", "name": "Other"},
+                ]
+            },
+        )
+
+    service, repository, connection_id, requests = _service(tmp_path, handler)
+
+    result = await service.refresh_connection(connection_id)
+
+    assert result.status == "succeeded"
+    assert result.model_count == 2
+    assert [request.method for request in requests] == ["GET"]
+    assert requests[0].url.host == "8.8.8.8"
+    rows = repository.list_catalog_models("local", connection_id=connection_id)
+    assert [row["model_id"] for row in rows] == [
+        "provider/model",
+        "provider/other",
+    ]
+    assert "catalog-secret" not in json.dumps(rows)
+    connection = repository.get_connection("local", connection_id)
+    assert connection.health == "online"
+    assert connection.model_count == 2
+
+
+@pytest.mark.asyncio
+async def test_non_chat_connection_can_refresh_without_inferred_chat_offering(
+    tmp_path: Path,
+) -> None:
+    def handler(request: Request) -> Response:
+        return Response(
+            200,
+            json={
+                "data": [
+                    {"id": "provider/audio", "operations": ["synthesize_speech"]},
+                    {"id": "provider/unclassified"},
+                ]
+            },
+        )
+
+    service, repository, connection_id, requests = _service(
+        tmp_path,
+        handler,
+        scopes=["audio"],
+    )
+
+    result = await service.refresh_connection(connection_id)
+
+    assert result.status == "succeeded"
+    assert [request.method for request in requests] == ["GET"]
+    assert {
+        row["model_id"] for row in repository.list_catalog_models("local")
+    } == {"provider/audio", "provider/unclassified"}
+    offerings = repository.list_catalog_offerings("local")
+    assert [(row["model_id"], row["operation"]) for row in offerings] == [
+        ("provider/audio", "synthesize_speech")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_keeps_previous_inventory_stale(tmp_path: Path) -> None:
+    responses = iter(
+        [
+            Response(200, json={"data": [{"id": "provider/model"}]}),
+            Response(503),
+        ]
+    )
+    service, repository, connection_id, _requests = _service(
+        tmp_path, lambda _request: next(responses)
+    )
+
+    assert (await service.refresh_connection(connection_id)).status == "succeeded"
+    failed = await service.refresh_connection(connection_id)
+
+    assert failed.status == "failed"
+    assert failed.error_code == "unreachable"
+    rows = repository.list_catalog_models("local", connection_id=connection_id)
+    assert rows[0]["status"] == "stale"
+    connection = repository.get_connection("local", connection_id)
+    assert connection.health == "offline"
+    assert connection.last_error_code == "unreachable"
+
+
+@pytest.mark.asyncio
+async def test_blocked_fake_ip_records_stable_failure_and_offline_health(
+    tmp_path: Path,
+) -> None:
+    service, repository, connection_id, requests = _service(
+        tmp_path,
+        lambda _request: Response(200, json={"data": []}),
+        resolver=lambda _host, _port: ["198.18.0.1"],
+    )
+
+    with pytest.raises(ProviderEgressError) as exc_info:
+        await service.refresh_connection(connection_id)
+
+    assert exc_info.value.code == "provider_address_blocked"
+    assert requests == []
+    refresh = repository.list_catalog_refreshes(
+        "local", connection_id=connection_id
+    )[0]
+    assert refresh["status"] == "failed"
+    assert refresh["error_code"] == "provider_address_blocked"
+    connection = repository.get_connection("local", connection_id)
+    assert connection.health == "offline"
+    assert connection.last_error_code == "provider_address_blocked"
+
+
+@pytest.mark.asyncio
+async def test_disabled_connection_fails_before_network(tmp_path: Path) -> None:
+    service, repository, connection_id, requests = _service(
+        tmp_path,
+        lambda _request: Response(200, json={"data": [{"id": "model"}]}),
+    )
+    repository.update_connection(
+        "local",
+        connection_id,
+        payload=RouterConnectionUpdate(enabled=False),
+    )
+
+    with pytest.raises(RouterServiceError, match="已停用"):
+        await service.refresh_connection(connection_id)
+    assert requests == []
+
+
+def test_normalization_does_not_infer_capabilities_or_implicit_pricing(
+    tmp_path: Path,
+) -> None:
+    repository = SQLiteRouterRepository(tmp_path)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="provider",
+            kind="newapi",
+            base_url="https://provider.example/v1",
+            api_key="secret",
+            scopes=["chat"],
+        ),
+    )
+
+    models, offerings, count, truncated = normalize_provider_catalog(
+        [
+            {
+                "id": "image-looking-name",
+                "pricing": {"input": "0.1", "output": "0.2"},
+            }
+        ],
+        connection=connection,
+        observed_at="2026-08-21T00:00:00+00:00",
+    )
+
+    assert count == 1 and truncated is False
+    assert models[0]["capability_state"] == "capabilities_unclassified"
+    assert offerings[0]["operation"] == "chat"
+    assert offerings[0]["capability_source"] == "connection_scope"
+    assert offerings[0]["pricing"] is None
+
+
+def test_explicit_price_requires_currency_and_unit(tmp_path: Path) -> None:
+    repository = SQLiteRouterRepository(tmp_path)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="provider",
+            kind="newapi",
+            base_url="https://provider.example/v1",
+            api_key="secret",
+            scopes=["chat"],
+        ),
+    )
+    _models, offerings, _count, _truncated = normalize_provider_catalog(
+        [
+            {
+                "id": "priced-model",
+                "pricing": {
+                    "currency": "usd",
+                    "unit": "per_token",
+                    "input": "0.000001",
+                    "output": "0.000002",
+                },
+            }
+        ],
+        connection=connection,
+        observed_at="2026-08-21T00:00:00+00:00",
+    )
+    assert offerings[0]["pricing"] == {
+        "currency": "USD",
+        "unit": "per_token",
+        "input_price": "0.000001",
+        "output_price": "0.000002",
+        "source": "provider_catalog",
+        "observed_at": "2026-08-21T00:00:00+00:00",
+        "status": "reported",
+        "billing_authoritative": False,
+    }

--- a/server/tests/test_provider_chat_canary_repository.py
+++ b/server/tests/test_provider_chat_canary_repository.py
@@ -112,7 +112,7 @@ def test_v12_to_v13_is_additive_and_preserves_round2_rows(tmp_path: Path) -> Non
     restarted = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
 
     with sqlite3.connect(restarted.database_path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 13
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 14
         tables = {
             row[0]
             for row in connection.execute(

--- a/server/tests/test_provider_chat_certification_api.py
+++ b/server/tests/test_provider_chat_certification_api.py
@@ -110,6 +110,9 @@ async def test_certification_admin_routes_require_session_csrf_and_idempotency(
         assert (
             await client.post(f"/api/router/connections/{connection_id}/models/refresh")
         ).status_code == 401
+        assert (
+            await client.post(f"/api/router/connections/{connection_id}/catalog/refresh")
+        ).status_code == 401
 
         paired = await client.post(
             "/api/router/admin/session", json={"pairing_secret": PAIRING_SECRET}
@@ -131,6 +134,18 @@ async def test_certification_admin_routes_require_session_csrf_and_idempotency(
         assert len(refreshed.json()["model_ids"]) == 500
         assert refreshed.json()["model_count"] == 501
         assert refreshed.json()["truncated"] is True
+
+        catalog_refreshed = await client.post(
+            f"/api/router/connections/{connection_id}/catalog/refresh",
+            headers={"X-ModelMirror-CSRF": csrf},
+        )
+        assert catalog_refreshed.status_code == 200
+        assert catalog_refreshed.json()["contract_version"] == (
+            "modelmirror-provider-catalog-v1"
+        )
+        assert catalog_refreshed.json()["model_count"] == 501
+        assert catalog_refreshed.json()["truncated"] is False
+        assert "secret-key" not in catalog_refreshed.text
 
         missing_idempotency = await client.post(
             f"/api/router/connections/{connection_id}/certifications/chat",

--- a/server/tests/test_provider_chat_certification_repository.py
+++ b/server/tests/test_provider_chat_certification_repository.py
@@ -70,7 +70,7 @@ def test_v11_to_current_schema_is_additive_and_preserves_connection(
     repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
 
     with sqlite3.connect(database_path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 13
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 14
         table = connection.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
             ("provider_chat_certifications",),


### PR DESCRIPTION
## Summary

- Add the tenant-scoped SQLite v14 provider catalog refresh, inventory, and offering records with additive migration and stale/retired safeguards.
- Add unified provider catalog/readiness projection services plus public and admin APIs without changing existing catalog contracts.
- Reorganize Settings into Overview, Providers and Catalog, and Routing and Experiments while preserving Marble and the external newAPI management boundary.
- Keep the public model list and prompt selector on their established user-facing semantics: 552 models and 546 adapted models; runtime readiness evidence remains in Settings only.

## Scope boundaries

- This is Round 4 control-plane work only.
- It does not migrate /api/chat, change SSE, switch the default provider, or alter Round 3 Canary routing.
- It does not add tenant UI, RBAC, billing, credits, recharge, payments, or authoritative pricing.
- It performs no paid model call and does not embed or proxy the newAPI administration UI.

## Validation

- Focused backend tests: 50 passed.
- Focused frontend tests: 40 passed.
- Full frontend suite with bounded workers: 466 passed.
- Frontend typecheck: passed.
- Frontend production build: passed.
- Full backend suite: 3575 passed, 29 skipped, 20 failed. The same 20 environment/baseline failures reproduced on clean origin/main at 4f942f73149ea33a81df795b4035c37f9b49fe64: missing Agency Worker build output and Node/TypeScript loader environment for skill semantic tests. Clean-baseline targeted reproduction: 20 failed, 64 passed.
- Core Compose, independent newAPI Compose, and optional overlay configuration validation: passed.
- git diff --check: passed.
- Sensitive-information scan: no real credentials; only explicit test pairing placeholders.

## Preview acceptance

- Frontend and backend preview endpoints returned 200.
- Admin pairing and shared session behavior were exercised.
- Two managed providers were visible.
- A newAPI catalog refresh completed with two models, not truncated, using the v1 catalog contract.
- No /api/chat request or billed model call was made.
- Final visible Settings acceptance was completed before publication.

## Risk and rollback

- SQLite v14 is additive; existing connection, credential, certification, and Canary records are not rewritten.
- Older code can ignore the new tables. On rollback, retain the v14 tables and provider data.
- Failed or truncated refreshes preserve the last successful inventory rather than retiring models.
- R5 remains the explicit boundary for ordinary Chat migration and newAPI default gating.