### PR TITLE
feature: 完善 Skill 执行指导 V2 运行体验

### DIFF
--- a/client/src/components/skill-runtime/SkillApplicationCard.test.tsx
+++ b/client/src/components/skill-runtime/SkillApplicationCard.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import SkillApplicationCard, {
+  buildSkillApplicationStates,
+  requiredSkillIdsFromWorkflowNodes,
+  type SkillRuntimeStatusEventLike,
+} from "./SkillApplicationCard";
+
+describe("SkillApplicationCard", () => {
+  it("keeps required and optional sources distinct while aggregating evidence", () => {
+    const events: SkillRuntimeStatusEventLike[] = [
+      { event: "skill_runtime_status", status: "required", skill_id: "pdf" },
+      { event: "skill_runtime_status", status: "available", skill_id: "plugin-helper" },
+      { event: "skill_runtime_status", status: "reading", skill_id: "plugin-helper" },
+      { event: "skill_runtime_status", status: "repair_requested", required_skill_ids: ["pdf"] },
+      { event: "skill_runtime_status", status: "reading", skill_id: "pdf", resource_paths: ["SKILL.md"] },
+      { event: "skill_runtime_status", status: "verified", required_skill_ids: ["pdf"] },
+      { event: "skill_runtime_status", status: "staged", skill_id: "pdf", resource_count: 3, resource_paths: ["SKILL.md", "references/guide.md"] },
+      { event: "skill_runtime_status", status: "resource_accessed", skill_id: "pdf", resource_count: 1, resource_paths: ["references/guide.md"] },
+    ];
+
+    expect(buildSkillApplicationStates(events)).toMatchObject([
+      {
+        skillId: "pdf",
+        requirement: "required",
+        read: true,
+        verified: true,
+        repairRequested: true,
+        stagedResourceCount: 3,
+        accessedResourceCount: 1,
+      },
+      {
+        skillId: "plugin-helper",
+        requirement: "available",
+        read: true,
+        verified: false,
+      },
+    ]);
+  });
+
+  it("renders a stable waiting row before the first runtime event", () => {
+    render(<SkillApplicationCard events={[]} expectedRequiredSkillIds={["tdd"]} />);
+
+    expect(screen.getByText("tdd")).toBeVisible();
+    expect(screen.getByText("等待读取")).toBeVisible();
+    expect(screen.getByText(/读取证明交付/)).toBeVisible();
+  });
+
+  it("extracts only explicit skills_runtime selections", () => {
+    expect(requiredSkillIdsFromWorkflowNodes([
+      {
+        data: {
+          kind: "runtime_middleware",
+          runtimeMiddlewareId: "skills_runtime",
+          runtimeMiddlewareConfig: { skill_ids: "pdf, tdd\npdf", auto_discover: true },
+        },
+      },
+      {
+        data: {
+          kind: "plugin_resource",
+          runtimeMiddlewareConfig: { skill_ids: "plugin-helper" },
+        },
+      },
+    ])).toEqual(["pdf", "tdd"]);
+  });
+});

--- a/client/src/components/skill-runtime/SkillApplicationCard.tsx
+++ b/client/src/components/skill-runtime/SkillApplicationCard.tsx
@@ -1,0 +1,311 @@
+import {
+  AlertTriangle,
+  BookOpenCheck,
+  CheckCircle2,
+  FileSearch,
+  RefreshCw,
+} from "lucide-react";
+
+export type SkillApplicationStatus =
+  | "required"
+  | "available"
+  | "reading"
+  | "staged"
+  | "resource_accessed"
+  | "repair_requested"
+  | "verified"
+  | "failed";
+
+export interface SkillRuntimeStatusEventLike {
+  event: string;
+  status?: string;
+  skill_id?: string;
+  activated_skill_id?: string;
+  required_skill_ids?: string[];
+  available_skill_ids?: string[];
+  skill_version_id?: string;
+  resource_count?: number;
+  resource_paths?: string[];
+  error_code?: string;
+}
+
+export interface SkillApplicationState {
+  skillId: string;
+  requirement: "required" | "available";
+  versionId: string;
+  read: boolean;
+  stagedResourceCount: number;
+  accessedResourceCount: number;
+  resourcePaths: string[];
+  repairRequested: boolean;
+  verified: boolean;
+  failed: boolean;
+  errorCode: string;
+}
+
+export function requiredSkillIdsFromWorkflowNodes(
+  nodes: Array<{
+    data?: {
+      kind?: unknown;
+      runtimeMiddlewareId?: unknown;
+      runtimeMiddlewareConfig?: unknown;
+    };
+  }>,
+): string[] {
+  const ids = new Set<string>();
+  nodes.forEach((node) => {
+    const data = node.data;
+    if (
+      !data
+      || data.kind !== "runtime_middleware"
+      || data.runtimeMiddlewareId !== "skills_runtime"
+    ) return;
+    const config = data.runtimeMiddlewareConfig;
+    if (!config || typeof config !== "object" || Array.isArray(config)) return;
+    String((config as Record<string, unknown>).skill_ids || "")
+      .split(/[,\n]+/)
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .forEach((skillId) => ids.add(skillId));
+  });
+  return [...ids].sort();
+}
+
+function cleanIds(values: unknown): string[] {
+  return Array.isArray(values)
+    ? values
+        .filter((value): value is string => typeof value === "string")
+        .map((value) => value.trim())
+        .filter(Boolean)
+    : [];
+}
+
+function createState(
+  skillId: string,
+  requirement: SkillApplicationState["requirement"] = "required",
+): SkillApplicationState {
+  return {
+    skillId,
+    requirement,
+    versionId: "",
+    read: false,
+    stagedResourceCount: 0,
+    accessedResourceCount: 0,
+    resourcePaths: [],
+    repairRequested: false,
+    verified: false,
+    failed: false,
+    errorCode: "",
+  };
+}
+
+export function buildSkillApplicationStates(
+  events: SkillRuntimeStatusEventLike[],
+  expectedRequiredSkillIds: string[] = [],
+): SkillApplicationState[] {
+  const states = new Map<string, SkillApplicationState>();
+  const ensure = (
+    skillId: string,
+    requirement: SkillApplicationState["requirement"] = "required",
+  ) => {
+    const clean = skillId.trim();
+    if (!clean) return null;
+    const existing = states.get(clean);
+    if (existing) {
+      if (requirement === "required") existing.requirement = "required";
+      return existing;
+    }
+    const next = createState(clean, requirement);
+    states.set(clean, next);
+    return next;
+  };
+
+  expectedRequiredSkillIds.forEach((skillId) => ensure(skillId, "required"));
+
+  events.forEach((event) => {
+    if (event.event !== "skill_runtime_status") return;
+    const status = event.status as SkillApplicationStatus | undefined;
+    const directSkillId = String(
+      event.skill_id || event.activated_skill_id || "",
+    ).trim();
+    const requiredIds = cleanIds(event.required_skill_ids);
+    const availableIds = cleanIds(event.available_skill_ids);
+    if (status === "required") {
+      ensure(directSkillId, "required");
+      requiredIds.forEach((skillId) => ensure(skillId, "required"));
+    }
+    if (status === "available") {
+      ensure(directSkillId, "available");
+      availableIds.forEach((skillId) => ensure(skillId, "available"));
+    }
+    if (["enable", "install", "upgrade"].includes(String(status))) {
+      ensure(directSkillId, "required");
+    }
+
+    let targets = directSkillId ? [directSkillId] : requiredIds;
+    if (
+      targets.length === 0
+      && ["repair_requested", "verified", "failed"].includes(String(status))
+    ) {
+      targets = [...states.values()]
+        .filter((state) => state.requirement === "required")
+        .map((state) => state.skillId);
+    }
+    targets.forEach((skillId) => {
+      const currentRequirement = states.get(skillId)?.requirement;
+      const state = ensure(
+        skillId,
+        status === "available"
+          ? "available"
+          : currentRequirement ?? "required",
+      );
+      if (!state) return;
+      if (event.skill_version_id) state.versionId = event.skill_version_id;
+      if (status === "reading") state.read = true;
+      if (status === "staged") {
+        state.stagedResourceCount = Math.max(
+          state.stagedResourceCount,
+          Number(event.resource_count) || 0,
+        );
+      }
+      if (status === "resource_accessed") {
+        state.accessedResourceCount += Math.max(0, Number(event.resource_count) || 0);
+      }
+      if (status === "repair_requested") state.repairRequested = true;
+      if (status === "verified") state.verified = true;
+      if (status === "failed") {
+        state.failed = true;
+        state.errorCode = String(event.error_code || "skill_application_failed");
+      }
+      cleanIds(event.resource_paths).forEach((path) => {
+        if (!state.resourcePaths.includes(path) && state.resourcePaths.length < 12) {
+          state.resourcePaths.push(path);
+        }
+      });
+    });
+  });
+
+  return [...states.values()].sort((left, right) => {
+    if (left.requirement !== right.requirement) {
+      return left.requirement === "required" ? -1 : 1;
+    }
+    return left.skillId.localeCompare(right.skillId);
+  });
+}
+
+function statePresentation(state: SkillApplicationState) {
+  if (state.failed) {
+    return {
+      label: "未通过",
+      className: "border-rose-300/25 bg-rose-300/10 text-rose-100",
+      Icon: AlertTriangle,
+    };
+  }
+  if (state.verified) {
+    return {
+      label: "已核验",
+      className: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100",
+      Icon: CheckCircle2,
+    };
+  }
+  if (state.repairRequested) {
+    return {
+      label: "正在纠偏",
+      className: "border-amber-300/25 bg-amber-300/10 text-amber-100",
+      Icon: RefreshCw,
+    };
+  }
+  if (state.read) {
+    return {
+      label: "已读取",
+      className: "border-cyan-300/25 bg-cyan-300/10 text-cyan-100",
+      Icon: BookOpenCheck,
+    };
+  }
+  return {
+    label: state.requirement === "required" ? "等待读取" : "可选",
+    className: "border-white/10 bg-white/[0.04] text-slate-300",
+    Icon: FileSearch,
+  };
+}
+
+export default function SkillApplicationCard({
+  className = "",
+  events,
+  expectedRequiredSkillIds = [],
+}: {
+  className?: string;
+  events: SkillRuntimeStatusEventLike[];
+  expectedRequiredSkillIds?: string[];
+}) {
+  const states = buildSkillApplicationStates(events, expectedRequiredSkillIds);
+  if (states.length === 0) return null;
+  const verifiedCount = states.filter((state) => state.verified).length;
+  const requiredCount = states.filter((state) => state.requirement === "required").length;
+
+  return (
+    <section
+      aria-label="Skill 应用状态"
+      aria-live="polite"
+      className={`rounded-lg border border-cyan-300/20 bg-cyan-300/[0.055] ${className}`}
+    >
+      <div className="flex flex-col gap-1 border-b border-cyan-200/10 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-xs font-semibold text-cyan-50">Skill 应用</h3>
+          <p className="mt-0.5 text-[11px] leading-4 text-slate-400">
+            {requiredCount > 0
+              ? `${verifiedCount}/${requiredCount} 个必用 Skill 已通过应用门`
+              : "当前仅有可选 Skill"}
+          </p>
+        </div>
+        <span className="text-[10px] text-cyan-100/70">读取证明交付，不代表质量认证</span>
+      </div>
+      <div className="divide-y divide-white/10">
+        {states.map((state) => {
+          const presentation = statePresentation(state);
+          const Icon = presentation.Icon;
+          return (
+            <div className="px-3 py-2.5" key={state.skillId}>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="break-all text-xs font-semibold text-slate-100">
+                      {state.skillId}
+                    </span>
+                    <span className="rounded-full border border-white/10 px-2 py-0.5 text-[10px] text-slate-400">
+                      {state.requirement === "required" ? "必须应用" : "插件提供，可选"}
+                    </span>
+                  </div>
+                  {state.versionId ? (
+                    <p className="mt-1 truncate font-mono text-[10px] text-slate-500">
+                      {state.versionId}
+                    </p>
+                  ) : null}
+                </div>
+                <span
+                  className={`inline-flex w-fit shrink-0 items-center gap-1.5 rounded-full border px-2 py-1 text-[10px] font-semibold ${presentation.className}`}
+                >
+                  <Icon aria-hidden="true" size={12} />
+                  {presentation.label}
+                </span>
+              </div>
+              {state.stagedResourceCount > 0 || state.accessedResourceCount > 0 ? (
+                <p className="mt-2 text-[11px] leading-4 text-slate-400">
+                  已暂存 {state.stagedResourceCount} 个资源，实际读取 {state.accessedResourceCount} 个
+                  {state.resourcePaths.length > 0
+                    ? `：${state.resourcePaths.slice(0, 4).join("、")}${state.resourcePaths.length > 4 ? " 等" : ""}`
+                    : ""}
+                </p>
+              ) : null}
+              {state.failed ? (
+                <p className="mt-2 break-all text-[11px] text-rose-100/90">
+                  {state.errorCode}
+                </p>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/workflow/WorkflowEditor.conversion.test.tsx
+++ b/client/src/components/workflow/WorkflowEditor.conversion.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type WorkflowDefinition, type WorkflowNodeKind } from "../../types/workflow";
+import { type RuntimeMiddlewareNode } from "../../types/runtimeMiddleware";
 import WorkflowEditor from "./WorkflowEditor";
 import { type WorkflowNodeRegistryResponse } from "./workflowNodeRegistry";
 
@@ -145,6 +146,62 @@ function jsonResponse(value: unknown) {
   });
 }
 
+function skillRuntimeMiddleware(): RuntimeMiddlewareNode {
+  return {
+    id: "skills_runtime",
+    kind: "runtime_middleware.skills_runtime",
+    title: "Skill 执行指导",
+    description: "要求 Agent 实际读取选定 Skill。",
+    category: "tool",
+    icon: "BookOpenCheck",
+    enabled: true,
+    fields: [
+      { name: "skill_ids", label: "选择必用 Skill", type: "textarea" },
+      {
+        name: "auto_discover",
+        label: "允许发现其他已安装 Skill",
+        type: "boolean",
+        default: false,
+      },
+      {
+        name: "catalog_search",
+        label: "允许按需检索已核验 Skill 目录",
+        type: "boolean",
+        default: false,
+      },
+    ],
+  };
+}
+
+function workflowWithSkillRuntime(): WorkflowDefinition {
+  const definition = ordinaryWorkflow();
+  definition.nodes.push({
+    id: "skills-runtime",
+    type: "workflowNode",
+    position: { x: 300, y: 260 },
+    data: {
+      kind: "runtime_middleware",
+      title: "Skill 执行指导",
+      description: "要求 Agent 实际读取选定 Skill。",
+      runtimeMiddlewareId: "skills_runtime",
+      runtimeMiddlewareKind: "runtime_middleware.skills_runtime",
+      runtimeMiddlewareConfig: {
+        skill_ids: "pdf, tdd",
+        auto_discover: true,
+        catalog_search: true,
+      },
+    },
+  });
+  definition.edges.push({
+    id: "bind-skills-runtime",
+    source: "skills-runtime",
+    target: "agent",
+    sourceHandle: "middleware-binding",
+    targetHandle: "middleware",
+  });
+  return definition;
+}
+
 describe("WorkflowEditor Xpert entry repair", () => {
   beforeEach(() => {
     registryAvailable = true;
@@ -175,7 +232,9 @@ describe("WorkflowEditor Xpert entry repair", () => {
         if (url === "/api/workflow-native/validate") {
           return Promise.resolve(jsonResponse(staticValidation));
         }
-        if (url === "/api/runtime/middleware-nodes") return Promise.resolve(jsonResponse([]));
+        if (url === "/api/runtime/middleware-nodes") {
+          return Promise.resolve(jsonResponse([skillRuntimeMiddleware()]));
+        }
         if (url.startsWith("/api/xperts")) {
           return Promise.resolve(jsonResponse({ items: [], total: 0, version: "test" }));
         }
@@ -294,5 +353,42 @@ describe("WorkflowEditor Xpert entry repair", () => {
           String(request) === "/api/xperts" && init?.method === "POST",
       ),
     ).toBe(false);
+  });
+
+  it("edits required Skills as removable tags and keeps discovery advanced", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <MemoryRouter>
+        <WorkflowEditor
+          initialDefinition={workflowWithSkillRuntime()}
+          onSave={onSave}
+          saveLabel="保存测试草稿"
+          workflowId="classic-skill-runtime"
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByTestId("rf__node-skills-runtime"));
+    expect(
+      await screen.findByRole("button", { name: "移除必用 Skill：pdf" }),
+    ).toBeVisible();
+    expect(screen.getByRole("button", { name: "移除必用 Skill：tdd" })).toBeVisible();
+    expect(screen.queryByText("允许发现其他已安装 Skill")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "展开高级选项" }));
+    expect((await screen.findAllByText("允许发现其他已安装 Skill")).length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("button", { name: "移除必用 Skill：pdf" }));
+    fireEvent.click(screen.getByRole("button", { name: "保存测试草稿" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce());
+    const saved = onSave.mock.calls[0][0] as WorkflowDefinition;
+    expect(
+      saved.nodes.find((node) => node.id === "skills-runtime")?.data
+        .runtimeMiddlewareConfig,
+    ).toMatchObject({
+      skill_ids: "tdd",
+      auto_discover: true,
+      catalog_search: true,
+    });
   });
 });

--- a/client/src/components/workflow/WorkflowEditor.test.ts
+++ b/client/src/components/workflow/WorkflowEditor.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   createNodeData,
   normalizeWorkflowNodePositions,
+  parseSkillRuntimeIds,
+  updateSkillRuntimeIds,
 } from "./WorkflowEditor";
 import {
   knowledgePipelineItems,
@@ -10,6 +12,12 @@ import {
 } from "./workflowNodeRegistry";
 
 describe("WorkflowEditor palette defaults", () => {
+  it("normalizes the tag-based required Skill editor without duplicate IDs", () => {
+    expect(parseSkillRuntimeIds("pdf, tdd\npdf")).toEqual(["pdf", "tdd"]);
+    expect(updateSkillRuntimeIds("pdf", "tdd", "add")).toBe("pdf, tdd");
+    expect(updateSkillRuntimeIds("pdf, tdd", "pdf", "remove")).toBe("tdd");
+  });
+
   it("provides editable defaults for every local palette item", () => {
     const items = [
       ...workflowPaletteSections.flatMap((section) => section.items),

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -16,7 +16,7 @@ import {
   type OnConnectEnd,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { Upload } from "lucide-react";
+import { Upload, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { DEFAULT_WORKFLOW_AGENT_MODEL_ID } from "../../data/modelOptions";
@@ -113,6 +113,29 @@ const nodeConfigResourceCache = new Map<
   { data: unknown; at: number }
 >();
 const NODE_CONFIG_CACHE_TTL_MS = 60_000;
+
+export function parseSkillRuntimeIds(value: unknown): string[] {
+  return [...new Set(
+    String(value ?? "")
+      .split(/[,\n]+/)
+      .map((item) => item.trim())
+      .filter(Boolean),
+  )];
+}
+
+export function updateSkillRuntimeIds(
+  value: unknown,
+  skillId: string,
+  action: "add" | "remove",
+): string {
+  const cleanSkillId = skillId.trim();
+  const current = parseSkillRuntimeIds(value);
+  if (!cleanSkillId) return current.join(", ");
+  if (action === "remove") {
+    return current.filter((item) => item !== cleanSkillId).join(", ");
+  }
+  return [...new Set([...current, cleanSkillId])].join(", ");
+}
 
 async function cachedFetchResource<T>(
   key: string,
@@ -2054,6 +2077,11 @@ function AgentStudioPanel({
                             ? String(resource.data.toolsetId || "未选择 Toolset")
                             : String(resource.data.pluginId || "未选择 Plugin")}
                     </span>
+                    {resource.data.kind === "plugin_resource" ? (
+                      <span className="mt-1 block text-[10px] text-cyan-100/70">
+                        插件提供的 Skill 为可选，Agent 主动启用后才必须读取
+                      </span>
+                    ) : null}
                   </span>
                 </button>
               ))}
@@ -2682,6 +2710,7 @@ function NodeConfig({
   const [publishedXperts, setPublishedXperts] = useState<XpertSummary[]>([]);
   const [publishedXpertsError, setPublishedXpertsError] = useState("");
   const [installedSkills, setInstalledSkills] = useState<TrustSelectableSkill[]>([]);
+  const [showSkillAdvancedOptions, setShowSkillAdvancedOptions] = useState(false);
   const [visionModels, setVisionModels] = useState<
     Array<{ model_id: string; label: string }>
   >([]);
@@ -2864,8 +2893,16 @@ function NodeConfig({
     : undefined;
   const skillCreatorMiddleware = isSkillCreatorMiddleware(data);
   const legacySkillCreatorMiddleware = isLegacySkillCreatorMiddleware(data);
+  const skillRuntimeMiddleware =
+    data.kind === "runtime_middleware"
+    && data.runtimeMiddlewareId === "skills_runtime";
   const visibleRuntimeMiddlewareFields = (data.runtimeMiddlewareFields ?? []).filter(
     (field) => {
+      if (
+        skillRuntimeMiddleware
+        && field.name !== "skill_ids"
+        && !showSkillAdvancedOptions
+      ) return false;
       if (!skillCreatorMiddleware) return true;
       if (field.name === "authoring_mode") return false;
       if (legacySkillCreatorMiddleware) return true;
@@ -2876,13 +2913,15 @@ function NodeConfig({
   );
   const appendTrustedSkill = (skillId: string) => {
     if (!skillId || !runtimeMiddlewareConfig) return;
-    const current = String(runtimeMiddlewareConfig.skill_ids ?? "")
-      .split(/[,\n]+/)
-      .map((item) => item.trim())
-      .filter(Boolean);
-    if (!current.includes(skillId)) current.push(skillId);
-    onRuntimeMiddlewareConfigChange(node.id, "skill_ids", current.join(", "));
+    onRuntimeMiddlewareConfigChange(
+      node.id,
+      "skill_ids",
+      updateSkillRuntimeIds(runtimeMiddlewareConfig.skill_ids, skillId, "add"),
+    );
   };
+  const selectedRuntimeSkillIds = parseSkillRuntimeIds(
+    runtimeMiddlewareConfig?.skill_ids,
+  );
   const boundMiddlewares =
     data.kind === "workflow_agent"
       ? edges
@@ -4049,7 +4088,9 @@ function NodeConfig({
             </p>
           ) : (
             <>
-              <p className="text-xs font-semibold text-slate-300">中间件配置</p>
+              <p className="text-xs font-semibold text-slate-300">
+                {skillRuntimeMiddleware ? "必须实际应用的 Skill" : "中间件配置"}
+              </p>
               {visibleRuntimeMiddlewareFields.map((field) => (
                 <Field
                   key={field.name}
@@ -4120,24 +4161,62 @@ function NodeConfig({
                         skills={installedSkills}
                         value=""
                       />
-                      <textarea
-                        className={`${textInputClass()} min-h-24 resize-none leading-6`}
-                        onChange={(event) =>
-                          updateRuntimeMiddlewareConfig(
-                            field.name,
-                            event.target.value,
-                          )
-                        }
-                        placeholder={field.placeholder}
-                        rows={field.rows ?? 3}
-                        value={runtimeMiddlewareStringValue(
-                          runtimeMiddlewareConfig,
-                          field,
-                        )}
-                      />
+                      {selectedRuntimeSkillIds.length > 0 ? (
+                        <div className="flex flex-wrap gap-2 rounded-lg border border-white/10 bg-white/[0.035] p-2.5">
+                          {selectedRuntimeSkillIds.map((skillId) => {
+                            const installed = installedSkills.find(
+                              (skill) => skill.skill_id === skillId,
+                            );
+                            return (
+                              <span
+                                className="inline-flex max-w-full items-center gap-2 rounded-full border border-cyan-300/25 bg-cyan-300/10 py-1 pl-2.5 pr-1.5 text-xs text-cyan-50"
+                                key={skillId}
+                              >
+                                <span className="min-w-0 truncate">
+                                  {installed?.name || skillId}
+                                </span>
+                                <button
+                                  aria-label={`移除必用 Skill：${installed?.name || skillId}`}
+                                  className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-cyan-100 transition hover:bg-cyan-200/15 focus-visible:outline-none"
+                                  onClick={() =>
+                                    updateRuntimeMiddlewareConfig(
+                                      field.name,
+                                      updateSkillRuntimeIds(
+                                        runtimeMiddlewareConfig?.skill_ids,
+                                        skillId,
+                                        "remove",
+                                      ),
+                                    )
+                                  }
+                                  type="button"
+                                >
+                                  <X aria-hidden="true" size={13} />
+                                </button>
+                              </span>
+                            );
+                          })}
+                        </div>
+                      ) : (
+                        <p className="rounded-lg border border-dashed border-white/15 bg-white/[0.025] px-3 py-3 text-xs leading-5 text-slate-400">
+                          尚未选择必用 Skill。选择后，Agent 必须先调用 skill_read 才能提交答案或执行副作用工具。
+                        </p>
+                      )}
                       <p className="text-[11px] leading-5 text-slate-500">
-                        手工输入仍会在保存和运行时由 Server 重新校验；禁用项不能通过选择器加入。
+                        脚本不会自动运行。如 Skill 需要执行脚本，还要单独绑定 Sandbox Shell 和命令白名单。
                       </p>
+                      <button
+                        aria-expanded={showSkillAdvancedOptions}
+                        className="text-left text-xs font-semibold text-slate-300 underline decoration-white/20 underline-offset-4 transition hover:text-white"
+                        onClick={() => setShowSkillAdvancedOptions((current) => !current)}
+                        type="button"
+                      >
+                        {showSkillAdvancedOptions ? "收起高级选项" : "展开高级选项"}
+                      </button>
+                      {!showSkillAdvancedOptions ? (
+                        <p className="text-[11px] leading-5 text-slate-500">
+                          高级选项包含自动发现、目录检索和经审批安装。候选不会自动变成必用 Skill。
+                        </p>
+                      ) : null}
                     </div>
                   ) : null}
 

--- a/client/src/components/workflow/WorkflowRun.tsx
+++ b/client/src/components/workflow/WorkflowRun.tsx
@@ -11,6 +11,9 @@ import SkillCreatorCaptureButton, {
 import SkillCreatorHandoffCard, {
   latestSkillCreatorHandoff,
 } from "../skill-creator/SkillCreatorHandoffCard";
+import SkillApplicationCard, {
+  requiredSkillIdsFromWorkflowNodes,
+} from "../skill-runtime/SkillApplicationCard";
 import { useSkillCreatorStatus } from "../../hooks/useSkillCreatorStatus";
 import {
   fetchFileOutputs,
@@ -561,19 +564,6 @@ export function buildRunSteps(events: WorkflowRunEvent[]) {
       return;
     }
     if (event.event === "skill_runtime_status") {
-      const statusText =
-        event.status === "find"
-          ? `本地 Skill 检索完成：${event.result_count ?? 0} 项候选`
-          : event.status === "enable"
-            ? `已为本轮激活 Skill：${event.activated_skill_id ?? event.candidate_id ?? "-"}`
-            : event.status === "install"
-              ? `Skill 已安装并仅授权本轮使用：${event.activated_skill_id ?? "-"}`
-              : event.status === "upgrade"
-                ? `Skill 已升级并仅授权本轮使用：${event.activated_skill_id ?? "-"}`
-                : event.status === "reject"
-                  ? `用户已拒绝本轮 Skill 候选：${event.candidate_id ?? "-"}`
-                  : `Skill 状态已更新：${event.status ?? "completed"}`;
-      step.output = appendStepOutput(step.output, statusText, step.type);
       return;
     }
     if (event.event === "client_tool_waiting") {
@@ -964,6 +954,10 @@ export default function WorkflowRun({
   }, [events]);
 
   const runSteps = useMemo(() => buildRunSteps(events), [events]);
+  const expectedRequiredSkillIds = useMemo(
+    () => requiredSkillIdsFromWorkflowNodes(definition.nodes),
+    [definition.nodes],
+  );
   const skillCaptureSource = useMemo(
     () => completedWorkflowCaptureSource(events, taskId, runId, isRunning),
     [events, isRunning, runId, taskId],
@@ -1991,6 +1985,11 @@ export default function WorkflowRun({
       ) : null}
 
       <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        <SkillApplicationCard
+          className="mb-3"
+          events={events}
+          expectedRequiredSkillIds={expectedRequiredSkillIds}
+        />
         {runHistory.length > 0 ? (
           <div className="mb-3 rounded-lg border border-white/10 bg-white/[0.03] p-3">
             <p className="text-[11px] font-semibold text-slate-400">最近运行</p>

--- a/client/src/pages/XpertChatPage.file-assets.test.ts
+++ b/client/src/pages/XpertChatPage.file-assets.test.ts
@@ -6,6 +6,7 @@ import {
   consumeSelectedXpertFiles,
   fileOutputsForRun,
   isCurrentXpertConversationRequest,
+  parseXpertWorkflowEvents,
   selectedXpertFilesAfterConversationRestore,
   selectedXpertFilesAfterRefresh,
   unassociatedXpertFileOutputs,
@@ -17,6 +18,20 @@ import {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+it("recovers structured Skill application events and ignores malformed history", () => {
+  const events = parseXpertWorkflowEvents([
+    'data: {"event":"skill_runtime_status","status":"required","skill_id":"pdf"}',
+    "",
+    "data: not-json",
+    "",
+    'data: {"event":"skill_runtime_status","status":"verified","required_skill_ids":["pdf"]}',
+    "",
+  ].join("\n"));
+
+  expect(events).toHaveLength(2);
+  expect(events[1]).toMatchObject({ status: "verified" });
 });
 
 function file(assetId: string): XpertFileAsset {

--- a/client/src/pages/XpertChatPage.tsx
+++ b/client/src/pages/XpertChatPage.tsx
@@ -9,6 +9,9 @@ import SandboxWorkspacePanel from "../components/runtime/SandboxWorkspacePanel";
 import DataXResultCard from "../components/datax/DataXResultCard";
 import FileOutputTray from "../components/FileOutputTray";
 import FileMemoryPanel from "../components/xpert/FileMemoryPanel";
+import SkillApplicationCard, {
+  requiredSkillIdsFromWorkflowNodes,
+} from "../components/skill-runtime/SkillApplicationCard";
 import SkillCreatorCaptureButton, {
   xpertMessageCaptureSource,
 } from "../components/skill-creator/SkillCreatorCaptureButton";
@@ -66,6 +69,14 @@ interface XpertRunEvent {
   status?: string;
   candidate_id?: string;
   activated_skill_id?: string;
+  skill_id?: string;
+  skill_version_id?: string;
+  requirement?: "required" | "available";
+  required_skill_ids?: string[];
+  available_skill_ids?: string[];
+  resource_count?: number;
+  resource_paths?: string[];
+  error_code?: string;
   source_ref?: string;
   result_count?: number;
   sequence?: number;
@@ -264,6 +275,14 @@ function eventSummary(event: XpertRunEvent) {
   if (event.event === "workflow_end") return "最终回答已生成";
   if (event.event === "error") return event.message || "运行失败";
   if (event.event === "skill_runtime_status") {
+    if (event.status === "required") return `必须应用：${event.skill_id ?? "Skill"}`;
+    if (event.status === "available") return `插件提供，可选：${event.skill_id ?? "Skill"}`;
+    if (event.status === "reading") return `已读取：${event.skill_id ?? "Skill"}`;
+    if (event.status === "staged") return `已暂存 ${event.resource_count ?? 0} 个 Skill 资源`;
+    if (event.status === "resource_accessed") return `实际读取 ${event.resource_count ?? 0} 个支持资源`;
+    if (event.status === "repair_requested") return "已请求模型补做 Skill 读取";
+    if (event.status === "verified") return "Skill 应用门已通过";
+    if (event.status === "failed") return `Skill 应用未通过：${event.error_code ?? "unknown"}`;
     if (event.status === "find") return `本地 Skill 检索完成：${event.result_count ?? 0} 项候选`;
     if (event.status === "enable") return `已为本轮激活 ${event.activated_skill_id ?? event.candidate_id ?? "Skill"}`;
     if (event.status === "install") return `已安装并仅授权本轮使用：${event.activated_skill_id ?? "Skill"}`;
@@ -271,6 +290,23 @@ function eventSummary(event: XpertRunEvent) {
     if (event.status === "reject") return `已拒绝候选：${event.candidate_id ?? "Skill"}`;
   }
   return event.output || event.message || event.node_title || event.event;
+}
+
+export function parseXpertWorkflowEvents(text: string): XpertRunEvent[] {
+  const parsed: XpertRunEvent[] = [];
+  text.split(/\r?\n\r?\n/).forEach((block) => {
+    block.split(/\r?\n/).forEach((line) => {
+      if (!line.startsWith("data:")) return;
+      const raw = line.slice(5).trim();
+      if (!raw || raw === "[DONE]") return;
+      try {
+        parsed.push(JSON.parse(raw) as XpertRunEvent);
+      } catch {
+        // A malformed historical event must not break conversation recovery.
+      }
+    });
+  });
+  return parsed;
 }
 
 function roleCopy(role: XpertConversationMessage["role"]) {
@@ -411,6 +447,10 @@ export default function XpertChatPage() {
     () => publishedVersions.find((item) => item.version === version) ?? null,
     [publishedVersions, version],
   );
+  const expectedRequiredSkillIds = useMemo(
+    () => requiredSkillIdsFromWorkflowNodes(activeVersion?.workflow.nodes ?? []),
+    [activeVersion],
+  );
   const versionFeatures = activeVersion?.features ?? null;
   const openingQuestions = versionFeatures
     ? (versionFeatures.opening.enabled ? versionFeatures.opening.questions : [])
@@ -478,6 +518,7 @@ export default function XpertChatPage() {
     setFiles([]);
     setFileOutputs([]);
     setSelectedFileIds([]);
+    setEvents([]);
     setContextLoading(true);
     setError("");
     try {
@@ -508,6 +549,29 @@ export default function XpertChatPage() {
       setMemoryCandidates(candidatePayload.items);
       setTodos(todoItems);
       setToolMemories(toolMemoryPayload.items);
+      const linkedMessage = [...(conversation.messages ?? [])]
+        .reverse()
+        .find((message) => message.role === "assistant" && message.source_task_id);
+      if (linkedMessage?.source_task_id) {
+        try {
+          const response = await fetch(
+            `/api/workflow/run/${encodeURIComponent(linkedMessage.source_task_id)}/stream?after_sequence=0`,
+          );
+          if (response.ok) {
+            const restored = parseXpertWorkflowEvents(await response.text())
+              .filter((event) => event.event === "skill_runtime_status")
+              .slice(-80);
+            if (isCurrentXpertConversationRequest(
+              requestToken,
+              conversationRequestTokenRef.current,
+              nextConversationId,
+              conversationIdRef.current,
+            )) setEvents(restored);
+          }
+        } catch {
+          // Historical Skill status is best-effort; the conversation stays usable.
+        }
+      }
     } catch (caught) {
       if (isCurrentXpertConversationRequest(
         requestToken,
@@ -1512,6 +1576,12 @@ export default function XpertChatPage() {
             <div className="rounded-lg border border-white/10 bg-white/[0.04] p-3"><dt className="text-slate-500">状态</dt><dd className="mt-1 font-semibold text-white">{running ? "运行中" : trace?.run?.status ?? "待运行"}</dd></div>
             <div className="col-span-2 rounded-lg border border-white/10 bg-white/[0.04] p-3"><dt className="text-slate-500">Run ID</dt><dd className="mt-1 break-all font-mono text-[11px] text-slate-300">{runId || "-"}</dd></div>
           </dl>
+
+          <SkillApplicationCard
+            className="mt-3"
+            events={events}
+            expectedRequiredSkillIds={expectedRequiredSkillIds}
+          />
 
           <button
             className="mt-3 w-full rounded-lg border border-cyan-300/20 bg-cyan-300/10 px-3 py-2 text-xs font-semibold text-cyan-100"

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -396,6 +396,13 @@ export interface WorkflowRunEvent {
   duration_ms?: number;
   candidate_id?: string;
   activated_skill_id?: string;
+  skill_id?: string;
+  skill_version_id?: string;
+  requirement?: "required" | "available";
+  required_skill_ids?: string[];
+  available_skill_ids?: string[];
+  resource_count?: number;
+  resource_paths?: string[];
   source_ref?: string;
   result_count?: number;
 }

--- a/docs/SKILL_INTEGRATION.md
+++ b/docs/SKILL_INTEGRATION.md
@@ -272,7 +272,7 @@ curl -X DELETE http://localhost:8000/api/skills/anthropics-skills-skills-pdf
 
 ### 4.1 Skill Runtime Guidance V2 基础门
 
-`SKILL_RUNTIME_GUIDANCE_V2_ENABLED=true` 可在经典 Workflow 及其发布后的私有 Xpert 中启用真实应用门。用户显式选择、或本轮通过 `skill_enable` / `skill_install` 激活的 Skill 属于 `required`；插件附带及 `auto_discover` 候选保持 `available`，不会因为可见就冻结全部已安装 Skill。
+`SKILL_RUNTIME_GUIDANCE_V2_ENABLED=true` 默认在经典 Workflow 及其发布后的私有 Xpert 中启用真实应用门。用户显式选择、或本轮通过 `skill_enable` / `skill_install` 激活的 Skill 属于 `required`；插件附带及 `auto_discover` 候选保持 `available`，不会因为可见就冻结全部已安装 Skill。
 
 服务端在模型调用前固定 Skill 版本、内容摘要与信任指纹，并在接受最终答案或执行副作用、敏感、审批及 terminal 工具前核验同一运行的 `SkillApplicationReceipt`。存在必用 Skill 时会跳过基于模型的 Tool Selector，保留完整已授权工具集合，避免选择器先消耗模型额度或移除 Skill 所需能力。首次缺少 `skill_read` 时只允许一次服务端纠偏；再次遗漏会以稳定错误终止 Workflow，不创建审批卡或放行工具。`SKILL_APPLICATION_RECEIPT_MODE=off` 时该门失败关闭。
 
@@ -280,7 +280,9 @@ curl -X DELETE http://localhost:8000/api/skills/anthropics-skills-skills-pdf
 
 资源访问凭据只保存 Skill 相对路径、实际/预期摘要和工具名称，不保存搜索词、正文或工具参数。`skill_stage` 后的服务端映射绑定当前 Workspace、Skill 版本和内容合同，审批恢复继续使用同一映射；资源发生变化时 receipt 转为 `unverified`。
 
-本批次默认保持开关关闭，不改变旧节点数据。回退只需设回 `false` 并重启 Server；已有 Workflow、安装数据和 receipt 均保留。结构化运行卡将在后续批次交付。
+工作流配置面板以可删除标签维护必用 Skill；自动发现、目录检索和审批式安装收在高级选项中。WorkflowRun 与私有 Xpert Chat 使用同一张应用卡展示 `required / available / reading / staged / resource_accessed / repair_requested / verified / failed`，刷新后从持久化执行事件恢复。卡片只显示 Skill ID、版本标识、资源数量和有界相对路径；调用 `skill_read` 证明正文已交付给模型，但不等于输出语义质量已认证。
+
+旧节点无需迁移即可采用 V2，节点数据和既有 receipt 不会被重写。回退只需设置 `SKILL_RUNTIME_GUIDANCE_V2_ENABLED=false` 并重启 Server；已有 Workflow、安装数据和 receipt 均保留。
 
 ## 5. 测试指南
 

--- a/docs/XPERT_MIDDLEWARE.md
+++ b/docs/XPERT_MIDDLEWARE.md
@@ -144,7 +144,7 @@ Todo 管理接口：
 
 ## Sandbox Files / Shell / Skills Runtime
 
-`sandbox_files`、`sandbox_shell` 与 `skills_runtime` 已进入真实执行。绑定后的 `workflow_agent` 会按运行来源创建隔离工作区，并注册文件、命令、Skill 和产物工具；只启用 Sandbox 时不会隐式暴露 MCP 工具。
+`sandbox_files`、`sandbox_shell` 与 `skills_runtime` 已进入真实执行。绑定后的 `workflow_agent` 会按运行来源创建隔离工作区，并注册文件、命令、Skill 和产物工具；只启用 Sandbox 时不会隐式暴露 MCP 工具。`skills_runtime` 中用户选定的 Skill 必须实际调用 `skill_read`，插件附带和自动发现候选默认可选；运行卡会区分选择、读取、资源消费、自动纠偏和最终核验。
 
 sidecar 完全断网且不挂载主服务源码、`.env` 或密钥。命令只接受 argv 数组和固定白名单，工作区路径拒绝绝对路径、`..` 与 symlink 逃逸。每个副作用工具调用使用稳定 operation ID，HITL 恢复不会重复执行已完成操作。
 

--- a/docs/XPERT_SANDBOX.md
+++ b/docs/XPERT_SANDBOX.md
@@ -60,7 +60,7 @@ Skill 工具：
 
 `sandbox_shell` 只接受 argv 数组，不解析 shell 字符串、管道、重定向或命令替换。允许命令由中间件配置与服务端固定上限共同约束，超时会终止整个进程组，输出最多保留 64 KB。每次调用携带稳定 operation ID；已经完成的副作用操作在 HITL 恢复或请求重放时返回原结果，不重复执行。
 
-Skill 必须先由用户安装。`skills_runtime` 固定 1 至 10 个 Skill ID，发布 Xpert 时验证其存在；`skill_stage` 排除 `.git`、symlink、超限文件和路径逃逸。Skill 不会自动执行，脚本仍须通过 `sandbox_shell` 并经过权限、HITL 与审计链路。
+Skill 必须先由用户安装。`skills_runtime` 可选择 1 至 10 个必用 Skill，发布 Xpert 时验证其存在；插件附带和自动发现候选保持可选，只有本轮主动启用后才升级为必用。Agent 必须实际调用 `skill_read`，需要支持资源时再调用 `skill_stage`；后者排除 `.git`、symlink、超限文件和路径逃逸。Skill 脚本不会自动执行，仍须通过 `sandbox_shell`、命令白名单、信任检查与 HITL 审批链路。
 
 ## HITL 与安全顺序
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -54,7 +54,7 @@ SKILL_APPLICATION_RECEIPT_MODE=audit
 # Skill Runtime Guidance V2 的 PR1 基础门默认关闭；临时开启后，Workflow
 # 与私有 Xpert 中显式选择或本轮激活的 Skill 必须先有 verified skill_read
 # 凭据，才可提交答案或执行副作用工具。设回 false 可恢复原提示型行为。
-SKILL_RUNTIME_GUIDANCE_V2_ENABLED=false
+SKILL_RUNTIME_GUIDANCE_V2_ENABLED=true
 # The semantic provider remains disabled until explicitly configured. Router
 # shadow mode never changes the lexical skill-need-local-v3 result order.
 SKILL_SEMANTIC_RERANK_PROVIDER=none

--- a/server/main.py
+++ b/server/main.py
@@ -219,6 +219,7 @@ try:
         build_skill_runtime_guidance_plan,
         missing_required_skill_ids,
         skill_application_repair_instruction,
+        skill_guidance_plan_status_events,
         skill_runtime_guidance_enabled,
         tool_requires_skill_application,
     )
@@ -327,6 +328,7 @@ except ModuleNotFoundError:
         build_skill_runtime_guidance_plan,
         missing_required_skill_ids,
         skill_application_repair_instruction,
+        skill_guidance_plan_status_events,
         skill_runtime_guidance_enabled,
         tool_requires_skill_application,
     )
@@ -11148,6 +11150,31 @@ async def _run_workflow_response(
             )
             skill_guidance_plan: SkillRuntimeGuidancePlanV2 | None = None
             skill_guidance_contracts: dict[str, Any] = {}
+            announced_guidance_entries: set[tuple[str, str, str]] = set()
+
+            def emit_guidance_plan_statuses() -> None:
+                if skill_guidance_plan is None:
+                    return
+                for status_event in skill_guidance_plan_status_events(
+                    skill_guidance_plan
+                ):
+                    key = (
+                        str(status_event.get("skill_id") or ""),
+                        str(status_event.get("status") or ""),
+                        str(status_event.get("skill_version_id") or ""),
+                    )
+                    if key in announced_guidance_entries:
+                        continue
+                    announced_guidance_entries.add(key)
+                    events.append(
+                        {
+                            **status_event,
+                            "node_id": node.id,
+                            "node_title": title,
+                            "node_type": kind,
+                        }
+                    )
+
             if include_skills and not skill_runtime_guidance_enabled():
                 skills_config_for_bindings = dict(
                     skills_spec.config if skills_spec is not None else {}
@@ -11220,6 +11247,11 @@ async def _run_workflow_response(
                         or None
                     ),
                 )
+                if skill_guidance_plan is not None:
+                    pending_state["skill_guidance_plan_fingerprint"] = (
+                        skill_guidance_plan.fingerprint
+                    )
+                    emit_guidance_plan_statuses()
                 if (
                     skill_guidance_plan is not None
                     and skill_guidance_plan.required_skill_ids
@@ -11242,9 +11274,6 @@ async def _run_workflow_response(
                     )
                     messages[0] = ChatMessage(
                         role="system", content=react_system_prompt
-                    )
-                    pending_state["skill_guidance_plan_fingerprint"] = (
-                        skill_guidance_plan.fingerprint
                     )
             staged_skill_resources: dict[str, dict[str, Any]] = {}
 
@@ -11435,6 +11464,7 @@ async def _run_workflow_response(
                     pending_state["skill_guidance_plan_fingerprint"] = (
                         skill_guidance_plan.fingerprint
                     )
+                    emit_guidance_plan_statuses()
 
             async def observe_skill_guidance_contract(
                 contract: Any,
@@ -11935,14 +11965,82 @@ async def _run_workflow_response(
                 result: RuntimeToolResult,
             ) -> None:
                 await apply_skill_runtime_result(tool_name, arguments, result)
-                if skill_guidance_plan is not None and not result.is_error:
-                    await emit_guidance_verified()
-                if not tool_name.startswith("skill_"):
-                    return
                 metadata = dict(result.metadata or {})
+
+                if (
+                    tool_name in {"sandbox_read_file", "sandbox_search_files"}
+                    and not result.is_error
+                ):
+                    accessed_by_skill: dict[str, set[str]] = {}
+                    raw_accessed_paths = metadata.get("sandbox_accessed_paths")
+                    if isinstance(raw_accessed_paths, list):
+                        for raw_workspace_path in raw_accessed_paths[:100]:
+                            try:
+                                workspace_path = normalize_staged_workspace_path(
+                                    raw_workspace_path
+                                )
+                            except SkillRuntimeGuidanceError:
+                                continue
+                            staged = staged_skill_resources.get(workspace_path)
+                            if staged is None or not staged.get("text", False):
+                                continue
+                            accessed_by_skill.setdefault(
+                                str(staged["skill_id"]), set()
+                            ).add(str(staged["skill_path"]))
+                    for skill_id, resource_paths in sorted(
+                        accessed_by_skill.items()
+                    ):
+                        contract = skill_guidance_contracts.get(skill_id)
+                        events.append(
+                            {
+                                "event": "skill_runtime_status",
+                                "node_id": node.id,
+                                "node_title": title,
+                                "node_type": kind,
+                                "tool_name": tool_name,
+                                "status": "resource_accessed",
+                                "skill_id": skill_id,
+                                "skill_version_id": (
+                                    contract.version_id if contract else None
+                                ),
+                                "resource_count": len(resource_paths),
+                                "resource_paths": sorted(resource_paths)[:12],
+                                "run_id": run_id,
+                            }
+                        )
+                if not tool_name.startswith("skill_"):
+                    if skill_guidance_plan is not None and not result.is_error:
+                        await emit_guidance_verified()
+                    return
                 event_name = str(metadata.get("skill_runtime_event") or "").strip()
                 if metadata.get("approval_rejected"):
                     event_name = "reject"
+                skill_id = str(
+                    metadata.get("skill_id")
+                    or arguments.get("skill_id")
+                    or metadata.get("activated_skill_id")
+                    or ""
+                ).strip()
+                raw_resource_paths = metadata.get("application_resource_paths")
+                resource_paths = (
+                    sorted(
+                        {
+                            str(path).replace("\\", "/")
+                            for path in raw_resource_paths
+                            if isinstance(path, str)
+                            and path.strip()
+                            and len(path) <= 240
+                        }
+                    )
+                    if isinstance(raw_resource_paths, list)
+                    else []
+                )
+                if result.is_error and tool_name in {"skill_read", "skill_stage"}:
+                    event_name = "failed"
+                elif not result.is_error and tool_name == "skill_read":
+                    event_name = "reading"
+                elif not result.is_error and tool_name == "skill_stage":
+                    event_name = "staged"
                 events.append(
                     {
                         "event": "skill_runtime_status",
@@ -11951,13 +12049,22 @@ async def _run_workflow_response(
                         "node_type": kind,
                         "tool_name": tool_name,
                         "status": event_name or "completed",
+                        "skill_id": skill_id or None,
+                        "skill_version_id": metadata.get(
+                            "application_version_id"
+                        ),
                         "candidate_id": arguments.get("candidate_id"),
                         "activated_skill_id": metadata.get("activated_skill_id"),
                         "source_ref": metadata.get("source_ref"),
                         "result_count": metadata.get("result_count"),
+                        "resource_count": len(resource_paths),
+                        "resource_paths": resource_paths[:12],
+                        "error_code": metadata.get("error_code"),
                         "run_id": run_id,
                     }
                 )
+                if skill_guidance_plan is not None and not result.is_error:
+                    await emit_guidance_verified()
 
             async def call_workflow_runtime_tool_observed(
                 *,
@@ -11981,6 +12088,30 @@ async def _run_workflow_response(
                         middleware_specs=middleware_specs,
                     )
                 except RuntimeToolError as exc:
+                    if tool_name in {"skill_read", "skill_stage"}:
+                        events.append(
+                            {
+                                "event": "skill_runtime_status",
+                                "node_id": node.id,
+                                "node_title": title,
+                                "node_type": kind,
+                                "tool_name": tool_name,
+                                "status": "failed",
+                                "skill_id": str(
+                                    arguments.get("skill_id") or ""
+                                ).strip()
+                                or None,
+                                "error_code": str(
+                                    getattr(
+                                        exc,
+                                        "code",
+                                        "skill_application_tool_failed",
+                                    )
+                                    or "skill_application_tool_failed"
+                                ),
+                                "run_id": run_id,
+                            }
+                        )
                     await record_skill_runtime_failure(
                         tool_name,
                         arguments,
@@ -16653,6 +16784,20 @@ async def _run_workflow_response(
                                     break
 
                         if not success:
+                            if isinstance(last_error, SkillRuntimeGuidanceError):
+                                skill_failure_event = {
+                                    "event": "skill_runtime_status",
+                                    "node_id": node.id,
+                                    "node_title": title,
+                                    "node_type": kind,
+                                    "status": "failed",
+                                    "error_code": last_error.code,
+                                    "run_id": workflow_agent_run.run_id,
+                                }
+                                workflow_execution_store.append_event(
+                                    task_id, skill_failure_event
+                                )
+                                yield sse_payload(skill_failure_event)
                             if exception_handling == "empty_output":
                                 output = ""
                                 if not disable_output:

--- a/server/skills/runtime_guidance.py
+++ b/server/skills/runtime_guidance.py
@@ -89,8 +89,27 @@ class SkillRuntimeGuidancePlanV2:
 
 def skill_runtime_guidance_enabled() -> bool:
     return os.getenv(
-        "SKILL_RUNTIME_GUIDANCE_V2_ENABLED", "false"
+        "SKILL_RUNTIME_GUIDANCE_V2_ENABLED", "true"
     ).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def skill_guidance_plan_status_events(
+    plan: SkillRuntimeGuidancePlanV2,
+) -> tuple[dict[str, Any], ...]:
+    """Project a guidance plan into bounded, content-free runtime events."""
+
+    return tuple(
+        {
+            "event": "skill_runtime_status",
+            "status": entry.requirement,
+            "skill_id": entry.skill_id,
+            "requirement": entry.requirement,
+            "skill_version_id": entry.version_id,
+            "source_kind": entry.source_kind,
+            "run_id": plan.run_id,
+        }
+        for entry in plan.entries
+    )
 
 
 def build_skill_runtime_guidance_plan(

--- a/server/tests/test_skill_runtime_guidance.py
+++ b/server/tests/test_skill_runtime_guidance.py
@@ -9,6 +9,7 @@ from server.skills.runtime_guidance import (
     SkillRuntimeGuidanceError,
     build_skill_runtime_guidance_plan,
     missing_required_skill_ids,
+    skill_guidance_plan_status_events,
     skill_runtime_guidance_enabled,
     tool_requires_skill_application,
 )
@@ -24,13 +25,13 @@ def _contract(skill_id: str, marker: str):
     )
 
 
-def test_guidance_flag_defaults_off_and_accepts_explicit_true(
+def test_guidance_flag_defaults_on_and_accepts_explicit_false(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("SKILL_RUNTIME_GUIDANCE_V2_ENABLED", raising=False)
-    assert skill_runtime_guidance_enabled() is False
-    monkeypatch.setenv("SKILL_RUNTIME_GUIDANCE_V2_ENABLED", "true")
     assert skill_runtime_guidance_enabled() is True
+    monkeypatch.setenv("SKILL_RUNTIME_GUIDANCE_V2_ENABLED", "false")
+    assert skill_runtime_guidance_enabled() is False
 
 
 def test_plan_distinguishes_explicit_activated_plugin_and_auto_sources() -> None:
@@ -63,6 +64,14 @@ def test_plan_distinguishes_explicit_activated_plugin_and_auto_sources() -> None
         auto_discover=True,
         contracts=contracts,
     ).fingerprint
+    events = skill_guidance_plan_status_events(plan)
+    assert [event["status"] for event in events] == [
+        "required",
+        "required",
+        "available",
+    ]
+    assert all("content_digest" not in event for event in events)
+    assert all("trust_fingerprint" not in event for event in events)
 
 
 def test_required_skill_without_frozen_contract_fails_closed() -> None:

--- a/server/tests/test_workflow_agent_task_node.py
+++ b/server/tests/test_workflow_agent_task_node.py
@@ -2090,6 +2090,24 @@ async def test_skill_router_install_resume_activates_only_current_agent_run(
         def __init__(self) -> None:
             self.items: list[InstalledSkill] = []
             self.read_count = 0
+            self.version_id = "skillversion_router_pdf"
+            self.package_dir = tmp_path / "router-pdf"
+            self.package_dir.mkdir()
+            (self.package_dir / "SKILL.md").write_text(
+                "# Router PDF\n\nRead the contract before extracting fields.",
+                encoding="utf-8",
+            )
+            self.content_digest = compute_skill_content_digest(
+                {"SKILL.md": (self.package_dir / "SKILL.md").read_bytes()}
+            )
+            self.lifecycle_store = SimpleNamespace(
+                require_version=lambda version_id: SimpleNamespace(
+                    skill_id="router-pdf",
+                    source_kind="git",
+                    package_digest=self.content_digest,
+                    trust_fingerprint="2" * 64,
+                )
+            )
 
         def list_installed_skills(self) -> list[InstalledSkill]:
             return list(self.items)
@@ -2107,17 +2125,36 @@ async def test_skill_router_install_resume_activates_only_current_agent_run(
                 sub_path=sub_path,
                 source_ref=source_ref,
                 installed_at=time.time(),
+                source_kind="git",
+                content_digest=self.content_digest,
+                trust_fingerprint="2" * 64,
             )
             self.items = [installed]
             return installed
+
+        def bind_skill_versions(self, skill_ids) -> dict[str, str]:
+            return {
+                "router-pdf": self.version_id
+                for skill_id in skill_ids
+                if skill_id == "router-pdf"
+            }
+
+        def require_activation(self, skill_id: str, **kwargs) -> InstalledSkill:
+            assert skill_id == "router-pdf"
+            assert kwargs.get("version_id") == self.version_id
+            return self.items[0]
 
         def get_skill_content(self, skill_id: str) -> str:
             assert skill_id == "router-pdf"
             self.read_count += 1
             return "# Router PDF\n\nRead the contract before extracting fields."
 
-        def get_skill_directory(self, skill_id: str) -> Path:
-            raise AssertionError(f"skill_stage was not expected: {skill_id}")
+        def get_skill_directory(
+            self, skill_id: str, *, version_id: str | None = None
+        ) -> Path:
+            assert skill_id == "router-pdf"
+            assert version_id in {None, self.version_id}
+            return self.package_dir
 
     class RouterSandboxClient:
         async def request(self, payload: dict[str, Any]) -> dict[str, Any]:
@@ -2178,6 +2215,14 @@ async def test_skill_router_install_resume_activates_only_current_agent_run(
     index_path.write_text(json.dumps(index, ensure_ascii=False), encoding="utf-8")
 
     manager = RouterSkillManager()
+    receipt_store = SkillApplicationReceiptStore(tmp_path / "application-receipts")
+    monkeypatch.setattr(main_module, "get_skill_manager", lambda: manager)
+    monkeypatch.setattr(main_module, "skill_application_receipt_store", receipt_store)
+    monkeypatch.setattr(
+        main_module,
+        "skill_application_observer",
+        SkillApplicationObserver(receipt_store, lambda: manager),
+    )
     provider = SandboxToolsetProvider(
         SandboxWorkspaceStore(
             tmp_path / "router-runtime", workspace_root=tmp_path / "router-workspaces"
@@ -2309,7 +2354,24 @@ async def test_skill_router_install_resume_activates_only_current_agent_run(
     completed = executions.require(pending["task_id"])
     assert completed.status == "completed"
     assert completed.result == "used the activated skill"
-    assert manager.read_count == 1
+    receipt = receipt_store.list_receipts(skill_id="router-pdf")[0]
+    assert receipt.methods == ("skill_read",)
+    assert receipt.compliance_status == "verified"
+    assert any(
+        event.get("event") == "skill_runtime_status"
+        and event.get("status") == "required"
+        and event.get("skill_id") == "router-pdf"
+        for event in completed.events
+    ), [
+        (event.get("status"), event.get("skill_id"), event.get("required_skill_ids"))
+        for event in completed.events
+        if event.get("event") == "skill_runtime_status"
+    ]
+    assert any(
+        event.get("event") == "skill_runtime_status"
+        and event.get("status") == "verified"
+        for event in completed.events
+    )
     assert manager.items[0].source_ref == source_ref
     assert any(
         event.get("event") == "skill_runtime_status"
@@ -2621,6 +2683,19 @@ async def test_required_skill_repairs_direct_answer_once_before_completion(
     )
     assert any(
         event.get("event") == "skill_runtime_status"
+        and event.get("status") == "required"
+        and event.get("skill_id") == manager.skill_id
+        for event in events
+    )
+    assert any(
+        event.get("event") == "skill_runtime_status"
+        and event.get("status") == "reading"
+        and event.get("skill_id") == manager.skill_id
+        and event.get("resource_paths") == ["SKILL.md"]
+        for event in events
+    )
+    assert any(
+        event.get("event") == "skill_runtime_status"
         and event.get("status") == "verified"
         for event in events
     )
@@ -2708,6 +2783,23 @@ async def test_required_skill_can_stage_and_search_text_resource_with_receipt(
         and event.get("output") == "completed after consuming the reference"
         for event in events
     )
+    staged_event = next(
+        event
+        for event in events
+        if event.get("event") == "skill_runtime_status"
+        and event.get("status") == "staged"
+    )
+    assert staged_event["skill_id"] == manager.skill_id
+    assert staged_event["resource_count"] == 3
+    assert "references/guide.md" in staged_event["resource_paths"]
+    accessed_event = next(
+        event
+        for event in events
+        if event.get("event") == "skill_runtime_status"
+        and event.get("status") == "resource_accessed"
+    )
+    assert accessed_event["skill_id"] == manager.skill_id
+    assert accessed_event["resource_paths"] == ["references/guide.md"]
     receipt = receipt_store.list_receipts(skill_id=manager.skill_id)[0]
     assert "references/guide.md" in receipt.staged_resource_paths
     assert "references/guide.md" in receipt.read_resource_paths
@@ -3305,6 +3397,12 @@ async def test_required_skill_second_omission_fails_with_stable_code(
     events = _parse_sse_events(response.text)
     error = next(event for event in events if event.get("event") == "error")
     assert error["code"] == "skill_application_repair_exhausted"
+    assert any(
+        event.get("event") == "skill_runtime_status"
+        and event.get("status") == "failed"
+        and event.get("error_code") == "skill_application_repair_exhausted"
+        for event in events
+    )
     assert model_calls == 2
     assert manager.read_count == 0
     assert not any(

--- a/server/tests/test_xpert_runtime_approvals.py
+++ b/server/tests/test_xpert_runtime_approvals.py
@@ -113,6 +113,50 @@ def test_execution_store_suspend_claim_and_restart_recovery(tmp_path) -> None:
         reloaded.claim("task-1", worker_id="worker-b", lease_seconds=30)
 
 
+def test_execution_store_preserves_bounded_skill_runtime_status(tmp_path) -> None:
+    store = WorkflowExecutionStore(tmp_path)
+    store.create(
+        task_id="task-1",
+        run_id="run-1",
+        run_type="workflow",
+        workflow={"nodes": [], "edges": []},
+        inputs={"user_input": "hello"},
+    )
+
+    stored = store.append_event(
+        "task-1",
+        {
+            "event": "skill_runtime_status",
+            "status": "resource_accessed",
+            "skill_id": "pdf-reader",
+            "skill_version_id": "skillversion-1",
+            "requirement": "required",
+            "required_skill_ids": ["pdf-reader"],
+            "available_skill_ids": ["optional-helper"],
+            "resource_count": 9_999,
+            "resource_paths": [
+                "/host/private.txt",
+                "../escape.txt",
+                "C:\\private\\secret.txt",
+                *[f"references/item-{index}.md" for index in range(20)],
+            ],
+            "query": "must not persist",
+            "content": "must not persist",
+        },
+    ).events[-1]
+
+    assert stored["skill_id"] == "pdf-reader"
+    assert stored["skill_version_id"] == "skillversion-1"
+    assert stored["requirement"] == "required"
+    assert stored["required_skill_ids"] == ["pdf-reader"]
+    assert stored["available_skill_ids"] == ["optional-helper"]
+    assert stored["resource_count"] == 2_000
+    assert len(stored["resource_paths"]) == 12
+    assert all(path.startswith("references/") for path in stored["resource_paths"])
+    assert "query" not in stored
+    assert "content" not in stored
+
+
 @pytest.mark.asyncio
 async def test_hitl_interrupt_never_falls_back_to_provider(tmp_path) -> None:
     approvals = RuntimeApprovalStore(tmp_path)

--- a/server/xpert_runtime/execution_store.py
+++ b/server/xpert_runtime/execution_store.py
@@ -6,7 +6,7 @@ import threading
 import time
 import uuid
 from dataclasses import asdict, dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 
 
@@ -521,6 +521,13 @@ class WorkflowExecutionStore:
             "error_code",
             "tool_name",
             "status",
+            "skill_id",
+            "skill_version_id",
+            "requirement",
+            "required_skill_ids",
+            "available_skill_ids",
+            "resource_count",
+            "resource_paths",
             "candidate_id",
             "activated_skill_id",
             "source_ref",
@@ -557,6 +564,50 @@ class WorkflowExecutionStore:
         for key in ("session_id", "error_code"):
             if key in clean:
                 clean[key] = str(clean[key] or "")[:200]
+        for key in ("skill_id", "skill_version_id"):
+            if key in clean:
+                clean[key] = str(clean[key] or "")[:200]
+        if "requirement" in clean:
+            requirement = str(clean["requirement"] or "").strip()
+            clean["requirement"] = (
+                requirement if requirement in {"required", "available"} else ""
+            )
+        for key in ("required_skill_ids", "available_skill_ids"):
+            if key in clean:
+                values = clean[key] if isinstance(clean[key], list) else []
+                clean[key] = [str(value)[:200] for value in values[:200]]
+        if "resource_count" in clean:
+            value = clean["resource_count"]
+            clean["resource_count"] = (
+                min(2_000, max(0, int(value)))
+                if isinstance(value, (int, float)) and not isinstance(value, bool)
+                else 0
+            )
+        if "resource_paths" in clean:
+            values = (
+                clean["resource_paths"]
+                if isinstance(clean["resource_paths"], list)
+                else []
+            )
+            safe_paths: list[str] = []
+            for value in values[:100]:
+                raw_path = str(value or "").strip().replace("\\", "/")
+                path = PurePosixPath(raw_path)
+                if (
+                    not raw_path
+                    or "\x00" in raw_path
+                    or len(raw_path) > 240
+                    or path.is_absolute()
+                    or any(part in {"", ".", ".."} for part in path.parts)
+                    or (path.parts and ":" in path.parts[0])
+                ):
+                    continue
+                normalized = path.as_posix()
+                if normalized not in safe_paths:
+                    safe_paths.append(normalized)
+                if len(safe_paths) == 12:
+                    break
+            clean["resource_paths"] = safe_paths
         for key in ("message", "final_output"):
             if key in clean:
                 clean[key] = str(clean[key] or "")[:200_000]

--- a/server/xpert_runtime/middleware_registry.py
+++ b/server/xpert_runtime/middleware_registry.py
@@ -682,21 +682,22 @@ def register_builtin_middleware_nodes(
             id="skills_runtime",
             kind="runtime_middleware.skills_runtime",
             title="Skill 执行指导",
-            description="按需读取已安装 Skill；可选启用本地目录发现，并经审批安装固定提交版本。",
+            description="要求 Agent 实际读取选定 Skill，并按说明消费已暂存的支持资源。",
             category="tool",
             icon="BookOpenCheck",
             fields=[
                 RuntimeMiddlewareField(
                     name="skill_ids",
-                    label="已安装 Skill ID（逗号或换行分隔）",
+                    label="选择必用 Skill",
                     type="textarea",
                     rows=4,
                 ),
                 RuntimeMiddlewareField(
                     name="auto_discover",
-                    label="允许发现全部已安装 Skill",
+                    label="允许发现其他已安装 Skill",
                     type="boolean",
                     default=False,
+                    description="仅作为可选候选，不会要求 Agent 全部读取。",
                 ),
                 RuntimeMiddlewareField(
                     name="catalog_search",


### PR DESCRIPTION
## Summary

- 默认启用 Skill Runtime Guidance V2，并将必用 Skill 改为标签选择器，目录发现与审批式安装收进高级选项。
- 为 Workflow 与私有 Xpert 增加稳定的 Skill 应用卡，展示 required、available、reading、staged、resource_accessed、repair_requested、verified 与 failed。
- 持久化有界、脱敏的 Skill 运行事件，刷新后恢复应用状态，并补齐文档与回归测试。

## Validation

- Backend: 87 passed（一次性无网络容器）
- Frontend Vitest: 23 passed
- Production build: passed
- Independent preview: OpenRouter + deepseek/deepseek-chat real-provider workflow exercised
- git diff --check and sensitive diff scan: passed

## Known boundary

目录检索已验证不会把可选候选误升为必用；test-driven-development 候选因当前 Runtime 不兼容被正确阻断，因此本 PR 未覆盖兼容候选的审批、安装、读取完整正向 E2E。该边界按本轮验收约定不阻断提交。

## Rollback

Set SKILL_RUNTIME_GUIDANCE_V2_ENABLED=false and restart Server. Existing workflows, receipts, and installed Skills are preserved.