### PR TITLE
feature: Skill 执行指导应用门

### DIFF
--- a/docs/SKILL_INTEGRATION.md
+++ b/docs/SKILL_INTEGRATION.md
@@ -270,6 +270,14 @@ curl -X DELETE http://localhost:8000/api/skills/anthropics-skills-skills-pdf
 
 私有 Xpert、工作流、Goal 与 Handoff 可选择启用本地目录发现和审批式固定 SHA 安装；完整运行时边界见 [私有 Agent Skill 按需路由](./SKILL_RUNTIME_ROUTER.md)。
 
+### 4.1 Skill Runtime Guidance V2 基础门
+
+`SKILL_RUNTIME_GUIDANCE_V2_ENABLED=true` 可在经典 Workflow 及其发布后的私有 Xpert 中启用真实应用门。用户显式选择、或本轮通过 `skill_enable` / `skill_install` 激活的 Skill 属于 `required`；插件附带及 `auto_discover` 候选保持 `available`，不会因为可见就冻结全部已安装 Skill。
+
+服务端在模型调用前固定 Skill 版本、内容摘要与信任指纹，并在接受最终答案或执行副作用、敏感、审批及 terminal 工具前核验同一运行的 `SkillApplicationReceipt`。存在必用 Skill 时会跳过基于模型的 Tool Selector，保留完整已授权工具集合，避免选择器先消耗模型额度或移除 Skill 所需能力。首次缺少 `skill_read` 时只允许一次服务端纠偏；再次遗漏会以稳定错误终止 Workflow，不创建审批卡或放行工具。`SKILL_APPLICATION_RECEIPT_MODE=off` 时该门失败关闭。
+
+本批次默认保持开关关闭，不改变旧节点数据。回退只需设回 `false` 并重启 Server；已有 Workflow、安装数据和 receipt 均保留。多文件资源的自动只读工具与运行卡将在后续批次交付。
+
 ## 5. 测试指南
 
 后端测试不依赖外网，会在临时目录创建本地 git 仓库作为 mock Skill 源：

--- a/server/.env.example
+++ b/server/.env.example
@@ -51,6 +51,10 @@ SKILL_LIFECYCLE_MAX_BYTES=1073741824
 # off 可关闭写入；enforce 会在凭据不可写时使 Skill 应用失败关闭。
 # Creator Evaluation V2 内部始终强制复核 verified 凭据，不受 audit 回退影响。
 SKILL_APPLICATION_RECEIPT_MODE=audit
+# Skill Runtime Guidance V2 的 PR1 基础门默认关闭；临时开启后，Workflow
+# 与私有 Xpert 中显式选择或本轮激活的 Skill 必须先有 verified skill_read
+# 凭据，才可提交答案或执行副作用工具。设回 false 可恢复原提示型行为。
+SKILL_RUNTIME_GUIDANCE_V2_ENABLED=false
 # The semantic provider remains disabled until explicitly configured. Router
 # shadow mode never changes the lexical skill-need-local-v3 result order.
 SKILL_SEMANTIC_RERANK_PROVIDER=none

--- a/server/main.py
+++ b/server/main.py
@@ -207,10 +207,20 @@ except ModuleNotFoundError:
 
 try:
     from server.skills.application_receipts import (
+        SkillApplicationScope,
         SkillApplicationObserver,
         SkillApplicationReceiptError,
         SkillApplicationReceiptStore,
         application_receipt_mode,
+    )
+    from server.skills.runtime_guidance import (
+        SkillRuntimeGuidanceError,
+        SkillRuntimeGuidancePlanV2,
+        build_skill_runtime_guidance_plan,
+        missing_required_skill_ids,
+        skill_application_repair_instruction,
+        skill_runtime_guidance_enabled,
+        tool_requires_skill_application,
     )
     from server.skills.api import (
         get_builtin_skill_library,
@@ -305,10 +315,20 @@ try:
     )
 except ModuleNotFoundError:
     from skills.application_receipts import (
+        SkillApplicationScope,
         SkillApplicationObserver,
         SkillApplicationReceiptError,
         SkillApplicationReceiptStore,
         application_receipt_mode,
+    )
+    from skills.runtime_guidance import (
+        SkillRuntimeGuidanceError,
+        SkillRuntimeGuidancePlanV2,
+        build_skill_runtime_guidance_plan,
+        missing_required_skill_ids,
+        skill_application_repair_instruction,
+        skill_runtime_guidance_enabled,
+        tool_requires_skill_application,
     )
     from skills.api import (
         get_builtin_skill_library,
@@ -8485,6 +8505,16 @@ async def _run_workflow_response(
                     node_id,
                 ),
             ]
+            explicit_skill_ids = {
+                item.strip()
+                for spec in specs
+                if spec.middleware_id == "skills_runtime"
+                and spec.binding == "agent"
+                for item in re.split(
+                    r"[,\n]+", str(spec.config.get("skill_ids") or "")
+                )
+                if item.strip()
+            }
             plugin_snapshots = bound_plugin_snapshots(node_id)
             configured_ids = {item.middleware_id for item in specs}
             plugin_skill_ids: list[str] = []
@@ -8570,6 +8600,20 @@ async def _run_workflow_response(
                             dict.fromkeys([*existing, *plugin_skill_ids])
                         ),
                     }
+            resolved_skills = middleware_spec(specs, "skills_runtime")
+            if resolved_skills is not None:
+                resolved_skills.config = {
+                    **resolved_skills.config,
+                    # Server-derived provenance always overwrites untrusted config.
+                    "_server_explicit_skill_ids": sorted(explicit_skill_ids),
+                    "_server_plugin_skill_ids": sorted(
+                        {
+                            str(item).strip()
+                            for item in plugin_skill_ids
+                            if str(item).strip()
+                        }
+                    ),
+                }
             node = nodes_by_id.get(node_id)
             node_data = node.data if node is not None and isinstance(node.data, dict) else {}
             if (
@@ -9991,6 +10035,269 @@ async def _run_workflow_response(
                 node_events.append(payload_event)
             return node_events
 
+        def skill_guidance_source_ids(
+            spec: RuntimeMiddlewareSpec | None,
+        ) -> tuple[set[str], set[str], bool]:
+            if spec is None:
+                return set(), set(), False
+            config = dict(spec.config or {})
+
+            def configured_ids(name: str) -> set[str]:
+                value = config.get(name)
+                if isinstance(value, list):
+                    return {
+                        str(item).strip()
+                        for item in value
+                        if str(item).strip()
+                    }
+                return {
+                    item.strip()
+                    for item in re.split(r"[,\n]+", str(value or ""))
+                    if item.strip()
+                }
+
+            if "_server_explicit_skill_ids" in config:
+                explicit_ids = configured_ids("_server_explicit_skill_ids")
+            elif spec.binding == "agent":
+                explicit_ids = configured_ids("skill_ids")
+            else:
+                explicit_ids = set()
+            plugin_ids = configured_ids("_server_plugin_skill_ids")
+            if spec.binding == "plugin" and not plugin_ids:
+                plugin_ids = configured_ids("skill_ids")
+            return (
+                explicit_ids,
+                plugin_ids,
+                workflow_truthy(config.get("auto_discover", False)),
+            )
+
+        def skill_guidance_environment(
+            available_tools: list[Any],
+            middleware_context: MiddlewareContext | None,
+        ) -> SkillRuntimeEnvironment:
+            return SkillRuntimeEnvironment.from_metadata(
+                {
+                    "skill_runtime_environment": {
+                        "tool_names": sorted(
+                            {
+                                str(tool.name)
+                                for tool in available_tools
+                                if str(tool.name).strip()
+                            }
+                        ),
+                        "tool_providers": sorted(
+                            {
+                                str(tool.provider)
+                                for tool in available_tools
+                                if str(tool.provider).strip()
+                            }
+                        ),
+                        "credentials_available": False,
+                        "host_filesystem_available": False,
+                        "desktop_control_available": False,
+                    },
+                    "sandbox_config": (
+                        dict(middleware_context.metadata.get("sandbox_config") or {})
+                        if middleware_context is not None
+                        else {}
+                    ),
+                }
+            )
+
+        async def prepare_skill_guidance_plan(
+            *,
+            node: WorkflowNodePayload,
+            include_skills: bool,
+            available_tools: list[Any],
+            middleware_specs: list[RuntimeMiddlewareSpec] | None,
+            middleware_context: MiddlewareContext | None,
+            activated_skill_ids: set[str],
+            skill_version_bindings: dict[str, str],
+            skill_trust_authorizations: dict[str, str],
+            stored_plan_fingerprint: str | None = None,
+        ) -> tuple[
+            SkillRuntimeGuidancePlanV2 | None,
+            dict[str, Any],
+            dict[str, str],
+        ]:
+            skills_spec = middleware_spec(
+                middleware_specs or [], "skills_runtime"
+            )
+            guidance_enabled = bool(
+                include_skills
+                and skills_spec is not None
+                and runtime_run_type in {"workflow", "xpert"}
+                and skill_runtime_guidance_enabled()
+            )
+            if not guidance_enabled:
+                return None, {}, skill_version_bindings
+            if application_receipt_mode() == "off":
+                raise SkillRuntimeGuidanceError(
+                    "Skill application evidence is disabled for a required guidance node.",
+                    code="skill_application_evidence_unavailable",
+                )
+            explicit_ids, plugin_ids, auto_discover = skill_guidance_source_ids(
+                skills_spec
+            )
+            required_ids = explicit_ids | activated_skill_ids
+            known_ids = required_ids | plugin_ids
+            manager = get_skill_manager()
+            installed_items = {
+                str(item.skill_id): item
+                for item in await asyncio.to_thread(
+                    manager.list_installed_skills
+                )
+                if str(item.skill_id).strip()
+            }
+            missing_bindings = known_ids - set(skill_version_bindings)
+            if missing_bindings:
+                resolved_bindings = await asyncio.to_thread(
+                    manager.bind_skill_versions,
+                    missing_bindings,
+                )
+                skill_version_bindings.update(
+                    {
+                        str(skill_id): str(version_id)
+                        for skill_id, version_id in resolved_bindings.items()
+                        if str(skill_id).strip() and str(version_id).strip()
+                    }
+                )
+            contracts: dict[str, Any] = {}
+            environment = skill_guidance_environment(
+                available_tools, middleware_context
+            )
+            for skill_id in sorted(known_ids):
+                installed = installed_items.get(skill_id)
+                if installed is None:
+                    if skill_id in required_ids:
+                        raise SkillRuntimeGuidanceError(
+                            "Required Skill is no longer installed.",
+                            code="skill_application_contract_stale",
+                        )
+                    continue
+                runtime_version_id = skill_version_bindings.get(skill_id)
+                if skill_id in required_ids:
+                    activation_kwargs: dict[str, Any] = {
+                        "runtime_environment": environment,
+                        "ephemeral_authorizations": skill_trust_authorizations,
+                    }
+                    if runtime_version_id:
+                        activation_kwargs["version_id"] = runtime_version_id
+                    try:
+                        await asyncio.to_thread(
+                            manager.require_activation,
+                            skill_id,
+                            **activation_kwargs,
+                        )
+                    except Exception as exc:
+                        raise SkillRuntimeGuidanceError(
+                            "Required Skill failed trust or runtime compatibility "
+                            "preflight.",
+                            code=str(
+                                getattr(exc, "code", "")
+                                or "skill_runtime_incompatible"
+                            ),
+                        ) from exc
+                source_kind = str(
+                    getattr(installed, "source_kind", "") or "unknown"
+                )
+                content_digest = str(
+                    getattr(installed, "content_digest", "") or ""
+                ).lower()
+                trust_fingerprint = str(
+                    getattr(installed, "trust_fingerprint", "") or ""
+                ).lower() or None
+                guidance_version_id = runtime_version_id
+                if not runtime_version_id:
+                    if skill_id in required_ids:
+                        raise SkillRuntimeGuidanceError(
+                            "Required Skill has no immutable runtime version.",
+                            code="skill_application_evidence_unavailable",
+                        )
+                    continue
+                if runtime_version_id:
+                    try:
+                        snapshot = await asyncio.to_thread(
+                            manager.lifecycle_store.require_version,
+                            runtime_version_id,
+                        )
+                        source_kind = str(
+                            getattr(snapshot, "source_kind", "") or source_kind
+                        )
+                        content_digest = str(
+                            getattr(snapshot, "package_digest", "")
+                            or content_digest
+                        ).lower()
+                        trust_fingerprint = str(
+                            getattr(snapshot, "trust_fingerprint", "")
+                            or trust_fingerprint
+                            or ""
+                        ).lower() or None
+                    except Exception as exc:
+                        if skill_id in required_ids:
+                            raise SkillRuntimeGuidanceError(
+                                "Frozen Skill version could not be resolved.",
+                                code="skill_application_contract_stale",
+                            ) from exc
+                        continue
+                try:
+                    contracts[skill_id] = skill_application_observer.resolve_contract(
+                        skill_id,
+                        version_id=guidance_version_id,
+                        source_kind=source_kind,
+                        content_digest=content_digest or None,
+                        trust_fingerprint=trust_fingerprint,
+                        policy="require_read",
+                    )
+                except Exception as exc:
+                    if skill_id in required_ids:
+                        raise SkillRuntimeGuidanceError(
+                            "Required Skill application contract is unavailable.",
+                            code="skill_application_evidence_unavailable",
+                        ) from exc
+            plan = build_skill_runtime_guidance_plan(
+                task_id=task_id,
+                run_id=workflow_run.run_id,
+                node_id=node.id,
+                explicit_skill_ids=explicit_ids,
+                plugin_skill_ids=plugin_ids,
+                activated_skill_ids=activated_skill_ids,
+                auto_discover=auto_discover,
+                contracts=contracts,
+            )
+            if (
+                stored_plan_fingerprint
+                and stored_plan_fingerprint != plan.fingerprint
+            ):
+                raise SkillRuntimeGuidanceError(
+                    "Skill application plan changed while the run was suspended.",
+                    code="skill_application_contract_stale",
+                )
+            scope = SkillApplicationScope(
+                run_id=workflow_run.run_id,
+                task_id=task_id,
+                node_id=node.id,
+                runtime_kind=runtime_run_type,
+            )
+            for entry in plan.entries:
+                if entry.requirement == "required":
+                    try:
+                        skill_application_receipt_store.record_selection(
+                            contracts[entry.skill_id], scope
+                        )
+                    except Exception as exc:
+                        raise SkillRuntimeGuidanceError(
+                            "Skill application evidence is unavailable.",
+                            code="skill_application_evidence_unavailable",
+                        ) from exc
+            if skill_version_bindings:
+                await asyncio.to_thread(
+                    workflow_execution_store.bind_skill_versions,
+                    task_id,
+                    bindings=skill_version_bindings,
+                )
+            return plan, contracts, skill_version_bindings
+
         async def run_agent_strategy_v2(
             *,
             node: WorkflowNodePayload,
@@ -10069,7 +10376,41 @@ async def _run_workflow_response(
                 middleware_specs=middleware_specs,
                 apply_policy_filter=selector_spec is not None,
             )
-            if selector_spec is not None and available_tools:
+            selector_skills_spec = middleware_spec(
+                middleware_specs or [], "skills_runtime"
+            )
+            selector_explicit_ids, _selector_plugin_ids, _selector_auto = (
+                skill_guidance_source_ids(selector_skills_spec)
+                if selector_skills_spec is not None
+                else (set(), set(), False)
+            )
+            selector_guidance_required = bool(
+                include_skills
+                and skill_runtime_guidance_enabled()
+                and runtime_run_type in {"workflow", "xpert"}
+                and (
+                    selector_explicit_ids
+                    or {
+                        str(item).strip()
+                        for item in dict(resume_state or {}).get(
+                            "active_skill_ids", []
+                        )
+                        if str(item).strip()
+                    }
+                )
+            )
+            if selector_guidance_required and "skill_read" not in {
+                tool.name for tool in available_tools
+            }:
+                raise SkillRuntimeGuidanceError(
+                    "Required Skill cannot be read in the current runtime.",
+                    code="skill_runtime_incompatible",
+                )
+            if (
+                selector_spec is not None
+                and available_tools
+                and not selector_guidance_required
+            ):
                 required_tools = set()
                 if include_todo:
                     required_tools.update({"todo_list", "todo_create", "todo_update"})
@@ -10541,6 +10882,26 @@ async def _run_workflow_response(
                             ),
                         },
                     )
+            elif selector_spec is not None and selector_guidance_required:
+                selector_metadata = {
+                    "mode": "bypassed_required_skill_guidance",
+                    "selected": sorted(
+                        tool.name for tool in available_tools if tool.name
+                    ),
+                    "warning": None,
+                }
+                if middleware_context is not None:
+                    middleware_context.metadata["tool_selection"] = (
+                        selector_metadata
+                    )
+                if run_id:
+                    await run_registry.record_checkpoint(
+                        run_id,
+                        event_type="middleware.tool_selector.skipped",
+                        title="Runtime tool selector skipped",
+                        summary="required_skill_guidance_preflight",
+                        metadata=selector_metadata,
+                    )
 
             async def invoke_agent_model(messages: list[ChatMessage]) -> str:
                 def capture_actual_model(reported_model_id: str) -> None:
@@ -10723,6 +11084,21 @@ async def _run_workflow_response(
                 ).items()
                 if str(skill_id).strip() and str(version_id).strip()
             }
+            skill_trust_authorizations = {
+                str(skill_id): str(fingerprint)
+                for skill_id, fingerprint in dict(
+                    pending_state.get("skill_trust_authorizations") or {}
+                ).items()
+                if str(skill_id).strip() and str(fingerprint).strip()
+            }
+            guidance_repair_nodes = dict(
+                task_state.get("skill_guidance_repair_used_by_node") or {}
+            )
+            skill_guidance_repair_used = bool(
+                pending_state.get("skill_guidance_repair_used", False)
+                or guidance_repair_nodes.get(node.id, False)
+            )
+            skill_guidance_verified_emitted = False
             skill_application_policy = str(
                 runtime_metadata.get("skill_application_policy") or "require_read"
             ).strip()
@@ -10744,7 +11120,9 @@ async def _run_workflow_response(
                 if isinstance(raw_application_paths, list)
                 else []
             )
-            if include_skills:
+            skill_guidance_plan: SkillRuntimeGuidancePlanV2 | None = None
+            skill_guidance_contracts: dict[str, Any] = {}
+            if include_skills and not skill_runtime_guidance_enabled():
                 skills_config_for_bindings = dict(
                     skills_spec.config if skills_spec is not None else {}
                 )
@@ -10797,17 +11175,50 @@ async def _run_workflow_response(
                             policy=skill_application_policy,
                             required_resource_paths=skill_application_required_paths,
                         )
+            elif include_skills:
+                (
+                    skill_guidance_plan,
+                    skill_guidance_contracts,
+                    skill_version_bindings,
+                ) = await prepare_skill_guidance_plan(
+                    node=node,
+                    include_skills=include_skills,
+                    available_tools=available_tools,
+                    middleware_specs=middleware_specs,
+                    middleware_context=middleware_context,
+                    activated_skill_ids=active_skill_ids,
+                    skill_version_bindings=skill_version_bindings,
+                    skill_trust_authorizations=skill_trust_authorizations,
+                    stored_plan_fingerprint=(
+                        str(pending_state.get("skill_guidance_plan_fingerprint") or "")
+                        or None
+                    ),
+                )
+                if (
+                    skill_guidance_plan is not None
+                    and skill_guidance_plan.required_skill_ids
+                ):
+                    required_list = ", ".join(
+                        skill_guidance_plan.required_skill_ids
+                    )
+                    react_system_prompt += (
+                        "\n\nRequired Skill application: before a final answer or "
+                        "any side-effecting, sensitive, approval, or terminal tool, "
+                        "call skill_read for every required Skill ID: "
+                        f"{required_list}. Plugin-provided and auto-discovered Skills "
+                        "remain optional until explicitly enabled. Never claim a Skill "
+                        "was read without the tool result."
+                    )
+                    messages[0] = ChatMessage(
+                        role="system", content=react_system_prompt
+                    )
+                    pending_state["skill_guidance_plan_fingerprint"] = (
+                        skill_guidance_plan.fingerprint
+                    )
             if middleware_context is not None:
                 middleware_context.metadata["skill_version_bindings"] = (
                     skill_version_bindings
                 )
-            skill_trust_authorizations = {
-                str(skill_id): str(fingerprint)
-                for skill_id, fingerprint in dict(
-                    pending_state.get("skill_trust_authorizations") or {}
-                ).items()
-                if str(skill_id).strip() and str(fingerprint).strip()
-            }
             denied_skill_candidate_ids = {
                 str(item)
                 for item in (pending_state.get("denied_skill_candidate_ids") or [])
@@ -10818,6 +11229,132 @@ async def _run_workflow_response(
                 int(pending_state.get("catalog_install_count") or 0),
             )
             run_tool_memory: list[str] = []
+
+            async def guidance_missing_skill_ids() -> tuple[str, ...]:
+                if skill_guidance_plan is None:
+                    return ()
+                try:
+                    receipts = await asyncio.to_thread(
+                        skill_application_receipt_store.list_receipts,
+                        run_id=workflow_run.run_id,
+                        task_id=task_id,
+                    )
+                except Exception as exc:
+                    raise SkillRuntimeGuidanceError(
+                        "Skill application evidence is unavailable.",
+                        code="skill_application_evidence_unavailable",
+                    ) from exc
+                return missing_required_skill_ids(
+                    skill_guidance_plan, receipts
+                )
+
+            async def emit_guidance_verified() -> None:
+                nonlocal skill_guidance_verified_emitted
+                if skill_guidance_plan is None or skill_guidance_verified_emitted:
+                    return
+                if await guidance_missing_skill_ids():
+                    return
+                skill_guidance_verified_emitted = True
+                events.append(
+                    {
+                        "event": "skill_runtime_status",
+                        "node_id": node.id,
+                        "node_title": title,
+                        "node_type": kind,
+                        "status": "verified",
+                        "required_skill_ids": list(
+                            skill_guidance_plan.required_skill_ids
+                        ),
+                        "run_id": run_id,
+                    }
+                )
+
+            async def request_skill_guidance_repair() -> str | None:
+                nonlocal skill_guidance_repair_used
+                missing = await guidance_missing_skill_ids()
+                if not missing:
+                    await emit_guidance_verified()
+                    return None
+                if skill_guidance_repair_used:
+                    raise SkillRuntimeGuidanceError(
+                        "Required Skill was not applied after one repair attempt.",
+                        code="skill_application_repair_exhausted",
+                    )
+                skill_guidance_repair_used = True
+                pending_state["skill_guidance_repair_used"] = True
+                guidance_repair_nodes[node.id] = True
+                task_state["skill_guidance_repair_used_by_node"] = (
+                    guidance_repair_nodes
+                )
+                events.append(
+                    {
+                        "event": "skill_runtime_status",
+                        "node_id": node.id,
+                        "node_title": title,
+                        "node_type": kind,
+                        "status": "repair_requested",
+                        "required_skill_ids": list(missing),
+                        "run_id": run_id,
+                    }
+                )
+                if run_id:
+                    await run_registry.record_checkpoint(
+                        run_id,
+                        event_type="workflow_agent.skill_application_repair",
+                        title="Required Skill application repair",
+                        summary=f"missing={len(missing)}",
+                        severity="warning",
+                        metadata={
+                            "required_skill_ids": list(missing),
+                            "plan_fingerprint": skill_guidance_plan.fingerprint,
+                        },
+                    )
+                return skill_application_repair_instruction(missing)
+
+            async def refresh_skill_guidance_plan() -> None:
+                nonlocal skill_guidance_plan, skill_guidance_contracts
+                if skill_guidance_plan is None:
+                    return
+                (
+                    skill_guidance_plan,
+                    skill_guidance_contracts,
+                    _updated_bindings,
+                ) = await prepare_skill_guidance_plan(
+                    node=node,
+                    include_skills=include_skills,
+                    available_tools=available_tools,
+                    middleware_specs=middleware_specs,
+                    middleware_context=middleware_context,
+                    activated_skill_ids=active_skill_ids,
+                    skill_version_bindings=skill_version_bindings,
+                    skill_trust_authorizations=skill_trust_authorizations,
+                )
+                if skill_guidance_plan is not None:
+                    pending_state["skill_guidance_plan_fingerprint"] = (
+                        skill_guidance_plan.fingerprint
+                    )
+
+            async def observe_skill_guidance_contract(
+                contract: Any,
+                **observation: Any,
+            ) -> None:
+                try:
+                    await asyncio.to_thread(
+                        skill_application_receipt_store.observe,
+                        contract,
+                        SkillApplicationScope(
+                            run_id=workflow_run.run_id,
+                            task_id=task_id,
+                            node_id=node.id,
+                            runtime_kind=runtime_run_type,
+                        ),
+                        **observation,
+                    )
+                except Exception as exc:
+                    raise SkillRuntimeGuidanceError(
+                        "Skill application evidence is unavailable.",
+                        code="skill_application_evidence_unavailable",
+                    ) from exc
 
             async def record_skill_runtime_failure(
                 tool_name: str,
@@ -10832,21 +11369,32 @@ async def _run_workflow_response(
                 ).strip()
                 if not application_skill_id:
                     return
-                await asyncio.to_thread(
-                    record_skill_application,
-                    skill_id=application_skill_id,
-                    run_id=workflow_run.run_id,
-                    task_id=task_id,
-                    node_id=node.id,
-                    runtime_kind=runtime_run_type,
-                    version_id=(
-                        skill_version_bindings.get(application_skill_id) or None
-                    ),
-                    policy=skill_application_policy,
-                    required_resource_paths=skill_application_required_paths,
-                    tool_name=tool_name,
-                    error_code=error_code,
-                )
+                contract = skill_guidance_contracts.get(application_skill_id)
+                if skill_guidance_plan is not None and contract is not None:
+                    await observe_skill_guidance_contract(
+                        contract,
+                        tool_name=tool_name,
+                        error_code=error_code,
+                    )
+                else:
+                    await asyncio.to_thread(
+                        record_skill_application,
+                        skill_id=application_skill_id,
+                        run_id=workflow_run.run_id,
+                        task_id=task_id,
+                        node_id=node.id,
+                        runtime_kind=runtime_run_type,
+                        version_id=(
+                            skill_version_bindings.get(application_skill_id)
+                            or None
+                        ),
+                        policy=skill_application_policy,
+                        required_resource_paths=(
+                            skill_application_required_paths
+                        ),
+                        tool_name=tool_name,
+                        error_code=error_code,
+                    )
 
             async def apply_skill_runtime_result(
                 tool_name: str,
@@ -10857,6 +11405,18 @@ async def _run_workflow_response(
                 if not tool_name.startswith("skill_"):
                     return
                 metadata = dict(result.metadata or {})
+                trust_authorization = metadata.get("trust_authorization")
+                if isinstance(trust_authorization, dict):
+                    authorized_skill_id = str(
+                        trust_authorization.get("skill_id") or ""
+                    ).strip()
+                    trust_fingerprint = str(
+                        trust_authorization.get("trust_fingerprint") or ""
+                    ).strip()
+                    if authorized_skill_id and trust_fingerprint:
+                        skill_trust_authorizations[
+                            authorized_skill_id
+                        ] = trust_fingerprint
                 candidate_id = str(arguments.get("candidate_id") or "").strip()
                 if metadata.get("approval_rejected") and candidate_id:
                     denied_skill_candidate_ids.add(candidate_id)
@@ -10890,7 +11450,7 @@ async def _run_workflow_response(
                     activated_version_id = skill_version_bindings.get(
                         activated_skill_id
                     )
-                    if activated_version_id:
+                    if activated_version_id and skill_guidance_plan is None:
                         await asyncio.to_thread(
                             record_skill_application,
                             skill_id=activated_skill_id,
@@ -10902,6 +11462,8 @@ async def _run_workflow_response(
                             policy=skill_application_policy,
                             required_resource_paths=skill_application_required_paths,
                         )
+                    if skill_guidance_plan is not None:
+                        await refresh_skill_guidance_plan()
                 application_method = str(
                     metadata.get("application_method") or ""
                 ).strip()
@@ -10927,61 +11489,30 @@ async def _run_workflow_response(
                     )
                     if application_skill_id:
                         application_failed = bool(result.is_error)
-                        await asyncio.to_thread(
-                            record_skill_application,
-                            skill_id=application_skill_id,
-                            run_id=workflow_run.run_id,
-                            task_id=task_id,
-                            node_id=node.id,
-                            runtime_kind=runtime_run_type,
-                            version_id=(
-                                str(
-                                    metadata.get("application_version_id")
-                                    or metadata.get("skill_version_id")
-                                    or skill_version_bindings.get(
-                                        application_skill_id
-                                    )
-                                    or ""
-                                ).strip()
-                                or None
+                        observe_kwargs = {
+                            "method": (
+                                None if application_failed else application_method
                             ),
-                            source_kind=(
-                                str(
-                                    metadata.get("application_source_kind")
-                                    or ""
-                                ).strip()
-                                or None
-                            ),
-                            content_digest=(
-                                str(
-                                    metadata.get("application_content_digest")
-                                    or ""
-                                ).strip()
-                                or None
-                            ),
-                            policy=skill_application_policy,
-                            required_resource_paths=skill_application_required_paths,
-                            method=(None if application_failed else application_method),
-                            resource_paths=(
+                            "resource_paths": (
                                 application_paths
                                 if not application_failed
                                 and isinstance(application_paths, list)
                                 else ()
                             ),
-                            resource_digests=(
+                            "resource_digests": (
                                 dict(application_digests)
                                 if not application_failed
                                 and isinstance(application_digests, dict)
                                 else None
                             ),
-                            expected_resource_digests=(
+                            "expected_resource_digests": (
                                 dict(expected_application_digests)
                                 if not application_failed
                                 and isinstance(expected_application_digests, dict)
                                 else None
                             ),
-                            tool_name=tool_name,
-                            error_code=(
+                            "tool_name": tool_name,
+                            "error_code": (
                                 str(
                                     metadata.get("error_code")
                                     or "skill_application_tool_failed"
@@ -10989,19 +11520,54 @@ async def _run_workflow_response(
                                 if application_failed
                                 else None
                             ),
+                        }
+                        contract = skill_guidance_contracts.get(
+                            application_skill_id
                         )
-                trust_authorization = metadata.get("trust_authorization")
-                if isinstance(trust_authorization, dict):
-                    authorized_skill_id = str(
-                        trust_authorization.get("skill_id") or ""
-                    ).strip()
-                    trust_fingerprint = str(
-                        trust_authorization.get("trust_fingerprint") or ""
-                    ).strip()
-                    if authorized_skill_id and trust_fingerprint:
-                        skill_trust_authorizations[
-                            authorized_skill_id
-                        ] = trust_fingerprint
+                        if skill_guidance_plan is not None and contract is not None:
+                            await observe_skill_guidance_contract(
+                                contract,
+                                **observe_kwargs,
+                            )
+                        else:
+                            await asyncio.to_thread(
+                                record_skill_application,
+                                skill_id=application_skill_id,
+                                run_id=workflow_run.run_id,
+                                task_id=task_id,
+                                node_id=node.id,
+                                runtime_kind=runtime_run_type,
+                                version_id=(
+                                    str(
+                                        metadata.get("application_version_id")
+                                        or metadata.get("skill_version_id")
+                                        or skill_version_bindings.get(
+                                            application_skill_id
+                                        )
+                                        or ""
+                                    ).strip()
+                                    or None
+                                ),
+                                source_kind=(
+                                    str(
+                                        metadata.get("application_source_kind")
+                                        or ""
+                                    ).strip()
+                                    or None
+                                ),
+                                content_digest=(
+                                    str(
+                                        metadata.get("application_content_digest")
+                                        or ""
+                                    ).strip()
+                                    or None
+                                ),
+                                policy=skill_application_policy,
+                                required_resource_paths=(
+                                    skill_application_required_paths
+                                ),
+                                **observe_kwargs,
+                            )
                 increment = int(metadata.get("catalog_install_increment") or 0)
                 if increment > 0:
                     catalog_install_count += increment
@@ -11040,6 +11606,8 @@ async def _run_workflow_response(
                 if not tool_name.startswith("skill_"):
                     return
                 await apply_skill_runtime_result(tool_name, arguments, result)
+                if skill_guidance_plan is not None and not result.is_error:
+                    await emit_guidance_verified()
                 metadata = dict(result.metadata or {})
                 event_name = str(metadata.get("skill_runtime_event") or "").strip()
                 if metadata.get("approval_rejected"):
@@ -11228,6 +11796,17 @@ async def _run_workflow_response(
                     raise RuntimeMiddlewareFatalError(
                         f"Pending tool is no longer available: {pending_tool_name}"
                     )
+                if tool_requires_skill_application(
+                    tool_name=pending_tool_name,
+                    read_only=bool(pending_tool.read_only),
+                    sensitive=bool(pending_tool.sensitive),
+                    requires_approval=bool(pending_tool.requires_approval),
+                    terminal=bool(pending_tool.terminal),
+                ) and await guidance_missing_skill_ids():
+                    raise SkillRuntimeGuidanceError(
+                        "Required Skill evidence changed while approval was pending.",
+                        code="skill_application_contract_stale",
+                    )
                 ensure_tool_call_budget(1)
                 approval_payload = task_state.get("resolved_approval")
                 client_payload = task_state.get("resolved_client_tool")
@@ -11365,6 +11944,17 @@ async def _run_workflow_response(
                             ]
                         )
                         continue
+                    repair_instruction = await request_skill_guidance_repair()
+                    if repair_instruction:
+                        messages.extend(
+                            [
+                                ChatMessage(role="assistant", content=raw_response),
+                                ChatMessage(
+                                    role="user", content=repair_instruction
+                                ),
+                            ]
+                        )
+                        continue
                     output_text = raw_response
                     if run_id:
                         await run_registry.record_checkpoint(
@@ -11396,6 +11986,17 @@ async def _run_workflow_response(
                             ]
                         )
                         continue
+                    repair_instruction = await request_skill_guidance_repair()
+                    if repair_instruction:
+                        messages.extend(
+                            [
+                                ChatMessage(role="assistant", content=raw_response),
+                                ChatMessage(
+                                    role="user", content=repair_instruction
+                                ),
+                            ]
+                        )
+                        continue
                     output_text = raw_response
                     if run_id:
                         await run_registry.record_checkpoint(
@@ -11423,6 +12024,22 @@ async def _run_workflow_response(
                                         "Call the allowed Skill proposal tool with the "
                                         "complete package and design contract."
                                     ),
+                                ),
+                            ]
+                        )
+                        continue
+                    repair_instruction = await request_skill_guidance_repair()
+                    if repair_instruction:
+                        messages.extend(
+                            [
+                                ChatMessage(
+                                    role="assistant",
+                                    content=json.dumps(
+                                        decision, ensure_ascii=False
+                                    ),
+                                ),
+                                ChatMessage(
+                                    role="user", content=repair_instruction
                                 ),
                             ]
                         )
@@ -11524,6 +12141,34 @@ async def _run_workflow_response(
                             ChatMessage(role="user", content=batch_error)
                         )
                         continue
+
+                    batch_requires_guidance = any(
+                        tool_requires_skill_application(
+                            tool_name=batch_tool_name,
+                            read_only=bool(batch_tool.read_only),
+                            sensitive=bool(batch_tool.sensitive),
+                            requires_approval=bool(batch_tool.requires_approval),
+                            terminal=bool(batch_tool.terminal),
+                        )
+                        for batch_tool_name, _arguments, batch_tool in parsed_batch
+                    )
+                    if batch_requires_guidance:
+                        repair_instruction = await request_skill_guidance_repair()
+                        if repair_instruction:
+                            messages.extend(
+                                [
+                                    ChatMessage(
+                                        role="assistant",
+                                        content=json.dumps(
+                                            decision, ensure_ascii=False
+                                        ),
+                                    ),
+                                    ChatMessage(
+                                        role="user", content=repair_instruction
+                                    ),
+                                ]
+                            )
+                            continue
 
                     ensure_tool_call_budget(len(parsed_batch))
                     batch_id = f"batch_{uuid.uuid4().hex}"
@@ -11690,6 +12335,17 @@ async def _run_workflow_response(
                             )
                         )
                         continue
+                    repair_instruction = await request_skill_guidance_repair()
+                    if repair_instruction:
+                        messages.extend(
+                            [
+                                ChatMessage(role="assistant", content=raw_response),
+                                ChatMessage(
+                                    role="user", content=repair_instruction
+                                ),
+                            ]
+                        )
+                        continue
                     output_text = raw_response
                     if run_id:
                         await run_registry.record_checkpoint(
@@ -11716,6 +12372,29 @@ async def _run_workflow_response(
                             metadata={"iteration": iteration_index + 1},
                         )
                 else:
+                    if tool_requires_skill_application(
+                        tool_name=tool_name,
+                        read_only=bool(matched_tool.read_only),
+                        sensitive=bool(matched_tool.sensitive),
+                        requires_approval=bool(matched_tool.requires_approval),
+                        terminal=bool(matched_tool.terminal),
+                    ):
+                        repair_instruction = await request_skill_guidance_repair()
+                        if repair_instruction:
+                            messages.extend(
+                                [
+                                    ChatMessage(
+                                        role="assistant",
+                                        content=json.dumps(
+                                            decision, ensure_ascii=False
+                                        ),
+                                    ),
+                                    ChatMessage(
+                                        role="user", content=repair_instruction
+                                    ),
+                                ]
+                            )
+                            continue
                     ensure_tool_call_budget(1)
                     try:
                         call_result = await call_workflow_runtime_tool_observed(
@@ -11745,6 +12424,14 @@ async def _run_workflow_response(
                             ),
                             "skill_version_bindings": dict(
                                 sorted(skill_version_bindings.items())
+                            ),
+                            "skill_guidance_plan_fingerprint": (
+                                skill_guidance_plan.fingerprint
+                                if skill_guidance_plan is not None
+                                else None
+                            ),
+                            "skill_guidance_repair_used": (
+                                skill_guidance_repair_used
                             ),
                         }
                         raise
@@ -11979,6 +12666,17 @@ async def _run_workflow_response(
                     )
                 )
             else:
+                missing_after_iterations = await guidance_missing_skill_ids()
+                if missing_after_iterations:
+                    raise SkillRuntimeGuidanceError(
+                        "Required Skill application did not complete before the "
+                        "Agent iteration limit.",
+                        code=(
+                            "skill_application_repair_exhausted"
+                            if skill_guidance_repair_used
+                            else "skill_application_required"
+                        ),
+                    )
                 event = {
                     "event": "node_delta",
                     "node_id": node.id,
@@ -15591,7 +16289,10 @@ async def _run_workflow_response(
                                             attempt_exc.code
                                             if isinstance(
                                                 attempt_exc,
-                                                AgentStrategyError,
+                                                (
+                                                    AgentStrategyError,
+                                                    SkillRuntimeGuidanceError,
+                                                ),
                                             )
                                             else attempt_exc.__class__.__name__
                                         ),
@@ -15924,6 +16625,22 @@ async def _run_workflow_response(
                                     "Failed to update workflow_agent run status",
                                     exc_info=True,
                                 )
+                        guidance_error_code = str(
+                            getattr(exc, "code", "") or ""
+                        )
+                        if isinstance(exc, SkillRuntimeGuidanceError):
+                            raise WorkflowTerminationError(
+                                guidance_error_code,
+                                (
+                                    "Required Skill is incompatible with the "
+                                    "current runtime."
+                                    if guidance_error_code
+                                    == "skill_runtime_incompatible"
+                                    else "Required Skill application could not be "
+                                    "verified."
+                                ),
+                                node_id=node.id,
+                            ) from exc
                         yield sse_payload(
                             {
                                 "event": "error",

--- a/server/skills/runtime_guidance.py
+++ b/server/skills/runtime_guidance.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Literal, Mapping
+
+from .application_receipts import (
+    SkillApplicationContractV1,
+    SkillApplicationReceiptV1,
+)
+
+
+SKILL_RUNTIME_GUIDANCE_VERSION = "skill-runtime-guidance-v2"
+SkillGuidanceRequirement = Literal["required", "available"]
+SkillGuidanceSource = Literal["explicit", "activated", "plugin"]
+
+_GUIDANCE_HELPER_TOOLS = frozenset(
+    {
+        "skill_list",
+        "skill_read",
+        "skill_stage",
+        "skill_find",
+        "skill_enable",
+        "sandbox_list_files",
+        "sandbox_read_file",
+        "sandbox_search_files",
+    }
+)
+
+
+class SkillRuntimeGuidanceError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class SkillRuntimeGuidanceEntryV2:
+    skill_id: str
+    requirement: SkillGuidanceRequirement
+    sources: tuple[SkillGuidanceSource, ...]
+    contract_id: str
+    contract_fingerprint: str
+    version_id: str
+    source_kind: str
+    content_digest: str
+    trust_fingerprint: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class SkillRuntimeGuidancePlanV2:
+    version: str
+    task_id: str
+    run_id: str
+    node_id: str
+    entries: tuple[SkillRuntimeGuidanceEntryV2, ...]
+    auto_discover: bool
+    fingerprint: str
+
+    @property
+    def required_skill_ids(self) -> tuple[str, ...]:
+        return tuple(
+            entry.skill_id
+            for entry in self.entries
+            if entry.requirement == "required"
+        )
+
+    @property
+    def available_skill_ids(self) -> tuple[str, ...]:
+        return tuple(
+            entry.skill_id
+            for entry in self.entries
+            if entry.requirement == "available"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "task_id": self.task_id,
+            "run_id": self.run_id,
+            "node_id": self.node_id,
+            "entries": [asdict(entry) for entry in self.entries],
+            "auto_discover": self.auto_discover,
+            "fingerprint": self.fingerprint,
+        }
+
+
+def skill_runtime_guidance_enabled() -> bool:
+    return os.getenv(
+        "SKILL_RUNTIME_GUIDANCE_V2_ENABLED", "false"
+    ).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def build_skill_runtime_guidance_plan(
+    *,
+    task_id: str,
+    run_id: str,
+    node_id: str,
+    explicit_skill_ids: Iterable[str],
+    plugin_skill_ids: Iterable[str],
+    activated_skill_ids: Iterable[str],
+    auto_discover: bool,
+    contracts: Mapping[str, SkillApplicationContractV1],
+) -> SkillRuntimeGuidancePlanV2:
+    clean_task_id = _required_text(task_id, "task ID")
+    clean_run_id = _required_text(run_id, "run ID")
+    clean_node_id = _required_text(node_id, "node ID")
+    explicit = _skill_ids(explicit_skill_ids)
+    plugin = _skill_ids(plugin_skill_ids)
+    activated = _skill_ids(activated_skill_ids)
+    required = explicit | activated
+    all_known = required | plugin
+    entries: list[SkillRuntimeGuidanceEntryV2] = []
+    for skill_id in sorted(all_known):
+        contract = contracts.get(skill_id)
+        if contract is None:
+            if skill_id in required:
+                raise SkillRuntimeGuidanceError(
+                    "Required Skill no longer has a frozen application contract.",
+                    code="skill_application_contract_stale",
+                )
+            continue
+        if not contract.version_id or not contract.content_digest:
+            if skill_id in required:
+                raise SkillRuntimeGuidanceError(
+                    "Required Skill version evidence is incomplete.",
+                    code="skill_application_evidence_unavailable",
+                )
+            continue
+        if (
+            contract.source_kind in {"git", "local_import"}
+            and not contract.trust_fingerprint
+        ):
+            if skill_id in required:
+                raise SkillRuntimeGuidanceError(
+                    "Required third-party Skill trust evidence is unavailable.",
+                    code="skill_application_evidence_unavailable",
+                )
+            continue
+        sources: list[SkillGuidanceSource] = []
+        if skill_id in explicit:
+            sources.append("explicit")
+        if skill_id in activated:
+            sources.append("activated")
+        if skill_id in plugin:
+            sources.append("plugin")
+        entries.append(
+            SkillRuntimeGuidanceEntryV2(
+                skill_id=skill_id,
+                requirement="required" if skill_id in required else "available",
+                sources=tuple(sources),
+                contract_id=contract.contract_id,
+                contract_fingerprint=contract.fingerprint,
+                version_id=contract.version_id,
+                source_kind=contract.source_kind,
+                content_digest=contract.content_digest,
+                trust_fingerprint=contract.trust_fingerprint,
+            )
+        )
+    identity = {
+        "version": SKILL_RUNTIME_GUIDANCE_VERSION,
+        "task_id": clean_task_id,
+        "run_id": clean_run_id,
+        "node_id": clean_node_id,
+        "entries": [asdict(entry) for entry in entries],
+        "auto_discover": bool(auto_discover),
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(
+            identity,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return SkillRuntimeGuidancePlanV2(
+        version=SKILL_RUNTIME_GUIDANCE_VERSION,
+        task_id=clean_task_id,
+        run_id=clean_run_id,
+        node_id=clean_node_id,
+        entries=tuple(entries),
+        auto_discover=bool(auto_discover),
+        fingerprint=fingerprint,
+    )
+
+
+def missing_required_skill_ids(
+    plan: SkillRuntimeGuidancePlanV2,
+    receipts: Iterable[SkillApplicationReceiptV1 | Any],
+) -> tuple[str, ...]:
+    verified_contracts = {
+        str(getattr(receipt, "contract_fingerprint", ""))
+        for receipt in receipts
+        if str(getattr(receipt, "run_id", "")) == plan.run_id
+        and str(getattr(receipt, "task_id", "")) == plan.task_id
+        and plan.node_id in tuple(getattr(receipt, "node_ids", ()) or ())
+        and str(getattr(receipt, "compliance_status", "")) == "verified"
+    }
+    return tuple(
+        entry.skill_id
+        for entry in plan.entries
+        if entry.requirement == "required"
+        and entry.contract_fingerprint not in verified_contracts
+    )
+
+
+def tool_requires_skill_application(
+    *,
+    tool_name: str,
+    read_only: bool,
+    sensitive: bool,
+    requires_approval: bool,
+    terminal: bool,
+) -> bool:
+    clean_name = str(tool_name or "").strip()
+    if clean_name in _GUIDANCE_HELPER_TOOLS:
+        return False
+    return bool(not read_only or sensitive or requires_approval or terminal)
+
+
+def skill_application_repair_instruction(skill_ids: Iterable[str]) -> str:
+    missing = sorted(_skill_ids(skill_ids))
+    if not missing:
+        raise SkillRuntimeGuidanceError(
+            "Skill application repair requires at least one Skill.",
+            code="skill_application_required",
+        )
+    return (
+        "Required Skill application is incomplete. Before any final answer or "
+        "side-effecting tool, call skill_read for each of these server-selected "
+        f"Skill IDs: {', '.join(missing)}. Do not claim that a Skill was read "
+        "without the tool result. Then continue the original task using the "
+        "instructions that were returned."
+    )
+
+
+def _required_text(value: Any, field_name: str) -> str:
+    clean = str(value or "").strip()
+    if not clean or len(clean) > 240 or any(ord(char) < 32 for char in clean):
+        raise SkillRuntimeGuidanceError(
+            f"Invalid {field_name}.",
+            code="skill_application_contract_stale",
+        )
+    return clean
+
+
+def _skill_ids(values: Iterable[str]) -> set[str]:
+    result: set[str] = set()
+    for value in values:
+        clean = str(value or "").strip()
+        if not clean:
+            continue
+        if len(clean) > 240 or any(ord(char) < 32 for char in clean):
+            raise SkillRuntimeGuidanceError(
+                "Invalid Skill ID in guidance plan.",
+                code="skill_application_contract_stale",
+            )
+        result.add(clean)
+    return result

--- a/server/tests/test_skill_runtime_guidance.py
+++ b/server/tests/test_skill_runtime_guidance.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from server.skills.application_receipts import build_application_contract
+from server.skills.runtime_guidance import (
+    SkillRuntimeGuidanceError,
+    build_skill_runtime_guidance_plan,
+    missing_required_skill_ids,
+    skill_runtime_guidance_enabled,
+    tool_requires_skill_application,
+)
+
+
+def _contract(skill_id: str, marker: str):
+    return build_application_contract(
+        skill_id=skill_id,
+        source_kind="workspace_draft",
+        version_id=f"skillversion_{marker}",
+        content_digest=marker * 64,
+        policy="require_read",
+    )
+
+
+def test_guidance_flag_defaults_off_and_accepts_explicit_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SKILL_RUNTIME_GUIDANCE_V2_ENABLED", raising=False)
+    assert skill_runtime_guidance_enabled() is False
+    monkeypatch.setenv("SKILL_RUNTIME_GUIDANCE_V2_ENABLED", "true")
+    assert skill_runtime_guidance_enabled() is True
+
+
+def test_plan_distinguishes_explicit_activated_plugin_and_auto_sources() -> None:
+    contracts = {
+        "explicit-skill": _contract("explicit-skill", "1"),
+        "plugin-skill": _contract("plugin-skill", "2"),
+        "activated-skill": _contract("activated-skill", "3"),
+    }
+    plan = build_skill_runtime_guidance_plan(
+        task_id="task-1",
+        run_id="run-1",
+        node_id="agent-1",
+        explicit_skill_ids={"explicit-skill"},
+        plugin_skill_ids={"plugin-skill"},
+        activated_skill_ids={"activated-skill"},
+        auto_discover=True,
+        contracts=contracts,
+    )
+
+    assert plan.required_skill_ids == ("activated-skill", "explicit-skill")
+    assert plan.available_skill_ids == ("plugin-skill",)
+    assert plan.auto_discover is True
+    assert plan.fingerprint == build_skill_runtime_guidance_plan(
+        task_id="task-1",
+        run_id="run-1",
+        node_id="agent-1",
+        explicit_skill_ids={"explicit-skill"},
+        plugin_skill_ids={"plugin-skill"},
+        activated_skill_ids={"activated-skill"},
+        auto_discover=True,
+        contracts=contracts,
+    ).fingerprint
+
+
+def test_required_skill_without_frozen_contract_fails_closed() -> None:
+    with pytest.raises(SkillRuntimeGuidanceError) as exc_info:
+        build_skill_runtime_guidance_plan(
+            task_id="task-1",
+            run_id="run-1",
+            node_id="agent-1",
+            explicit_skill_ids={"missing-skill"},
+            plugin_skill_ids=set(),
+            activated_skill_ids=set(),
+            auto_discover=False,
+            contracts={},
+        )
+
+    assert exc_info.value.code == "skill_application_contract_stale"
+
+
+def test_missing_required_skills_requires_exact_verified_contract() -> None:
+    contract = _contract("required-skill", "4")
+    plan = build_skill_runtime_guidance_plan(
+        task_id="task-1",
+        run_id="run-1",
+        node_id="agent-1",
+        explicit_skill_ids={"required-skill"},
+        plugin_skill_ids=set(),
+        activated_skill_ids=set(),
+        auto_discover=False,
+        contracts={"required-skill": contract},
+    )
+    forged = SimpleNamespace(
+        task_id="task-1",
+        run_id="run-1",
+        node_ids=("agent-1",),
+        skill_id="required-skill",
+        contract_fingerprint="f" * 64,
+        compliance_status="verified",
+    )
+    verified = SimpleNamespace(
+        task_id="task-1",
+        run_id="run-1",
+        node_ids=("agent-1",),
+        skill_id="required-skill",
+        contract_fingerprint=contract.fingerprint,
+        compliance_status="verified",
+    )
+
+    assert missing_required_skill_ids(plan, [forged]) == ("required-skill",)
+    assert missing_required_skill_ids(plan, [forged, verified]) == ()
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "read_only", "sensitive", "requires_approval", "terminal", "expected"),
+    [
+        ("skill_read", True, False, False, False, False),
+        ("skill_stage", False, False, False, False, False),
+        ("skill_enable", False, False, False, False, False),
+        ("skill_install", False, True, True, False, True),
+        ("sandbox_read_file", True, False, False, False, False),
+        ("write_record", False, False, False, False, True),
+        ("sensitive_read", True, True, False, False, True),
+        ("approved_read", True, False, True, False, True),
+        ("terminal_read", True, False, False, True, True),
+    ],
+)
+def test_tool_gate_uses_server_tool_semantics(
+    tool_name: str,
+    read_only: bool,
+    sensitive: bool,
+    requires_approval: bool,
+    terminal: bool,
+    expected: bool,
+) -> None:
+    assert tool_requires_skill_application(
+        tool_name=tool_name,
+        read_only=read_only,
+        sensitive=sensitive,
+        requires_approval=requires_approval,
+        terminal=terminal,
+    ) is expected

--- a/server/tests/test_workflow_agent_task_node.py
+++ b/server/tests/test_workflow_agent_task_node.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import httpx
@@ -11,6 +12,10 @@ import pytest_asyncio
 
 import server.main as main_module
 from server.main import app
+from server.skills.application_receipts import (
+    SkillApplicationObserver,
+    SkillApplicationReceiptStore,
+)
 from server.skills.finder import SkillFinder, _fingerprint
 from server.skills.skill_manager import InstalledSkill
 from server.xpert_runtime import (
@@ -2313,6 +2318,511 @@ async def test_skill_router_install_resume_activates_only_current_agent_run(
         ensure_ascii=False,
         indent=2,
     )
+
+
+class GuidanceSkillManager:
+    skill_id = "required-guidance"
+    version_id = "skillversion_required_guidance_v1"
+    content_digest = "5" * 64
+
+    def __init__(self, package_dir: Path) -> None:
+        self.package_dir = package_dir
+        self.read_count = 0
+        self.installed = InstalledSkill(
+            skill_id=self.skill_id,
+            name="Required Guidance",
+            description="Required runtime instructions.",
+            repo_url="workspace://required-guidance",
+            sub_path="",
+            source_ref=None,
+            installed_at=time.time(),
+            source_kind="workspace_draft",
+            content_digest=self.content_digest,
+        )
+        self.lifecycle_store = SimpleNamespace(
+            require_version=lambda version_id: SimpleNamespace(
+                skill_id=self.skill_id,
+                source_kind="workspace_draft",
+                package_digest=self.content_digest,
+                trust_fingerprint=None,
+            )
+        )
+
+    def list_installed_skills(self) -> list[InstalledSkill]:
+        return [self.installed]
+
+    def bind_skill_versions(self, skill_ids) -> dict[str, str]:
+        return {
+            self.skill_id: self.version_id
+            for skill_id in skill_ids
+            if skill_id == self.skill_id
+        }
+
+    def require_activation(self, skill_id: str, **kwargs) -> InstalledSkill:
+        assert skill_id == self.skill_id
+        assert kwargs.get("version_id") in {None, self.version_id}
+        return self.installed
+
+    def get_skill_content(
+        self, skill_id: str, *, version_id: str | None = None
+    ) -> str:
+        assert skill_id == self.skill_id
+        assert version_id in {None, self.version_id}
+        self.read_count += 1
+        return (self.package_dir / "SKILL.md").read_text(encoding="utf-8")
+
+    def get_skill_directory(
+        self, skill_id: str, *, version_id: str | None = None
+    ) -> Path:
+        assert skill_id == self.skill_id
+        assert version_id in {None, self.version_id}
+        return self.package_dir
+
+
+class GuidanceSandboxClient:
+    async def request(self, payload: dict[str, Any]) -> dict[str, Any]:
+        assert payload.get("action") == "ensure_workspace"
+        return {"ok": True}
+
+
+def _install_guidance_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> tuple[GuidanceSkillManager, SkillApplicationReceiptStore]:
+    package_dir = tmp_path / "required-guidance"
+    package_dir.mkdir()
+    (package_dir / "SKILL.md").write_text(
+        "# Required Guidance\n\nRead this before acting.",
+        encoding="utf-8",
+    )
+    manager = GuidanceSkillManager(package_dir)
+    provider = SandboxToolsetProvider(
+        SandboxWorkspaceStore(
+            tmp_path / "sandbox-store",
+            workspace_root=tmp_path / "sandbox-workspaces",
+        ),
+        GuidanceSandboxClient(),
+        skill_manager=manager,
+    )
+    receipt_store = SkillApplicationReceiptStore(tmp_path / "application-receipts")
+    observer = SkillApplicationObserver(receipt_store, lambda: manager)
+    monkeypatch.setattr(main_module, "get_skill_manager", lambda: manager)
+    monkeypatch.setattr(main_module, "workflow_sandbox_provider", provider)
+    monkeypatch.setattr(
+        main_module.runtime_capabilities.require("sandbox_tools"),
+        "implementation",
+        provider,
+    )
+    monkeypatch.setattr(main_module, "skill_application_receipt_store", receipt_store)
+    monkeypatch.setattr(main_module, "skill_application_observer", observer)
+    monkeypatch.setenv("SKILL_RUNTIME_GUIDANCE_V2_ENABLED", "true")
+    monkeypatch.setenv("SKILL_APPLICATION_RECEIPT_MODE", "audit")
+    return manager, receipt_store
+
+
+def _bind_required_guidance(workflow: dict[str, Any]) -> None:
+    workflow["nodes"].append(
+        {
+            "id": "required-guidance-middleware",
+            "type": "runtime_middleware",
+            "data": {
+                "kind": "runtime_middleware",
+                "runtimeMiddlewareId": "skills_runtime",
+                "runtimeMiddlewareKind": "runtime_middleware.skills_runtime",
+                "middlewarePriority": "30",
+                "runtimeMiddlewareConfig": {
+                    "skill_ids": GuidanceSkillManager.skill_id,
+                    "auto_discover": False,
+                },
+            },
+        }
+    )
+    workflow["edges"].append(
+        {
+            "id": "bind-required-guidance",
+            "source": "required-guidance-middleware",
+            "target": "workflow_agent",
+            "sourceHandle": "middleware-binding",
+            "targetHandle": "middleware",
+        }
+    )
+
+
+def _bind_tool_selector(workflow: dict[str, Any]) -> None:
+    workflow["nodes"].append(
+        {
+            "id": "guidance-tool-selector",
+            "type": "runtime_middleware",
+            "data": {
+                "kind": "runtime_middleware",
+                "runtimeMiddlewareId": "llm_tool_selector",
+                "runtimeMiddlewareKind": (
+                    "runtime_middleware.llm_tool_selector"
+                ),
+                "middlewarePriority": "20",
+                "runtimeMiddlewareConfig": {"max_selected_tools": 8},
+            },
+        }
+    )
+    workflow["edges"].append(
+        {
+            "id": "bind-guidance-tool-selector",
+            "source": "guidance-tool-selector",
+            "target": "workflow_agent",
+            "sourceHandle": "middleware-binding",
+            "targetHandle": "middleware",
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "premature_response",
+    [
+        '{"answer":"claimed completion without reading"}',
+        "claimed completion without reading",
+    ],
+)
+async def test_required_skill_repairs_direct_answer_once_before_completion(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    premature_response: str,
+) -> None:
+    manager, receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+    responses = iter(
+        [
+            premature_response,
+            '{"tool":"skill_read","arguments":{"skill_id":"required-guidance"}}',
+            '{"answer":"completed after applying guidance"}',
+        ]
+    )
+    model_calls = 0
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        nonlocal model_calls
+        model_calls += 1
+        return next(responses)
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    workflow = _workflow_agent_strategy_workflow({"maxIterations": 5})
+    _bind_required_guidance(workflow)
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "follow the skill"}},
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    agent_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end"
+        and event.get("node_id") == "workflow_agent"
+    )
+    assert agent_end["output"] == "completed after applying guidance"
+    assert model_calls == 3
+    assert manager.read_count == 1
+    assert any(
+        event.get("event") == "skill_runtime_status"
+        and event.get("status") == "repair_requested"
+        for event in events
+    )
+    assert any(
+        event.get("event") == "skill_runtime_status"
+        and event.get("status") == "verified"
+        for event in events
+    )
+    receipt = receipt_store.list_receipts(skill_id=manager.skill_id)[0]
+    assert receipt.compliance_status == "verified"
+
+
+@pytest.mark.asyncio
+async def test_required_skill_blocks_mutating_tool_until_after_read(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manager, _receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+
+    class MutatingProvider(FakeWorkflowToolProvider):
+        def __init__(self) -> None:
+            super().__init__()
+            self.tools = [
+                RuntimeTool(
+                    name="mutate",
+                    description="Mutate test state",
+                    input_schema={"type": "object"},
+                    session_id="session-1",
+                    server_id="server-1",
+                    read_only=False,
+                )
+            ]
+            self.read_counts_at_call: list[int] = []
+
+        async def call_tool(self, call):
+            self.read_counts_at_call.append(manager.read_count)
+            return await super().call_tool(call)
+
+    provider = MutatingProvider()
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    monkeypatch.setattr(
+        main_module.runtime_capabilities.require("mcp_tools"),
+        "implementation",
+        provider,
+    )
+    responses = iter(
+        [
+            '{"tool":"mutate","arguments":{}}',
+            '{"tool":"skill_read","arguments":{"skill_id":"required-guidance"}}',
+            '{"tool":"mutate","arguments":{}}',
+            '{"answer":"mutation followed guidance"}',
+        ]
+    )
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        return next(responses)
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    workflow = _workflow_agent_strategy_workflow(
+        {
+            "toolMode": "mcp_tools",
+            "toolNames": "mutate",
+            "maxIterations": 6,
+        }
+    )
+    _bind_required_guidance(workflow)
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "mutate safely"}},
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    agent_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end"
+        and event.get("node_id") == "workflow_agent"
+    )
+    assert agent_end["output"] == "mutation followed guidance"
+    assert provider.read_counts_at_call == [1]
+
+
+@pytest.mark.asyncio
+async def test_required_skill_second_omission_fails_with_stable_code(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manager, _receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+    responses = iter(
+        [
+            '{"answer":"first unsupported claim"}',
+            '{"answer":"second unsupported claim"}',
+        ]
+    )
+    model_calls = 0
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        nonlocal model_calls
+        model_calls += 1
+        return next(responses)
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    workflow = _workflow_agent_strategy_workflow({"maxIterations": 4})
+    _bind_required_guidance(workflow)
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "skip twice"}},
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    error = next(event for event in events if event.get("event") == "error")
+    assert error["code"] == "skill_application_repair_exhausted"
+    assert model_calls == 2
+    assert manager.read_count == 0
+    assert not any(
+        event.get("event") == "node_end"
+        and event.get("node_id") == "workflow_agent"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_required_skill_preflight_stops_before_model_when_incompatible(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manager, _receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+
+    class IncompatibleSkill(RuntimeError):
+        code = "skill_runtime_incompatible"
+
+    def reject_activation(skill_id: str, **kwargs):
+        raise IncompatibleSkill("required runtime capability is unavailable")
+
+    monkeypatch.setattr(manager, "require_activation", reject_activation)
+    model_calls = 0
+
+    async def forbidden_model_call(*args, **kwargs):
+        nonlocal model_calls
+        model_calls += 1
+        raise AssertionError("model must not run before required Skill preflight")
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        forbidden_model_call,
+    )
+    workflow = _workflow_agent_strategy_workflow()
+    _bind_required_guidance(workflow)
+    _bind_tool_selector(workflow)
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "preflight"}},
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    error = next(event for event in events if event.get("event") == "error")
+    assert error["code"] == "skill_runtime_incompatible"
+    assert model_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_required_skill_corrupt_evidence_store_stops_before_model(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _manager, _receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+
+    class BrokenReceiptStore:
+        def record_selection(self, *args, **kwargs):
+            raise RuntimeError("corrupt receipt store")
+
+    monkeypatch.setattr(
+        main_module, "skill_application_receipt_store", BrokenReceiptStore()
+    )
+    model_calls = 0
+
+    async def forbidden_model_call(*args, **kwargs):
+        nonlocal model_calls
+        model_calls += 1
+        raise AssertionError("model must not run without a writable receipt store")
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        forbidden_model_call,
+    )
+    workflow = _workflow_agent_strategy_workflow()
+    _bind_required_guidance(workflow)
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "evidence"}},
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    error = next(event for event in events if event.get("event") == "error")
+    assert error["code"] == "skill_application_evidence_unavailable"
+    assert model_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_discovered_skill_remains_optional_without_enumeration(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manager, receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        return '{"answer":"completed without optional Skill"}'
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    workflow = _workflow_agent_strategy_workflow()
+    _bind_required_guidance(workflow)
+    middleware = next(
+        node
+        for node in workflow["nodes"]
+        if node["id"] == "required-guidance-middleware"
+    )
+    middleware["data"]["runtimeMiddlewareConfig"] = {
+        "auto_discover": True
+    }
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "optional"}},
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    agent_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end"
+        and event.get("node_id") == "workflow_agent"
+    )
+    assert agent_end["output"] == "completed without optional Skill"
+    assert manager.read_count == 0
+    assert receipt_store.list_receipts() == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- 新增 SkillRuntimeGuidancePlanV2，区分 required 与 available 来源。
- 显式 Skill 及运行中启用的 Skill 必须产生可信 skill_read receipt。
- 在最终答案、副作用工具、审批和 terminal 边界执行一次自动纠偏，第二次遗漏稳定失败。
- 功能开关默认关闭，关闭后完整回退现有提示型行为。

## Safety
- required Skill 在模型调用前完成信任、版本和运行能力预检。
- 并行批次与审批恢复不能绕过应用门。
- 不改变 Hook、Creator、Sandbox Sidecar 协议或公共 Xpert App。

## Validation
- 最新基线：origin/main@90401970。
- Skill/Workflow 核心受影响回归：139 passed。
- Evaluation、导入、生命周期和 Sandbox 交叉回归：55 passed。
- 上游 Workflow R17 交叉回归：99 passed。
- AST、diff check、路径白名单与敏感信息扫描通过。

## Rollback
设置 SKILL_RUNTIME_GUIDANCE_V2_ENABLED=false。