### PR TITLE
feature: R5B Managed Chat preferred 稳定路由

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,7 +85,7 @@ MODEL_MIRROR_PROVIDER_CHAT_CERTIFICATION_ENABLED=true
 MODEL_MIRROR_PROVIDER_CHAT_CERTIFICATION_MAX_AGE_SECONDS=86400
 # 仅控制用户显式会话 Canary；默认关闭，不改变当前默认数据面。
 MODEL_MIRROR_PROVIDER_CHAT_CANARY_ENABLED=false
-# R5 Managed Chat 部署总开关。R5A 只保存策略和资格；默认关闭且不接管 /api/chat。
+# R5 Managed Chat 部署总开关。默认关闭；R5B 仅接管 preferred 白名单普通文本。
 MODEL_CONTROL_CHAT_ENABLED=false
 # 生产环境外部注入规范主密钥；启用强制模式后不回退旧变量或本地密钥文件。
 MODEL_MIRROR_CREDENTIAL_MASTER_KEY=

--- a/client/src/components/settings/ProviderChatControlSettings.test.tsx
+++ b/client/src/components/settings/ProviderChatControlSettings.test.tsx
@@ -6,7 +6,7 @@ import ProviderChatControlSettings from "./ProviderChatControlSettings";
 const policy = {
   contract_version: "modelmirror-provider-chat-routing-v1",
   feature_enabled: false,
-  data_plane_integrated: false,
+  data_plane_integrated: true,
   configured_mode: "legacy",
   effective_mode: "legacy",
   auto_enabled: false,
@@ -24,7 +24,7 @@ const policy = {
 describe("ProviderChatControlSettings", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("keeps R5A data plane pending and saves an atomic revisioned policy", async () => {
+  it("describes the bounded R5B data plane and saves an atomic revisioned policy", async () => {
     const calls: Array<[RequestInfo | URL, RequestInit | undefined]> = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       calls.push([input, init]);
@@ -37,9 +37,7 @@ describe("ProviderChatControlSettings", () => {
             request_count: 0,
             observed_days: 0,
             success_rate: null,
-            blocking_reason_codes: [
-              "provider_chat_control_data_plane_pending_r5b",
-            ],
+            blocking_reason_codes: ["provider_chat_required_gate_pending_r5e"],
           }),
         );
       }
@@ -76,8 +74,8 @@ describe("ProviderChatControlSettings", () => {
     });
 
     render(<ProviderChatControlSettings csrfToken="csrf-test" />);
-    expect(await screen.findByText("R5A 管理与资格基础")).toBeInTheDocument();
-    expect(screen.getByText(/不会改变普通 Chat/)).toBeInTheDocument();
+    expect(await screen.findByText("R5B 普通文本稳定路由")).toBeInTheDocument();
+    expect(screen.getByText(/只接管白名单内的 default 普通文本/)).toBeInTheDocument();
     expect(
       (screen.getByRole("option", { name: /newapi_required_default/ }) as HTMLOptionElement)
         .disabled,

--- a/client/src/components/settings/ProviderChatControlSettings.tsx
+++ b/client/src/components/settings/ProviderChatControlSettings.tsx
@@ -260,7 +260,9 @@ export default function ProviderChatControlSettings({
         }),
       });
       if (!response.ok) throw new Error(await readError(response));
-      setMessage("Chat 控制策略已原子保存；R5A 不会改变 /api/chat 数据面。");
+      setMessage(
+        "Chat 控制策略已原子保存；newapi_preferred 仅在部署总开关开启时接管白名单普通文本。",
+      );
       await load();
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : "保存策略失败。");
@@ -275,10 +277,10 @@ export default function ProviderChatControlSettings({
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p className="text-sm font-semibold text-cyan-100">Managed Chat 控制策略</p>
-            <h2 className="mt-2 text-xl font-semibold text-white">R5A 管理与资格基础</h2>
+            <h2 className="mt-2 text-xl font-semibold text-white">R5B 普通文本稳定路由</h2>
             <p className="mt-2 max-w-[78ch] text-sm leading-6 text-slate-300">
-              本页只保存租户策略、逐能力路由和稳定模型资格。当前数据面尚未接入，
-              不会改变普通 Chat、Auto、Canary 或现有默认网关。
+              newapi_preferred 只接管白名单内的 default 普通文本与已提取文本附件。
+              Auto、工具、文件输出、多模态和 Canary 仍保持各自现有路径。
             </p>
           </div>
           <button
@@ -312,7 +314,7 @@ export default function ProviderChatControlSettings({
                 value={mode}
               >
                 <option value="legacy">legacy（保持现有静态路径）</option>
-                <option value="newapi_preferred">newapi_preferred（R5B 后生效）</option>
+                <option value="newapi_preferred">newapi_preferred（受部署总开关控制）</option>
                 <option disabled value="newapi_required_default">
                   newapi_required_default（等待 R5E）
                 </option>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,12 +160,15 @@ Chat certification、显式 newAPI Canary 和多模态专用目录的已有证�
 Round 5A 在控制面增加 `modelmirror-provider-chat-routing-v1`：`chat_text`、
 `chat_tools` 与 `chat_file_output` 各自具有独立认证、稳定模型资格和有序 Managed
 Provider 路由。SQLite v15 保存租户隔离的策略、资格、Gate 纪元以及不含用户正文的
-父运行/尝试 Receipt。该层当前只生成可审核的 Route Plan 基础，明确返回
-`data_plane_integrated=false`；`/api/chat`、Auto、SSE 和默认网关尚未接入。
+父运行/尝试 Receipt。
 
-`MODEL_CONTROL_CHAT_ENABLED` 默认关闭，且在 R5A 中即使开启也不会改变真实调度。
-后续 R5B 必须在独立 PR 中把普通文本 default 路径接入并验证“派发前可备用、派发后不
-重放”的边界，不能把 R5A 的管理绿测解释为数据面迁移完成。
+Round 5B 将 `gateway=default` 的白名单普通文本和已提取文本附件接入该契约。仅当
+`MODEL_CONTROL_CHAT_ENABLED=true` 且租户策略为 `newapi_preferred` 时接管；开关关闭、
+策略为 `legacy` 或模型不在稳定白名单时原样使用旧路径。首选 newAPI 只允许在资格、
+目录、凭据或 DNS/SSRF 预检失败且尚未派发 POST 时选择显式 Managed 备用。一旦 POST
+标记派发，HTTP 错误、超时、断流和不确定结果都不得调用第二 IP、Provider、模型或
+legacy 网关。Auto、工具、受控文件输出、多模态、Canary、SSE 成功字节和默认部署值
+保持不变；`newapi_required_default` 仍等待 R5E 门禁与人工批准。
 
 `/settings?section=overview|providers|routing` 共用一份 Provider 管理会话。Marble 等其他
 集成位于该门禁之外；newAPI 管理 UI 继续只通过安全外链访问，不嵌入或代理。

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -140,15 +140,19 @@ curl -H "Cache-Control: no-cache" "http://localhost:8000/api/models/control-plan
 代码时保留 v14 表；旧版本可忽略这些加法表，无需降级或重写数据库。
 
 R5A 升级至 SQLite v15 前仍需先停止 Server 写入并创建一致性备份。新增表只保存
-Managed Chat 的逐能力策略、资格、Gate 和脱敏 Receipt，不接管 `/api/chat`。部署变量：
+Managed Chat 的逐能力策略、资格、Gate 和脱敏 Receipt。R5B 可选择接管稳定白名单内的
+`gateway=default` 普通文本和已提取文本附件；部署变量：
 
 ```bash
 MODEL_CONTROL_CHAT_ENABLED=false
 ```
 
-默认值必须保持 `false`。R5A 管理接口即使在该变量开启时也会返回
-`data_plane_integrated=false`；不要据此宣称普通 Chat 已迁移。超过 90 天的运行与尝试
-记录可先 dry-run 检查：
+默认值必须保持 `false`。只有管理员已保存 `newapi_preferred`、稳定模型白名单和合格的
+有序 Managed 路由后，显式开启该变量才会接管对应普通文本。开关关闭、策略为 `legacy`
+或模型不在白名单时继续使用旧静态网关。Managed 首选目标只允许在 POST 前的资格、目录、
+凭据或出口预检失败时选择显式备用；POST 派发后不会调用第二 IP、Provider、模型或 legacy
+网关。Auto、工具、受控文件输出和多模态仍未迁移。超过 90 天的运行与尝试记录可先
+dry-run 检查：
 
 ```bash
 python -m server.model_router.cleanup_chat_receipts --storage-dir /app/model_router

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -156,7 +156,7 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
 - R4 受管 Provider 不会自动配置或接管普通 `/api/chat`。当前 default Chat 仍读取
   `LLM_GATEWAY_URL/KEY` 或 `OPENROUTER_API_KEY`；迁移和 newAPI 默认门禁属于 Round 5。
 
-## Managed Chat 策略与资格基础（Round 5A）
+## Managed Chat 策略与普通文本稳定路由（Round 5A—5B）
 
 - 内部契约版本为 `modelmirror-provider-chat-routing-v1`，将 `chat_text`、
   `chat_tools` 和 `chat_file_output` 分别认证和配置；普通文本认证不能证明工具或受控
@@ -167,10 +167,16 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
   Gate 纪元与脱敏验收证据。记录不包含 Prompt、消息、模型输出、Base URL 或凭据；遗留
   `running` 在重启后标为 `uncertain` 且不重放。
 - `GET/PUT /api/router/chat-control/policy` 使用 `expected_revision` 原子更新，避免覆盖并发
-  管理修改。`GET /api/router/chat-control/gate` 和 receipts 接口在 R5A 只提供只读门禁与
-  审计基础；required 激活尚不可用。
-- `MODEL_CONTROL_CHAT_ENABLED` 默认 `false`。即使显式打开，R5A 仍报告
-  `data_plane_integrated=false`，不会改变 default、Auto、Canary、SSE 或 legacy 网关。
+  管理修改。`GET /api/router/chat-control/gate` 和 receipts 接口提供只读门禁与脱敏运行
+  证据；required 激活仍不可用。
+- R5B 只接管 `gateway=default`、稳定模型白名单内的普通文本和已提取文本附件。
+  `MODEL_CONTROL_CHAT_ENABLED` 默认 `false`；关闭开关、选择 `legacy` 或使用白名单外模型
+  时继续走原有静态路径。
+- `newapi_preferred` 的首选 newAPI 只有在 POST 派发前的资格、目录、凭据或 DNS/SSRF
+  预检失败时才可选择显式 Managed 备用。POST 派发后不重试第二 IP，不切换备用、模型或
+  legacy Provider；逻辑运行和逐 Provider 尝试均写入不含请求/回答正文的 Receipt。
+- Auto、工具、受控文件输出、多模态与 Canary 不在 R5B 接管范围；
+  `newapi_required_default` 仍等待 R5E 的证据门禁与人工批准。
 - 清理命令 `python -m server.model_router.cleanup_chat_receipts --storage-dir <path>` 默认
   dry-run；只有显式增加 `--apply` 才会删除超过保留期的运行和尝试记录，默认保留 90 天。
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -143,7 +143,7 @@ MODEL_MIRROR_PROVIDER_CHAT_CERTIFICATION_ENABLED=true
 MODEL_MIRROR_PROVIDER_CHAT_CERTIFICATION_MAX_AGE_SECONDS=86400
 # Manual user-session Canary is opt-in at deployment and remains off by default.
 MODEL_MIRROR_PROVIDER_CHAT_CANARY_ENABLED=false
-# R5 Managed Chat master switch. R5A is management-only and never changes /api/chat.
+# R5 Managed Chat master switch. Off by default; R5B only routes preferred allowlisted text.
 MODEL_CONTROL_CHAT_ENABLED=false
 MODEL_MIRROR_CREDENTIAL_MASTER_KEY=
 MODEL_MIRROR_REQUIRE_EXTERNAL_CREDENTIAL_MASTER_KEY=false

--- a/server/main.py
+++ b/server/main.py
@@ -1039,6 +1039,7 @@ try:
         NoEligibleCandidateError,
         ProviderChatCanaryService,
         ProviderChatCanaryStreamEvidence,
+        ProviderChatStableService,
         ProviderChatTarget,
         ProviderChatTransport,
         RouterServiceError,
@@ -1054,6 +1055,7 @@ except ModuleNotFoundError:
         NoEligibleCandidateError,
         ProviderChatCanaryService,
         ProviderChatCanaryStreamEvidence,
+        ProviderChatStableService,
         ProviderChatTarget,
         ProviderChatTransport,
         RouterServiceError,
@@ -23125,6 +23127,7 @@ async def chat(payload: ChatRequest, request: Request):
         native_router_engine.service.egress_policy
     )
     chat_canary_service = ProviderChatCanaryService(router_service)
+    stable_chat_service = ProviderChatStableService(router_service)
     native_router_policy = router_service.get_policy()
     direct_audio_requested = any(
         message_has_audio(message.content) for message in payload.messages
@@ -23144,6 +23147,31 @@ async def chat(payload: ChatRequest, request: Request):
         direct_audio_requested or response_audio_requested
     )
     chat_canary_requested = payload.gateway == "newapi_canary"
+    stable_chat_shape_requested = bool(
+        stable_chat_service.control.feature_enabled()
+        and payload.gateway == "default"
+        and not is_omniroute_auto_model(payload.model_id)
+        and payload.tool_mode == "none"
+        and payload.output_mode == "none"
+        and payload.response_audio is None
+        and payload.skill_application is None
+        and payload.routing is None
+        and all(
+            isinstance(message.content, str)
+            or (
+                isinstance(message.content, list)
+                and all(
+                    isinstance(part, TextContentPart)
+                    or (
+                        isinstance(part, InputFileContentPart)
+                        and part.handling == "extract"
+                    )
+                    for part in message.content
+                )
+            )
+            for message in payload.messages
+        )
+    )
     chat_canary_session_id = (
         payload.routing.session_id
         if payload.routing is not None and payload.routing.session_id
@@ -23264,6 +23292,7 @@ async def chat(payload: ChatRequest, request: Request):
         and not use_native_router
         and not native_audio_requested
         and not direct_video_requested
+        and not stable_chat_shape_requested
     ):
         return JSONResponse(
             status_code=500,
@@ -23474,6 +23503,55 @@ async def chat(payload: ChatRequest, request: Request):
         return JSONResponse(
             status_code=500,
             content={"error": "后端校验请求时出错，请查看服务日志。"},
+        )
+
+    stable_chat_preflight = None
+    stable_chat_dispatch = None
+    use_stable_chat = False
+    if stable_chat_shape_requested:
+        try:
+            stable_chat_preflight = await stable_chat_service.begin(
+                payload.model_id, "chat_text"
+            )
+        except RouterServiceError as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"error": exc.hint, "code": exc.code},
+            )
+        except Exception:
+            logger.exception("Managed Chat preflight failed")
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "Managed Chat 路由预检失败，请检查控制面状态。",
+                    "code": "provider_chat_preflight_failed",
+                },
+            )
+        if stable_chat_preflight.intercepted:
+            stable_chat_dispatch = stable_chat_preflight.dispatch
+            if stable_chat_dispatch is None:
+                return JSONResponse(
+                    status_code=503,
+                    content={
+                        "error": "当前稳定模型没有通过预检的 Managed Provider 路径。",
+                        "code": stable_chat_preflight.error_code
+                        or "provider_chat_no_qualified_route",
+                        "route_receipt": stable_chat_preflight.route_receipt,
+                    },
+                )
+            use_stable_chat = True
+            url = stable_chat_dispatch.target.chat_completions_url
+            key = stable_chat_dispatch.target.api_key
+
+    if (
+        not url
+        and not use_native_router
+        and not native_audio_requested
+        and not direct_video_requested
+    ):
+        return JSONResponse(
+            status_code=500,
+            content={"error": LLM_GATEWAY_NOT_CONFIGURED_MESSAGE},
         )
 
     async def record_chat_skill_application_once() -> None:
@@ -24089,6 +24167,9 @@ async def chat(payload: ChatRequest, request: Request):
     chat_canary_post_started = False
     chat_canary_run_finalized = False
     chat_canary_started_at: float | None = None
+    stable_chat_post_started = False
+    stable_chat_run_finalized = False
+    stable_chat_started_at: float | None = None
     if chat_canary_requested:
         if use_chat_canary:
             try:
@@ -24177,7 +24258,7 @@ async def chat(payload: ChatRequest, request: Request):
         else httpx.AsyncClient(
             **(
                 ProviderChatTransport.client_kwargs()
-                if use_chat_canary
+                if use_chat_canary or use_stable_chat
                 else llm_client_kwargs()
             )
         )
@@ -24521,12 +24602,22 @@ async def chat(payload: ChatRequest, request: Request):
     ) -> httpx.Response:
         nonlocal chat_canary_post_started
         nonlocal chat_canary_started_at
+        nonlocal stable_chat_post_started
+        nonlocal stable_chat_started_at
         if direct_file_requested:
             logger.info("Sending file chat request model=%s code=upstream_send", model_id)
         elif use_chat_canary:
             logger.info(
                 "Sending managed chat canary request model=%s code=canary_upstream_send",
                 model_id,
+            )
+        elif use_stable_chat:
+            logger.info(
+                "Sending stable managed chat request model=%s provider_kind=%s code=managed_upstream_send",
+                model_id,
+                stable_chat_dispatch.target.provider_kind
+                if stable_chat_dispatch is not None
+                else "unknown",
             )
         else:
             logger.info("Sending chat request to model=%s gateway=%s", model_id, gateway_url)
@@ -24541,6 +24632,26 @@ async def chat(payload: ChatRequest, request: Request):
                 for target in native_plan.targets
             )
         )
+        if use_stable_chat:
+            if stable_chat_dispatch is None:
+                raise RuntimeError("provider_chat_stable_dispatch_missing")
+            if stable_chat_post_started:
+                raise RuntimeError("provider_chat_stable_duplicate_post_blocked")
+            prepared_request = (
+                provider_chat_transport.build_authorized_stream_request(
+                    client,
+                    stable_chat_dispatch.target,
+                    stable_chat_dispatch.authorized,
+                    request_payload,
+                    headers=request_headers,
+                )
+            )
+            stable_chat_service.mark_dispatched(stable_chat_dispatch)
+            stable_chat_post_started = True
+            stable_chat_started_at = time.perf_counter()
+            return await provider_chat_transport.send_authorized_stream(
+                client, prepared_request
+            )
         use_provider_chat_contract = bool(
             not native_audio_requested
             and not direct_video_requested
@@ -24844,15 +24955,75 @@ async def chat(payload: ChatRequest, request: Request):
         )
         chat_canary_run_finalized = True
 
+    def finalize_stable_chat_failure(
+        result_class: str,
+        error_code: str,
+        *,
+        status: str = "failed",
+        hard_failure: bool = False,
+    ) -> dict[str, object] | None:
+        nonlocal stable_chat_run_finalized
+        if (
+            not use_stable_chat
+            or stable_chat_dispatch is None
+            or stable_chat_run_finalized
+        ):
+            return None
+        e2e_ms = (
+            (time.perf_counter() - stable_chat_started_at) * 1000
+            if stable_chat_started_at is not None
+            else None
+        )
+        stable_chat_service.complete(
+            stable_chat_dispatch,
+            status=status,
+            result_class=result_class,
+            error_code=error_code,
+            actual_model=actual_model_id,
+            hard_failure=hard_failure,
+            e2e_ms=e2e_ms,
+        )
+        stable_chat_run_finalized = True
+        return stable_chat_service.route_receipt(
+            stable_chat_dispatch,
+            requested_model=payload.model_id,
+            actual_model=actual_model_id,
+            reason_codes=[error_code],
+            e2e_ms=e2e_ms,
+        )
+
     try:
         response = await send_initial_response()
+    except RouterServiceError as exc:
+        await finalize_runtime("error", actual_model_id, error=exc.code)
+        await close_request_client()
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={
+                "error": exc.hint,
+                "code": exc.code,
+                "route_receipt": stable_chat_service.route_receipt(
+                    stable_chat_dispatch,
+                    requested_model=payload.model_id,
+                    reason_codes=[exc.code],
+                ),
+            },
+        )
     except httpx.TimeoutException:
         finalize_chat_canary_failure(
+            "transient_failure", "provider_chat_timeout"
+        )
+        stable_receipt = finalize_stable_chat_failure(
             "transient_failure", "provider_chat_timeout"
         )
         if use_chat_canary:
             logger.warning(
                 "Managed chat canary timed out model=%s code=timeout",
+                actual_model_id,
+            )
+        elif use_stable_chat:
+            logger.warning(
+                "Managed Chat timed out model=%s code=timeout",
                 actual_model_id,
             )
         elif direct_file_requested:
@@ -24865,14 +25036,29 @@ async def chat(payload: ChatRequest, request: Request):
         finalize_native_audio_failure("timeout")
         await finalize_runtime("error", actual_model_id, error="timeout")
         await close_request_client()
-        return JSONResponse(status_code=504, content={"error": "模型响应超时，请稍后重试。"})
+        timeout_content: dict[str, object] = {
+            "error": "模型响应超时，请稍后重试。"
+        }
+        if stable_receipt is not None:
+            timeout_content.update(
+                code="provider_chat_timeout", route_receipt=stable_receipt
+            )
+        return JSONResponse(status_code=504, content=timeout_content)
     except httpx.HTTPError as exc:
         finalize_chat_canary_failure(
+            "transient_failure", "provider_chat_transport_error"
+        )
+        stable_receipt = finalize_stable_chat_failure(
             "transient_failure", "provider_chat_transport_error"
         )
         if use_chat_canary:
             logger.warning(
                 "Managed chat canary transport failed model=%s code=transport_error",
+                actual_model_id,
+            )
+        elif use_stable_chat:
+            logger.warning(
+                "Managed Chat transport failed model=%s code=transport_error",
                 actual_model_id,
             )
         elif direct_file_requested:
@@ -24897,12 +25083,30 @@ async def chat(payload: ChatRequest, request: Request):
             ),
         )
         await close_request_client()
-        return JSONResponse(status_code=502, content={"error": "模型服务暂时无法连接，请检查网络或代理配置。"})
+        transport_content: dict[str, object] = {
+            "error": "模型服务暂时无法连接，请检查网络或代理配置。"
+        }
+        if stable_receipt is not None:
+            transport_content.update(
+                code="provider_chat_transport_error",
+                route_receipt=stable_receipt,
+            )
+        return JSONResponse(status_code=502, content=transport_content)
     except Exception:
         finalize_chat_canary_failure(
             "uncertain", "provider_chat_unexpected_error", status="uncertain"
         )
-        if direct_file_requested:
+        stable_receipt = finalize_stable_chat_failure(
+            "uncertain",
+            "provider_chat_unexpected_error",
+            status="uncertain",
+        )
+        if use_stable_chat:
+            logger.warning(
+                "Managed Chat failed before stream model=%s code=upstream_error",
+                actual_model_id,
+            )
+        elif direct_file_requested:
             logger.warning(
                 "File chat upstream failed model=%s code=upstream_error",
                 actual_model_id,
@@ -24915,11 +25119,21 @@ async def chat(payload: ChatRequest, request: Request):
         finalize_native_audio_failure("upstream_error")
         await finalize_runtime("error", actual_model_id, error="unexpected upstream error")
         await close_request_client()
-        return JSONResponse(status_code=500, content={"error": "后端代理请求时出错，请查看服务日志。"})
+        unexpected_content: dict[str, object] = {
+            "error": "后端代理请求时出错，请查看服务日志。"
+        }
+        if stable_receipt is not None:
+            unexpected_content.update(
+                code="provider_chat_unexpected_error",
+                route_receipt=stable_receipt,
+            )
+        return JSONResponse(status_code=500, content=unexpected_content)
 
     if response.status_code >= 400:
         body = await response.aread()
         await response.aclose()
+        stable_http_receipt = None
+        stable_http_error_code = None
         if use_chat_canary:
             result_class, canary_error_code = (
                 chat_canary_service.classify_http_failure(response.status_code)
@@ -24932,6 +25146,29 @@ async def chat(payload: ChatRequest, request: Request):
                 response.status_code,
                 actual_model_id,
                 canary_error_code,
+            )
+        elif use_stable_chat:
+            (
+                stable_result_class,
+                stable_http_error_code,
+                stable_hard_failure,
+            ) = stable_chat_service.classify_http_failure(response.status_code)
+            stable_http_receipt = finalize_stable_chat_failure(
+                stable_result_class,
+                stable_http_error_code,
+                hard_failure=stable_hard_failure,
+            )
+            message = (
+                chat_file_upstream_error(response.status_code)[0]
+                if direct_file_requested
+                else "Managed Chat 请求失败；本次请求未重放到其他 Provider。"
+            )
+            data = None
+            logger.warning(
+                "Managed Chat failed status=%s model=%s code=%s",
+                response.status_code,
+                actual_model_id,
+                stable_http_error_code,
             )
         elif direct_file_requested:
             message, file_error_code = chat_file_upstream_error(
@@ -24956,7 +25193,7 @@ async def chat(payload: ChatRequest, request: Request):
                 response.status_code,
                 actual_model_id,
             )
-        elif not direct_file_requested and not use_chat_canary:
+        elif not direct_file_requested and not use_chat_canary and not use_stable_chat:
             logger.warning(
                 "OpenRouter error status=%s model=%s message=%s body=%s",
                 response.status_code,
@@ -24969,6 +25206,7 @@ async def chat(payload: ChatRequest, request: Request):
             not use_omniroute
             and not use_native_router
             and not use_chat_canary
+            and not use_stable_chat
             and not native_audio_requested
             and should_fallback_gateway_to_openrouter(
             response.status_code,
@@ -25064,6 +25302,7 @@ async def chat(payload: ChatRequest, request: Request):
             not use_omniroute
             and not use_native_router
             and not use_chat_canary
+            and not use_stable_chat
             and not native_audio_requested
             and response.status_code >= 400
             and should_fallback_model(
@@ -25186,9 +25425,15 @@ async def chat(payload: ChatRequest, request: Request):
             await finalize_runtime("error", actual_model_id, error=message)
             finalize_native_audio_failure(f"http_{response.status_code}")
             await close_request_client()
+            error_content: dict[str, object] = {"error": message}
+            if stable_http_receipt is not None:
+                error_content.update(
+                    code=stable_http_error_code,
+                    route_receipt=stable_http_receipt,
+                )
             return JSONResponse(
                 status_code=response.status_code,
-                content={"error": message},
+                content=error_content,
             )
 
     omniroute_header_state = (
@@ -25203,6 +25448,13 @@ async def chat(payload: ChatRequest, request: Request):
             started_at=chat_canary_started_at or chat_request_started_at
         )
         if use_chat_canary
+        else None
+    )
+    stable_chat_stream_evidence = (
+        ProviderChatCanaryStreamEvidence(
+            started_at=stable_chat_started_at or chat_request_started_at
+        )
+        if use_stable_chat
         else None
     )
     capture_chat_media = bool(
@@ -25616,6 +25868,7 @@ async def chat(payload: ChatRequest, request: Request):
 
     async def stream_response():
         nonlocal chat_canary_run_finalized
+        nonlocal stable_chat_run_finalized
         buffer = ""
         accumulated_chunks: list[str] = []
         file_stream_state: dict[str, Any] = {}
@@ -25624,9 +25877,13 @@ async def chat(payload: ChatRequest, request: Request):
         stream_completed = False
         deferred_done = False
         file_terminal_receipt: dict[str, Any] | None = None
+        stable_file_summary: dict[str, object] | None = None
+        stable_terminal_receipt: dict[str, object] | None = None
         sidecar_ttft_ms: float | None = None
         chat_canary_transport_error: str | None = None
         chat_canary_client_cancelled = False
+        stable_chat_transport_error: str | None = None
+        stable_chat_client_cancelled = False
         try:
             if fallback_notice:
                 payload_json = json.dumps(
@@ -25652,6 +25909,8 @@ async def chat(payload: ChatRequest, request: Request):
                 for line in complete_lines:
                     if chat_canary_stream_evidence is not None:
                         chat_canary_stream_evidence.feed(line)
+                    if stable_chat_stream_evidence is not None:
+                        stable_chat_stream_evidence.feed(line)
                     if use_omniroute:
                         update_stream_state(line, omniroute_stream_state)
                         if (
@@ -25671,13 +25930,13 @@ async def chat(payload: ChatRequest, request: Request):
                     if line.lstrip().startswith(":"):
                         continue
                     if (
-                        (use_omniroute or native_audio_requested or direct_file_requested or capture_chat_media or chat_canary_requested)
+                        (use_omniroute or native_audio_requested or direct_file_requested or capture_chat_media or chat_canary_requested or use_stable_chat)
                         and line.strip() == "data: [DONE]"
                     ):
                         deferred_done = True
                         continue
                     if (
-                        (use_omniroute or native_audio_requested or direct_file_requested or capture_chat_media or chat_canary_requested)
+                        (use_omniroute or native_audio_requested or direct_file_requested or capture_chat_media or chat_canary_requested or use_stable_chat)
                         and deferred_done
                         and not line.strip()
                     ):
@@ -25687,20 +25946,30 @@ async def chat(payload: ChatRequest, request: Request):
                 await asyncio.sleep(0)
             stream_completed = True
         except asyncio.CancelledError:
-            if not use_chat_canary:
+            if not use_chat_canary and not use_stable_chat:
                 raise
             runtime_status = "error"
             runtime_error = "client cancelled"
             chat_canary_transport_error = "provider_chat_client_cancelled"
             chat_canary_client_cancelled = True
+            if use_stable_chat:
+                stable_chat_transport_error = "provider_chat_client_cancelled"
+                stable_chat_client_cancelled = True
         except httpx.HTTPError:
             runtime_status = "error"
             runtime_error = "stream interrupted"
             if use_chat_canary:
                 chat_canary_transport_error = "provider_chat_stream_interrupted"
+            if use_stable_chat:
+                stable_chat_transport_error = "provider_chat_stream_interrupted"
             if direct_file_requested:
                 logger.warning(
                     "File chat stream failed model=%s code=stream_interrupted",
+                    actual_model_id,
+                )
+            elif use_stable_chat:
+                logger.warning(
+                    "Managed Chat stream failed model=%s code=stream_interrupted",
                     actual_model_id,
                 )
             else:
@@ -25716,9 +25985,16 @@ async def chat(payload: ChatRequest, request: Request):
             runtime_error = "stream proxy failed"
             if use_chat_canary:
                 chat_canary_transport_error = "provider_chat_stream_interrupted"
+            if use_stable_chat:
+                stable_chat_transport_error = "provider_chat_stream_interrupted"
             if direct_file_requested:
                 logger.warning(
                     "File chat stream failed model=%s code=stream_proxy_failed",
+                    actual_model_id,
+                )
+            elif use_stable_chat:
+                logger.warning(
+                    "Managed Chat stream failed model=%s code=stream_proxy_failed",
                     actual_model_id,
                 )
             else:
@@ -25767,9 +26043,45 @@ async def chat(payload: ChatRequest, request: Request):
                     "error", actual_model_id, error="client cancelled"
                 )
                 return
+            if (
+                stable_chat_client_cancelled
+                and stable_chat_stream_evidence is not None
+                and stable_chat_dispatch is not None
+                and not stable_chat_run_finalized
+            ):
+                e2e_ms = (
+                    (time.perf_counter() - stable_chat_started_at) * 1000
+                    if stable_chat_started_at is not None
+                    else None
+                )
+                stable_chat_service.complete(
+                    stable_chat_dispatch,
+                    status="cancelled",
+                    result_class="client_cancelled",
+                    error_code="provider_chat_client_cancelled",
+                    actual_model=(
+                        stable_chat_stream_evidence.actual_model
+                        or actual_model_id
+                    ),
+                    client_cancelled=True,
+                    ttft_ms=stable_chat_stream_evidence.ttft_ms,
+                    e2e_ms=e2e_ms,
+                    prompt_tokens=stable_chat_stream_evidence.prompt_tokens,
+                    completion_tokens=stable_chat_stream_evidence.completion_tokens,
+                    total_tokens=stable_chat_stream_evidence.total_tokens,
+                )
+                stable_chat_run_finalized = True
+                await response.aclose()
+                await close_request_client()
+                await finalize_runtime(
+                    "error", actual_model_id, error="client cancelled"
+                )
+                return
             if buffer:
                 if chat_canary_stream_evidence is not None:
                     chat_canary_stream_evidence.feed(buffer)
+                if stable_chat_stream_evidence is not None:
+                    stable_chat_stream_evidence.feed(buffer)
                 if use_omniroute:
                     update_stream_state(buffer, omniroute_stream_state)
                     if (
@@ -25789,7 +26101,7 @@ async def chat(payload: ChatRequest, request: Request):
                 if buffer.lstrip().startswith(":"):
                     pass
                 elif (
-                    (use_omniroute or native_audio_requested or direct_file_requested or capture_chat_media or chat_canary_requested)
+                    (use_omniroute or native_audio_requested or direct_file_requested or capture_chat_media or chat_canary_requested or use_stable_chat)
                     and buffer.strip() == "data: [DONE]"
                 ):
                     deferred_done = True
@@ -25870,7 +26182,10 @@ async def chat(payload: ChatRequest, request: Request):
                         resolved_chat_files,
                         originals_retained=originals_retained,
                     )
-                    file_terminal_receipt = receipt
+                    if use_stable_chat:
+                        stable_file_summary = receipt["files"]
+                    else:
+                        file_terminal_receipt = receipt
                 elif runtime_status in {"completed", "output_limit"}:
                     runtime_status = "error"
                     runtime_error = (
@@ -26260,6 +26575,71 @@ async def chat(payload: ChatRequest, request: Request):
                         "version": "2",
                     }
                 )
+            if use_stable_chat and stable_chat_stream_evidence is not None:
+                (
+                    stable_status,
+                    stable_result_class,
+                    stable_error_code,
+                    _stable_checks,
+                    _stable_warnings,
+                ) = stable_chat_stream_evidence.finish(
+                    transport_completed=stream_completed,
+                    transport_error_code=stable_chat_transport_error,
+                )
+                observed_model = (
+                    stable_chat_stream_evidence.actual_model or actual_model_id
+                )
+                if (
+                    stable_status == "succeeded"
+                    and stable_chat_stream_evidence.actual_model is not None
+                    and stable_chat_stream_evidence.actual_model != payload.model_id
+                ):
+                    stable_status = "failed"
+                    stable_result_class = "hard_failure"
+                    stable_error_code = "provider_chat_model_mismatch"
+                e2e_ms = (
+                    (time.perf_counter() - stable_chat_started_at) * 1000
+                    if stable_chat_started_at is not None
+                    else None
+                )
+                if stable_chat_dispatch is not None and not stable_chat_run_finalized:
+                    stable_chat_service.complete(
+                        stable_chat_dispatch,
+                        status=stable_status,
+                        result_class=stable_result_class,
+                        error_code=stable_error_code,
+                        actual_model=observed_model,
+                        client_cancelled=stable_result_class == "client_cancelled",
+                        hard_failure=stable_result_class == "hard_failure",
+                        ttft_ms=stable_chat_stream_evidence.ttft_ms,
+                        e2e_ms=e2e_ms,
+                        prompt_tokens=stable_chat_stream_evidence.prompt_tokens,
+                        completion_tokens=stable_chat_stream_evidence.completion_tokens,
+                        total_tokens=stable_chat_stream_evidence.total_tokens,
+                    )
+                    stable_chat_run_finalized = True
+                if stable_status != "succeeded":
+                    runtime_status = "error"
+                    runtime_error = stable_error_code or "provider_chat_stream_failed"
+                stable_terminal_receipt = stable_chat_service.route_receipt(
+                    stable_chat_dispatch,
+                    requested_model=payload.model_id,
+                    actual_model=observed_model,
+                    reason_codes=(
+                        [stable_error_code] if stable_error_code else ["qualified"]
+                    ),
+                    request_id=response.headers.get("x-request-id"),
+                    ttft_ms=stable_chat_stream_evidence.ttft_ms,
+                    e2e_ms=e2e_ms,
+                    prompt_tokens=stable_chat_stream_evidence.prompt_tokens,
+                    completion_tokens=stable_chat_stream_evidence.completion_tokens,
+                    total_tokens=stable_chat_stream_evidence.total_tokens,
+                )
+                if stable_file_summary is not None:
+                    stable_terminal_receipt["files"] = stable_file_summary
+                if not direct_file_requested:
+                    yield route_receipt_sse(stable_terminal_receipt)
+
             if use_chat_canary and chat_canary_stream_evidence is not None:
                 (
                     canary_status,
@@ -26375,6 +26755,17 @@ async def chat(payload: ChatRequest, request: Request):
                     }
                 )
             if direct_file_requested:
+                if use_stable_chat:
+                    file_terminal_receipt = (
+                        stable_terminal_receipt
+                        if runtime_status in {"completed", "output_limit"}
+                        else None
+                    )
+                    if (
+                        file_terminal_receipt is None
+                        and stable_terminal_receipt is not None
+                    ):
+                        yield route_receipt_sse(stable_terminal_receipt)
                 for event in chat_file_terminal_events(
                     file_terminal_receipt,
                     failure_error_emitted=runtime_status == "error",
@@ -26387,6 +26778,7 @@ async def chat(payload: ChatRequest, request: Request):
                 or native_audio_succeeded
                 or captured_outputs
                 or chat_canary_requested
+                or use_stable_chat
             ):
                 yield b"data: [DONE]\n\n"
             if runtime_status in {"completed", "output_limit"}:

--- a/server/model_router/__init__.py
+++ b/server/model_router/__init__.py
@@ -50,6 +50,11 @@ from .chat_canary import (
     ProviderChatCanaryService,
     ProviderChatCanaryStreamEvidence,
 )
+from .chat_stable import (
+    ProviderChatStableDispatch,
+    ProviderChatStablePreflight,
+    ProviderChatStableService,
+)
 
 __all__ = [
     "CompressionMode",
@@ -69,6 +74,9 @@ __all__ = [
     "ProviderChatCanaryDispatch",
     "ProviderChatCanaryService",
     "ProviderChatCanaryStreamEvidence",
+    "ProviderChatStableDispatch",
+    "ProviderChatStablePreflight",
+    "ProviderChatStableService",
     "ProviderChatEndpointResolver",
     "ProviderChatTarget",
     "ProviderChatTransport",

--- a/server/model_router/chat_control.py
+++ b/server/model_router/chat_control.py
@@ -40,10 +40,7 @@ CHAT_CONTROL_CAPABILITIES: tuple[ProviderChatCapability, ...] = (
 
 
 class ProviderChatControlService:
-    """R5A management-plane policy, qualification, and receipt foundation.
-
-    The service deliberately does not participate in /api/chat dispatch until R5B.
-    """
+    """Managed Chat policy, qualification, gate, and receipt foundation."""
 
     def __init__(self, router_service: ModelRouterService) -> None:
         self.router_service = router_service
@@ -68,7 +65,7 @@ class ProviderChatControlService:
         if payload.mode == "newapi_required_default":
             raise RouterServiceError(
                 "provider_chat_required_activation_not_available",
-                "R5A 仅建设管理基础；强制默认必须等待 R5E 门禁和人工批准。",
+                "强制默认必须等待 R5E 门禁和人工批准。",
                 status_code=409,
             )
 
@@ -190,11 +187,11 @@ class ProviderChatControlService:
             blockers.append("provider_chat_control_text_route_required")
         if any(not item.valid for item in policy.qualifications):
             blockers.append("provider_chat_control_qualification_stale")
-        blockers.append("provider_chat_control_data_plane_pending_r5b")
         blockers.append("provider_chat_required_gate_pending_r5e")
         return ProviderChatControlGateResponse(
             contract_version=PROVIDER_CHAT_ROUTING_CONTRACT_VERSION,
             feature_enabled=policy.feature_enabled,
+            data_plane_integrated=True,
             policy_fingerprint=policy.policy_fingerprint,
             configured_mode=policy.configured_mode,
             blocking_reason_codes=list(dict.fromkeys(blockers)),
@@ -218,19 +215,53 @@ class ProviderChatControlService:
             else "legacy"
         )
         enabled = self.feature_enabled()
-        reason = (
-            "provider_chat_control_feature_disabled"
-            if not enabled
-            else "provider_chat_control_data_plane_pending_r5b"
-        )
+        if not enabled:
+            reason = "provider_chat_control_feature_disabled"
+            available = False
+            would_block = False
+        elif configured_mode == "legacy":
+            reason = "provider_chat_control_legacy_mode"
+            available = False
+            would_block = False
+        else:
+            policy = self._policy_response(bundle)
+            if clean_model not in policy.stable_model_ids:
+                reason = "provider_chat_model_not_stable"
+                available = False
+                would_block = False
+            else:
+                text_route = next(
+                    (
+                        route
+                        for route in policy.routes
+                        if route.capability == capability
+                    ),
+                    None,
+                )
+                route_ids = text_route.connection_ids if text_route else []
+                valid_ids = {
+                    item.connection_id
+                    for item in policy.qualifications
+                    if item.capability == capability
+                    and item.model_id == clean_model
+                    and item.valid
+                }
+                available = any(item in valid_ids for item in route_ids)
+                would_block = not available
+                reason = (
+                    "qualified"
+                    if available
+                    else "provider_chat_no_qualified_route"
+                )
         return ProviderChatControlPublicStatus(
             contract_version=PROVIDER_CHAT_ROUTING_CONTRACT_VERSION,
             feature_enabled=enabled,
+            data_plane_integrated=True,
             model_id=clean_model,
             capability=capability,
             effective_mode=configured_mode if enabled else "legacy",
-            available=False,
-            would_block=False,
+            available=available,
+            would_block=would_block,
             reason_code=reason,
         )
 
@@ -350,6 +381,7 @@ class ProviderChatControlService:
             return ProviderChatControlPolicyResponse(
                 contract_version=PROVIDER_CHAT_ROUTING_CONTRACT_VERSION,
                 feature_enabled=self.feature_enabled(),
+                data_plane_integrated=True,
                 configured_mode="legacy",
                 effective_mode="legacy",
                 auto_enabled=False,
@@ -377,6 +409,7 @@ class ProviderChatControlService:
         return ProviderChatControlPolicyResponse(
             contract_version=PROVIDER_CHAT_ROUTING_CONTRACT_VERSION,
             feature_enabled=enabled,
+            data_plane_integrated=True,
             configured_mode=configured_mode,
             effective_mode=configured_mode if enabled else "legacy",
             auto_enabled=bool(policy["auto_enabled"]),

--- a/server/model_router/chat_stable.py
+++ b/server/model_router/chat_stable.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+
+from .chat_control import ProviderChatControlService
+from .egress import AuthorizedProviderTarget, ProviderEgressError
+from .provider_chat import ProviderChatTarget, ProviderChatTransport
+from .schemas import ProviderChatCapability
+from .service import ModelRouterService, RouterServiceError
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderChatStableDispatch:
+    run_id: str
+    attempt_id: str
+    policy_fingerprint: str
+    capability: ProviderChatCapability
+    requested_model: str
+    target: ProviderChatTarget
+    authorized: AuthorizedProviderTarget
+    position: int
+    reason_codes: tuple[str, ...]
+    started_at: float
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderChatStablePreflight:
+    intercepted: bool
+    dispatch: ProviderChatStableDispatch | None = None
+    error_code: str | None = None
+    route_receipt: dict[str, object] | None = None
+
+
+class ProviderChatStableService:
+    """Plan one stable Managed Chat request without storing request content."""
+
+    def __init__(self, router_service: ModelRouterService) -> None:
+        self.router_service = router_service
+        self.repository = router_service.repository
+        self.control = ProviderChatControlService(router_service)
+        self.transport = ProviderChatTransport(router_service.egress_policy)
+
+    async def begin(
+        self,
+        model_id: str,
+        capability: ProviderChatCapability = "chat_text",
+    ) -> ProviderChatStablePreflight:
+        if not self.control.feature_enabled():
+            return ProviderChatStablePreflight(intercepted=False)
+        policy = self.control.get_policy()
+        clean_model = str(model_id or "").strip()
+        if (
+            policy.effective_mode == "legacy"
+            or clean_model not in policy.stable_model_ids
+        ):
+            return ProviderChatStablePreflight(intercepted=False)
+
+        route = next(
+            (item for item in policy.routes if item.capability == capability),
+            None,
+        )
+        route_ids = list(route.connection_ids if route else [])
+        epoch = self._repository_method("get_open_chat_control_gate_epoch")(
+            self.router_service.tenant_id,
+            policy.policy_fingerprint,
+        )
+        run_id = f"chatrun_{uuid.uuid4().hex}"
+        self._repository_method("claim_chat_control_run")(
+            self.router_service.tenant_id,
+            run_id=run_id,
+            policy_fingerprint=policy.policy_fingerprint,
+            capability=capability,
+            requested_model=clean_model,
+            strategy=policy.effective_mode,
+            gateway="default",
+            epoch_id=str(epoch["id"]) if epoch is not None else None,
+            is_real_user=True,
+            primary_newapi=True,
+        )
+
+        qualification_by_connection = {
+            item.connection_id: item
+            for item in policy.qualifications
+            if item.capability == capability and item.model_id == clean_model
+        }
+        failures: list[str] = []
+        for position, connection_id in enumerate(route_ids):
+            connection = self.repository.get_connection(
+                self.router_service.tenant_id, connection_id
+            )
+            attempt_id = f"chatattempt_{uuid.uuid4().hex}"
+            self._repository_method("claim_chat_control_attempt")(
+                self.router_service.tenant_id,
+                attempt_id=attempt_id,
+                run_id=run_id,
+                capability=capability,
+                position=position,
+                connection_id=connection_id,
+                provider_kind=connection.kind,
+            )
+            qualification = qualification_by_connection.get(connection_id)
+            if qualification is None or not qualification.valid:
+                reason = (
+                    qualification.reason_code
+                    if qualification is not None
+                    else "provider_chat_qualification_missing"
+                )
+                self._complete_preflight_attempt(attempt_id, reason)
+                failures.append(reason)
+                continue
+            try:
+                target = ProviderChatTarget.create(
+                    source="managed",
+                    provider_kind=connection.kind,
+                    base_url=connection.base_url,
+                    api_key=self.repository.resolve_api_key(
+                        self.router_service.tenant_id, connection_id
+                    ),
+                    connection_id=connection_id,
+                )
+                authorized = await self.transport.authorize_managed_target(target)
+            except ProviderEgressError as exc:
+                self._complete_preflight_attempt(attempt_id, exc.code)
+                failures.append(exc.code)
+                continue
+            except Exception as exc:
+                reason = getattr(exc, "code", None) or "provider_chat_preflight_failed"
+                self._complete_preflight_attempt(attempt_id, str(reason))
+                failures.append(str(reason))
+                continue
+
+            reason_codes = list(dict.fromkeys(failures))
+            if position:
+                reason_codes.append("provider_chat_preflight_backup_selected")
+            return ProviderChatStablePreflight(
+                intercepted=True,
+                dispatch=ProviderChatStableDispatch(
+                    run_id=run_id,
+                    attempt_id=attempt_id,
+                    policy_fingerprint=policy.policy_fingerprint,
+                    capability=capability,
+                    requested_model=clean_model,
+                    target=target,
+                    authorized=authorized,
+                    position=position,
+                    reason_codes=tuple(reason_codes),
+                    started_at=time.perf_counter(),
+                ),
+            )
+
+        error_code = failures[-1] if failures else "provider_chat_no_qualified_route"
+        self._repository_method("complete_chat_control_run")(
+            self.router_service.tenant_id,
+            run_id,
+            status="failed",
+            result_class="preflight_failure",
+            reason_codes=list(dict.fromkeys(failures or [error_code])),
+        )
+        return ProviderChatStablePreflight(
+            intercepted=True,
+            error_code=error_code,
+            route_receipt=self.route_receipt(
+                None,
+                requested_model=clean_model,
+                reason_codes=list(dict.fromkeys(failures or [error_code])),
+            ),
+        )
+
+    def mark_dispatched(self, dispatch: ProviderChatStableDispatch) -> None:
+        policy = self.control.get_policy()
+        qualification = next(
+            (
+                item
+                for item in policy.qualifications
+                if item.capability == dispatch.capability
+                and item.model_id == dispatch.requested_model
+                and item.connection_id == dispatch.target.connection_id
+            ),
+            None,
+        )
+        if (
+            policy.effective_mode != "newapi_preferred"
+            or policy.policy_fingerprint != dispatch.policy_fingerprint
+            or qualification is None
+            or not qualification.valid
+        ):
+            code = "provider_chat_policy_or_qualification_changed"
+            self._complete_preflight_attempt(dispatch.attempt_id, code)
+            self._repository_method("complete_chat_control_run")(
+                self.router_service.tenant_id,
+                dispatch.run_id,
+                status="failed",
+                result_class="preflight_failure",
+                reason_codes=[code],
+            )
+            raise RouterServiceError(
+                code,
+                "Chat 路由策略或资格已变化，请刷新设置后重试。",
+                status_code=409,
+            )
+        self._repository_method("mark_chat_control_attempt_dispatched")(
+            self.router_service.tenant_id, dispatch.attempt_id
+        )
+
+    def complete(
+        self,
+        dispatch: ProviderChatStableDispatch,
+        *,
+        status: str,
+        result_class: str,
+        error_code: str | None = None,
+        actual_model: str | None = None,
+        client_cancelled: bool = False,
+        hard_failure: bool = False,
+        ttft_ms: float | None = None,
+        e2e_ms: float | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+        reason_codes: list[str] | None = None,
+    ) -> None:
+        codes = list(dispatch.reason_codes)
+        if reason_codes:
+            codes.extend(reason_codes)
+        if error_code:
+            codes.append(error_code)
+        codes = list(dict.fromkeys(codes))
+        self._repository_method("complete_chat_control_attempt")(
+            self.router_service.tenant_id,
+            dispatch.attempt_id,
+            status=status,
+            result_class=result_class,
+            error_code=error_code,
+            actual_model=actual_model,
+            ttft_ms=ttft_ms,
+            e2e_ms=e2e_ms,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+        )
+        self._repository_method("complete_chat_control_run")(
+            self.router_service.tenant_id,
+            dispatch.run_id,
+            status=status,
+            result_class=result_class,
+            reason_codes=codes,
+            actual_model=actual_model,
+            client_cancelled=client_cancelled,
+            hard_failure=hard_failure,
+            ttft_ms=ttft_ms,
+            e2e_ms=e2e_ms,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+        )
+
+    @staticmethod
+    def classify_http_failure(status_code: int) -> tuple[str, str, bool]:
+        code = f"provider_chat_http_{status_code}"
+        if status_code in {401, 402, 403, 404}:
+            return "hard_failure", code, True
+        if status_code == 429 or status_code >= 500:
+            return "transient_failure", code, False
+        return "request_failure", code, False
+
+    @staticmethod
+    def route_receipt(
+        dispatch: ProviderChatStableDispatch | None,
+        *,
+        requested_model: str,
+        actual_model: str | None = None,
+        reason_codes: list[str] | None = None,
+        request_id: str | None = None,
+        ttft_ms: float | None = None,
+        e2e_ms: float | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+    ) -> dict[str, object]:
+        codes = list(dispatch.reason_codes) if dispatch is not None else []
+        codes.extend(reason_codes or [])
+        return {
+            "requested_model": requested_model,
+            "actual_model": actual_model or requested_model,
+            "provider": None,
+            "strategy": "newapi_preferred",
+            "engine": (
+                dispatch.target.provider_kind
+                if dispatch is not None
+                else "managed_chat_blocked"
+            ),
+            "reason_codes": list(dict.fromkeys(codes)),
+            "latency_ms": e2e_ms,
+            "ttft_ms": ttft_ms,
+            "tokens": {
+                "input": prompt_tokens,
+                "output": completion_tokens,
+                "total": total_tokens,
+            },
+            "response_cost_usd": None,
+            "cost_kind": "unavailable",
+            "fallback_attempts": dispatch.position if dispatch is not None else 0,
+            "cache_hit": None,
+            "request_id": request_id,
+            "version": "2",
+        }
+
+    def _complete_preflight_attempt(self, attempt_id: str, code: str) -> None:
+        self._repository_method("complete_chat_control_attempt")(
+            self.router_service.tenant_id,
+            attempt_id,
+            status="failed",
+            result_class="preflight_failure",
+            error_code=code,
+        )
+
+    def _repository_method(self, name: str):
+        method = getattr(self.repository, name, None)
+        if not callable(method):
+            raise RouterServiceError(
+                "provider_chat_control_storage_unavailable",
+                "当前 Router 存储不支持 Managed Chat 路由。",
+                status_code=503,
+            )
+        return method

--- a/server/model_router/provider_chat.py
+++ b/server/model_router/provider_chat.py
@@ -7,7 +7,7 @@ from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 import httpx
 
-from .egress import ProviderEgressPolicy
+from .egress import AuthorizedProviderTarget, ProviderEgressPolicy
 
 
 PROVIDER_CHAT_CONTRACT_VERSION = "modelmirror-provider-chat-v1"
@@ -179,6 +179,45 @@ class ProviderChatTransport:
         return await client.send(
             request,
             stream=True,
+        )
+
+    async def authorize_managed_target(
+        self, target: ProviderChatTarget
+    ) -> AuthorizedProviderTarget:
+        if target.source != "managed":
+            raise ValueError("provider_chat_managed_target_required")
+        return await self.egress_policy.authorize(target.chat_completions_url)
+
+    @staticmethod
+    def build_authorized_stream_request(
+        client: httpx.AsyncClient,
+        target: ProviderChatTarget,
+        authorized: AuthorizedProviderTarget,
+        payload: Mapping[str, object],
+        *,
+        headers: Mapping[str, str] | None = None,
+    ) -> httpx.Request:
+        """Build one pinned request so dispatch can be recorded before send."""
+
+        if target.source != "managed":
+            raise ValueError("provider_chat_managed_target_required")
+        request_headers = target.authorization_headers(headers)
+        return client.build_request(
+            "POST",
+            authorized.pinned_urls[0],
+            headers=authorized.request_headers(request_headers),
+            extensions=authorized.extensions,
+            json=dict(payload),
+        )
+
+    @staticmethod
+    async def send_authorized_stream(
+        client: httpx.AsyncClient, request: httpx.Request
+    ) -> httpx.Response:
+        return await client.send(
+            request,
+            stream=True,
+            follow_redirects=False,
         )
 
     @asynccontextmanager

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -2223,6 +2223,23 @@ class SQLiteRouterRepository:
             ).fetchone()
         return dict(row)
 
+    def get_open_chat_control_gate_epoch(
+        self, tenant_id: str, policy_fingerprint: str
+    ) -> dict[str, object] | None:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM provider_chat_gate_epochs
+                WHERE tenant_id = ? AND policy_fingerprint = ?
+                  AND status = 'open' AND closed_at IS NULL
+                ORDER BY started_at DESC, id DESC
+                LIMIT 1
+                """,
+                (clean_tenant, policy_fingerprint),
+            ).fetchone()
+        return dict(row) if row is not None else None
+
     def claim_chat_canary_run(
         self,
         tenant_id: str,

--- a/server/tests/test_provider_chat_control_api.py
+++ b/server/tests/test_provider_chat_control_api.py
@@ -33,7 +33,7 @@ def _app(tmp_path: Path) -> FastAPI:
 
 
 @pytest.mark.asyncio
-async def test_public_status_is_redacted_no_store_and_does_not_gate_data_plane(
+async def test_public_status_is_redacted_no_store_and_reports_r5b_integration(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -49,7 +49,7 @@ async def test_public_status_is_redacted_no_store_and_does_not_gate_data_plane(
     assert response.headers["cache-control"] == "no-store"
     payload = response.json()
     assert payload["contract_version"] == "modelmirror-provider-chat-routing-v1"
-    assert payload["data_plane_integrated"] is False
+    assert payload["data_plane_integrated"] is True
     assert payload["available"] is False
     assert payload["would_block"] is False
     assert "tenant" not in response.text
@@ -102,7 +102,11 @@ async def test_admin_policy_gate_and_receipts_require_session_and_csrf(
         gate = await client.get("/api/router/chat-control/gate")
         assert gate.status_code == 200
         assert gate.json()["required_activation_available"] is False
-        assert "provider_chat_control_data_plane_pending_r5b" in gate.json()[
+        assert gate.json()["data_plane_integrated"] is True
+        assert "provider_chat_control_data_plane_pending_r5b" not in gate.json()[
+            "blocking_reason_codes"
+        ]
+        assert "provider_chat_required_gate_pending_r5e" in gate.json()[
             "blocking_reason_codes"
         ]
         receipts = await client.get("/api/router/chat-control/receipts")

--- a/server/tests/test_provider_chat_control_service.py
+++ b/server/tests/test_provider_chat_control_service.py
@@ -105,7 +105,7 @@ def _service(tmp_path: Path) -> tuple[ProviderChatControlService, SQLiteRouterRe
     return ProviderChatControlService(ModelRouterService(repository)), repository
 
 
-def test_default_policy_is_legacy_and_r5a_public_status_never_blocks(
+def test_default_policy_is_legacy_and_r5b_public_status_never_blocks(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -118,7 +118,7 @@ def test_default_policy_is_legacy_and_r5a_public_status_never_blocks(
     assert policy.configured_mode == "legacy"
     assert policy.effective_mode == "legacy"
     assert policy.feature_enabled is False
-    assert policy.data_plane_integrated is False
+    assert policy.data_plane_integrated is True
     assert public.available is False
     assert public.would_block is False
     assert public.reason_code == "provider_chat_control_feature_disabled"
@@ -151,9 +151,14 @@ def test_atomic_policy_accepts_qualified_newapi_primary_and_managed_fallback(
 
     assert policy.revision == 1
     assert policy.effective_mode == "newapi_preferred"
-    assert policy.data_plane_integrated is False
+    assert policy.data_plane_integrated is True
     assert len(policy.qualifications) == 2
     assert all(item.valid for item in policy.qualifications)
+    public = service.public_status(MODEL_ID, "chat_text")
+    assert public.data_plane_integrated is True
+    assert public.available is True
+    assert public.would_block is False
+    assert public.reason_code == "qualified"
     serialized = policy.model_dump_json()
     assert "newAPI-secret" not in serialized
     assert "OpenRouter-secret" not in serialized

--- a/server/tests/test_provider_chat_stable_chat.py
+++ b/server/tests/test_provider_chat_stable_chat.py
@@ -1,0 +1,546 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server import main as main_module
+from server.file_assets.document_parser import ParsedDocument, ParsedSection
+from server.file_assets.service import ResolvedChatFile
+from server.main import app
+from server.model_router import (
+    ModelRouterService,
+    RouterConnectionCreate,
+    SQLiteRouterRepository,
+    configure_model_router,
+    get_model_router_service,
+)
+from server.model_router.chat_control import ProviderChatControlService
+from server.model_router.egress import ProviderEgressPolicy
+from server.model_router.schemas import (
+    ProviderChatControlPolicyUpdate,
+    ProviderChatControlRouteUpdate,
+)
+
+
+MODEL_ID = "provider/model"
+
+
+@pytest_asyncio.fixture
+async def client():
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
+
+
+def _qualified_connection(
+    repository: SQLiteRouterRepository, *, name: str, kind: str
+) -> str:
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name=name,
+            kind=kind,
+            base_url=f"https://{name.casefold()}.example/v1",
+            api_key=f"{name}-secret",
+            scopes=["chat"],
+        ),
+    )
+    repository.save_test_result(
+        "local",
+        connection.id,
+        health="online",
+        model_count=1,
+        checked_at="2026-08-21T00:00:00+00:00",
+    )
+    fingerprint = repository.connection_config_fingerprint("local", connection.id)
+    refresh_id = f"refresh-{connection.id}"
+    repository.claim_catalog_refresh(
+        "local",
+        refresh_id=refresh_id,
+        connection_id=connection.id,
+        connection_fingerprint=fingerprint,
+    )
+    repository.complete_catalog_refresh(
+        "local",
+        refresh_id,
+        connection_id=connection.id,
+        models=[
+            {
+                "model_id": MODEL_ID,
+                "normalized_model_id": MODEL_ID,
+                "capability_state": "declared",
+            }
+        ],
+        offerings=[],
+        model_count=1,
+        truncated=False,
+        catalog_fingerprint=f"catalog-{connection.id}",
+        observed_at="2026-08-21T00:00:00+00:00",
+    )
+    certification, created = repository.claim_chat_certification(
+        "local",
+        certification_id=f"cert-{connection.id}",
+        connection_id=connection.id,
+        connection_fingerprint=fingerprint,
+        contract_version="modelmirror-provider-chat-v1",
+        capability="chat_text",
+        requested_model=MODEL_ID,
+        idempotency_key_hash=hashlib.sha256(connection.id.encode()).hexdigest(),
+    )
+    assert created is True
+    repository.complete_chat_certification(
+        "local",
+        str(certification["id"]),
+        status="passed",
+        checks={"capability_verified": True},
+        warning_codes=[],
+        actual_model=MODEL_ID,
+    )
+    return connection.id
+
+
+def _service(
+    tmp_path: Path, *, block_primary: bool = False
+) -> tuple[ModelRouterService, SQLiteRouterRepository, str, str]:
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+
+    def resolve(host: str, _port: int):
+        if block_primary and host.startswith("newapi"):
+            return ["10.0.0.8"]
+        return ["8.8.8.8"]
+
+    service = ModelRouterService(
+        repository,
+        egress_policy=ProviderEgressPolicy(resolver=resolve),
+    )
+    newapi_id = _qualified_connection(repository, name="newAPI", kind="newapi")
+    backup_id = _qualified_connection(
+        repository, name="OpenRouter", kind="openrouter"
+    )
+    ProviderChatControlService(service).update_policy(
+        ProviderChatControlPolicyUpdate(
+            expected_revision=0,
+            mode="newapi_preferred",
+            stable_model_ids=[MODEL_ID],
+            routes=[
+                ProviderChatControlRouteUpdate(
+                    capability="chat_text",
+                    connection_ids=[newapi_id, backup_id],
+                )
+            ],
+        )
+    )
+    return service, repository, newapi_id, backup_id
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        chunks: list[str],
+        body: bytes = b"",
+        stream_error: bool = False,
+    ):
+        self.status_code = status_code
+        self.headers = {
+            "content-type": "text/event-stream",
+            "x-request-id": "request-1",
+        }
+        self._chunks = chunks
+        self._body = body
+        self._stream_error = stream_error
+        self.closed = False
+
+    async def aiter_text(self):
+        for index, chunk in enumerate(self._chunks):
+            yield chunk
+            if self._stream_error and index == 0:
+                raise httpx.ReadError("stream interrupted")
+
+    async def aread(self) -> bytes:
+        return self._body
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _fake_client(
+    sent: list[dict[str, Any]],
+    *,
+    status_code: int = 200,
+    send_error: Exception | None = None,
+    stream_error: bool = False,
+):
+    chunks = [
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{"content":"OK"}},"finish_reason":null}}]}}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}\n\n',
+        "data: [DONE]\n\n",
+    ]
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+
+        def build_request(self, method, url, **kwargs):
+            return {"method": method, "url": str(url), **kwargs}
+
+        async def send(self, request, *, stream, follow_redirects=False):
+            assert stream is True
+            sent.append(request)
+            if send_error is not None:
+                raise send_error
+            return _FakeResponse(
+                status_code=status_code,
+                chunks=chunks if status_code < 400 else [],
+                body=b"upstream private error",
+                stream_error=stream_error,
+            )
+
+        async def aclose(self):
+            return None
+
+    return FakeClient
+
+
+def _request() -> dict[str, object]:
+    return {
+        "model_id": MODEL_ID,
+        "gateway": "default",
+        "messages": [{"role": "user", "content": "private user text"}],
+    }
+
+
+class _ResolvedFileService:
+    def __init__(self) -> None:
+        self.resolved = ResolvedChatFile(
+            asset_id="file_" + "a" * 32,
+            scope_id="chat-session-1",
+            display_name="notes.md",
+            format_id="markdown",
+            media_type="text/markdown",
+            byte_size=20,
+            handling="extract",
+            parsed_document=ParsedDocument(
+                format="markdown",
+                title="notes.md",
+                sections=(ParsedSection(text="untrusted file text", page=1),),
+                extracted_chars=19,
+            ),
+        )
+        self.finalized: list[bool] = []
+
+    def resolve_chat_inputs(
+        self, _selections, *, scope_id: str, native_pdf_verified: bool = False
+    ):
+        assert scope_id == "chat-session-1"
+        assert native_pdf_verified is False
+        return (self.resolved,)
+
+    def finalize_chat_inputs(self, _files, *, success: bool) -> bool:
+        self.finalized.append(success)
+        return success
+
+
+def _disable_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    def unavailable_runtime():
+        raise RuntimeError("runtime unavailable in routing test")
+
+    monkeypatch.setattr(main_module, "create_default_runtime", unavailable_runtime)
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("", ""))
+
+
+@pytest.mark.asyncio
+async def test_preferred_text_chat_uses_one_pinned_newapi_post_and_receipt(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, newapi_id, _backup_id = _service(tmp_path)
+    configure_model_router(service)
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    _disable_runtime(monkeypatch)
+    monkeypatch.setattr(main_module.httpx, "AsyncClient", _fake_client(sent))
+    try:
+        response = await client.post("/api/chat", json=_request())
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 200, response.text
+    assert len(sent) == 1
+    assert sent[0]["url"] == "https://8.8.8.8/v1/chat/completions"
+    assert sent[0]["headers"]["Host"] == "newapi.example"
+    assert sent[0]["extensions"]["sni_hostname"] == "newapi.example"
+    assert response.text.count("event: route_receipt") == 1
+    assert response.text.index("event: route_receipt") < response.text.index(
+        "data: [DONE]"
+    )
+    receipt_event = next(
+        item
+        for item in response.text.split("\n\n")
+        if item.startswith("event: route_receipt")
+    )
+    receipt = json.loads(receipt_event.split("data:", 1)[1].strip())
+    assert receipt["engine"] == "newapi"
+    assert receipt["strategy"] == "newapi_preferred"
+    assert receipt["tokens"]["total"] == 3
+    assert "connection_id" not in receipt
+    stored = repository.list_chat_control_receipts("local")
+    assert stored["runs"][0]["status"] == "succeeded"
+    assert stored["attempts"][0]["connection_id"] == newapi_id
+    assert stored["attempts"][0]["dispatched"] == 1
+    with sqlite3.connect(repository.database_path) as database:
+        dump = "\n".join(database.iterdump())
+    assert "private user text" not in dump
+    assert "OK" not in dump
+
+
+@pytest.mark.asyncio
+async def test_preferred_accepts_only_confirmed_text_extracted_file_path(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, _newapi_id, _backup_id = _service(tmp_path)
+    configure_model_router(service)
+    sent: list[dict[str, Any]] = []
+    file_service = _ResolvedFileService()
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    _disable_runtime(monkeypatch)
+    monkeypatch.setattr(main_module, "get_file_asset_service", lambda: file_service)
+    monkeypatch.setattr(main_module.httpx, "AsyncClient", _fake_client(sent))
+    payload = {
+        "model_id": MODEL_ID,
+        "gateway": "default",
+        "file_scope_id": "chat-session-1",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "summarize"},
+                    {
+                        "type": "input_file",
+                        "asset_id": "file_" + "a" * 32,
+                        "handling": "extract",
+                        "confirmation_revision": 1,
+                    },
+                ],
+            }
+        ],
+    }
+    try:
+        response = await client.post("/api/chat", json=payload)
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 200, response.text
+    assert len(sent) == 1
+    serialized_messages = json.dumps(sent[0]["json"]["messages"], ensure_ascii=False)
+    assert "untrusted file text" in serialized_messages
+    assert "不可信的用户数据" in serialized_messages
+    assert "input_file" not in serialized_messages
+    assert response.text.count("event: route_receipt") == 1
+    assert response.text.count("event: message_end") == 1
+    receipt_event = next(
+        item
+        for item in response.text.split("\n\n")
+        if item.startswith("event: route_receipt")
+    )
+    receipt = json.loads(receipt_event.split("data:", 1)[1].strip())
+    assert receipt["engine"] == "newapi"
+    assert receipt["files"]["handling"] == "extract"
+    assert file_service.finalized == [True]
+    with sqlite3.connect(repository.database_path) as database:
+        dump = "\n".join(database.iterdump())
+    assert "untrusted file text" not in dump
+
+
+@pytest.mark.asyncio
+async def test_preferred_http_failure_never_posts_backup_or_legacy(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, _newapi_id, backup_id = _service(tmp_path)
+    configure_model_router(service)
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    _disable_runtime(monkeypatch)
+    monkeypatch.setattr(
+        main_module.httpx, "AsyncClient", _fake_client(sent, status_code=503)
+    )
+    try:
+        response = await client.post("/api/chat", json=_request())
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 503
+    assert len(sent) == 1
+    assert "newapi.example" == sent[0]["headers"]["Host"]
+    assert "upstream private error" not in response.text
+    payload = response.json()
+    assert payload["code"] == "provider_chat_http_503"
+    assert payload["route_receipt"]["engine"] == "newapi"
+    attempts = repository.list_chat_control_receipts("local")["attempts"]
+    assert len(attempts) == 1
+    assert attempts[0]["dispatched"] == 1
+    assert attempts[0]["connection_id"] != backup_id
+
+
+@pytest.mark.asyncio
+async def test_preferred_connect_failure_after_dispatch_never_replays(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, _newapi_id, _backup_id = _service(tmp_path)
+    configure_model_router(service)
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    _disable_runtime(monkeypatch)
+    monkeypatch.setattr(
+        main_module.httpx,
+        "AsyncClient",
+        _fake_client(sent, send_error=httpx.ConnectError("connect failed")),
+    )
+    try:
+        response = await client.post("/api/chat", json=_request())
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 502
+    assert len(sent) == 1
+    payload = response.json()
+    assert payload["code"] == "provider_chat_transport_error"
+    assert payload["route_receipt"]["engine"] == "newapi"
+    receipts = repository.list_chat_control_receipts("local")
+    assert len(receipts["attempts"]) == 1
+    assert receipts["attempts"][0]["dispatched"] == 1
+    assert receipts["attempts"][0]["result_class"] == "transient_failure"
+
+
+@pytest.mark.asyncio
+async def test_preferred_stream_interruption_records_failure_without_replay(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, _newapi_id, _backup_id = _service(tmp_path)
+    configure_model_router(service)
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    _disable_runtime(monkeypatch)
+    monkeypatch.setattr(
+        main_module.httpx,
+        "AsyncClient",
+        _fake_client(sent, stream_error=True),
+    )
+    try:
+        response = await client.post("/api/chat", json=_request())
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 200
+    assert len(sent) == 1
+    assert "provider_chat_stream_interrupted" in response.text
+    assert response.text.count("event: route_receipt") == 1
+    assert response.text.count("data: [DONE]") == 1
+    receipts = repository.list_chat_control_receipts("local")
+    assert len(receipts["attempts"]) == 1
+    assert receipts["attempts"][0]["dispatched"] == 1
+    assert receipts["attempts"][0]["result_class"] == "transient_failure"
+
+
+@pytest.mark.asyncio
+async def test_preflight_failure_selects_explicit_backup_before_only_post(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, _newapi_id, backup_id = _service(
+        tmp_path, block_primary=True
+    )
+    configure_model_router(service)
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    _disable_runtime(monkeypatch)
+    monkeypatch.setattr(main_module.httpx, "AsyncClient", _fake_client(sent))
+    try:
+        response = await client.post("/api/chat", json=_request())
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 200
+    assert len(sent) == 1
+    assert sent[0]["headers"]["Host"] == "openrouter.example"
+    receipt_event = next(
+        item
+        for item in response.text.split("\n\n")
+        if item.startswith("event: route_receipt")
+    )
+    receipt = json.loads(receipt_event.split("data:", 1)[1].strip())
+    assert receipt["engine"] == "openrouter"
+    assert receipt["fallback_attempts"] == 1
+    assert "provider_chat_preflight_backup_selected" in receipt["reason_codes"]
+    attempts = repository.list_chat_control_receipts("local")["attempts"]
+    assert len(attempts) == 2
+    selected = next(item for item in attempts if item["connection_id"] == backup_id)
+    assert selected["dispatched"] == 1
+
+
+@pytest.mark.asyncio
+async def test_disabled_flag_preserves_legacy_gateway_bytes_and_no_receipt(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, _newapi_id, _backup_id = _service(tmp_path)
+    configure_model_router(service)
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "false")
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("https://legacy.example/v1/chat/completions", "legacy-secret"),
+    )
+    monkeypatch.setattr(main_module.httpx, "AsyncClient", _fake_client(sent))
+    _disable_runtime(monkeypatch)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("https://legacy.example/v1/chat/completions", "legacy-secret"),
+    )
+    original_get_bundle = repository.get_chat_control_policy_bundle
+    repository.get_chat_control_policy_bundle = lambda _tenant: (_ for _ in ()).throw(
+        AssertionError("disabled feature must not read the control policy")
+    )
+    try:
+        response = await client.post("/api/chat", json=_request())
+    finally:
+        repository.get_chat_control_policy_bundle = original_get_bundle
+        configure_model_router(original_service)
+
+    assert response.status_code == 200
+    assert len(sent) == 1
+    assert sent[0]["url"] == "https://legacy.example/v1/chat/completions"
+    assert "event: route_receipt" not in response.text
+    assert repository.list_chat_control_receipts("local")["runs"] == []

--- a/server/tests/test_provider_chat_stable_service.py
+++ b/server/tests/test_provider_chat_stable_service.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from server.model_router.chat_control import ProviderChatControlService
+from server.model_router.chat_stable import ProviderChatStableService
+from server.model_router.egress import ProviderEgressPolicy
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import (
+    ProviderChatControlPolicyUpdate,
+    ProviderChatControlRouteUpdate,
+    RouterConnectionCreate,
+    RouterConnectionUpdate,
+)
+from server.model_router.service import ModelRouterService, RouterServiceError
+
+
+MODEL_ID = "provider/model"
+
+
+def _qualified_connection(
+    repository: SQLiteRouterRepository, *, name: str, kind: str
+) -> str:
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name=name,
+            kind=kind,
+            base_url=f"https://{name.casefold()}.example/v1",
+            api_key=f"{name}-secret",
+            scopes=["chat"],
+        ),
+    )
+    repository.save_test_result(
+        "local",
+        connection.id,
+        health="online",
+        model_count=1,
+        checked_at="2026-08-21T00:00:00+00:00",
+    )
+    fingerprint = repository.connection_config_fingerprint("local", connection.id)
+    refresh_id = f"refresh-{connection.id}"
+    repository.claim_catalog_refresh(
+        "local",
+        refresh_id=refresh_id,
+        connection_id=connection.id,
+        connection_fingerprint=fingerprint,
+    )
+    repository.complete_catalog_refresh(
+        "local",
+        refresh_id,
+        connection_id=connection.id,
+        models=[
+            {
+                "model_id": MODEL_ID,
+                "normalized_model_id": MODEL_ID,
+                "capability_state": "declared",
+            }
+        ],
+        offerings=[],
+        model_count=1,
+        truncated=False,
+        catalog_fingerprint=f"catalog-{connection.id}",
+        observed_at="2026-08-21T00:00:00+00:00",
+    )
+    certification, created = repository.claim_chat_certification(
+        "local",
+        certification_id=f"cert-{connection.id}",
+        connection_id=connection.id,
+        connection_fingerprint=fingerprint,
+        contract_version="modelmirror-provider-chat-v1",
+        capability="chat_text",
+        requested_model=MODEL_ID,
+        idempotency_key_hash=hashlib.sha256(connection.id.encode()).hexdigest(),
+    )
+    assert created is True
+    repository.complete_chat_certification(
+        "local",
+        str(certification["id"]),
+        status="passed",
+        checks={"capability_verified": True},
+        warning_codes=[],
+        actual_model=MODEL_ID,
+    )
+    return connection.id
+
+
+def _service(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    service = ModelRouterService(
+        repository,
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda host, _port: (
+                ["10.0.0.8"] if host.startswith("newapi") else ["8.8.8.8"]
+            )
+        ),
+    )
+    newapi_id = _qualified_connection(repository, name="newAPI", kind="newapi")
+    backup_id = _qualified_connection(
+        repository, name="OpenRouter", kind="openrouter"
+    )
+    ProviderChatControlService(service).update_policy(
+        ProviderChatControlPolicyUpdate(
+            expected_revision=0,
+            mode="newapi_preferred",
+            stable_model_ids=[MODEL_ID],
+            routes=[
+                ProviderChatControlRouteUpdate(
+                    capability="chat_text",
+                    connection_ids=[newapi_id, backup_id],
+                )
+            ],
+        )
+    )
+    return ProviderChatStableService(service), repository, newapi_id, backup_id
+
+
+@pytest.mark.asyncio
+async def test_preferred_selects_backup_only_after_primary_preflight_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+
+    result = await service.begin(MODEL_ID)
+
+    assert result.intercepted is True
+    assert result.dispatch is not None
+    assert result.dispatch.target.connection_id == backup_id
+    assert result.dispatch.position == 1
+    assert result.dispatch.reason_codes == (
+        "provider_address_blocked",
+        "provider_chat_preflight_backup_selected",
+    )
+    receipts = repository.list_chat_control_receipts("local")
+    assert len(receipts["runs"]) == 1
+    attempts = receipts["attempts"]
+    assert [(item["connection_id"], item["dispatched"]) for item in attempts] == [
+        (newapi_id, 0),
+        (backup_id, 0),
+    ]
+    assert attempts[0]["error_code"] == "provider_address_blocked"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rechecks_policy_and_records_no_post_on_stale_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, _newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    result = await service.begin(MODEL_ID)
+    assert result.dispatch is not None
+    repository.update_connection(
+        "local",
+        backup_id,
+        RouterConnectionUpdate(base_url="https://changed.example/v1"),
+    )
+
+    with pytest.raises(RouterServiceError) as exc_info:
+        service.mark_dispatched(result.dispatch)
+
+    assert exc_info.value.code == "provider_chat_policy_or_qualification_changed"
+    receipts = repository.list_chat_control_receipts("local")
+    selected = next(
+        item for item in receipts["attempts"] if item["connection_id"] == backup_id
+    )
+    assert selected["dispatched"] == 0
+    assert selected["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rechecks_feature_flag_before_post(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, _newapi_id, _backup_id = _service(tmp_path, monkeypatch)
+    result = await service.begin(MODEL_ID)
+    assert result.dispatch is not None
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "false")
+
+    with pytest.raises(RouterServiceError) as exc_info:
+        service.mark_dispatched(result.dispatch)
+
+    assert exc_info.value.code == "provider_chat_policy_or_qualification_changed"
+    receipts = repository.list_chat_control_receipts("local")
+    selected = next(
+        item
+        for item in receipts["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )
+    assert selected["dispatched"] == 0
+    assert selected["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_completion_is_tenant_scoped_and_stores_no_content(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, _newapi_id, _backup_id = _service(tmp_path, monkeypatch)
+    result = await service.begin(MODEL_ID)
+    assert result.dispatch is not None
+    service.mark_dispatched(result.dispatch)
+    service.complete(
+        result.dispatch,
+        status="succeeded",
+        result_class="success",
+        actual_model=MODEL_ID,
+        ttft_ms=12.5,
+        e2e_ms=42.0,
+        total_tokens=3,
+    )
+
+    receipts = repository.list_chat_control_receipts("local")
+    assert receipts["runs"][0]["status"] == "succeeded"
+    assert receipts["attempts"][-1]["dispatched"] == 1
+    assert repository.list_chat_control_receipts("other")["runs"] == []
+    with sqlite3.connect(repository.database_path) as database:
+        dump = "\n".join(database.iterdump())
+    assert "private prompt" not in dump
+    assert "model answer" not in dump
+
+
+@pytest.mark.asyncio
+async def test_feature_disabled_and_non_stable_models_use_legacy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, _newapi_id, _backup_id = _service(tmp_path, monkeypatch)
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "false")
+    original_get_bundle = repository.get_chat_control_policy_bundle
+    repository.get_chat_control_policy_bundle = lambda _tenant: (_ for _ in ()).throw(
+        AssertionError("disabled feature must not read the control policy")
+    )
+    disabled = await service.begin(MODEL_ID)
+    repository.get_chat_control_policy_bundle = original_get_bundle
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    outside = await service.begin("provider/other")
+
+    assert disabled.intercepted is False
+    assert outside.intercepted is False
+    assert repository.list_chat_control_receipts("local")["runs"] == []


### PR DESCRIPTION
## Summary

- Route allowlisted gateway=default text and extracted-text file requests through the R5 Managed Chat contract.
- Enforce newAPI-first preflight with an explicit Managed backup only before dispatch.
- Mark the attempt immediately before the single pinned POST and prohibit Provider, IP, model, or legacy replay after dispatch.
- Persist tenant-scoped redacted parent-run and attempt receipts; expose qualified public status and R5B Settings copy.
- Keep Auto, tools, file output, multimodal, Canary, required-default activation, catalog counts, and default deployment behavior unchanged.

## Safety and rollback

- MODEL_CONTROL_CHAT_ENABLED remains false by default.
- Turning the flag off or selecting legacy restores the original gateway path.
- newapi_required_default remains blocked pending R5E gates and human approval.
- No production dependency or destructive migration was added.

## Validation

- Core R5B service and chat tests: 12 passed.
- Affected backend regression suite: 122 passed, 4 warnings.
- Frontend full suite: 96 files / 506 tests passed.
- Frontend typecheck and production build passed.
- Core, independent newAPI, and overlay Compose config checks passed.
- Full backend run: 3712 passed, 29 skipped; 20 known environment-baseline failures plus one long-suite timing threshold that passed independently on both candidate and clean baseline.
- git diff --check and sensitive-data scan passed.

## Real newAPI acceptance

- Alias certification correctly failed closed on actual-model mismatch.
- Canonical deepseek/deepseek-v4-flash certification passed.
- User browser Chat returned successfully through newapi_preferred with one dispatched newAPI attempt, no fallback, matching requested/actual model, one route receipt before one DONE marker, and 17 reported tokens.
- Receipt tables contain no prompt, message, output, Base URL, or credential fields.
- Preview was returned to legacy with the real connection disabled after acceptance.