### PR TITLE
feature: Skill Hook V2 类型化运行时与可信凭据闭环

### DIFF
--- a/docs/SKILL_INTEGRATION.md
+++ b/docs/SKILL_INTEGRATION.md
@@ -290,7 +290,9 @@ Hook V2 的唯一标准入口是 `hooks/manifest.json`，版本固定为 `modelm
 
 `SkillApplicationReceiptV2` 在保留 V1 receipt ID 和普通应用合同的同时增加 `hook_execute` 及有界 Hook evidence；旧 V1 记录读取时得到空 evidence，不补造执行事实。Evidence 只保存 Hook/事件/模式、manifest/script/context/result 摘要、脱敏 code、结果类型和 verified 状态，不保存参数、正文、stdout/stderr 或模型输出。涉及 Hook 的后续评测必须另外取得 verified V2 evidence。
 
-当前 `SKILL_PLUGIN_HOOK_V2_ENABLED=false`：服务端会校验包、扫描信任风险并投影脱敏 `hookCapability`，但不会改变旧 Hook 的执行行为。类型化执行顺序、Creator 创作和新工作流体验在后续批次完成；将开关保持为 false 即可回退本合同尚未接管的运行路径。
+当前 `SKILL_PLUGIN_HOOK_V2_ENABLED=false`，旧节点仍走 `legacy_argv`。独立预览或测试环境开启后，`typed_v2` 会在固定版本的受保护 `skill_authoring_v1` Sidecar profile 中运行：PreToolUse 先于 HITL，`guard + deny` 不创建审批卡；PostToolUse validation 失败会明确标记副作用已经发生且不会自动回滚。Annotation 技术故障告警后继续，validation/guard 的超时、损坏结果或 Sidecar 故障失败关闭。
+
+类型化 Hook 只接收有界脱敏 context，并把严格 JSON 写入服务端冻结的 result 路径。脚本不能选择 executable、argv、cwd 或权限，也不能改写工具参数、输出或审批结果。每次执行结束会以 `{}` 覆盖 context/result；Application Receipt 和 `skill_hook_status` 只保留摘要、稳定 code 与状态。并行工具在任何 provider 调用前完成整批 PreToolUse 检查，同一中间件的 Hook 脚本串行执行以隔离临时 context；工具本身仍可按原策略并行。审批恢复会在同一 Server 进程内复用已 sealed 的 Skill workspace，服务重启只复用 verified evidence，不持久化 Sidecar capability。Creator 创作和新工作流体验留给下一批次；保持开关为 false 即可完整回退类型化执行。
 
 ## 5. 测试指南
 

--- a/docs/XPERT_AUTOMATION.md
+++ b/docs/XPERT_AUTOMATION.md
@@ -42,7 +42,9 @@ Automation 通过文件 Store 原子保存到 Runtime storage。RunRegistry 使�
 
 ### Plugin Hooks
 
-`plugin_hooks` 只读取用户已安装 Skill 中显式的 `modelmirror-hooks.json`。支持 `SessionStart`、`PreToolUse`、`PostToolUse` 和 `SessionEnd`。Hook 文件先安全 staging 到当前隔离工作区，再通过无网 Sandbox 以 argv 方式运行；不允许 shell 字符串、在线下载、仓库或密钥访问。可配置 fail-open 或 fail-closed。
+缺少 `hook_mode` 或显式选择 `legacy_argv` 的 `plugin_hooks` 继续读取已安装 Skill 根目录的 `modelmirror-hooks.json`，保留原有 `SessionStart / PreToolUse / PostToolUse / SessionEnd` argv 行为和 `fail_closed` 配置。
+
+`hook_mode=typed_v2` 只读取标准 `hooks/manifest.json`，并受 `SKILL_PLUGIN_HOOK_V2_ENABLED` 控制。运行器固定 Python/Node、无网 `skill_authoring_v1` profile、受保护 Skill 只读目录与 `work/` 写入目录；PreToolUse 顺序固定为 Hook -> deny/validation -> HITL -> provider，PostToolUse 在 provider 后执行。Annotation 故障按告警继续，validation/guard 故障失败关闭；任何类型都不能修改参数、输出、审批或权限。运行状态写入脱敏 `skill_hook_status` 和 Application Receipt V2，不保存 context、结果正文、stdout/stderr 或模型输出。PR2 保持开关默认关闭，新节点默认值和运行卡在后续体验批次启用。
 
 ## 管理接口
 

--- a/server/main.py
+++ b/server/main.py
@@ -821,6 +821,8 @@ try:
         RuntimeMiddlewareFatalError,
         RuntimeMiddlewareSpec,
         RuntimeTodoStore,
+        SkillHookRuntimeError,
+        ToolCallRequest,
         SandboxSidecarClient,
         SandboxToolsetProvider,
         SandboxWorkspaceStore,
@@ -847,6 +849,10 @@ try:
         build_xpert_file_memory_middleware,
         build_human_in_the_loop_middleware,
         build_plugin_hooks_middleware,
+        build_plugin_hooks_v2_middleware,
+        drain_skill_hook_status_events,
+        plugin_hook_runtime_mode,
+        typed_hook_skill_ids,
         configure_approval_coordinator,
         configure_approval_decision_validator,
         configure_approval_reopen_validator,
@@ -940,6 +946,8 @@ except ModuleNotFoundError:
         RuntimeMiddlewareFatalError,
         RuntimeMiddlewareSpec,
         RuntimeTodoStore,
+        SkillHookRuntimeError,
+        ToolCallRequest,
         SandboxSidecarClient,
         SandboxToolsetProvider,
         SandboxWorkspaceStore,
@@ -966,6 +974,10 @@ except ModuleNotFoundError:
         build_xpert_file_memory_middleware,
         build_human_in_the_loop_middleware,
         build_plugin_hooks_middleware,
+        build_plugin_hooks_v2_middleware,
+        drain_skill_hook_status_events,
+        plugin_hook_runtime_mode,
+        typed_hook_skill_ids,
         configure_approval_coordinator,
         configure_approval_decision_validator,
         configure_approval_reopen_validator,
@@ -8961,6 +8973,58 @@ async def _run_workflow_response(
                     )
                 )
             hitl = middleware_spec(specs, "human_in_the_loop")
+            plugin_hooks = middleware_spec(specs, "plugin_hooks")
+            hook_mode = (
+                plugin_hook_runtime_mode(plugin_hooks)
+                if plugin_hooks is not None
+                else None
+            )
+            typed_hook_ids = typed_hook_skill_ids(plugin_hooks)
+            if plugin_hooks is not None and hook_mode == "typed_v2":
+                if runtime_run_type == "xpert_app":
+                    raise RuntimeMiddlewareFatalError(
+                        "Public Xpert Apps cannot use typed Skill Hooks."
+                    )
+                typed_hook_middleware = build_plugin_hooks_v2_middleware(
+                    plugin_hooks,
+                    skill_manager=get_skill_manager(),
+                    sandbox_provider=workflow_sandbox_provider,
+                    application_observer=skill_application_observer,
+                )
+                runtime_metadata = task_state.setdefault("runtime_metadata", {})
+                current_bindings = {
+                    str(skill_id): str(version_id)
+                    for skill_id, version_id in dict(
+                        runtime_metadata.get("skill_version_bindings") or {}
+                    ).items()
+                    if str(skill_id).strip() and str(version_id).strip()
+                }
+                missing_hook_ids = set(typed_hook_ids) - set(current_bindings)
+                if missing_hook_ids:
+                    resolved = await asyncio.to_thread(
+                        get_skill_manager().bind_skill_versions,
+                        missing_hook_ids,
+                    )
+                    current_bindings.update(
+                        {
+                            str(skill_id): str(version_id)
+                            for skill_id, version_id in resolved.items()
+                            if str(skill_id).strip() and str(version_id).strip()
+                        }
+                    )
+                if any(skill_id not in current_bindings for skill_id in typed_hook_ids):
+                    raise RuntimeMiddlewareFatalError(
+                        "Typed Skill Hook has no immutable runtime version."
+                    )
+                runtime_metadata["skill_version_bindings"] = dict(
+                    sorted(current_bindings.items())
+                )
+                await asyncio.to_thread(
+                    workflow_execution_store.bind_skill_versions,
+                    task_id,
+                    bindings=current_bindings,
+                )
+                middlewares.append(typed_hook_middleware)
             if hitl is not None:
                 middlewares.append(
                     build_human_in_the_loop_middleware(
@@ -8969,14 +9033,17 @@ async def _run_workflow_response(
                         mcp_hub_trusted_service.record_runtime_event,
                     )
                 )
-            plugin_hooks = middleware_spec(specs, "plugin_hooks")
-            if plugin_hooks is not None:
+            if plugin_hooks is not None and hook_mode == "legacy_argv":
                 middlewares.append(
                     build_plugin_hooks_middleware(
                         plugin_hooks,
-                        get_skill_manager(),
-                        workflow_sandbox_provider,
+                        skill_manager=get_skill_manager(),
+                        sandbox_provider=workflow_sandbox_provider,
                     )
+                )
+            elif plugin_hooks is not None and hook_mode != "typed_v2":
+                raise RuntimeMiddlewareFatalError(
+                    "Skill Hook middleware mode is unsupported."
                 )
             pipeline = MiddlewarePipeline(middlewares)
             scope_type, scope_id = runtime_todo_scope(node.id)
@@ -9231,6 +9298,9 @@ async def _run_workflow_response(
                 workflow_runtime_context.get("app_policy") or {}
             )
             run_context = task_state.get("runtime_metadata") or {}
+            context_metadata["skill_version_bindings"] = dict(
+                run_context.get("skill_version_bindings") or {}
+            )
             for metadata_key in (
                 "xpert_id",
                 "conversation_id",
@@ -10830,6 +10900,43 @@ async def _run_workflow_response(
 
             tool_calls_used = 0
 
+            def strategy_tool_metadata(
+                *, tool_call_id: str, iteration: int
+            ) -> dict[str, Any]:
+                return {
+                    "agent_kind": kind,
+                    "agent_node_id": node.id,
+                    "tool_call_id": tool_call_id,
+                    "iteration": iteration,
+                    "agent_strategy_v2": True,
+                    "knowledge_read_enabled": include_knowledge_read,
+                    "knowledge_write_enabled": include_knowledge_write,
+                    "knowledge_base_ids": list(knowledge_base_ids or []),
+                    "external_xpert_tools": list(external_xpert_tools or []),
+                    "toolset_resources": list(toolset_resources or []),
+                    "max_tool_depth": max_tool_depth,
+                }
+
+            async def preflight_tool_batch(
+                calls: list[tuple[str, dict[str, Any], str]], iteration: int
+            ) -> None:
+                if pipeline is None or middleware_context is None:
+                    return
+                await pipeline.before_tool_batch(
+                    [
+                        ToolCallRequest(
+                            tool_name=tool_name,
+                            arguments=arguments,
+                            metadata=strategy_tool_metadata(
+                                tool_call_id=tool_call_id,
+                                iteration=iteration,
+                            ),
+                        )
+                        for tool_name, arguments, tool_call_id in calls
+                    ],
+                    middleware_context,
+                )
+
             async def execute_tool(
                 tool_name: str,
                 arguments: dict[str, Any],
@@ -10850,19 +10957,10 @@ async def _run_workflow_response(
                         arguments=arguments,
                         node=node,
                         title=title,
-                        metadata={
-                            "agent_kind": kind,
-                            "agent_node_id": node.id,
-                            "tool_call_id": tool_call_id,
-                            "iteration": iteration,
-                            "agent_strategy_v2": True,
-                            "knowledge_read_enabled": include_knowledge_read,
-                            "knowledge_write_enabled": include_knowledge_write,
-                            "knowledge_base_ids": list(knowledge_base_ids or []),
-                            "external_xpert_tools": list(external_xpert_tools or []),
-                            "toolset_resources": list(toolset_resources or []),
-                            "max_tool_depth": max_tool_depth,
-                        },
+                        metadata=strategy_tool_metadata(
+                            tool_call_id=tool_call_id,
+                            iteration=iteration,
+                        ),
                         pipeline=pipeline,
                         middleware_context=middleware_context,
                         middleware_specs=middleware_specs,
@@ -10875,6 +10973,8 @@ async def _run_workflow_response(
                     raise RuntimeToolError(
                         tool_name, str(exc), code="tool_denied"
                     ) from exc
+                except SkillHookRuntimeError:
+                    raise
                 except RuntimeMiddlewareFatalError as exc:
                     raise RuntimeToolError(
                         tool_name, str(exc), code="tool_denied"
@@ -10903,6 +11003,7 @@ async def _run_workflow_response(
                     temperature=temperature,
                     max_tokens=agent_max_tokens,
                     parallel_tool_calls=parallel_tool_calls,
+                    tool_batch_preflight=preflight_tool_batch,
                     history_messages=history_messages,
                 )
                 result = await runner.run()
@@ -12254,6 +12355,11 @@ async def _run_workflow_response(
                 if skill_guidance_plan is not None and not result.is_error:
                     await emit_guidance_verified()
 
+            def append_skill_hook_runtime_events() -> None:
+                if middleware_context is None:
+                    return
+                events.extend(drain_skill_hook_status_events(middleware_context))
+
             async def call_workflow_runtime_tool_observed(
                 *,
                 tool_name: str,
@@ -12265,7 +12371,7 @@ async def _run_workflow_response(
                         tool_name,
                         arguments,
                     )
-                    return await call_workflow_runtime_tool(
+                    result = await call_workflow_runtime_tool(
                         tool_name=tool_name,
                         arguments=arguments,
                         node=node,
@@ -12316,6 +12422,8 @@ async def _run_workflow_response(
                             code="skill_application_contract_stale",
                         ) from exc
                     raise
+                append_skill_hook_runtime_events()
+                return result
 
             async def remember_tool_result(
                 tool: Any,
@@ -12496,6 +12604,7 @@ async def _run_workflow_response(
                     pending_arguments,
                     call_result,
                 )
+                append_skill_hook_runtime_events()
                 pending_result_text = runtime_tool_result_text(call_result)
                 await remember_tool_result(
                     pending_tool,
@@ -12833,6 +12942,27 @@ async def _run_workflow_response(
 
                     ensure_tool_call_budget(len(parsed_batch))
                     batch_id = f"batch_{uuid.uuid4().hex}"
+                    if pipeline is not None and middleware_context is not None:
+                        await pipeline.before_tool_batch(
+                            [
+                                ToolCallRequest(
+                                    tool_name=batch_tool_name,
+                                    arguments=batch_arguments,
+                                    metadata=tool_call_metadata(
+                                        iteration=iteration_index + 1,
+                                        batch_id=batch_id,
+                                        batch_index=batch_index,
+                                    ),
+                                )
+                                for batch_index, (
+                                    batch_tool_name,
+                                    batch_arguments,
+                                    _batch_tool,
+                                ) in enumerate(parsed_batch)
+                            ],
+                            middleware_context,
+                        )
+                        append_skill_hook_runtime_events()
                     tool_calls_used += len(parsed_batch)
 
                     async def execute_parallel_tool(
@@ -12897,6 +13027,8 @@ async def _run_workflow_response(
                             raise
                         except SkillRuntimeGuidanceError:
                             raise
+                        except SkillHookRuntimeError:
+                            raise
                         except Exception as exc:
                             error_summary = workflow_error_summary(exc)
                             if run_id:
@@ -12926,6 +13058,7 @@ async def _run_workflow_response(
                             for index, item in enumerate(parsed_batch)
                         ]
                     )
+                    append_skill_hook_runtime_events()
                     event = {
                         "event": "node_delta",
                         "node_id": node.id,
@@ -13107,6 +13240,7 @@ async def _run_workflow_response(
                         arguments,
                         call_result,
                     )
+                    append_skill_hook_runtime_events()
                     tool_result_text = runtime_tool_result_text(call_result)
                     await remember_tool_result(
                         matched_tool,
@@ -16196,17 +16330,24 @@ async def _run_workflow_response(
                                 raw_history,
                                 "[Conversation history is supplied as prior messages.]",
                             )
-                        await agent_pipeline.before_agent(
-                            {
-                                "model_id": model_id,
-                                "messages": history_messages,
-                                "node_id": node.id,
-                                "middleware_ids": [
-                                    item.middleware_id for item in agent_specs
-                                ],
-                            },
-                            agent_context,
-                        )
+                        agent_context.metadata["hook_task_input"] = task_input
+                        try:
+                            await agent_pipeline.before_agent(
+                                {
+                                    "model_id": model_id,
+                                    "messages": history_messages,
+                                    "node_id": node.id,
+                                    "middleware_ids": [
+                                        item.middleware_id for item in agent_specs
+                                    ],
+                                },
+                                agent_context,
+                            )
+                        finally:
+                            for hook_event in drain_skill_hook_status_events(
+                                agent_context
+                            ):
+                                yield sse_payload(hook_event)
                         await run_registry.record_checkpoint(
                             workflow_agent_run.run_id,
                             event_type="workflow_agent.started",
@@ -17144,6 +17285,7 @@ async def _run_workflow_response(
                                                 attempt_exc,
                                                 (
                                                     AgentStrategyError,
+                                                    SkillHookRuntimeError,
                                                     SkillRuntimeGuidanceError,
                                                 ),
                                             )
@@ -17308,15 +17450,24 @@ async def _run_workflow_response(
                                     "content_length": len(output[:20_000]),
                                 },
                             )
-                        await agent_pipeline.after_agent(
-                            {
-                                "model_id": model_id,
-                                "node_id": node.id,
-                                "status": "completed",
-                                "output_length": len(output or ""),
-                            },
-                            agent_context,
-                        )
+                        try:
+                            await agent_pipeline.after_agent(
+                                {
+                                    "model_id": model_id,
+                                    "node_id": node.id,
+                                    "status": "completed",
+                                    "output_length": len(output or ""),
+                                    "output_digest": hashlib.sha256(
+                                        (output or "").encode("utf-8")
+                                    ).hexdigest(),
+                                },
+                                agent_context,
+                            )
+                        finally:
+                            for hook_event in drain_skill_hook_status_events(
+                                agent_context
+                            ):
+                                yield sse_payload(hook_event)
                         compression_stats = agent_context.metadata.get(
                             "context_compression"
                         )
@@ -17442,6 +17593,11 @@ async def _run_workflow_response(
                             },
                         )
                     except RuntimeInterrupt:
+                        if agent_context is not None:
+                            for hook_event in drain_skill_hook_status_events(
+                                agent_context
+                            ):
+                                yield sse_payload(hook_event)
                         raise
                     except Exception as exc:
                         if runtime_run_type == "skill_evaluation":
@@ -17472,6 +17628,11 @@ async def _run_workflow_response(
                                     "Failed to finalize workflow_agent middleware",
                                     exc_info=True,
                                 )
+                            finally:
+                                for hook_event in drain_skill_hook_status_events(
+                                    agent_context
+                                ):
+                                    yield sse_payload(hook_event)
                         if workflow_agent_run is not None:
                             try:
                                 await run_registry.update_run(

--- a/server/tests/fixtures/skill_hook_v2_gold/scripts/check_release.py
+++ b/server/tests/fixtures/skill_hook_v2_gold/scripts/check_release.py
@@ -16,7 +16,12 @@ def main() -> int:
 
     with open(args.context, encoding="utf-8") as handle:
         context = json.load(handle)
-    arguments = context.get("arguments")
+    tool_context = context.get("tool")
+    arguments = (
+        tool_context.get("arguments") if isinstance(tool_context, dict) else None
+    )
+    if not isinstance(arguments, dict):
+        arguments = context.get("arguments")
     path_value = arguments.get("path", "") if isinstance(arguments, dict) else ""
     suffix = PurePosixPath(str(path_value).replace("\\", "/")).suffix.casefold()
     denied = suffix in DENIED_SUFFIXES

--- a/server/tests/test_agent_strategies.py
+++ b/server/tests/test_agent_strategies.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from server.xpert_runtime import RuntimeTool, RuntimeToolError, RuntimeToolResult
+from server.xpert_runtime.interrupts import RuntimeMiddlewareFatalError
 from server.xpert_runtime.agent_strategy import (
     AgentModelError,
     AgentModelTurn,
@@ -396,6 +397,52 @@ async def test_parallel_tool_calls_execute_concurrently_but_keep_message_order()
         message for message in model.requests[1]["messages"] if message["role"] == "tool"
     ]
     assert [message["tool_call_id"] for message in tool_messages] == ["call_1", "call_2"]
+
+
+@pytest.mark.asyncio
+async def test_parallel_batch_preflight_blocks_every_tool_before_execution() -> None:
+    model = FakeModelClient(
+        [
+            tool_turn(
+                ("call_1", "first", '{"query":"one"}'),
+                ("call_2", "second", '{"query":"two"}'),
+            )
+        ]
+    )
+    executed: list[str] = []
+    preflight_calls: list[list[tuple[str, dict[str, Any], str]]] = []
+
+    async def execute(name: str, arguments: dict[str, Any], call_id: str, iteration: int):
+        executed.append(name)
+        return RuntimeToolResult(output=name)
+
+    failure = RuntimeMiddlewareFatalError("batch rejected")
+
+    async def preflight(
+        calls: list[tuple[str, dict[str, Any], str]], iteration: int
+    ) -> None:
+        assert iteration == 1
+        preflight_calls.append(calls)
+        raise failure
+
+    with pytest.raises(RuntimeMiddlewareFatalError) as exc_info:
+        await make_runner(
+            model,
+            execute,
+            strategy="function_calling",
+            parallel_tool_calls=True,
+            tool_batch_preflight=preflight,
+            tools=[runtime_tool("first"), runtime_tool("second")],
+        ).run()
+
+    assert exc_info.value is failure
+    assert executed == []
+    assert preflight_calls == [
+        [
+            ("first", {"query": "one"}, "call_1"),
+            ("second", {"query": "two"}, "call_2"),
+        ]
+    ]
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_workflow_agent_task_node.py
+++ b/server/tests/test_workflow_agent_task_node.py
@@ -34,6 +34,8 @@ from server.xpert_runtime.agent_strategy import (
     AgentModelTurn,
     AgentToolCall,
 )
+from server.xpert_runtime.middleware import AgentMiddleware
+from server.xpert_runtime.plugin_hooks_v2 import SkillHookRuntimeError
 from server.xpert_runtime.todo_store import RuntimeTodoStore
 
 
@@ -1042,6 +1044,368 @@ async def test_workflow_agent_executes_safe_parallel_tool_batch_in_decision_orde
     )
     assert agent_end["output"] == "parallel complete"
     assert [call.tool_name for call in provider.calls] == ["fetch", "lookup"]
+
+
+@pytest.mark.asyncio
+async def test_parallel_post_hook_failure_terminates_the_agent_node(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    provider, restore_provider = _install_fake_tool_provider()
+    provider.tools[0].parallel_safe = True
+    provider.tools.append(
+        RuntimeTool(
+            name="lookup",
+            description="Look up test content",
+            input_schema={"type": "object"},
+            read_only=True,
+            parallel_safe=True,
+        )
+    )
+    package_dir = tmp_path / "hook-skill"
+    package_dir.mkdir()
+    (package_dir / "SKILL.md").write_text("# Hook Skill\n", encoding="utf-8")
+    manager = GuidanceSkillManager(package_dir)
+    executions = WorkflowExecutionStore(tmp_path / "executions")
+    model_calls = 0
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        nonlocal model_calls
+        model_calls += 1
+        return json.dumps(
+            {
+                "tools": [
+                    {"tool": "fetch", "arguments": {"query": "first"}},
+                    {"tool": "lookup", "arguments": {"query": "second"}},
+                ]
+            }
+        )
+
+    async def wrap_tool(request, handler, _context):
+        response = await handler(request)
+        if request.tool_name == "fetch":
+            raise SkillHookRuntimeError(
+                "PostToolUse validation failed after execution.",
+                code="skill_hook_validation_failed",
+            )
+        return response
+
+    monkeypatch.setattr(
+        main_module,
+        "build_plugin_hooks_v2_middleware",
+        lambda *args, **kwargs: AgentMiddleware(
+            name="typed-hook-test", wrap_tool_call=wrap_tool
+        ),
+    )
+    monkeypatch.setattr(main_module, "get_skill_manager", lambda: manager)
+    monkeypatch.setattr(main_module, "workflow_execution_store", executions)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    workflow = _workflow_agent_strategy_workflow(
+        {
+            "toolMode": "mcp_tools",
+            "toolNames": "fetch,lookup",
+            "maxIterations": "3",
+            "parallelToolCalls": "true",
+            "maxToolConcurrency": "2",
+            "maxToolCalls": "4",
+        }
+    )
+    workflow["nodes"].append(
+        {
+            "id": "typed-hooks",
+            "type": "runtime_middleware",
+            "data": {
+                "kind": "runtime_middleware",
+                "runtimeMiddlewareId": "plugin_hooks",
+                "runtimeMiddlewareKind": "runtime_middleware.plugin_hooks",
+                "middlewarePriority": "60",
+                "runtimeMiddlewareConfig": {
+                    "hook_mode": "typed_v2",
+                    "skill_ids": manager.skill_id,
+                },
+            },
+        }
+    )
+    workflow["edges"].append(
+        {
+            "id": "bind-typed-hooks",
+            "source": "typed-hooks",
+            "target": "workflow_agent",
+            "sourceHandle": "middleware-binding",
+            "targetHandle": "middleware",
+        }
+    )
+
+    try:
+        response = await client.post(
+            "/api/workflow/run",
+            json={"workflow": workflow, "inputs": {"user_input": "parallel"}},
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    assert any(
+        event.get("event") == "error"
+        and event.get("node_id") == "workflow_agent"
+        and "PostToolUse validation failed" in str(event.get("message") or "")
+        for event in events
+    ), response.text
+    assert model_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_function_calling_strategy_does_not_downgrade_hook_failure(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    provider, restore_provider = _install_fake_tool_provider()
+    package_dir = tmp_path / "hook-skill-v2"
+    package_dir.mkdir()
+    (package_dir / "SKILL.md").write_text("# Hook Skill\n", encoding="utf-8")
+    manager = GuidanceSkillManager(package_dir)
+    executions = WorkflowExecutionStore(tmp_path / "executions-v2")
+    model_calls = 0
+
+    class FakeAgentModelClient:
+        def __init__(self, **kwargs: Any) -> None:
+            return None
+
+        async def complete(self, **kwargs: Any) -> AgentModelTurn:
+            nonlocal model_calls
+            model_calls += 1
+            if model_calls == 1:
+                return AgentModelTurn(
+                    tool_calls=[
+                        AgentToolCall(
+                            call_id="hook_call",
+                            name="fetch",
+                            raw_arguments='{"query":"hook"}',
+                        )
+                    ],
+                    finish_reason="tool_calls",
+                )
+            return AgentModelTurn(content="must not continue", finish_reason="stop")
+
+    async def wrap_tool(request, handler, _context):
+        await handler(request)
+        raise SkillHookRuntimeError(
+            "PostToolUse validation failed after execution.",
+            code="skill_hook_validation_failed",
+        )
+
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", True)
+    monkeypatch.setattr(
+        main_module, "OpenAICompatibleAgentModelClient", FakeAgentModelClient
+    )
+    monkeypatch.setattr(
+        main_module,
+        "build_plugin_hooks_v2_middleware",
+        lambda *args, **kwargs: AgentMiddleware(
+            name="typed-hook-test", wrap_tool_call=wrap_tool
+        ),
+    )
+    monkeypatch.setattr(main_module, "get_skill_manager", lambda: manager)
+    monkeypatch.setattr(main_module, "workflow_execution_store", executions)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    workflow = _workflow_agent_strategy_workflow(
+        {
+            "toolMode": "mcp_tools",
+            "toolNames": "fetch",
+            "agentStrategy": "function_calling",
+            "maxIterations": "3",
+        }
+    )
+    workflow["nodes"].append(
+        {
+            "id": "typed-hooks-v2",
+            "type": "runtime_middleware",
+            "data": {
+                "kind": "runtime_middleware",
+                "runtimeMiddlewareId": "plugin_hooks",
+                "runtimeMiddlewareKind": "runtime_middleware.plugin_hooks",
+                "middlewarePriority": "60",
+                "runtimeMiddlewareConfig": {
+                    "hook_mode": "typed_v2",
+                    "skill_ids": manager.skill_id,
+                },
+            },
+        }
+    )
+    workflow["edges"].append(
+        {
+            "id": "bind-typed-hooks-v2",
+            "source": "typed-hooks-v2",
+            "target": "workflow_agent",
+            "sourceHandle": "middleware-binding",
+            "targetHandle": "middleware",
+        }
+    )
+
+    try:
+        response = await client.post(
+            "/api/workflow/run",
+            json={"workflow": workflow, "inputs": {"user_input": "hook"}},
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    assert any(
+        event.get("event") == "error"
+        and "PostToolUse validation failed" in str(event.get("message") or "")
+        for event in events
+    ), response.text
+    assert model_calls == 1
+    assert len(provider.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_function_calling_parallel_hook_preflight_blocks_the_entire_batch(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    provider, restore_provider = _install_fake_tool_provider()
+    provider.tools[0].parallel_safe = True
+    provider.tools.append(
+        RuntimeTool(
+            name="lookup",
+            description="Look up test content",
+            input_schema={"type": "object"},
+            read_only=True,
+            parallel_safe=True,
+        )
+    )
+    package_dir = tmp_path / "hook-skill-v2-batch"
+    package_dir.mkdir()
+    (package_dir / "SKILL.md").write_text("# Hook Skill\n", encoding="utf-8")
+    manager = GuidanceSkillManager(package_dir)
+    executions = WorkflowExecutionStore(tmp_path / "executions-v2-batch")
+    model_calls = 0
+    preflight_tools: list[list[str]] = []
+
+    class FakeAgentModelClient:
+        def __init__(self, **kwargs: Any) -> None:
+            return None
+
+        async def complete(self, **kwargs: Any) -> AgentModelTurn:
+            nonlocal model_calls
+            model_calls += 1
+            return AgentModelTurn(
+                tool_calls=[
+                    AgentToolCall(
+                        call_id="hook_call_1",
+                        name="fetch",
+                        raw_arguments='{"query":"first"}',
+                    ),
+                    AgentToolCall(
+                        call_id="hook_call_2",
+                        name="lookup",
+                        raw_arguments='{"query":"second"}',
+                    ),
+                ],
+                finish_reason="tool_calls",
+            )
+
+    async def before_tool_batch(requests, _context):
+        preflight_tools.append([request.tool_name for request in requests])
+        raise SkillHookRuntimeError(
+            "PreToolUse guard denied the parallel batch.",
+            code="skill_hook_denied",
+        )
+
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", True)
+    monkeypatch.setattr(
+        main_module, "OpenAICompatibleAgentModelClient", FakeAgentModelClient
+    )
+    monkeypatch.setattr(
+        main_module,
+        "build_plugin_hooks_v2_middleware",
+        lambda *args, **kwargs: AgentMiddleware(
+            name="typed-hook-batch-test", before_tool_batch=before_tool_batch
+        ),
+    )
+    monkeypatch.setattr(main_module, "get_skill_manager", lambda: manager)
+    monkeypatch.setattr(main_module, "workflow_execution_store", executions)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    workflow = _workflow_agent_strategy_workflow(
+        {
+            "toolMode": "mcp_tools",
+            "toolNames": "fetch,lookup",
+            "agentStrategy": "function_calling",
+            "parallelToolCalls": "true",
+            "maxIterations": "3",
+        }
+    )
+    workflow["nodes"].append(
+        {
+            "id": "typed-hooks-v2-batch",
+            "type": "runtime_middleware",
+            "data": {
+                "kind": "runtime_middleware",
+                "runtimeMiddlewareId": "plugin_hooks",
+                "runtimeMiddlewareKind": "runtime_middleware.plugin_hooks",
+                "middlewarePriority": "60",
+                "runtimeMiddlewareConfig": {
+                    "hook_mode": "typed_v2",
+                    "skill_ids": manager.skill_id,
+                },
+            },
+        }
+    )
+    workflow["edges"].append(
+        {
+            "id": "bind-typed-hooks-v2-batch",
+            "source": "typed-hooks-v2-batch",
+            "target": "workflow_agent",
+            "sourceHandle": "middleware-binding",
+            "targetHandle": "middleware",
+        }
+    )
+
+    try:
+        response = await client.post(
+            "/api/workflow/run",
+            json={"workflow": workflow, "inputs": {"user_input": "parallel hook"}},
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    assert any(
+        event.get("event") == "error"
+        and "PreToolUse guard denied" in str(event.get("message") or "")
+        for event in events
+    ), response.text
+    assert preflight_tools == [["fetch", "lookup"]]
+    assert provider.calls == []
+    assert model_calls == 1
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_workflow_native_validate.py
+++ b/server/tests/test_workflow_native_validate.py
@@ -1956,6 +1956,21 @@ async def test_automation_middleware_configuration_is_validated(
     )
     invalid_hooks = await validate(client, workflow)
     assert "plugin_hooks_skills_required" in issue_codes(invalid_hooks)
+    assert "skill_hook_legacy_middleware" in issue_codes(invalid_hooks)
+
+    middleware["data"]["runtimeMiddlewareConfig"] = {
+        "hook_mode": "typed_v2",
+        "skill_ids": "release-hook",
+    }
+    valid_typed_hooks = await validate(client, workflow)
+    assert "skill_hook_legacy_middleware" not in issue_codes(valid_typed_hooks)
+    assert "skill_hook_mode_invalid" not in issue_codes(valid_typed_hooks)
+
+    middleware["data"]["runtimeMiddlewareConfig"]["fail_closed"] = False
+    invalid_typed_policy = await validate(client, workflow)
+    assert "skill_hook_v2_fail_closed_unsupported" in issue_codes(
+        invalid_typed_policy
+    )
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_xpert_runtime_plugin_hooks_v2.py
+++ b/server/tests/test_xpert_runtime_plugin_hooks_v2.py
@@ -1,0 +1,1117 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable
+
+import pytest
+
+from server.skills.application_receipts import (
+    SkillApplicationReceiptStore,
+    SkillApplicationScope,
+    build_application_contract,
+)
+from server.skills.package_validation import compute_skill_content_digest
+from server.sandbox_sidecar.engine import SandboxEngine
+from server.xpert_runtime.approval_store import RuntimeApprovalStore
+from server.xpert_runtime.core_middlewares import RuntimeMiddlewareSpec
+from server.xpert_runtime.hitl_middleware import build_human_in_the_loop_middleware
+from server.xpert_runtime.middleware import MiddlewarePipeline
+from server.xpert_runtime.models import (
+    MiddlewareContext,
+    ModelCallRequest,
+    ModelCallResponse,
+    ToolCallRequest,
+    ToolCallResponse,
+)
+from server.xpert_runtime.plugin_hooks_v2 import (
+    SkillHookRuntimeError,
+    build_plugin_hooks_v2_middleware,
+    drain_skill_hook_status_events,
+    typed_hook_skill_ids,
+)
+from server.xpert_runtime.sandbox_store import SandboxWorkspaceStore
+from server.xpert_runtime.sandbox_toolset import SandboxToolsetProvider
+from server.xpert_runtime.toolset import RuntimeToolResult
+
+
+SKILL_ID = "typed-hook"
+VERSION_ID = "skillver_typed_hook_1"
+PACKAGE_DIGEST = "a" * 64
+
+
+class FakeSkillManager:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.activation_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get_skill_directory(
+        self, skill_id: str, *, version_id: str | None = None
+    ) -> Path:
+        assert skill_id == SKILL_ID
+        assert version_id == VERSION_ID
+        return self.root / VERSION_ID / skill_id
+
+    def require_activation(self, skill_id: str, **kwargs: Any) -> None:
+        self.activation_calls.append((skill_id, kwargs))
+
+
+class RealReceiptObserver:
+    def __init__(self, root: Path) -> None:
+        self.store = SkillApplicationReceiptStore(root)
+
+    def record(self, **kwargs: Any):
+        contract = build_application_contract(
+            skill_id=kwargs["skill_id"],
+            source_kind="workspace_draft",
+            version_id=kwargs.get("version_id"),
+            content_digest=PACKAGE_DIGEST,
+            policy=kwargs.get("policy", "advisory"),
+        )
+        return self.store.observe(
+            contract,
+            SkillApplicationScope(
+                run_id=kwargs.get("run_id"),
+                task_id=kwargs.get("task_id"),
+                node_id=kwargs.get("node_id"),
+                runtime_kind=kwargs.get("runtime_kind", "workflow"),
+            ),
+            method=kwargs.get("method"),
+            tool_name=kwargs.get("tool_name"),
+            error_code=kwargs.get("error_code"),
+            hook_evidence=kwargs.get("hook_evidence", ()),
+        )
+
+
+class FakeSandboxProvider:
+    def __init__(
+        self,
+        skill_root: Path,
+        result_factory: Callable[[dict[str, Any], list[str]], dict[str, Any]],
+    ) -> None:
+        self.skill_root = skill_root
+        self.result_factory = result_factory
+        self.files: dict[str, str] = {}
+        self.calls: list[Any] = []
+        self.write_history: list[tuple[str, str]] = []
+        self.shell_count = 0
+        self.fail_shell = False
+
+    async def call_tool(self, call: Any) -> RuntimeToolResult:
+        self.calls.append(call)
+        if call.tool_name == "skill_stage":
+            return RuntimeToolResult(output='{"ok":true}')
+        if call.tool_name == "sandbox_write_file":
+            path = str(call.arguments["path"])
+            content = str(call.arguments.get("content") or "")
+            self.files[path] = content
+            self.write_history.append((path, content))
+            return RuntimeToolResult(output=json.dumps({"ok": True, "path": path}))
+        if call.tool_name == "sandbox_read_file":
+            path = str(call.arguments["path"])
+            if path.startswith(f"skills/{SKILL_ID}/"):
+                relative = path.removeprefix(f"skills/{SKILL_ID}/")
+                content = (self.skill_root / relative).read_text(encoding="utf-8")
+                digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                return RuntimeToolResult(
+                    output=json.dumps({"ok": True, "path": path, "content": content}),
+                    metadata={"sandbox_accessed_digests": {path: digest}},
+                )
+            content = self.files[path]
+            return RuntimeToolResult(
+                output=json.dumps({"ok": True, "path": path, "content": content})
+            )
+        if call.tool_name == "sandbox_shell":
+            self.shell_count += 1
+            if self.fail_shell:
+                raise RuntimeError("sidecar unavailable with secret body")
+            argv = list(call.arguments["argv"])
+            context_path = "work/" + argv[argv.index("--context") + 1]
+            result_path = "work/" + argv[argv.index("--result") + 1]
+            context = json.loads(self.files[context_path])
+            self.files[result_path] = json.dumps(
+                self.result_factory(context, argv), ensure_ascii=False
+            )
+            return RuntimeToolResult(
+                output=json.dumps(
+                    {
+                        "ok": True,
+                        "exit_code": 0,
+                        "stdout": "ignored secret stdout",
+                        "stderr": "",
+                    }
+                )
+            )
+        raise AssertionError(f"unexpected tool: {call.tool_name}")
+
+
+def _write_skill(
+    tmp_path: Path,
+    hooks: list[dict[str, Any]],
+) -> tuple[Path, FakeSkillManager]:
+    root = tmp_path / VERSION_ID / SKILL_ID
+    (root / "hooks").mkdir(parents=True)
+    (root / "scripts").mkdir()
+    scripts = {str(hook["script_path"]) for hook in hooks}
+    for script in scripts:
+        path = root / script
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("print('hook')\n", encoding="utf-8")
+    (root / "hooks" / "manifest.json").write_text(
+        json.dumps(
+            {"version": "modelmirror-hook-manifest-v2", "hooks": hooks},
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    return root, FakeSkillManager(tmp_path)
+
+
+def _hook(
+    *,
+    hook_id: str,
+    event: str,
+    mode: str,
+    tool_names: list[str] | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "hook_id": hook_id,
+        "event": event,
+        "mode": mode,
+        "script_path": f"scripts/{hook_id}.py",
+        "purpose": "Synthetic runtime check",
+        "acceptance_checks": ["Returns a typed result"],
+        "timeout_seconds": 5,
+    }
+    if tool_names is not None:
+        result["tool_names"] = tool_names
+    return result
+
+
+def _context(task_input: str = "test task") -> MiddlewareContext:
+    return MiddlewareContext(
+        task_id="task-1",
+        trace_id="run-1",
+        metadata={
+            "run_id": "run-1",
+            "node_id": "agent-1",
+            "runtime_run_type": "workflow",
+            "hook_task_input": task_input,
+            "skill_version_bindings": {SKILL_ID: VERSION_ID},
+        },
+    )
+
+
+def _middleware(
+    manager: FakeSkillManager,
+    sandbox: FakeSandboxProvider,
+    observer: RealReceiptObserver,
+):
+    return build_plugin_hooks_v2_middleware(
+        RuntimeMiddlewareSpec(
+            node_id="hooks",
+            middleware_id="plugin_hooks",
+            config={"hook_mode": "typed_v2", "skill_ids": SKILL_ID},
+        ),
+        skill_manager=manager,
+        sandbox_provider=sandbox,
+        application_observer=observer,
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_annotation_is_injected_and_private_context_is_redacted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    root, manager = _write_skill(
+        tmp_path,
+        [_hook(hook_id="start_note", event="session_start", mode="annotation")],
+    )
+    sandbox = FakeSandboxProvider(
+        root,
+        lambda _context, _argv: {
+            "version": "modelmirror-hook-result-v1",
+            "outputs": [
+                {
+                    "type": "annotation",
+                    "code": "release.naming",
+                    "severity": "warning",
+                    "message": "Check the release naming convention.",
+                }
+            ],
+        },
+    )
+    observer = RealReceiptObserver(tmp_path / "receipts")
+    pipeline = MiddlewarePipeline([_middleware(manager, sandbox, observer)])
+    task_prefix = "publish C:\\Users\\private\\release "
+    task_input = (
+        task_prefix
+        + ("x" * (8_182 - len(task_prefix)))
+        + " token=super-secret-token"
+    )
+    context = _context(task_input)
+
+    await pipeline.before_agent({}, context)
+
+    captured_messages: list[dict[str, Any]] = []
+
+    async def model_handler(request: ModelCallRequest) -> ModelCallResponse:
+        captured_messages.extend(request.messages)
+        return ModelCallResponse(text="ok")
+
+    await pipeline.run_model_call(
+        ModelCallRequest("model", [{"role": "user", "content": "go"}]),
+        model_handler,
+        context,
+    )
+
+    assert any("release.naming" in item["content"] for item in captured_messages)
+    context_writes = [
+        content
+        for path, content in sandbox.write_history
+        if path.endswith("context.json") and content != "{}"
+    ]
+    assert context_writes
+    persisted_context = context_writes[0]
+    assert "super-secret-token" not in persisted_context
+    assert "token=sup" not in persisted_context
+    assert "C:\\Users\\private" not in persisted_context
+    receipts = observer.store.list_receipts(run_id="run-1", skill_id=SKILL_ID)
+    assert receipts[0].hook_evidence[0].verified is True
+    serialized = json.dumps(
+        [event for event in drain_skill_hook_status_events(context)],
+        ensure_ascii=False,
+    )
+    assert "super-secret-token" not in serialized
+    assert "Check the release naming convention" not in serialized
+    assert all(
+        content == "{}"
+        for path, content in sandbox.files.items()
+        if path.endswith(("context.json", "result.json"))
+    )
+
+
+@pytest.mark.asyncio
+async def test_guard_deny_happens_before_hitl_and_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    root, manager = _write_skill(
+        tmp_path,
+        [
+            _hook(
+                hook_id="deny_delete",
+                event="pre_tool_use",
+                mode="guard",
+                tool_names=["delete_file"],
+            )
+        ],
+    )
+    sandbox = FakeSandboxProvider(
+        root,
+        lambda _context, _argv: {
+            "version": "modelmirror-hook-result-v1",
+            "outputs": [
+                {"type": "deny", "code": "delete.denied", "message": "No"}
+            ],
+        },
+    )
+    approvals = RuntimeApprovalStore(tmp_path / "approvals")
+    observer = RealReceiptObserver(tmp_path / "receipts")
+    pipeline = MiddlewarePipeline(
+        [
+            _middleware(manager, sandbox, observer),
+            build_human_in_the_loop_middleware(
+                RuntimeMiddlewareSpec(
+                    node_id="hitl",
+                    middleware_id="human_in_the_loop",
+                    config={"interrupt_on_tools": "*"},
+                ),
+                approvals,
+            ),
+        ]
+    )
+    provider_called = False
+    context = _context()
+
+    async def handler(_request: ToolCallRequest) -> ToolCallResponse:
+        nonlocal provider_called
+        provider_called = True
+        return ToolCallResponse(output="must not run")
+
+    with pytest.raises(SkillHookRuntimeError) as caught:
+        await pipeline.run_tool_call(
+            ToolCallRequest("delete_file", {"path": "work/release.txt"}),
+            handler,
+            context,
+        )
+    assert caught.value.code == "skill_hook_denied"
+    assert provider_called is False
+    assert approvals.list_requests() == []
+    statuses = [event["status"] for event in drain_skill_hook_status_events(context)]
+    assert "denied" in statuses
+    assert "completed" not in statuses
+
+
+@pytest.mark.asyncio
+async def test_hitl_edit_is_revalidated_with_edited_arguments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    root, manager = _write_skill(
+        tmp_path,
+        [
+            _hook(
+                hook_id="protect_path",
+                event="pre_tool_use",
+                mode="guard",
+                tool_names=["write_file"],
+            )
+        ],
+    )
+
+    def result(context: dict[str, Any], _argv: list[str]) -> dict[str, Any]:
+        path = str(context["tool"]["arguments"].get("path") or "")
+        output = (
+            {"type": "deny", "code": "path.denied", "message": "No"}
+            if path == "work/blocked.txt"
+            else {
+                "type": "validation",
+                "code": "path.allowed",
+                "passed": True,
+                "message": "OK",
+            }
+        )
+        return {"version": "modelmirror-hook-result-v1", "outputs": [output]}
+
+    sandbox = FakeSandboxProvider(root, result)
+    observer = RealReceiptObserver(tmp_path / "receipts")
+    pipeline = MiddlewarePipeline(
+        [
+            _middleware(manager, sandbox, observer),
+            build_human_in_the_loop_middleware(
+                RuntimeMiddlewareSpec(
+                    node_id="hitl",
+                    middleware_id="human_in_the_loop",
+                    config={"interrupt_on_tools": "*"},
+                ),
+                RuntimeApprovalStore(tmp_path / "approvals"),
+            ),
+        ]
+    )
+    provider_called = False
+
+    async def handler(_request: ToolCallRequest) -> ToolCallResponse:
+        nonlocal provider_called
+        provider_called = True
+        return ToolCallResponse(output="must not run")
+
+    request = ToolCallRequest(
+        "write_file",
+        {"path": "work/allowed.txt"},
+        metadata={
+            "resolved_approval": {
+                "approval_id": "approval-1",
+                "decision": "edit",
+                "edited_arguments": {"path": "work/blocked.txt"},
+            }
+        },
+    )
+    with pytest.raises(SkillHookRuntimeError) as caught:
+        await pipeline.run_tool_call(request, handler, _context())
+    assert caught.value.code == "skill_hook_denied"
+    assert provider_called is False
+    assert sandbox.shell_count == 2
+
+
+@pytest.mark.asyncio
+async def test_hitl_rejection_does_not_forge_post_tool_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    root, manager = _write_skill(
+        tmp_path,
+        [
+            _hook(
+                hook_id="validate_result",
+                event="post_tool_use",
+                mode="validation",
+                tool_names=["write_file"],
+            )
+        ],
+    )
+    sandbox = FakeSandboxProvider(
+        root,
+        lambda _context, _argv: {
+            "version": "modelmirror-hook-result-v1",
+            "outputs": [
+                {
+                    "type": "validation",
+                    "code": "result.valid",
+                    "passed": True,
+                    "message": "OK",
+                }
+            ],
+        },
+    )
+    observer = RealReceiptObserver(tmp_path / "receipts")
+    pipeline = MiddlewarePipeline(
+        [
+            _middleware(manager, sandbox, observer),
+            build_human_in_the_loop_middleware(
+                RuntimeMiddlewareSpec(
+                    node_id="hitl",
+                    middleware_id="human_in_the_loop",
+                    config={"interrupt_on_tools": "*"},
+                ),
+                RuntimeApprovalStore(tmp_path / "approvals"),
+            ),
+        ]
+    )
+    provider_called = False
+
+    async def handler(_request: ToolCallRequest) -> ToolCallResponse:
+        nonlocal provider_called
+        provider_called = True
+        return ToolCallResponse(output="must not run")
+
+    response = await pipeline.run_tool_call(
+        ToolCallRequest(
+            "write_file",
+            {"path": "work/release.txt"},
+            metadata={
+                "resolved_approval": {
+                    "approval_id": "approval-1",
+                    "decision": "reject",
+                    "message": "Rejected by user",
+                }
+            },
+        ),
+        handler,
+        _context(),
+    )
+
+    assert response.metadata["approval_rejected"] is True
+    assert provider_called is False
+    assert sandbox.shell_count == 0
+    assert observer.store.list_receipts(run_id="run-1", skill_id=SKILL_ID) == []
+
+
+@pytest.mark.asyncio
+async def test_parallel_batch_preflight_is_all_or_none_and_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    root, manager = _write_skill(
+        tmp_path,
+        [
+            _hook(
+                hook_id="batch_guard",
+                event="pre_tool_use",
+                mode="guard",
+                tool_names=["safe_a", "safe_b"],
+            )
+        ],
+    )
+
+    def result(context: dict[str, Any], _argv: list[str]) -> dict[str, Any]:
+        denied = context["tool"]["name"] == "safe_b"
+        return {
+            "version": "modelmirror-hook-result-v1",
+            "outputs": [
+                (
+                    {"type": "deny", "code": "batch.denied", "message": "No"}
+                    if denied
+                    else {
+                        "type": "validation",
+                        "code": "batch.allowed",
+                        "passed": True,
+                        "message": "OK",
+                    }
+                )
+            ],
+        }
+
+    sandbox = FakeSandboxProvider(root, result)
+    pipeline = MiddlewarePipeline(
+        [_middleware(manager, sandbox, RealReceiptObserver(tmp_path / "receipts"))]
+    )
+    requests = [ToolCallRequest("safe_a", {}), ToolCallRequest("safe_b", {})]
+    with pytest.raises(SkillHookRuntimeError) as caught:
+        await pipeline.before_tool_batch(requests, _context())
+    assert caught.value.code == "skill_hook_denied"
+    assert sandbox.shell_count == 2
+
+
+@pytest.mark.asyncio
+async def test_verified_pre_tool_evidence_is_reused_after_context_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    root, manager = _write_skill(
+        tmp_path,
+        [
+            _hook(
+                hook_id="stable_guard",
+                event="pre_tool_use",
+                mode="guard",
+                tool_names=["publish"],
+            )
+        ],
+    )
+    sandbox = FakeSandboxProvider(
+        root,
+        lambda _context, _argv: {
+            "version": "modelmirror-hook-result-v1",
+            "outputs": [
+                {
+                    "type": "validation",
+                    "code": "publish.allowed",
+                    "passed": True,
+                    "message": "OK",
+                }
+            ],
+        },
+    )
+    observer = RealReceiptObserver(tmp_path / "receipts")
+    request = ToolCallRequest("publish", {"path": "work/release.txt"})
+
+    await MiddlewarePipeline([_middleware(manager, sandbox, observer)]).before_tool_batch(
+        [request], _context()
+    )
+    recovered_pipeline = MiddlewarePipeline([_middleware(manager, sandbox, observer)])
+
+    async def handler(_request: ToolCallRequest) -> ToolCallResponse:
+        return ToolCallResponse(output="published")
+
+    await recovered_pipeline.run_tool_call(request, handler, _context())
+
+    assert sandbox.shell_count == 1
+
+
+@pytest.mark.asyncio
+async def test_parallel_post_hooks_do_not_expose_concurrent_context_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    root, manager = _write_skill(
+        tmp_path,
+        [
+            _hook(
+                hook_id="post_check",
+                event="post_tool_use",
+                mode="validation",
+                tool_names=["safe_a", "safe_b"],
+            )
+        ],
+    )
+
+    class ConcurrentSandbox(FakeSandboxProvider):
+        active_shells = 0
+        max_active_shells = 0
+
+        async def call_tool(self, call: Any) -> RuntimeToolResult:
+            if call.tool_name != "sandbox_shell":
+                return await super().call_tool(call)
+            self.active_shells += 1
+            self.max_active_shells = max(self.max_active_shells, self.active_shells)
+            try:
+                await asyncio.sleep(0.02)
+                return await super().call_tool(call)
+            finally:
+                self.active_shells -= 1
+
+    sandbox = ConcurrentSandbox(
+        root,
+        lambda _context, _argv: {
+            "version": "modelmirror-hook-result-v1",
+            "outputs": [
+                {
+                    "type": "validation",
+                    "code": "post.valid",
+                    "passed": True,
+                    "message": "OK",
+                }
+            ],
+        },
+    )
+    pipeline = MiddlewarePipeline(
+        [_middleware(manager, sandbox, RealReceiptObserver(tmp_path / "receipts"))]
+    )
+    context = _context()
+
+    async def handler(_request: ToolCallRequest) -> ToolCallResponse:
+        return ToolCallResponse(output="ok")
+
+    await asyncio.gather(
+        pipeline.run_tool_call(ToolCallRequest("safe_a", {}), handler, context),
+        pipeline.run_tool_call(ToolCallRequest("safe_b", {}), handler, context),
+    )
+
+    assert sandbox.shell_count == 2
+    assert sandbox.max_active_shells == 1
+
+
+@pytest.mark.asyncio
+async def test_annotation_failure_opens_but_validation_failure_closes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    annotation_root, annotation_manager = _write_skill(
+        tmp_path / "annotation",
+        [_hook(hook_id="note", event="session_start", mode="annotation")],
+    )
+    annotation_sandbox = FakeSandboxProvider(
+        annotation_root, lambda _context, _argv: {}
+    )
+    annotation_sandbox.fail_shell = True
+    annotation_context = _context()
+    annotation_observer = RealReceiptObserver(
+        tmp_path / "annotation-receipts"
+    )
+    await MiddlewarePipeline(
+        [
+            _middleware(
+                annotation_manager,
+                annotation_sandbox,
+                annotation_observer,
+            )
+        ]
+    ).before_agent({}, annotation_context)
+    assert "skill_hook_execution_failed" in annotation_context.metadata[
+        "middleware_warnings"
+    ][0]
+    failed_receipt = annotation_observer.store.list_receipts(
+        run_id="run-1", skill_id=SKILL_ID
+    )[0]
+    assert failed_receipt.error_codes == ("skill_hook_execution_failed",)
+    assert failed_receipt.hook_evidence[0].verified is False
+
+    validation_root, validation_manager = _write_skill(
+        tmp_path / "validation",
+        [_hook(hook_id="check", event="session_start", mode="validation")],
+    )
+    validation_sandbox = FakeSandboxProvider(
+        validation_root, lambda _context, _argv: {}
+    )
+    validation_sandbox.fail_shell = True
+    with pytest.raises(SkillHookRuntimeError) as caught:
+        await MiddlewarePipeline(
+            [
+                _middleware(
+                    validation_manager,
+                    validation_sandbox,
+                    RealReceiptObserver(tmp_path / "validation-receipts"),
+                )
+            ]
+        ).before_agent({}, _context())
+    assert caught.value.code == "skill_hook_execution_failed"
+
+
+@pytest.mark.asyncio
+async def test_evidence_store_failure_opens_only_for_annotation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+
+    class FailingReceiptObserver:
+        def record(self, **_kwargs: Any):
+            raise RuntimeError("receipt store unavailable")
+
+    def passed_result(mode: str) -> dict[str, Any]:
+        output = (
+            {
+                "type": "annotation",
+                "code": "note.ready",
+                "severity": "info",
+                "message": "Ready",
+            }
+            if mode == "annotation"
+            else {
+                "type": "validation",
+                "code": "check.ready",
+                "passed": True,
+                "message": "Ready",
+            }
+        )
+        return {"version": "modelmirror-hook-result-v1", "outputs": [output]}
+
+    annotation_root, annotation_manager = _write_skill(
+        tmp_path / "annotation-store",
+        [_hook(hook_id="note", event="session_start", mode="annotation")],
+    )
+    annotation_context = _context()
+    await MiddlewarePipeline(
+        [
+            _middleware(
+                annotation_manager,
+                FakeSandboxProvider(
+                    annotation_root,
+                    lambda _context, _argv: passed_result("annotation"),
+                ),
+                FailingReceiptObserver(),  # type: ignore[arg-type]
+            )
+        ]
+    ).before_agent({}, annotation_context)
+    assert "skill_hook_evidence_unavailable" in annotation_context.metadata[
+        "middleware_warnings"
+    ][0]
+
+    validation_root, validation_manager = _write_skill(
+        tmp_path / "validation-store",
+        [_hook(hook_id="check", event="session_start", mode="validation")],
+    )
+    with pytest.raises(SkillHookRuntimeError) as caught:
+        await MiddlewarePipeline(
+            [
+                _middleware(
+                    validation_manager,
+                    FakeSandboxProvider(
+                        validation_root,
+                        lambda _context, _argv: passed_result("validation"),
+                    ),
+                    FailingReceiptObserver(),  # type: ignore[arg-type]
+                )
+            ]
+        ).before_agent({}, _context())
+    assert caught.value.code == "skill_hook_evidence_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_workspace_provision_failure_does_not_write_to_fallback_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    root, manager = _write_skill(
+        tmp_path,
+        [_hook(hook_id="check", event="session_start", mode="validation")],
+    )
+
+    class FailingProvisionSandbox(FakeSandboxProvider):
+        async def provision_skill_hook_workspace(self, **_kwargs: Any):
+            raise RuntimeError("protected workspace unavailable")
+
+    sandbox = FailingProvisionSandbox(root, lambda _context, _argv: {})
+
+    with pytest.raises(SkillHookRuntimeError) as caught:
+        await MiddlewarePipeline(
+            [_middleware(manager, sandbox, RealReceiptObserver(tmp_path / "receipts"))]
+        ).before_agent({}, _context())
+
+    assert caught.value.code == "skill_hook_execution_failed"
+    assert sandbox.calls == []
+    assert sandbox.write_history == []
+
+
+@pytest.mark.asyncio
+async def test_event_timeout_budget_fails_before_any_hook_executes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    hooks = [
+        _hook(hook_id=f"budget_{index}", event="session_start", mode="validation")
+        for index in range(3)
+    ]
+    for hook in hooks:
+        hook["timeout_seconds"] = 60
+    root, manager = _write_skill(tmp_path, hooks)
+    sandbox = FakeSandboxProvider(root, lambda _context, _argv: {})
+
+    with pytest.raises(SkillHookRuntimeError) as caught:
+        await MiddlewarePipeline(
+            [_middleware(manager, sandbox, RealReceiptObserver(tmp_path / "receipts"))]
+        ).before_agent({}, _context())
+
+    assert caught.value.code == "skill_hook_budget_exceeded"
+    assert sandbox.shell_count == 0
+
+
+@pytest.mark.asyncio
+async def test_guard_fails_closed_when_sanitized_context_exceeds_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    root, manager = _write_skill(
+        tmp_path,
+        [
+            _hook(
+                hook_id="bounded_guard",
+                event="pre_tool_use",
+                mode="guard",
+                tool_names=["publish"],
+            )
+        ],
+    )
+    sandbox = FakeSandboxProvider(root, lambda _context, _argv: {})
+    arguments = {f"field_{index}": "x" * 2_000 for index in range(40)}
+
+    with pytest.raises(SkillHookRuntimeError) as caught:
+        await MiddlewarePipeline(
+            [_middleware(manager, sandbox, RealReceiptObserver(tmp_path / "receipts"))]
+        ).before_tool_batch([ToolCallRequest("publish", arguments)], _context())
+
+    assert caught.value.code == "skill_hook_context_invalid"
+    assert sandbox.shell_count == 0
+
+
+@pytest.mark.asyncio
+async def test_post_tool_validation_failure_reports_irreversible_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    root, manager = _write_skill(
+        tmp_path,
+        [
+            _hook(
+                hook_id="verify_result",
+                event="post_tool_use",
+                mode="validation",
+                tool_names=["publish"],
+            )
+        ],
+    )
+    sandbox = FakeSandboxProvider(
+        root,
+        lambda _context, _argv: {
+            "version": "modelmirror-hook-result-v1",
+            "outputs": [
+                {
+                    "type": "validation",
+                    "code": "publish.invalid",
+                    "passed": False,
+                    "message": "Invalid",
+                }
+            ],
+        },
+    )
+    pipeline = MiddlewarePipeline(
+        [_middleware(manager, sandbox, RealReceiptObserver(tmp_path / "receipts"))]
+    )
+    provider_called = False
+
+    async def handler(_request: ToolCallRequest) -> ToolCallResponse:
+        nonlocal provider_called
+        provider_called = True
+        return ToolCallResponse(output="published")
+
+    with pytest.raises(SkillHookRuntimeError) as caught:
+        await pipeline.run_tool_call(
+            ToolCallRequest("publish", {}), handler, _context()
+        )
+    assert caught.value.code == "skill_hook_validation_failed"
+    assert "not rolled back" in str(caught.value)
+    assert provider_called is True
+
+
+def test_typed_hook_runtime_is_disabled_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SKILL_PLUGIN_HOOK_V2_ENABLED", raising=False)
+    root, manager = _write_skill(
+        tmp_path,
+        [_hook(hook_id="note", event="session_start", mode="annotation")],
+    )
+    with pytest.raises(SkillHookRuntimeError) as caught:
+        _middleware(
+            manager,
+            FakeSandboxProvider(root, lambda _context, _argv: {}),
+            RealReceiptObserver(tmp_path / "receipts"),
+        )
+    assert caught.value.code == "skill_hook_v2_disabled"
+
+
+def test_typed_hook_runtime_rejects_an_empty_skill_binding() -> None:
+    with pytest.raises(SkillHookRuntimeError) as caught:
+        typed_hook_skill_ids(
+            RuntimeMiddlewareSpec(
+                node_id="hooks",
+                middleware_id="plugin_hooks",
+                config={"hook_mode": "typed_v2", "skill_ids": ""},
+            )
+        )
+    assert caught.value.code == "skill_hook_manifest_invalid"
+
+
+@pytest.mark.asyncio
+async def test_session_end_runs_once_when_later_finalization_reports_an_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    root, manager = _write_skill(
+        tmp_path,
+        [_hook(hook_id="end_check", event="session_end", mode="validation")],
+    )
+    sandbox = FakeSandboxProvider(
+        root,
+        lambda _context, _argv: {
+            "version": "modelmirror-hook-result-v1",
+            "outputs": [
+                {
+                    "type": "validation",
+                    "code": "session.complete",
+                    "passed": True,
+                    "message": "OK",
+                }
+            ],
+        },
+    )
+    pipeline = MiddlewarePipeline(
+        [_middleware(manager, sandbox, RealReceiptObserver(tmp_path / "receipts"))]
+    )
+    context = _context()
+
+    await pipeline.after_agent(
+        {"status": "completed", "output_length": 2, "output_digest": "b" * 64},
+        context,
+    )
+    await pipeline.after_agent({"status": "error"}, context)
+
+    assert sandbox.shell_count == 1
+
+
+@pytest.mark.asyncio
+async def test_gold_hook_executes_through_real_sandbox_engine(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_PLUGIN_HOOK_V2_ENABLED", "true")
+    fixture_source = (
+        Path(__file__).parent / "fixtures" / "skill_hook_v2_gold"
+    ).resolve()
+    fixture = tmp_path / "gold-skill"
+    shutil.copytree(fixture_source, fixture)
+    package = {
+        path.relative_to(fixture).as_posix(): path.read_bytes()
+        for path in fixture.rglob("*")
+        if path.is_file()
+    }
+    package_digest = compute_skill_content_digest(package)
+
+    class GoldManager:
+        def __init__(self) -> None:
+            self.lifecycle_store = SimpleNamespace(
+                require_version=lambda version_id: SimpleNamespace(
+                    skill_id=SKILL_ID,
+                    version_id=version_id,
+                    package_digest=package_digest,
+                    source_kind="workspace_draft",
+                    trust_fingerprint=None,
+                )
+            )
+
+        def get_skill_directory(
+            self, skill_id: str, *, version_id: str | None = None
+        ) -> Path:
+            assert skill_id == SKILL_ID
+            assert version_id == VERSION_ID
+            return fixture
+
+        def list_installed_skills(self):
+            return [SimpleNamespace(skill_id=SKILL_ID)]
+
+        def require_activation(self, _skill_id: str, **_kwargs: Any) -> None:
+            return None
+
+    class EngineClient:
+        def __init__(self, engine: SandboxEngine) -> None:
+            self.engine = engine
+
+        async def request(self, payload: dict[str, Any]) -> dict[str, Any]:
+            return self.engine.dispatch(payload)
+
+        async def health(
+            self, *, required_profile: str | None = None
+        ) -> dict[str, Any]:
+            result = self.engine.dispatch(
+                {"action": "health", "workspace_id": "health"}
+            )
+            assert required_profile in result["profiles"]
+            return result
+
+    manager = GoldManager()
+    sandbox_root = tmp_path / "sandbox"
+    provider = SandboxToolsetProvider(
+        SandboxWorkspaceStore(
+            tmp_path / "sandbox-store",
+            workspace_root=sandbox_root,
+        ),
+        EngineClient(SandboxEngine(sandbox_root, require_landlock=True)),
+        skill_manager=manager,
+    )
+    observer = RealReceiptObserver(tmp_path / "receipts")
+    middleware = build_plugin_hooks_v2_middleware(
+        RuntimeMiddlewareSpec(
+            node_id="hooks",
+            middleware_id="plugin_hooks",
+            config={"hook_mode": "typed_v2", "skill_ids": SKILL_ID},
+        ),
+        skill_manager=manager,
+        sandbox_provider=provider,
+        application_observer=observer,
+    )
+    pipeline = MiddlewarePipeline([middleware])
+    provider_called = False
+    initial_context = _context()
+
+    async def handler(_request: ToolCallRequest) -> ToolCallResponse:
+        nonlocal provider_called
+        provider_called = True
+        return ToolCallResponse(output="written")
+
+    with pytest.raises(SkillHookRuntimeError) as caught:
+        await pipeline.run_tool_call(
+            ToolCallRequest(
+                "sandbox_write_file", {"path": "work/release.exe", "content": "x"}
+            ),
+            handler,
+            initial_context,
+        )
+    assert caught.value.code == "skill_hook_denied"
+    assert provider_called is False
+    receipts = observer.store.list_receipts(run_id="run-1", skill_id=SKILL_ID)
+    assert receipts[0].hook_evidence[0].code == "release_extension_denied"
+    markers = list(sandbox_root.glob("*/.modelmirror/profile.json"))
+    assert len(markers) == 1
+    marker = json.loads(markers[0].read_text(encoding="utf-8"))
+    assert marker["profile"] == "skill_authoring_v1"
+    workspace = markers[0].parents[1]
+    assert (
+        workspace / "skills" / "authoring-resource" / "scripts" / "check_release.py"
+    ).read_bytes() == (fixture / "scripts" / "check_release.py").read_bytes()
+    assert all(
+        path.read_text(encoding="utf-8") == "{}"
+        for path in (workspace / "work" / ".modelmirror-hooks").rglob("*.json")
+    )
+
+    recovered_context = _context()
+    await pipeline.run_tool_call(
+        ToolCallRequest(
+            "sandbox_write_file", {"path": "work/release.txt", "content": "x"}
+        ),
+        handler,
+        recovered_context,
+    )
+    assert provider_called is True
+    assert len(list(sandbox_root.glob("*/.modelmirror/profile.json"))) == 1
+    provider_called = False
+
+    (fixture / "scripts" / "check_release.py").write_text(
+        "print('tampered')\n", encoding="utf-8"
+    )
+    with pytest.raises(SkillHookRuntimeError) as stale:
+        await pipeline.run_tool_call(
+            ToolCallRequest(
+                "sandbox_write_file", {"path": "work/release.txt", "content": "x"}
+            ),
+            handler,
+            _context(),
+        )
+    assert stale.value.code == "skill_hook_contract_stale"
+    assert provider_called is False
+
+    await pipeline.after_agent({"status": "error"}, recovered_context)
+    assert list(sandbox_root.glob("*/.modelmirror/profile.json")) == []

--- a/server/workflow_native/validate.py
+++ b/server/workflow_native/validate.py
@@ -3466,6 +3466,35 @@ def validate_node_configuration(
                     )
                 )
         if middleware_id == "plugin_hooks":
+            hook_mode = str(config.get("hook_mode") or "").strip()
+            if hook_mode and hook_mode not in {"legacy_argv", "typed_v2"}:
+                issues.append(
+                    ValidationIssue(
+                        code="skill_hook_mode_invalid",
+                        message="plugin_hooks hook_mode must be legacy_argv or typed_v2.",
+                        node_id=node.id,
+                    )
+                )
+            if hook_mode == "typed_v2" and "fail_closed" in config:
+                issues.append(
+                    ValidationIssue(
+                        code="skill_hook_v2_fail_closed_unsupported",
+                        message=(
+                            "typed_v2 derives failure policy from each Hook mode; "
+                            "remove the legacy fail_closed setting."
+                        ),
+                        node_id=node.id,
+                    )
+                )
+            if hook_mode != "typed_v2":
+                issues.append(
+                    ValidationIssue(
+                        code="skill_hook_legacy_middleware",
+                        message="This Skill Hook middleware uses the legacy argv contract.",
+                        severity="warning",
+                        node_id=node.id,
+                    )
+                )
             skill_ids = [
                 value.strip()
                 for value in re.split(

--- a/server/xpert_runtime/__init__.py
+++ b/server/xpert_runtime/__init__.py
@@ -255,6 +255,14 @@ from .automation_api import (
 )
 from .ralph_loop import RalphLoopResult, run_ralph_loop
 from .plugin_hooks import build_plugin_hooks_middleware
+from .plugin_hooks_v2 import (
+    HOOK_RUNTIME_MODE,
+    SkillHookRuntimeError,
+    build_plugin_hooks_v2_middleware,
+    drain_skill_hook_status_events,
+    plugin_hook_runtime_mode,
+    typed_hook_skill_ids,
+)
 from .authoring_store import (
     AuthoringProposal,
     AuthoringProposalConflictError,
@@ -476,6 +484,12 @@ __all__ = [
     "RalphLoopResult",
     "run_ralph_loop",
     "build_plugin_hooks_middleware",
+    "HOOK_RUNTIME_MODE",
+    "SkillHookRuntimeError",
+    "build_plugin_hooks_v2_middleware",
+    "drain_skill_hook_status_events",
+    "plugin_hook_runtime_mode",
+    "typed_hook_skill_ids",
     "AuthoringProposal",
     "AuthoringProposalConflictError",
     "AuthoringProposalError",

--- a/server/xpert_runtime/agent_strategy/runner.py
+++ b/server/xpert_runtime/agent_strategy/runner.py
@@ -12,6 +12,7 @@ from typing import Any, Awaitable, Callable
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError
 
+from ..interrupts import RuntimeMiddlewareFatalError
 from ..toolset import RuntimeTool, RuntimeToolError, RuntimeToolResult
 from .models import (
     AgentModelClient,
@@ -27,6 +28,9 @@ from .react import build_react_prompt, parse_react_decision
 
 
 ToolExecutor = Callable[[str, dict[str, Any], str, int], Awaitable[RuntimeToolResult]]
+ToolBatchPreflight = Callable[
+    [list[tuple[str, dict[str, Any], str]], int], Awaitable[None]
+]
 
 MAX_TOOL_CALLS_PER_ROUND = 8
 MAX_OBSERVATION_CHARS = 16_000
@@ -71,6 +75,7 @@ class AgentStrategyRunner:
         temperature: float = 0.7,
         max_tokens: int = 1024,
         parallel_tool_calls: bool = False,
+        tool_batch_preflight: ToolBatchPreflight | None = None,
         history_messages: list[dict[str, Any]] | None = None,
     ) -> None:
         if strategy not in {"auto", "function_calling", "react"}:
@@ -85,6 +90,7 @@ class AgentStrategyRunner:
         self.temperature = min(max(float(temperature), 0.0), 2.0)
         self.max_tokens = max(int(max_tokens), 1)
         self.parallel_tool_calls = bool(parallel_tool_calls)
+        self.tool_batch_preflight = tool_batch_preflight
         self.history_messages = [
             deepcopy(message)
             for message in list(history_messages or [])
@@ -121,6 +127,8 @@ class AgentStrategyRunner:
                 )
                 return await self._run_react()
         except AgentStrategyError:
+            raise
+        except RuntimeMiddlewareFatalError:
             raise
         except AgentModelError as exc:
             raise self._error(exc.message, code="model_error") from exc
@@ -376,6 +384,23 @@ class AgentStrategyRunner:
         limited_calls = calls[:MAX_TOOL_CALLS_PER_ROUND]
         overflow = calls[MAX_TOOL_CALLS_PER_ROUND:]
         if self.parallel_tool_calls and len(limited_calls) > 1:
+            if self.tool_batch_preflight is not None:
+                valid_calls: list[tuple[str, dict[str, Any], str]] = []
+                for call in limited_calls:
+                    binding = self.binding_by_alias.get(call.name)
+                    if binding is None:
+                        continue
+                    try:
+                        arguments = json.loads(call.raw_arguments or "{}")
+                    except ValueError:
+                        continue
+                    if not isinstance(arguments, dict) or any(
+                        binding.validator.iter_errors(arguments)
+                    ):
+                        continue
+                    valid_calls.append((binding.tool.name, arguments, call.call_id))
+                if valid_calls:
+                    await self.tool_batch_preflight(valid_calls, iteration)
             outcomes = list(
                 await asyncio.gather(
                     *(self._execute_tool_call(call, iteration) for call in limited_calls)
@@ -502,6 +527,8 @@ class AgentStrategyRunner:
             )
         except Exception as exc:
             if hasattr(exc, "continuation") and hasattr(exc, "approval_id"):
+                raise
+            if isinstance(exc, RuntimeMiddlewareFatalError):
                 raise
             raise self._error(
                 str(exc) or exc.__class__.__name__,

--- a/server/xpert_runtime/hitl_middleware.py
+++ b/server/xpert_runtime/hitl_middleware.py
@@ -8,7 +8,7 @@ from typing import Any, Callable
 from .approval_store import RuntimeApprovalRequest, RuntimeApprovalStore
 from .core_middlewares import RuntimeMiddlewareSpec
 from .interrupts import RuntimeInterrupt, RuntimeMiddlewareFatalError
-from .middleware import AgentMiddleware
+from .middleware import AgentMiddleware, TOOL_REVALIDATE_METADATA_KEY
 from .models import MiddlewareContext, ToolCallRequest, ToolCallResponse
 
 
@@ -32,7 +32,7 @@ def build_human_in_the_loop_middleware(
         context: MiddlewareContext,
     ) -> ToolCallResponse:
         if not _requires_review(request.tool_name, rules):
-            return await handler(request)
+            return await handler(_without_server_revalidator(request))
 
         resolved = request.metadata.get("resolved_approval")
         if isinstance(resolved, dict):
@@ -218,7 +218,7 @@ async def _apply_resolution(
                     "tool_name": request.tool_name,
                 },
             )
-        return await handler(request)
+        return await handler(_without_server_revalidator(request))
     if decision == "edit":
         edited = resolved.get("edited_arguments")
         if not isinstance(edited, dict):
@@ -258,9 +258,13 @@ async def _apply_resolution(
                         "tool_name": request.tool_name,
                     },
                 )
-        return await handler(
-            request.with_updates(arguments=dict(edited), metadata=metadata)
+        edited_request = request.with_updates(
+            arguments=dict(edited), metadata=metadata
         )
+        revalidate = metadata.get(TOOL_REVALIDATE_METADATA_KEY)
+        if callable(revalidate):
+            await revalidate(edited_request)
+        return await handler(_without_server_revalidator(edited_request))
     if decision == "reject":
         hub_approval = request.metadata.get("hub_approval")
         if isinstance(hub_approval, dict) and hub_event_recorder is not None:
@@ -286,6 +290,14 @@ async def _apply_resolution(
             },
         )
     raise RuntimeMiddlewareFatalError(f"Unsupported approval decision: {decision}.")
+
+
+def _without_server_revalidator(request: ToolCallRequest) -> ToolCallRequest:
+    if TOOL_REVALIDATE_METADATA_KEY not in request.metadata:
+        return request
+    metadata = dict(request.metadata)
+    metadata.pop(TOOL_REVALIDATE_METADATA_KEY, None)
+    return request.with_updates(metadata=metadata)
 
 
 def _tool_rules(value: Any) -> dict[str, bool]:

--- a/server/xpert_runtime/middleware.py
+++ b/server/xpert_runtime/middleware.py
@@ -35,6 +35,13 @@ ToolWrapper = Callable[
     [ToolCallRequest, ToolCallHandler, MiddlewareContext],
     MaybeAwaitable[ToolCallResponse],
 ]
+ToolBatchHook = Callable[
+    [list[ToolCallRequest], MiddlewareContext],
+    MaybeAwaitable[None],
+]
+
+
+TOOL_REVALIDATE_METADATA_KEY = "_server_pre_tool_revalidate"
 
 
 @dataclass(slots=True)
@@ -48,6 +55,7 @@ class AgentMiddleware:
     after_agent: AgentStateHook | None = None
     wrap_model_call: ModelWrapper | None = None
     wrap_tool_call: ToolWrapper | None = None
+    before_tool_batch: ToolBatchHook | None = None
     enabled: bool = True
 
 
@@ -178,6 +186,25 @@ class MiddlewarePipeline:
 
             wrapped = call
         return await wrapped(request)
+
+    async def before_tool_batch(
+        self,
+        requests: list[ToolCallRequest],
+        context: MiddlewareContext,
+    ) -> None:
+        """Preflight a parallel batch before any provider call starts."""
+
+        frozen = [
+            request.with_updates(
+                arguments=dict(request.arguments or {}),
+                metadata=dict(request.metadata or {}),
+            )
+            for request in requests
+        ]
+        for middleware in self._enabled():
+            if middleware.before_tool_batch is None:
+                continue
+            await _maybe_await(middleware.before_tool_batch(frozen, context))
 
     def _enabled(self) -> list[AgentMiddleware]:
         return [middleware for middleware in self._middlewares if middleware.enabled]

--- a/server/xpert_runtime/plugin_hooks_v2.py
+++ b/server/xpert_runtime/plugin_hooks_v2.py
@@ -1,0 +1,1354 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+try:
+    from server.skills.application_receipts import SkillHookApplicationEvidenceV2
+    from server.skills.hook_contract import (
+        HOOK_MANIFEST_PATH,
+        MAX_HOOK_EVENT_BUDGET_SECONDS,
+        MAX_HOOKS_PER_EVENT,
+        SkillHookContractError,
+        SkillHookDefinitionV2,
+        SkillHookManifestV2,
+        parse_hook_manifest,
+        parse_hook_result,
+        skill_plugin_hook_v2_enabled,
+    )
+except ModuleNotFoundError as exc:  # Docker copies server/* into /app.
+    if exc.name != "server":
+        raise
+    from skills.application_receipts import SkillHookApplicationEvidenceV2
+    from skills.hook_contract import (
+        HOOK_MANIFEST_PATH,
+        MAX_HOOK_EVENT_BUDGET_SECONDS,
+        MAX_HOOKS_PER_EVENT,
+        SkillHookContractError,
+        SkillHookDefinitionV2,
+        SkillHookManifestV2,
+        parse_hook_manifest,
+        parse_hook_result,
+        skill_plugin_hook_v2_enabled,
+    )
+
+from .core_middlewares import RuntimeMiddlewareSpec
+from .interrupts import RuntimeMiddlewareFatalError
+from .middleware import (
+    AgentMiddleware,
+    TOOL_REVALIDATE_METADATA_KEY,
+)
+from .models import (
+    MiddlewareContext,
+    ModelCallRequest,
+    ToolCallRequest,
+    ToolCallResponse,
+)
+from .plugin_hooks import _csv, _require_plugin_skill_trust
+from .toolset import RuntimeToolCall, RuntimeToolError, RuntimeToolResult
+
+
+HOOK_RUNTIME_MODE = "typed_v2"
+HOOK_CONTEXT_VERSION = "modelmirror-hook-context-v1"
+MAX_HOOK_CONTEXT_BYTES = 32 * 1024
+MAX_SESSION_TASK_BYTES = 8 * 1024
+MAX_CONTEXT_DEPTH = 4
+MAX_CONTEXT_ARRAY_ITEMS = 50
+MAX_CONTEXT_STRING_CHARS = 2_000
+
+_CACHE_KEY = "_skill_hook_v2_cache"
+_STAGED_KEY = "_skill_hook_v2_staged"
+_ANNOTATIONS_KEY = "_skill_hook_v2_annotations"
+_STATUS_EVENTS_KEY = "skill_hook_status_events"
+_SESSION_END_FINALIZED_KEY = "_skill_hook_v2_session_end_finalized"
+_SENSITIVE_KEY = re.compile(
+    r"(?i)(?:api[_-]?key|authorization|credential|cookie|password|secret|token)"
+)
+_SECRET_TEXT = re.compile(
+    r"(?i)(?:bearer\s+[A-Za-z0-9._~+/=-]{8,}|sk-[A-Za-z0-9_-]{12,}|"
+    r"(?:api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;]{6,})"
+)
+_WINDOWS_ABSOLUTE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
+_EMBEDDED_ABSOLUTE_PATH = re.compile(
+    r"(?i)(?:[A-Z]:[\\/][^\s\"']+|/(?:Users|home|var|tmp|etc|root)/[^\s\"']+)"
+)
+
+
+class SkillHookRuntimeError(RuntimeMiddlewareFatalError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class _LoadedHook:
+    skill_id: str
+    version_id: str
+    root: Path
+    manifest: SkillHookManifestV2
+    manifest_digest: str
+    definition: SkillHookDefinitionV2
+    script_digest: str
+    command: str
+
+
+def plugin_hook_runtime_mode(spec: RuntimeMiddlewareSpec) -> str:
+    raw = str(spec.config.get("hook_mode") or "").strip()
+    return raw or "legacy_argv"
+
+
+def build_plugin_hooks_v2_middleware(
+    spec: RuntimeMiddlewareSpec,
+    *,
+    skill_manager: Any,
+    sandbox_provider: Any,
+    application_observer: Any,
+) -> AgentMiddleware:
+    if not skill_plugin_hook_v2_enabled():
+        raise SkillHookRuntimeError(
+            "Typed Skill Hook runtime is disabled.",
+            code="skill_hook_v2_disabled",
+        )
+    if "fail_closed" in spec.config:
+        raise SkillHookRuntimeError(
+            "typed_v2 does not accept the legacy fail_closed setting.",
+            code="skill_hook_manifest_invalid",
+        )
+    skill_ids = tuple(dict.fromkeys(_csv(spec.config.get("skill_ids"))))
+    if not skill_ids:
+        raise SkillHookRuntimeError(
+            "Typed Skill Hook middleware requires at least one Skill.",
+            code="skill_hook_manifest_invalid",
+        )
+    if len(skill_ids) > 10:
+        raise SkillHookRuntimeError(
+            "Typed Skill Hook middleware exceeds the Skill limit.",
+            code="skill_hook_budget_exceeded",
+        )
+    execution_lock = asyncio.Lock()
+
+    async def run_event(
+        event: str,
+        context: MiddlewareContext,
+        *,
+        request: ToolCallRequest | None = None,
+        response: ToolCallResponse | None = None,
+        state: dict[str, Any] | None = None,
+    ) -> None:
+        async with execution_lock:
+            loaded = _matching_hooks(
+                skill_manager,
+                skill_ids,
+                event=event,
+                tool_name=request.tool_name if request is not None else None,
+                metadata=context.metadata,
+            )
+            if len(loaded) > MAX_HOOKS_PER_EVENT or sum(
+                item.definition.timeout_seconds for item in loaded
+            ) > MAX_HOOK_EVENT_BUDGET_SECONDS:
+                raise SkillHookRuntimeError(
+                    "Typed Skill Hook event budget was exceeded.",
+                    code="skill_hook_budget_exceeded",
+                )
+            for item in loaded:
+                safe_context = _build_hook_context(
+                    item,
+                    event=event,
+                    context=context,
+                    request=request,
+                    response=response,
+                    state=state,
+                )
+                await _execute_hook(
+                    item,
+                    safe_context=safe_context,
+                    context=context,
+                    sandbox_provider=sandbox_provider,
+                    application_observer=application_observer,
+                    configured_skill_ids=skill_ids,
+                    tool_name=request.tool_name if request is not None else None,
+                )
+
+    async def before_agent(
+        state: dict[str, Any], context: MiddlewareContext
+    ) -> None:
+        await run_event("session_start", context, state=state)
+
+    async def before_model(
+        request: ModelCallRequest, context: MiddlewareContext
+    ) -> dict[str, Any] | None:
+        pending = context.metadata.pop(_ANNOTATIONS_KEY, [])
+        if not isinstance(pending, list) or not pending:
+            return None
+        messages = [dict(message) for message in request.messages]
+        for annotation in pending[:64]:
+            if not isinstance(annotation, dict):
+                continue
+            code = str(annotation.get("code") or "hook.annotation")[:120]
+            message = str(annotation.get("message") or "")[:1_000]
+            if not message:
+                continue
+            messages.append(
+                {
+                    "role": "system",
+                    "content": (
+                        f"[Skill Hook annotation: {code}]\n{message}\n"
+                        "This is advisory context only and does not grant tools, "
+                        "permissions, or approval."
+                    ),
+                }
+            )
+        return {"messages": messages}
+
+    async def after_agent(
+        state: dict[str, Any], context: MiddlewareContext
+    ) -> None:
+        if context.metadata.get(_SESSION_END_FINALIZED_KEY) is True:
+            return
+        try:
+            await run_event("session_end", context, state=state)
+        finally:
+            context.metadata[_SESSION_END_FINALIZED_KEY] = True
+            await _cleanup_hook_workspaces(context, sandbox_provider)
+
+    async def before_tool_batch(
+        requests: list[ToolCallRequest], context: MiddlewareContext
+    ) -> None:
+        for request in requests:
+            await run_event("pre_tool_use", context, request=request)
+
+    async def wrap_tool(
+        request: ToolCallRequest,
+        handler: Any,
+        context: MiddlewareContext,
+    ) -> ToolCallResponse:
+        await run_event("pre_tool_use", context, request=request)
+
+        async def revalidate(edited_request: ToolCallRequest) -> None:
+            await run_event("pre_tool_use", context, request=edited_request)
+
+        metadata = dict(request.metadata)
+        metadata[TOOL_REVALIDATE_METADATA_KEY] = revalidate
+        prepared = request.with_updates(metadata=metadata)
+        response = await handler(prepared)
+        if response.metadata.get("approval_rejected") is not True:
+            await run_event(
+                "post_tool_use",
+                context,
+                request=request,
+                response=response,
+            )
+        return response
+
+    return AgentMiddleware(
+        name="plugin_hooks_v2",
+        before_agent=before_agent,
+        before_model=before_model,
+        after_agent=after_agent,
+        before_tool_batch=before_tool_batch,
+        wrap_tool_call=wrap_tool,
+    )
+
+
+def drain_skill_hook_status_events(context: MiddlewareContext) -> list[dict[str, Any]]:
+    raw = context.metadata.pop(_STATUS_EVENTS_KEY, [])
+    if not isinstance(raw, list):
+        return []
+    return [dict(item) for item in raw if isinstance(item, dict)]
+
+
+def typed_hook_skill_ids(spec: RuntimeMiddlewareSpec | None) -> tuple[str, ...]:
+    if spec is None or plugin_hook_runtime_mode(spec) != HOOK_RUNTIME_MODE:
+        return ()
+    result = tuple(dict.fromkeys(_csv(spec.config.get("skill_ids"))))
+    if not result:
+        raise SkillHookRuntimeError(
+            "Typed Skill Hook middleware requires at least one Skill.",
+            code="skill_hook_manifest_invalid",
+        )
+    if len(result) > 10:
+        raise SkillHookRuntimeError(
+            "Typed Skill Hook middleware exceeds the Skill limit.",
+            code="skill_hook_budget_exceeded",
+        )
+    return result
+
+
+async def _cleanup_hook_workspaces(
+    context: MiddlewareContext, sandbox_provider: Any
+) -> None:
+    cleanup = getattr(sandbox_provider, "cleanup_skill_hook_workspace", None)
+    staged = context.metadata.get(_STAGED_KEY)
+    if not callable(cleanup) or not isinstance(staged, dict):
+        return
+    workspace_ids = {
+        str(item.get("workspace_id") or "")
+        for item in staged.values()
+        if isinstance(item, dict) and str(item.get("workspace_id") or "").strip()
+    }
+    for workspace_id in sorted(workspace_ids):
+        try:
+            await cleanup(workspace_id)
+        except Exception:
+            context.metadata.setdefault("middleware_warnings", []).append(
+                "plugin_hooks_v2 workspace cleanup failed"
+            )
+    context.metadata.pop(_STAGED_KEY, None)
+
+
+def _matching_hooks(
+    skill_manager: Any,
+    skill_ids: Iterable[str],
+    *,
+    event: str,
+    tool_name: str | None,
+    metadata: dict[str, Any],
+) -> list[_LoadedHook]:
+    result: list[_LoadedHook] = []
+    bindings = metadata.get("skill_version_bindings")
+    bindings = bindings if isinstance(bindings, dict) else {}
+    for skill_id in skill_ids:
+        version_id = str(bindings.get(skill_id) or "").strip()
+        if not version_id:
+            raise SkillHookRuntimeError(
+                "Typed Skill Hook has no immutable version binding.",
+                code="skill_hook_contract_stale",
+            )
+        try:
+            _require_plugin_skill_trust(
+                skill_manager,
+                skill_id,
+                metadata,
+                check_runtime=False,
+            )
+            root = Path(
+                skill_manager.get_skill_directory(
+                    skill_id, version_id=version_id
+                )
+            ).resolve()
+            available_paths: list[str] = []
+            for path in root.rglob("*"):
+                if path.is_symlink():
+                    raise SkillHookContractError(
+                        "Hook package contains an unsafe link."
+                    )
+                if path.is_file():
+                    available_paths.append(path.relative_to(root).as_posix())
+            manifest_path = (root / HOOK_MANIFEST_PATH).resolve()
+            if (
+                root not in manifest_path.parents
+                or not manifest_path.is_file()
+                or manifest_path.is_symlink()
+            ):
+                raise SkillHookContractError("Hook manifest is unavailable.")
+            manifest_bytes = manifest_path.read_bytes()
+            manifest = parse_hook_manifest(
+                manifest_bytes, available_paths=available_paths
+            )
+            manifest_digest = _sha256_bytes(manifest_bytes)
+        except SkillHookRuntimeError:
+            raise
+        except Exception as exc:
+            raise SkillHookRuntimeError(
+                "Typed Skill Hook manifest could not be verified.",
+                code=str(
+                    getattr(exc, "code", "") or "skill_hook_manifest_invalid"
+                ),
+            ) from exc
+        for definition in manifest.hooks:
+            if definition.event != event:
+                continue
+            if tool_name is not None and tool_name not in definition.tool_names:
+                continue
+            script_path = root.joinpath(
+                *PurePosixPath(definition.script_path).parts
+            )
+            try:
+                resolved_script = script_path.resolve(strict=True)
+                resolved_script.relative_to(root)
+                if script_path.is_symlink() or not resolved_script.is_file():
+                    raise OSError("unsafe script")
+                script_bytes = resolved_script.read_bytes()
+            except (OSError, ValueError) as exc:
+                raise SkillHookRuntimeError(
+                    "Typed Skill Hook script is unavailable.",
+                    code="skill_hook_contract_stale",
+                ) from exc
+            command = "python" if definition.script_path.endswith(".py") else "node"
+            try:
+                _require_plugin_skill_trust(
+                    skill_manager,
+                    skill_id,
+                    metadata,
+                    commands={command},
+                )
+            except Exception as exc:
+                raise SkillHookRuntimeError(
+                    "Typed Skill Hook runtime is incompatible.",
+                    code=str(
+                        getattr(exc, "code", "") or "skill_runtime_incompatible"
+                    ),
+                ) from exc
+            result.append(
+                _LoadedHook(
+                    skill_id=skill_id,
+                    version_id=version_id,
+                    root=root,
+                    manifest=manifest,
+                    manifest_digest=manifest_digest,
+                    definition=definition,
+                    script_digest=_sha256_bytes(script_bytes),
+                    command=command,
+                )
+            )
+    return result
+
+
+async def _execute_hook(
+    item: _LoadedHook,
+    *,
+    safe_context: dict[str, Any],
+    context: MiddlewareContext,
+    sandbox_provider: Any,
+    application_observer: Any,
+    configured_skill_ids: Iterable[str],
+    tool_name: str | None,
+) -> None:
+    context_bytes = _json_bytes(safe_context)
+    context_digest = _sha256_bytes(context_bytes)
+    if safe_context.get("truncated") is True and item.definition.mode != "annotation":
+        await _record_failed_evidence(
+            application_observer,
+            context=context,
+            item=item,
+            context_digest=context_digest,
+            result_digest=_sha256_bytes(b"{}"),
+            tool_name=tool_name,
+            code="skill_hook_context_invalid",
+        )
+        await _emit_status(
+            context,
+            item,
+            "failed",
+            tool_name=tool_name,
+            code="skill_hook_context_invalid",
+        )
+        raise SkillHookRuntimeError(
+            "Typed Skill Hook context exceeded the safe limit.",
+            code="skill_hook_context_invalid",
+        )
+    execution_key = _sha256_json(
+        {
+            "task_id": context.task_id,
+            "run_id": context.metadata.get("run_id"),
+            "node_id": context.metadata.get("node_id"),
+            "skill_id": item.skill_id,
+            "version_id": item.version_id,
+            "hook_id": item.definition.hook_id,
+            "event": item.definition.event,
+            "manifest_digest": item.manifest_digest,
+            "script_digest": item.script_digest,
+            "context_digest": context_digest,
+        }
+    )
+    cached = _cached_outcome(context, execution_key)
+    if cached is None:
+        cached = _receipt_outcome(
+            application_observer,
+            context=context,
+            item=item,
+            context_digest=context_digest,
+        )
+    if cached is not None:
+        _cache_outcome(context, execution_key, cached)
+        _raise_cached_block(cached, item)
+        return
+
+    await _emit_status(context, item, "planned", tool_name=tool_name)
+    result_digest = _sha256_bytes(b"{}")
+    operation_id = f"hook:{execution_key[:40]}"
+    work_root = f"work/.modelmirror-hooks/{operation_id.replace(':', '_')}"
+    context_path = f"{work_root}/context.json"
+    result_path = f"{work_root}/result.json"
+    shell_context_path = context_path.removeprefix("work/")
+    shell_result_path = result_path.removeprefix("work/")
+    evidence: list[SkillHookApplicationEvidenceV2] = []
+    outcome: dict[str, Any] = {"block_code": None, "block_message": None}
+    cleanup_error: Exception | None = None
+    hook_workspace: dict[str, str] | None = None
+    try:
+        hook_workspace = await _stage_skill_once(
+            item,
+            context=context,
+            sandbox_provider=sandbox_provider,
+            configured_skill_ids=configured_skill_ids,
+        )
+        await _verify_staged_script(
+            item,
+            context=context,
+            sandbox_provider=sandbox_provider,
+            configured_skill_ids=configured_skill_ids,
+            operation_id=operation_id,
+            hook_workspace=hook_workspace,
+        )
+        await _emit_status(context, item, "running", tool_name=tool_name)
+        await _sandbox_call(
+            sandbox_provider,
+            context,
+            configured_skill_ids,
+            RuntimeToolCall(
+                tool_name="sandbox_write_file",
+                arguments={
+                    "path": context_path,
+                    "content": context_bytes.decode("utf-8"),
+                },
+                metadata=_sandbox_metadata(
+                    context,
+                    configured_skill_ids,
+                    item.command,
+                    f"{operation_id}:context",
+                ),
+            ),
+            hook_workspace=hook_workspace,
+        )
+        await _sandbox_call(
+            sandbox_provider,
+            context,
+            configured_skill_ids,
+            RuntimeToolCall(
+                tool_name="sandbox_write_file",
+                arguments={"path": result_path, "content": "{}"},
+                metadata=_sandbox_metadata(
+                    context,
+                    configured_skill_ids,
+                    item.command,
+                    f"{operation_id}:result-init",
+                ),
+            ),
+            hook_workspace=hook_workspace,
+        )
+        shell_result = await _sandbox_call(
+            sandbox_provider,
+            context,
+            configured_skill_ids,
+            RuntimeToolCall(
+                tool_name="sandbox_shell",
+                arguments={
+                    "argv": [
+                        item.command,
+                        f"../skills/{hook_workspace['skill_alias']}/{item.definition.script_path}",
+                        "--context",
+                        shell_context_path,
+                        "--result",
+                        shell_result_path,
+                    ],
+                    "cwd": "work",
+                    "timeout_seconds": item.definition.timeout_seconds,
+                },
+                metadata=_sandbox_metadata(
+                    context,
+                    configured_skill_ids,
+                    item.command,
+                    f"{operation_id}:execute",
+                ),
+            ),
+            hook_workspace=hook_workspace,
+        )
+        shell_payload = _runtime_output_object(shell_result)
+        if int(shell_payload.get("exit_code", 1)) != 0:
+            raise SkillHookRuntimeError(
+                "Typed Skill Hook script failed.",
+                code="skill_hook_execution_failed",
+            )
+        read_result = await _sandbox_call(
+            sandbox_provider,
+            context,
+            configured_skill_ids,
+            RuntimeToolCall(
+                tool_name="sandbox_read_file",
+                arguments={"path": result_path, "max_chars": 200_000},
+                metadata=_sandbox_metadata(
+                    context,
+                    configured_skill_ids,
+                    item.command,
+                    f"{operation_id}:result-read",
+                ),
+            ),
+            hook_workspace=hook_workspace,
+        )
+        result_payload = _runtime_output_object(read_result)
+        raw_result = result_payload.get("content")
+        if not isinstance(raw_result, str):
+            raise SkillHookRuntimeError(
+                "Typed Skill Hook did not write a result.",
+                code="skill_hook_result_invalid",
+            )
+        result_bytes = raw_result.encode("utf-8")
+        result_digest = _sha256_bytes(result_bytes)
+        parsed = parse_hook_result(
+            result_bytes,
+            hook_event=item.definition.event,
+            hook_mode=item.definition.mode,
+        )
+        outputs = list(parsed.outputs)
+        if not outputs and item.definition.mode == "annotation":
+            evidence.append(
+                _hook_evidence(
+                    item,
+                    context_digest=context_digest,
+                    result_digest=result_digest,
+                    code="hook_completed",
+                    result_type="annotation",
+                    verified=True,
+                )
+            )
+        for output in outputs:
+            result_type = "annotation"
+            status = "annotated"
+            if output.output_type == "deny":
+                result_type = "denied"
+                status = "denied"
+                outcome = {
+                    "block_code": "skill_hook_denied",
+                    "block_message": "Typed Skill Hook denied the tool call.",
+                }
+            elif output.output_type == "validation":
+                result_type = (
+                    "validation_passed" if output.passed else "validation_failed"
+                )
+                status = "validated" if output.passed else "failed"
+                if output.passed is False:
+                    outcome = {
+                        "block_code": "skill_hook_validation_failed",
+                        "block_message": (
+                            "Typed Skill Hook validation failed after the tool "
+                            "already executed; the side effect was not rolled back."
+                            if item.definition.event == "post_tool_use"
+                            else "Typed Skill Hook validation failed."
+                        ),
+                    }
+            evidence.append(
+                _hook_evidence(
+                    item,
+                    context_digest=context_digest,
+                    result_digest=result_digest,
+                    code=output.code,
+                    result_type=result_type,
+                    verified=True,
+                )
+            )
+            await _emit_status(
+                context,
+                item,
+                status,
+                tool_name=tool_name,
+                code=output.code,
+            )
+            if (
+                output.output_type == "annotation"
+                and item.definition.event in {"session_start", "post_tool_use"}
+            ):
+                context.metadata.setdefault(_ANNOTATIONS_KEY, []).append(
+                    {"code": output.code, "message": output.message}
+                )
+        _record_evidence(
+            application_observer,
+            context=context,
+            item=item,
+            evidence=evidence,
+            tool_name=tool_name,
+        )
+        _cache_outcome(context, execution_key, outcome)
+        if not outcome.get("block_code"):
+            await _emit_status(
+                context,
+                item,
+                "completed",
+                tool_name=tool_name,
+            )
+    except Exception as exc:
+        outcome["error_in_flight"] = True
+        if isinstance(exc, SkillHookRuntimeError) and exc.code in {
+            "skill_hook_denied",
+            "skill_hook_validation_failed",
+        }:
+            raise
+        code = str(getattr(exc, "code", "") or "skill_hook_execution_failed")
+        if code not in {
+            "skill_hook_context_invalid",
+            "skill_hook_result_invalid",
+            "skill_hook_contract_stale",
+            "skill_hook_execution_failed",
+            "skill_hook_evidence_unavailable",
+            "skill_runtime_incompatible",
+        }:
+            code = "skill_hook_execution_failed"
+        await _record_failed_evidence(
+            application_observer,
+            context=context,
+            item=item,
+            context_digest=context_digest,
+            result_digest=result_digest,
+            tool_name=tool_name,
+            code=code,
+        )
+        await _emit_status(
+            context, item, "failed", tool_name=tool_name, code=code
+        )
+        if item.definition.mode == "annotation":
+            context.metadata.setdefault("middleware_warnings", []).append(
+                f"plugin_hooks_v2 {item.definition.hook_id} failed: {code}"
+            )
+            return
+        raise SkillHookRuntimeError(
+            "Typed Skill Hook execution could not be verified.", code=code
+        ) from exc
+    finally:
+        if hook_workspace is not None:
+            for suffix, path in (
+                ("wipe-context", context_path),
+                ("wipe-result", result_path),
+            ):
+                try:
+                    await _sandbox_call(
+                        sandbox_provider,
+                        context,
+                        configured_skill_ids,
+                        RuntimeToolCall(
+                            tool_name="sandbox_write_file",
+                            arguments={"path": path, "content": "{}"},
+                            metadata=_sandbox_metadata(
+                                context,
+                                configured_skill_ids,
+                                item.command,
+                                f"{operation_id}:{suffix}",
+                            ),
+                        ),
+                        hook_workspace=hook_workspace,
+                    )
+                except Exception as exc:  # Mode policy is applied below.
+                    cleanup_error = cleanup_error or exc
+        if cleanup_error is not None:
+            await _emit_status(
+                context,
+                item,
+                "failed",
+                tool_name=tool_name,
+                code="skill_hook_execution_failed",
+            )
+            if item.definition.mode == "annotation":
+                context.metadata.setdefault("middleware_warnings", []).append(
+                    "plugin_hooks_v2 cleanup failed: skill_hook_execution_failed"
+                )
+            elif not outcome.get("block_code") and not outcome.get(
+                "error_in_flight"
+            ):
+                raise SkillHookRuntimeError(
+                    "Typed Skill Hook cleanup failed.",
+                    code="skill_hook_execution_failed",
+                ) from cleanup_error
+    _raise_cached_block(outcome, item)
+
+
+async def _stage_skill_once(
+    item: _LoadedHook,
+    *,
+    context: MiddlewareContext,
+    sandbox_provider: Any,
+    configured_skill_ids: Iterable[str],
+) -> dict[str, str]:
+    staged = context.metadata.setdefault(_STAGED_KEY, {})
+    if not isinstance(staged, dict):
+        raise SkillHookRuntimeError(
+            "Typed Skill Hook stage state is invalid.",
+            code="skill_hook_contract_stale",
+        )
+    key = f"{item.skill_id}:{item.version_id}:{item.manifest_digest}"
+    existing = staged.get(key)
+    if isinstance(existing, dict):
+        return dict(existing)
+    provision = getattr(sandbox_provider, "provision_skill_hook_workspace", None)
+    if callable(provision):
+        binding = await provision(
+            skill_id=item.skill_id,
+            version_id=item.version_id,
+            package_root=item.root,
+            task_id=str(context.task_id or ""),
+            run_id=str(context.metadata.get("run_id") or ""),
+            node_id=str(context.metadata.get("node_id") or ""),
+        )
+        if not isinstance(binding, dict):
+            raise SkillHookRuntimeError(
+                "Skill Hook workspace binding is invalid.",
+                code="skill_hook_execution_failed",
+            )
+        normalized = {
+            "workspace_id": str(binding.get("workspace_id") or ""),
+            "skill_alias": str(binding.get("skill_alias") or ""),
+        }
+        if not all(normalized.values()):
+            raise SkillHookRuntimeError(
+                "Skill Hook workspace binding is incomplete.",
+                code="skill_hook_execution_failed",
+            )
+        staged[key] = normalized
+        return normalized
+    result = await _sandbox_call(
+        sandbox_provider,
+        context,
+        configured_skill_ids,
+        RuntimeToolCall(
+            tool_name="skill_stage",
+            arguments={"skill_id": item.skill_id},
+            metadata=_sandbox_metadata(
+                context,
+                configured_skill_ids,
+                item.command,
+                f"hook-stage:{_sha256_bytes(key.encode('utf-8'))[:40]}",
+            ),
+        ),
+        hook_workspace=None,
+    )
+    if result.is_error:
+        raise SkillHookRuntimeError(
+            "Typed Skill Hook package could not be staged.",
+            code="skill_hook_execution_failed",
+        )
+    fallback = {"workspace_id": "", "skill_alias": item.skill_id}
+    staged[key] = fallback
+    return fallback
+
+
+async def _verify_staged_script(
+    item: _LoadedHook,
+    *,
+    context: MiddlewareContext,
+    sandbox_provider: Any,
+    configured_skill_ids: Iterable[str],
+    operation_id: str,
+    hook_workspace: dict[str, str],
+) -> None:
+    workspace_path = (
+        f"skills/{hook_workspace['skill_alias']}/{item.definition.script_path}"
+    )
+    result = await _sandbox_call(
+        sandbox_provider,
+        context,
+        configured_skill_ids,
+        RuntimeToolCall(
+            tool_name="sandbox_read_file",
+            arguments={"path": workspace_path, "max_chars": 200_000},
+            metadata=_sandbox_metadata(
+                context,
+                configured_skill_ids,
+                item.command,
+                f"{operation_id}:script-verify",
+            ),
+        ),
+        hook_workspace=hook_workspace,
+    )
+    digests = result.metadata.get("sandbox_accessed_digests")
+    actual = str(digests.get(workspace_path) or "") if isinstance(digests, dict) else ""
+    if actual != item.script_digest:
+        raise SkillHookRuntimeError(
+            "Staged Skill Hook script no longer matches its immutable version.",
+            code="skill_hook_contract_stale",
+        )
+
+
+async def _sandbox_call(
+    sandbox_provider: Any,
+    context: MiddlewareContext,
+    configured_skill_ids: Iterable[str],
+    call: RuntimeToolCall,
+    *,
+    hook_workspace: dict[str, str] | None,
+) -> RuntimeToolResult:
+    try:
+        call_hook_tool = getattr(sandbox_provider, "call_skill_hook_tool", None)
+        workspace_id = str((hook_workspace or {}).get("workspace_id") or "")
+        if workspace_id and callable(call_hook_tool):
+            return await call_hook_tool(workspace_id, call)
+        return await sandbox_provider.call_tool(call)
+    except RuntimeToolError:
+        raise
+    except Exception as exc:
+        raise SkillHookRuntimeError(
+            "The isolated Skill Hook runtime is unavailable.",
+            code="skill_hook_execution_failed",
+        ) from exc
+
+
+def _sandbox_metadata(
+    context: MiddlewareContext,
+    configured_skill_ids: Iterable[str],
+    command: str,
+    iteration: str,
+) -> dict[str, Any]:
+    source = context.metadata
+    metadata = {
+        key: source.get(key)
+        for key in (
+            "run_id",
+            "node_id",
+            "runtime_run_type",
+            "xpert_id",
+            "conversation_id",
+            "goal_id",
+            "goal_step_id",
+            "handoff_id",
+            "skill_trust_authorizations",
+            "skill_version_bindings",
+        )
+        if source.get(key) is not None
+    }
+    metadata.update(
+        {
+            "task_id": context.task_id,
+            "iteration": iteration,
+            "skills_config": {
+                "skill_ids": list(configured_skill_ids),
+                "auto_discover": False,
+            },
+            "sandbox_config": {
+                "allowed_commands": command,
+                "timeout_seconds": 60,
+            },
+        }
+    )
+    return metadata
+
+
+def _build_hook_context(
+    item: _LoadedHook,
+    *,
+    event: str,
+    context: MiddlewareContext,
+    request: ToolCallRequest | None,
+    response: ToolCallResponse | None,
+    state: dict[str, Any] | None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "version": HOOK_CONTEXT_VERSION,
+        "event": event,
+        "skill": {
+            "skill_id": item.skill_id,
+            "version_id": item.version_id,
+            "manifest_digest": item.manifest_digest,
+        },
+        "hook": {
+            "hook_id": item.definition.hook_id,
+            "mode": item.definition.mode,
+        },
+    }
+    if event == "session_start":
+        task_input = _sanitize_text(
+            str(context.metadata.get("hook_task_input") or ""),
+            max_chars=MAX_SESSION_TASK_BYTES,
+        )
+        payload["session"] = {
+            "task_input": task_input,
+            "runtime_kind": str(
+                context.metadata.get("runtime_run_type") or "workflow"
+            )[:80],
+            "capabilities": _sanitize_value(
+                context.metadata.get("skill_runtime_environment") or {}, 1
+            ),
+        }
+    elif event == "pre_tool_use" and request is not None:
+        payload["tool"] = {
+            "name": request.tool_name,
+            "arguments": _sanitize_value(request.arguments, 1),
+        }
+    elif event == "post_tool_use" and request is not None and response is not None:
+        payload["tool"] = {
+            "name": request.tool_name,
+            "success": not bool(response.metadata.get("is_error")),
+            "content_types": _bounded_string_list(
+                response.metadata.get("content_types"), limit=20
+            ),
+            "output_length": len(response.output or ""),
+            "output_digest": _sha256_bytes((response.output or "").encode("utf-8")),
+            "artifact_paths": _relative_artifact_paths(response.metadata),
+        }
+    elif event == "session_end":
+        state = state or {}
+        payload["session"] = {
+            "status": str(state.get("status") or "completed")[:80],
+            "output_length": max(0, int(state.get("output_length") or 0)),
+            "output_digest": str(state.get("output_digest") or "")[:64] or None,
+        }
+    encoded = _json_bytes(payload)
+    if len(encoded) <= MAX_HOOK_CONTEXT_BYTES:
+        return payload
+    return {
+        "version": HOOK_CONTEXT_VERSION,
+        "event": event,
+        "skill": payload["skill"],
+        "hook": payload["hook"],
+        "truncated": True,
+        "source_digest": _sha256_bytes(encoded),
+        **(
+            {"tool": {"name": request.tool_name}}
+            if request is not None
+            else {}
+        ),
+    }
+
+
+def _sanitize_value(value: Any, depth: int) -> Any:
+    if depth > MAX_CONTEXT_DEPTH:
+        return "[TRUNCATED]"
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return _sanitize_text(value, max_chars=MAX_CONTEXT_STRING_CHARS)
+    if isinstance(value, list):
+        return [
+            _sanitize_value(item, depth + 1)
+            for item in value[:MAX_CONTEXT_ARRAY_ITEMS]
+        ]
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for raw_key in sorted(value, key=lambda item: str(item))[:100]:
+            key = str(raw_key)[:200]
+            result[key] = (
+                "[REDACTED]"
+                if _SENSITIVE_KEY.search(key)
+                else _sanitize_value(value[raw_key], depth + 1)
+            )
+        return result
+    return _sanitize_text(str(value), max_chars=MAX_CONTEXT_STRING_CHARS)
+
+
+def _sanitize_text(value: str, *, max_chars: int) -> str:
+    clean = value.replace("\x00", "")
+    if _WINDOWS_ABSOLUTE_PATH.match(clean) or clean.startswith("/"):
+        return "[REDACTED_PATH]"
+    clean = _EMBEDDED_ABSOLUTE_PATH.sub("[REDACTED_PATH]", clean)
+    clean = _SECRET_TEXT.sub("[REDACTED]", clean)
+    return _truncate_utf8(clean, max_chars)
+
+
+def _truncate_utf8(value: str, max_bytes: int) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+
+def _relative_artifact_paths(metadata: dict[str, Any]) -> list[str]:
+    candidates: list[Any] = []
+    for key in ("file_output",):
+        item = metadata.get(key)
+        if isinstance(item, dict):
+            candidates.extend([item.get("relative_path"), item.get("path")])
+    raw_many = metadata.get("file_outputs")
+    if isinstance(raw_many, list):
+        for item in raw_many[:20]:
+            if isinstance(item, dict):
+                candidates.extend([item.get("relative_path"), item.get("path")])
+    result: list[str] = []
+    for raw in candidates:
+        clean = str(raw or "").strip().replace("\\", "/")
+        path = PurePosixPath(clean)
+        if (
+            clean
+            and not path.is_absolute()
+            and all(part not in {"", ".", ".."} for part in path.parts)
+            and len(clean) <= 240
+        ):
+            result.append(path.as_posix())
+    return sorted(set(result))[:20]
+
+
+def _bounded_string_list(value: Any, *, limit: int) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item)[:100] for item in value[:limit]]
+
+
+def _record_evidence(
+    application_observer: Any,
+    *,
+    context: MiddlewareContext,
+    item: _LoadedHook,
+    evidence: Iterable[SkillHookApplicationEvidenceV2],
+    tool_name: str | None,
+) -> None:
+    try:
+        receipt = application_observer.record(
+            skill_id=item.skill_id,
+            version_id=item.version_id,
+            run_id=str(context.metadata.get("run_id") or "") or None,
+            task_id=context.task_id,
+            node_id=str(context.metadata.get("node_id") or "") or None,
+            runtime_kind=str(
+                context.metadata.get("runtime_run_type") or "workflow"
+            ),
+            policy="advisory",
+            method="hook_execute",
+            tool_name=tool_name,
+            hook_evidence=list(evidence),
+        )
+        if receipt is None:
+            raise RuntimeError("receipt disabled")
+    except Exception as exc:
+        raise SkillHookRuntimeError(
+            "Typed Skill Hook evidence could not be persisted.",
+            code="skill_hook_evidence_unavailable",
+        ) from exc
+
+
+async def _record_failed_evidence(
+    application_observer: Any,
+    *,
+    context: MiddlewareContext,
+    item: _LoadedHook,
+    context_digest: str,
+    result_digest: str,
+    tool_name: str | None,
+    code: str,
+) -> None:
+    try:
+        application_observer.record(
+            skill_id=item.skill_id,
+            version_id=item.version_id,
+            run_id=str(context.metadata.get("run_id") or "") or None,
+            task_id=context.task_id,
+            node_id=str(context.metadata.get("node_id") or "") or None,
+            runtime_kind=str(
+                context.metadata.get("runtime_run_type") or "workflow"
+            ),
+            policy="advisory",
+            method="hook_execute",
+            tool_name=tool_name,
+            error_code=code,
+            hook_evidence=[
+                _hook_evidence(
+                    item,
+                    context_digest=context_digest,
+                    result_digest=result_digest,
+                    code=_failure_evidence_code(code),
+                    result_type="failed",
+                    verified=False,
+                )
+            ],
+        )
+    except Exception:
+        return
+
+
+def _failure_evidence_code(code: str) -> str:
+    normalized = re.sub(r"[^a-z0-9.-]+", ".", str(code).strip().lower())
+    normalized = normalized.strip(".-")[:120]
+    return normalized if normalized and normalized[0].isalpha() else "hook.failed"
+
+
+def _hook_evidence(
+    item: _LoadedHook,
+    *,
+    context_digest: str,
+    result_digest: str,
+    code: str,
+    result_type: str,
+    verified: bool,
+) -> SkillHookApplicationEvidenceV2:
+    return SkillHookApplicationEvidenceV2(
+        hook_id=item.definition.hook_id,
+        hook_event=item.definition.event,
+        hook_mode=item.definition.mode,
+        manifest_digest=item.manifest_digest,
+        script_digest=item.script_digest,
+        context_digest=context_digest,
+        result_digest=result_digest,
+        code=code,
+        result_type=result_type,  # type: ignore[arg-type]
+        verified=verified,
+    )
+
+
+def _receipt_outcome(
+    application_observer: Any,
+    *,
+    context: MiddlewareContext,
+    item: _LoadedHook,
+    context_digest: str,
+) -> dict[str, Any] | None:
+    store = getattr(application_observer, "store", None)
+    if store is None or not hasattr(store, "list_receipts"):
+        return None
+    try:
+        receipts = store.list_receipts(
+            run_id=str(context.metadata.get("run_id") or "") or None,
+            task_id=context.task_id,
+            skill_id=item.skill_id,
+        )
+    except Exception as exc:
+        raise SkillHookRuntimeError(
+            "Typed Skill Hook evidence is unavailable.",
+            code="skill_hook_evidence_unavailable",
+        ) from exc
+    matches = [
+        evidence
+        for receipt in receipts
+        if receipt.version_id == item.version_id
+        for evidence in receipt.hook_evidence
+        if evidence.hook_id == item.definition.hook_id
+        and evidence.hook_event == item.definition.event
+        and evidence.hook_mode == item.definition.mode
+        and evidence.manifest_digest == item.manifest_digest
+        and evidence.script_digest == item.script_digest
+        and evidence.context_digest == context_digest
+        and evidence.verified
+    ]
+    if not matches:
+        return None
+    outcomes = {
+        (
+            "skill_hook_denied"
+            if evidence.result_type == "denied"
+            else (
+                "skill_hook_validation_failed"
+                if evidence.result_type == "validation_failed"
+                else None
+            )
+        )
+        for evidence in matches
+    }
+    blocking = {item for item in outcomes if item}
+    if len(blocking) > 1:
+        raise SkillHookRuntimeError(
+            "Typed Skill Hook evidence conflicts.",
+            code="skill_hook_evidence_unavailable",
+        )
+    block_code = next(iter(blocking), None)
+    return {
+        "block_code": block_code,
+        "block_message": (
+            "Typed Skill Hook denied the tool call."
+            if block_code == "skill_hook_denied"
+            else (
+                "Typed Skill Hook validation failed."
+                if block_code
+                else None
+            )
+        ),
+    }
+
+
+def _cached_outcome(
+    context: MiddlewareContext, execution_key: str
+) -> dict[str, Any] | None:
+    cache = context.metadata.get(_CACHE_KEY)
+    if not isinstance(cache, dict):
+        return None
+    item = cache.get(execution_key)
+    return dict(item) if isinstance(item, dict) else None
+
+
+def _cache_outcome(
+    context: MiddlewareContext, execution_key: str, outcome: dict[str, Any]
+) -> None:
+    cache = context.metadata.setdefault(_CACHE_KEY, {})
+    if not isinstance(cache, dict):
+        raise SkillHookRuntimeError(
+            "Typed Skill Hook cache state is invalid.",
+            code="skill_hook_contract_stale",
+        )
+    cache[execution_key] = dict(outcome)
+
+
+def _raise_cached_block(outcome: dict[str, Any], item: _LoadedHook) -> None:
+    code = str(outcome.get("block_code") or "")
+    if not code:
+        return
+    raise SkillHookRuntimeError(
+        str(outcome.get("block_message") or "Typed Skill Hook blocked execution."),
+        code=code,
+    )
+
+
+async def _emit_status(
+    context: MiddlewareContext,
+    item: _LoadedHook,
+    status: str,
+    *,
+    tool_name: str | None = None,
+    code: str | None = None,
+) -> None:
+    payload = {
+        "event": "skill_hook_status",
+        "status": status,
+        "task_id": context.task_id,
+        "run_id": str(context.metadata.get("run_id") or "") or None,
+        "node_id": str(context.metadata.get("node_id") or "") or None,
+        "skill_id": item.skill_id,
+        "version_id": item.version_id,
+        "hook_id": item.definition.hook_id,
+        "hook_event": item.definition.event,
+        "hook_mode": item.definition.mode,
+        "tool_name": tool_name,
+        "code": code,
+    }
+    context.metadata.setdefault(_STATUS_EVENTS_KEY, []).append(payload)
+    store = context.store
+    if store is None or not hasattr(store, "record_event"):
+        return
+    try:
+        await store.record_event(
+            "skill_hook_status",
+            task_id=context.task_id,
+            trace_id=context.trace_id,
+            payload={key: value for key, value in payload.items() if key != "event"},
+            severity=("error" if status in {"denied", "failed"} else "info"),
+        )
+    except Exception:
+        context.metadata.setdefault("middleware_warnings", []).append(
+            "plugin_hooks_v2 event persistence failed"
+        )
+
+
+def _runtime_output_object(result: RuntimeToolResult) -> dict[str, Any]:
+    try:
+        payload = json.loads(result.output or "{}")
+    except json.JSONDecodeError as exc:
+        raise SkillHookRuntimeError(
+            "Sandbox returned an invalid Hook response.",
+            code="skill_hook_execution_failed",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise SkillHookRuntimeError(
+            "Sandbox returned an invalid Hook response.",
+            code="skill_hook_execution_failed",
+        )
+    return payload
+
+
+def _json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Any) -> str:
+    return _sha256_bytes(_json_bytes(value))
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+__all__ = [
+    "HOOK_RUNTIME_MODE",
+    "SkillHookRuntimeError",
+    "build_plugin_hooks_v2_middleware",
+    "drain_skill_hook_status_events",
+    "plugin_hook_runtime_mode",
+    "typed_hook_skill_ids",
+]

--- a/server/xpert_runtime/sandbox_toolset.py
+++ b/server/xpert_runtime/sandbox_toolset.py
@@ -101,6 +101,10 @@ class SandboxToolsetProvider:
         self._evaluation_guard = threading.RLock()
         self._evaluation_workspaces: dict[str, dict[str, str]] = {}
         self._evaluation_usage: dict[str, dict[str, Any]] = {}
+        self._skill_hook_token = object()
+        self._skill_hook_guard = threading.RLock()
+        self._skill_hook_provision_lock = asyncio.Lock()
+        self._skill_hook_workspaces: dict[str, dict[str, str]] = {}
 
     def configure_skill_evaluation(
         self, overlay_resolver: Callable[[str], Any] | None
@@ -259,6 +263,250 @@ class SandboxToolsetProvider:
             "tool_names": sorted(str(item) for item in raw.get("tool_names", set())),
         }
 
+    async def provision_skill_hook_workspace(
+        self,
+        *,
+        skill_id: str,
+        version_id: str,
+        package_root: str | Path,
+        task_id: str,
+        run_id: str,
+        node_id: str,
+    ) -> dict[str, str]:
+        """Seed one immutable Hook Skill into the protected authoring profile."""
+
+        health = await self.client.health(required_profile="skill_authoring_v1")
+        self.require_skill_hook_attestation(health)
+        clean_skill_id = str(skill_id or "").strip()
+        clean_version_id = str(version_id or "").strip()
+        root = Path(package_root).resolve(strict=True)
+        if not clean_skill_id or not clean_version_id or not root.is_dir():
+            raise RuntimeToolError(
+                "skill_hook",
+                "Skill Hook package binding is invalid.",
+                code="skill_hook_contract_stale",
+            )
+        package_files: list[tuple[Path, bytes]] = []
+        total_bytes = 0
+        for path in sorted(root.rglob("*")):
+            if path.is_symlink():
+                raise RuntimeToolError(
+                    "skill_hook",
+                    "Skill Hook package contains an unsafe link.",
+                    code="skill_hook_contract_stale",
+                )
+            if not path.is_file() or ".git" in path.parts:
+                continue
+            relative = path.relative_to(root)
+            content = path.read_bytes()
+            if len(content) > SKILL_STAGE_MAX_FILE_BYTES:
+                raise RuntimeToolError(
+                    "skill_hook",
+                    "Skill Hook package file exceeds the runtime limit.",
+                    code="skill_hook_contract_stale",
+                )
+            total_bytes += len(content)
+            package_files.append((relative, content))
+        if (
+            not package_files
+            or len(package_files) > SKILL_STAGE_MAX_FILES
+            or total_bytes > SKILL_STAGE_MAX_TOTAL_BYTES
+        ):
+            raise RuntimeToolError(
+                "skill_hook",
+                "Skill Hook package exceeds the runtime limits.",
+                code="skill_hook_contract_stale",
+            )
+        try:
+            snapshot = self.skill_manager.lifecycle_store.require_version(
+                clean_version_id
+            )
+            expected_digest = str(snapshot.package_digest or "").strip().lower()
+        except Exception as exc:
+            raise RuntimeToolError(
+                "skill_hook",
+                "Frozen Skill Hook version is unavailable.",
+                code="skill_hook_contract_stale",
+            ) from exc
+        actual_digest = compute_skill_content_digest(
+            {relative.as_posix(): content for relative, content in package_files}
+        )
+        if (
+            str(getattr(snapshot, "skill_id", "") or "").strip()
+            != clean_skill_id
+            or actual_digest != expected_digest
+        ):
+            raise RuntimeToolError(
+                "skill_hook",
+                "Frozen Skill Hook package no longer matches its version.",
+                code="skill_hook_contract_stale",
+            )
+        binding_key = hashlib.sha256(
+            json.dumps(
+                [
+                    str(task_id or ""),
+                    str(run_id or ""),
+                    str(node_id or ""),
+                    clean_skill_id,
+                    clean_version_id,
+                    actual_digest,
+                ],
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        async with self._skill_hook_provision_lock:
+            with self._skill_hook_guard:
+                existing = next(
+                    (
+                        dict(item)
+                        for item in self._skill_hook_workspaces.values()
+                        if item.get("binding_key") == binding_key
+                    ),
+                    None,
+                )
+            if existing is not None:
+                return {
+                    "workspace_id": existing["workspace_id"],
+                    "skill_alias": existing["skill_alias"],
+                    "package_digest": actual_digest,
+                }
+            return await self._create_skill_hook_workspace(
+                task_id=str(task_id or ""),
+                run_id=str(run_id or ""),
+                node_id=str(node_id or ""),
+                skill_id=clean_skill_id,
+                version_id=clean_version_id,
+                actual_digest=actual_digest,
+                binding_key=binding_key,
+                package_files=package_files,
+            )
+
+    async def _create_skill_hook_workspace(
+        self,
+        *,
+        task_id: str,
+        run_id: str,
+        node_id: str,
+        skill_id: str,
+        version_id: str,
+        actual_digest: str,
+        binding_key: str,
+        package_files: list[tuple[Path, bytes]],
+    ) -> dict[str, str]:
+        workspace = self.store.get_or_create_workspace(
+            scope_type="skill_hook",
+            scope_id=(
+                f"{task_id}:{run_id}:{node_id}:{skill_id}:"
+                f"{version_id}:{uuid.uuid4().hex}"
+            ),
+            node_id=node_id,
+            quota_bytes=64 * 1024 * 1024,
+            expires_at=time.time() + 24 * 60 * 60,
+            metadata={
+                "skill_id": skill_id,
+                "version_id": version_id,
+                "package_digest": actual_digest,
+                "profile": "skill_authoring_v1",
+            },
+        )
+        response = await self.client.request(
+            {
+                "action": "ensure_workspace",
+                "workspace_id": workspace.workspace_id,
+                "profile": "skill_authoring_v1",
+            }
+        )
+        capability = str(response.get("provisioning_capability") or "")
+        if not capability:
+            raise RuntimeToolError(
+                "skill_hook",
+                "Sandbox sidecar did not return a Hook provisioning capability.",
+                code="skill_hook_execution_failed",
+            )
+        with self._skill_hook_guard:
+            self._skill_hook_workspaces[workspace.workspace_id] = {
+                "workspace_id": workspace.workspace_id,
+                "capability": capability,
+                "skill_id": skill_id,
+                "version_id": version_id,
+                "skill_alias": "authoring-resource",
+                "binding_key": binding_key,
+            }
+        try:
+            for index, (relative, content) in enumerate(package_files):
+                await self.client.request(
+                    {
+                        "action": "seed_file",
+                        "workspace_id": workspace.workspace_id,
+                        "profile": "skill_authoring_v1",
+                        "provisioning_capability": capability,
+                        "path": f"skills/authoring-resource/{relative.as_posix()}",
+                        "content_base64": base64.b64encode(content).decode("ascii"),
+                        "quota_bytes": workspace.quota_bytes,
+                        "operation_id": (
+                            f"hook-seed:{hashlib.sha256(f'{actual_digest}:{index}'.encode()).hexdigest()[:40]}"
+                        ),
+                    }
+                )
+            await self.client.request(
+                {
+                    "action": "seal_workspace",
+                    "workspace_id": workspace.workspace_id,
+                    "profile": "skill_authoring_v1",
+                    "provisioning_capability": capability,
+                }
+            )
+            return {
+                "workspace_id": workspace.workspace_id,
+                "skill_alias": "authoring-resource",
+                "package_digest": actual_digest,
+            }
+        except BaseException:
+            with self._skill_hook_guard:
+                self._skill_hook_workspaces.pop(workspace.workspace_id, None)
+            try:
+                await self.client.request(
+                    {
+                        "action": "cleanup_workspace",
+                        "workspace_id": workspace.workspace_id,
+                        "profile": "skill_authoring_v1",
+                        "provisioning_capability": capability,
+                    }
+                )
+            finally:
+                raise
+
+    async def call_skill_hook_tool(
+        self, workspace_id: str, call: RuntimeToolCall
+    ) -> RuntimeToolResult:
+        self._skill_hook_binding(workspace_id)
+        metadata = dict(call.metadata or {})
+        metadata["skill_hook_workspace_id"] = workspace_id
+        metadata["_skill_hook_internal_token"] = self._skill_hook_token
+        return await self.call_tool(
+            RuntimeToolCall(
+                tool_name=call.tool_name,
+                arguments=dict(call.arguments or {}),
+                metadata=metadata,
+            )
+        )
+
+    async def cleanup_skill_hook_workspace(self, workspace_id: str) -> None:
+        binding = self._skill_hook_binding(workspace_id)
+        try:
+            await self.client.request(
+                {
+                    "action": "cleanup_workspace",
+                    "workspace_id": workspace_id,
+                    "profile": "skill_authoring_v1",
+                    "provisioning_capability": binding["capability"],
+                }
+            )
+        finally:
+            with self._skill_hook_guard:
+                self._skill_hook_workspaces.pop(workspace_id, None)
+
     async def list_tools(self) -> list[RuntimeTool]:
         return [
             RuntimeTool("sandbox_list_files", "List files in the current isolated workspace.", {"type": "object", "properties": {"path": {"type": "string"}}}, "sandbox"),
@@ -353,6 +601,17 @@ class SandboxToolsetProvider:
         tool = await self.find_tool(call.tool_name)
         if tool is None:
             raise RuntimeToolError(call.tool_name, "Sandbox tool not found.", code="tool_not_found")
+        is_skill_hook = self._is_skill_hook_call(call)
+        if is_skill_hook and call.tool_name not in {
+            "sandbox_read_file",
+            "sandbox_write_file",
+            "sandbox_shell",
+        }:
+            raise RuntimeToolError(
+                call.tool_name,
+                "Tool is outside the fixed Skill Hook runtime allowlist.",
+                code="skill_hook_execution_failed",
+            )
         workspace = self._workspace(call)
         is_evaluation = self._is_skill_evaluation(call)
         if is_evaluation:
@@ -371,10 +630,10 @@ class SandboxToolsetProvider:
                     {"skill_read": False, "skill_stage": False, "tool_names": set()},
                 )
                 usage.setdefault("tool_names", set()).add(call.tool_name)
-        else:
+        elif not is_skill_hook:
             await self.client.request({"action": "ensure_workspace", "workspace_id": workspace.workspace_id})
         try:
-            if not is_evaluation:
+            if not is_evaluation and not is_skill_hook:
                 await self._stage_context_attachments(workspace, call)
             if call.tool_name == "skill_list":
                 return self._skill_list(call)
@@ -398,6 +657,20 @@ class SandboxToolsetProvider:
 
     def _workspace(self, call: RuntimeToolCall) -> SandboxWorkspace:
         metadata = call.metadata
+        if self._is_skill_hook_call(call):
+            workspace_id = str(metadata.get("skill_hook_workspace_id") or "").strip()
+            binding = self._skill_hook_binding(workspace_id)
+            workspace = self.store.get_workspace(workspace_id)
+            if (
+                workspace.scope_type != "skill_hook"
+                or binding.get("workspace_id") != workspace.workspace_id
+            ):
+                raise RuntimeToolError(
+                    call.tool_name,
+                    "Skill Hook workspace binding changed.",
+                    code="skill_hook_contract_stale",
+                )
+            return workspace
         if self._is_skill_evaluation(call):
             workspace_id = str(metadata.get("skill_evaluation_workspace_id") or "").strip()
             item_id = str(metadata.get("skill_evaluation_item_id") or "").strip()
@@ -469,6 +742,14 @@ class SandboxToolsetProvider:
             request.update(
                 {
                     "profile": "skill_evaluation_v1",
+                    "provisioning_capability": binding["capability"],
+                }
+            )
+        elif self._is_skill_hook_call(call):
+            binding = self._skill_hook_binding(workspace.workspace_id)
+            request.update(
+                {
+                    "profile": "skill_authoring_v1",
                     "provisioning_capability": binding["capability"],
                 }
             )
@@ -1553,6 +1834,21 @@ class SandboxToolsetProvider:
     def _is_skill_evaluation(call: RuntimeToolCall) -> bool:
         return str(call.metadata.get("runtime_run_type") or "") == "skill_evaluation"
 
+    def _is_skill_hook_call(self, call: RuntimeToolCall) -> bool:
+        return call.metadata.get("_skill_hook_internal_token") is self._skill_hook_token
+
+    def _skill_hook_binding(self, workspace_id: str) -> dict[str, str]:
+        clean = str(workspace_id or "").strip()
+        with self._skill_hook_guard:
+            binding = self._skill_hook_workspaces.get(clean)
+            if binding is None:
+                raise RuntimeToolError(
+                    "skill_hook",
+                    "Skill Hook workspace capability is unavailable.",
+                    code="skill_hook_execution_failed",
+                )
+            return dict(binding)
+
     @staticmethod
     def _require_skill_evaluation_tool(call: RuntimeToolCall) -> None:
         allowed = {
@@ -1599,6 +1895,35 @@ class SandboxToolsetProvider:
             raise RuntimeToolError(
                 "skill_evaluation",
                 "Sandbox sidecar cannot prove the required Skill evaluation isolation profile.",
+                code="sandbox_profile_attestation_failed",
+            )
+
+    @staticmethod
+    def require_skill_hook_attestation(health: dict[str, Any]) -> None:
+        profiles = health.get("profiles")
+        profile = (
+            profiles.get("skill_authoring_v1")
+            if isinstance(profiles, dict)
+            else None
+        )
+        allowed = (
+            set(profile.get("allowed_commands") or [])
+            if isinstance(profile, dict)
+            else set()
+        )
+        if (
+            health.get("engine") != "modelmirror-sandbox-v1"
+            or health.get("landlock_required") is not True
+            or not isinstance(profile, dict)
+            or profile.get("network_policy") != "container_network_none_required"
+            or set(profile.get("read_only_roots") or []) != {"inputs", "skills"}
+            or set(profile.get("writable_roots") or []) != {"work", ".tmp"}
+            or set(profile.get("write_file_roots") or []) != {"work"}
+            or allowed != {"python", "python3", "node", "rg"}
+        ):
+            raise RuntimeToolError(
+                "skill_hook",
+                "Sandbox sidecar cannot prove the required Skill Hook isolation profile.",
                 code="sandbox_profile_attestation_failed",
             )
 
@@ -1667,6 +1992,11 @@ class SandboxToolsetProvider:
             "tool_name": call.tool_name,
             "arguments": call.arguments,
         }
+        hook_workspace_id = str(
+            call.metadata.get("skill_hook_workspace_id") or ""
+        ).strip()
+        if hook_workspace_id:
+            payload["skill_hook_workspace_id"] = hook_workspace_id
         digest = hashlib.sha256(json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")).hexdigest()
         return f"op:{digest[:40]}"
 


### PR DESCRIPTION
## 增量

- 新增 typed_v2 Hook Runtime，严格执行标准 manifest/result 合同并固定 Python/Node 入口。
- 在无网 skill_authoring_v1 Sidecar profile 中按不可变 Skill 版本暂存和执行，限制上下文、路径、命令与事件预算。
- 固定 PreToolUse → HITL → provider → PostToolUse 顺序；guard deny 在审批前阻断，validation/guard 技术故障失败关闭，annotation 告警后继续。
- Application Receipt V2 记录脱敏 Hook evidence，并通过 skill_hook_status 暴露结构化运行状态。
- 保留 legacy_argv 与公共 Xpert App 既有边界；SKILL_PLUGIN_HOOK_V2_ENABLED 仍默认关闭。

## 证伪修复

- 为 Strategy V2 并行 Function Calling 增加整批预检，任一 Hook 拒绝时 provider 零调用。
- HITL 编辑后的参数重新执行 PreToolUse；用户拒绝审批时不再伪造 PostToolUse evidence。
- secret 与绝对路径先脱敏再截断，覆盖跨 2/8 KiB 边界的凭据前缀。
- Hook 版本、脚本、manifest、context 和 receipt 变化均失败关闭或使旧 evidence 失效。

## 验证

- 后端 Hook/Workflow/HITL/MCP Hub/Skill/Sandbox 组合矩阵：367 passed。
- 前端生产构建：npm.cmd run build 通过。
- git diff --check 与敏感信息扫描通过。
- 已基于 origin/main@0d70a161 验证 PR #253 MCP Hub 可信通道交叉兼容。

## 边界与回退

- 本 PR 不包含 Creator Hook 创作、工作流配置 UI、运行卡或默认启用，这些属于 PR3。
- 未修改 Sidecar 协议或镜像，未重建或重启共享 Docker。
- 回退方式：保持或设置 SKILL_PLUGIN_HOOK_V2_ENABLED=false，Legacy Hook 不受影响。