### PR TITLE
feature: Skill Creator 中间件 V2 交接体验

### DIFF
--- a/client/src/components/runtime/RuntimeApprovalPanel.test.tsx
+++ b/client/src/components/runtime/RuntimeApprovalPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import RuntimeApprovalPanel, { type RuntimeApproval } from "./RuntimeApprovalPanel";
 
@@ -16,6 +16,95 @@ afterEach(() => {
 });
 
 describe("RuntimeApprovalPanel Skill install approval", () => {
+  it("does not flash an empty approval card while the initial request is loading", async () => {
+    let resolveRequest!: (response: Response) => void;
+    const pendingResponse = new Promise<Response>((resolve) => {
+      resolveRequest = resolve;
+    });
+    const fetchMock = vi.fn(() => pendingResponse);
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <RuntimeApprovalPanel
+        pollIntervalMs={60_000}
+        requestTypes={["tool_call", "final_output"]}
+        taskId="task-empty"
+        title="Agent 运行审批"
+      />,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText("Agent 运行审批")).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveRequest(await jsonResponse({ items: [] }));
+      await pendingResponse;
+    });
+    expect(screen.queryByText("Agent 运行审批")).not.toBeInTheDocument();
+  });
+
+  it("does not restart polling when an equivalent request-type array is recreated", async () => {
+    const fetchMock = vi.fn(() => jsonResponse({ items: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { rerender } = render(
+      <RuntimeApprovalPanel
+        pollIntervalMs={60_000}
+        requestTypes={["tool_call", "final_output"]}
+        taskId="task-stable"
+      />,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <RuntimeApprovalPanel
+        pollIntervalMs={60_000}
+        requestTypes={["tool_call", "final_output"]}
+        taskId="task-stable"
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an explicit empty request-type filter distinct from no filter", async () => {
+    const approval: RuntimeApproval = {
+      approval_id: "approval-filtered",
+      request_type: "tool_call",
+      task_id: "task-filtered",
+      run_id: "run-filtered",
+      node_id: "agent-filtered",
+      node_title: "Filtered Agent",
+      status: "pending",
+      revision: 1,
+      scope_type: "workflow",
+      scope_id: "task-filtered",
+      tool_name: "skill_read",
+      arguments: {},
+      description: "This approval must remain filtered.",
+      content_preview: "",
+      allowed_decisions: ["approve", "reject"],
+      expires_at: 2_000_000_000,
+      created_at: 1_900_000_000,
+      metadata: {},
+    };
+    vi.stubGlobal("fetch", vi.fn(() => jsonResponse({ items: [approval] })));
+
+    render(
+      <RuntimeApprovalPanel
+        pollIntervalMs={60_000}
+        requestTypes={[]}
+        taskId="task-filtered"
+      />,
+    );
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText(approval.description)).not.toBeInTheDocument();
+  });
+
   it("shows trusted fixed-SHA details without exposing editable install arguments", async () => {
     const approval: RuntimeApproval = {
       approval_id: "approval-skill-install",

--- a/client/src/components/runtime/RuntimeApprovalPanel.tsx
+++ b/client/src/components/runtime/RuntimeApprovalPanel.tsx
@@ -138,6 +138,9 @@ export default function RuntimeApprovalPanel({
   const [editText, setEditText] = useState("");
   const [messageDrafts, setMessageDrafts] = useState<Record<string, string>>({});
   const [replacementDrafts, setReplacementDrafts] = useState<Record<string, string>>({});
+  const requestTypeKey = requestTypes === undefined
+    ? null
+    : [...new Set(requestTypes)].sort().join("\u0000");
 
   const query = useMemo(() => {
     const params = new URLSearchParams({ status: "pending", limit: compact ? "20" : "100" });
@@ -162,9 +165,16 @@ export default function RuntimeApprovalPanel({
       if (!response.ok) {
         throw new Error(approvalError(payload, "审批列表加载失败"));
       }
+      const allowedRequestTypes = requestTypeKey === null
+        ? null
+        : new Set(
+            requestTypeKey
+              ? requestTypeKey.split("\u0000") as RuntimeApproval["request_type"][]
+              : [],
+          );
       setItems(
         (payload?.items ?? []).filter(
-          (item) => !requestTypes || requestTypes.includes(item.request_type),
+          (item) => !allowedRequestTypes || allowedRequestTypes.has(item.request_type),
         ),
       );
       setError("");
@@ -175,7 +185,7 @@ export default function RuntimeApprovalPanel({
     } finally {
       if (!quiet) setLoading(false);
     }
-  }, [query, requestTypes, runId, scopeId, scopeType, taskId]);
+  }, [query, requestTypeKey, runId, scopeId, scopeType, taskId]);
 
   useEffect(() => {
     void load();
@@ -237,7 +247,7 @@ export default function RuntimeApprovalPanel({
     }
   }
 
-  if (!loading && !error && items.length === 0) return null;
+  if (!error && items.length === 0) return null;
 
   return (
     <section className="rounded-lg border border-amber-300/25 bg-amber-300/[0.065] p-3">

--- a/client/src/components/skill-creator/SkillCreatorCaptureButton.test.tsx
+++ b/client/src/components/skill-creator/SkillCreatorCaptureButton.test.tsx
@@ -133,4 +133,25 @@ describe("trusted Skill Creator capture sources", () => {
 
     expect(screen.queryByRole("button", { name: "沉淀为 Skill" })).not.toBeInTheDocument();
   });
+
+  it("supports an explicit retry label without changing the capture contract", () => {
+    render(
+      <MemoryRouter>
+        <SkillCreatorCaptureButton
+          busyLabel="正在重试..."
+          enabled
+          label="重试创建 Creator 会话"
+          source={{
+            sourceKind: "workflow_classic",
+            taskId: "task-2",
+            runId: "run-2",
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "重试创建 Creator 会话" }),
+    ).toBeVisible();
+  });
 });

--- a/client/src/components/skill-creator/SkillCreatorCaptureButton.tsx
+++ b/client/src/components/skill-creator/SkillCreatorCaptureButton.tsx
@@ -90,9 +90,13 @@ export function completedWorkflowCaptureSource(
 export default function SkillCreatorCaptureButton({
   enabled,
   source,
+  label = "沉淀为 Skill",
+  busyLabel = "正在创建会话...",
 }: {
   enabled: boolean;
   source: SkillCreatorCaptureSource;
+  label?: string;
+  busyLabel?: string;
 }) {
   const navigate = useNavigate();
   const [busy, setBusy] = useState(false);
@@ -142,7 +146,7 @@ export default function SkillCreatorCaptureButton({
         onClick={() => void capture()}
         type="button"
       >
-        {busy ? "正在创建会话..." : "沉淀为 Skill"}
+        {busy ? busyLabel : label}
       </button>
       {error ? (
         <span className="max-w-72 text-[11px] leading-5 text-rose-200" role="alert">

--- a/client/src/components/skill-creator/SkillCreatorHandoffCard.test.tsx
+++ b/client/src/components/skill-creator/SkillCreatorHandoffCard.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WorkflowRunEvent } from "../../types/workflow";
+import SkillCreatorHandoffCard, {
+  latestSkillCreatorHandoff,
+  skillCreatorHandoffFailureCopy,
+  type SkillCreatorHandoffEvent,
+} from "./SkillCreatorHandoffCard";
+
+function renderCard(event: SkillCreatorHandoffEvent) {
+  return render(
+    <MemoryRouter initialEntries={["/workflow"]}>
+      <Routes>
+        <Route
+          element={(
+            <SkillCreatorHandoffCard
+              captureEnabled
+              captureSource={{
+                sourceKind: "workflow_classic",
+                taskId: "task-1",
+                runId: "run-1",
+              }}
+              event={event}
+            />
+          )}
+          path="/workflow"
+        />
+        <Route element={<p>Creator destination</p>} path="/skills/create/:sessionId" />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Skill Creator workflow handoff card", () => {
+  it("recovers the latest persisted handoff event", () => {
+    const events = [
+      { event: "workflow_meta", task_id: "task-1" },
+      {
+        event: "skill_creator_handoff",
+        status: "ready",
+        session_id: "creator-old",
+      },
+      {
+        event: "skill_creator_handoff",
+        status: "ready",
+        session_id: "creator-current",
+      },
+      { event: "workflow_end", run_id: "run-1" },
+    ] as WorkflowRunEvent[];
+
+    expect(latestSkillCreatorHandoff(events)?.session_id).toBe("creator-current");
+  });
+
+  it("links a ready handoff to the trusted Creator session", () => {
+    renderCard({
+      event: "skill_creator_handoff",
+      status: "ready",
+      session_id: "creator/session",
+    });
+
+    expect(screen.getByText("Creator 会话已准备好")).toBeVisible();
+    expect(screen.getByText(/工作流分析会作为待确认素材显示/)).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: "前往 Creator 检查分析" }),
+    ).toHaveAttribute("href", "/skills/create/creator%2Fsession");
+    expect(screen.queryByRole("button", { name: "沉淀为 Skill" })).not.toBeInTheDocument();
+  });
+
+  it("shows a stable reason and retries through trusted workflow capture", async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(new Response(JSON.stringify({
+        session: { session_id: "creator-retried" },
+      }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      })),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    renderCard({
+      event: "skill_creator_handoff",
+      status: "failed",
+      error_code: "skill_creator_handoff_unavailable",
+    });
+
+    expect(screen.getByText(
+      skillCreatorHandoffFailureCopy("skill_creator_handoff_unavailable"),
+    )).toBeVisible();
+    await userEvent.click(
+      screen.getByRole("button", { name: "重试创建 Creator 会话" }),
+    );
+
+    expect(await screen.findByText("Creator destination")).toBeVisible();
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({
+      mode: "run",
+      source_kind: "workflow_classic",
+      source_task_id: "task-1",
+      source_run_id: "run-1",
+    });
+  });
+
+  it("fails closed when a ready event is missing its session id", () => {
+    renderCard({
+      event: "skill_creator_handoff",
+      status: "ready",
+    });
+
+    expect(screen.getByText("Creator 交接未完成")).toBeVisible();
+    expect(screen.queryByRole("link", { name: "前往 Creator 检查分析" })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/skill-creator/SkillCreatorHandoffCard.tsx
+++ b/client/src/components/skill-creator/SkillCreatorHandoffCard.tsx
@@ -1,0 +1,112 @@
+import { Link } from "react-router-dom";
+import type { WorkflowRunEvent } from "../../types/workflow";
+import SkillCreatorCaptureButton, {
+  type SkillCreatorCaptureSource,
+} from "./SkillCreatorCaptureButton";
+
+export interface SkillCreatorHandoffEvent extends WorkflowRunEvent {
+  event: "skill_creator_handoff";
+  status: "ready" | "failed";
+  session_id?: string;
+  error_code?: string;
+}
+
+export function latestSkillCreatorHandoff(
+  events: WorkflowRunEvent[],
+): SkillCreatorHandoffEvent | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (
+      event.event === "skill_creator_handoff"
+      && (event.status === "ready" || event.status === "failed")
+    ) {
+      return event as SkillCreatorHandoffEvent;
+    }
+  }
+  return null;
+}
+
+export function skillCreatorHandoffFailureCopy(errorCode?: string) {
+  if (errorCode === "skill_creator_handoff_unavailable") {
+    return "Creator 当前未启用或暂不可用。启用后可从这次可信运行重新创建会话。";
+  }
+  if (errorCode === "skill_creator_handoff_conflict") {
+    return "这次运行已存在冲突的 Creator 来源记录，需要核对来源后再重试。";
+  }
+  return "工作流结果已保留，但 Creator 会话没有创建成功。你可以安全重试。";
+}
+
+export default function SkillCreatorHandoffCard({
+  event,
+  captureEnabled,
+  captureSource,
+}: {
+  event: SkillCreatorHandoffEvent;
+  captureEnabled: boolean;
+  captureSource: SkillCreatorCaptureSource | null;
+}) {
+  const sessionId = event.session_id?.trim() ?? "";
+  const ready = event.status === "ready" && Boolean(sessionId);
+
+  if (ready) {
+    return (
+      <section
+        aria-labelledby="skill-creator-handoff-title"
+        className="rounded-lg border border-emerald-300/25 bg-emerald-300/[0.07] p-3"
+      >
+        <div className="flex flex-col gap-3">
+          <div className="min-w-0">
+            <p
+              className="text-xs font-semibold text-emerald-100"
+              id="skill-creator-handoff-title"
+            >
+              Creator 会话已准备好
+            </p>
+            <p className="mt-1 text-[11px] leading-5 text-slate-400">
+              原始需求已安全转交。工作流分析会作为待确认素材显示，你检查后再生成方案；这里不会直接创建或安装 Skill。
+            </p>
+          </div>
+          <Link
+            className="inline-flex min-h-10 w-full items-center justify-center rounded-full border border-emerald-300/30 bg-emerald-300/10 px-4 text-xs font-semibold text-emerald-50 transition hover:bg-emerald-300/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-200/50"
+            to={`/skills/create/${encodeURIComponent(sessionId)}`}
+          >
+            前往 Creator 检查分析
+          </Link>
+        </div>
+      </section>
+    );
+  }
+
+  const errorCode = event.error_code?.trim() || "skill_creator_handoff_failed";
+  return (
+    <section
+      aria-labelledby="skill-creator-handoff-failed-title"
+      className="rounded-lg border border-amber-300/30 bg-amber-300/[0.08] p-3"
+    >
+      <div className="flex flex-col gap-3">
+        <div className="min-w-0">
+          <p
+            className="text-xs font-semibold text-amber-50"
+            id="skill-creator-handoff-failed-title"
+          >
+            Creator 交接未完成
+          </p>
+          <p className="mt-1 text-[11px] leading-5 text-amber-100/80">
+            {skillCreatorHandoffFailureCopy(errorCode)}
+          </p>
+          <p className="mt-1 break-all font-mono text-[10px] text-amber-200/60">
+            错误码：{errorCode}
+          </p>
+        </div>
+        {captureEnabled && captureSource ? (
+          <SkillCreatorCaptureButton
+            busyLabel="正在重试..."
+            enabled
+            label="重试创建 Creator 会话"
+            source={captureSource}
+          />
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/skill-creator/SkillCreatorMiddlewareModePanel.test.tsx
+++ b/client/src/components/skill-creator/SkillCreatorMiddlewareModePanel.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import SkillCreatorMiddlewareModePanel from "./SkillCreatorMiddlewareModePanel";
+
+describe("SkillCreatorMiddlewareModePanel", () => {
+  it("warns about Legacy behavior and requires an explicit upgrade click", async () => {
+    const onUpgrade = vi.fn();
+    render(<SkillCreatorMiddlewareModePanel legacy onUpgrade={onUpgrade} />);
+
+    expect(screen.getByText("Legacy")).toBeVisible();
+    expect(screen.getByText("此节点仍使用旧的一次性提案路径")).toBeVisible();
+    expect(onUpgrade).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "确认升级为 Creator V2" }),
+    );
+    expect(onUpgrade).toHaveBeenCalledTimes(1);
+  });
+
+  it("explains the V2 boundary without exposing a migration action", () => {
+    render(<SkillCreatorMiddlewareModePanel legacy={false} onUpgrade={vi.fn()} />);
+
+    expect(screen.getByText("Creator V2")).toBeVisible();
+    expect(screen.getByText("分析需求并创建 Creator 会话")).toBeVisible();
+    expect(screen.getByText(/不会直接生成或安装 Skill/)).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "确认升级为 Creator V2" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/skill-creator/SkillCreatorMiddlewareModePanel.tsx
+++ b/client/src/components/skill-creator/SkillCreatorMiddlewareModePanel.tsx
@@ -1,0 +1,44 @@
+export default function SkillCreatorMiddlewareModePanel({
+  legacy,
+  onUpgrade,
+}: {
+  legacy: boolean;
+  onUpgrade: () => void;
+}) {
+  if (legacy) {
+    return (
+      <div className="rounded-lg border border-amber-300/30 bg-amber-300/10 p-3 text-xs leading-5 text-amber-50">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full border border-amber-200/30 bg-amber-200/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-100">
+            Legacy
+          </span>
+          <p className="font-semibold">此节点仍使用旧的一次性提案路径</p>
+        </div>
+        <p className="mt-2 text-amber-100/80">
+          旧路径依赖 Runtime 工具模式，生成质量与 Creator 质量门不一致。升级只修改当前画布节点，不会迁移其他工作流。
+        </p>
+        <button
+          className="mt-3 min-h-10 rounded-full border border-amber-200/35 bg-amber-200/10 px-3 text-xs font-semibold text-amber-50 transition hover:bg-amber-200/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-200/50"
+          onClick={onUpgrade}
+          type="button"
+        >
+          确认升级为 Creator V2
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-indigo-300/25 bg-indigo-300/10 p-3 text-xs leading-5 text-indigo-50">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="rounded-full border border-indigo-200/30 bg-indigo-200/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-indigo-100">
+          Creator V2
+        </span>
+        <p className="font-semibold">分析需求并创建 Creator 会话</p>
+      </div>
+      <p className="mt-2 text-indigo-100/80">
+        工作流只做需求梳理，不会直接生成或安装 Skill。完成后，用户会在 Creator 中检查分析、确认素材并生成方案。请用紫色端口绑定一个 workflow_agent；V2 不要求工具模式。
+      </p>
+    </div>
+  );
+}

--- a/client/src/components/skill-creator/SkillResourcePlanPanel.test.tsx
+++ b/client/src/components/skill-creator/SkillResourcePlanPanel.test.tsx
@@ -45,8 +45,8 @@ const plan: SkillResourcePlan = {
     { step_id: "review", instruction: "Review unsupported claims." },
     { step_id: "render", instruction: "Render the final report." },
   ],
-  output_contract: ["Return a factual incident report."],
-  failure_modes: ["Mark missing facts as unconfirmed."],
+  output_contract: ["- Return a factual incident report."],
+  failure_modes: ["• Mark missing facts as unconfirmed."],
   resources: [{
     resource_id: "resource_existing",
     spec_digest: "c".repeat(64),
@@ -91,6 +91,16 @@ afterEach(() => {
 });
 
 describe("SkillResourcePlanPanel", () => {
+  it("shows the output and failure contract before technical details are expanded", () => {
+    render(<SkillResourcePlanPanel onSession={vi.fn()} session={session} status={status} />);
+
+    expect(screen.getByRole("heading", { name: "交付结果" })).toBeVisible();
+    expect(screen.getByText(/Return a factual incident report\./)).toBeVisible();
+    expect(screen.getByRole("heading", { name: "遇到信息不足时" })).toBeVisible();
+    expect(screen.getByText(/Mark missing facts as unconfirmed\./)).toBeVisible();
+    expect(screen.getByText("共 4 步执行流程")).toBeVisible();
+  });
+
   it("generates a plan without writing resource files", async () => {
     const emptySession = { ...session, resource_plan: null };
     const plannedSession = { ...session, resource_plan: { ...plan, resources: [] } };

--- a/client/src/components/skill-creator/SkillResourcePlanPanel.tsx
+++ b/client/src/components/skill-creator/SkillResourcePlanPanel.tsx
@@ -60,6 +60,10 @@ function errorMessage(value: unknown, fallback: string) {
   return value instanceof Error && value.message ? value.message : fallback;
 }
 
+function summaryItem(value: string) {
+  return value.replace(/^\s*[-•]\s*/, "").trim();
+}
+
 export default function SkillResourcePlanPanel({ session, status, onSession }: Props) {
   const plan = session.resource_plan ?? null;
   const legacyFlow = session.authoring_flow !== "resource";
@@ -313,10 +317,25 @@ export default function SkillResourcePlanPanel({ session, status, onSession }: P
                 </div>
               )) : <p className="text-sm text-emerald-100">这个任务不需要额外资源，保持简单即可。</p>}
             </div>
+            <p className="mt-4 text-xs font-semibold text-slate-300">共 {plan.workflow_steps.length} 步执行流程</p>
+            <div className="mt-3 grid gap-3 lg:grid-cols-2">
+              <section className="rounded-md border border-white/10 bg-white/[0.025] p-3" aria-labelledby="creator-plan-output-heading">
+                <h5 className="text-sm font-semibold text-white" id="creator-plan-output-heading">交付结果</h5>
+                <ul className="mt-2 space-y-1.5 text-xs leading-5 text-slate-300">
+                  {plan.output_contract.map((item) => <li key={item}>• {summaryItem(item)}</li>)}
+                </ul>
+              </section>
+              <section className="rounded-md border border-white/10 bg-white/[0.025] p-3" aria-labelledby="creator-plan-failure-heading">
+                <h5 className="text-sm font-semibold text-white" id="creator-plan-failure-heading">遇到信息不足时</h5>
+                <ul className="mt-2 space-y-1.5 text-xs leading-5 text-slate-300">
+                  {plan.failure_modes.map((item) => <li key={item}>• {summaryItem(item)}</li>)}
+                </ul>
+              </section>
+            </div>
           </div>
 
           <details className="rounded-lg border border-white/10 bg-white/[0.02] p-4">
-            <summary className="cursor-pointer text-sm font-semibold text-slate-300">调整技术细节（可选）</summary>
+            <summary className="cursor-pointer text-sm font-semibold text-slate-300">查看并调整完整方案（可选）</summary>
             <div className="mt-5 space-y-5">
           <div className="grid gap-4 lg:grid-cols-2">
             <label className="block">

--- a/client/src/components/workflow/WorkflowEditor.test.ts
+++ b/client/src/components/workflow/WorkflowEditor.test.ts
@@ -24,6 +24,35 @@ describe("WorkflowEditor palette defaults", () => {
     }
   });
 
+  it("creates newly dragged Skill Creator middleware in V2 handoff mode", () => {
+    const data = createNodeData("runtime_middleware", {
+      kind: "runtime_middleware",
+      runtimeMiddlewareId: "skill_creator",
+      runtimeMiddlewareKind: "runtime_middleware.skill_creator",
+      title: "Skill 创建器",
+      description: "完成需求分析后创建 Creator 会话。",
+      metadata: {},
+      fields: [
+        {
+          name: "authoring_mode",
+          label: "创建方式",
+          type: "select",
+          default: "creator_handoff",
+        },
+        {
+          name: "allow_create",
+          label: "允许创建",
+          type: "boolean",
+          default: true,
+        },
+      ],
+    });
+
+    expect(data.runtimeMiddlewareConfig).toEqual({
+      authoring_mode: "creator_handoff",
+    });
+  });
+
   it("keeps R1 deployment nodes planner-independent with safe defaults", () => {
     expect(createNodeData("scheduled_start")).toMatchObject({
       scheduleType: "interval",

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -60,6 +60,11 @@ import {
 } from "../../utils/workflowStorage";
 import { reconcileRuntimeMiddlewareNodes } from "../../utils/runtimeMiddlewareMigration";
 import {
+  creatorHandoffMiddlewareConfig,
+  isLegacySkillCreatorMiddleware,
+  isSkillCreatorMiddleware,
+} from "../../utils/skillCreatorMiddleware";
+import {
   getSkillCatalogApprovalState,
   reconcileSkillCatalogApprovals,
 } from "../../utils/skillCatalogApproval";
@@ -91,6 +96,7 @@ import {
 import TrustedSkillSelect, {
   type TrustSelectableSkill,
 } from "../skill-trust/TrustedSkillSelect";
+import SkillCreatorMiddlewareModePanel from "../skill-creator/SkillCreatorMiddlewareModePanel";
 import {
   createDataTableNodeData,
   createTypedCanvasNodeData,
@@ -352,13 +358,21 @@ function parseRuntimeMiddlewarePayload(
 
 function createRuntimeMiddlewareConfig(
   fields: RuntimeMiddlewareField[],
+  middlewareId: string,
 ): Record<string, unknown> {
-  return fields.reduce<Record<string, unknown>>((config, field) => {
+  const config = fields.reduce<Record<string, unknown>>((current, field) => {
     if (field.default !== undefined) {
-      config[field.name] = field.default;
+      current[field.name] = field.default;
     }
-    return config;
+    return current;
   }, {});
+  if (
+    middlewareId === "skill_creator"
+    && config.authoring_mode === "creator_handoff"
+  ) {
+    return creatorHandoffMiddlewareConfig();
+  }
+  return config;
 }
 
 export function createNodeData(
@@ -919,7 +933,7 @@ export function createNodeData(
       runtimeMiddlewareKind: middlewareKind,
       runtimeMiddlewareFields: fields,
       runtimeMiddlewareMetadata: payload?.metadata ?? {},
-      runtimeMiddlewareConfig: createRuntimeMiddlewareConfig(fields),
+      runtimeMiddlewareConfig: createRuntimeMiddlewareConfig(fields, middlewareId),
       middlewarePriority: "100",
     };
   }
@@ -2821,6 +2835,18 @@ function NodeConfig({
   const runtimeMiddlewareConfig = isRecord(data.runtimeMiddlewareConfig)
     ? data.runtimeMiddlewareConfig
     : undefined;
+  const skillCreatorMiddleware = isSkillCreatorMiddleware(data);
+  const legacySkillCreatorMiddleware = isLegacySkillCreatorMiddleware(data);
+  const visibleRuntimeMiddlewareFields = (data.runtimeMiddlewareFields ?? []).filter(
+    (field) => {
+      if (!skillCreatorMiddleware) return true;
+      if (field.name === "authoring_mode") return false;
+      if (legacySkillCreatorMiddleware) return true;
+      return !["allow_create", "allow_update", "allowed_draft_ids"].includes(
+        field.name,
+      );
+    },
+  );
   const appendTrustedSkill = (skillId: string) => {
     if (!skillId || !runtimeMiddlewareConfig) return;
     const current = String(runtimeMiddlewareConfig.skill_ids ?? "")
@@ -4048,9 +4074,20 @@ function NodeConfig({
 
       {data.kind === "runtime_middleware" ? (
         <div className="space-y-4">
-          <div className="rounded-lg border border-indigo-300/25 bg-indigo-300/10 px-3 py-2 text-xs leading-5 text-indigo-50">
-            使用紫色端口绑定到一个 workflow_agent，或使用普通端口作为线性中间件。两种连接方式不可混用。
-          </div>
+          {skillCreatorMiddleware ? (
+            <SkillCreatorMiddlewareModePanel
+              legacy={legacySkillCreatorMiddleware}
+              onUpgrade={() =>
+                update({
+                  runtimeMiddlewareConfig: creatorHandoffMiddlewareConfig(),
+                })
+              }
+            />
+          ) : (
+            <div className="rounded-lg border border-indigo-300/25 bg-indigo-300/10 px-3 py-2 text-xs leading-5 text-indigo-50">
+              使用紫色端口绑定到一个 workflow_agent，或使用普通端口作为线性中间件。两种连接方式不可混用。
+            </div>
+          )}
           <Field label="执行优先级（0-1000）">
             <input
               className={textInputClass()}
@@ -4063,9 +4100,11 @@ function NodeConfig({
               value={data.middlewarePriority ?? "100"}
             />
           </Field>
-          <div className="rounded-lg border border-indigo-300/25 bg-indigo-300/10 px-3 py-2 text-xs leading-5 text-indigo-50">
-            绑定模式仅作用于目标 workflow_agent；线性模式会影响其后执行的智能体。核心中间件已接入真实 MiddlewarePipeline。
-          </div>
+          {!skillCreatorMiddleware ? (
+            <div className="rounded-lg border border-indigo-300/25 bg-indigo-300/10 px-3 py-2 text-xs leading-5 text-indigo-50">
+              绑定模式仅作用于目标 workflow_agent；线性模式会影响其后执行的智能体。核心中间件已接入真实 MiddlewarePipeline。
+            </div>
+          ) : null}
           <div className="rounded-lg border border-white/10 bg-white/[0.035] px-3 py-2">
             <p className="text-xs font-semibold text-slate-200">
               {data.runtimeMiddlewareKind ?? "runtime_middleware.unknown"}
@@ -4074,14 +4113,16 @@ function NodeConfig({
               ID：{data.runtimeMiddlewareId ?? "unknown"}
             </p>
           </div>
-          {(data.runtimeMiddlewareFields ?? []).length === 0 ? (
+          {visibleRuntimeMiddlewareFields.length === 0 ? (
             <p className="rounded-lg border border-dashed border-white/15 bg-white/[0.035] px-3 py-4 text-sm leading-6 text-slate-400">
-              此中间件暂无可配置字段。
+              {skillCreatorMiddleware
+                ? "Creator V2 不需要额外权限配置。运行成功后由你前往 Creator 继续规划。"
+                : "此中间件暂无可配置字段。"}
             </p>
           ) : (
             <>
               <p className="text-xs font-semibold text-slate-300">中间件配置</p>
-              {(data.runtimeMiddlewareFields ?? []).map((field) => (
+              {visibleRuntimeMiddlewareFields.map((field) => (
                 <Field
                   key={field.name}
                   label={`${field.label}${field.required ? " *" : ""}`}
@@ -5951,7 +5992,7 @@ function WorkflowCanvas({
         ) : null}
       </section>
 
-      <aside className="surface-panel flex min-h-[520px] flex-col rounded-lg p-4">
+      <aside className="surface-panel flex min-h-[520px] min-w-0 flex-col rounded-lg p-4">
         <div className="flex items-start justify-between gap-3 border-b border-white/10 pb-3">
           <div>
             <p className="text-sm font-semibold text-white">工作台</p>

--- a/client/src/components/workflow/WorkflowNodeCard.tsx
+++ b/client/src/components/workflow/WorkflowNodeCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { type WorkflowNode } from "../../types/workflow";
+import { isLegacySkillCreatorMiddleware } from "../../utils/skillCreatorMiddleware";
 
 const nodeMeta = {
   input: {
@@ -342,6 +343,7 @@ export default function WorkflowNodeCard({ data, selected }: NodeProps<WorkflowN
   const multiRoutes = data.kind === "multi_route" && Array.isArray(data.routes)
     ? data.routes.filter((route) => route.id && route.label)
     : [];
+  const legacySkillCreator = isLegacySkillCreatorMiddleware(data);
 
   const statusClassName =
     runStatus === "running"
@@ -460,6 +462,11 @@ export default function WorkflowNodeCard({ data, selected }: NodeProps<WorkflowN
         <h3 className="max-w-24 truncate text-xs font-semibold leading-tight text-white">
           {data.title}
         </h3>
+        {legacySkillCreator ? (
+          <span className="rounded-full border border-amber-300/30 bg-amber-300/10 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-amber-100">
+            Legacy
+          </span>
+        ) : null}
       </div>
 
       {showInfo ? (

--- a/client/src/components/workflow/WorkflowRun.handoff-recovery.test.ts
+++ b/client/src/components/workflow/WorkflowRun.handoff-recovery.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildRunSteps,
+  persistWorkflowRunRecovery,
+  readWorkflowRunRecovery,
+  workflowRunRecoveryKey,
+} from "./WorkflowRun";
+
+afterEach(() => {
+  window.sessionStorage.clear();
+});
+
+describe("WorkflowRun handoff recovery pointer", () => {
+  it("does not leave a completed Creator handoff as a running workflow step", () => {
+    const steps = buildRunSteps([
+      {
+        event: "node_end",
+        node_id: "agent",
+        node_title: "梳理需求",
+        node_type: "workflow_agent",
+        output: "需求分析完成。",
+      },
+      {
+        event: "skill_creator_handoff",
+        status: "ready",
+        node_id: "creator",
+        session_id: "creator-1",
+      },
+      { event: "workflow_end", final_output: "需求分析完成。" },
+    ]);
+
+    expect(steps).toEqual([
+      expect.objectContaining({ id: "agent", status: "done" }),
+    ]);
+    expect(steps.some((step) => step.status === "running")).toBe(false);
+  });
+
+  it("stores only bounded task and run ids for page refresh recovery", () => {
+    const taskId = "a".repeat(32);
+    const runId = "123e4567-e89b-42d3-a456-426614174000";
+    persistWorkflowRunRecovery("workflow-1", {
+      taskId,
+      runId,
+    });
+
+    expect(readWorkflowRunRecovery("workflow-1")).toEqual({
+      taskId,
+      runId,
+    });
+    expect(JSON.parse(
+      window.sessionStorage.getItem(workflowRunRecoveryKey("workflow-1")) ?? "{}",
+    )).toEqual({ taskId, runId });
+  });
+
+  it("drops malformed or overlong pointers instead of requesting arbitrary paths", () => {
+    const key = workflowRunRecoveryKey("workflow-2");
+    window.sessionStorage.setItem(key, "not-json");
+    expect(readWorkflowRunRecovery("workflow-2")).toBeNull();
+    expect(window.sessionStorage.getItem(key)).toBeNull();
+
+    window.sessionStorage.setItem(key, JSON.stringify({
+      taskId: "t".repeat(201),
+      runId: "123e4567-e89b-42d3-a456-426614174000",
+    }));
+    expect(readWorkflowRunRecovery("workflow-2")).toBeNull();
+    expect(window.sessionStorage.getItem(key)).toBeNull();
+  });
+});

--- a/client/src/components/workflow/WorkflowRun.tsx
+++ b/client/src/components/workflow/WorkflowRun.tsx
@@ -8,6 +8,9 @@ import FileOutputTray from "../FileOutputTray";
 import SkillCreatorCaptureButton, {
   completedWorkflowCaptureSource,
 } from "../skill-creator/SkillCreatorCaptureButton";
+import SkillCreatorHandoffCard, {
+  latestSkillCreatorHandoff,
+} from "../skill-creator/SkillCreatorHandoffCard";
 import { useSkillCreatorStatus } from "../../hooks/useSkillCreatorStatus";
 import {
   fetchFileOutputs,
@@ -97,6 +100,69 @@ interface RunHistoryEntry {
   finishedAt: number;
   status: "completed" | "cancelled" | "error";
   summary: string;
+}
+
+interface WorkflowRunRecoveryPointer {
+  taskId: string;
+  runId: string | null;
+}
+
+const WORKFLOW_RUN_RECOVERY_PREFIX = "modelmirror-workflow-run-v1";
+const WORKFLOW_TASK_ID_PATTERN = /^[0-9a-f]{32}$/i;
+const RUNTIME_RUN_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function workflowRunRecoveryKey(workflowId: string) {
+  return `${WORKFLOW_RUN_RECOVERY_PREFIX}:${workflowId.trim()}`;
+}
+
+export function readWorkflowRunRecovery(
+  workflowId: string,
+): WorkflowRunRecoveryPointer | null {
+  if (typeof window === "undefined" || !workflowId.trim()) return null;
+  const key = workflowRunRecoveryKey(workflowId);
+  try {
+    const parsed = JSON.parse(window.sessionStorage.getItem(key) ?? "null") as
+      | { taskId?: unknown; runId?: unknown }
+      | null;
+    const taskId = typeof parsed?.taskId === "string" ? parsed.taskId.trim() : "";
+    const runId = typeof parsed?.runId === "string" ? parsed.runId.trim() : "";
+    if (
+      !WORKFLOW_TASK_ID_PATTERN.test(taskId)
+      || (runId && !RUNTIME_RUN_ID_PATTERN.test(runId))
+    ) {
+      window.sessionStorage.removeItem(key);
+      return null;
+    }
+    return { taskId, runId: runId || null };
+  } catch {
+    window.sessionStorage.removeItem(key);
+    return null;
+  }
+}
+
+export function persistWorkflowRunRecovery(
+  workflowId: string,
+  pointer: WorkflowRunRecoveryPointer,
+) {
+  const cleanWorkflowId = workflowId.trim();
+  const taskId = pointer.taskId.trim();
+  const runId = pointer.runId?.trim() || null;
+  if (
+    typeof window === "undefined"
+    || !cleanWorkflowId
+    || !taskId
+    || !WORKFLOW_TASK_ID_PATTERN.test(taskId)
+    || (runId !== null && !RUNTIME_RUN_ID_PATTERN.test(runId))
+  ) return;
+  try {
+    window.sessionStorage.setItem(
+      workflowRunRecoveryKey(cleanWorkflowId),
+      JSON.stringify({ taskId, runId }),
+    );
+  } catch {
+    // Session recovery is best-effort and never blocks workflow execution.
+  }
 }
 
 interface WorkflowFileFormatCapability {
@@ -429,7 +495,7 @@ function RuntimeCheckpointList({
   );
 }
 
-function buildRunSteps(events: WorkflowRunEvent[]) {
+export function buildRunSteps(events: WorkflowRunEvent[]) {
   const steps: WorkflowRunStep[] = [];
   const byNodeId = new Map<string, WorkflowRunStep>();
 
@@ -456,7 +522,11 @@ function buildRunSteps(events: WorkflowRunEvent[]) {
   }
 
   events.forEach((event, index) => {
-    if (event.event === "workflow_meta" || event.event === "workflow_end") {
+    if (
+      event.event === "workflow_meta"
+      || event.event === "workflow_end"
+      || event.event === "skill_creator_handoff"
+    ) {
       return;
     }
     if (event.event === "error" && !event.node_id) {
@@ -898,6 +968,10 @@ export default function WorkflowRun({
     () => completedWorkflowCaptureSource(events, taskId, runId, isRunning),
     [events, isRunning, runId, taskId],
   );
+  const skillCreatorHandoff = useMemo(
+    () => latestSkillCreatorHandoff(events),
+    [events],
+  );
   const skillCaptureEnabled = Boolean(
     skillCreatorStatus?.enabled
     && skillCreatorStatus.supported_sources.includes("workflow_classic"),
@@ -937,6 +1011,51 @@ export default function WorkflowRun({
     }
     await refreshWorkflowFileOutputs();
   }
+
+  useEffect(() => {
+    const recovery = readWorkflowRunRecovery(definition.id);
+    if (!recovery) return;
+    const abort = new AbortController();
+    let active = true;
+
+    setTaskId(recovery.taskId);
+    setRunId(recovery.runId);
+    runMetaRef.current = {
+      taskId: recovery.taskId,
+      runId: recovery.runId,
+    };
+    setIsResuming(true);
+    fetch(
+      `/api/workflow/run/${encodeURIComponent(recovery.taskId)}/stream?after_sequence=0`,
+      { signal: abort.signal },
+    )
+      .then(async (response) => {
+        if (!response.ok) {
+          if (response.status === 404) {
+            window.sessionStorage.removeItem(workflowRunRecoveryKey(definition.id));
+          }
+          throw new Error("无法恢复上次运行。请重新运行工作流。");
+        }
+        await consumeWorkflowResponse(response, true);
+      })
+      .catch((caught) => {
+        if (!active || (caught instanceof DOMException && caught.name === "AbortError")) {
+          return;
+        }
+        setError(caught instanceof Error ? caught.message : "无法恢复上次运行。");
+      })
+      .finally(() => {
+        if (active) setIsResuming(false);
+      });
+
+    return () => {
+      active = false;
+      abort.abort();
+    };
+    // The persisted task pointer is scoped by immutable workflow id. Event
+    // handlers intentionally remain the same ones used by live execution.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [definition.id]);
 
   async function selectWorkflowFile(
     variableName: string,
@@ -1166,6 +1285,12 @@ export default function WorkflowRun({
       if (responseRunId) {
         setRunId(responseRunId);
         runMetaRef.current.runId = responseRunId;
+      }
+      if (responseTaskId) {
+        persistWorkflowRunRecovery(definition.id, {
+          taskId: responseTaskId,
+          runId: responseRunId,
+        });
       }
 
       await consumeWorkflowResponse(response);
@@ -1447,8 +1572,8 @@ export default function WorkflowRun({
     <aside
       className={
         embedded
-          ? "flex min-h-0 flex-1 flex-col"
-          : "surface-panel flex min-h-0 flex-col rounded-lg"
+          ? "flex min-h-0 min-w-0 flex-1 flex-col"
+          : "surface-panel flex min-h-0 min-w-0 flex-col rounded-lg"
       }
     >
       <div className="border-b border-white/10 p-4">
@@ -2200,7 +2325,17 @@ export default function WorkflowRun({
         </div>
       ) : null}
 
-      {skillCaptureSource && skillCaptureEnabled ? (
+      {skillCreatorHandoff ? (
+        <div className="border-t border-white/10 p-4">
+          <SkillCreatorHandoffCard
+            captureEnabled={skillCaptureEnabled}
+            captureSource={skillCaptureSource}
+            event={skillCreatorHandoff}
+          />
+        </div>
+      ) : null}
+
+      {!skillCreatorHandoff && skillCaptureSource && skillCaptureEnabled ? (
         <div className="border-t border-white/10 p-4">
           <div className="flex flex-col gap-3 rounded-lg border border-emerald-300/20 bg-emerald-300/[0.06] p-3 sm:flex-row sm:items-center sm:justify-between">
             <div>

--- a/client/src/pages/SkillCreatorPages.test.tsx
+++ b/client/src/pages/SkillCreatorPages.test.tsx
@@ -100,6 +100,79 @@ afterEach(() => {
 });
 
 describe("Skill Creator pages", () => {
+  it("opens trusted workflow evidence after saving the handoff requirement", async () => {
+    let currentSession: SkillCreatorSession = {
+      ...baseSession,
+      mode: "run",
+      source_kind: "workflow_classic",
+      source_task_id: "task-1",
+      source_run_id: "run-1",
+      evidence_confirmed: false,
+      selected_evidence: [],
+    };
+    const preview = {
+      preview_fingerprint: "f".repeat(64),
+      source_kind: "workflow_classic",
+      source_task_id: "task-1",
+      source_run_id: "run-1",
+      candidates: [
+        {
+          candidate_id: "intent-summary",
+          kind: "intent_summary",
+          title: "目标摘要",
+          summary: "把客户访谈整理成决策简报。",
+          content_hash: "1".repeat(64),
+          default_selected: true,
+        },
+        {
+          candidate_id: "workflow-analysis",
+          kind: "final_output_excerpt",
+          title: "最终输出片段",
+          summary: "**缺失信息：** 请确认访谈格式。",
+          content_hash: "2".repeat(64),
+          default_selected: false,
+        },
+      ],
+    };
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/skills/creator/status") return jsonResponse(status);
+      if (url === "/api/skills/creator/sessions/creator_1" && !init?.method) {
+        return jsonResponse({ session: currentSession });
+      }
+      if (url === "/api/skills/creator/sessions/creator_1" && init?.method === "PATCH") {
+        currentSession = { ...currentSession, session_revision: 3 };
+        return jsonResponse({ session: currentSession });
+      }
+      if (url.endsWith("/source-preview") && init?.method === "POST") {
+        return jsonResponse(preview);
+      }
+      return jsonResponse({ detail: `not found: ${url}` }, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <MemoryRouter initialEntries={["/skills/create/creator_1"]}>
+        <Routes>
+          <Route element={<SkillCreatorStudioPage />} path="/skills/create/:sessionId" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole("heading", { name: "把你的做法变成可复用的 Skill" });
+    await userEvent.click(screen.getByRole("button", { name: "保存需求，查看素材" }));
+
+    expect(await screen.findByText("工作流分析不会自动写入方案")).toBeVisible();
+    expect(screen.getByText("已选 1 项")).toBeVisible();
+    expect(screen.getByRole("checkbox", { name: /目标摘要/ })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /工作流生成的需求分析/ })).not.toBeChecked();
+    expect(screen.getByText("缺失信息： 请确认访谈格式。")).toBeVisible();
+    expect(screen.getByRole("button", { name: "保存选中素材并继续" })).toBeEnabled();
+    expect(fetchMock.mock.calls.some(([input, init]) =>
+      String(input).endsWith("/source-preview") && (init as RequestInit | undefined)?.method === "POST"
+    )).toBe(true);
+  });
+
   it("fails closed on a disabled direct route", async () => {
     vi.stubGlobal("fetch", vi.fn(() => jsonResponse({
       ...status,

--- a/client/src/pages/SkillCreatorStudioPage.tsx
+++ b/client/src/pages/SkillCreatorStudioPage.tsx
@@ -85,6 +85,41 @@ const EVIDENCE_LABELS: Record<SkillCreatorEvidenceCandidate["kind"], string> = {
   final_output_excerpt: "最终输出片段",
 };
 
+function evidenceLabel(
+  candidate: SkillCreatorEvidenceCandidate,
+  sourceKind?: SkillCreatorSession["source_kind"],
+) {
+  if (candidate.kind === "final_output_excerpt" && sourceKind === "workflow_classic") {
+    return "工作流生成的需求分析";
+  }
+  return EVIDENCE_LABELS[candidate.kind];
+}
+
+function evidenceSummary(candidate: SkillCreatorEvidenceCandidate) {
+  if (candidate.kind === "io_shape") {
+    try {
+      const payload = JSON.parse(candidate.summary) as {
+        inputs?: Array<{ name?: string; type?: string }>;
+        output?: { type?: string; present?: boolean };
+      };
+      const inputs = (payload.inputs ?? [])
+        .map((item) => `${item.name || "未命名输入"}（${item.type || "未知类型"}）`)
+        .join("、") || "未声明";
+      const output = payload.output?.present === false
+        ? "无"
+        : payload.output?.type || "文本";
+      return `输入：${inputs}；输出：${output}`;
+    } catch {
+      // Fall through to the bounded plain-text presentation below.
+    }
+  }
+  return candidate.summary
+    .replace(/\*\*/g, "")
+    .replace(/\s*[（(]workflow_agent[）)]/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 function splitLines(value: string) {
   return value.split("\n").map((item) => item.trim()).filter(Boolean);
 }
@@ -343,6 +378,24 @@ export default function SkillCreatorStudioPage() {
   const validManualDescription = manualDescription.trim().length > 0 && manualDescription.trim().length <= 1_024;
   const selectedEvidenceCount = selectedEvidence.size;
 
+  function applySourcePreview(
+    value: SkillCreatorSession,
+    preview: SkillCreatorSourcePreview,
+  ) {
+    setSourcePreview(preview);
+    const availableIds = new Set(preview.candidates.map((item) => item.candidate_id));
+    const persistedIds = value.selected_evidence
+      .map((item) => item.candidate_id)
+      .filter((candidateId) => availableIds.has(candidateId));
+    setSelectedEvidence(new Set(
+      value.evidence_confirmed || value.selected_evidence.length > 0
+        ? persistedIds
+        : preview.candidates
+            .filter((item) => item.default_selected)
+            .map((item) => item.candidate_id),
+    ));
+  }
+
   async function saveIntent() {
     if (!session) return;
     setBusy("intent");
@@ -377,8 +430,17 @@ export default function SkillCreatorStudioPage() {
       await hydrate(updated, { preserveActiveStep: true });
       setActiveStep(1);
       setNotice(status?.resource_authoring_enabled
-        ? "需求已保存。接下来让 AI 给出方案；需要补充信息时，它会明确提问。"
+        ? updated.mode === "run"
+          ? "需求已保存。请检查工作流素材，确认哪些内容可以用于方案。"
+          : "需求已保存。接下来让 AI 给出方案；需要补充信息时，它会明确提问。"
         : "需求已保存。接下来确认 AI 的理解并生成草稿。");
+      if (updated.mode === "run" && updated.source_kind) {
+        try {
+          applySourcePreview(updated, await previewSkillCreatorSource(updated));
+        } catch (previewError) {
+          handleError(previewError, "需求已保存，但脱敏素材暂时无法加载。请在下一步重试。");
+        }
+      }
     } catch (caught) {
       handleError(caught, "用途保存失败。");
     } finally {
@@ -402,18 +464,7 @@ export default function SkillCreatorStudioPage() {
     setError("");
     try {
       const preview = await previewSkillCreatorSource(session);
-      setSourcePreview(preview);
-      const availableIds = new Set(preview.candidates.map((item) => item.candidate_id));
-      const persistedIds = session.selected_evidence
-        .map((item) => item.candidate_id)
-        .filter((candidateId) => availableIds.has(candidateId));
-      setSelectedEvidence(new Set(
-        session.evidence_confirmed || session.selected_evidence.length > 0
-          ? persistedIds
-          : preview.candidates
-              .filter((item) => item.default_selected)
-              .map((item) => item.candidate_id),
-      ));
+      applySourcePreview(session, preview);
     } catch (caught) {
       handleError(caught, "脱敏素材加载失败。");
     } finally {
@@ -766,7 +817,7 @@ export default function SkillCreatorStudioPage() {
                 <p className="max-w-xl text-xs leading-5 text-slate-500">一句话模式会补上通用边界与“不得编造”要求；你仍会在下一步确认 AI 的具体方案。</p>
                 <button className="inline-flex items-center gap-2 rounded-full bg-hire-300 px-5 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500" disabled={!intentComplete || Boolean(busy)} onClick={() => void saveIntent()} type="button">
                   <ArrowRight aria-hidden="true" size={15} />
-                  {busy === "intent" ? "正在准备…" : "继续，让 AI 完善"}
+                  {busy === "intent" ? "正在保存…" : session.mode === "run" ? "保存需求，查看素材" : "保存需求并继续"}
                 </button>
               </div>
             </section>
@@ -777,29 +828,37 @@ export default function SkillCreatorStudioPage() {
               {session.mode !== "blank" && session.source_kind ? <section className="rounded-lg border border-white/10 bg-surface-900/80 p-5 sm:p-6" aria-labelledby="creator-evidence-heading">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                   <div>
-                    <h2 className="text-xl font-semibold text-white" id="creator-evidence-heading">确认用于草稿的素材</h2>
-                    <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">只保存服务端生成的脱敏摘要和内容哈希。完整对话、工具参数、附件与 Sandbox 文件不会进入 Creator。</p>
+                    <h2 className="text-xl font-semibold text-white" id="creator-evidence-heading">选择方案可以使用的素材</h2>
+                    <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">只保存脱敏摘要和内容哈希。完整对话、工具参数、附件与 Sandbox 文件不会进入 Creator。</p>
                   </div>
-                  <span className="w-fit rounded-full bg-white/[0.055] px-3 py-1.5 text-xs font-semibold text-slate-300">已选 {session.selected_evidence.length} 项</span>
+                  <span className="w-fit rounded-full bg-white/[0.055] px-3 py-1.5 text-xs font-semibold text-slate-300">已选 {sourcePreview ? selectedEvidenceCount : session.selected_evidence.length} 项</span>
                 </div>
 
                 {sourcePreview ? (
                   <div className="mt-5">
+                    {session.source_kind === "workflow_classic" ? (
+                      <div className="mb-4 rounded-md border border-brand-300/20 bg-brand-300/[0.06] px-4 py-3">
+                        <p className="text-sm font-semibold text-brand-100">工作流分析不会自动写入方案</p>
+                        <p className="mt-1 text-xs leading-5 text-slate-300">请阅读“工作流生成的需求分析”。只有你主动勾选并保存后，它才会成为资源规划依据。</p>
+                      </div>
+                    ) : null}
                     <div className="grid gap-3 lg:grid-cols-2">
-                      {sourcePreview.candidates.map((candidate) => (
-                        <label className={`flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition ${selectedEvidence.has(candidate.candidate_id) ? "border-brand-300/35 bg-brand-300/[0.08]" : "border-white/10 bg-white/[0.025] hover:bg-white/[0.045]"}`} key={candidate.candidate_id}>
+                      {sourcePreview.candidates.map((candidate) => {
+                        const label = evidenceLabel(candidate, session.source_kind);
+                        const summary = evidenceSummary(candidate);
+                        return <label className={`flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition ${selectedEvidence.has(candidate.candidate_id) ? "border-brand-300/35 bg-brand-300/[0.08]" : "border-white/10 bg-white/[0.025] hover:bg-white/[0.045]"}`} key={candidate.candidate_id}>
                           <input checked={selectedEvidence.has(candidate.candidate_id)} className="mt-1 h-4 w-4 accent-cyan-300" onChange={() => toggleEvidence(candidate.candidate_id)} type="checkbox" />
                           <span className="min-w-0">
-                            <span className="text-xs font-semibold text-brand-100">{EVIDENCE_LABELS[candidate.kind]}</span>
-                            <span className="mt-1 block text-sm font-semibold text-white">{candidate.title}</span>
-                            <span className="mt-2 block text-xs leading-5 text-slate-400">{candidate.summary}</span>
-                            {candidate.kind === "final_output_excerpt" ? <span className="mt-2 block text-[11px] text-amber-100">输出片段默认不选中，请逐项确认。</span> : null}
+                            <span className="text-xs font-semibold text-brand-100">{label}</span>
+                            {candidate.title && candidate.title !== label ? <span className="mt-1 block text-sm font-semibold text-white">{candidate.title}</span> : null}
+                            <span className="mt-2 block whitespace-pre-wrap break-words text-xs leading-5 text-slate-300">{summary}</span>
+                            {candidate.kind === "final_output_excerpt" ? <span className="mt-2 block text-[11px] text-amber-100">模型输出默认不选中，请确认内容准确后再勾选。</span> : null}
                           </span>
-                        </label>
-                      ))}
+                        </label>;
+                      })}
                     </div>
                     <div className="mt-4 flex justify-end">
-                      <button className="rounded-full border border-brand-300/30 bg-brand-300/10 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:bg-brand-300/20 disabled:opacity-50" disabled={busy === "evidence"} onClick={() => void saveEvidence()} type="button">{busy === "evidence" ? "正在保存…" : `保存 ${selectedEvidenceCount} 项素材`}</button>
+                      <button className="rounded-full border border-brand-300/30 bg-brand-300/10 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:bg-brand-300/20 disabled:opacity-50" disabled={busy === "evidence"} onClick={() => void saveEvidence()} type="button">{busy === "evidence" ? "正在保存…" : "保存选中素材并继续"}</button>
                     </div>
                   </div>
                 ) : (

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -319,6 +319,7 @@ export interface WorkflowRunEvent {
     | "sandbox_operation_finished"
     | "sandbox_artifact_published"
     | "skill_runtime_status"
+    | "skill_creator_handoff"
     | "heartbeat"
     | "node_end"
     | "workflow_cancelled"
@@ -338,6 +339,8 @@ export interface WorkflowRunEvent {
   wait_id?: string;
   resume_at?: number;
   host_id?: string;
+  session_id?: string;
+  error_code?: string;
   request_type?: "tool_call" | "final_output" | "manual_input";
   tool_name?: string;
   workspace_id?: string;

--- a/client/src/utils/runtimeMiddlewareMigration.test.ts
+++ b/client/src/utils/runtimeMiddlewareMigration.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from "vitest";
 import type { RuntimeMiddlewareNode } from "../types/runtimeMiddleware";
 import type { WorkflowNode } from "../types/workflow";
 import { reconcileRuntimeMiddlewareNodes } from "./runtimeMiddlewareMigration";
+import {
+  creatorHandoffMiddlewareConfig,
+  isLegacySkillCreatorMiddleware,
+  skillCreatorAuthoringMode,
+} from "./skillCreatorMiddleware";
 
 describe("reconcileRuntimeMiddlewareNodes", () => {
   it("upgrades an existing Skill Runtime field snapshot without losing user config", () => {
@@ -96,5 +101,64 @@ describe("reconcileRuntimeMiddlewareNodes", () => {
 
     expect(migrated[0]).toBe(input);
     expect(migrated[1]).toBe(unknown);
+  });
+
+  it("keeps saved Skill Creator nodes in Legacy mode until explicit upgrade", () => {
+    const legacy: WorkflowNode = {
+      id: "skill-creator-legacy",
+      type: "workflowNode",
+      position: { x: 0, y: 0 },
+      data: {
+        kind: "runtime_middleware",
+        title: "Skill 创建器",
+        description: "旧节点",
+        runtimeMiddlewareId: "skill_creator",
+        runtimeMiddlewareKind: "runtime_middleware.skill_creator",
+        runtimeMiddlewareConfig: {
+          allow_create: true,
+          allow_update: false,
+          allowed_draft_ids: "draft-1",
+        },
+      },
+    };
+    const definition: RuntimeMiddlewareNode = {
+      id: "skill_creator",
+      kind: "runtime_middleware.skill_creator",
+      title: "Skill 创建器",
+      description: "完成需求分析后创建 Creator 会话。",
+      category: "tool",
+      icon: "WandSparkles",
+      enabled: true,
+      fields: [
+        {
+          name: "authoring_mode",
+          label: "创建方式",
+          type: "select",
+          default: "creator_handoff",
+        },
+        { name: "allow_create", label: "允许创建", type: "boolean", default: true },
+        { name: "allow_update", label: "允许更新", type: "boolean", default: true },
+      ],
+    };
+
+    const [migrated] = reconcileRuntimeMiddlewareNodes([legacy], [definition]);
+
+    expect(migrated.data.runtimeMiddlewareConfig).toEqual({
+      allow_create: true,
+      allow_update: false,
+      allowed_draft_ids: "draft-1",
+    });
+    expect(isLegacySkillCreatorMiddleware(migrated.data)).toBe(true);
+  });
+
+  it("uses a minimal V2 config for explicit Skill Creator upgrades", () => {
+    const config = creatorHandoffMiddlewareConfig();
+
+    expect(config).toEqual({ authoring_mode: "creator_handoff" });
+    expect(skillCreatorAuthoringMode(config)).toBe("creator_handoff");
+    expect(skillCreatorAuthoringMode(undefined)).toBe("legacy_proposal");
+    expect(config).not.toHaveProperty("allow_create");
+    expect(config).not.toHaveProperty("allow_update");
+    expect(config).not.toHaveProperty("allowed_draft_ids");
   });
 });

--- a/client/src/utils/runtimeMiddlewareMigration.ts
+++ b/client/src/utils/runtimeMiddlewareMigration.ts
@@ -1,5 +1,6 @@
 import type { RuntimeMiddlewareNode } from "../types/runtimeMiddleware";
 import type { WorkflowNode } from "../types/workflow";
+import { SKILL_CREATOR_MIDDLEWARE_ID } from "./skillCreatorMiddleware";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -25,7 +26,14 @@ export function reconcileRuntimeMiddlewareNodes(
       ? node.data.runtimeMiddlewareConfig
       : {};
     const nextConfig: Record<string, unknown> = { ...existingConfig };
+    const preserveLegacySkillCreatorMode =
+      middlewareId === SKILL_CREATOR_MIDDLEWARE_ID
+      && existingConfig.authoring_mode === undefined;
     definition.fields.forEach((field) => {
+      if (
+        preserveLegacySkillCreatorMode
+        && field.name === "authoring_mode"
+      ) return;
       if (nextConfig[field.name] === undefined && field.default !== undefined) {
         nextConfig[field.name] = field.default;
       }

--- a/client/src/utils/skillCreatorMiddleware.ts
+++ b/client/src/utils/skillCreatorMiddleware.ts
@@ -1,0 +1,31 @@
+import type { WorkflowNodeData } from "../types/workflow";
+
+export const SKILL_CREATOR_MIDDLEWARE_ID = "skill_creator";
+export const SKILL_CREATOR_HANDOFF_MODE = "creator_handoff";
+export const SKILL_CREATOR_LEGACY_MODE = "legacy_proposal";
+
+export function skillCreatorAuthoringMode(
+  config: Record<string, unknown> | null | undefined,
+) {
+  const value = typeof config?.authoring_mode === "string"
+    ? config.authoring_mode.trim()
+    : "";
+  return value === SKILL_CREATOR_HANDOFF_MODE
+    ? SKILL_CREATOR_HANDOFF_MODE
+    : SKILL_CREATOR_LEGACY_MODE;
+}
+
+export function isSkillCreatorMiddleware(data: WorkflowNodeData) {
+  return data.kind === "runtime_middleware"
+    && data.runtimeMiddlewareId === SKILL_CREATOR_MIDDLEWARE_ID;
+}
+
+export function isLegacySkillCreatorMiddleware(data: WorkflowNodeData) {
+  return isSkillCreatorMiddleware(data)
+    && skillCreatorAuthoringMode(data.runtimeMiddlewareConfig)
+      === SKILL_CREATOR_LEGACY_MODE;
+}
+
+export function creatorHandoffMiddlewareConfig(): Record<string, unknown> {
+  return { authoring_mode: SKILL_CREATOR_HANDOFF_MODE };
+}

--- a/docs/XPERT_AUTHORING.md
+++ b/docs/XPERT_AUTHORING.md
@@ -14,11 +14,15 @@
 
 ## 中间件
 
-`xpert_authoring` 和 `skill_creator` 仅可绑定到 `workflow_agent`，并要求 `toolMode=mcp_tools`。两者通过既有 Tool Permission Policy、HITL、audit、LLM 工具选择器和 checkpoint 管线执行。
+`xpert_authoring` 仅可绑定到 `workflow_agent`，并要求 `toolMode=mcp_tools`。它通过既有 Tool Permission Policy、HITL、audit、LLM 工具选择器和 checkpoint 管线执行，提供资源目录、草稿读取、创建/更新提案和提案校验工具；`allowed_xpert_ids` 是运行时访问边界，来源 Xpert 只能额外读取自己的草稿。
 
-`xpert_authoring` 提供资源目录、草稿读取、创建/更新提案和提案校验工具；`skill_creator` 提供对应的 Skill 工具。配置中的 `allowed_xpert_ids` 与 `allowed_draft_ids` 是运行时访问边界；来源 Xpert 只能额外读取自己的草稿。
+新拖入的 `skill_creator` 默认使用 `authoring_mode=creator_handoff`。它仍只允许绑定一个 `workflow_agent`，但不要求 Runtime 工具模式，也不向普通 Agent 暴露 Skill 提案工具。Agent 只完成用途、输入、输出、边界和缺失信息分析；经典工作流成功持久化后，Server 创建一个可信 Creator Session 并返回交接事件。工作流 Agent 的文本不是 Skill 包，正式创建必须在 Creator 中由用户继续完成资源计划、资源构建、评测与独立安装。
 
-每个 run 最多创建 5 条提案，每个来源最多保留 20 条 pending 提案。工具不提供 publish、install、delete 或 archive 动作。
+运行面板只在当前浏览器标签会话保存有界 task/run ID，不保存需求、输出或 trace；刷新后通过持久执行流恢复 `skill_creator_handoff` 卡片。`ready` 卡片直接进入精确 Creator Session，`failed` 卡片展示稳定错误码并复用可信 workflow capture API 重试。存在自动交接事件时不再显示重复的普通“沉淀为 Skill”入口。
+
+未保存 `authoring_mode` 的旧节点继续按 `legacy_proposal` 运行：要求 `toolMode=mcp_tools`，并保留 `allow_create`、`allow_update` 和 `allowed_draft_ids` 的原提案边界。画布只在用户显式确认后把当前节点升级为 Creator V2，不批量迁移其他工作流。
+
+Legacy 路径每个 run 最多创建 5 条提案，每个来源最多保留 20 条 pending 提案。工具不提供 publish、install、delete 或 archive 动作。Creator V2 交接不创建 Authoring Proposal，也不会在工作流内调用 Planner、批准草稿或安装 Skill。
 
 ## 提案状态与并发
 

--- a/docs/XPERT_MIDDLEWARE.md
+++ b/docs/XPERT_MIDDLEWARE.md
@@ -12,9 +12,11 @@
 
 写回只创建 create/update 候选，正式写入必须经过人工审批和 revision 冲突检查。旧扁平字段会编译为隐式配置，显式绑定优先。公开 App 只有 `allow_xpert_memory=true` 时可只读，候选生成与写回始终禁止。详见 `docs/XPERT_FILE_MEMORY.md`。
 
-## Xpert / Skill 自编写（2026-07-18）
+## Xpert / Skill 自编写（2026-08-21）
 
-`xpert_authoring` 与 `skill_creator` 是 proposal-only Agent 中间件。它们要求绑定 `workflow_agent` 并启用 Runtime 工具模式，允许 Agent 在显式资源范围内读取草稿、创建或更新提案并运行校验；不暴露 publish、install、delete 或直接覆盖动作。
+`xpert_authoring` 保持 proposal-only Agent 中间件：要求绑定 `workflow_agent` 并启用 Runtime 工具模式，允许 Agent 在显式资源范围内读取草稿、创建或更新提案并运行校验；不暴露 publish、install、delete 或直接覆盖动作。
+
+新 `skill_creator` 节点默认进入 Creator V2 交接模式。它只要求 Agent 做简短需求分析，工作流成功完成后由 Server 以可信 task/run 创建 Creator Session；不会向 Agent 暴露提案工具，也不会直接生成 `SKILL.md`、批准或安装。运行面板提供 Creator 链接，用户在独立 Creator 工作台继续资源规划、构建、评测和安装。未声明 `authoring_mode` 的历史节点保留 Legacy 提案语义，并在画布显示告警和显式升级入口。
 
 Registry 契约现包含 `config_version`、`execution_status`、`requires_tool_mode`、`app_policy` 与 `security_category`。Workflow 校验、Xpert 发布和 App 部署预检消费相同契约；两类自编写能力固定为 `app_policy=forbidden`。提案批准只写 Xpert/Workspace Skill 草稿，revision 冲突不得 fail-open。完整提案、Skill 包和 API 边界见 `docs/XPERT_AUTHORING.md`。
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -28,8 +28,9 @@ EXPERT_TEAM_AGENCY_HITL_ENABLED=0
 # 私有控制台 Skill Creator V1 默认开启；公共 Xpert App 始终禁用。
 # 设为 false 并重启 Server 可同时关闭 Creator API 与界面入口。
 SKILL_CREATOR_V2_ENABLED=true
-# Workflow Skill Creator V2 handoff remains opt-in until its canvas experience ships.
-SKILL_CREATOR_MIDDLEWARE_V2_ENABLED=false
+# 新拖入的 Workflow Skill Creator 使用可信 Creator 交接；设为 false 可回退，
+# 已保存且未声明 authoring_mode 的旧节点仍按 Legacy 提案路径运行。
+SKILL_CREATOR_MIDDLEWARE_V2_ENABLED=true
 # 资源化 Creator 已具备规划、分段构建和脚本离线实测；PR 3 工作台完成前默认关闭。
 SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED=true
 # 私有 Creator 默认启用可复用套件、资源级进化和跨版本回归；设为 false 可回退旧三例流程。

--- a/server/skills/creator_handoff.py
+++ b/server/skills/creator_handoff.py
@@ -20,7 +20,9 @@ Clarify only the intended use, expected inputs, expected output, boundaries, and
 missing information. Do not write SKILL.md, resource files, tool calls,
 installation steps, or an authoring proposal. Finish the user's workflow task
 normally; ModelMirror will create the Creator session only after the workflow
-has completed successfully.
+has completed successfully. Use the same primary language as the user's request.
+Return concise plain text without Markdown syntax so the analysis remains readable
+in the workflow result and Creator evidence review.
 """.strip()
 
 _HANDOFF_ERROR_CODES = {
@@ -58,7 +60,7 @@ class SkillCreatorHandoffService:
     ) -> None:
         self.creator_service = creator_service
         self.enabled = (
-            os.getenv("SKILL_CREATOR_MIDDLEWARE_V2_ENABLED", "false")
+            os.getenv("SKILL_CREATOR_MIDDLEWARE_V2_ENABLED", "true")
             .strip()
             .lower()
             in {"1", "true", "yes", "on"}

--- a/server/skills/creator_resource_runtime.py
+++ b/server/skills/creator_resource_runtime.py
@@ -55,6 +55,17 @@ class WorkflowCreatorResourcePlanner:
                 "Creator resource planner returned an unsupported contract version.",
                 code="skill_creator_resource_planner_invalid",
             )
+        # A clarification response is intentionally non-committal. Models can still
+        # speculate about resources despite the prompt, so discard those suggestions
+        # at the model boundary and let the typed plan store validate the questions.
+        # The discarded values never reach a Store or an Authoring Proposal.
+        if isinstance(payload.get("clarifications"), list) and payload["clarifications"]:
+            payload["resources"] = []
+        else:
+            _constrain_model_source_ids(
+                payload,
+                allowed_source_ids=set(request.allowed_source_ids),
+            )
         return payload
 
 
@@ -189,6 +200,45 @@ def parse_resource_plan_output(value: Any) -> dict[str, Any]:
     return payload
 
 
+def _constrain_model_source_ids(
+    payload: dict[str, Any], *, allowed_source_ids: set[str]
+) -> None:
+    """Keep model-authored provenance inside the server-frozen requirement set.
+
+    Resource source IDs are internal identifiers rather than user content. A model may
+    paraphrase or invent one even when the prompt includes the allow-list. Preserve valid
+    IDs, discard unknown IDs, and bind an otherwise unbound resource to the session intent.
+    Malformed non-list/non-string values remain untouched so the typed Store rejects them.
+    """
+
+    resources = payload.get("resources")
+    if not isinstance(resources, list):
+        return
+    fallback = "intent" if "intent" in allowed_source_ids else None
+    constrained: list[Any] = []
+    for raw in resources:
+        if not isinstance(raw, dict):
+            constrained.append(raw)
+            continue
+        source_ids = raw.get("source_ids")
+        if not isinstance(source_ids, list) or any(
+            not isinstance(source_id, str) for source_id in source_ids
+        ):
+            constrained.append(raw)
+            continue
+        retained = list(
+            dict.fromkeys(
+                source_id.strip()
+                for source_id in source_ids
+                if source_id.strip() in allowed_source_ids
+            )
+        )
+        if not retained and fallback is not None:
+            retained = [fallback]
+        constrained.append({**raw, "source_ids": retained})
+    payload["resources"] = constrained
+
+
 def _decode_resource_plan_json(text: str) -> Any:
     """Decode one versioned plan while tolerating harmless model narration.
 
@@ -252,6 +302,10 @@ def _resource_planner_prompt() -> str:
         "return at most five concise clarifications and an empty resources array. Do not invent "
         "facts. When previous_plan contains clarification_answers, use them as trusted user "
         "answers and produce a revised plan.\n\n"
+        "Use the same primary natural language as definition.intent for every human-readable "
+        "field, including skill_description, workflow instructions, output contracts, failure "
+        "modes, resource purposes, acceptance checks, and clarification questions. Keep only "
+        "skill_name and fixed JSON enum values in their required machine-readable form.\n\n"
         "A previous plan is advisory, never authoritative. When the current definition or "
         "target draft differs, re-evaluate every resource from scratch. If the user explicitly "
         "requires a supported resource type for a deterministic or reusable concern, either "
@@ -259,7 +313,9 @@ def _resource_planner_prompt() -> str:
         "be planned safely; do not silently preserve an incompatible previous plan.\n\n"
         "For updates, account for every target_draft.resource_inventory path with exactly one "
         "keep, update, or delete action. New paths use create. Dependencies are expressed as "
-        "resource paths. Use only allowed_source_ids and real workflow step IDs.\n\n"
+        "resource paths. Source IDs are opaque server tokens: copy only exact values from "
+        "allowed_source_ids, and use intent when no narrower source applies. Use only real "
+        "workflow step IDs.\n\n"
         "Use the pinned planning guidance below only to reason about requirements and "
         "resource necessity. This phase stops before frontmatter, file content, or a typed "
         "Authoring Proposal is written.\n\nPinned planning guidance:\n\n"

--- a/server/tests/test_skill_creator_middleware_handoff.py
+++ b/server/tests/test_skill_creator_middleware_handoff.py
@@ -230,6 +230,18 @@ def _failing_handoff_workflow() -> dict:
     return workflow
 
 
+def test_handoff_is_enabled_by_default_with_explicit_env_rollback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SKILL_CREATOR_MIDDLEWARE_V2_ENABLED", raising=False)
+    enabled = SkillCreatorHandoffService(SimpleNamespace())
+    assert enabled.enabled is True
+
+    monkeypatch.setenv("SKILL_CREATOR_MIDDLEWARE_V2_ENABLED", "false")
+    disabled = SkillCreatorHandoffService(SimpleNamespace())
+    assert disabled.enabled is False
+
+
 def test_handoff_store_is_idempotent_and_hydrates_pristine_capture(
     tmp_path: Path,
 ) -> None:
@@ -650,6 +662,10 @@ async def test_completed_v2_middleware_creates_one_session_without_proposal_tool
     assert model_calls == 1
     assert captured["prompt"] == session.intent
     assert SKILL_CREATOR_HANDOFF_ROLE_INSTRUCTION in captured["system_prompt"]
+    assert "same primary language as the user's request" in captured[
+        "system_prompt"
+    ].lower()
+    assert "plain text without markdown" in captured["system_prompt"].lower()
     after = {
         item.proposal_id for item in main_module.authoring_proposal_store.list(limit=500)
     }

--- a/server/tests/test_skill_creator_resource_plan.py
+++ b/server/tests/test_skill_creator_resource_plan.py
@@ -274,6 +274,26 @@ def test_unknown_model_enum_values_still_fail_closed(
     assert caught.value.code == code
 
 
+def test_unknown_source_requirement_still_fails_closed_at_store_boundary(
+    tmp_path: Path,
+) -> None:
+    resource = {
+        "kind": "reference",
+        "action": "create",
+        "generation_cost": "medium",
+        "path": "references/rules.md",
+        "purpose": "Keep detailed rules out of SKILL.md.",
+        "source_ids": ["invented-requirement"],
+        "used_by_steps": ["collect"],
+        "acceptance_checks": ["Contains only supplied rules."],
+    }
+
+    with pytest.raises(SkillCreatorValidationError) as caught:
+        _save(SkillResourcePlanStore(tmp_path), _payload(resources=[resource]))
+
+    assert caught.value.code == "skill_creator_resource_source_unknown"
+
+
 def test_clarification_answers_are_immutable_and_require_regeneration(tmp_path: Path) -> None:
     store = SkillResourcePlanStore(tmp_path)
     plan = _save(

--- a/server/tests/test_skill_creator_resource_service.py
+++ b/server/tests/test_skill_creator_resource_service.py
@@ -283,6 +283,10 @@ def test_resource_planner_workflow_has_no_tools_and_strict_contract() -> None:
     assert "do not create a script for subjective judgment" in agent["data"][
         "rolePrompt"
     ].lower()
+    assert "same primary natural language as definition.intent" in agent["data"][
+        "rolePrompt"
+    ].lower()
+    assert "source ids are opaque server tokens" in agent["data"]["rolePrompt"].lower()
     assert "## 1. Turn the session into explicit requirements" in agent["data"][
         "rolePrompt"
     ]
@@ -324,6 +328,95 @@ async def test_workflow_resource_planner_accepts_only_versioned_json() -> None:
     with pytest.raises(SkillCreatorValidationError) as caught:
         await invalid.plan(request)
     assert caught.value.code == "skill_creator_resource_planner_invalid"
+
+
+@pytest.mark.asyncio
+async def test_workflow_resource_planner_discards_precommitted_resources_when_clarifying() -> None:
+    request = ResourcePlanningRequest(
+        session={"session_id": "skillcreator_test", "session_revision": 3},
+        target_draft=None,
+        current_plan=None,
+        allowed_source_ids=["intent"],
+    )
+    clarification = {
+        "id": "input_format",
+        "question": "Which input fields are authoritative?",
+        "reason": "The supplied examples do not define a stable input contract.",
+    }
+    speculative_resource = {
+        "kind": "asset",
+        "action": "create",
+        "path": "assets/report-template.md",
+        "purpose": "Render the final report.",
+        "source_ids": ["intent"],
+        "used_by_steps": ["deliver"],
+        "depends_on": [],
+        "acceptance_checks": ["Contains every required section."],
+    }
+
+    async def runner(_invocation):
+        return json.dumps(
+            {
+                "resource_plan_version": RESOURCE_PLAN_VERSION,
+                **_plan_payload(
+                    clarifications=[clarification],
+                    resources=[speculative_resource],
+                ),
+            }
+        )
+
+    planner = WorkflowCreatorResourcePlanner(
+        model_id="gateway/default-text",
+        model_available=lambda: True,
+        runner=runner,
+    )
+
+    payload = await planner.plan(request)
+
+    assert payload["clarifications"] == [clarification]
+    assert payload["resources"] == []
+
+
+@pytest.mark.asyncio
+async def test_workflow_resource_planner_constrains_model_source_ids() -> None:
+    request = ResourcePlanningRequest(
+        session={"session_id": "skillcreator_test", "session_revision": 3},
+        target_draft=None,
+        current_plan=None,
+        allowed_source_ids=["intent", "expected_output"],
+    )
+    resource = {
+        "kind": "asset",
+        "action": "create",
+        "path": "assets/report-template.md",
+        "purpose": "Render the final report.",
+        "source_ids": ["expected_output", "invented-requirement"],
+        "used_by_steps": ["deliver"],
+        "depends_on": [],
+        "acceptance_checks": ["Contains every required section."],
+    }
+
+    async def runner(_invocation):
+        return json.dumps(
+            {
+                "resource_plan_version": RESOURCE_PLAN_VERSION,
+                **_plan_payload(resources=[resource]),
+            }
+        )
+
+    planner = WorkflowCreatorResourcePlanner(
+        model_id="gateway/default-text",
+        model_available=lambda: True,
+        runner=runner,
+    )
+
+    payload = await planner.plan(request)
+
+    assert payload["resources"][0]["source_ids"] == ["expected_output"]
+
+    resource["source_ids"] = ["invented-requirement"]
+    fallback_payload = await planner.plan(request)
+    assert fallback_payload["resources"][0]["source_ids"] == ["intent"]
 
 
 def test_resource_planner_extracts_one_versioned_json_from_model_narration() -> None:

--- a/server/tests/test_xpert_runtime_middleware_registry.py
+++ b/server/tests/test_xpert_runtime_middleware_registry.py
@@ -60,7 +60,12 @@ def test_registry_list_returns_builtin_nodes() -> None:
     skill_creator = registry.get("skill_creator")
     assert authoring is not None and skill_creator is not None
     assert authoring.requires_tool_mode == "mcp_tools"
-    assert skill_creator.requires_tool_mode == "mcp_tools"
+    assert skill_creator.requires_tool_mode is None
+    authoring_mode = next(
+        field for field in skill_creator.fields if field.name == "authoring_mode"
+    )
+    assert authoring_mode.default == "creator_handoff"
+    assert authoring_mode.options == ["creator_handoff", "legacy_proposal"]
     assert skill_creator.metadata["supported_authoring_modes"] == [
         "legacy_proposal",
         "creator_handoff",

--- a/server/xpert_runtime/middleware_registry.py
+++ b/server/xpert_runtime/middleware_registry.py
@@ -173,10 +173,21 @@ def register_builtin_middleware_nodes(
             id="skill_creator",
             kind="runtime_middleware.skill_creator",
             title="Skill 创建器",
-            description="创建或修改 Workspace Skill 提案；批准后生成草稿，仍需用户显式安装。",
+            description=(
+                "完成需求分析后创建 Creator 会话；"
+                "不会直接生成、批准或安装 Skill。"
+            ),
             category="tool",
             icon="WandSparkles",
             fields=[
+                RuntimeMiddlewareField(
+                    name="authoring_mode",
+                    label="创建方式",
+                    type="select",
+                    default="creator_handoff",
+                    options=["creator_handoff", "legacy_proposal"],
+                    description="新节点使用 Creator V2；旧节点仅在用户确认后升级。",
+                ),
                 RuntimeMiddlewareField(
                     name="allow_create",
                     label="允许创建提案",
@@ -210,7 +221,6 @@ def register_builtin_middleware_nodes(
                     "creator_handoff",
                 ],
             },
-            requires_tool_mode="mcp_tools",
             app_policy="forbidden",
             security_category="authoring",
         )


### PR DESCRIPTION
## Summary

- 新拖入的 Skill Creator 中间件默认使用 creator_handoff；旧节点继续兼容 Legacy 提案路径，并可在当前画布显式升级。
- 工作流完成后创建或恢复可信 Creator Session，以交接卡引导用户继续资源规划、构建、评测与安装，不直接生成或安装 Skill。
- 补齐交接失败恢复、重复沉淀入口抑制、中文为主的界面文案及 390px 响应式体验。
- 修复 Agent 运行审批闪烁，并基于真实 Provider 证伪结果收紧资源 Planner 边界：澄清阶段不预生成资源，来源 ID 仅使用服务端允许值。

## Validation

- 后端相关回归：157 passed。
- 资源 Planner 聚焦回归：13 passed。
- 前端 Vitest：93 files / 484 tests passed。
- 前端生产构建通过；仅保留既有 chunk warning。
- DeepSeek V4 Flash 0731 真实 Provider：工作流交接 ready、proposal events 为 0；Creator Planner 在信息不足时返回 4 个必要澄清问题且未预提交资源。
- 1440px 与 390px 独立预览均无页面横向溢出。
- git diff check、路径白名单和 staged 敏感模式扫描均通过。

## Compatibility and rollback

- 未声明 authoring_mode 的既有节点保持 legacy_proposal 行为。
- 设置 SKILL_CREATOR_MIDDLEWARE_V2_ENABLED=false 并重启 Server 可回退默认 V2 交接，不影响独立 Creator 与旧工作流。
- 未修改 Hook、Skill Runtime、Sandbox sidecar 或最终 Skill 包合同。