### PR TITLE
Skill Hook V2 PR1：合同、信任与应用凭据

### DIFF
--- a/docs/SKILL_INTEGRATION.md
+++ b/docs/SKILL_INTEGRATION.md
@@ -284,6 +284,14 @@ curl -X DELETE http://localhost:8000/api/skills/anthropics-skills-skills-pdf
 
 旧节点无需迁移即可采用 V2，节点数据和既有 receipt 不会被重写。回退只需设置 `SKILL_RUNTIME_GUIDANCE_V2_ENABLED=false` 并重启 Server；已有 Workflow、安装数据和 receipt 均保留。
 
+### 4.2 Skill Hook V2 包合同
+
+Hook V2 的唯一标准入口是 `hooks/manifest.json`，版本固定为 `modelmirror-hook-manifest-v2`；实现脚本仍放在 `scripts/`。Manifest 只能声明稳定 Hook ID、四类固定事件、`annotation / validation / guard` 模式、工具事件的精确工具名、包内 `.py / .js` 脚本、用途、验收条件和 1–60 秒超时。服务端根据扩展名选择运行时，不接受 executable、argv、cwd、环境变量、宿主路径、regex 或通配工具名。根目录 `modelmirror-hooks.json` 仅属于旧 `legacy_argv` 节点，不是 V2 包入口。
+
+`SkillApplicationReceiptV2` 在保留 V1 receipt ID 和普通应用合同的同时增加 `hook_execute` 及有界 Hook evidence；旧 V1 记录读取时得到空 evidence，不补造执行事实。Evidence 只保存 Hook/事件/模式、manifest/script/context/result 摘要、脱敏 code、结果类型和 verified 状态，不保存参数、正文、stdout/stderr 或模型输出。涉及 Hook 的后续评测必须另外取得 verified V2 evidence。
+
+当前 `SKILL_PLUGIN_HOOK_V2_ENABLED=false`：服务端会校验包、扫描信任风险并投影脱敏 `hookCapability`，但不会改变旧 Hook 的执行行为。类型化执行顺序、Creator 创作和新工作流体验在后续批次完成；将开关保持为 false 即可回退本合同尚未接管的运行路径。
+
 ## 5. 测试指南
 
 后端测试不依赖外网，会在临时目录创建本地 git 仓库作为 mock Skill 源：

--- a/server/.env.example
+++ b/server/.env.example
@@ -55,6 +55,9 @@ SKILL_APPLICATION_RECEIPT_MODE=audit
 # 与私有 Xpert 中显式选择或本轮激活的 Skill 必须先有 verified skill_read
 # 凭据，才可提交答案或执行副作用工具。设回 false 可恢复原提示型行为。
 SKILL_RUNTIME_GUIDANCE_V2_ENABLED=true
+# Skill Hook V2 PR1 仅发布固定 manifest/result 合同和应用凭据；Runtime、
+# Creator 与新节点尚未启用。PR3 验收前保持 false 可完整回退旧 Hook。
+SKILL_PLUGIN_HOOK_V2_ENABLED=false
 # The semantic provider remains disabled until explicitly configured. Router
 # shadow mode never changes the lexical skill-need-local-v3 result order.
 SKILL_SEMANTIC_RERANK_PROVIDER=none

--- a/server/skills/api.py
+++ b/server/skills/api.py
@@ -129,6 +129,7 @@ class SkillPayload(BaseModel):
     trust_acknowledgement_required: bool = False
     trust_acknowledgement_satisfied: bool = True
     trust_reason_codes: list[str] = Field(default_factory=list)
+    hook_capability: dict[str, object] = Field(default_factory=dict)
 
 
 class SkillTrustAcknowledgementRequest(BaseModel):
@@ -467,6 +468,34 @@ async def materialize_skillset(
 
 def _payload_from_skill(skill: InstalledSkill) -> SkillPayload:
     trust_projection = _trust_projection(skill)
+    manager = get_skill_manager()
+    projector = getattr(manager, "get_hook_capability", None)
+    try:
+        hook_capability = projector(skill.skill_id) if callable(projector) else None
+    except SkillManagerError:
+        hook_capability = {
+            "available": True,
+            "manifestVersion": None,
+            "manifestFingerprint": None,
+            "hookCount": 0,
+            "events": [],
+            "modes": [],
+            "contractValid": False,
+            "runnable": False,
+            "errorCode": "skill_hook_manifest_invalid",
+        }
+    if hook_capability is None:
+        hook_capability = {
+            "available": False,
+            "manifestVersion": None,
+            "manifestFingerprint": None,
+            "hookCount": 0,
+            "events": [],
+            "modes": [],
+            "contractValid": False,
+            "runnable": False,
+            "errorCode": None,
+        }
     return SkillPayload(
         skill_id=skill.skill_id,
         name=skill.name,
@@ -490,6 +519,7 @@ def _payload_from_skill(skill: InstalledSkill) -> SkillPayload:
         trust_package_digest=skill.trust_package_digest,
         trust_directory_tree_sha=skill.trust_directory_tree_sha,
         trust_verified_at=skill.trust_verified_at,
+        hook_capability=hook_capability,
         **trust_projection,
     )
 

--- a/server/skills/application_receipts.py
+++ b/server/skills/application_receipts.py
@@ -13,17 +13,30 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Iterable, Literal, Mapping
 
 
-APPLICATION_RECEIPT_VERSION = "skill-application-receipt-v1"
+APPLICATION_CONTRACT_VERSION = "skill-application-receipt-v1"
+APPLICATION_RECEIPT_V1_VERSION = "skill-application-receipt-v1"
+APPLICATION_RECEIPT_VERSION = "skill-application-receipt-v2"
+APPLICATION_RECEIPT_IDENTITY_VERSION = APPLICATION_RECEIPT_V1_VERSION
 ApplicationPolicy = Literal["advisory", "require_read", "require_stage"]
-ApplicationMethod = Literal["prompt_injected", "skill_read", "skill_stage"]
+ApplicationMethod = Literal[
+    "prompt_injected", "skill_read", "skill_stage", "hook_execute"
+]
 ApplicationStatus = Literal["selected", "applied", "failed"]
 ComplianceStatus = Literal["verified", "incomplete", "unverified"]
 
 _DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 _SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,239}$")
-_METHOD_ORDER = {"prompt_injected": 0, "skill_read": 1, "skill_stage": 2}
+_HOOK_ID_RE = re.compile(r"^[a-z][a-z0-9_-]{0,79}$")
+_HOOK_CODE_RE = re.compile(r"^[a-z][a-z0-9_.-]{0,119}$")
+_METHOD_ORDER = {
+    "prompt_injected": 0,
+    "skill_read": 1,
+    "skill_stage": 2,
+    "hook_execute": 3,
+}
 _MAX_RESOURCE_PATHS = 500
 _MAX_REFERENCES = 64
+_MAX_HOOK_EVIDENCE = 64
 _MAX_RECEIPTS = 2_000
 _RETENTION_SECONDS = 30 * 24 * 60 * 60
 _MAX_SNAPSHOT_BYTES = 64 * 1024 * 1024
@@ -61,6 +74,24 @@ class SkillApplicationScope:
     runtime_kind: str
 
 
+@dataclass(frozen=True, slots=True)
+class SkillHookApplicationEvidenceV2:
+    hook_id: str
+    hook_event: Literal[
+        "session_start", "pre_tool_use", "post_tool_use", "session_end"
+    ]
+    hook_mode: Literal["annotation", "validation", "guard"]
+    manifest_digest: str
+    script_digest: str
+    context_digest: str
+    result_digest: str
+    code: str
+    result_type: Literal[
+        "annotation", "validation_passed", "validation_failed", "denied", "failed"
+    ]
+    verified: bool
+
+
 @dataclass(slots=True)
 class SkillApplicationReceiptV1:
     receipt_id: str
@@ -90,11 +121,16 @@ class SkillApplicationReceiptV1:
     resource_paths_truncated: bool = False
     tool_names: tuple[str, ...] = ()
     error_codes: tuple[str, ...] = ()
+    hook_evidence: tuple[SkillHookApplicationEvidenceV2, ...] = ()
     references: tuple[str, ...] = ()
     application_status: ApplicationStatus = "selected"
     compliance_status: ComplianceStatus = "incomplete"
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
+
+
+# Existing imports keep working while new callers can name the current schema.
+SkillApplicationReceiptV2 = SkillApplicationReceiptV1
 
 
 def application_receipt_mode() -> Literal["off", "audit", "enforce"]:
@@ -128,7 +164,7 @@ def build_application_contract(
             code="skill_application_contract_limit",
         )
     identity = {
-        "version": APPLICATION_RECEIPT_VERSION,
+        "version": APPLICATION_CONTRACT_VERSION,
         "skill_id": clean_skill_id,
         "source_kind": clean_source,
         "version_id": clean_version,
@@ -140,7 +176,7 @@ def build_application_contract(
     fingerprint = _sha256_json(identity)
     return SkillApplicationContractV1(
         contract_id=f"skillappcontract_{fingerprint[:32]}",
-        version=APPLICATION_RECEIPT_VERSION,
+        version=APPLICATION_CONTRACT_VERSION,
         skill_id=clean_skill_id,
         source_kind=clean_source,
         version_id=clean_version,
@@ -202,6 +238,7 @@ class SkillApplicationReceiptStore:
         expected_resource_digests: Mapping[str, str] | None = None,
         tool_name: str | None = None,
         error_code: str | None = None,
+        hook_evidence: Iterable[SkillHookApplicationEvidenceV2] = (),
     ) -> SkillApplicationReceiptV1 | None:
         if application_receipt_mode() == "off":
             return None
@@ -225,6 +262,25 @@ class SkillApplicationReceiptStore:
         )
         clean_tool = _optional_identifier(tool_name, "tool name")
         clean_error = _optional_identifier(error_code, "error code")
+        clean_hook_evidence = self._hook_evidence(hook_evidence)
+        if clean_hook_evidence and method != "hook_execute":
+            raise SkillApplicationReceiptError(
+                "Hook evidence requires the hook_execute application method.",
+                code="skill_application_receipt_invalid",
+            )
+        if method == "hook_execute" and clean_error is None and not clean_hook_evidence:
+            raise SkillApplicationReceiptError(
+                "A successful Hook execution requires verified evidence.",
+                code="skill_application_receipt_invalid",
+            )
+        if (
+            any(evidence.result_type == "failed" for evidence in clean_hook_evidence)
+            and clean_error is None
+        ):
+            raise SkillApplicationReceiptError(
+                "Failed Hook evidence requires an execution error.",
+                code="skill_application_receipt_invalid",
+            )
         receipt_id = self._receipt_id(contract, clean_scope)
         with self._lock:
             self._ensure_writable_unlocked()
@@ -292,6 +348,7 @@ class SkillApplicationReceiptStore:
             if clean_error:
                 errors.add(clean_error)
             updated = copy.deepcopy(item)
+            updated.version = APPLICATION_RECEIPT_VERSION
             updated.node_ids = tuple(
                 sorted(
                     {
@@ -356,6 +413,27 @@ class SkillApplicationReceiptStore:
             )
             updated.tool_names = tuple(sorted(tools))[:64]
             updated.error_codes = tuple(sorted(errors))[:64]
+            merged_hook_evidence = {
+                self._hook_evidence_key(evidence): evidence
+                for evidence in item.hook_evidence
+            }
+            for evidence in clean_hook_evidence:
+                evidence_key = self._hook_evidence_key(evidence)
+                previous_evidence = merged_hook_evidence.get(evidence_key)
+                if previous_evidence is not None and previous_evidence != evidence:
+                    raise SkillApplicationReceiptError(
+                        "Hook evidence verification state changed.",
+                        code="skill_application_receipt_conflict",
+                    )
+                merged_hook_evidence[evidence_key] = evidence
+            if len(merged_hook_evidence) > _MAX_HOOK_EVIDENCE:
+                raise SkillApplicationReceiptError(
+                    "Skill application receipt has too much Hook evidence.",
+                    code="skill_application_receipt_limit",
+                )
+            updated.hook_evidence = tuple(
+                merged_hook_evidence[key] for key in sorted(merged_hook_evidence)
+            )
             updated.application_status = (
                 "applied"
                 if updated.methods
@@ -427,6 +505,28 @@ class SkillApplicationReceiptStore:
             raise SkillApplicationReceiptError(
                 "Skill application receipt is incomplete.",
                 code="skill_application_receipt_incomplete",
+            )
+        return item
+
+    def require_verified_hook_evidence(
+        self,
+        receipt_id: str,
+        *,
+        hook_ids: Iterable[str] = (),
+    ) -> SkillApplicationReceiptV1:
+        item = self.require_verified(receipt_id)
+        required_hook_ids = {
+            _safe_identifier(hook_id, "Hook ID") for hook_id in hook_ids
+        }
+        verified_hook_ids = {evidence.hook_id for evidence in item.hook_evidence}
+        if (
+            not item.hook_evidence
+            or any(not evidence.verified for evidence in item.hook_evidence)
+            or not required_hook_ids.issubset(verified_hook_ids)
+        ):
+            raise SkillApplicationReceiptError(
+                "Verified Hook application evidence is unavailable.",
+                code="skill_hook_evidence_unavailable",
             )
         return item
 
@@ -558,7 +658,11 @@ class SkillApplicationReceiptStore:
             policy=raw.get("policy"),
             required_resource_paths=raw.get("required_resource_paths") or (),
         )
-        if raw.get("version") != APPLICATION_RECEIPT_VERSION:
+        raw_version = raw.get("version")
+        if raw_version not in {
+            APPLICATION_RECEIPT_V1_VERSION,
+            APPLICATION_RECEIPT_VERSION,
+        }:
             raise ValueError("invalid version")
         if raw.get("contract_id") != contract.contract_id or raw.get("contract_fingerprint") != contract.fingerprint:
             raise ValueError("invalid contract identity")
@@ -607,6 +711,24 @@ class SkillApplicationReceiptStore:
             raise ValueError("invalid application status")
         if compliance_status not in {"verified", "incomplete", "unverified"}:
             raise ValueError("invalid compliance status")
+        hook_evidence = (
+            ()
+            if raw_version == APPLICATION_RECEIPT_V1_VERSION
+            else cls._decode_hook_evidence(raw.get("hook_evidence"))
+        )
+        error_codes = _decode_identifier_list(
+            raw.get("error_codes"), field_name="error code", limit=64
+        )
+        if raw_version == APPLICATION_RECEIPT_V1_VERSION and "hook_execute" in methods:
+            raise ValueError("V1 receipt cannot contain Hook execution evidence")
+        if "hook_execute" in methods and not hook_evidence:
+            raise ValueError("Hook execution method requires evidence")
+        if hook_evidence and "hook_execute" not in methods and not error_codes:
+            raise ValueError("Hook evidence is not bound to an execution or failure")
+        if any(evidence.result_type == "failed" for evidence in hook_evidence) and (
+            "hook_execute" in methods or not error_codes
+        ):
+            raise ValueError("Failed Hook evidence is recorded as a successful execution")
         item = SkillApplicationReceiptV1(
             receipt_id=receipt_id,
             version=APPLICATION_RECEIPT_VERSION,
@@ -638,9 +760,8 @@ class SkillApplicationReceiptStore:
             tool_names=_decode_identifier_list(
                 raw.get("tool_names"), field_name="tool name", limit=64
             ),
-            error_codes=_decode_identifier_list(
-                raw.get("error_codes"), field_name="error code", limit=64
-            ),
+            error_codes=error_codes,
+            hook_evidence=hook_evidence,
             references=_decode_identifier_list(
                 raw.get("references"), field_name="reference ID", limit=64
             ),
@@ -675,7 +796,7 @@ class SkillApplicationReceiptStore:
     ) -> str:
         fingerprint = _sha256_json(
             {
-                "version": APPLICATION_RECEIPT_VERSION,
+                "version": APPLICATION_RECEIPT_IDENTITY_VERSION,
                 "contract_fingerprint": contract.fingerprint,
                 "run_id": scope.run_id,
                 "task_id": scope.task_id,
@@ -696,6 +817,157 @@ class SkillApplicationReceiptStore:
             if path in allowed and digest:
                 result[path] = digest
         return dict(sorted(result.items()))
+
+    @classmethod
+    def _hook_evidence(
+        cls, values: Iterable[SkillHookApplicationEvidenceV2]
+    ) -> tuple[SkillHookApplicationEvidenceV2, ...]:
+        result: dict[tuple[str, ...], SkillHookApplicationEvidenceV2] = {}
+        for value in values:
+            if not isinstance(value, SkillHookApplicationEvidenceV2):
+                raise SkillApplicationReceiptError(
+                    "Invalid Hook application evidence.",
+                    code="skill_application_receipt_invalid",
+                )
+            evidence = cls._validate_hook_evidence(value)
+            evidence_key = cls._hook_evidence_key(evidence)
+            previous = result.get(evidence_key)
+            if previous is not None and previous != evidence:
+                raise SkillApplicationReceiptError(
+                    "Hook evidence verification state changed.",
+                    code="skill_application_receipt_conflict",
+                )
+            result[evidence_key] = evidence
+        if len(result) > _MAX_HOOK_EVIDENCE:
+            raise SkillApplicationReceiptError(
+                "Skill application receipt has too much Hook evidence.",
+                code="skill_application_receipt_limit",
+            )
+        return tuple(result[key] for key in sorted(result))
+
+    @classmethod
+    def _decode_hook_evidence(
+        cls, value: Any
+    ) -> tuple[SkillHookApplicationEvidenceV2, ...]:
+        raw_items = value or []
+        if not isinstance(raw_items, list) or len(raw_items) > _MAX_HOOK_EVIDENCE:
+            raise ValueError("invalid Hook evidence")
+        items: list[SkillHookApplicationEvidenceV2] = []
+        for raw in raw_items:
+            if not isinstance(raw, dict) or set(raw) != {
+                "hook_id",
+                "hook_event",
+                "hook_mode",
+                "manifest_digest",
+                "script_digest",
+                "context_digest",
+                "result_digest",
+                "code",
+                "result_type",
+                "verified",
+            }:
+                raise ValueError("invalid Hook evidence")
+            try:
+                item = SkillHookApplicationEvidenceV2(**raw)
+                items.append(cls._validate_hook_evidence(item))
+            except (TypeError, SkillApplicationReceiptError) as exc:
+                raise ValueError("invalid Hook evidence") from exc
+        normalized = cls._hook_evidence(items)
+        if len(normalized) != len(items):
+            raise ValueError("duplicate Hook evidence")
+        return normalized
+
+    @staticmethod
+    def _validate_hook_evidence(
+        value: SkillHookApplicationEvidenceV2,
+    ) -> SkillHookApplicationEvidenceV2:
+        hook_id = _safe_identifier(value.hook_id, "Hook ID")
+        code = _safe_identifier(value.code, "Hook result code")
+        if not _HOOK_ID_RE.fullmatch(hook_id) or not _HOOK_CODE_RE.fullmatch(code):
+            raise SkillApplicationReceiptError(
+                "Invalid Hook evidence identifier.",
+                code="skill_application_receipt_invalid",
+            )
+        if value.hook_event not in {
+            "session_start",
+            "pre_tool_use",
+            "post_tool_use",
+            "session_end",
+        }:
+            raise SkillApplicationReceiptError(
+                "Invalid Hook event.", code="skill_application_receipt_invalid"
+            )
+        if value.hook_mode not in {"annotation", "validation", "guard"}:
+            raise SkillApplicationReceiptError(
+                "Invalid Hook mode.", code="skill_application_receipt_invalid"
+            )
+        if value.result_type not in {
+            "annotation",
+            "validation_passed",
+            "validation_failed",
+            "denied",
+            "failed",
+        }:
+            raise SkillApplicationReceiptError(
+                "Invalid Hook result type.",
+                code="skill_application_receipt_invalid",
+            )
+        if value.result_type == "annotation" and value.hook_mode != "annotation":
+            raise SkillApplicationReceiptError(
+                "Annotation evidence requires an annotation Hook.",
+                code="skill_application_receipt_invalid",
+            )
+        if value.result_type in {"validation_passed", "validation_failed"} and (
+            value.hook_mode not in {"validation", "guard"}
+        ):
+            raise SkillApplicationReceiptError(
+                "Validation evidence requires a validation or guard Hook.",
+                code="skill_application_receipt_invalid",
+            )
+        if value.result_type == "denied" and (
+            value.hook_mode != "guard" or value.hook_event != "pre_tool_use"
+        ):
+            raise SkillApplicationReceiptError(
+                "Deny evidence requires a guard pre_tool_use Hook.",
+                code="skill_application_receipt_invalid",
+            )
+        if not isinstance(value.verified, bool):
+            raise SkillApplicationReceiptError(
+                "Invalid Hook verification state.",
+                code="skill_application_receipt_invalid",
+            )
+        return SkillHookApplicationEvidenceV2(
+            hook_id=hook_id,
+            hook_event=value.hook_event,
+            hook_mode=value.hook_mode,
+            manifest_digest=_required_digest(
+                value.manifest_digest, "Hook manifest digest"
+            ),
+            script_digest=_required_digest(value.script_digest, "Hook script digest"),
+            context_digest=_required_digest(
+                value.context_digest, "Hook context digest"
+            ),
+            result_digest=_required_digest(value.result_digest, "Hook result digest"),
+            code=code,
+            result_type=value.result_type,
+            verified=value.verified,
+        )
+
+    @staticmethod
+    def _hook_evidence_key(
+        value: SkillHookApplicationEvidenceV2,
+    ) -> tuple[str, ...]:
+        return (
+            value.hook_id,
+            value.hook_event,
+            value.hook_mode,
+            value.manifest_digest,
+            value.script_digest,
+            value.context_digest,
+            value.result_digest,
+            value.code,
+            value.result_type,
+        )
 
     @staticmethod
     def _compliance_status(item: SkillApplicationReceiptV1) -> ComplianceStatus:
@@ -721,6 +993,12 @@ class SkillApplicationReceiptStore:
         ):
             return "unverified"
         methods = set(item.methods)
+        if item.hook_evidence and any(
+            not evidence.verified for evidence in item.hook_evidence
+        ):
+            return "unverified"
+        if "hook_execute" in methods and not item.hook_evidence:
+            return "unverified"
         if item.policy == "advisory":
             satisfied = bool(methods)
         elif item.policy == "require_read":
@@ -846,6 +1124,7 @@ class SkillApplicationObserver:
         expected_resource_digests: Mapping[str, str] | None = None,
         tool_name: str | None = None,
         error_code: str | None = None,
+        hook_evidence: Iterable[SkillHookApplicationEvidenceV2] = (),
     ) -> SkillApplicationReceiptV1 | None:
         contract = self.resolve_contract(
             skill_id,
@@ -871,6 +1150,7 @@ class SkillApplicationObserver:
             expected_resource_digests=expected_resource_digests,
             tool_name=tool_name,
             error_code=error_code,
+            hook_evidence=hook_evidence,
         )
 
 
@@ -901,6 +1181,15 @@ def _optional_digest(value: Any, field_name: str) -> str | None:
         return None
     clean = str(value).strip().lower()
     if not _DIGEST_RE.fullmatch(clean):
+        raise SkillApplicationReceiptError(
+            f"Invalid {field_name}.", code="skill_application_receipt_invalid"
+        )
+    return clean
+
+
+def _required_digest(value: Any, field_name: str) -> str:
+    clean = _optional_digest(value, field_name)
+    if clean is None:
         raise SkillApplicationReceiptError(
             f"Invalid {field_name}.", code="skill_application_receipt_invalid"
         )
@@ -965,14 +1254,18 @@ def _decode_quarantine_record(value: Any) -> dict[str, Any] | None:
 
 
 __all__ = [
+    "APPLICATION_CONTRACT_VERSION",
     "APPLICATION_RECEIPT_VERSION",
+    "APPLICATION_RECEIPT_V1_VERSION",
     "SkillApplicationContractV1",
     "SkillApplicationReceiptError",
     "SkillApplicationObserver",
     "SkillApplicationReceiptStorageError",
     "SkillApplicationReceiptStore",
     "SkillApplicationReceiptV1",
+    "SkillApplicationReceiptV2",
     "SkillApplicationScope",
+    "SkillHookApplicationEvidenceV2",
     "application_receipt_mode",
     "build_application_contract",
 ]

--- a/server/skills/draft_store.py
+++ b/server/skills/draft_store.py
@@ -125,7 +125,7 @@ class WorkspaceSkillDraftStore:
     MAX_FILES = 40
     MAX_FILE_BYTES = 1024 * 1024
     MAX_TOTAL_BYTES = 5 * 1024 * 1024
-    ALLOWED_ROOTS = {"scripts", "references", "assets", "agents"}
+    ALLOWED_ROOTS = {"scripts", "references", "assets", "agents", "hooks"}
 
     def __init__(self, storage_dir: str | Path | None = None) -> None:
         package_dir = Path(__file__).resolve().parent
@@ -1155,6 +1155,10 @@ class WorkspaceSkillDraftStore:
         if path.parts[0] == "agents" and normalized != "agents/openai.yaml":
             raise SkillDraftValidationError(
                 "Only agents/openai.yaml is supported under agents/."
+            )
+        if path.parts[0] == "hooks" and normalized != "hooks/manifest.json":
+            raise SkillDraftValidationError(
+                "Only hooks/manifest.json is supported under hooks/."
             )
         return normalized
 

--- a/server/skills/hook_contract.py
+++ b/server/skills/hook_contract.py
@@ -1,0 +1,533 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import posixpath
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Iterable, Literal, Mapping
+
+
+HOOK_MANIFEST_PATH = "hooks/manifest.json"
+HOOK_MANIFEST_VERSION = "modelmirror-hook-manifest-v2"
+HOOK_RESULT_VERSION = "modelmirror-hook-result-v1"
+LEGACY_HOOK_MANIFEST_PATH = "modelmirror-hooks.json"
+
+MAX_HOOKS_PER_SKILL = 12
+MAX_HOOK_SKILLS_PER_NODE = 10
+MAX_HOOKS_PER_EVENT = 20
+MAX_HOOK_EVENT_BUDGET_SECONDS = 120
+MAX_HOOK_OUTPUTS = 20
+DEFAULT_HOOK_TIMEOUT_SECONDS = 15
+
+HookEvent = Literal[
+    "session_start", "pre_tool_use", "post_tool_use", "session_end"
+]
+HookMode = Literal["annotation", "validation", "guard"]
+HookOutputType = Literal["annotation", "validation", "deny"]
+HookSeverity = Literal["info", "warning"]
+
+_HOOK_EVENTS = {
+    "session_start",
+    "pre_tool_use",
+    "post_tool_use",
+    "session_end",
+}
+_HOOK_MODES = {"annotation", "validation", "guard"}
+_HOOK_ID_RE = re.compile(r"^[a-z][a-z0-9_-]{0,79}$")
+_CODE_RE = re.compile(r"^[a-z][a-z0-9_.-]{0,119}$")
+_TOOL_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+
+
+class SkillHookContractError(ValueError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "skill_hook_manifest_invalid",
+        path: str = HOOK_MANIFEST_PATH,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.path = path
+
+
+@dataclass(frozen=True, slots=True)
+class SkillHookDefinitionV2:
+    hook_id: str
+    event: HookEvent
+    mode: HookMode
+    tool_names: tuple[str, ...]
+    script_path: str
+    purpose: str
+    acceptance_checks: tuple[str, ...]
+    timeout_seconds: int = DEFAULT_HOOK_TIMEOUT_SECONDS
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "hook_id": self.hook_id,
+            "event": self.event,
+            "mode": self.mode,
+            "tool_names": list(self.tool_names),
+            "script_path": self.script_path,
+            "purpose": self.purpose,
+            "acceptance_checks": list(self.acceptance_checks),
+            "timeout_seconds": self.timeout_seconds,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SkillHookManifestV2:
+    version: str
+    hooks: tuple[SkillHookDefinitionV2, ...]
+    fingerprint: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "hooks": [hook.to_dict() for hook in self.hooks],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SkillHookResultOutputV1:
+    output_type: HookOutputType
+    code: str
+    message: str
+    severity: HookSeverity | None = None
+    passed: bool | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "type": self.output_type,
+            "code": self.code,
+            "message": self.message,
+        }
+        if self.severity is not None:
+            result["severity"] = self.severity
+        if self.passed is not None:
+            result["passed"] = self.passed
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class SkillHookResultV1:
+    version: str
+    outputs: tuple[SkillHookResultOutputV1, ...]
+
+
+def skill_plugin_hook_v2_enabled() -> bool:
+    return os.getenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def parse_hook_manifest(
+    content: str | bytes,
+    *,
+    available_paths: Iterable[str] = (),
+) -> SkillHookManifestV2:
+    payload = _load_json_object(content, label="Hook manifest")
+    _require_exact_keys(payload, {"version", "hooks"}, label="Hook manifest")
+    if payload.get("version") != HOOK_MANIFEST_VERSION:
+        raise SkillHookContractError("Hook manifest version is unsupported.")
+    raw_hooks = payload.get("hooks")
+    if not isinstance(raw_hooks, list) or not raw_hooks:
+        raise SkillHookContractError("Hook manifest must declare at least one Hook.")
+    if len(raw_hooks) > MAX_HOOKS_PER_SKILL:
+        raise SkillHookContractError(
+            f"A Skill can declare at most {MAX_HOOKS_PER_SKILL} Hooks."
+        )
+    known_paths = {_normalize_package_path(path) for path in available_paths}
+    hooks: list[SkillHookDefinitionV2] = []
+    seen_ids: set[str] = set()
+    for index, raw_hook in enumerate(raw_hooks):
+        if not isinstance(raw_hook, dict):
+            raise SkillHookContractError(f"Hook {index + 1} must be an object.")
+        hook_id = raw_hook.get("hook_id")
+        if not isinstance(hook_id, str) or not _HOOK_ID_RE.fullmatch(hook_id):
+            raise SkillHookContractError(f"Hook {index + 1} has an invalid hook_id.")
+        if hook_id in seen_ids:
+            raise SkillHookContractError("Hook IDs must be unique.")
+        seen_ids.add(hook_id)
+        event = raw_hook.get("event")
+        mode = raw_hook.get("mode")
+        if event not in _HOOK_EVENTS or mode not in _HOOK_MODES:
+            raise SkillHookContractError(
+                f"Hook '{hook_id}' has an invalid event or mode."
+            )
+        if mode == "guard" and event != "pre_tool_use":
+            raise SkillHookContractError(
+                f"Guard Hook '{hook_id}' must use pre_tool_use."
+            )
+        expected_keys = {
+            "hook_id",
+            "event",
+            "mode",
+            "script_path",
+            "purpose",
+            "acceptance_checks",
+        }
+        if event in {"pre_tool_use", "post_tool_use"}:
+            expected_keys.add("tool_names")
+        if "timeout_seconds" in raw_hook:
+            expected_keys.add("timeout_seconds")
+        _require_exact_keys(raw_hook, expected_keys, label=f"Hook {index + 1}")
+        tool_names = (
+            _tool_names(raw_hook.get("tool_names"), hook_id=hook_id)
+            if event in {"pre_tool_use", "post_tool_use"}
+            else ()
+        )
+        if event in {"pre_tool_use", "post_tool_use"} and not tool_names:
+            raise SkillHookContractError(
+                f"Tool Hook '{hook_id}' must name at least one exact tool."
+            )
+        script_path = _script_path(raw_hook.get("script_path"), hook_id=hook_id)
+        if script_path not in known_paths:
+            raise SkillHookContractError(
+                f"Hook '{hook_id}' references a missing script.", path=script_path
+            )
+        purpose = _bounded_text(raw_hook.get("purpose"), label="purpose", limit=1000)
+        checks = _bounded_text_list(
+            raw_hook.get("acceptance_checks"),
+            label="acceptance_checks",
+            max_items=20,
+            item_limit=500,
+        )
+        timeout = raw_hook.get("timeout_seconds", DEFAULT_HOOK_TIMEOUT_SECONDS)
+        if isinstance(timeout, bool) or not isinstance(timeout, int) or not 1 <= timeout <= 60:
+            raise SkillHookContractError(
+                f"Hook '{hook_id}' timeout_seconds must be between 1 and 60."
+            )
+        hooks.append(
+            SkillHookDefinitionV2(
+                hook_id=hook_id,
+                event=event,
+                mode=mode,
+                tool_names=tool_names,
+                script_path=script_path,
+                purpose=purpose,
+                acceptance_checks=checks,
+                timeout_seconds=timeout,
+            )
+        )
+    manifest_payload = {
+        "version": HOOK_MANIFEST_VERSION,
+        "hooks": [hook.to_dict() for hook in hooks],
+    }
+    return SkillHookManifestV2(
+        version=HOOK_MANIFEST_VERSION,
+        hooks=tuple(hooks),
+        fingerprint=_sha256_json(manifest_payload),
+    )
+
+
+def parse_hook_result(
+    content: str | bytes,
+    *,
+    hook_event: HookEvent,
+    hook_mode: HookMode,
+) -> SkillHookResultV1:
+    if hook_event not in _HOOK_EVENTS or hook_mode not in _HOOK_MODES:
+        raise SkillHookContractError(
+            "Hook result boundary is invalid.", code="skill_hook_result_invalid"
+        )
+    payload = _load_json_object(
+        content, label="Hook result", code="skill_hook_result_invalid"
+    )
+    _require_exact_keys(
+        payload,
+        {"version", "outputs"},
+        label="Hook result",
+        code="skill_hook_result_invalid",
+    )
+    if payload.get("version") != HOOK_RESULT_VERSION:
+        raise SkillHookContractError(
+            "Hook result version is unsupported.", code="skill_hook_result_invalid"
+        )
+    raw_outputs = payload.get("outputs")
+    if not isinstance(raw_outputs, list) or len(raw_outputs) > MAX_HOOK_OUTPUTS:
+        raise SkillHookContractError(
+            f"Hook result outputs must be a list of at most {MAX_HOOK_OUTPUTS} items.",
+            code="skill_hook_result_invalid",
+        )
+    outputs: list[SkillHookResultOutputV1] = []
+    seen_codes: set[str] = set()
+    for index, raw_output in enumerate(raw_outputs):
+        if not isinstance(raw_output, dict):
+            raise SkillHookContractError(
+                f"Hook output {index + 1} must be an object.",
+                code="skill_hook_result_invalid",
+            )
+        output_type = raw_output.get("type")
+        expected_keys = {
+            "annotation": {"type", "code", "severity", "message"},
+            "validation": {"type", "code", "passed", "message"},
+            "deny": {"type", "code", "message"},
+        }.get(output_type)
+        if expected_keys is None:
+            raise SkillHookContractError(
+                f"Hook output {index + 1} has an unknown type.",
+                code="skill_hook_result_invalid",
+            )
+        _require_exact_keys(
+            raw_output,
+            expected_keys,
+            label=f"Hook output {index + 1}",
+            code="skill_hook_result_invalid",
+        )
+        code_value = raw_output.get("code")
+        if not isinstance(code_value, str) or not _CODE_RE.fullmatch(code_value):
+            raise SkillHookContractError(
+                f"Hook output {index + 1} has an invalid code.",
+                code="skill_hook_result_invalid",
+            )
+        if code_value in seen_codes:
+            raise SkillHookContractError(
+                "Hook output codes must be unique.", code="skill_hook_result_invalid"
+            )
+        seen_codes.add(code_value)
+        message = _bounded_text(
+            raw_output.get("message"),
+            label="message",
+            limit=1000,
+            code="skill_hook_result_invalid",
+        )
+        severity: HookSeverity | None = None
+        passed: bool | None = None
+        if output_type == "annotation":
+            if hook_mode != "annotation":
+                raise SkillHookContractError(
+                    "Only annotation Hooks can return annotations.",
+                    code="skill_hook_result_invalid",
+                )
+            severity_value = raw_output.get("severity")
+            if severity_value not in {"info", "warning"}:
+                raise SkillHookContractError(
+                    "Hook annotation severity is invalid.",
+                    code="skill_hook_result_invalid",
+                )
+            severity = severity_value
+        elif output_type == "validation":
+            if hook_mode not in {"validation", "guard"}:
+                raise SkillHookContractError(
+                    "Only validation or guard Hooks can return validations.",
+                    code="skill_hook_result_invalid",
+                )
+            passed_value = raw_output.get("passed")
+            if not isinstance(passed_value, bool):
+                raise SkillHookContractError(
+                    "Hook validation passed must be boolean.",
+                    code="skill_hook_result_invalid",
+                )
+            passed = passed_value
+        elif hook_mode != "guard" or hook_event != "pre_tool_use":
+            raise SkillHookContractError(
+                "Deny outputs are only valid for guard pre_tool_use Hooks.",
+                code="skill_hook_result_invalid",
+            )
+        outputs.append(
+            SkillHookResultOutputV1(
+                output_type=output_type,
+                code=code_value,
+                message=message,
+                severity=severity,
+                passed=passed,
+            )
+        )
+    if hook_mode in {"validation", "guard"} and not outputs:
+        raise SkillHookContractError(
+            "Validation and guard Hooks must return a typed decision.",
+            code="skill_hook_result_invalid",
+        )
+    return SkillHookResultV1(version=HOOK_RESULT_VERSION, outputs=tuple(outputs))
+
+
+def hook_capability_projection(
+    content: str | bytes | None,
+    *,
+    available_paths: Iterable[str] = (),
+) -> dict[str, Any]:
+    if content is None:
+        return {
+            "available": False,
+            "manifestVersion": None,
+            "manifestFingerprint": None,
+            "hookCount": 0,
+            "events": [],
+            "modes": [],
+            "contractValid": False,
+            "runnable": False,
+            "errorCode": None,
+        }
+    try:
+        manifest = parse_hook_manifest(content, available_paths=available_paths)
+    except SkillHookContractError as exc:
+        return {
+            "available": True,
+            "manifestVersion": None,
+            "manifestFingerprint": None,
+            "hookCount": 0,
+            "events": [],
+            "modes": [],
+            "contractValid": False,
+            "runnable": False,
+            "errorCode": exc.code,
+        }
+    return {
+        "available": True,
+        "manifestVersion": manifest.version,
+        "manifestFingerprint": manifest.fingerprint,
+        "hookCount": len(manifest.hooks),
+        "events": sorted({hook.event for hook in manifest.hooks}),
+        "modes": sorted({hook.mode for hook in manifest.hooks}),
+        "contractValid": True,
+        "runnable": skill_plugin_hook_v2_enabled(),
+        "errorCode": None,
+    }
+
+
+def _load_json_object(
+    content: str | bytes,
+    *,
+    label: str,
+    code: str = "skill_hook_manifest_invalid",
+) -> dict[str, Any]:
+    try:
+        text = content.decode("utf-8", errors="strict") if isinstance(content, bytes) else content
+        if not isinstance(text, str):
+            raise TypeError
+        payload = json.loads(text, object_pairs_hook=_reject_duplicate_keys)
+    except (UnicodeDecodeError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise SkillHookContractError(
+            f"{label} must be strict UTF-8 JSON.", code=code
+        ) from exc
+    if not isinstance(payload, dict):
+        raise SkillHookContractError(f"{label} must be an object.", code=code)
+    return payload
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def _require_exact_keys(
+    payload: Mapping[str, Any],
+    expected: set[str],
+    *,
+    label: str,
+    code: str = "skill_hook_manifest_invalid",
+) -> None:
+    if set(payload) != expected:
+        raise SkillHookContractError(
+            f"{label} fields do not match the fixed contract.", code=code
+        )
+
+
+def _normalize_package_path(value: str) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.replace("\\", "/")
+
+
+def _script_path(value: Any, *, hook_id: str) -> str:
+    if not isinstance(value, str):
+        raise SkillHookContractError(f"Hook '{hook_id}' script_path is invalid.")
+    normalized = posixpath.normpath(value)
+    path = PurePosixPath(value)
+    if (
+        value != normalized
+        or value.startswith("/")
+        or "\\" in value
+        or ".." in path.parts
+        or any(not part or part.startswith(".") for part in path.parts)
+        or not path.parts
+        or path.parts[0] != "scripts"
+        or path.suffix.casefold() not in {".py", ".js"}
+    ):
+        raise SkillHookContractError(f"Hook '{hook_id}' script_path is invalid.")
+    return value
+
+
+def _tool_names(value: Any, *, hook_id: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or len(value) > 64:
+        raise SkillHookContractError(f"Hook '{hook_id}' tool_names is invalid.")
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not _TOOL_NAME_RE.fullmatch(item):
+            raise SkillHookContractError(
+                f"Hook '{hook_id}' must use exact tool names."
+            )
+        result.append(item)
+    if len(set(result)) != len(result):
+        raise SkillHookContractError(f"Hook '{hook_id}' repeats a tool name.")
+    return tuple(sorted(result))
+
+
+def _bounded_text(
+    value: Any,
+    *,
+    label: str,
+    limit: int,
+    code: str = "skill_hook_manifest_invalid",
+) -> str:
+    if not isinstance(value, str) or value != value.strip() or not value or len(value) > limit:
+        raise SkillHookContractError(f"Hook {label} is invalid.", code=code)
+    return value
+
+
+def _bounded_text_list(
+    value: Any,
+    *,
+    label: str,
+    max_items: int,
+    item_limit: int,
+) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value or len(value) > max_items:
+        raise SkillHookContractError(f"Hook {label} is invalid.")
+    result = tuple(
+        _bounded_text(item, label=label, limit=item_limit) for item in value
+    )
+    if len(set(result)) != len(result):
+        raise SkillHookContractError(f"Hook {label} contains duplicates.")
+    return result
+
+
+def _sha256_json(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+__all__ = [
+    "DEFAULT_HOOK_TIMEOUT_SECONDS",
+    "HOOK_MANIFEST_PATH",
+    "HOOK_MANIFEST_VERSION",
+    "HOOK_RESULT_VERSION",
+    "LEGACY_HOOK_MANIFEST_PATH",
+    "MAX_HOOK_EVENT_BUDGET_SECONDS",
+    "MAX_HOOK_OUTPUTS",
+    "MAX_HOOK_SKILLS_PER_NODE",
+    "MAX_HOOKS_PER_EVENT",
+    "MAX_HOOKS_PER_SKILL",
+    "SkillHookContractError",
+    "SkillHookDefinitionV2",
+    "SkillHookManifestV2",
+    "SkillHookResultOutputV1",
+    "SkillHookResultV1",
+    "hook_capability_projection",
+    "parse_hook_manifest",
+    "parse_hook_result",
+    "skill_plugin_hook_v2_enabled",
+]

--- a/server/skills/package_validation.py
+++ b/server/skills/package_validation.py
@@ -17,15 +17,21 @@ import yaml
 from yaml.nodes import MappingNode
 from yaml.tokens import AliasToken, AnchorToken
 
+from .hook_contract import (
+    HOOK_MANIFEST_PATH,
+    SkillHookContractError,
+    parse_hook_manifest,
+)
 
-VALIDATOR_VERSION = "skill-package-v2.1"
+
+VALIDATOR_VERSION = "skill-package-v2.2"
 
 MAX_FILES = 40
 MAX_FILE_BYTES = 1024 * 1024
 MAX_TOTAL_BYTES = 5 * 1024 * 1024
 MAX_PATH_CHARS = 240
 MAX_PATH_SEGMENT_BYTES = 255
-ALLOWED_ROOTS = frozenset({"scripts", "references", "assets", "agents"})
+ALLOWED_ROOTS = frozenset({"scripts", "references", "assets", "agents", "hooks"})
 SUPPORTED_FRONTMATTER_FIELDS = frozenset(
     {
         "name",
@@ -178,7 +184,7 @@ _MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]\n]*\]\(([^)\n]+)\)")
 _FENCED_CODE_RE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 _INLINE_RESOURCE_PATH_RE = re.compile(
-    r"(?<![A-Za-z0-9._+@/-])(?P<path>(?:scripts|references|assets|agents)/"
+    r"(?<![A-Za-z0-9._+@/-])(?P<path>(?:scripts|references|assets|agents|hooks)/"
     r"[A-Za-z0-9][A-Za-z0-9._+@/-]*\.[A-Za-z0-9]{1,12}"
     r"(?:#[A-Za-z0-9._-]+)?)(?=$|[\s'\"),;:])"
 )
@@ -364,6 +370,18 @@ def validate_skill_package(
         frontmatter = _parse_skill_frontmatter(markdown_text, issues)
     for path, text in clean_files.items():
         _check_static_syntax(path, text, issues)
+    hook_manifest = clean_files.get(HOOK_MANIFEST_PATH)
+    if hook_manifest is not None:
+        try:
+            parse_hook_manifest(hook_manifest, available_paths=clean_files)
+        except SkillHookContractError as exc:
+            issues.append(
+                SkillPackageIssue(
+                    code=exc.code,
+                    message=str(exc),
+                    path=exc.path,
+                )
+            )
 
     parsed = _validate_frontmatter(frontmatter, clean_root, issues)
     if markdown_text is not None:
@@ -639,6 +657,15 @@ def _validate_file_path(
             SkillPackageIssue(
                 code="agents_file_unsupported",
                 message="Only agents/openai.yaml is supported under agents/.",
+                path=value,
+            )
+        )
+        return None
+    if path.parts[0] == "hooks" and value != HOOK_MANIFEST_PATH:
+        issues.append(
+            SkillPackageIssue(
+                code="hooks_file_unsupported",
+                message="Only hooks/manifest.json is supported under hooks/.",
                 path=value,
             )
         )

--- a/server/skills/skill_manager.py
+++ b/server/skills/skill_manager.py
@@ -17,6 +17,7 @@ from typing import Any, Literal, Mapping
 from urllib.parse import urlparse
 
 from .draft_store import SkillDraftValidationError, WorkspaceSkillDraftStore
+from .hook_contract import HOOK_MANIFEST_PATH, hook_capability_projection
 from .local_import import LocalSkillImport, SkillLocalImportError, SkillLocalImportStore
 from .package_validation import compute_package_digest
 from .trust_scanner import SkillTrustTreeEntry, scan_skill_trust_receipt
@@ -1394,6 +1395,51 @@ class SkillManager:
                 installed.get(normalized_skill_id, {}),
                 version_id=version_id,
             )
+
+    def get_hook_capability(
+        self, skill_id: str, *, version_id: str | None = None
+    ) -> dict[str, Any]:
+        """Project bounded Hook metadata without exposing manifest rules or code."""
+
+        root = self.get_skill_directory(skill_id, version_id=version_id)
+        manifest_path = root / HOOK_MANIFEST_PATH
+        try:
+            if manifest_path.is_symlink():
+                raise OSError("unsafe Hook manifest")
+            if not manifest_path.exists():
+                return hook_capability_projection(None)
+            if not manifest_path.is_file():
+                raise OSError("unsafe Hook manifest")
+            content = manifest_path.read_bytes()
+            available_paths = [
+                path.relative_to(root).as_posix()
+                for path in root.rglob("*")
+                if path.is_file() and not path.is_symlink()
+            ]
+            projection = hook_capability_projection(
+                content,
+                available_paths=available_paths,
+            )
+            if version_id is None:
+                installed = self.get_installed_skill(skill_id)
+                if (
+                    installed.source_kind in {"git", "local_import"}
+                    and not installed.trust_router_eligible
+                ):
+                    projection["runnable"] = False
+            return projection
+        except OSError:
+            return {
+                "available": True,
+                "manifestVersion": None,
+                "manifestFingerprint": None,
+                "hookCount": 0,
+                "events": [],
+                "modes": [],
+                "contractValid": False,
+                "runnable": False,
+                "errorCode": "skill_hook_manifest_invalid",
+            }
 
     def bind_skill_versions(self, skill_ids: list[str] | set[str] | tuple[str, ...]) -> dict[str, str]:
         """Freeze active lifecycle versions for one newly-started run."""

--- a/server/skills/trust_scanner.py
+++ b/server/skills/trust_scanner.py
@@ -11,6 +11,11 @@ from pathlib import PurePosixPath
 from typing import Any, Iterable, Literal, Mapping, Sequence
 from urllib.parse import urlsplit
 
+from .hook_contract import (
+    HOOK_MANIFEST_PATH,
+    SkillHookContractError,
+    parse_hook_manifest,
+)
 from .package_validation import (
     SkillPackageIssue,
     _check_file_directory_conflicts,
@@ -64,6 +69,8 @@ _HARD_BLOCK_FINDING_CODES = {
     "package_files_type",
     "package_size_exceeded",
     "skill_markdown_empty",
+    "skill_hook_manifest_invalid",
+    "skill_hook_path_unsupported",
     "trust_directory_tree_missing",
     "trust_file_count_exceeded",
     "trust_file_size_exceeded",
@@ -606,6 +613,60 @@ def scan_skill_trust_receipt(
     if "SKILL.md" not in text_files:
         state.add("trust_skill_markdown_missing", "critical", "The package does not contain a readable UTF-8 SKILL.md at its root.", risk="critical", path="SKILL.md")
 
+    hook_capability: dict[str, Any] | None = None
+    hook_manifest = text_files.get(HOOK_MANIFEST_PATH)
+    if hook_manifest is not None:
+        unsupported_hook_paths = sorted(
+            path
+            for path in raw_files
+            if path.startswith("hooks/") and path != HOOK_MANIFEST_PATH
+        )
+        for path in unsupported_hook_paths:
+            state.add(
+                "skill_hook_path_unsupported",
+                "critical",
+                "A V2 Hook package may only contain hooks/manifest.json under hooks/.",
+                risk="critical",
+                path=path,
+            )
+        try:
+            manifest = parse_hook_manifest(
+                hook_manifest,
+                available_paths=text_files,
+            )
+        except SkillHookContractError as exc:
+            state.add(
+                exc.code,
+                "critical",
+                str(exc),
+                risk="critical",
+                path=exc.path,
+            )
+            hook_capability = {
+                "manifestVersion": None,
+                "manifestFingerprint": None,
+                "hookCount": 0,
+                "events": [],
+                "contractValid": False,
+                "v2Runnable": False,
+            }
+        else:
+            state.add(
+                "trust_plugin_hook",
+                "warning",
+                "The Skill declares deterministic offline plugin Hooks and requires explicit confirmation.",
+                risk="medium",
+                path=HOOK_MANIFEST_PATH,
+            )
+            hook_capability = {
+                "manifestVersion": manifest.version,
+                "manifestFingerprint": manifest.fingerprint,
+                "hookCount": len(manifest.hooks),
+                "events": sorted({hook.event for hook in manifest.hooks}),
+                "contractValid": True,
+                "v2Runnable": True,
+            }
+
     package_issues: list[SkillPackageIssue] = []
     frontmatter: dict[str, Any] | None = None
     parsed: dict[str, Any] | None = None
@@ -683,6 +744,8 @@ def scan_skill_trust_receipt(
         "destructive": bool(_DESTRUCTIVE_RE.search(all_text)),
         "securitySensitive": bool(_SECURITY_SENSITIVE_RE.search(all_text)),
     }
+    if hook_capability is not None:
+        capabilities["pluginHook"] = bool(hook_capability.get("contractValid"))
     capability_messages = {
         "network": ("trust_network_required", "The Skill declares network access."),
         "credentials": ("trust_credentials_required", "The Skill declares credential or token requirements."),
@@ -755,6 +818,10 @@ def scan_skill_trust_receipt(
         not blocked
         and not finding_codes.intersection(_ROUTER_EXCLUDED_FINDING_CODES)
     )
+    if hook_capability is not None:
+        hook_capability["v2Runnable"] = bool(
+            hook_capability.get("contractValid") and router_eligible
+        )
     trust_status: TrustStatus = "blocked" if blocked else "verified" if state.risk_level == "low" else "conditional"
     install_policy: InstallPolicy = "block" if blocked else "allow" if state.risk_level == "low" else "confirm"
     compatibility: CompatibilityStatus = "unsupported" if blocked else "portable" if state.risk_level == "low" else "conditional"
@@ -790,6 +857,8 @@ def scan_skill_trust_receipt(
         "capabilities": capabilities,
         "findings": [finding.to_dict() for finding in findings],
     }
+    if hook_capability is not None:
+        receipt_payload["hookCapability"] = hook_capability
     receipt_payload["trustFingerprint"] = sha256_json(receipt_payload)
     return receipt_payload
 

--- a/server/tests/fixtures/skill_hook_v2_gold/SKILL.md
+++ b/server/tests/fixtures/skill_hook_v2_gold/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: release-file-guard
+description: Check release file names before writing published artifacts.
+---
+
+# Release file guard
+
+Before `sandbox_write_file`, run the guard declared in `hooks/manifest.json`.
+The guard allows ordinary release files and denies executable extensions.

--- a/server/tests/fixtures/skill_hook_v2_gold/hooks/manifest.json
+++ b/server/tests/fixtures/skill_hook_v2_gold/hooks/manifest.json
@@ -1,0 +1,18 @@
+{
+  "version": "modelmirror-hook-manifest-v2",
+  "hooks": [
+    {
+      "hook_id": "check-release-name",
+      "event": "pre_tool_use",
+      "mode": "guard",
+      "tool_names": ["sandbox_write_file"],
+      "script_path": "scripts/check_release.py",
+      "purpose": "Reject executable release file names before a write.",
+      "acceptance_checks": [
+        "Allow a safe relative release path.",
+        "Deny executable file extensions."
+      ],
+      "timeout_seconds": 15
+    }
+  ]
+}

--- a/server/tests/fixtures/skill_hook_v2_gold/scripts/check_release.py
+++ b/server/tests/fixtures/skill_hook_v2_gold/scripts/check_release.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import PurePosixPath
+
+
+DENIED_SUFFIXES = {".bat", ".cmd", ".com", ".exe", ".msi", ".ps1", ".sh"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--context", required=True)
+    parser.add_argument("--result", required=True)
+    args = parser.parse_args()
+
+    with open(args.context, encoding="utf-8") as handle:
+        context = json.load(handle)
+    arguments = context.get("arguments")
+    path_value = arguments.get("path", "") if isinstance(arguments, dict) else ""
+    suffix = PurePosixPath(str(path_value).replace("\\", "/")).suffix.casefold()
+    denied = suffix in DENIED_SUFFIXES
+    output = (
+        {
+            "type": "deny",
+            "code": "release_extension_denied",
+            "message": "Executable release file extensions are not allowed.",
+        }
+        if denied
+        else {
+            "type": "validation",
+            "code": "release_name_allowed",
+            "passed": True,
+            "message": "The release file extension is allowed.",
+        }
+    )
+    with open(args.result, "w", encoding="utf-8", newline="\n") as handle:
+        json.dump(
+            {"version": "modelmirror-hook-result-v1", "outputs": [output]},
+            handle,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/tests/test_skill_application_receipts.py
+++ b/server/tests/test_skill_application_receipts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+from dataclasses import replace
 import hashlib
 import json
 from pathlib import Path
@@ -11,11 +12,13 @@ import pytest
 
 from server.skills.application_receipts import (
     APPLICATION_RECEIPT_VERSION,
+    APPLICATION_RECEIPT_V1_VERSION,
     SkillApplicationObserver,
     SkillApplicationReceiptError,
     SkillApplicationReceiptStorageError,
     SkillApplicationReceiptStore,
     SkillApplicationScope,
+    SkillHookApplicationEvidenceV2,
     build_application_contract,
 )
 from server.skills.creator_evaluation import SkillEvaluationStore, SkillEvaluationValidationError
@@ -102,6 +105,196 @@ def test_contract_and_receipt_distinguish_selection_from_application(tmp_path):
     assert second_node is not None
     assert second_node.receipt_id == applied.receipt_id
     assert second_node.node_ids == ("second-agent", "workflow-agent")
+
+
+def test_v2_persists_bounded_hook_evidence_and_requires_verified_execution(tmp_path):
+    store = SkillApplicationReceiptStore(tmp_path)
+    contract = _contract(policy="advisory")
+    evidence = SkillHookApplicationEvidenceV2(
+        hook_id="check-release-name",
+        hook_event="pre_tool_use",
+        hook_mode="guard",
+        manifest_digest=_digest("manifest"),
+        script_digest=_digest("script"),
+        context_digest=_digest("redacted-context"),
+        result_digest=_digest("typed-result"),
+        code="release_name_allowed",
+        result_type="validation_passed",
+        verified=True,
+    )
+
+    receipt = store.observe(
+        contract,
+        _scope(),
+        method="hook_execute",
+        tool_name="skill_hook_execute",
+        hook_evidence=(evidence,),
+    )
+
+    assert receipt is not None
+    assert receipt.version == APPLICATION_RECEIPT_VERSION
+    assert receipt.methods == ("hook_execute",)
+    assert receipt.compliance_status == "verified"
+    assert receipt.hook_evidence == (evidence,)
+    assert store.require_verified_hook_evidence(
+        receipt.receipt_id, hook_ids=("check-release-name",)
+    ).receipt_id == receipt.receipt_id
+    persisted = store.snapshot_path.read_text(encoding="utf-8")
+    assert "redacted-context" not in persisted
+    assert "typed-result" not in persisted
+
+
+def test_v1_receipt_migrates_without_fabricating_hook_evidence(tmp_path):
+    store = SkillApplicationReceiptStore(tmp_path)
+    selected = store.record_selection(_contract(), _scope())
+    assert selected is not None
+    payload = json.loads(store.snapshot_path.read_text(encoding="utf-8"))
+    payload["version"] = APPLICATION_RECEIPT_V1_VERSION
+    payload["receipts"][0]["version"] = APPLICATION_RECEIPT_V1_VERSION
+    payload["receipts"][0].pop("hook_evidence", None)
+    store.snapshot_path.write_text(
+        json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+    )
+
+    migrated = SkillApplicationReceiptStore(tmp_path).require(selected.receipt_id)
+
+    assert migrated.version == APPLICATION_RECEIPT_VERSION
+    assert migrated.hook_evidence == ()
+    assert migrated.receipt_id == selected.receipt_id
+
+
+def test_hook_evidence_rejects_impossible_deny_boundary(tmp_path):
+    store = SkillApplicationReceiptStore(tmp_path)
+    evidence = SkillHookApplicationEvidenceV2(
+        hook_id="late-deny",
+        hook_event="post_tool_use",
+        hook_mode="guard",
+        manifest_digest=_digest("manifest"),
+        script_digest=_digest("script"),
+        context_digest=_digest("context"),
+        result_digest=_digest("result"),
+        code="late_deny",
+        result_type="denied",
+        verified=True,
+    )
+
+    with pytest.raises(SkillApplicationReceiptError):
+        store.observe(
+            _contract(policy="advisory"),
+            _scope(),
+            method="hook_execute",
+            hook_evidence=(evidence,),
+        )
+
+
+def test_unverified_hook_evidence_cannot_satisfy_verified_gate(tmp_path):
+    store = SkillApplicationReceiptStore(tmp_path)
+    evidence = SkillHookApplicationEvidenceV2(
+        hook_id="check-release-name",
+        hook_event="pre_tool_use",
+        hook_mode="guard",
+        manifest_digest=_digest("manifest"),
+        script_digest=_digest("script"),
+        context_digest=_digest("context"),
+        result_digest=_digest("result"),
+        code="release_name_allowed",
+        result_type="validation_passed",
+        verified=False,
+    )
+
+    receipt = store.observe(
+        _contract(policy="advisory"),
+        _scope(),
+        method="hook_execute",
+        hook_evidence=(evidence,),
+    )
+
+    assert receipt is not None
+    assert receipt.compliance_status == "unverified"
+    with pytest.raises(SkillApplicationReceiptError) as error:
+        store.require_verified_hook_evidence(receipt.receipt_id)
+    assert error.value.code == "skill_application_receipt_incomplete"
+
+
+@pytest.mark.parametrize(
+    "invalid_evidence",
+    [
+        SkillHookApplicationEvidenceV2(
+            hook_id="check-release-name",
+            hook_event="pre_tool_use",
+            hook_mode="guard",
+            manifest_digest="",
+            script_digest=_digest("script"),
+            context_digest=_digest("context"),
+            result_digest=_digest("result"),
+            code="release_name_allowed",
+            result_type="validation_passed",
+            verified=True,
+        ),
+        SkillHookApplicationEvidenceV2(
+            hook_id="check-release-name",
+            hook_event="pre_tool_use",
+            hook_mode="guard",
+            manifest_digest=_digest("manifest"),
+            script_digest=_digest("script"),
+            context_digest=_digest("context"),
+            result_digest=_digest("result"),
+            code="wrong_result_type",
+            result_type="annotation",
+            verified=True,
+        ),
+    ],
+)
+def test_hook_evidence_requires_all_digests_and_matching_mode(
+    tmp_path, invalid_evidence
+):
+    store = SkillApplicationReceiptStore(tmp_path)
+
+    with pytest.raises(SkillApplicationReceiptError) as error:
+        store.observe(
+            _contract(policy="advisory"),
+            _scope(),
+            method="hook_execute",
+            hook_evidence=(invalid_evidence,),
+        )
+
+    assert error.value.code == "skill_application_receipt_invalid"
+
+
+def test_failed_hook_evidence_cannot_be_recorded_as_success(tmp_path):
+    store = SkillApplicationReceiptStore(tmp_path)
+    evidence = SkillHookApplicationEvidenceV2(
+        hook_id="check-release-name",
+        hook_event="pre_tool_use",
+        hook_mode="guard",
+        manifest_digest=_digest("manifest"),
+        script_digest=_digest("script"),
+        context_digest=_digest("context"),
+        result_digest=_digest("result"),
+        code="hook_process_failed",
+        result_type="failed",
+        verified=True,
+    )
+    with pytest.raises(SkillApplicationReceiptError):
+        store.observe(
+            _contract(policy="advisory"),
+            _scope(),
+            method="hook_execute",
+            hook_evidence=(evidence,),
+        )
+
+    failed = store.observe(
+        _contract(policy="advisory"),
+        _scope(),
+        method="hook_execute",
+        error_code="skill_hook_execution_failed",
+        hook_evidence=(replace(evidence, verified=False),),
+    )
+
+    assert failed is not None
+    assert failed.methods == ()
+    assert failed.application_status == "failed"
+    assert failed.compliance_status == "unverified"
 
 
 def test_resource_read_evidence_does_not_forge_skill_read_method(tmp_path):

--- a/server/tests/test_skill_hook_contract.py
+++ b/server/tests/test_skill_hook_contract.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+import json
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+import pytest
+
+from server.skills.hook_contract import (
+    HOOK_MANIFEST_VERSION,
+    HOOK_RESULT_VERSION,
+    SkillHookContractError,
+    hook_capability_projection,
+    parse_hook_manifest,
+    parse_hook_result,
+)
+from server.skills.package_validation import validate_skill_package
+from server.skills.skill_manager import InstalledSkill, SkillManager
+
+
+def _hook(
+    *,
+    hook_id: str = "check-release-name",
+    event: str = "pre_tool_use",
+    mode: str = "guard",
+    tool_names: list[str] | None = None,
+    script_path: str = "scripts/check_release.py",
+) -> dict:
+    return {
+        "hook_id": hook_id,
+        "event": event,
+        "mode": mode,
+        "tool_names": ["sandbox_write_file"] if tool_names is None else tool_names,
+        "script_path": script_path,
+        "purpose": "Reject unsafe release file names before a write.",
+        "acceptance_checks": ["Allow a safe relative release path.", "Deny an executable extension."],
+        "timeout_seconds": 15,
+    }
+
+
+def _manifest(*hooks: dict) -> str:
+    return json.dumps(
+        {"version": HOOK_MANIFEST_VERSION, "hooks": list(hooks or (_hook(),))},
+        ensure_ascii=False,
+    )
+
+
+def _skill_markdown() -> str:
+    return (
+        "---\n"
+        "name: release-file-guard\n"
+        "description: Check release file names before writing published artifacts.\n"
+        "---\n\n"
+        "# Release file guard\n\n"
+        "The immutable Hook contract is in `hooks/manifest.json`.\n"
+    )
+
+
+def _gold_fixture_root() -> Path:
+    return Path(__file__).parent / "fixtures" / "skill_hook_v2_gold"
+
+
+def test_parses_fixed_manifest_and_projects_only_bounded_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    content = _manifest()
+
+    manifest = parse_hook_manifest(
+        content,
+        available_paths={"hooks/manifest.json", "scripts/check_release.py"},
+    )
+
+    assert manifest.version == HOOK_MANIFEST_VERSION
+    assert len(manifest.hooks) == 1
+    assert manifest.hooks[0].tool_names == ("sandbox_write_file",)
+    assert len(manifest.fingerprint) == 64
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "false")
+    projection = hook_capability_projection(
+        content, available_paths={"hooks/manifest.json", "scripts/check_release.py"}
+    )
+    assert projection == {
+        "available": True,
+        "manifestVersion": HOOK_MANIFEST_VERSION,
+        "manifestFingerprint": manifest.fingerprint,
+        "hookCount": 1,
+        "events": ["pre_tool_use"],
+        "modes": ["guard"],
+        "contractValid": True,
+        "runnable": False,
+        "errorCode": None,
+    }
+    assert "purpose" not in projection
+    assert "tool_names" not in projection
+
+
+def test_installed_projection_is_bounded_and_disabled_before_runtime_pr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "false")
+    manager = SkillManager(
+        installed_dir=tmp_path / "installed",
+        tmp_dir=tmp_path / "tmp",
+    )
+    skill = InstalledSkill(
+        skill_id="release-file-guard",
+        name="Release file guard",
+        description="Check release names.",
+        repo_url="plugin://fixture/v1",
+        sub_path="release-file-guard",
+        installed_at=time.time(),
+        source_kind="plugin",
+        source_id="fixture",
+        source_revision=1,
+    )
+    root = manager.installed_dir / skill.skill_id
+    (root / "scripts").mkdir(parents=True)
+    (root / "hooks").mkdir()
+    (root / "SKILL.md").write_text(_skill_markdown(), encoding="utf-8")
+    (root / "scripts" / "check_release.py").write_text(
+        "raise SystemExit(0)\n", encoding="utf-8"
+    )
+    (root / "hooks" / "manifest.json").write_text(_manifest(), encoding="utf-8")
+    manager._write_metadata({skill.skill_id: asdict(skill)})
+
+    projection = manager.get_hook_capability(skill.skill_id)
+
+    assert projection["available"] is True
+    assert projection["contractValid"] is True
+    assert projection["runnable"] is False
+    assert "purpose" not in projection
+    assert "tool_names" not in projection
+    assert "script_path" not in projection
+
+
+@pytest.mark.parametrize(
+    ("path", "output_type", "code"),
+    [
+        ("release/report.pdf", "validation", "release_name_allowed"),
+        ("release/installer.exe", "deny", "release_extension_denied"),
+    ],
+)
+def test_gold_fixture_validates_and_runs_offline(
+    tmp_path: Path,
+    path: str,
+    output_type: str,
+    code: str,
+) -> None:
+    root = _gold_fixture_root()
+    files = {
+        item.relative_to(root).as_posix(): item.read_text(encoding="utf-8")
+        for item in root.rglob("*")
+        if item.is_file() and item.name != "SKILL.md"
+    }
+    validation = validate_skill_package(
+        root_name="release-file-guard",
+        skill_markdown=(root / "SKILL.md").read_text(encoding="utf-8"),
+        files=files,
+    )
+    assert validation.valid is True, validation.issues
+
+    context_path = tmp_path / "context.json"
+    result_path = tmp_path / "result.json"
+    context_path.write_text(
+        json.dumps({"tool_name": "sandbox_write_file", "arguments": {"path": path}}),
+        encoding="utf-8",
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            str(root / "scripts" / "check_release.py"),
+            "--context",
+            str(context_path),
+            "--result",
+            str(result_path),
+        ],
+        check=True,
+        capture_output=True,
+        timeout=10,
+    )
+    parsed = parse_hook_result(
+        result_path.read_text(encoding="utf-8"),
+        hook_event="pre_tool_use",
+        hook_mode="guard",
+    )
+
+    assert parsed.outputs[0].output_type == output_type
+    assert parsed.outputs[0].code == code
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda hook: hook.update(command="python"),
+        lambda hook: hook.update(argv=["--unsafe"]),
+        lambda hook: hook.update(tool_names=["sandbox_*"]),
+        lambda hook: hook.update(script_path="../outside.py"),
+        lambda hook: hook.update(script_path="scripts/check_release.sh"),
+        lambda hook: hook.update(event="session_start"),
+        lambda hook: hook.update(mode="guard", event="session_end", tool_names=[]),
+    ],
+)
+def test_rejects_manifest_escape_hatches_and_invalid_event_mode_combinations(
+    mutation,
+) -> None:
+    hook = _hook()
+    mutation(hook)
+
+    with pytest.raises(SkillHookContractError) as error:
+        parse_hook_manifest(
+            _manifest(hook), available_paths={"scripts/check_release.py"}
+        )
+
+    assert error.value.code == "skill_hook_manifest_invalid"
+
+
+def test_requires_unique_ids_exact_script_and_strict_json() -> None:
+    duplicate = _manifest(_hook(), _hook())
+    duplicate_key = (
+        '{"version":"modelmirror-hook-manifest-v2",'
+        '"version":"modelmirror-hook-manifest-v2","hooks":[]}'
+    )
+
+    for content, paths in (
+        (duplicate, {"scripts/check_release.py"}),
+        (_manifest(), {"scripts/other.py"}),
+        (duplicate_key, set()),
+    ):
+        with pytest.raises(SkillHookContractError):
+            parse_hook_manifest(content, available_paths=paths)
+
+
+def test_session_hook_omits_tool_filter_and_timeout_defaults_to_fifteen() -> None:
+    hook = _hook(
+        hook_id="summarize-session",
+        event="session_end",
+        mode="annotation",
+        tool_names=[],
+    )
+    hook.pop("tool_names")
+    hook.pop("timeout_seconds")
+
+    manifest = parse_hook_manifest(
+        _manifest(hook), available_paths={"scripts/check_release.py"}
+    )
+
+    assert manifest.hooks[0].tool_names == ()
+    assert manifest.hooks[0].timeout_seconds == 15
+
+
+def test_package_validation_allows_only_canonical_hook_manifest() -> None:
+    valid = validate_skill_package(
+        root_name="release-file-guard",
+        skill_markdown=_skill_markdown(),
+        files={
+            "scripts/check_release.py": "import sys\nraise SystemExit(0)\n",
+            "hooks/manifest.json": _manifest(),
+        },
+    )
+    unsupported = validate_skill_package(
+        root_name="release-file-guard",
+        skill_markdown=_skill_markdown(),
+        files={
+            "scripts/check_release.py": "raise SystemExit(0)\n",
+            "hooks/extra.json": _manifest(),
+        },
+    )
+    missing_script = validate_skill_package(
+        root_name="release-file-guard",
+        skill_markdown=_skill_markdown(),
+        files={"hooks/manifest.json": _manifest()},
+    )
+
+    assert valid.valid is True, valid.issues
+    assert valid.package is not None
+    assert "hooks/manifest.json" in valid.package.files
+    assert {issue.code for issue in unsupported.issues} >= {"hooks_file_unsupported"}
+    assert {issue.code for issue in missing_script.issues} >= {
+        "skill_hook_manifest_invalid"
+    }
+
+
+def test_manifest_or_script_change_invalidates_package_and_manifest_digests() -> None:
+    first_manifest = _manifest()
+    changed_hook = _hook()
+    changed_hook["timeout_seconds"] = 16
+    changed_manifest = _manifest(changed_hook)
+    files = {
+        "scripts/check_release.py": "raise SystemExit(0)\n",
+        "hooks/manifest.json": first_manifest,
+    }
+    first = validate_skill_package(
+        root_name="release-file-guard",
+        skill_markdown=_skill_markdown(),
+        files=files,
+    )
+    manifest_changed = validate_skill_package(
+        root_name="release-file-guard",
+        skill_markdown=_skill_markdown(),
+        files={**files, "hooks/manifest.json": changed_manifest},
+    )
+    script_changed = validate_skill_package(
+        root_name="release-file-guard",
+        skill_markdown=_skill_markdown(),
+        files={**files, "scripts/check_release.py": "raise SystemExit(1)\n"},
+    )
+
+    assert first.package is not None
+    assert manifest_changed.package is not None
+    assert script_changed.package is not None
+    assert len(
+        {
+            first.package.content_digest,
+            manifest_changed.package.content_digest,
+            script_changed.package.content_digest,
+        }
+    ) == 3
+    assert parse_hook_manifest(
+        first_manifest, available_paths=files
+    ).fingerprint != parse_hook_manifest(
+        changed_manifest, available_paths=files
+    ).fingerprint
+
+
+def test_parses_typed_results_and_rejects_rewrites_or_wrong_deny_boundary() -> None:
+    valid = parse_hook_result(
+        json.dumps(
+            {
+                "version": HOOK_RESULT_VERSION,
+                "outputs": [
+                    {
+                        "type": "deny",
+                        "code": "release_name_denied",
+                        "message": "Executable extensions are not allowed.",
+                    }
+                ],
+            }
+        ),
+        hook_event="pre_tool_use",
+        hook_mode="guard",
+    )
+    assert valid.outputs[0].output_type == "deny"
+
+    rewrite = json.dumps(
+        {
+            "version": HOOK_RESULT_VERSION,
+            "outputs": [
+                {
+                    "type": "validation",
+                    "code": "checked",
+                    "passed": True,
+                    "message": "Safe.",
+                    "new_arguments": {"path": "changed"},
+                }
+            ],
+        }
+    )
+    deny_after = json.dumps(
+        {
+            "version": HOOK_RESULT_VERSION,
+            "outputs": [
+                {"type": "deny", "code": "late_deny", "message": "Too late."}
+            ],
+        }
+    )
+    with pytest.raises(SkillHookContractError):
+        parse_hook_result(rewrite, hook_event="post_tool_use", hook_mode="validation")
+    with pytest.raises(SkillHookContractError):
+        parse_hook_result(deny_after, hook_event="post_tool_use", hook_mode="guard")
+
+    invalid_message = json.dumps(
+        {
+            "version": HOOK_RESULT_VERSION,
+            "outputs": [
+                {
+                    "type": "annotation",
+                    "code": "empty_message",
+                    "severity": "warning",
+                    "message": "",
+                }
+            ],
+        }
+    )
+    with pytest.raises(SkillHookContractError) as invalid:
+        parse_hook_result(
+            invalid_message, hook_event="session_start", hook_mode="annotation"
+        )
+    assert invalid.value.code == "skill_hook_result_invalid"

--- a/server/tests/test_skill_trust_scanner.py
+++ b/server/tests/test_skill_trust_scanner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 
 import pytest
 
@@ -71,6 +72,8 @@ def test_pure_text_skill_is_low_risk_and_directly_installable() -> None:
     assert receipt["packageDigest"]
     assert receipt["scannerVersion"] == SKILL_TRUST_SCANNER_VERSION
     assert receipt["findings"] == []
+    assert "pluginHook" not in receipt["capabilities"]
+    assert "hookCapability" not in receipt
 
 
 def test_local_python_and_file_write_are_medium_risk() -> None:
@@ -85,6 +88,114 @@ def test_local_python_and_file_write_are_medium_risk() -> None:
     assert receipt["routerEligible"] is True
     assert receipt["summary"]["scriptCount"] == 1
     assert {"trust_local_script", "trust_sandbox_write_required"} <= _codes(receipt)
+
+
+def test_valid_v2_hook_requires_confirmation_and_projects_capability() -> None:
+    manifest = json.dumps(
+        {
+            "version": "modelmirror-hook-manifest-v2",
+            "hooks": [
+                {
+                    "hook_id": "check-release-name",
+                    "event": "pre_tool_use",
+                    "mode": "guard",
+                    "tool_names": ["sandbox_write_file"],
+                    "script_path": "scripts/check_release.py",
+                    "purpose": "Reject unsafe release file names before a write.",
+                    "acceptance_checks": ["Allow safe names.", "Deny executable extensions."],
+                    "timeout_seconds": 15,
+                }
+            ],
+        }
+    ).encode()
+    receipt = _scan(
+        _entry("SKILL.md", _markdown()),
+        _entry("scripts/check_release.py", b"raise SystemExit(0)\n"),
+        _entry("hooks/manifest.json", manifest),
+    )
+
+    assert receipt["installPolicy"] == "confirm"
+    assert receipt["capabilities"]["pluginHook"] is True
+    assert receipt["hookCapability"] == {
+        "manifestVersion": "modelmirror-hook-manifest-v2",
+        "manifestFingerprint": receipt["hookCapability"]["manifestFingerprint"],
+        "hookCount": 1,
+        "events": ["pre_tool_use"],
+        "contractValid": True,
+        "v2Runnable": True,
+    }
+    assert len(receipt["hookCapability"]["manifestFingerprint"]) == 64
+    assert "trust_plugin_hook" in _codes(receipt)
+
+
+def test_v2_hook_with_invalid_script_is_not_runtime_eligible() -> None:
+    manifest = json.dumps(
+        {
+            "version": "modelmirror-hook-manifest-v2",
+            "hooks": [
+                {
+                    "hook_id": "check-release-name",
+                    "event": "pre_tool_use",
+                    "mode": "guard",
+                    "tool_names": ["sandbox_write_file"],
+                    "script_path": "scripts/check_release.py",
+                    "purpose": "Reject unsafe release file names before a write.",
+                    "acceptance_checks": ["Allow safe names.", "Deny executable extensions."],
+                    "timeout_seconds": 15,
+                }
+            ],
+        }
+    ).encode()
+    receipt = _scan(
+        _entry("SKILL.md", _markdown()),
+        _entry("scripts/check_release.py", b"def broken(:\n"),
+        _entry("hooks/manifest.json", manifest),
+    )
+
+    assert receipt["installPolicy"] == "confirm"
+    assert receipt["routerEligible"] is False
+    assert receipt["hookCapability"]["contractValid"] is True
+    assert receipt["hookCapability"]["v2Runnable"] is False
+    assert "python_syntax_invalid" in _codes(receipt)
+
+
+@pytest.mark.parametrize(
+    ("manifest", "extra_entries"),
+    [
+        (b"{}", ()),
+        (
+            json.dumps(
+                {
+                    "version": "modelmirror-hook-manifest-v2",
+                    "hooks": [
+                        {
+                            "hook_id": "unsafe-runtime",
+                            "event": "pre_tool_use",
+                            "mode": "guard",
+                            "tool_names": ["sandbox_write_file"],
+                            "script_path": "scripts/check.sh",
+                            "purpose": "Reject unsafe writes.",
+                            "acceptance_checks": ["Deny an unsafe write."],
+                            "timeout_seconds": 15,
+                        }
+                    ],
+                }
+            ).encode(),
+            (_entry("scripts/check.sh", b"exit 0\n"),),
+        ),
+    ],
+)
+def test_invalid_v2_hook_manifest_is_blocked(manifest: bytes, extra_entries: tuple) -> None:
+    receipt = _scan(
+        _entry("SKILL.md", _markdown()),
+        _entry("hooks/manifest.json", manifest),
+        *extra_entries,
+    )
+
+    assert receipt["trustStatus"] == "blocked"
+    assert receipt["installPolicy"] == "block"
+    assert receipt["routerEligible"] is False
+    assert "skill_hook_manifest_invalid" in _codes(receipt)
 
 
 def test_python_subprocess_is_high_risk_shell_capability() -> None:


### PR DESCRIPTION
## Summary

- 新增严格的 hooks/manifest.json 与 modelmirror-hook-result-v1 合同，固定事件、模式、精确工具名、脚本路径和限额。
- 将 Hook manifest 与脚本纳入 Skill 包校验、内容摘要、信任扫描和已安装能力投影；非法合同失败关闭。
- Application Receipt 兼容升级至 V2，保留 V1 ID 并新增有界、脱敏、可验证的 Hook evidence。
- 增加离线 release-file-guard 金标包，固定后续 Runtime/Creator E2E 基线。
- SKILL_PLUGIN_HOOK_V2_ENABLED 仍默认 false，本 PR 不接管现有 Legacy Hook Runtime。

## Gate 0

上一轮高价值 TDD Skill 的 skill_runtime_incompatible 源于其确实声明 Bash、npm 和 package manager，而当前运行未绑定这些能力；不是能力解析误判。本 PR 未放宽信任或运行能力。

## Falsification fixes

- 禁止空 digest 伪造 Hook evidence。
- 严格绑定 result type、Hook mode 与事件边界。
- 技术失败不得记为成功应用。
- 语法损坏脚本可提示风险安装，但不得进入 Router 或标记 V2 runnable。
- 已安装投影不返回用途、工具匹配、manifest 规则或脚本内容。

## Validation

- 118 passed, 1 skipped：包、信任、草稿、本地导入、安装和 Legacy Hook 回归。
- 77 passed, 1 deselected：Hook 合同、信任兼容与 Receipt V2 核心集。
- 16 passed：实体金标包校验及离线 allow/deny CLI。
- Python py_compile 与 git diff --check 通过。
- 敏感信息与路径白名单核对通过。

完整 Receipt 套件另有 1 个 Windows 路径排序失败；信任服务另有 Windows checkout 原始字节摘要失败。两者均已在未修改的最新 origin/main 精确复现，未在本 PR 扩大范围修复。