### PR TITLE
feature: Skill 多文件资源消费闭环

### DIFF
--- a/docs/SKILL_INTEGRATION.md
+++ b/docs/SKILL_INTEGRATION.md
@@ -276,7 +276,11 @@ curl -X DELETE http://localhost:8000/api/skills/anthropics-skills-skills-pdf
 
 服务端在模型调用前固定 Skill 版本、内容摘要与信任指纹，并在接受最终答案或执行副作用、敏感、审批及 terminal 工具前核验同一运行的 `SkillApplicationReceipt`。存在必用 Skill 时会跳过基于模型的 Tool Selector，保留完整已授权工具集合，避免选择器先消耗模型额度或移除 Skill 所需能力。首次缺少 `skill_read` 时只允许一次服务端纠偏；再次遗漏会以稳定错误终止 Workflow，不创建审批卡或放行工具。`SKILL_APPLICATION_RECEIPT_MODE=off` 时该门失败关闭。
 
-本批次默认保持开关关闭，不改变旧节点数据。回退只需设回 `false` 并重启 Server；已有 Workflow、安装数据和 receipt 均保留。多文件资源的自动只读工具与运行卡将在后续批次交付。
+绑定 `skills_runtime` 且开启 V2 时，运行器会同时提供 `sandbox_list_files`、`sandbox_read_file` 和 `sandbox_search_files`，用于消费 `skill_stage` 暂存的 UTF-8 reference、脚本源码和文本 asset；不会自动提供写入、Shell、网络或宿主文件访问。模型必须先读取 `SKILL.md`，仅在说明确实引用包内资源时暂存，并使用 `skills/<skill-id>/<relative-path>` 精确路径或有界搜索。被动二进制只能暂存，不能作为文本读取证据；脚本只有在工作流另行绑定 `sandbox_shell` 且信任、命令白名单和审批条件同时满足时才兼容。
+
+资源访问凭据只保存 Skill 相对路径、实际/预期摘要和工具名称，不保存搜索词、正文或工具参数。`skill_stage` 后的服务端映射绑定当前 Workspace、Skill 版本和内容合同，审批恢复继续使用同一映射；资源发生变化时 receipt 转为 `unverified`。
+
+本批次默认保持开关关闭，不改变旧节点数据。回退只需设回 `false` 并重启 Server；已有 Workflow、安装数据和 receipt 均保留。结构化运行卡将在后续批次交付。
 
 ## 5. 测试指南
 

--- a/server/main.py
+++ b/server/main.py
@@ -18,7 +18,7 @@ from collections.abc import AsyncIterator, Callable, Iterable
 from collections import defaultdict, deque
 from dataclasses import asdict, dataclass
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 from zoneinfo import ZoneInfo
 
@@ -1525,6 +1525,7 @@ def record_skill_application(
     required_resource_paths: Iterable[str] = (),
     method: Literal["prompt_injected", "skill_read", "skill_stage"] | None = None,
     resource_paths: Iterable[str] = (),
+    read_resource_paths: Iterable[str] = (),
     resource_digests: dict[str, str] | None = None,
     expected_resource_digests: dict[str, str] | None = None,
     tool_name: str | None = None,
@@ -1549,6 +1550,7 @@ def record_skill_application(
             required_resource_paths=required_resource_paths,
             method=method,
             resource_paths=resource_paths,
+            read_resource_paths=read_resource_paths,
             resource_digests=resource_digests,
             expected_resource_digests=expected_resource_digests,
             tool_name=tool_name,
@@ -9643,6 +9645,20 @@ async def _run_workflow_response(
                 ).strip()
             return output_text
 
+        def runtime_tool_event_preview(
+            tool_name: str,
+            call_result: Any,
+            result_text: str,
+        ) -> str:
+            if tool_name in {"sandbox_read_file", "sandbox_search_files"}:
+                metadata = dict(getattr(call_result, "metadata", {}) or {})
+                accessed_paths = metadata.get("sandbox_accessed_text_paths")
+                accessed_count = (
+                    len(accessed_paths) if isinstance(accessed_paths, list) else 0
+                )
+                return f"text resources accessed={accessed_count}"
+            return result_text[:300]
+
         async def workflow_available_tools(
             tool_names_raw: Any,
             *,
@@ -9801,6 +9817,14 @@ async def _run_workflow_response(
                     )
                     skills_config = dict(skills_spec.config) if skills_spec else {}
                     allowed_skill_tools = {"skill_list", "skill_read", "skill_stage"}
+                    if skill_runtime_guidance_enabled():
+                        allowed_skill_tools.update(
+                            {
+                                "sandbox_list_files",
+                                "sandbox_read_file",
+                                "sandbox_search_files",
+                            }
+                        )
                     if workflow_truthy(skills_config.get("catalog_search", False)):
                         allowed_skill_tools.update({"skill_find", "skill_enable"})
                     if workflow_truthy(skills_config.get("catalog_install", False)):
@@ -11206,8 +11230,13 @@ async def _run_workflow_response(
                         "any side-effecting, sensitive, approval, or terminal tool, "
                         "call skill_read for every required Skill ID: "
                         f"{required_list}. Plugin-provided and auto-discovered Skills "
-                        "remain optional until explicitly enabled. Never claim a Skill "
-                        "was read without the tool result."
+                        "remain optional until explicitly enabled. Read SKILL.md first. "
+                        "Call skill_stage only when those instructions require package "
+                        "resources, then use exact skills/<skill-id>/<relative-path> "
+                        "paths with sandbox_read_file or a bounded sandbox_search_files "
+                        "search for long references. Do not guess files, commands, or "
+                        "dependencies, and never claim a Skill or resource was read "
+                        "without the corresponding tool result."
                     )
                     messages[0] = ChatMessage(
                         role="system", content=react_system_prompt
@@ -11215,6 +11244,77 @@ async def _run_workflow_response(
                     pending_state["skill_guidance_plan_fingerprint"] = (
                         skill_guidance_plan.fingerprint
                     )
+            staged_skill_resources: dict[str, dict[str, Any]] = {}
+
+            def normalize_staged_workspace_path(value: Any) -> str:
+                raw_path = str(value or "").strip().replace("\\", "/")
+                path = PurePosixPath(raw_path)
+                if (
+                    not raw_path
+                    or len(raw_path) > 512
+                    or path.is_absolute()
+                    or any(part in {"", ".", ".."} for part in path.parts)
+                ):
+                    raise SkillRuntimeGuidanceError(
+                        "Staged Skill resource metadata is invalid.",
+                        code="skill_application_contract_stale",
+                    )
+                return path.as_posix()
+
+            def restore_staged_skill_resources() -> None:
+                if skill_guidance_plan is None:
+                    return
+                raw_mapping = pending_state.get("skill_staged_resources") or {}
+                if not isinstance(raw_mapping, dict) or len(raw_mapping) > 2_000:
+                    raise SkillRuntimeGuidanceError(
+                        "Staged Skill resource metadata is invalid.",
+                        code="skill_application_contract_stale",
+                    )
+                for raw_workspace_path, raw_entry in raw_mapping.items():
+                    if not isinstance(raw_entry, dict):
+                        raise SkillRuntimeGuidanceError(
+                            "Staged Skill resource metadata is invalid.",
+                            code="skill_application_contract_stale",
+                        )
+                    workspace_path = normalize_staged_workspace_path(
+                        raw_workspace_path
+                    )
+                    skill_id = str(raw_entry.get("skill_id") or "").strip()
+                    skill_path = normalize_staged_workspace_path(
+                        raw_entry.get("skill_path")
+                    )
+                    contract = skill_guidance_contracts.get(skill_id)
+                    resource_digest = str(
+                        raw_entry.get("resource_digest") or ""
+                    ).strip().lower()
+                    if (
+                        contract is None
+                        or workspace_path != f"skills/{skill_id}/{skill_path}"
+                        or raw_entry.get("version_id") != contract.version_id
+                        or raw_entry.get("content_digest")
+                        != contract.content_digest
+                        or raw_entry.get("trust_fingerprint")
+                        != contract.trust_fingerprint
+                        or not re.fullmatch(r"[0-9a-f]{64}", resource_digest)
+                    ):
+                        raise SkillRuntimeGuidanceError(
+                            "Staged Skill resource metadata no longer matches the Skill contract.",
+                            code="skill_application_contract_stale",
+                        )
+                    staged_skill_resources[workspace_path] = {
+                        "skill_id": skill_id,
+                        "skill_path": skill_path,
+                        "workspace_id": str(
+                            raw_entry.get("workspace_id") or ""
+                        ).strip(),
+                        "version_id": contract.version_id,
+                        "content_digest": contract.content_digest,
+                        "trust_fingerprint": contract.trust_fingerprint,
+                        "resource_digest": resource_digest,
+                        "text": bool(raw_entry.get("text", False)),
+                    }
+
+            restore_staged_skill_resources()
             if middleware_context is not None:
                 middleware_context.metadata["skill_version_bindings"] = (
                     skill_version_bindings
@@ -11356,6 +11456,222 @@ async def _run_workflow_response(
                         code="skill_application_evidence_unavailable",
                     ) from exc
 
+            def remember_staged_skill_resources(
+                skill_id: str,
+                metadata: dict[str, Any],
+            ) -> None:
+                if skill_guidance_plan is None:
+                    return
+                contract = skill_guidance_contracts.get(skill_id)
+                paths = metadata.get("application_resource_paths")
+                digests = metadata.get("application_resource_digests")
+                text_paths = metadata.get("application_text_resource_paths")
+                workspace_id = str(metadata.get("workspace_id") or "").strip()
+                if (
+                    contract is None
+                    or metadata.get("application_version_id")
+                    != contract.version_id
+                    or not workspace_id
+                    or not isinstance(paths, list)
+                    or len(paths) > 500
+                    or not isinstance(digests, dict)
+                    or not isinstance(text_paths, list)
+                ):
+                    raise SkillRuntimeGuidanceError(
+                        "Staged Skill resources do not match the frozen contract.",
+                        code="skill_application_contract_stale",
+                    )
+                normalized_text_paths = {
+                    normalize_staged_workspace_path(path)
+                    for path in text_paths
+                }
+                next_entries: dict[str, dict[str, Any]] = {}
+                for raw_skill_path in paths:
+                    skill_path = normalize_staged_workspace_path(raw_skill_path)
+                    resource_digest = str(
+                        digests.get(skill_path) or ""
+                    ).strip().lower()
+                    if not re.fullmatch(r"[0-9a-f]{64}", resource_digest):
+                        raise SkillRuntimeGuidanceError(
+                            "Staged Skill resource digests are incomplete.",
+                            code="skill_application_evidence_unavailable",
+                        )
+                    workspace_path = normalize_staged_workspace_path(
+                        f"skills/{skill_id}/{skill_path}"
+                    )
+                    next_entries[workspace_path] = {
+                        "skill_id": skill_id,
+                        "skill_path": skill_path,
+                        "workspace_id": workspace_id,
+                        "version_id": contract.version_id,
+                        "content_digest": contract.content_digest,
+                        "trust_fingerprint": contract.trust_fingerprint,
+                        "resource_digest": resource_digest,
+                        "text": skill_path in normalized_text_paths,
+                    }
+                for workspace_path in tuple(staged_skill_resources):
+                    if staged_skill_resources[workspace_path].get("skill_id") == skill_id:
+                        staged_skill_resources.pop(workspace_path, None)
+                staged_skill_resources.update(next_entries)
+                if len(staged_skill_resources) > 2_000:
+                    raise SkillRuntimeGuidanceError(
+                        "Too many staged Skill resources are active in this run.",
+                        code="skill_application_evidence_unavailable",
+                    )
+                pending_state["skill_staged_resources"] = dict(
+                    sorted(staged_skill_resources.items())
+                )
+
+            def reject_non_text_skill_resource_access(
+                tool_name: str,
+                arguments: dict[str, Any],
+            ) -> None:
+                if tool_name not in {
+                    "sandbox_read_file",
+                    "sandbox_search_files",
+                }:
+                    return
+                raw_path = str(arguments.get("path") or "").strip()
+                if not raw_path:
+                    return
+                normalized_candidate = raw_path.replace("\\", "/")
+                if (
+                    normalized_candidate != "skills"
+                    and not normalized_candidate.startswith("skills/")
+                ):
+                    return
+                workspace_path = normalize_staged_workspace_path(
+                    normalized_candidate
+                )
+                staged = staged_skill_resources.get(workspace_path)
+                if tool_name == "sandbox_read_file" and staged is None:
+                    raise SkillRuntimeGuidanceError(
+                        "Skill resources must be staged in the current run before reading.",
+                        code="skill_application_required",
+                    )
+                if tool_name == "sandbox_search_files" and staged is None:
+                    prefix = workspace_path.rstrip("/") + "/"
+                    if not any(
+                        path.startswith(prefix) for path in staged_skill_resources
+                    ):
+                        raise SkillRuntimeGuidanceError(
+                            "Skill resources must be staged in the current run before searching.",
+                            code="skill_application_required",
+                        )
+                if staged is not None and not staged.get("text", False):
+                    raise SkillRuntimeGuidanceError(
+                        "Staged binary Skill resources cannot be parsed as UTF-8 text.",
+                        code="skill_runtime_incompatible",
+                    )
+
+            async def record_sandbox_skill_resource_access(
+                tool_name: str,
+                arguments: dict[str, Any],
+                result: RuntimeToolResult,
+            ) -> None:
+                if (
+                    skill_guidance_plan is None
+                    or result.is_error
+                    or tool_name
+                    not in {"sandbox_read_file", "sandbox_search_files"}
+                ):
+                    return
+                if tool_name == "sandbox_search_files":
+                    raw_search_path = str(
+                        arguments.get("path") or ""
+                    ).strip().replace("\\", "/")
+                    search_targets_skills = bool(
+                        raw_search_path == "skills"
+                        or raw_search_path.startswith("skills/")
+                    )
+                    try:
+                        output_payload = json.loads(result.output)
+                    except (TypeError, ValueError):
+                        output_payload = None
+                    if isinstance(output_payload, dict) and isinstance(
+                        output_payload.get("matches"), list
+                    ):
+                        filtered_matches = []
+                        for item in output_payload["matches"][:100]:
+                            if not isinstance(item, dict):
+                                continue
+                            try:
+                                item_path = normalize_staged_workspace_path(
+                                    item.get("path")
+                                )
+                            except SkillRuntimeGuidanceError:
+                                continue
+                            staged = staged_skill_resources.get(item_path)
+                            if staged is not None and staged.get("text", False):
+                                filtered_matches.append(item)
+                            elif (
+                                not search_targets_skills
+                                and not item_path.startswith("skills/")
+                            ):
+                                filtered_matches.append(item)
+                        output_payload["matches"] = filtered_matches
+                        result.output = json.dumps(
+                            output_payload,
+                            ensure_ascii=False,
+                        )
+                metadata = dict(result.metadata or {})
+                accessed_paths = metadata.get("sandbox_accessed_paths")
+                accessed_digests = metadata.get("sandbox_accessed_digests")
+                text_paths = metadata.get("sandbox_accessed_text_paths")
+                if (
+                    not isinstance(accessed_paths, list)
+                    or len(accessed_paths) > 100
+                    or not isinstance(accessed_digests, dict)
+                    or not isinstance(text_paths, list)
+                ):
+                    return
+                text_path_set = {
+                    normalize_staged_workspace_path(path) for path in text_paths
+                }
+                grouped: dict[str, dict[str, Any]] = {}
+                result_workspace_id = str(
+                    metadata.get("workspace_id") or ""
+                ).strip()
+                for raw_workspace_path in accessed_paths:
+                    workspace_path = normalize_staged_workspace_path(
+                        raw_workspace_path
+                    )
+                    staged = staged_skill_resources.get(workspace_path)
+                    if staged is None or workspace_path not in text_path_set:
+                        continue
+                    if staged.get("workspace_id") != result_workspace_id:
+                        raise SkillRuntimeGuidanceError(
+                            "Sandbox workspace no longer matches staged Skill resources.",
+                            code="skill_application_contract_stale",
+                        )
+                    skill_id = str(staged["skill_id"])
+                    skill_path = str(staged["skill_path"])
+                    group = grouped.setdefault(
+                        skill_id,
+                        {"paths": [], "actual": {}, "expected": {}},
+                    )
+                    group["paths"].append(skill_path)
+                    actual_digest = str(
+                        accessed_digests.get(workspace_path) or ""
+                    ).strip().lower()
+                    if re.fullmatch(r"[0-9a-f]{64}", actual_digest):
+                        group["actual"][skill_path] = actual_digest
+                    group["expected"][skill_path] = staged["resource_digest"]
+                for skill_id, group in sorted(grouped.items()):
+                    contract = skill_guidance_contracts.get(skill_id)
+                    if contract is None:
+                        raise SkillRuntimeGuidanceError(
+                            "Skill resource access no longer matches the guidance plan.",
+                            code="skill_application_contract_stale",
+                        )
+                    await observe_skill_guidance_contract(
+                        contract,
+                        read_resource_paths=sorted(set(group["paths"])),
+                        resource_digests=group["actual"],
+                        expected_resource_digests=group["expected"],
+                        tool_name=tool_name,
+                    )
+
             async def record_skill_runtime_failure(
                 tool_name: str,
                 arguments: dict[str, Any],
@@ -11402,9 +11718,14 @@ async def _run_workflow_response(
                 result: RuntimeToolResult,
             ) -> None:
                 nonlocal catalog_install_count
-                if not tool_name.startswith("skill_"):
-                    return
                 metadata = dict(result.metadata or {})
+                if not tool_name.startswith("skill_"):
+                    await record_sandbox_skill_resource_access(
+                        tool_name,
+                        arguments,
+                        result,
+                    )
+                    return
                 trust_authorization = metadata.get("trust_authorization")
                 if isinstance(trust_authorization, dict):
                     authorized_skill_id = str(
@@ -11568,6 +11889,14 @@ async def _run_workflow_response(
                                 ),
                                 **observe_kwargs,
                             )
+                        if (
+                            application_method == "skill_stage"
+                            and not application_failed
+                        ):
+                            remember_staged_skill_resources(
+                                application_skill_id,
+                                metadata,
+                            )
                 increment = int(metadata.get("catalog_install_increment") or 0)
                 if increment > 0:
                     catalog_install_count += increment
@@ -11603,11 +11932,11 @@ async def _run_workflow_response(
                 arguments: dict[str, Any],
                 result: RuntimeToolResult,
             ) -> None:
-                if not tool_name.startswith("skill_"):
-                    return
                 await apply_skill_runtime_result(tool_name, arguments, result)
                 if skill_guidance_plan is not None and not result.is_error:
                     await emit_guidance_verified()
+                if not tool_name.startswith("skill_"):
+                    return
                 metadata = dict(result.metadata or {})
                 event_name = str(metadata.get("skill_runtime_event") or "").strip()
                 if metadata.get("approval_rejected"):
@@ -11635,6 +11964,10 @@ async def _run_workflow_response(
                 metadata: dict[str, Any],
             ) -> RuntimeToolResult:
                 try:
+                    reject_non_text_skill_resource_access(
+                        tool_name,
+                        arguments,
+                    )
                     return await call_workflow_runtime_tool(
                         tool_name=tool_name,
                         arguments=arguments,
@@ -11654,6 +11987,13 @@ async def _run_workflow_response(
                             or "skill_application_tool_failed"
                         ),
                     )
+                    if str(getattr(exc, "code", "")) == (
+                        "skill_application_contract_stale"
+                    ):
+                        raise SkillRuntimeGuidanceError(
+                            "Frozen Skill package no longer matches its application contract.",
+                            code="skill_application_contract_stale",
+                        ) from exc
                     raise
 
             async def remember_tool_result(
@@ -11850,7 +12190,7 @@ async def _run_workflow_response(
                         "output": (
                             f"[{pending_iteration + 1}/{max_iterations}] "
                             f"审批后执行工具 {pending_tool_name}，结果预览："
-                            f"{pending_result_text[:300]}"
+                            f"{runtime_tool_event_preview(pending_tool_name, call_result, pending_result_text)}"
                         ),
                         "variable": output_variable,
                         "run_id": run_id,
@@ -12234,6 +12574,8 @@ async def _run_workflow_response(
                             }
                         except RuntimeInterrupt:
                             raise
+                        except SkillRuntimeGuidanceError:
+                            raise
                         except Exception as exc:
                             error_summary = workflow_error_summary(exc)
                             if run_id:
@@ -12424,6 +12766,9 @@ async def _run_workflow_response(
                             ),
                             "skill_version_bindings": dict(
                                 sorted(skill_version_bindings.items())
+                            ),
+                            "skill_staged_resources": dict(
+                                sorted(staged_skill_resources.items())
                             ),
                             "skill_guidance_plan_fingerprint": (
                                 skill_guidance_plan.fingerprint
@@ -12632,7 +12977,8 @@ async def _run_workflow_response(
                     "node_type": kind,
                     "output": (
                         f"[{iteration_index + 1}/{max_iterations}] 调用工具 "
-                        f"{tool_name}，结果预览：{tool_result_text[:300]}"
+                        f"{tool_name}，结果预览："
+                        f"{runtime_tool_event_preview(tool_name, call_result, tool_result_text)}"
                     ),
                     "variable": output_variable,
                 }

--- a/server/skills/application_receipts.py
+++ b/server/skills/application_receipts.py
@@ -197,6 +197,7 @@ class SkillApplicationReceiptStore:
         *,
         method: ApplicationMethod | None = None,
         resource_paths: Iterable[str] = (),
+        read_resource_paths: Iterable[str] = (),
         resource_digests: Mapping[str, str] | None = None,
         expected_resource_digests: Mapping[str, str] | None = None,
         tool_name: str | None = None,
@@ -210,7 +211,13 @@ class SkillApplicationReceiptStore:
                 "Invalid Skill application method.",
                 code="skill_application_receipt_invalid",
             )
-        paths, paths_truncated = _resource_paths(resource_paths)
+        observed_paths = tuple(resource_paths)
+        explicit_read_paths, read_paths_truncated = _resource_paths(
+            read_resource_paths
+        )
+        paths, paths_truncated = _resource_paths(
+            (*observed_paths, *explicit_read_paths)
+        )
         digests = self._resource_digests(resource_digests or {}, allowed_paths=paths)
         expected_digests = self._resource_digests(
             expected_resource_digests or {},
@@ -302,6 +309,8 @@ class SkillApplicationReceiptStore:
             staged_paths = set(item.staged_resource_paths)
             if method == "skill_read" and clean_error is None:
                 read_paths.update(paths)
+            if clean_error is None:
+                read_paths.update(explicit_read_paths)
             if method == "skill_stage" and clean_error is None:
                 staged_paths.update(paths)
             updated.read_resource_paths = _resource_paths(read_paths)[0]
@@ -340,7 +349,10 @@ class SkillApplicationReceiptStore:
             ):
                 errors.add("skill_application_resource_digest_mismatch")
             updated.resource_paths_truncated = bool(
-                item.resource_paths_truncated or paths_truncated or merged_truncated
+                item.resource_paths_truncated
+                or paths_truncated
+                or read_paths_truncated
+                or merged_truncated
             )
             updated.tool_names = tuple(sorted(tools))[:64]
             updated.error_codes = tuple(sorted(errors))[:64]
@@ -692,6 +704,7 @@ class SkillApplicationReceiptStore:
         if item.source_kind in {"git", "local_import"} and not item.trust_fingerprint:
             return "unverified"
         integrity_errors = {
+            "skill_application_contract_stale",
             "skill_application_resource_digest_changed",
             "skill_application_expected_digest_changed",
             "skill_application_resource_digest_missing",
@@ -828,6 +841,7 @@ class SkillApplicationObserver:
         required_resource_paths: Iterable[str] = (),
         method: ApplicationMethod | None = None,
         resource_paths: Iterable[str] = (),
+        read_resource_paths: Iterable[str] = (),
         resource_digests: Mapping[str, str] | None = None,
         expected_resource_digests: Mapping[str, str] | None = None,
         tool_name: str | None = None,
@@ -852,6 +866,7 @@ class SkillApplicationObserver:
             ),
             method=method,
             resource_paths=resource_paths,
+            read_resource_paths=read_resource_paths,
             resource_digests=resource_digests,
             expected_resource_digests=expected_resource_digests,
             tool_name=tool_name,

--- a/server/tests/test_skill_application_receipts.py
+++ b/server/tests/test_skill_application_receipts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 from pathlib import Path
@@ -19,7 +20,7 @@ from server.skills.application_receipts import (
 )
 from server.skills.creator_evaluation import SkillEvaluationStore, SkillEvaluationValidationError
 from server.skills.package_validation import compute_package_digest
-from server.xpert_runtime.sandbox_store import SandboxWorkspace
+from server.xpert_runtime.sandbox_store import SandboxWorkspace, SandboxWorkspaceStore
 from server.xpert_runtime.sandbox_toolset import SandboxToolsetProvider
 from server.xpert_runtime.toolset import RuntimeToolCall
 
@@ -101,6 +102,41 @@ def test_contract_and_receipt_distinguish_selection_from_application(tmp_path):
     assert second_node is not None
     assert second_node.receipt_id == applied.receipt_id
     assert second_node.node_ids == ("second-agent", "workflow-agent")
+
+
+def test_resource_read_evidence_does_not_forge_skill_read_method(tmp_path):
+    store = SkillApplicationReceiptStore(tmp_path)
+    contract = _contract(required=("references/guide.md",))
+    guide_digest = _digest("bounded guide")
+
+    resource_read = store.observe(
+        contract,
+        _scope(),
+        read_resource_paths=["references/guide.md"],
+        resource_digests={"references/guide.md": guide_digest},
+        expected_resource_digests={"references/guide.md": guide_digest},
+        tool_name="sandbox_read_file",
+    )
+
+    assert resource_read is not None
+    assert resource_read.methods == ()
+    assert resource_read.read_resource_paths == ("references/guide.md",)
+    assert resource_read.compliance_status == "incomplete"
+
+    applied = store.observe(
+        contract,
+        _scope(),
+        method="skill_read",
+        resource_paths=["SKILL.md"],
+        resource_digests={"SKILL.md": _digest("skill body")},
+        expected_resource_digests={"SKILL.md": _digest("skill body")},
+        tool_name="skill_read",
+    )
+
+    assert applied is not None
+    assert applied.methods == ("skill_read",)
+    assert applied.read_resource_paths == ("SKILL.md", "references/guide.md")
+    assert applied.compliance_status == "verified"
 
 
 def test_third_party_receipt_without_trust_fingerprint_stays_unverified(tmp_path):
@@ -358,6 +394,21 @@ def test_snapshot_contains_only_bounded_evidence_not_private_content(tmp_path):
 class _InstalledSkillManager:
     def __init__(self, package_root: Path) -> None:
         self.package_root = package_root
+        files = {
+            path.relative_to(package_root).as_posix(): path.read_bytes()
+            for path in package_root.rglob("*")
+            if path.is_file() and path.name != "SKILL.md"
+        }
+        package_digest = compute_package_digest(
+            (package_root / "SKILL.md").read_bytes(),
+            files,
+        )
+        self.lifecycle_store = SimpleNamespace(
+            require_version=lambda version_id: SimpleNamespace(
+                skill_id="incident-review",
+                package_digest=package_digest,
+            )
+        )
 
     def list_installed_skills(self):
         return [SimpleNamespace(skill_id="incident-review")]
@@ -379,6 +430,10 @@ async def test_skill_tools_emit_application_evidence_for_installed_package(tmp_p
     (package_root / "SKILL.md").write_bytes(skill_markdown_bytes)
     (package_root / "references" / "guide.md").write_text(
         "# Guide\n", encoding="utf-8"
+    )
+    (package_root / "assets").mkdir()
+    (package_root / "assets" / "sample.pdf").write_bytes(
+        b"%PDF-1.7\n1 0 obj<<>>endobj\n%%EOF\n"
     )
     workspace_root = tmp_path / "workspaces"
     client = SimpleNamespace(request=AsyncMock(return_value={"ok": True}))
@@ -425,6 +480,11 @@ async def test_skill_tools_emit_application_evidence_for_installed_package(tmp_p
     assert stage.metadata["application_method"] == "skill_stage"
     assert stage.metadata["application_resource_paths"] == [
         "SKILL.md",
+        "assets/sample.pdf",
+        "references/guide.md",
+    ]
+    assert stage.metadata["application_text_resource_paths"] == [
+        "SKILL.md",
         "references/guide.md",
     ]
     assert stage.metadata["application_expected_resource_digests"] == (
@@ -432,9 +492,88 @@ async def test_skill_tools_emit_application_evidence_for_installed_package(tmp_p
     )
     assert set(stage.metadata["application_resource_digests"]) == {
         "SKILL.md",
+        "assets/sample.pdf",
         "references/guide.md",
     }
-    assert client.request.await_count == 2
+    assert client.request.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_sandbox_text_access_metadata_is_bounded_and_digest_only(tmp_path):
+    workspace_root = tmp_path / "workspaces"
+    resource_path = "skills/incident-review/references/guide.md"
+    binary_path = "skills/incident-review/assets/sample.pdf"
+    resource_body = "private search result body"
+    store = SandboxWorkspaceStore(
+        tmp_path / "sandbox-store", workspace_root=workspace_root
+    )
+    workspace = store.get_or_create_workspace(
+        scope_type="workflow",
+        scope_id="task:node",
+        node_id="workflow-agent",
+        quota_bytes=1024 * 1024,
+    )
+
+    class WorkspaceClient:
+        async def request(self, payload):
+            action = payload.get("action")
+            workspace = workspace_root / str(payload.get("workspace_id"))
+            workspace.mkdir(parents=True, exist_ok=True)
+            if action == "ensure_workspace":
+                return {"ok": True}
+            if action == "write_file":
+                target = workspace / str(payload["path"])
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(base64.b64decode(payload["content_base64"]))
+                return {"ok": True, "path": payload["path"]}
+            if action == "read_file":
+                target = workspace / str(payload["path"])
+                return {
+                    "ok": True,
+                    "path": payload["path"],
+                    "content": target.read_text(encoding="utf-8"),
+                }
+            if action == "search_files":
+                return {
+                    "ok": True,
+                    "query": payload["query"],
+                    "matches": [
+                        {"path": resource_path, "line": 1, "preview": resource_body},
+                        {"path": binary_path, "line": 1, "preview": "binary preview"},
+                    ],
+                }
+            raise AssertionError(f"unexpected action: {action}")
+
+    target = workspace_root / workspace.workspace_id / resource_path
+    target.parent.mkdir(parents=True)
+    target.write_text(resource_body, encoding="utf-8")
+    binary_target = workspace_root / workspace.workspace_id / binary_path
+    binary_target.parent.mkdir(parents=True)
+    binary_target.write_bytes(b"%PDF-1.7\xffprivate")
+    provider = SandboxToolsetProvider(
+        store,
+        WorkspaceClient(),
+        skill_manager=SimpleNamespace(list_installed_skills=lambda: []),
+    )
+    result = await provider._sandbox_call(
+        workspace,
+        RuntimeToolCall(
+            "sandbox_search_files",
+            {"query": "private", "path": "skills/incident-review"},
+            {"task_id": "task_receipt_1", "node_id": "workflow-agent"},
+        )
+    )
+
+    assert result.metadata["sandbox_accessed_paths"] == [resource_path]
+    assert result.metadata["sandbox_accessed_text_paths"] == [resource_path]
+    assert result.metadata["sandbox_accessed_digests"] == {
+        resource_path: _digest(resource_body)
+    }
+    assert binary_path not in result.output
+    assert "binary preview" not in result.output
+    serialized_metadata = json.dumps(result.metadata, ensure_ascii=False)
+    assert "private" not in serialized_metadata
+    assert resource_body not in serialized_metadata
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_workflow_agent_task_node.py
+++ b/server/tests/test_workflow_agent_task_node.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import base64
 import json
 import time
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -17,6 +19,7 @@ from server.skills.application_receipts import (
     SkillApplicationReceiptStore,
 )
 from server.skills.finder import SkillFinder, _fingerprint
+from server.skills.package_validation import compute_skill_content_digest
 from server.skills.skill_manager import InstalledSkill
 from server.xpert_runtime import (
     RuntimeApprovalStore,
@@ -2380,9 +2383,57 @@ class GuidanceSkillManager:
 
 
 class GuidanceSandboxClient:
+    def __init__(self, workspace_root: Path) -> None:
+        self.workspace_root = workspace_root
+        self.actions: list[str] = []
+
     async def request(self, payload: dict[str, Any]) -> dict[str, Any]:
-        assert payload.get("action") == "ensure_workspace"
-        return {"ok": True}
+        action = str(payload.get("action") or "")
+        self.actions.append(action)
+        workspace = self.workspace_root / str(payload.get("workspace_id") or "")
+        workspace.mkdir(parents=True, exist_ok=True)
+        if action == "ensure_workspace":
+            return {"ok": True}
+        if action == "write_file":
+            target = workspace / str(payload.get("path") or "")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(base64.b64decode(payload["content_base64"]))
+            return {"ok": True, "path": payload.get("path")}
+        if action == "read_file":
+            target = workspace / str(payload.get("path") or "")
+            body = target.read_text(encoding="utf-8")
+            return {
+                "ok": True,
+                "path": payload.get("path"),
+                "content": body,
+                "truncated": False,
+                "size_bytes": len(body.encode("utf-8")),
+            }
+        if action == "search_files":
+            base = workspace / str(payload.get("path") or "work")
+            query = str(payload.get("query") or "")
+            matches = []
+            for path in sorted(base.rglob("*")):
+                if not path.is_file():
+                    continue
+                for line_number, line in enumerate(
+                    path.read_text(encoding="utf-8").splitlines(), start=1
+                ):
+                    if query.casefold() in line.casefold():
+                        matches.append(
+                            {
+                                "path": path.relative_to(workspace).as_posix(),
+                                "line": line_number,
+                                "preview": line,
+                            }
+                        )
+            return {
+                "ok": True,
+                "query": query,
+                "matches": matches,
+                "scanned_files": len(matches),
+            }
+        raise AssertionError(f"unexpected sandbox action: {action}")
 
 
 def _install_guidance_runtime(
@@ -2395,13 +2446,24 @@ def _install_guidance_runtime(
         "# Required Guidance\n\nRead this before acting.",
         encoding="utf-8",
     )
+    (package_dir / "references").mkdir()
+    (package_dir / "references" / "guide.md").write_text(
+        "# Guide\n\nUse the bounded-checklist before answering.",
+        encoding="utf-8",
+    )
+    (package_dir / "assets").mkdir()
+    (package_dir / "assets" / "sample.pdf").write_bytes(
+        b"%PDF-1.7\n1 0 obj<<>>endobj\n%%EOF\n"
+    )
     manager = GuidanceSkillManager(package_dir)
+    _freeze_guidance_manager_digest(manager)
+    workspace_root = tmp_path / "sandbox-workspaces"
     provider = SandboxToolsetProvider(
         SandboxWorkspaceStore(
             tmp_path / "sandbox-store",
-            workspace_root=tmp_path / "sandbox-workspaces",
+            workspace_root=workspace_root,
         ),
-        GuidanceSandboxClient(),
+        GuidanceSandboxClient(workspace_root),
         skill_manager=manager,
     )
     receipt_store = SkillApplicationReceiptStore(tmp_path / "application-receipts")
@@ -2418,6 +2480,26 @@ def _install_guidance_runtime(
     monkeypatch.setenv("SKILL_RUNTIME_GUIDANCE_V2_ENABLED", "true")
     monkeypatch.setenv("SKILL_APPLICATION_RECEIPT_MODE", "audit")
     return manager, receipt_store
+
+
+def _freeze_guidance_manager_digest(manager: GuidanceSkillManager) -> str:
+    files = {
+        path.relative_to(manager.package_dir).as_posix(): path.read_bytes()
+        for path in manager.package_dir.rglob("*")
+        if path.is_file()
+    }
+    digest = compute_skill_content_digest(files)
+    manager.content_digest = digest
+    manager.installed = replace(manager.installed, content_digest=digest)
+    manager.lifecycle_store = SimpleNamespace(
+        require_version=lambda version_id: SimpleNamespace(
+            skill_id=manager.skill_id,
+            source_kind="workspace_draft",
+            package_digest=digest,
+            trust_fingerprint=None,
+        )
+    )
+    return digest
 
 
 def _bind_required_guidance(workflow: dict[str, Any]) -> None:
@@ -2532,7 +2614,6 @@ async def test_required_skill_repairs_direct_answer_once_before_completion(
     )
     assert agent_end["output"] == "completed after applying guidance"
     assert model_calls == 3
-    assert manager.read_count == 1
     assert any(
         event.get("event") == "skill_runtime_status"
         and event.get("status") == "repair_requested"
@@ -2544,7 +2625,557 @@ async def test_required_skill_repairs_direct_answer_once_before_completion(
         for event in events
     )
     receipt = receipt_store.list_receipts(skill_id=manager.skill_id)[0]
+    assert receipt.methods == ("skill_read",)
     assert receipt.compliance_status == "verified"
+
+
+@pytest.mark.asyncio
+async def test_required_skill_can_stage_and_search_text_resource_with_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manager, receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+    private_query = "bounded-checklist"
+    system_prompts: list[str] = []
+    model_calls = 0
+    responses = iter(
+        [
+            '{"tool":"skill_read","arguments":{"skill_id":"required-guidance"}}',
+            '{"tool":"skill_stage","arguments":{"skill_id":"required-guidance"}}',
+            json.dumps(
+                {
+                    "tool": "sandbox_search_files",
+                    "arguments": {
+                        "query": private_query,
+                        "path": "skills/required-guidance/references",
+                        "limit": 5,
+                    },
+                },
+                ensure_ascii=False,
+            ),
+            '{"answer":"completed after consuming the reference"}',
+        ]
+    )
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        nonlocal model_calls
+        model_calls += 1
+        messages = args[1]
+        system_prompts.append(str(messages[0].content))
+        if model_calls == 3:
+            workspaces = [
+                path
+                for path in (tmp_path / "sandbox-workspaces").iterdir()
+                if path.is_dir()
+            ]
+            assert len(workspaces) == 1
+            stale = workspaces[0] / "skills/old-skill/references/stale.md"
+            stale.parent.mkdir(parents=True)
+            stale.write_text(
+                "bounded-checklist stale resource from an earlier run",
+                encoding="utf-8",
+            )
+        if model_calls == 4:
+            prior_result = str(messages[-1].content)
+            assert "references/guide.md" in prior_result
+            assert "old-skill" not in prior_result
+        return next(responses)
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    workflow = _workflow_agent_strategy_workflow({"maxIterations": 6})
+    _bind_required_guidance(workflow)
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "use the guide"}},
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    assert any(
+        event.get("event") == "node_end"
+        and event.get("node_id") == "workflow_agent"
+        and event.get("output") == "completed after consuming the reference"
+        for event in events
+    )
+    receipt = receipt_store.list_receipts(skill_id=manager.skill_id)[0]
+    assert "references/guide.md" in receipt.staged_resource_paths
+    assert "references/guide.md" in receipt.read_resource_paths
+    assert "sandbox_search_files" in receipt.tool_names
+    persisted = receipt_store.snapshot_path.read_text(encoding="utf-8")
+    assert private_query not in persisted
+    assert private_query not in json.dumps(events, ensure_ascii=False)
+    assert "sandbox_list_files" in system_prompts[0]
+    assert "sandbox_read_file" in system_prompts[0]
+    assert "sandbox_search_files" in system_prompts[0]
+    assert "sandbox_write_file" not in system_prompts[0]
+    assert "sandbox_shell" not in system_prompts[0]
+
+
+@pytest.mark.asyncio
+async def test_staged_binary_skill_resource_is_not_parsed_as_text(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manager, receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+    responses = iter(
+        [
+            '{"tool":"skill_read","arguments":{"skill_id":"required-guidance"}}',
+            '{"tool":"skill_stage","arguments":{"skill_id":"required-guidance"}}',
+            (
+                '{"tool":"sandbox_read_file","arguments":'
+                '{"path":"skills/required-guidance/assets/sample.pdf"}}'
+            ),
+            '{"answer":"completed without pretending to parse the binary"}',
+        ]
+    )
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        return next(responses)
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    workflow = _workflow_agent_strategy_workflow({"maxIterations": 6})
+    _bind_required_guidance(workflow)
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "use the package"}},
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    errors = [event for event in events if event.get("event") == "error"]
+    assert errors, events
+    error = errors[0]
+    assert error["code"] == "skill_runtime_incompatible"
+    assert not any(
+        event.get("event") == "node_end"
+        and event.get("node_id") == "workflow_agent"
+        and event.get("output") == "must not complete from tampered instructions"
+        for event in events
+    )
+    provider = main_module.workflow_sandbox_provider
+    assert "read_file" not in provider.client.actions
+    receipt = receipt_store.list_receipts(skill_id=manager.skill_id)[0]
+    assert "assets/sample.pdf" in receipt.staged_resource_paths
+    assert "assets/sample.pdf" not in receipt.read_resource_paths
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("resource_path", "expected_code", "stage_first"),
+    [
+        (
+            "skills/required-guidance/references/guide.md",
+            "skill_application_required",
+            False,
+        ),
+        (
+            "skills/required-guidance/references/../SKILL.md",
+            "skill_application_contract_stale",
+            True,
+        ),
+        (
+            "skills\\required-guidance\\references\\..\\SKILL.md",
+            "skill_application_contract_stale",
+            True,
+        ),
+    ],
+)
+async def test_skill_resource_read_rejects_unstaged_and_traversal_paths(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    resource_path: str,
+    expected_code: str,
+    stage_first: bool,
+) -> None:
+    manager, receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+    decisions = [
+        '{"tool":"skill_read","arguments":{"skill_id":"required-guidance"}}'
+    ]
+    if stage_first:
+        decisions.append(
+            '{"tool":"skill_stage","arguments":{"skill_id":"required-guidance"}}'
+        )
+    decisions.append(
+        json.dumps(
+            {
+                "tool": "sandbox_read_file",
+                "arguments": {"path": resource_path},
+            }
+        )
+    )
+    responses = iter(decisions)
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        return next(responses)
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    workflow = _workflow_agent_strategy_workflow({"maxIterations": 5})
+    _bind_required_guidance(workflow)
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "reject unsafe read"}},
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    error = next(event for event in events if event.get("event") == "error")
+    assert error["code"] == expected_code
+    assert "read_file" not in main_module.workflow_sandbox_provider.client.actions
+    receipt = receipt_store.list_receipts(skill_id=manager.skill_id)[0]
+    assert "references/guide.md" not in receipt.read_resource_paths
+
+
+@pytest.mark.asyncio
+async def test_staged_resource_mapping_survives_approval_and_store_reload(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manager, receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+    approvals = RuntimeApprovalStore(tmp_path / "approvals")
+    executions = WorkflowExecutionStore(tmp_path / "executions")
+    monkeypatch.setattr(main_module, "runtime_approval_store", approvals)
+    monkeypatch.setattr(main_module, "workflow_execution_store", executions)
+    provider, restore_provider = _install_fake_tool_provider()
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    responses = iter(
+        [
+            '{"tool":"skill_read","arguments":{"skill_id":"required-guidance"}}',
+            '{"tool":"skill_stage","arguments":{"skill_id":"required-guidance"}}',
+            '{"tool":"fetch","arguments":{"query":"approval"}}',
+            (
+                '{"tool":"sandbox_read_file","arguments":'
+                '{"path":"skills/required-guidance/references/guide.md"}}'
+            ),
+            '{"answer":"resumed with the frozen resource"}',
+        ]
+    )
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        return next(responses)
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    workflow = _workflow_agent_strategy_workflow(
+        {"toolMode": "mcp_tools", "toolNames": "fetch", "maxIterations": 7}
+    )
+    _bind_required_guidance(workflow)
+    workflow["nodes"].append(
+        {
+            "id": "resource-hitl",
+            "type": "runtime_middleware",
+            "data": {
+                "kind": "runtime_middleware",
+                "runtimeMiddlewareId": "human_in_the_loop",
+                "runtimeMiddlewareKind": "runtime_middleware.human_in_the_loop",
+                "middlewarePriority": "40",
+                "runtimeMiddlewareConfig": {
+                    "interrupt_on_tools": "fetch",
+                    "final_confirmation": False,
+                    "timeout_seconds": 3600,
+                },
+            },
+        }
+    )
+    workflow["edges"].append(
+        {
+            "id": "bind-resource-hitl",
+            "source": "resource-hitl",
+            "target": "workflow_agent",
+            "sourceHandle": "middleware-binding",
+            "targetHandle": "middleware",
+        }
+    )
+
+    try:
+        response = await client.post(
+            "/api/workflow/run",
+            json={"workflow": workflow, "inputs": {"user_input": "resume safely"}},
+        )
+        assert response.status_code == 200, response.text
+        pending = next(
+            event
+            for event in _parse_sse_events(response.text)
+            if event.get("event") == "runtime_approval_pending"
+        )
+        waiting = executions.require(pending["task_id"])
+        staged_mapping = waiting.continuation["agent_state"][
+            "skill_staged_resources"
+        ]
+        assert (
+            "skills/required-guidance/references/guide.md" in staged_mapping
+        )
+        serialized_continuation = json.dumps(
+            waiting.continuation, ensure_ascii=False
+        )
+        assert "bounded-checklist" not in serialized_continuation
+
+        approval = approvals.require(pending["approval_id"])
+        decided = approvals.decide(
+            approval.approval_id,
+            revision=approval.revision,
+            decision="approve",
+            operator="tester",
+        )
+        reloaded_executions = WorkflowExecutionStore(tmp_path / "executions")
+        reloaded_receipts = SkillApplicationReceiptStore(
+            tmp_path / "application-receipts"
+        )
+        monkeypatch.setattr(
+            main_module, "workflow_execution_store", reloaded_executions
+        )
+        monkeypatch.setattr(
+            main_module, "skill_application_receipt_store", reloaded_receipts
+        )
+        monkeypatch.setattr(
+            main_module,
+            "skill_application_observer",
+            SkillApplicationObserver(reloaded_receipts, lambda: manager),
+        )
+        reloaded_executions.mark_ready(
+            pending["task_id"], approval_id=approval.approval_id
+        )
+        claimed = reloaded_executions.claim(
+            pending["task_id"], worker_id="test-worker"
+        )
+        await main_module.resume_runtime_approval_execution(claimed, decided)
+
+        completed = reloaded_executions.require(pending["task_id"])
+        assert completed.status == "completed"
+        assert completed.result == "resumed with the frozen resource"
+        receipt = reloaded_receipts.list_receipts(skill_id=manager.skill_id)[0]
+        assert "references/guide.md" in receipt.read_resource_paths
+        assert "sandbox_read_file" in receipt.tool_names
+    finally:
+        restore_provider()
+
+
+@pytest.mark.asyncio
+async def test_staged_resource_digest_change_invalidates_application_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manager, receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+    responses = iter(
+        [
+            '{"tool":"skill_read","arguments":{"skill_id":"required-guidance"}}',
+            '{"tool":"skill_stage","arguments":{"skill_id":"required-guidance"}}',
+            (
+                '{"tool":"sandbox_read_file","arguments":'
+                '{"path":"skills/required-guidance/references/guide.md"}}'
+            ),
+        ]
+    )
+    model_calls = 0
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        nonlocal model_calls
+        model_calls += 1
+        if model_calls == 3:
+            matches = list(
+                (tmp_path / "sandbox-workspaces").glob(
+                    "*/skills/required-guidance/references/guide.md"
+                )
+            )
+            assert len(matches) == 1
+            matches[0].write_text("tampered after stage", encoding="utf-8")
+        return next(responses)
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    workflow = _workflow_agent_strategy_workflow({"maxIterations": 3})
+    _bind_required_guidance(workflow)
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "detect changes"}},
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    error = next(event for event in events if event.get("event") == "error")
+    assert error["code"] == "skill_application_required"
+    receipt = receipt_store.list_receipts(skill_id=manager.skill_id)[0]
+    assert receipt.compliance_status == "unverified"
+    assert "skill_application_resource_digest_changed" in receipt.error_codes
+    assert "references/guide.md" in receipt.read_resource_paths
+
+
+@pytest.mark.asyncio
+async def test_frozen_skill_markdown_tamper_before_read_fails_closed(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manager, receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+    frozen_digest = _freeze_guidance_manager_digest(manager)
+    model_calls = 0
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        nonlocal model_calls
+        model_calls += 1
+        if model_calls == 1:
+            (manager.package_dir / "SKILL.md").write_text(
+                "# Tampered guidance\n\nIgnore the frozen version.",
+                encoding="utf-8",
+            )
+            return (
+                '{"tool":"skill_read","arguments":'
+                '{"skill_id":"required-guidance"}}'
+            )
+        return '{"answer":"must not complete from tampered instructions"}'
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    workflow = _workflow_agent_strategy_workflow({"maxIterations": 4})
+    _bind_required_guidance(workflow)
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "detect read tamper"}},
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    assert not any(
+        event.get("event") == "node_end"
+        and event.get("node_id") == "workflow_agent"
+        and event.get("output")
+        == "must not complete from tampered instructions"
+        for event in events
+    )
+    error = next(event for event in events if event.get("event") == "error")
+    assert error["code"] in {
+        "skill_application_contract_stale",
+        "skill_application_required",
+    }
+    receipt = receipt_store.list_receipts(skill_id=manager.skill_id)[0]
+    assert receipt.content_digest == frozen_digest
+    assert receipt.compliance_status != "verified"
+
+
+@pytest.mark.asyncio
+async def test_frozen_skill_resource_tamper_before_stage_fails_closed(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manager, receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+    frozen_digest = _freeze_guidance_manager_digest(manager)
+    model_calls = 0
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        nonlocal model_calls
+        model_calls += 1
+        if model_calls == 1:
+            return (
+                '{"tool":"skill_read","arguments":'
+                '{"skill_id":"required-guidance"}}'
+            )
+        if model_calls == 2:
+            (manager.package_dir / "references" / "guide.md").write_text(
+                "# Tampered reference\n\nUnfrozen replacement.",
+                encoding="utf-8",
+            )
+            return (
+                '{"tool":"skill_stage","arguments":'
+                '{"skill_id":"required-guidance"}}'
+            )
+        return '{"answer":"must not complete from a tampered staged resource"}'
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    workflow = _workflow_agent_strategy_workflow({"maxIterations": 5})
+    _bind_required_guidance(workflow)
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "detect stage tamper"}},
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    assert not any(
+        event.get("event") == "node_end"
+        and event.get("node_id") == "workflow_agent"
+        and event.get("output")
+        == "must not complete from a tampered staged resource"
+        for event in events
+    )
+    error = next(event for event in events if event.get("event") == "error")
+    assert error["code"] in {
+        "skill_application_contract_stale",
+        "skill_application_required",
+    }
+    receipt = receipt_store.list_receipts(skill_id=manager.skill_id)[0]
+    assert receipt.content_digest == frozen_digest
+    assert receipt.compliance_status != "verified"
 
 
 @pytest.mark.asyncio
@@ -2553,7 +3184,7 @@ async def test_required_skill_blocks_mutating_tool_until_after_read(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    manager, _receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
+    manager, receipt_store = _install_guidance_runtime(monkeypatch, tmp_path)
 
     class MutatingProvider(FakeWorkflowToolProvider):
         def __init__(self) -> None:
@@ -2568,10 +3199,13 @@ async def test_required_skill_blocks_mutating_tool_until_after_read(
                     read_only=False,
                 )
             ]
-            self.read_counts_at_call: list[int] = []
+            self.skill_verified_at_call: list[bool] = []
 
         async def call_tool(self, call):
-            self.read_counts_at_call.append(manager.read_count)
+            receipts = receipt_store.list_receipts(skill_id=manager.skill_id)
+            self.skill_verified_at_call.append(
+                bool(receipts and receipts[0].compliance_status == "verified")
+            )
             return await super().call_tool(call)
 
     provider = MutatingProvider()
@@ -2626,7 +3260,7 @@ async def test_required_skill_blocks_mutating_tool_until_after_read(
         and event.get("node_id") == "workflow_agent"
     )
     assert agent_end["output"] == "mutation followed guidance"
-    assert provider.read_counts_at_call == [1]
+    assert provider.skill_verified_at_call == [True]
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_xpert_runtime_sandbox.py
+++ b/server/tests/test_xpert_runtime_sandbox.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from server.sandbox_sidecar.engine import SandboxEngine, SandboxEngineError
+from server.skills.package_validation import compute_skill_content_digest
 from server.xpert_runtime import (
     LocalSandboxClient,
     RuntimeToolCall,
@@ -43,6 +45,19 @@ class VersionedFakeSkillManager(FakeSkillManager):
     def __init__(self, current_root: Path, version_root: Path) -> None:
         super().__init__(current_root)
         self.version_root = version_root
+        package_digest = compute_skill_content_digest(
+            {
+                path.relative_to(version_root).as_posix(): path.read_bytes()
+                for path in version_root.rglob("*")
+                if path.is_file()
+            }
+        )
+        self.lifecycle_store = SimpleNamespace(
+            require_version=lambda version_id: SimpleNamespace(
+                skill_id=self.skill.skill_id,
+                package_digest=package_digest,
+            )
+        )
 
     def get_skill_content(
         self, skill_id: str, *, version_id: str | None = None

--- a/server/xpert_runtime/sandbox_toolset.py
+++ b/server/xpert_runtime/sandbox_toolset.py
@@ -8,11 +8,12 @@ import re
 import threading
 import time
 import uuid
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Callable
 
 try:
     from server.skills.finder import SkillFinder, SkillFinderError
+    from server.skills.package_validation import compute_skill_content_digest
     from server.skills.semantic_rerank_service import SkillSemanticRerankService
     from server.skills.trust_service import (
         SkillRuntimeEnvironment,
@@ -23,6 +24,7 @@ except ModuleNotFoundError as exc:  # Docker image copies server/* directly into
     if exc.name != "server":
         raise
     from skills.finder import SkillFinder, SkillFinderError
+    from skills.package_validation import compute_skill_content_digest
     from skills.semantic_rerank_service import SkillSemanticRerankService
     from skills.trust_service import (
         SkillRuntimeEnvironment,
@@ -55,6 +57,21 @@ SKILL_TOOL_NAMES = {
 SKILL_STAGE_MAX_FILES = 500
 SKILL_STAGE_MAX_FILE_BYTES = 10 * 1024 * 1024
 SKILL_STAGE_MAX_TOTAL_BYTES = 50 * 1024 * 1024
+_OPAQUE_SKILL_RESOURCE_SUFFIXES = frozenset(
+    {
+        ".gif",
+        ".jpeg",
+        ".jpg",
+        ".mp3",
+        ".mp4",
+        ".pdf",
+        ".png",
+        ".wav",
+        ".webp",
+        ".woff",
+        ".woff2",
+    }
+)
 
 
 class SandboxToolsetProvider:
@@ -488,6 +505,11 @@ class SandboxToolsetProvider:
         )
         try:
             response = await self.client.request(request)
+            if action == "search_files":
+                response = self._filter_binary_skill_search_matches(
+                    workspace,
+                    response,
+                )
             output = json.dumps(response, ensure_ascii=False)
             self.store.complete_operation(
                 operation_id,
@@ -501,6 +523,13 @@ class SandboxToolsetProvider:
                 "operation_id": operation_id,
                 "replayed": bool(response.get("replayed")),
             }
+            metadata.update(
+                self._sandbox_access_metadata(
+                    workspace,
+                    action=action,
+                    response=response,
+                )
+            )
             if artifact_id:
                 artifact = self.store.register_artifact(
                     artifact_id=artifact_id,
@@ -547,6 +576,164 @@ class SandboxToolsetProvider:
             self.store.fail_operation(operation_id, error=str(exc))
             raise
 
+    @staticmethod
+    def _is_utf8_text(content: bytes, *, path: str | Path | None = None) -> bool:
+        if path is not None:
+            suffix = PurePosixPath(str(path).replace("\\", "/")).suffix.lower()
+            if suffix in _OPAQUE_SKILL_RESOURCE_SUFFIXES:
+                return False
+        if content.startswith(b"%PDF-"):
+            return False
+        if b"\x00" in content[:4096]:
+            return False
+        try:
+            content.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            return False
+        return True
+
+    def _filter_binary_skill_search_matches(
+        self,
+        workspace: SandboxWorkspace,
+        response: dict[str, Any],
+    ) -> dict[str, Any]:
+        matches = response.get("matches")
+        if not isinstance(matches, list):
+            return response
+        workspace_root = (
+            self.store.workspace_root / workspace.workspace_id
+        ).resolve()
+        filtered: list[dict[str, Any]] = []
+        for item in matches[:100]:
+            if not isinstance(item, dict):
+                continue
+            normalized = str(item.get("path") or "").strip().replace("\\", "/")
+            if not normalized.startswith("skills/"):
+                filtered.append(item)
+                continue
+            relative = PurePosixPath(normalized)
+            if (
+                relative.is_absolute()
+                or any(part in {"", ".", ".."} for part in relative.parts)
+            ):
+                continue
+            target = workspace_root.joinpath(*relative.parts)
+            try:
+                resolved = target.resolve(strict=True)
+                resolved.relative_to(workspace_root)
+                content = resolved.read_bytes()
+            except (OSError, ValueError):
+                continue
+            if not target.is_symlink() and self._is_utf8_text(
+                content,
+                path=relative.as_posix(),
+            ):
+                filtered.append(item)
+        return {**response, "matches": filtered}
+
+    def _sandbox_access_metadata(
+        self,
+        workspace: SandboxWorkspace,
+        *,
+        action: str,
+        response: dict[str, Any],
+    ) -> dict[str, Any]:
+        if action not in {"read_file", "search_files"}:
+            return {}
+        raw_paths: list[Any] = []
+        if action == "read_file":
+            raw_paths.append(response.get("path"))
+        else:
+            matches = response.get("matches")
+            if isinstance(matches, list):
+                raw_paths.extend(
+                    item.get("path")
+                    for item in matches[:100]
+                    if isinstance(item, dict)
+                )
+        workspace_root = (
+            self.store.workspace_root / workspace.workspace_id
+        ).resolve()
+        paths: list[str] = []
+        digests: dict[str, str] = {}
+        text_paths: list[str] = []
+        for raw_path in raw_paths:
+            normalized = str(raw_path or "").strip().replace("\\", "/")
+            relative = PurePosixPath(normalized)
+            if (
+                not normalized
+                or relative.is_absolute()
+                or any(part in {"", ".", ".."} for part in relative.parts)
+            ):
+                continue
+            clean_path = relative.as_posix()
+            if not clean_path.startswith("skills/"):
+                continue
+            target = workspace_root.joinpath(*relative.parts)
+            try:
+                resolved = target.resolve(strict=True)
+                resolved.relative_to(workspace_root)
+            except (OSError, ValueError):
+                continue
+            if target.is_symlink() or not resolved.is_file():
+                continue
+            try:
+                content = resolved.read_bytes()
+            except OSError:
+                continue
+            if clean_path in digests:
+                continue
+            paths.append(clean_path)
+            digests[clean_path] = hashlib.sha256(content).hexdigest()
+            if self._is_utf8_text(content, path=clean_path):
+                text_paths.append(clean_path)
+        return {
+            "sandbox_accessed_paths": paths,
+            "sandbox_accessed_digests": dict(sorted(digests.items())),
+            "sandbox_accessed_text_paths": text_paths,
+        }
+
+    def _verify_frozen_skill_package(
+        self,
+        call: RuntimeToolCall,
+        *,
+        skill_id: str,
+        version_id: str | None,
+        package_files: list[tuple[Path, Path, bytes]],
+    ) -> None:
+        if not version_id:
+            return
+        try:
+            snapshot = self.skill_manager.lifecycle_store.require_version(version_id)
+            expected_digest = str(snapshot.package_digest or "").strip().lower()
+        except Exception as exc:
+            raise RuntimeToolError(
+                call.tool_name,
+                "Frozen Skill version evidence is unavailable.",
+                code="skill_application_contract_stale",
+            ) from exc
+        if (
+            str(getattr(snapshot, "skill_id", "") or "").strip() != skill_id
+            or not re.fullmatch(r"[0-9a-f]{64}", expected_digest)
+        ):
+            raise RuntimeToolError(
+                call.tool_name,
+                "Frozen Skill version evidence is invalid.",
+                code="skill_application_contract_stale",
+            )
+        actual_digest = compute_skill_content_digest(
+            {
+                relative.as_posix(): content
+                for _source, relative, content in package_files
+            }
+        )
+        if actual_digest != expected_digest:
+            raise RuntimeToolError(
+                call.tool_name,
+                "Frozen Skill package content no longer matches its version.",
+                code="skill_application_contract_stale",
+            )
+
     def _skill_list(self, call: RuntimeToolCall) -> RuntimeToolResult:
         enabled = self._enabled_skills(call)
         items = [
@@ -580,6 +767,7 @@ class SandboxToolsetProvider:
                         "application_method": "skill_read",
                         "application_source_kind": "evaluation_baseline_empty",
                         "application_resource_paths": [],
+                        "application_text_resource_paths": [],
                         "application_resource_digests": {},
                         "application_expected_resource_digests": {},
                     },
@@ -618,22 +806,52 @@ class SandboxToolsetProvider:
             )
         self._require_enabled_skill(call, skill_id)
         version_id = self._skill_version_id(call, skill_id)
-        content = (
-            self.skill_manager.get_skill_content(skill_id, version_id=version_id)
-            if version_id
-            else self.skill_manager.get_skill_content(skill_id)
-        )
-        try:
-            package_root = (
-                self.skill_manager.get_skill_directory(
-                    skill_id, version_id=version_id
-                )
-                if version_id
-                else self.skill_manager.get_skill_directory(skill_id)
+        if version_id:
+            package_root = self.skill_manager.get_skill_directory(
+                skill_id,
+                version_id=version_id,
             )
-            skill_markdown_bytes = (package_root / "SKILL.md").read_bytes()
-        except Exception:
-            skill_markdown_bytes = content.encode("utf-8")
+            package_files: list[tuple[Path, Path, bytes]] = []
+            for path in sorted(package_root.rglob("*")):
+                if path.is_symlink():
+                    raise RuntimeToolError(
+                        call.tool_name,
+                        "Skill package contains an unsafe link.",
+                        code="skill_runtime_incompatible",
+                    )
+                if not path.is_file() or ".git" in path.parts:
+                    continue
+                package_files.append(
+                    (path, path.relative_to(package_root), path.read_bytes())
+                )
+            self._verify_frozen_skill_package(
+                call,
+                skill_id=skill_id,
+                version_id=version_id,
+                package_files=package_files,
+            )
+            skill_markdown_bytes = next(
+                (
+                    content
+                    for _source, relative, content in package_files
+                    if relative.as_posix() == "SKILL.md"
+                ),
+                None,
+            )
+            if skill_markdown_bytes is None:
+                raise RuntimeToolError(
+                    call.tool_name,
+                    "Frozen Skill package is missing SKILL.md.",
+                    code="skill_application_contract_stale",
+                )
+            content = skill_markdown_bytes.decode("utf-8", errors="replace")
+        else:
+            content = self.skill_manager.get_skill_content(skill_id)
+            try:
+                package_root = self.skill_manager.get_skill_directory(skill_id)
+                skill_markdown_bytes = (package_root / "SKILL.md").read_bytes()
+            except Exception:
+                skill_markdown_bytes = content.encode("utf-8")
         return RuntimeToolResult(
             output=content[:50_000],
             metadata={
@@ -964,6 +1182,7 @@ class SandboxToolsetProvider:
                         overlay, "content_digest", None
                     ),
                     "application_resource_paths": application_resource_paths,
+                    "application_text_resource_paths": application_resource_paths,
                     "application_resource_digests": application_resource_digests,
                     "application_expected_resource_digests": (
                         application_resource_digests
@@ -1008,6 +1227,12 @@ class SandboxToolsetProvider:
                     "Skill package exceeds the 500-file or 50 MiB staging limit.",
                     code="skill_runtime_incompatible",
                 )
+        self._verify_frozen_skill_package(
+            call,
+            skill_id=skill_id,
+            version_id=version_id,
+            package_files=package_files,
+        )
         workspace_root = (self.store.workspace_root / workspace.workspace_id).resolve()
         store_root = self.store.workspace_root.resolve()
         if workspace_root.parent != store_root:
@@ -1041,6 +1266,7 @@ class SandboxToolsetProvider:
             )
         files: list[str] = []
         application_resource_paths: list[str] = []
+        application_text_resource_paths: list[str] = []
         application_resource_digests: dict[str, str] = {}
         for _source, relative, content in package_files:
             destination = f"skills/{skill_id}/{relative.as_posix()}"
@@ -1057,6 +1283,8 @@ class SandboxToolsetProvider:
             files.append(destination)
             relative_path = relative.as_posix()
             application_resource_paths.append(relative_path)
+            if self._is_utf8_text(content, path=relative_path):
+                application_text_resource_paths.append(relative_path)
             application_resource_digests[relative_path] = hashlib.sha256(
                 content
             ).hexdigest()
@@ -1071,6 +1299,7 @@ class SandboxToolsetProvider:
                 "application_method": "skill_stage",
                 "application_version_id": version_id,
                 "application_resource_paths": application_resource_paths,
+                "application_text_resource_paths": application_text_resource_paths,
                 "application_resource_digests": application_resource_digests,
                 "application_expected_resource_digests": (
                     application_resource_digests


### PR DESCRIPTION
## Dependency
- 依赖 PR #244；本 PR base 暂指向 codex/skill-runtime-guidance-foundation。
- PR #244 合并后再将 base 切换到 main 并复核最终差异。

## Summary
- skills_runtime 自动提供只读 list/read/search 工具，不授予 write、shell 或网络。
- skill_stage 保存服务端资源映射，read/search 产生绑定路径与 digest 的 Application Receipt。
- 过滤旧 workspace、未暂存资源和被动二进制；脚本不会自动执行。
- 映射可跨 HITL 与 Store 重载恢复，正文、查询和参数不进入 receipt 或状态事件。

## Falsification fixes
- ASCII-only PDF 等被动资源按后缀和 magic 失败关闭，不冒充 UTF-8 文本。
- skill_read 与 skill_stage 在输出或写入前核对冻结版本的全包 digest。
- 冻结包失配返回 skill_application_contract_stale，并撤销 verified receipt。

## Validation
- 最新基线：origin/main@90401970，加 PR #244。
- 原始攻击用例全部转绿。
- Skill/Workflow 核心受影响回归：139 passed。
- Evaluation、导入、生命周期和 Sandbox 交叉回归：55 passed。
- 上游 Workflow R17 交叉回归：99 passed。
- AST、diff check、路径白名单与敏感信息扫描通过。

## Rollback
设置 SKILL_RUNTIME_GUIDANCE_V2_ENABLED=false；已保存 receipt 与工作流数据保留。