### PR TITLE
feature: R5C 接入 Auto 独立证据管道

### DIFF
--- a/client/src/components/settings/ProviderChatControlSettings.test.tsx
+++ b/client/src/components/settings/ProviderChatControlSettings.test.tsx
@@ -24,7 +24,7 @@ const policy = {
 describe("ProviderChatControlSettings", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("describes the bounded R5B data plane and saves an atomic revisioned policy", async () => {
+  it("describes the bounded R5C data plane and saves an atomic revisioned policy", async () => {
     const calls: Array<[RequestInfo | URL, RequestInit | undefined]> = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       calls.push([input, init]);
@@ -74,8 +74,9 @@ describe("ProviderChatControlSettings", () => {
     });
 
     render(<ProviderChatControlSettings csrfToken="csrf-test" />);
-    expect(await screen.findByText("R5B 普通文本稳定路由")).toBeInTheDocument();
+    expect(await screen.findByText("R5C 稳定路由与 Auto 证据")).toBeInTheDocument();
     expect(screen.getByText(/只接管白名单内的 default 普通文本/)).toBeInTheDocument();
+    expect(screen.getByText(/Auto 继续沿用 Native 或 OmniRoute/)).toBeInTheDocument();
     expect(
       (screen.getByRole("option", { name: /newapi_required_default/ }) as HTMLOptionElement)
         .disabled,
@@ -87,6 +88,7 @@ describe("ProviderChatControlSettings", () => {
     fireEvent.change(screen.getByLabelText("稳定模型允许列表"), {
       target: { value: "provider/model" },
     });
+    fireEvent.click(screen.getByText("启用 Auto 独立证据管道（不改变选路）"));
     fireEvent.click(screen.getAllByRole("button", { name: "添加目标" })[0]);
     fireEvent.click(screen.getByRole("button", { name: "原子保存策略" }));
 
@@ -98,6 +100,7 @@ describe("ProviderChatControlSettings", () => {
     expect(body).toMatchObject({
       expected_revision: 0,
       mode: "newapi_preferred",
+      auto_enabled: true,
       stable_model_ids: ["provider/model"],
     });
     expect(body.routes[0]).toEqual({

--- a/client/src/components/settings/ProviderChatControlSettings.tsx
+++ b/client/src/components/settings/ProviderChatControlSettings.tsx
@@ -277,10 +277,11 @@ export default function ProviderChatControlSettings({
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p className="text-sm font-semibold text-cyan-100">Managed Chat 控制策略</p>
-            <h2 className="mt-2 text-xl font-semibold text-white">R5B 普通文本稳定路由</h2>
+            <h2 className="mt-2 text-xl font-semibold text-white">R5C 稳定路由与 Auto 证据</h2>
             <p className="mt-2 max-w-[78ch] text-sm leading-6 text-slate-300">
               newapi_preferred 只接管白名单内的 default 普通文本与已提取文本附件。
-              Auto、工具、文件输出、多模态和 Canary 仍保持各自现有路径。
+              Auto 继续沿用 Native 或 OmniRoute 的现有选路，仅在独立门禁开启时写入脱敏运行与尝试证据。
+              工具、文件输出、多模态和 Canary 仍保持各自现有路径。
             </p>
           </div>
           <button
@@ -327,7 +328,7 @@ export default function ProviderChatControlSettings({
                 onChange={(event) => setAutoEnabled(event.target.checked)}
                 type="checkbox"
               />
-              保存 Auto 独立迁移门禁（R5C 前不生效）
+              启用 Auto 独立证据管道（不改变选路）
             </label>
           </div>
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -170,6 +170,14 @@ Round 5B 将 `gateway=default` 的白名单普通文本和已提取文本附件�
 legacy 网关。Auto、工具、受控文件输出、多模态、Canary、SSE 成功字节和默认部署值
 保持不变；`newapi_required_default` 仍等待 R5E 门禁与人工批准。
 
+Round 5C 在不改变 Auto 选路的前提下，把 `gateway=auto` 的普通文本接入同一父运行/尝试
+证据管道。该入口由租户策略中的独立 `auto_enabled` 门禁控制，默认关闭；关闭时 Auto
+继续原样运行且不写 v15 Receipt。Native Router 的每个实际 Provider 目标分别记录一次
+attempt，并保留其既有 POST 后失败转向下一目标语义；OmniRoute 在 ModelMirror 边界只
+记录一次 sidecar attempt，内部 Provider 重试明确标记为 `provider_attempts_not_observed`，
+不扩展 sidecar 协议。Auto 运行固定 `primary_newapi=false`，不得计入 R5E required 门禁。
+工具、文件输出和多模态仍不进入该证据接入范围。
+
 `/settings?section=overview|providers|routing` 共用一份 Provider 管理会话。Marble 等其他
 集成位于该门禁之外；newAPI 管理 UI 继续只通过安全外链访问，不嵌入或代理。
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -151,7 +151,14 @@ MODEL_CONTROL_CHAT_ENABLED=false
 有序 Managed 路由后，显式开启该变量才会接管对应普通文本。开关关闭、策略为 `legacy`
 或模型不在白名单时继续使用旧静态网关。Managed 首选目标只允许在 POST 前的资格、目录、
 凭据或出口预检失败时选择显式备用；POST 派发后不会调用第二 IP、Provider、模型或 legacy
-网关。Auto、工具、受控文件输出和多模态仍未迁移。超过 90 天的运行与尝试记录可先
+网关。
+
+R5C 使用同一部署开关，并由设置页租户策略中的 `auto_enabled` 提供独立、默认关闭的
+Auto 门禁。开启后只为普通文本 Auto 写入脱敏父运行/尝试证据，不改变 Native 或
+OmniRoute 选路。Native 每个实际目标分别记录；OmniRoute 只记录一次 sidecar 边界尝试，
+内部 Provider 重试标记为不可观测。若 v15 Receipt 无法在派发前建立，已开启门禁的 Auto
+请求失败关闭；关闭 `auto_enabled` 即可恢复旧 Auto 路径。Auto 记录不计入 required
+资格样本。工具、受控文件输出和多模态仍未迁移。超过 90 天的运行与尝试记录可先
 dry-run 检查：
 
 ```bash

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -156,7 +156,7 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
 - R4 受管 Provider 不会自动配置或接管普通 `/api/chat`。当前 default Chat 仍读取
   `LLM_GATEWAY_URL/KEY` 或 `OPENROUTER_API_KEY`；迁移和 newAPI 默认门禁属于 Round 5。
 
-## Managed Chat 策略与普通文本稳定路由（Round 5A—5B）
+## Managed Chat 策略、稳定路由与 Auto 证据（Round 5A—5C）
 
 - 内部契约版本为 `modelmirror-provider-chat-routing-v1`，将 `chat_text`、
   `chat_tools` 和 `chat_file_output` 分别认证和配置；普通文本认证不能证明工具或受控
@@ -175,7 +175,12 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
 - `newapi_preferred` 的首选 newAPI 只有在 POST 派发前的资格、目录、凭据或 DNS/SSRF
   预检失败时才可选择显式 Managed 备用。POST 派发后不重试第二 IP，不切换备用、模型或
   legacy Provider；逻辑运行和逐 Provider 尝试均写入不含请求/回答正文的 Receipt。
-- Auto、工具、受控文件输出、多模态与 Canary 不在 R5B 接管范围；
+- R5C 不改变 Auto 的实际选路和重试语义，只在 `MODEL_CONTROL_CHAT_ENABLED=true` 且
+  租户策略 `auto_enabled=true` 时为普通文本 Auto 写入统一 Receipt。Native 每个真实
+  Provider 目标独立记录 attempt；OmniRoute 只记录 ModelMirror 可见的一次 sidecar
+  attempt，内部重试标记 `provider_attempts_not_observed`。Auto 记录始终设置
+  `primary_newapi=false`，不计入 R5E required 门禁。
+- 工具、受控文件输出、多模态与 Canary 不在 R5C 证据接入范围；
   `newapi_required_default` 仍等待 R5E 的证据门禁与人工批准。
 - 清理命令 `python -m server.model_router.cleanup_chat_receipts --storage-dir <path>` 默认
   dry-run；只有显式增加 `--apply` 才会删除超过保留期的运行和尝试记录，默认保留 90 天。
@@ -185,5 +190,6 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
 关闭管理面或回退路由不得删除 Provider SQLite、newAPI 数据目录、旧主密钥或迁移
 备份。将 `MODEL_MIRROR_PROVIDER_CHAT_CANARY_ENABLED=false` 可立即关闭 Round 3 入口；
 将 `MODEL_CONTROL_CHAT_ENABLED=false` 保持 R5 数据面关闭。代码回退保留 v15 表和
-脱敏证据，旧版本可忽略新表继续运行。部署回退通过恢复上一版本
+脱敏证据；只需将策略 `auto_enabled=false` 即可停止新增 Auto 证据而不改变 Auto 调度。
+旧版本可忽略新表继续运行。部署回退通过恢复上一版本
 Compose 与对应显式环境配置完成。

--- a/server/main.py
+++ b/server/main.py
@@ -1038,7 +1038,9 @@ except ModuleNotFoundError:
 
 try:
     from server.model_router import (
+        AUTO_SIDECAR_ATTEMPTS_NOT_OBSERVED,
         NoEligibleCandidateError,
+        ProviderChatAutoAuditService,
         ProviderChatCanaryService,
         ProviderChatCanaryStreamEvidence,
         ProviderChatStableService,
@@ -1054,7 +1056,9 @@ try:
     )
 except ModuleNotFoundError:
     from model_router import (
+        AUTO_SIDECAR_ATTEMPTS_NOT_OBSERVED,
         NoEligibleCandidateError,
+        ProviderChatAutoAuditService,
         ProviderChatCanaryService,
         ProviderChatCanaryStreamEvidence,
         ProviderChatStableService,
@@ -23272,6 +23276,7 @@ async def chat(payload: ChatRequest, request: Request):
         native_router_engine.service.egress_policy
     )
     chat_canary_service = ProviderChatCanaryService(router_service)
+    auto_audit_service = ProviderChatAutoAuditService(router_service)
     stable_chat_service = ProviderChatStableService(router_service)
     native_router_policy = router_service.get_policy()
     direct_audio_requested = any(
@@ -23292,6 +23297,27 @@ async def chat(payload: ChatRequest, request: Request):
         direct_audio_requested or response_audio_requested
     )
     chat_canary_requested = payload.gateway == "newapi_canary"
+    auto_audit_shape_requested = bool(
+        payload.gateway == "auto"
+        and payload.tool_mode == "none"
+        and payload.output_mode == "none"
+        and payload.response_audio is None
+        and payload.skill_application is None
+        and not direct_audio_requested
+        and not direct_video_requested
+        and not direct_file_requested
+        and all(
+            isinstance(message.content, str)
+            or (
+                isinstance(message.content, list)
+                and all(
+                    isinstance(part, TextContentPart)
+                    for part in message.content
+                )
+            )
+            for message in payload.messages
+        )
+    )
     stable_chat_shape_requested = bool(
         stable_chat_service.control.feature_enabled()
         and payload.gateway == "default"
@@ -24361,6 +24387,31 @@ async def chat(payload: ChatRequest, request: Request):
                     eligibility=chat_canary_eligibility,
                 )
 
+    auto_audit_run = None
+    if auto_audit_shape_requested:
+        try:
+            auto_audit_run = auto_audit_service.begin(
+                payload.model_id,
+                strategy=(
+                    "auto_native" if use_native_router else "auto_sidecar"
+                ),
+                sidecar_boundary=use_omniroute,
+            )
+        except RouterServiceError as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"error": exc.hint, "code": exc.code},
+            )
+        except Exception:
+            logger.exception("Auto Chat audit preflight failed")
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "Auto 调用审计暂时不可用，本次请求未派发。",
+                    "code": "provider_chat_auto_audit_unavailable",
+                },
+            )
+
     runtime_pipeline = None
     runtime_context = None
     if (
@@ -24423,6 +24474,29 @@ async def chat(payload: ChatRequest, request: Request):
     )
     fallback_notice = ""
     audio_finalized = False
+    auto_current_attempt = None
+    auto_audit_run_finalized = False
+
+    def auto_attempt_for_dispatch():
+        nonlocal auto_current_attempt
+        if auto_audit_run is None:
+            return None
+        if use_native_router and native_plan is not None:
+            target = native_plan.targets[native_target_index]
+            position = native_target_index
+            connection_id = target.connection_id
+            provider_kind = target.provider_chat_target.provider_kind
+        else:
+            position = 0
+            connection_id = None
+            provider_kind = "omniroute"
+        auto_current_attempt = auto_audit_service.claim_attempt(
+            auto_audit_run,
+            position=position,
+            connection_id=connection_id,
+            provider_kind=provider_kind,
+        )
+        return auto_current_attempt
 
     def finalize_native_audio_failure(outcome: str) -> None:
         nonlocal audio_finalized
@@ -24749,6 +24823,7 @@ async def chat(payload: ChatRequest, request: Request):
         nonlocal chat_canary_started_at
         nonlocal stable_chat_post_started
         nonlocal stable_chat_started_at
+        nonlocal auto_current_attempt
         if direct_file_requested:
             logger.info("Sending file chat request model=%s code=upstream_send", model_id)
         elif use_chat_canary:
@@ -24796,6 +24871,14 @@ async def chat(payload: ChatRequest, request: Request):
             stable_chat_started_at = time.perf_counter()
             return await provider_chat_transport.send_authorized_stream(
                 client, prepared_request
+            )
+        if auto_audit_run is not None:
+            auto_current_attempt = auto_attempt_for_dispatch()
+            if auto_current_attempt is None:
+                raise RuntimeError("provider_chat_auto_attempt_missing")
+            auto_audit_service.mark_dispatched(
+                auto_audit_run,
+                auto_current_attempt,
             )
         use_provider_chat_contract = bool(
             not native_audio_requested
@@ -25029,6 +25112,12 @@ async def chat(payload: ChatRequest, request: Request):
                 )
             except (httpx.TimeoutException, httpx.HTTPError) as exc:
                 last_error = exc
+                complete_auto_attempt(
+                    status="failed",
+                    result_class="transient_failure",
+                    error_code="provider_chat_transport_error",
+                    actual_model=target.model_id,
+                )
                 native_router_engine.record_outcome(
                     native_plan,
                     target,
@@ -25052,6 +25141,17 @@ async def chat(payload: ChatRequest, request: Request):
                 429,
             } or candidate_response.status_code >= 500
             if retryable_status:
+                auto_result_class, auto_error_code, _auto_hard_failure = (
+                    auto_audit_service.classify_http_failure(
+                        candidate_response.status_code
+                    )
+                )
+                complete_auto_attempt(
+                    status="failed",
+                    result_class=auto_result_class,
+                    error_code=auto_error_code,
+                    actual_model=target.model_id,
+                )
                 native_router_engine.record_outcome(
                     native_plan,
                     target,
@@ -25071,6 +25171,104 @@ async def chat(payload: ChatRequest, request: Request):
         raise httpx.ConnectError("No native dispatch target was available.")
 
     chat_request_started_at = time.perf_counter()
+
+    def complete_auto_attempt(
+        *,
+        status: str,
+        result_class: str,
+        error_code: str | None = None,
+        actual_model: str | None = None,
+        ttft_ms: float | None = None,
+        e2e_ms: float | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+    ) -> None:
+        if auto_audit_run is None or auto_current_attempt is None:
+            return
+        elapsed_ms = (
+            e2e_ms
+            if e2e_ms is not None
+            else (time.perf_counter() - auto_current_attempt.started_at) * 1000
+        )
+        auto_audit_service.complete_attempt(
+            auto_audit_run,
+            auto_current_attempt,
+            status=status,
+            result_class=result_class,
+            error_code=error_code,
+            actual_model=actual_model,
+            ttft_ms=ttft_ms,
+            e2e_ms=elapsed_ms,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+        )
+
+    def finalize_auto_run(
+        *,
+        status: str,
+        result_class: str,
+        error_code: str | None = None,
+        actual_model: str | None = None,
+        client_cancelled: bool = False,
+        hard_failure: bool = False,
+        ttft_ms: float | None = None,
+        e2e_ms: float | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+    ) -> None:
+        nonlocal auto_audit_run_finalized
+        if auto_audit_run is None or auto_audit_run_finalized:
+            return
+        reason_codes = []
+        if len(auto_audit_run.attempts) > 1:
+            reason_codes.append("provider_chat_auto_fallback_used")
+        if error_code:
+            reason_codes.append(error_code)
+        auto_audit_service.complete_run(
+            auto_audit_run,
+            status=status,
+            result_class=result_class,
+            reason_codes=reason_codes,
+            actual_model=actual_model,
+            client_cancelled=client_cancelled,
+            hard_failure=hard_failure,
+            ttft_ms=ttft_ms,
+            e2e_ms=(
+                e2e_ms
+                if e2e_ms is not None
+                else (time.perf_counter() - auto_audit_run.started_at) * 1000
+            ),
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+        )
+        auto_audit_run_finalized = True
+
+    def finalize_auto_failure(
+        result_class: str,
+        error_code: str,
+        *,
+        status: str = "failed",
+        client_cancelled: bool = False,
+        hard_failure: bool = False,
+    ) -> None:
+        complete_auto_attempt(
+            status=status,
+            result_class=result_class,
+            error_code=error_code,
+            actual_model=actual_model_id,
+        )
+        finalize_auto_run(
+            status=status,
+            result_class=result_class,
+            error_code=error_code,
+            actual_model=actual_model_id,
+            client_cancelled=client_cancelled,
+            hard_failure=hard_failure,
+        )
 
     def finalize_chat_canary_failure(
         result_class: str,
@@ -25140,21 +25338,22 @@ async def chat(payload: ChatRequest, request: Request):
     try:
         response = await send_initial_response()
     except RouterServiceError as exc:
+        finalize_auto_failure("preflight_failure", exc.code)
         await finalize_runtime("error", actual_model_id, error=exc.code)
         await close_request_client()
-        return JSONResponse(
-            status_code=exc.status_code,
-            content={
-                "error": exc.hint,
-                "code": exc.code,
-                "route_receipt": stable_chat_service.route_receipt(
-                    stable_chat_dispatch,
-                    requested_model=payload.model_id,
-                    reason_codes=[exc.code],
-                ),
-            },
-        )
+        error_content: dict[str, object] = {
+            "error": exc.hint,
+            "code": exc.code,
+        }
+        if use_stable_chat:
+            error_content["route_receipt"] = stable_chat_service.route_receipt(
+                stable_chat_dispatch,
+                requested_model=payload.model_id,
+                reason_codes=[exc.code],
+            )
+        return JSONResponse(status_code=exc.status_code, content=error_content)
     except httpx.TimeoutException:
+        finalize_auto_failure("transient_failure", "provider_chat_timeout")
         finalize_chat_canary_failure(
             "transient_failure", "provider_chat_timeout"
         )
@@ -25190,6 +25389,9 @@ async def chat(payload: ChatRequest, request: Request):
             )
         return JSONResponse(status_code=504, content=timeout_content)
     except httpx.HTTPError as exc:
+        finalize_auto_failure(
+            "transient_failure", "provider_chat_transport_error"
+        )
         finalize_chat_canary_failure(
             "transient_failure", "provider_chat_transport_error"
         )
@@ -25238,6 +25440,9 @@ async def chat(payload: ChatRequest, request: Request):
             )
         return JSONResponse(status_code=502, content=transport_content)
     except Exception:
+        finalize_auto_failure(
+            "uncertain", "provider_chat_unexpected_error", status="uncertain"
+        )
         finalize_chat_canary_failure(
             "uncertain", "provider_chat_unexpected_error", status="uncertain"
         )
@@ -25277,6 +25482,25 @@ async def chat(payload: ChatRequest, request: Request):
     if response.status_code >= 400:
         body = await response.aread()
         await response.aclose()
+        if auto_audit_run is not None:
+            (
+                auto_result_class,
+                auto_http_error_code,
+                auto_hard_failure,
+            ) = auto_audit_service.classify_http_failure(response.status_code)
+            complete_auto_attempt(
+                status="failed",
+                result_class=auto_result_class,
+                error_code=auto_http_error_code,
+                actual_model=actual_model_id,
+            )
+            finalize_auto_run(
+                status="failed",
+                result_class=auto_result_class,
+                error_code=auto_http_error_code,
+                actual_model=actual_model_id,
+                hard_failure=auto_hard_failure,
+            )
         stable_http_receipt = None
         stable_http_error_code = None
         if use_chat_canary:
@@ -25639,6 +25863,12 @@ async def chat(payload: ChatRequest, request: Request):
                     )
                 except (httpx.TimeoutException, httpx.HTTPError) as exc:
                     runtime_error = "transport_error"
+                    complete_auto_attempt(
+                        status="failed",
+                        result_class="transient_failure",
+                        error_code="provider_chat_transport_error",
+                        actual_model=selected_target.model_id,
+                    )
                     if direct_file_requested:
                         logger.warning(
                             "File chat native fallback failed model=%s code=transport_error",
@@ -25666,6 +25896,17 @@ async def chat(payload: ChatRequest, request: Request):
                 if current_response.status_code >= 400:
                     status_code = current_response.status_code
                     runtime_error = f"http_{status_code}"
+                    (
+                        auto_result_class,
+                        auto_error_code,
+                        _auto_hard_failure,
+                    ) = auto_audit_service.classify_http_failure(status_code)
+                    complete_auto_attempt(
+                        status="failed",
+                        result_class=auto_result_class,
+                        error_code=auto_error_code,
+                        actual_model=selected_target.model_id,
+                    )
                     await current_response.aread()
                     await current_response.aclose()
                     current_response = None
@@ -25730,6 +25971,24 @@ async def chat(payload: ChatRequest, request: Request):
                             yield encoded
                     await asyncio.sleep(0)
                 stream_transport_finished = True
+            except asyncio.CancelledError:
+                complete_auto_attempt(
+                    status="cancelled",
+                    result_class="client_cancelled",
+                    error_code="provider_chat_client_cancelled",
+                    actual_model=selected_target.model_id,
+                    ttft_ms=attempt_ttft_ms,
+                )
+                finalize_auto_run(
+                    status="cancelled",
+                    result_class="client_cancelled",
+                    error_code="provider_chat_client_cancelled",
+                    actual_model=selected_target.model_id,
+                    client_cancelled=True,
+                    ttft_ms=attempt_ttft_ms,
+                )
+                await close_request_client()
+                raise
             except Exception as exc:
                 stream_exception = exc
                 if direct_file_requested:
@@ -25796,6 +26055,32 @@ async def chat(payload: ChatRequest, request: Request):
                         if finish_reason == "length"
                         else "completed"
                     )
+                    complete_auto_attempt(
+                        status="succeeded",
+                        result_class=(
+                            "output_limit"
+                            if runtime_status == "output_limit"
+                            else "success"
+                        ),
+                        actual_model=selected_target.model_id,
+                        ttft_ms=attempt_ttft_ms,
+                        e2e_ms=elapsed_ms,
+                        prompt_tokens=(
+                            state.get("tokens_in")
+                            if isinstance(state.get("tokens_in"), int)
+                            else None
+                        ),
+                        completion_tokens=(
+                            state.get("tokens_out")
+                            if isinstance(state.get("tokens_out"), int)
+                            else None
+                        ),
+                        total_tokens=(
+                            state.get("tokens_total")
+                            if isinstance(state.get("tokens_total"), int)
+                            else None
+                        ),
+                    )
                     native_router_engine.record_outcome(
                         native_plan,
                         selected_target,
@@ -25815,6 +26100,14 @@ async def chat(payload: ChatRequest, request: Request):
                     )
                 else:
                     runtime_error = "stream interrupted"
+                    complete_auto_attempt(
+                        status="failed",
+                        result_class="transient_failure",
+                        error_code="provider_chat_stream_interrupted",
+                        actual_model=selected_target.model_id,
+                        ttft_ms=attempt_ttft_ms,
+                        e2e_ms=elapsed_ms,
+                    )
                     native_router_engine.record_outcome(
                         native_plan,
                         selected_target,
@@ -25840,6 +26133,21 @@ async def chat(payload: ChatRequest, request: Request):
                 break
 
             outcome = "empty_stream" if stream_exception is None else "stream_error"
+            complete_auto_attempt(
+                status="failed",
+                result_class=(
+                    "hard_failure"
+                    if outcome == "empty_stream"
+                    else "transient_failure"
+                ),
+                error_code=(
+                    "provider_chat_empty_stream"
+                    if outcome == "empty_stream"
+                    else "provider_chat_stream_interrupted"
+                ),
+                actual_model=selected_target.model_id,
+                e2e_ms=elapsed_ms,
+            )
             native_router_engine.record_outcome(
                 native_plan,
                 selected_target,
@@ -25973,6 +26281,33 @@ async def chat(payload: ChatRequest, request: Request):
             },
             "version": "2",
         }
+        auto_run_status = "succeeded" if upstream_completed else "failed"
+        auto_run_result = (
+            "output_limit"
+            if runtime_status == "output_limit"
+            else "success"
+            if upstream_completed
+            else "hard_failure"
+            if runtime_error == "empty_stream"
+            else "transient_failure"
+        )
+        auto_run_error = (
+            None
+            if upstream_completed
+            else "provider_chat_empty_stream"
+            if runtime_error == "empty_stream"
+            else "provider_chat_stream_interrupted"
+        )
+        finalize_auto_run(
+            status=auto_run_status,
+            result_class=auto_run_result,
+            error_code=auto_run_error,
+            actual_model=selected_target.model_id,
+            ttft_ms=final_ttft_ms,
+            prompt_tokens=tokens_in if isinstance(tokens_in, int) else None,
+            completion_tokens=tokens_out if isinstance(tokens_out, int) else None,
+            total_tokens=tokens_total if isinstance(tokens_total, int) else None,
+        )
         if direct_file_requested:
             _file_succeeded, file_terminal_events = (
                 await finalize_native_chat_file_events(
@@ -26091,6 +26426,15 @@ async def chat(payload: ChatRequest, request: Request):
                 await asyncio.sleep(0)
             stream_completed = True
         except asyncio.CancelledError:
+            if auto_audit_run is not None:
+                runtime_status = "error"
+                runtime_error = "client cancelled"
+                finalize_auto_failure(
+                    "client_cancelled",
+                    "provider_chat_client_cancelled",
+                    status="cancelled",
+                    client_cancelled=True,
+                )
             if not use_chat_canary and not use_stable_chat:
                 raise
             runtime_status = "error"
@@ -26613,6 +26957,15 @@ async def chat(payload: ChatRequest, request: Request):
                         "algorithm_version": "sidecar",
                     }
                 )
+                if auto_audit_run is not None:
+                    receipt["reason_codes"] = list(
+                        dict.fromkeys(
+                            [
+                                *list(receipt.get("reason_codes") or []),
+                                AUTO_SIDECAR_ATTEMPTS_NOT_OBSERVED,
+                            ]
+                        )
+                    )
                 yield route_receipt_sse(receipt)
                 if not omniroute_stream_state.get("content_observed"):
                     runtime_status = "error"
@@ -26653,6 +27006,82 @@ async def chat(payload: ChatRequest, request: Request):
                     if runtime_error == "stream interrupted"
                     else "stream_error"
                 )
+                if auto_audit_run is not None:
+                    sidecar_actual_model = str(
+                        omniroute_stream_state.get("actual_model")
+                        or omniroute_header_state.get("actual_model")
+                        or actual_model_id
+                    )
+                    sidecar_result_class = (
+                        "success"
+                        if sidecar_outcome == "success"
+                        else "hard_failure"
+                        if sidecar_outcome == "empty_stream"
+                        else "transient_failure"
+                    )
+                    sidecar_error_code = (
+                        None
+                        if sidecar_outcome == "success"
+                        else "provider_chat_empty_stream"
+                        if sidecar_outcome == "empty_stream"
+                        else "provider_chat_stream_interrupted"
+                    )
+                    sidecar_prompt_tokens = (
+                        omniroute_stream_state.get("tokens_in")
+                        if isinstance(
+                            omniroute_stream_state.get("tokens_in"), int
+                        )
+                        else None
+                    )
+                    sidecar_total_tokens = (
+                        omniroute_stream_state.get("tokens_total")
+                        if isinstance(
+                            omniroute_stream_state.get("tokens_total"), int
+                        )
+                        else None
+                    )
+                    complete_auto_attempt(
+                        status=(
+                            "succeeded"
+                            if sidecar_outcome == "success"
+                            else "failed"
+                        ),
+                        result_class=sidecar_result_class,
+                        error_code=sidecar_error_code,
+                        actual_model=sidecar_actual_model,
+                        ttft_ms=sidecar_ttft_ms,
+                        e2e_ms=sidecar_e2e_ms,
+                        prompt_tokens=sidecar_prompt_tokens,
+                        completion_tokens=(
+                            omniroute_stream_state.get("tokens_out")
+                            if isinstance(
+                                omniroute_stream_state.get("tokens_out"), int
+                            )
+                            else None
+                        ),
+                        total_tokens=sidecar_total_tokens,
+                    )
+                    finalize_auto_run(
+                        status=(
+                            "succeeded"
+                            if sidecar_outcome == "success"
+                            else "failed"
+                        ),
+                        result_class=sidecar_result_class,
+                        error_code=sidecar_error_code,
+                        actual_model=sidecar_actual_model,
+                        ttft_ms=sidecar_ttft_ms,
+                        e2e_ms=sidecar_e2e_ms,
+                        prompt_tokens=sidecar_prompt_tokens,
+                        completion_tokens=(
+                            omniroute_stream_state.get("tokens_out")
+                            if isinstance(
+                                omniroute_stream_state.get("tokens_out"), int
+                            )
+                            else None
+                        ),
+                        total_tokens=sidecar_total_tokens,
+                    )
                 recorder = getattr(
                     get_model_router_service().repository,
                     "record_router_candidate_sample",

--- a/server/model_router/__init__.py
+++ b/server/model_router/__init__.py
@@ -55,6 +55,12 @@ from .chat_stable import (
     ProviderChatStablePreflight,
     ProviderChatStableService,
 )
+from .chat_auto import (
+    AUTO_SIDECAR_ATTEMPTS_NOT_OBSERVED,
+    ProviderChatAutoAttempt,
+    ProviderChatAutoAuditService,
+    ProviderChatAutoRun,
+)
 
 __all__ = [
     "CompressionMode",
@@ -74,12 +80,16 @@ __all__ = [
     "ProviderChatCanaryDispatch",
     "ProviderChatCanaryService",
     "ProviderChatCanaryStreamEvidence",
+    "ProviderChatAutoAttempt",
+    "ProviderChatAutoAuditService",
+    "ProviderChatAutoRun",
     "ProviderChatStableDispatch",
     "ProviderChatStablePreflight",
     "ProviderChatStableService",
     "ProviderChatEndpointResolver",
     "ProviderChatTarget",
     "ProviderChatTransport",
+    "AUTO_SIDECAR_ATTEMPTS_NOT_OBSERVED",
     "RouterConnection",
     "RouterConnectionCreate",
     "RouterConnectionNotFound",

--- a/server/model_router/chat_auto.py
+++ b/server/model_router/chat_auto.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+
+from .chat_control import ProviderChatControlService
+from .service import ModelRouterService, RouterServiceError
+
+
+AUTO_SIDECAR_ATTEMPTS_NOT_OBSERVED = "provider_attempts_not_observed"
+
+
+@dataclass(slots=True)
+class ProviderChatAutoAttempt:
+    attempt_id: str
+    position: int
+    connection_id: str | None
+    provider_kind: str
+    started_at: float
+    dispatched: bool = False
+    finalized: bool = False
+
+
+@dataclass(slots=True)
+class ProviderChatAutoRun:
+    run_id: str
+    policy_fingerprint: str
+    requested_model: str
+    strategy: str
+    boundary_reason_codes: tuple[str, ...]
+    started_at: float
+    attempts: dict[int, ProviderChatAutoAttempt] = field(default_factory=dict)
+    finalized: bool = False
+
+
+class ProviderChatAutoAuditService:
+    """Persist Auto routing evidence without observing request or response text."""
+
+    def __init__(self, router_service: ModelRouterService) -> None:
+        self.router_service = router_service
+        self.repository = router_service.repository
+        self.control = ProviderChatControlService(router_service)
+
+    def enabled(self) -> bool:
+        if not self.control.feature_enabled():
+            return False
+        return self.control.get_policy().auto_enabled
+
+    def begin(
+        self,
+        requested_model: str,
+        *,
+        strategy: str,
+        sidecar_boundary: bool = False,
+    ) -> ProviderChatAutoRun | None:
+        if not self.control.feature_enabled():
+            return None
+        policy = self.control.get_policy()
+        if not policy.auto_enabled:
+            return None
+        run = ProviderChatAutoRun(
+            run_id=f"chatrun_{uuid.uuid4().hex}",
+            policy_fingerprint=policy.policy_fingerprint,
+            requested_model=str(requested_model or "").strip(),
+            strategy=strategy,
+            boundary_reason_codes=(
+                (AUTO_SIDECAR_ATTEMPTS_NOT_OBSERVED,)
+                if sidecar_boundary
+                else ()
+            ),
+            started_at=time.perf_counter(),
+        )
+        self._repository_method("claim_chat_control_run")(
+            self.router_service.tenant_id,
+            run_id=run.run_id,
+            policy_fingerprint=run.policy_fingerprint,
+            capability="chat_text",
+            requested_model=run.requested_model,
+            strategy=run.strategy,
+            gateway="auto",
+            epoch_id=None,
+            is_real_user=True,
+            primary_newapi=False,
+        )
+        return run
+
+    def claim_attempt(
+        self,
+        run: ProviderChatAutoRun,
+        *,
+        position: int,
+        connection_id: str | None,
+        provider_kind: str,
+    ) -> ProviderChatAutoAttempt:
+        if run.finalized:
+            raise RouterServiceError(
+                "provider_chat_auto_run_finalized",
+                "Auto 审计运行已结束，不能再派发新的 Provider 尝试。",
+                status_code=409,
+            )
+        existing = run.attempts.get(position)
+        if existing is not None:
+            return existing
+        attempt = ProviderChatAutoAttempt(
+            attempt_id=f"chatattempt_{uuid.uuid4().hex}",
+            position=position,
+            connection_id=connection_id,
+            provider_kind=provider_kind,
+            started_at=time.perf_counter(),
+        )
+        self._repository_method("claim_chat_control_attempt")(
+            self.router_service.tenant_id,
+            attempt_id=attempt.attempt_id,
+            run_id=run.run_id,
+            capability="chat_text",
+            position=position,
+            connection_id=connection_id,
+            provider_kind=provider_kind,
+        )
+        run.attempts[position] = attempt
+        return attempt
+
+    def mark_dispatched(
+        self,
+        run: ProviderChatAutoRun,
+        attempt: ProviderChatAutoAttempt,
+    ) -> None:
+        if attempt.dispatched:
+            raise RouterServiceError(
+                "provider_chat_auto_duplicate_post_blocked",
+                "Auto Provider 尝试已派发，禁止重复调用。",
+                status_code=409,
+            )
+        policy = self.control.get_policy()
+        if (
+            not self.control.feature_enabled()
+            or not policy.auto_enabled
+            or policy.policy_fingerprint != run.policy_fingerprint
+        ):
+            code = "provider_chat_auto_policy_changed"
+            self.complete_attempt(
+                run,
+                attempt,
+                status="failed",
+                result_class="preflight_failure",
+                error_code=code,
+            )
+            self.complete_run(
+                run,
+                status="failed",
+                result_class="preflight_failure",
+                reason_codes=[code],
+            )
+            raise RouterServiceError(
+                code,
+                "Auto 迁移门禁或控制策略已变化，请刷新后重试。",
+                status_code=409,
+            )
+        self._repository_method("mark_chat_control_attempt_dispatched")(
+            self.router_service.tenant_id,
+            attempt.attempt_id,
+        )
+        attempt.dispatched = True
+
+    def complete_attempt(
+        self,
+        run: ProviderChatAutoRun,
+        attempt: ProviderChatAutoAttempt,
+        *,
+        status: str,
+        result_class: str,
+        error_code: str | None = None,
+        actual_model: str | None = None,
+        ttft_ms: float | None = None,
+        e2e_ms: float | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+    ) -> None:
+        if attempt.finalized:
+            return
+        self._repository_method("complete_chat_control_attempt")(
+            self.router_service.tenant_id,
+            attempt.attempt_id,
+            status=status,
+            result_class=result_class,
+            error_code=error_code,
+            actual_model=actual_model,
+            ttft_ms=ttft_ms,
+            e2e_ms=e2e_ms,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+        )
+        attempt.finalized = True
+
+    def complete_run(
+        self,
+        run: ProviderChatAutoRun,
+        *,
+        status: str,
+        result_class: str,
+        reason_codes: list[str] | None = None,
+        actual_model: str | None = None,
+        client_cancelled: bool = False,
+        hard_failure: bool = False,
+        ttft_ms: float | None = None,
+        e2e_ms: float | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+    ) -> None:
+        if run.finalized:
+            return
+        codes = list(run.boundary_reason_codes)
+        codes.extend(reason_codes or [])
+        self._repository_method("complete_chat_control_run")(
+            self.router_service.tenant_id,
+            run.run_id,
+            status=status,
+            result_class=result_class,
+            reason_codes=list(dict.fromkeys(codes)),
+            actual_model=actual_model,
+            client_cancelled=client_cancelled,
+            hard_failure=hard_failure,
+            ttft_ms=ttft_ms,
+            e2e_ms=e2e_ms,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+        )
+        run.finalized = True
+
+    @staticmethod
+    def classify_http_failure(status_code: int) -> tuple[str, str, bool]:
+        code = f"provider_chat_http_{status_code}"
+        if status_code in {401, 402, 403, 404}:
+            return "hard_failure", code, True
+        if status_code == 429 or status_code >= 500:
+            return "transient_failure", code, False
+        return "request_failure", code, False
+
+    def _repository_method(self, name: str):
+        method = getattr(self.repository, name, None)
+        if not callable(method):
+            raise RouterServiceError(
+                "provider_chat_control_storage_unavailable",
+                "当前 Router 存储不支持 Auto 调用审计。",
+                status_code=503,
+            )
+        return method

--- a/server/model_router/chat_control.py
+++ b/server/model_router/chat_control.py
@@ -338,6 +338,7 @@ class ProviderChatControlService:
                         if row.get("actual_model")
                         else None
                     ),
+                    gateway=str(row["gateway"]),
                     strategy=str(row["strategy"]),
                     status=str(row["status"]),
                     result_class=(

--- a/server/model_router/schemas.py
+++ b/server/model_router/schemas.py
@@ -506,6 +506,7 @@ class ProviderChatControlRunSummary(BaseModel):
     capability: ProviderChatCapability
     requested_model: str
     actual_model: str | None = None
+    gateway: str
     strategy: str
     status: str
     result_class: str | None = None

--- a/server/tests/test_native_router_chat.py
+++ b/server/tests/test_native_router_chat.py
@@ -19,6 +19,8 @@ from server.model_router import (
     get_model_router_service,
 )
 from server.model_router.egress import ProviderEgressPolicy
+from server.model_router.chat_control import ProviderChatControlService
+from server.model_router.schemas import ProviderChatControlPolicyUpdate
 
 
 @pytest_asyncio.fixture
@@ -124,6 +126,13 @@ async def test_native_auto_retries_empty_stream_before_visible_output(
 ) -> None:
     original_service = get_model_router_service()
     service = native_service(tmp_path)
+    ProviderChatControlService(service).update_policy(
+        ProviderChatControlPolicyUpdate(
+            expected_revision=0,
+            mode="legacy",
+            auto_enabled=True,
+        )
+    )
     configure_model_router(service)
     sent_models: list[str] = []
 
@@ -178,6 +187,7 @@ async def test_native_auto_retries_empty_stream_before_visible_output(
             return None
 
     try:
+        monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
         monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
         monkeypatch.setattr(main_module.httpx, "AsyncClient", FakeChatClient)
         response = await client.post(
@@ -236,6 +246,18 @@ async def test_native_auto_retries_empty_stream_before_visible_output(
     assert diagnostics["recent_decisions"][0]["budget"][
         "settled_cost_usd"
     ] == pytest.approx(0.000008)
+    stored = service.repository.list_chat_control_receipts("local")
+    assert len(stored["runs"]) == 1
+    assert stored["runs"][0]["gateway"] == "auto"
+    assert stored["runs"][0]["strategy"] == "auto_native"
+    assert stored["runs"][0]["primary_newapi"] == 0
+    assert [item["position"] for item in stored["attempts"]] == [0, 1]
+    assert [item["dispatched"] for item in stored["attempts"]] == [1, 1]
+    assert stored["attempts"][0]["error_code"] == "provider_chat_empty_stream"
+    assert stored["attempts"][1]["status"] == "succeeded"
+    assert "provider_chat_auto_fallback_used" in stored["runs"][0][
+        "reason_codes_json"
+    ]
 
 
 def test_native_canary_assignment_is_stable() -> None:

--- a/server/tests/test_omniroute_integration.py
+++ b/server/tests/test_omniroute_integration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -9,6 +10,14 @@ import pytest_asyncio
 
 from server import main as main_module
 from server.main import ChatRoutingOptions, app, omniroute_model_for_request
+from server.model_router import configure_model_router, get_model_router_service
+from server.model_router.chat_control import ProviderChatControlService
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import (
+    ProviderChatControlPolicyUpdate,
+    RouterPolicy,
+)
+from server.model_router.service import ModelRouterService
 from server.omniroute.catalog import OmniRouteCatalogService, normalize_models
 from server.omniroute.client import OmniRouteClientError
 from server.omniroute.config import OmniRouteSettings
@@ -478,6 +487,118 @@ async def test_omniroute_chat_forwards_headers_and_emits_one_receipt(
     assert receipt["tokens"]["total"] == 7
     assert receipt["response_cost_usd"] == 0.00125
     assert receipt["request_id"] == "req-123"
+
+
+@pytest.mark.asyncio
+async def test_auto_sidecar_records_one_boundary_attempt_without_internal_claims(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    repository.save_policy(
+        "local", RouterPolicy(tenant_id="local", engine="sidecar")
+    )
+    service = ModelRouterService(repository)
+    ProviderChatControlService(service).update_policy(
+        ProviderChatControlPolicyUpdate(
+            expected_revision=0,
+            mode="legacy",
+            auto_enabled=True,
+        )
+    )
+    configure_model_router(service)
+    sent_requests: list[dict[str, Any]] = []
+
+    class FakeResponse:
+        status_code = 200
+        headers = {
+            "X-OmniRoute-Model": "openai/gpt-4o",
+            "X-OmniRoute-Provider": "openai",
+            "X-OmniRoute-Request-Id": "req-auto-audit",
+        }
+        content = b""
+
+        async def aiter_text(self):
+            yield 'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n'
+            yield (
+                'data: {"model":"openai/gpt-4o","choices":[],'
+                '"usage":{"prompt_tokens":5,"completion_tokens":2,'
+                '"total_tokens":7}}\n\n'
+            )
+            yield "data: [DONE]\n\n"
+
+        async def aread(self):
+            return self.content
+
+        async def aclose(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def build_request(self, method, url, headers, json):
+            request = {
+                "method": method,
+                "url": url,
+                "headers": headers,
+                "json": json,
+            }
+            sent_requests.append(request)
+            return request
+
+        async def send(self, request, stream):
+            assert stream is True
+            return FakeResponse()
+
+        async def aclose(self):
+            return None
+
+    try:
+        monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+        monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+        monkeypatch.setattr(
+            main_module,
+            "create_default_runtime",
+            lambda: (_ for _ in ()).throw(RuntimeError("runtime disabled")),
+        )
+        monkeypatch.setattr(
+            main_module,
+            "get_omniroute_settings",
+            lambda: enabled_settings(),
+        )
+        monkeypatch.setattr(main_module.httpx, "AsyncClient", FakeClient)
+        response = await client.post(
+            "/api/chat",
+            json={
+                "model_id": "auto",
+                "gateway": "auto",
+                "messages": [{"role": "user", "content": "private text"}],
+                "routing": {"mode": "balanced"},
+            },
+        )
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 200, response.text
+    assert len(sent_requests) == 1
+    receipt_event = next(
+        event
+        for event in response.text.split("\n\n")
+        if event.startswith("event: route_receipt")
+    )
+    receipt = json.loads(receipt_event.split("data:", 1)[1].strip())
+    assert "provider_attempts_not_observed" in receipt["reason_codes"]
+    stored = repository.list_chat_control_receipts("local")
+    assert len(stored["runs"]) == 1
+    assert stored["runs"][0]["strategy"] == "auto_sidecar"
+    assert stored["runs"][0]["primary_newapi"] == 0
+    assert len(stored["attempts"]) == 1
+    assert stored["attempts"][0]["provider_kind"] == "omniroute"
+    assert stored["attempts"][0]["connection_id"] is None
+    assert stored["attempts"][0]["dispatched"] == 1
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_provider_chat_auto_service.py
+++ b/server/tests/test_provider_chat_auto_service.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from server.model_router.chat_auto import (
+    AUTO_SIDECAR_ATTEMPTS_NOT_OBSERVED,
+    ProviderChatAutoAuditService,
+)
+from server.model_router.chat_control import ProviderChatControlService
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import ProviderChatControlPolicyUpdate
+from server.model_router.service import ModelRouterService, RouterServiceError
+
+
+def _service(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    auto_enabled: bool = True,
+) -> tuple[
+    ProviderChatAutoAuditService,
+    ProviderChatControlService,
+    SQLiteRouterRepository,
+]:
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    router_service = ModelRouterService(repository)
+    control = ProviderChatControlService(router_service)
+    control.update_policy(
+        ProviderChatControlPolicyUpdate(
+            expected_revision=0,
+            mode="legacy",
+            auto_enabled=auto_enabled,
+        )
+    )
+    return ProviderChatAutoAuditService(router_service), control, repository
+
+
+def test_auto_gate_defaults_to_no_evidence_when_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, _control, repository = _service(
+        tmp_path, monkeypatch, auto_enabled=False
+    )
+
+    assert service.enabled() is False
+    assert service.begin("auto", strategy="auto_native") is None
+    assert repository.list_chat_control_receipts("local")["runs"] == []
+
+
+def test_sidecar_is_one_attempt_and_marks_internal_attempts_unobserved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, control, repository = _service(tmp_path, monkeypatch)
+
+    run = service.begin(
+        "auto", strategy="auto_sidecar", sidecar_boundary=True
+    )
+    assert run is not None
+    attempt = service.claim_attempt(
+        run,
+        position=0,
+        connection_id=None,
+        provider_kind="omniroute",
+    )
+    service.mark_dispatched(run, attempt)
+    service.complete_attempt(
+        run,
+        attempt,
+        status="succeeded",
+        result_class="success",
+        actual_model="provider/model",
+        ttft_ms=12.0,
+        e2e_ms=34.0,
+        total_tokens=7,
+    )
+    service.complete_run(
+        run,
+        status="succeeded",
+        result_class="success",
+        actual_model="provider/model",
+        ttft_ms=12.0,
+        e2e_ms=34.0,
+        total_tokens=7,
+    )
+
+    receipts = repository.list_chat_control_receipts("local")
+    assert len(receipts["runs"]) == 1
+    assert receipts["runs"][0]["gateway"] == "auto"
+    assert receipts["runs"][0]["primary_newapi"] == 0
+    assert receipts["runs"][0]["is_real_user"] == 1
+    assert receipts["runs"][0]["reason_codes_json"] == (
+        f'["{AUTO_SIDECAR_ATTEMPTS_NOT_OBSERVED}"]'
+    )
+    assert len(receipts["attempts"]) == 1
+    assert receipts["attempts"][0]["provider_kind"] == "omniroute"
+    assert receipts["attempts"][0]["connection_id"] is None
+    assert receipts["attempts"][0]["dispatched"] == 1
+    admin_receipt = control.receipts().runs[0]
+    assert admin_receipt.gateway == "auto"
+    assert admin_receipt.strategy == "auto_sidecar"
+
+
+def test_native_attempts_are_independent_and_tenant_scoped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, _control, repository = _service(tmp_path, monkeypatch)
+    run = service.begin("auto", strategy="auto_native")
+    assert run is not None
+
+    first = service.claim_attempt(
+        run,
+        position=0,
+        connection_id="conn-a",
+        provider_kind="newapi",
+    )
+    service.mark_dispatched(run, first)
+    service.complete_attempt(
+        run,
+        first,
+        status="failed",
+        result_class="transient_failure",
+        error_code="provider_chat_http_503",
+    )
+    second = service.claim_attempt(
+        run,
+        position=1,
+        connection_id="conn-b",
+        provider_kind="openrouter",
+    )
+    service.mark_dispatched(run, second)
+    service.complete_attempt(
+        run,
+        second,
+        status="succeeded",
+        result_class="success",
+        actual_model="provider/model-b",
+    )
+    service.complete_run(
+        run,
+        status="succeeded",
+        result_class="success",
+        reason_codes=["provider_chat_auto_fallback_used"],
+        actual_model="provider/model-b",
+    )
+
+    receipts = repository.list_chat_control_receipts("local")
+    assert [item["position"] for item in receipts["attempts"]] == [0, 1]
+    assert [item["connection_id"] for item in receipts["attempts"]] == [
+        "conn-a",
+        "conn-b",
+    ]
+    assert repository.list_chat_control_receipts("other")["runs"] == []
+
+
+def test_policy_change_blocks_dispatch_before_provider_post(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, control, repository = _service(tmp_path, monkeypatch)
+    run = service.begin("auto", strategy="auto_native")
+    assert run is not None
+    attempt = service.claim_attempt(
+        run,
+        position=0,
+        connection_id="conn-a",
+        provider_kind="newapi",
+    )
+    control.update_policy(
+        ProviderChatControlPolicyUpdate(
+            expected_revision=1,
+            mode="legacy",
+            auto_enabled=False,
+        )
+    )
+
+    with pytest.raises(RouterServiceError) as exc_info:
+        service.mark_dispatched(run, attempt)
+
+    assert exc_info.value.code == "provider_chat_auto_policy_changed"
+    receipts = repository.list_chat_control_receipts("local")
+    assert receipts["attempts"][0]["dispatched"] == 0
+    assert receipts["attempts"][0]["status"] == "failed"
+    assert receipts["runs"][0]["status"] == "failed"
+
+
+def test_auto_evidence_never_stores_prompt_or_model_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, _control, repository = _service(tmp_path, monkeypatch)
+    run = service.begin("auto", strategy="auto_sidecar", sidecar_boundary=True)
+    assert run is not None
+    attempt = service.claim_attempt(
+        run,
+        position=0,
+        connection_id=None,
+        provider_kind="omniroute",
+    )
+    service.mark_dispatched(run, attempt)
+    service.complete_attempt(
+        run,
+        attempt,
+        status="succeeded",
+        result_class="success",
+        actual_model="provider/model",
+    )
+    service.complete_run(
+        run,
+        status="succeeded",
+        result_class="success",
+        actual_model="provider/model",
+    )
+
+    with sqlite3.connect(repository.database_path) as database:
+        dump = "\n".join(database.iterdump())
+    assert "private prompt" not in dump
+    assert "model answer" not in dump

--- a/server/tests/test_provider_chat_stable_chat.py
+++ b/server/tests/test_provider_chat_stable_chat.py
@@ -302,9 +302,18 @@ async def test_preferred_text_chat_uses_one_pinned_newapi_post_and_receipt(
     assert stored["attempts"][0]["connection_id"] == newapi_id
     assert stored["attempts"][0]["dispatched"] == 1
     with sqlite3.connect(repository.database_path) as database:
-        dump = "\n".join(database.iterdump())
-    assert "private user text" not in dump
-    assert "OK" not in dump
+        receipt_rows = repr(
+            {
+                "runs": database.execute(
+                    "SELECT * FROM provider_chat_runs"
+                ).fetchall(),
+                "attempts": database.execute(
+                    "SELECT * FROM provider_chat_attempts"
+                ).fetchall(),
+            }
+        )
+    assert "private user text" not in receipt_rows
+    assert "OK" not in receipt_rows
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add the default-off Auto evidence gate and persist tenant-scoped parent run/provider attempt receipts
- preserve existing Auto selection and fallback semantics: Native records each real target, while OmniRoute records one sidecar-boundary attempt with internal attempts marked unobserved
- exclude Auto samples from the future required-default gate and keep tools, file output, multimodal, Canary, Catalog counts, and default routing unchanged
- update Settings copy, architecture/deployment guidance, and focused regression coverage

## Validation

- `43 passed`: R5C Auto, Native, OmniRoute, stable Chat, and upstream Skill runtime-guidance intersection tests
- frontend full suite: `97 files / 512 passed`
- frontend typecheck and production build passed
- backend full suite: `3720 passed, 29 skipped, 20 failed`; all 20 failures match the previously reproduced baseline environment set (missing Agency Worker build output and unavailable TypeScript execution environment)
- Core, independent newAPI, and explicit Overlay Compose configs passed
- `git diff --check` and sensitive-literal scan passed
- isolated browser acceptance completed one real `gateway=auto` request: one ModelMirror-to-OmniRoute POST, one successful sidecar attempt, actual model `deepseek/deepseek-v4-flash-0731`, and no client retry

## Boundaries

- no change to Auto route choice or existing POST-failure fallback behavior
- no new production dependency or database migration
- no tools, controlled file output, multimodal, RAG, Workflow, Agent, Coding, billing, or multi-tenant expansion
- OmniRoute internal provider attempts remain explicitly `provider_attempts_not_observed`