### PR TITLE
feature: R5D 接入受控 Chat 工具与文件输出

### DIFF
--- a/client/src/components/settings/ProviderChatControlSettings.test.tsx
+++ b/client/src/components/settings/ProviderChatControlSettings.test.tsx
@@ -24,7 +24,7 @@ const policy = {
 describe("ProviderChatControlSettings", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("describes the bounded R5C data plane and saves an atomic revisioned policy", async () => {
+  it("describes the bounded R5D data plane and saves an atomic revisioned policy", async () => {
     const calls: Array<[RequestInfo | URL, RequestInit | undefined]> = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       calls.push([input, init]);
@@ -74,8 +74,9 @@ describe("ProviderChatControlSettings", () => {
     });
 
     render(<ProviderChatControlSettings csrfToken="csrf-test" />);
-    expect(await screen.findByText("R5C 稳定路由与 Auto 证据")).toBeInTheDocument();
-    expect(screen.getByText(/只接管白名单内的 default 普通文本/)).toBeInTheDocument();
+    expect(await screen.findByText("R5D 稳定路由与逐能力执行")).toBeInTheDocument();
+    expect(screen.getByText(/default 普通文本、MCP 工具与受控文件输出/)).toBeInTheDocument();
+    expect(screen.getByText(/能力之间不能互借认证/)).toBeInTheDocument();
     expect(screen.getByText(/Auto 继续沿用 Native 或 OmniRoute/)).toBeInTheDocument();
     expect(
       (screen.getByRole("option", { name: /newapi_required_default/ }) as HTMLOptionElement)

--- a/client/src/components/settings/ProviderChatControlSettings.tsx
+++ b/client/src/components/settings/ProviderChatControlSettings.tsx
@@ -261,7 +261,7 @@ export default function ProviderChatControlSettings({
       });
       if (!response.ok) throw new Error(await readError(response));
       setMessage(
-        "Chat 控制策略已原子保存；newapi_preferred 仅在部署总开关开启时接管白名单普通文本。",
+        "Chat 控制策略已原子保存；newapi_preferred 仅在部署总开关开启时按逐能力资格接管白名单请求。",
       );
       await load();
     } catch (reason) {
@@ -277,11 +277,11 @@ export default function ProviderChatControlSettings({
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p className="text-sm font-semibold text-cyan-100">Managed Chat 控制策略</p>
-            <h2 className="mt-2 text-xl font-semibold text-white">R5C 稳定路由与 Auto 证据</h2>
+            <h2 className="mt-2 text-xl font-semibold text-white">R5D 稳定路由与逐能力执行</h2>
             <p className="mt-2 max-w-[78ch] text-sm leading-6 text-slate-300">
-              newapi_preferred 只接管白名单内的 default 普通文本与已提取文本附件。
+              newapi_preferred 按独立资格接管白名单内的 default 普通文本、MCP 工具与受控文件输出；能力之间不能互借认证。
               Auto 继续沿用 Native 或 OmniRoute 的现有选路，仅在独立门禁开启时写入脱敏运行与尝试证据。
-              工具、文件输出、多模态和 Canary 仍保持各自现有路径。
+              工具执行和文件渲染仍由 ModelMirror Runtime 完成；多模态和 Canary 保持各自现有路径。
             </p>
           </div>
           <button

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -178,6 +178,14 @@ attempt，并保留其既有 POST 后失败转向下一目标语义；OmniRoute 
 不扩展 sidecar 协议。Auto 运行固定 `primary_newapi=false`，不得计入 R5E required 门禁。
 工具、文件输出和多模态仍不进入该证据接入范围。
 
+Round 5D 将 `gateway=default` 的 MCP 工具模式和 `output_mode=allowlisted` 分别接入
+`chat_tools` 与 `chat_file_output` 路由。两者必须具备当前连接指纹、精确模型和对应能力
+认证；普通文本资格不能替代。控制面只选择并固定 Managed Provider：MCP 工具仍由
+ModelMirror Runtime 执行，文件规格仍由 allowlisted renderer 校验和落盘，Provider 不会
+获得工具凭据或本地文件权限。多步模型调用在首次派发前固定同一连接和批准 IP，后续步骤
+重新校验策略但不得切换 Provider、模型、IP 或 legacy 路径；Receipt 只保存聚合指标和
+稳定原因码，不保存消息、工具结果或生成内容。专用多模态与 Canary 行为不变。
+
 `/settings?section=overview|providers|routing` 共用一份 Provider 管理会话。Marble 等其他
 集成位于该门禁之外；newAPI 管理 UI 继续只通过安全外链访问，不嵌入或代理。
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -97,7 +97,7 @@ docker compose -f docker-compose.yml `
 ModelMirror 不得删除该目录。newAPI 上游为带附加条款的 AGPLv3 项目；本仓库不
 嵌入或修改其管理 UI，部署者仍需自行完成许可证与业务使用合规审查。
 
-### Provider Control Plane、v14 Catalog 与 R5A Chat 管理基础
+### Provider Control Plane、v14 Catalog 与 R5D Managed Chat
 
 Provider 管理面仍需外部注入至少 32 字符的
 `MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET` 和规范凭据主密钥。升级到 SQLite v14
@@ -158,7 +158,24 @@ Auto 门禁。开启后只为普通文本 Auto 写入脱敏父运行/尝试证�
 OmniRoute 选路。Native 每个实际目标分别记录；OmniRoute 只记录一次 sidecar 边界尝试，
 内部 Provider 重试标记为不可观测。若 v15 Receipt 无法在派发前建立，已开启门禁的 Auto
 请求失败关闭；关闭 `auto_enabled` 即可恢复旧 Auto 路径。Auto 记录不计入 required
-资格样本。工具、受控文件输出和多模态仍未迁移。超过 90 天的运行与尝试记录可先
+资格样本。
+
+R5D 使用同一部署开关，将 default MCP 工具模式和受控文件输出分别绑定到
+`chat_tools`、`chat_file_output` 的有序 Managed 路由。管理员必须先对每个稳定模型和
+每个目标连接完成对应能力认证；`chat_text` 认证不能替代。MCP 工具仍由 ModelMirror
+Runtime 按既有权限执行，文件仍由 allowlisted renderer 生成，Provider 不获得工具凭据
+或本地文件权限。首次 Provider 派发后，多步模型决策只能继续使用同一连接和预检批准的
+IP；连接、策略或资格漂移会失败关闭，不转向备用或 legacy。关闭
+`MODEL_CONTROL_CHAT_ENABLED` 即恢复全部旧静态路径；多模态与 Canary 不受影响。
+
+Direct Chat 可以读取已连接 MCP Catalog 中明确标记为只读、无需审批、非敏感且非终止性的
+工具；调用仍经 Catalog Service 重新执行策略校验。该接入使用独立的 Chat Runtime 能力，
+不会把 Catalog 工具加入 Workflow 或 Agent 的既有工具集合。受控文件输出还要求
+`FILE_OUTPUT_ASSETS_ENABLED=true`、`CHAT_FILE_OUTPUT_TOOL_ENABLED=true`，且
+`FILE_ASSET_STORE_MODE` 为 `shadow` 或 `native`；存储仍为 `legacy` 时能力接口失败关闭，
+不得仅因 Managed 资格通过而向前端宣称可用。
+
+超过 90 天的运行与尝试记录可先
 dry-run 检查：
 
 ```bash

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -1,8 +1,8 @@
 # Model Provider Control Plane
 
-状态：Round 0–4 已合并；Round 5A 正在建设管理、资格和审计基础；默认数据面切换未批准
-Round 5A 实施基线：`origin/main@f5d2081acb444fee5de947031455b2050f259019`
-更新日期：2026-08-21
+状态：Round 0–4、Round 5A–5C 已合并；Round 5D 正在接入工具与受控文件输出；默认数据面切换未批准
+Round 5D 当前基线：`origin/main@20dd124e364701ee6ac569cc8de15d102eb1a07b`
+更新日期：2026-08-22
 
 ## 决策
 
@@ -35,6 +35,10 @@ Provider Control Plane 的会话、SQLite 或主密钥。它只加入独立外�
   不触发自动刷新、自动认证、自动路由或付费请求。
 - Round 5A 只增加 Managed Chat 的逐能力认证、稳定策略、资格和脱敏 Receipt 基础；
   不接管 `/api/chat`。真实调度从 Round 5B 开始并需独立验收。
+- Round 5B 只迁移稳定白名单内的 default 普通文本与已提取文本附件；Round 5C 只为
+  Auto 接入不改变选路的独立证据管道。
+- Round 5D 只迁移 MCP 工具和受控文件输出的 Provider 选择与 Receipt；工具执行、权限、
+  文件渲染和专用多模态协议仍由既有 Runtime 负责。
 - newAPI 是否成为强制默认数据面由后续独立决策决定。
 - 任一门禁失败时保留现有静态数据面和 SQLite，不自动迁移或删除数据。
 
@@ -156,7 +160,7 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
 - R4 受管 Provider 不会自动配置或接管普通 `/api/chat`。当前 default Chat 仍读取
   `LLM_GATEWAY_URL/KEY` 或 `OPENROUTER_API_KEY`；迁移和 newAPI 默认门禁属于 Round 5。
 
-## Managed Chat 策略、稳定路由与 Auto 证据（Round 5A—5C）
+## Managed Chat 策略、稳定路由与 Auto 证据（Round 5A—5D）
 
 - 内部契约版本为 `modelmirror-provider-chat-routing-v1`，将 `chat_text`、
   `chat_tools` 和 `chat_file_output` 分别认证和配置；普通文本认证不能证明工具或受控
@@ -180,8 +184,14 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
   Provider 目标独立记录 attempt；OmniRoute 只记录 ModelMirror 可见的一次 sidecar
   attempt，内部重试标记 `provider_attempts_not_observed`。Auto 记录始终设置
   `primary_newapi=false`，不计入 R5E required 门禁。
-- 工具、受控文件输出、多模态与 Canary 不在 R5C 证据接入范围；
-  `newapi_required_default` 仍等待 R5E 的证据门禁与人工批准。
+- R5D 将 `gateway=default` 的 MCP 工具模式和 `output_mode=allowlisted` 分别接入
+  `chat_tools` 与 `chat_file_output`。两条路径都必须使用同一精确模型的独立当前认证；
+  缺失资格时在派发前阻断，不能借用 `chat_text` 或静默进入 legacy。
+- 工具由 ModelMirror Runtime 执行，文件由 allowlisted renderer 校验；Provider 只接收
+  既有安全模型输入，不接收 MCP 凭据或本地文件权限。需要多次模型决策时保持同一连接和
+  已批准 IP，策略漂移则失败关闭，不跨 Provider 重放。
+- 多模态与 Canary 不在 R5D 接入范围；`newapi_required_default` 仍等待 R5E 的证据门禁
+  与人工批准。
 - 清理命令 `python -m server.model_router.cleanup_chat_receipts --storage-dir <path>` 默认
   dry-run；只有显式增加 `--apply` 才会删除超过保留期的运行和尝试记录，默认保留 90 天。
 

--- a/docs/task-cards/provider-chat-r5d.md
+++ b/docs/task-cards/provider-chat-r5d.md
@@ -1,0 +1,73 @@
+# 任务卡：Provider Chat R5D
+
+## 1. 单一目标
+
+- 将 `gateway=default` 的 MCP 工具模式与受控文件输出分别接入
+  `chat_tools`、`chat_file_output` 的 Managed Provider 路由和 v15 Receipt。
+- 保留既有 Runtime 工具执行、权限、文件渲染、SSE 与前端交互契约。
+
+## 2. 已证实基线
+
+| 结论 | 证据 |
+| --- | --- |
+| 当前基线 | `origin/main@20dd124e364701ee6ac569cc8de15d102eb1a07b` |
+| R5A 已保存逐能力认证、路由和资格 | `server/model_router/chat_control.py`、`chat_certification.py` |
+| R5B 已接管稳定白名单普通文本 | `server/model_router/chat_stable.py`、`server/main.py` |
+| 工具模式仍读取旧静态网关 | `server/main.py::stream_chat_toolset_text` |
+| 文件输出仍只认可旧固定 OpenRouter 目标 | `server/main.py::validate_chat_output_request` |
+
+## 3. 范围与风险
+
+- 允许修改：Provider Chat 稳定路由、`/api/chat` 工具/文件分支、文件输出发送注入、
+  对应测试、设置说明和控制面文档。
+- 禁止修改：公开 Chat 请求与 SSE 成功契约、工具执行权限、文件 renderer、多模态、
+  Canary、Auto 选路、Agent、Workflow、RAG、Coding、模型目录口径与计费。
+- 数据影响：不迁移 Schema；继续写入现有租户隔离的 v15 run/attempt Receipt。
+- 依赖影响：不新增或升级生产依赖。
+- 主要风险：多步模型调用跨 Provider 重放、策略漂移后继续派发、能力认证互借、
+  Receipt 或日志保存用户/工具/文件正文。
+
+## 4. 实现约束
+
+1. 只有精确模型、当前连接指纹和对应能力认证均有效时才选择目标。
+2. `chat_text` 认证不能替代 `chat_tools` 或 `chat_file_output`。
+3. 第一次 Provider 派发前允许选择显式备用；派发后固定同一连接和批准 IP。
+4. 多步工具决策或文件输出后续步骤必须重新检查当前策略；漂移时失败关闭。
+5. Provider 只获得既有安全模型输入和公开 Tool Schema，不获得工具凭据或本地权限。
+6. Runtime 继续执行 MCP 工具、权限和文件渲染；控制面不复制执行器。
+7. flag 关闭、策略为 `legacy` 或模型不在稳定白名单时保持旧路径。
+8. Direct Chat 只接入已连接且无需审批的只读 Catalog 工具，不扩大 Workflow/Agent 工具集。
+9. 文件输出存储未进入 `shadow` 或 `native` 时必须在能力投影阶段失败关闭。
+
+## 5. 验收
+
+- 能力路由、资格隔离、IP pinning、策略漂移、同目标多步和脱敏测试通过。
+- 旧工具、文件输出、R5B 文本、R5C Auto、Canary 与多模态回归通过。
+- 前端全量测试、typecheck、生产构建通过。
+- 后端全量测试、Compose 配置、Diff、Git 状态和敏感信息扫描完成。
+- 独立预览器显示 R5D 状态；真实能力认证和实际工具/文件调用仅在逐次额度授权后执行。
+
+### 独立预览验收证据（2026-08-22）
+
+- 自动门禁通过：R5D 工具/文件专项 59 项、受影响后端 172 项、前端 526 项、
+  typecheck、production build、Compose 配置和敏感信息扫描。后端全量为
+  3925 passed、29 skipped、20 个已知环境失败；失败仅来自 Agency Worker
+  构建产物缺失、Expert Team Agency 及 Skill 跨语言索引环境，不涉及 R5D。
+- `chat_tools` 真实调用通过：OpenRouter 单一尝试、实际模型与请求模型一致，
+  444 tokens，E2E 3699.48 ms；Catalog 工具调用继续经过只读、无需审批、
+  非敏感策略门禁，且后续模型步骤保持同一 Managed Target。
+- 文件输出首次调用在 Provider 派发后因预览仍使用 legacy 文件存储而失败；
+  根因修复为能力投影在存储模式不是 `shadow` 或 `native` 时提前失败关闭，
+  并将独立预览改为专属 native 文件卷。
+- 修复后的 `chat_file_output` 真实复测通过：OpenRouter 单一尝试、实际模型与
+  请求模型一致，587 tokens，E2E 2418.21 ms；生成 19-byte 文件，SHA-256 为
+  `2961d59aff0ac8696e8cb90757a96da422e84c6bbbb01f72bba55e16638bef7d`。
+- 最近验收窗口只有一个 `/api/chat` 请求；Router SQLite 和服务日志均未出现
+  用户提示、模型回复或文件正文。文件卷仅保存用户明确请求的生成产物。
+
+## 6. 停止与回退
+
+- 若出现派发后跨 Provider 回退、重复执行工具、未授权真实调用、正文落入 Receipt、
+  专用模态回归或需要新增依赖，立即停止。
+- 回退代码并设置 `MODEL_CONTROL_CHAT_ENABLED=false` 即恢复旧静态路径。
+- 保留 v15 表、Provider 凭据、newAPI 数据和现有 Receipt，不执行降级或删除。

--- a/server/file_assets/api.py
+++ b/server/file_assets/api.py
@@ -62,9 +62,14 @@ from .service import (
 )
 
 try:
-    from server.model_router.api import get_catalog_coordinator
+    from server.model_router.api import (
+        get_catalog_coordinator,
+        get_model_router_service,
+    )
+    from server.model_router.chat_control import ProviderChatControlService
 except ModuleNotFoundError:
-    from model_router.api import get_catalog_coordinator
+    from model_router.api import get_catalog_coordinator, get_model_router_service
+    from model_router.chat_control import ProviderChatControlService
 
 
 MIB = 1024 * 1024
@@ -783,6 +788,17 @@ def _http_error(exc: FileAssetServiceError) -> HTTPException:
 
 
 async def _verified_chat_output_tool(model_id: str) -> bool:
+    if ProviderChatControlService.feature_enabled():
+        try:
+            managed_status = ProviderChatControlService(
+                get_model_router_service()
+            ).public_status(model_id, "chat_file_output")
+        except Exception:
+            # An enabled control plane fails closed when its qualification
+            # projection cannot be read; never borrow the legacy allowlist.
+            return False
+        if managed_status.effective_mode != "legacy":
+            return managed_status.available
     if verified_chat_output_provider(
         model_id=model_id,
         gateway_url=_active_chat_url(),

--- a/server/file_assets/chat_output.py
+++ b/server/file_assets/chat_output.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import re
 from dataclasses import dataclass
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
@@ -18,6 +19,9 @@ OPENROUTER_CHAT_COMPLETIONS_URL = "https://openrouter.ai/api/v1/chat/completions
 _VERIFIED_CHAT_OUTPUT_TARGETS = {
     "openai/gpt-5.6-luna": "openai",
 }
+ChatOutputResponseSender = Callable[
+    [httpx.AsyncClient, dict[str, Any]], Awaitable[httpx.Response]
+]
 _SANDBOX_MARKDOWN_LINK_RE = re.compile(
     r"\[[^\]\r\n]{0,500}\]\(\s*sandbox:[^)\r\n]{1,2000}\)",
     re.IGNORECASE,
@@ -58,11 +62,19 @@ CREATE_FILE_TOOL = {
 
 
 class ChatOutputError(RuntimeError):
-    def __init__(self, status_code: int, error_code: str, message: str) -> None:
+    def __init__(
+        self,
+        status_code: int,
+        error_code: str,
+        message: str,
+        *,
+        upstream_status_code: int | None = None,
+    ) -> None:
         super().__init__(message)
         self.status_code = status_code
         self.error_code = error_code
         self.message = message
+        self.upstream_status_code = upstream_status_code
 
 
 @dataclass(frozen=True, slots=True)
@@ -108,6 +120,7 @@ async def run_chat_output_turn(
     scope_id: str,
     output_context_id: str,
     provider_tag: str | None = None,
+    response_sender: ChatOutputResponseSender | None = None,
 ) -> ChatOutputResult:
     request_payload: dict[str, Any] = {
         "model": model_id,
@@ -132,7 +145,14 @@ async def run_chat_output_turn(
         request_payload["stop"] = stop
 
     async with httpx.AsyncClient(**client_kwargs) as client:
-        first = await _stream_once(client, url=url, key=key, headers=headers, payload=request_payload)
+        first = await _stream_once(
+            client,
+            url=url,
+            key=key,
+            headers=headers,
+            payload=request_payload,
+            response_sender=response_sender,
+        )
         _require_exact_model(first.actual_model, model_id)
         if len(first.tool_calls) > 1:
             raise ChatOutputError(
@@ -222,6 +242,7 @@ async def run_chat_output_turn(
                 key=key,
                 headers=headers,
                 payload=second_payload,
+                response_sender=response_sender,
             )
         except ChatOutputError:
             text_chunks = tuple(first.text_chunks) or (
@@ -281,16 +302,26 @@ async def _stream_once(
     key: str,
     headers: dict[str, str],
     payload: dict[str, Any],
+    response_sender: ChatOutputResponseSender | None = None,
 ) -> _StreamResult:
-    response = await client.send(
-        client.build_request("POST", url, headers=headers, json=payload), stream=True
+    response = (
+        await response_sender(client, payload)
+        if response_sender is not None
+        else await client.send(
+            client.build_request("POST", url, headers=headers, json=payload),
+            stream=True,
+        )
     )
     if response.status_code >= 400:
+        upstream_status_code = response.status_code
         await response.aclose()
         raise ChatOutputError(
             502,
             "output_model_upstream_error",
             "The selected model connection rejected the file-output request.",
+            upstream_status_code=(
+                upstream_status_code if response_sender is not None else None
+            ),
         )
     text_chunks: list[str] = []
     calls: dict[int, dict[str, str]] = {}

--- a/server/file_assets/output_service.py
+++ b/server/file_assets/output_service.py
@@ -125,9 +125,10 @@ class FileOutputService:
     ) -> FileOutputCapabilitiesResponse:
         clean_purpose = FilePurpose(purpose)
         master_enabled = self.enabled
+        store_enabled = self.file_service.mode in {"shadow", "native"}
         chat_tool_enabled = _env_enabled("CHAT_FILE_OUTPUT_TOOL_ENABLED")
         purpose_supported = clean_purpose in _PURPOSES
-        ready = master_enabled and purpose_supported and (
+        ready = master_enabled and store_enabled and purpose_supported and (
             clean_purpose is not FilePurpose.CHAT
             or (chat_tool_enabled and verified_chat_tool is True)
         )
@@ -137,6 +138,9 @@ class FileOutputService:
         elif not master_enabled:
             status = "disabled"
             reason = "Unified output assets are disabled by configuration."
+        elif not store_enabled:
+            status = "disabled"
+            reason = "The unified file asset store is disabled."
         elif not purpose_supported:
             status = "disabled"
             reason = "This module is outside the output-asset closure scope."

--- a/server/main.py
+++ b/server/main.py
@@ -14,7 +14,7 @@ import sys
 import tempfile
 import time
 import uuid
-from collections.abc import AsyncIterator, Callable, Iterable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from collections import defaultdict, deque
 from dataclasses import asdict, dataclass
 from datetime import datetime
@@ -804,6 +804,7 @@ try:
         InMemoryToolAuditStore,
         ExternalXpertToolsetProvider,
         KnowledgeToolsetProvider,
+        CatalogMCPToolsetProvider,
         CompositeMCPToolsetProvider,
         HubMCPToolsetProvider,
         MCPToolsetProvider,
@@ -929,6 +930,7 @@ except ModuleNotFoundError:
         InMemoryToolAuditStore,
         ExternalXpertToolsetProvider,
         KnowledgeToolsetProvider,
+        CatalogMCPToolsetProvider,
         CompositeMCPToolsetProvider,
         HubMCPToolsetProvider,
         MCPToolsetProvider,
@@ -1434,10 +1436,6 @@ configure_mcp_hub_review(mcp_hub_review_service)
 configure_mcp_hub_trusted(mcp_hub_trusted_service)
 workflow_curated_mcp_provider = MCPToolsetProvider(tool_registry, mcp_manager)
 workflow_hub_mcp_provider = HubMCPToolsetProvider(mcp_hub_service)
-workflow_mcp_provider = CompositeMCPToolsetProvider(
-    workflow_curated_mcp_provider,
-    workflow_hub_mcp_provider,
-)
 toolset_store = ToolsetStore()
 toolset_credential_store = CredentialStore(toolset_store.storage_dir)
 mcp_catalog_workspace_store = MCPCatalogWorkspaceStore()
@@ -1455,6 +1453,16 @@ mcp_catalog_service = MCPCatalogService(
     owner_id=os.getenv("MODELMIRROR_DEFAULT_OWNER_ID", "local"),
 )
 configure_mcp_catalog(mcp_catalog_service)
+workflow_catalog_mcp_provider = CatalogMCPToolsetProvider(mcp_catalog_service)
+workflow_mcp_provider = CompositeMCPToolsetProvider(
+    workflow_curated_mcp_provider,
+    workflow_hub_mcp_provider,
+)
+chat_mcp_provider = CompositeMCPToolsetProvider(
+    workflow_curated_mcp_provider,
+    workflow_catalog_mcp_provider,
+    workflow_hub_mcp_provider,
+)
 toolset_service = ToolsetService(
     toolset_store,
     toolset_credential_store,
@@ -1802,6 +1810,11 @@ runtime_capabilities.register(
     "mcp_tools",
     workflow_mcp_provider,
     description="MCP tools runtime capability for workflow and agents.",
+)
+runtime_capabilities.register(
+    "chat_mcp_tools",
+    chat_mcp_provider,
+    description="Policy-safe MCP tools available to direct Chat Runtime.",
 )
 register_todo_toolset_capability(runtime_capabilities, workflow_todo_provider)
 register_sandbox_toolset_capability(runtime_capabilities, workflow_sandbox_provider)
@@ -3224,6 +3237,7 @@ async def validate_chat_output_request(
     payload: ChatRequest,
     *,
     gateway_url: str,
+    verify_legacy_target: bool = True,
     direct_audio_requested: bool,
     direct_video_requested: bool,
     direct_file_requested: bool,
@@ -3271,9 +3285,8 @@ async def validate_chat_output_request(
             status_code=422,
             detail="File output requires both the current Chat scope and a stable turn context.",
         )
-    if not await model_supports_chat_output_tool(
-        payload.model_id,
-        gateway_url=gateway_url,
+    if verify_legacy_target and not await model_supports_chat_output_tool(
+        payload.model_id, gateway_url=gateway_url
     ):
         raise HTTPException(
             status_code=422,
@@ -4136,6 +4149,14 @@ class ChatCompletionContentError(RuntimeError):
         self.diagnostics = diagnostics
 
 
+class ChatCompletionUpstreamError(RuntimeError):
+    """Preserve upstream status for internal routing without exposing its body."""
+
+    def __init__(self, status_code: int, message: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
 def chat_sse_delta(text: str) -> bytes:
     payload = json.dumps(
         {"choices": [{"delta": {"content": text}}]},
@@ -4231,6 +4252,11 @@ async def collect_chat_completion_text(
     allow_json_reasoning_fallback: bool = False,
     json_required_top_level_key: str | None = None,
     completion_diagnostics: dict[str, Any] | None = None,
+    response_sender: Callable[
+        [httpx.AsyncClient, dict[str, Any]], Awaitable[httpx.Response]
+    ]
+    | None = None,
+    client_kwargs_override: dict[str, Any] | None = None,
 ) -> str:
     if gateway_url is not None:
         url = gateway_url
@@ -4274,16 +4300,20 @@ async def collect_chat_completion_text(
     )
 
     async with execution_operation("model_call"), httpx.AsyncClient(
-        **llm_client_kwargs()
+        **(client_kwargs_override or llm_client_kwargs())
     ) as client:
-        response = await client.post(
-            url,
-            headers=llm_gateway_headers(key),
-            json=request_payload,
+        response = (
+            await response_sender(client, request_payload)
+            if response_sender is not None
+            else await client.post(
+                url,
+                headers=llm_gateway_headers(key),
+                json=request_payload,
+            )
         )
         if response.status_code >= 400:
             message, _ = parse_upstream_error(response.status_code, response.content)
-            raise RuntimeError(message)
+            raise ChatCompletionUpstreamError(response.status_code, message)
         data = response.json()
         if not isinstance(data, dict):
             raise RuntimeError("模型返回了无法解析的响应。")
@@ -4535,9 +4565,16 @@ async def stream_chat_toolset_text(
     model_id_override: str | None = None,
     gateway_url: str | None = None,
     gateway_key: str | None = None,
+    response_sender: Callable[
+        [httpx.AsyncClient, dict[str, Any]], Awaitable[httpx.Response]
+    ]
+    | None = None,
+    client_kwargs_override: dict[str, Any] | None = None,
+    actual_model_observer: Callable[[str], None] | None = None,
+    usage_observer: Callable[[dict[str, int]], None] | None = None,
 ) -> AsyncIterator[str]:
     requested_tools = parse_chat_tool_names(payload.tool_names)
-    all_tools = await workflow_mcp_provider.list_tools()
+    all_tools = await chat_mcp_provider.list_tools()
     available_tools = [
         tool
         for tool in all_tools
@@ -4584,6 +4621,10 @@ async def stream_chat_toolset_text(
                 max_tokens=payload.max_tokens,
                 gateway_url=gateway_url,
                 gateway_key=gateway_key,
+                response_sender=response_sender,
+                client_kwargs_override=client_kwargs_override,
+                actual_model_observer=actual_model_observer,
+                usage_observer=usage_observer,
             )
         ).strip()
         decision = extract_json_decision(raw_response)
@@ -4679,6 +4720,7 @@ async def stream_chat_toolset_text(
             runtime_capabilities,
             runtime_pipeline,
             tool_context,
+            capability_name="chat_mcp_tools",
             policy=workflow_tool_policy,
             audit_store=audit_store or workflow_tool_audit_store,
         )
@@ -23872,12 +23914,17 @@ async def chat(payload: ChatRequest, request: Request):
             for message in payload.messages
         )
     )
+    stable_chat_capability = (
+        "chat_file_output"
+        if payload.output_mode == "allowlisted"
+        else "chat_tools"
+        if payload.tool_mode == "mcp_tools"
+        else "chat_text"
+    )
     stable_chat_shape_requested = bool(
         stable_chat_service.control.feature_enabled()
         and payload.gateway == "default"
         and not is_omniroute_auto_model(payload.model_id)
-        and payload.tool_mode == "none"
-        and payload.output_mode == "none"
         and payload.response_audio is None
         and payload.skill_application is None
         and payload.routing is None
@@ -24024,12 +24071,126 @@ async def chat(payload: ChatRequest, request: Request):
             content={"error": LLM_GATEWAY_NOT_CONFIGURED_MESSAGE},
         )
 
+    stable_chat_post_started = False
+    stable_chat_run_finalized = False
+    stable_chat_started_at: float | None = None
+    stable_capability_model_calls = 0
+
+    async def send_stable_capability_response(
+        request_client: httpx.AsyncClient,
+        request_payload: dict[str, Any],
+        *,
+        stream: bool,
+    ) -> httpx.Response:
+        """Send every step to the one preflighted target and pinned address."""
+
+        nonlocal stable_chat_post_started
+        nonlocal stable_chat_started_at
+        nonlocal stable_capability_model_calls
+        if not use_stable_chat or stable_chat_dispatch is None:
+            raise RuntimeError("provider_chat_stable_dispatch_missing")
+        if stable_chat_post_started:
+            stable_chat_service.ensure_dispatch_current(stable_chat_dispatch)
+        else:
+            stable_chat_service.mark_dispatched(stable_chat_dispatch)
+            stable_chat_post_started = True
+            stable_chat_started_at = time.perf_counter()
+        stable_capability_model_calls += 1
+        prepared_request = provider_chat_transport.build_authorized_stream_request(
+            request_client,
+            stable_chat_dispatch.target,
+            stable_chat_dispatch.authorized,
+            request_payload,
+            headers=llm_gateway_headers(stable_chat_dispatch.target.api_key),
+        )
+        return await request_client.send(
+            prepared_request,
+            stream=stream,
+            follow_redirects=False,
+        )
+
+    async def send_stable_stream_response(
+        request_client: httpx.AsyncClient,
+        request_payload: dict[str, Any],
+    ) -> httpx.Response:
+        return await send_stable_capability_response(
+            request_client, request_payload, stream=True
+        )
+
+    async def send_stable_json_response(
+        request_client: httpx.AsyncClient,
+        request_payload: dict[str, Any],
+    ) -> httpx.Response:
+        return await send_stable_capability_response(
+            request_client, request_payload, stream=False
+        )
+
+    def finalize_stable_capability(
+        *,
+        status: str,
+        result_class: str,
+        error_code: str | None = None,
+        actual_model: str | None = None,
+        client_cancelled: bool = False,
+        hard_failure: bool = False,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+        request_id: str | None = None,
+        storage_already_finalized: bool = False,
+    ) -> dict[str, object] | None:
+        nonlocal stable_chat_run_finalized
+        if (
+            not use_stable_chat
+            or stable_chat_dispatch is None
+            or stable_chat_run_finalized
+        ):
+            return None
+        e2e_ms = (
+            (time.perf_counter() - stable_chat_started_at) * 1000
+            if stable_chat_started_at is not None
+            else None
+        )
+        reason_codes = [f"provider_chat_{stable_chat_capability}_managed"]
+        if stable_capability_model_calls > 1:
+            reason_codes.append("provider_chat_multi_step_same_target")
+        if error_code:
+            reason_codes.append(error_code)
+        if not storage_already_finalized:
+            stable_chat_service.complete(
+                stable_chat_dispatch,
+                status=status,
+                result_class=result_class,
+                error_code=error_code,
+                actual_model=actual_model or payload.model_id,
+                client_cancelled=client_cancelled,
+                hard_failure=hard_failure,
+                e2e_ms=e2e_ms,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+                reason_codes=reason_codes,
+            )
+        stable_chat_run_finalized = True
+        return stable_chat_service.route_receipt(
+            stable_chat_dispatch,
+            requested_model=payload.model_id,
+            actual_model=actual_model or payload.model_id,
+            reason_codes=reason_codes,
+            e2e_ms=e2e_ms,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            request_id=request_id,
+        )
+
     try:
         rate_limit_or_raise(client_ip(request))
         validate_chat_file_request(payload)
         await validate_chat_output_request(
             payload,
             gateway_url=url,
+            verify_legacy_target=not stable_chat_shape_requested,
             direct_audio_requested=direct_audio_requested,
             direct_video_requested=direct_video_requested,
             direct_file_requested=direct_file_requested,
@@ -24236,7 +24397,7 @@ async def chat(payload: ChatRequest, request: Request):
     if stable_chat_shape_requested:
         try:
             stable_chat_preflight = await stable_chat_service.begin(
-                payload.model_id, "chat_text"
+                payload.model_id, stable_chat_capability
             )
         except RouterServiceError as exc:
             return JSONResponse(
@@ -24267,6 +24428,21 @@ async def chat(payload: ChatRequest, request: Request):
             use_stable_chat = True
             url = stable_chat_dispatch.target.chat_completions_url
             key = stable_chat_dispatch.target.api_key
+
+    if (
+        payload.output_mode == "allowlisted"
+        and stable_chat_shape_requested
+        and not use_stable_chat
+        and not await model_supports_chat_output_tool(
+            payload.model_id, gateway_url=url
+        )
+    ):
+        return JSONResponse(
+            status_code=422,
+            content={
+                "error": "The exact selected model is not currently verified for tool calling."
+            },
+        )
 
     if (
         not url
@@ -24303,11 +24479,15 @@ async def chat(payload: ChatRequest, request: Request):
 
     if payload.output_mode == "allowlisted":
         try:
-            provider_tag = verified_chat_output_provider(
-                model_id=payload.model_id,
-                gateway_url=url,
+            provider_tag = (
+                None
+                if use_stable_chat
+                else verified_chat_output_provider(
+                    model_id=payload.model_id,
+                    gateway_url=url,
+                )
             )
-            if provider_tag is None:
+            if provider_tag is None and not use_stable_chat:
                 raise ChatOutputError(
                     422,
                     "output_target_not_verified",
@@ -24317,7 +24497,11 @@ async def chat(payload: ChatRequest, request: Request):
                 url=url,
                 key=key,
                 headers=llm_gateway_headers(key),
-                client_kwargs=llm_client_kwargs(),
+                client_kwargs=(
+                    ProviderChatTransport.client_kwargs()
+                    if use_stable_chat
+                    else llm_client_kwargs()
+                ),
                 model_id=payload.model_id,
                 messages=upstream_chat_messages(payload.messages),
                 temperature=payload.temperature,
@@ -24329,36 +24513,102 @@ async def chat(payload: ChatRequest, request: Request):
                 scope_id=payload.file_scope_id or "",
                 output_context_id=payload.output_context_id or "",
                 provider_tag=provider_tag,
+                response_sender=(
+                    send_stable_stream_response if use_stable_chat else None
+                ),
             )
             await record_chat_skill_application_once()
+        except RouterServiceError as exc:
+            route_receipt = finalize_stable_capability(
+                status="failed",
+                result_class="preflight_failure",
+                error_code=exc.code,
+                storage_already_finalized=not stable_chat_post_started,
+            )
+            content: dict[str, object] = {"error": exc.hint, "code": exc.code}
+            if route_receipt is not None:
+                content["route_receipt"] = route_receipt
+            return JSONResponse(status_code=exc.status_code, content=content)
         except ChatOutputError as exc:
+            managed_error_code = None
+            managed_hard_failure = False
+            result_class = (
+                "transient_failure"
+                if exc.status_code >= 500
+                else "request_failure"
+            )
+            if use_stable_chat and exc.upstream_status_code is not None:
+                (
+                    result_class,
+                    managed_error_code,
+                    managed_hard_failure,
+                ) = stable_chat_service.classify_http_failure(
+                    exc.upstream_status_code
+                )
+            error_code = managed_error_code or exc.error_code
+            route_receipt = finalize_stable_capability(
+                status="failed",
+                result_class=result_class,
+                error_code=error_code,
+                hard_failure=managed_hard_failure,
+            )
+            content: dict[str, object] = {
+                "error": exc.message,
+                "code": error_code,
+            }
+            if route_receipt is not None:
+                content["route_receipt"] = route_receipt
             return JSONResponse(
                 status_code=exc.status_code,
-                content={"error": exc.message, "code": exc.error_code},
+                content=content,
             )
         except FileAssetServiceError as exc:
+            route_receipt = finalize_stable_capability(
+                status="failed",
+                result_class="request_failure",
+                error_code=exc.error_code,
+            )
+            content = {"error": exc.message, "code": exc.error_code}
+            if route_receipt is not None:
+                content["route_receipt"] = route_receipt
             return JSONResponse(
                 status_code=exc.status_code,
-                content={"error": exc.message, "code": exc.error_code},
+                content=content,
             )
         except Exception:
             logger.warning(
                 "Chat output request failed model=%s code=output_chat_failed",
                 payload.model_id,
             )
+            route_receipt = finalize_stable_capability(
+                status="uncertain",
+                result_class="uncertain",
+                error_code="output_chat_failed",
+            )
+            content = {
+                "error": "The selected model could not complete the file-output turn.",
+                "code": "output_chat_failed",
+            }
+            if route_receipt is not None:
+                content["route_receipt"] = route_receipt
             return JSONResponse(
                 status_code=503,
-                content={
-                    "error": "The selected model could not complete the file-output turn.",
-                    "code": "output_chat_failed",
-                },
+                content=content,
             )
 
         usage = output_result.usage
         input_tokens = usage.get("prompt_tokens") or usage.get("input_tokens")
         output_tokens = usage.get("completion_tokens") or usage.get("output_tokens")
         total_tokens = usage.get("total_tokens")
-        receipt = {
+        receipt = finalize_stable_capability(
+            status="succeeded",
+            result_class="success",
+            actual_model=output_result.actual_model,
+            prompt_tokens=input_tokens,
+            completion_tokens=output_tokens,
+            total_tokens=total_tokens,
+            request_id=output_result.request_id,
+        ) or {
             "requested_model": payload.model_id,
             "actual_model": output_result.actual_model,
             "provider": None,
@@ -24892,9 +25142,6 @@ async def chat(payload: ChatRequest, request: Request):
     chat_canary_post_started = False
     chat_canary_run_finalized = False
     chat_canary_started_at: float | None = None
-    stable_chat_post_started = False
-    stable_chat_run_finalized = False
-    stable_chat_started_at: float | None = None
     if chat_canary_requested:
         if use_chat_canary:
             try:
@@ -25140,6 +25387,26 @@ async def chat(payload: ChatRequest, request: Request):
     if payload.tool_mode == "mcp_tools":
         chat_event_store = RuntimeEventStore()
         chat_audit_store = InMemoryToolAuditStore()
+        tool_actual_model_id = payload.model_id
+        tool_usage: dict[str, int] = {}
+
+        def observe_tool_actual_model(value: str) -> None:
+            nonlocal tool_actual_model_id
+            reported_model_id = value.strip()
+            if not reported_model_id:
+                return
+            if use_stable_chat and reported_model_id != payload.model_id:
+                raise RouterServiceError(
+                    "provider_chat_actual_model_mismatch",
+                    "Managed Chat 返回了不同模型，本次工具决策未执行。",
+                    status_code=502,
+                )
+            tool_actual_model_id = reported_model_id
+
+        def observe_tool_usage(values: dict[str, int]) -> None:
+            for metric, value in values.items():
+                tool_usage[metric] = tool_usage.get(metric, 0) + max(0, int(value))
+
         requested_tools = parse_chat_tool_names(payload.tool_names)
         chat_run = await run_registry.create_run(
             "chat",
@@ -25216,8 +25483,20 @@ async def chat(payload: ChatRequest, request: Request):
                     model_id_override=(
                         actual_model_id if use_native_router else None
                     ),
-                    gateway_url=url if use_native_router else None,
-                    gateway_key=key if use_native_router else None,
+                    gateway_url=url if use_native_router or use_stable_chat else None,
+                    gateway_key=key if use_native_router or use_stable_chat else None,
+                    response_sender=(
+                        send_stable_json_response if use_stable_chat else None
+                    ),
+                    client_kwargs_override=(
+                        ProviderChatTransport.client_kwargs()
+                        if use_stable_chat
+                        else None
+                    ),
+                    actual_model_observer=(
+                        observe_tool_actual_model if use_stable_chat else None
+                    ),
+                    usage_observer=(observe_tool_usage if use_stable_chat else None),
                 ):
                     if tool_ttft_ms is None and delta:
                         tool_ttft_ms = (
@@ -25298,9 +25577,63 @@ async def chat(payload: ChatRequest, request: Request):
                             "version": "2",
                         }
                     )
+                managed_receipt = finalize_stable_capability(
+                    status="succeeded",
+                    result_class="success",
+                    actual_model=tool_actual_model_id,
+                    prompt_tokens=(
+                        tool_usage.get("prompt_tokens")
+                        or tool_usage.get("input_tokens")
+                    ),
+                    completion_tokens=(
+                        tool_usage.get("completion_tokens")
+                        or tool_usage.get("output_tokens")
+                    ),
+                    total_tokens=tool_usage.get("total_tokens"),
+                )
+                if managed_receipt is not None:
+                    yield route_receipt_sse(managed_receipt)
+            except asyncio.CancelledError:
+                runtime_status = "cancelled"
+                runtime_error = "client cancelled"
+                finalize_stable_capability(
+                    status="cancelled",
+                    result_class="client_cancelled",
+                    error_code="provider_chat_client_cancelled",
+                    actual_model=tool_actual_model_id,
+                    client_cancelled=True,
+                    prompt_tokens=(
+                        tool_usage.get("prompt_tokens")
+                        or tool_usage.get("input_tokens")
+                    ),
+                    completion_tokens=(
+                        tool_usage.get("completion_tokens")
+                        or tool_usage.get("output_tokens")
+                    ),
+                    total_tokens=tool_usage.get("total_tokens"),
+                )
+                try:
+                    await run_registry.update_run(
+                        chat_run.run_id,
+                        status="cancelled",
+                        error=runtime_error,
+                        metadata={
+                            "output_length": len("".join(accumulated_chunks))
+                        },
+                    )
+                except Exception as update_exc:
+                    logger.warning(
+                        "Chat runtime run cancellation update failed: %s",
+                        update_exc,
+                    )
+                raise
             except Exception as exc:
                 runtime_status = "error"
-                runtime_error = str(exc)
+                runtime_error = (
+                    "Managed Chat 工具路径执行失败，请检查控制面 Receipt。"
+                    if use_stable_chat
+                    else str(exc)
+                )
                 if use_native_router and native_plan is not None:
                     native_router_engine.record_outcome(
                         native_plan,
@@ -25312,12 +25645,59 @@ async def chat(payload: ChatRequest, request: Request):
                         * 1000,
                         outcome="tool_runtime_error",
                     )
-                logger.warning("Runtime chat toolset failed: %s", exc)
+                managed_result_class = "request_failure"
+                managed_hard_failure = False
+                if isinstance(exc, RouterServiceError):
+                    managed_error_code = exc.code
+                    if not stable_chat_post_started:
+                        managed_result_class = "preflight_failure"
+                elif use_stable_chat and isinstance(
+                    exc, ChatCompletionUpstreamError
+                ):
+                    (
+                        managed_result_class,
+                        managed_error_code,
+                        managed_hard_failure,
+                    ) = stable_chat_service.classify_http_failure(
+                        exc.status_code
+                    )
+                else:
+                    managed_error_code = "provider_chat_tool_runtime_error"
+                managed_receipt = finalize_stable_capability(
+                    status="failed",
+                    result_class=managed_result_class,
+                    error_code=managed_error_code,
+                    actual_model=tool_actual_model_id,
+                    hard_failure=managed_hard_failure,
+                    prompt_tokens=(
+                        tool_usage.get("prompt_tokens")
+                        or tool_usage.get("input_tokens")
+                    ),
+                    completion_tokens=(
+                        tool_usage.get("completion_tokens")
+                        or tool_usage.get("output_tokens")
+                    ),
+                    total_tokens=tool_usage.get("total_tokens"),
+                    storage_already_finalized=(
+                        isinstance(exc, RouterServiceError)
+                        and not stable_chat_post_started
+                    ),
+                )
+                if use_stable_chat:
+                    logger.warning(
+                        "Managed Chat toolset failed model=%s code=%s",
+                        payload.model_id,
+                        managed_error_code,
+                    )
+                    checkpoint_summary = managed_error_code
+                else:
+                    logger.warning("Runtime chat toolset failed: %s", exc)
+                    checkpoint_summary = str(exc)[:500]
                 await record_chat_checkpoint(
                     chat_run.run_id,
                     event_type="chat.failed",
                     title="Chat toolset failed",
-                    summary=str(exc)[:500],
+                    summary=checkpoint_summary,
                     severity="error",
                     metadata={"model_id": payload.model_id},
                 )
@@ -25330,7 +25710,9 @@ async def chat(payload: ChatRequest, request: Request):
                     )
                 except Exception as update_exc:
                     logger.warning("Chat runtime run failure update failed: %s", update_exc)
-                yield chat_sse_error(str(exc))
+                if managed_receipt is not None:
+                    yield route_receipt_sse(managed_receipt)
+                yield chat_sse_error(runtime_error)
             finally:
                 if runtime_status == "completed":
                     await record_chat_skill_application_once()
@@ -25344,7 +25726,8 @@ async def chat(payload: ChatRequest, request: Request):
                         )
                     except Exception as update_exc:
                         logger.warning("Chat runtime run completion update failed: %s", update_exc)
-                yield b"data: [DONE]\n\n"
+                if runtime_status != "cancelled":
+                    yield b"data: [DONE]\n\n"
                 await close_request_client()
                 await finalize_runtime(
                     runtime_status,

--- a/server/model_router/chat_stable.py
+++ b/server/model_router/chat_stable.py
@@ -169,6 +169,25 @@ class ProviderChatStableService:
         )
 
     def mark_dispatched(self, dispatch: ProviderChatStableDispatch) -> None:
+        try:
+            self.ensure_dispatch_current(dispatch)
+        except RouterServiceError as exc:
+            self._complete_preflight_attempt(dispatch.attempt_id, exc.code)
+            self._repository_method("complete_chat_control_run")(
+                self.router_service.tenant_id,
+                dispatch.run_id,
+                status="failed",
+                result_class="preflight_failure",
+                reason_codes=[exc.code],
+            )
+            raise
+        self._repository_method("mark_chat_control_attempt_dispatched")(
+            self.router_service.tenant_id, dispatch.attempt_id
+        )
+
+    def ensure_dispatch_current(self, dispatch: ProviderChatStableDispatch) -> None:
+        """Fail closed if a multi-step capability drifts between model calls."""
+
         policy = self.control.get_policy()
         qualification = next(
             (
@@ -187,22 +206,11 @@ class ProviderChatStableService:
             or not qualification.valid
         ):
             code = "provider_chat_policy_or_qualification_changed"
-            self._complete_preflight_attempt(dispatch.attempt_id, code)
-            self._repository_method("complete_chat_control_run")(
-                self.router_service.tenant_id,
-                dispatch.run_id,
-                status="failed",
-                result_class="preflight_failure",
-                reason_codes=[code],
-            )
             raise RouterServiceError(
                 code,
                 "Chat 路由策略或资格已变化，请刷新设置后重试。",
                 status_code=409,
             )
-        self._repository_method("mark_chat_control_attempt_dispatched")(
-            self.router_service.tenant_id, dispatch.attempt_id
-        )
 
     def complete(
         self,

--- a/server/tests/test_chat_file_output.py
+++ b/server/tests/test_chat_file_output.py
@@ -202,6 +202,96 @@ async def test_native_tool_round_trip_is_exact_single_and_no_fallback(
 
 
 @pytest.mark.asyncio
+async def test_injected_sender_keeps_both_file_output_steps_on_one_target() -> None:
+    model_id = "provider/tool-model"
+    arguments = json.dumps(
+        {"format_id": "plain_text", "filename": "report.txt", "content": "hello"},
+        separators=(",", ":"),
+    )
+    observed_urls: list[str] = []
+    sent_payloads: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        observed_urls.append(str(request.url))
+        if len(observed_urls) == 1:
+            return _sse(
+                [
+                    {
+                        "model": model_id,
+                        "choices": [
+                            {
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "call_1",
+                                            "function": {
+                                                "name": "modelmirror_create_file",
+                                                "arguments": arguments,
+                                            },
+                                        }
+                                    ]
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ],
+                    }
+                ],
+                request_id="req-first",
+            )
+        return _sse(
+            [
+                {
+                    "model": model_id,
+                    "choices": [
+                        {"delta": {"content": "Created."}, "finish_reason": "stop"}
+                    ],
+                }
+            ],
+            request_id="req-second",
+        )
+
+    async def send_pinned(
+        client: httpx.AsyncClient, payload: dict
+    ) -> httpx.Response:
+        sent_payloads.append(payload)
+        request = client.build_request(
+            "POST",
+            "https://8.8.8.8/v1/chat/completions",
+            headers={"Host": "provider.example"},
+            json=payload,
+        )
+        return await client.send(request, stream=True, follow_redirects=False)
+
+    service = _OutputService()
+    result = await run_chat_output_turn(
+        url="https://provider.example/v1/chat/completions",
+        key="test-key",
+        headers={},
+        client_kwargs={"transport": httpx.MockTransport(handler)},
+        model_id=model_id,
+        messages=[{"role": "user", "content": "Create a text report."}],
+        temperature=0.2,
+        max_tokens=1000,
+        top_p=None,
+        seed=None,
+        stop=None,
+        output_service=service,  # type: ignore[arg-type]
+        scope_id="chat-output-scope",
+        output_context_id="chat-output-scope",
+        response_sender=send_pinned,
+    )
+
+    assert len(sent_payloads) == 2
+    assert observed_urls == [
+        "https://8.8.8.8/v1/chat/completions",
+        "https://8.8.8.8/v1/chat/completions",
+    ]
+    assert all("provider" not in payload for payload in sent_payloads)
+    assert result.output is not None and result.output.status == "completed"
+
+
+@pytest.mark.asyncio
 async def test_model_replacement_is_rejected_before_any_file_render() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return _sse(
@@ -294,6 +384,7 @@ async def test_output_request_is_fail_closed_before_upstream(
 
     monkeypatch.setenv("FILE_OUTPUT_ASSETS_ENABLED", "true")
     monkeypatch.setenv("CHAT_FILE_OUTPUT_TOOL_ENABLED", "true")
+    monkeypatch.setenv("FILE_ASSET_STORE_MODE", "native")
     monkeypatch.setattr(main_module, "get_catalog_coordinator", lambda: _Catalog())
     with pytest.raises(Exception) as smart:
         await validate_chat_output_request(
@@ -320,6 +411,7 @@ async def test_output_gate_accepts_only_real_provider_verified_target(
 ) -> None:
     monkeypatch.setenv("FILE_OUTPUT_ASSETS_ENABLED", "true")
     monkeypatch.setenv("CHAT_FILE_OUTPUT_TOOL_ENABLED", "true")
+    monkeypatch.setenv("FILE_ASSET_STORE_MODE", "native")
     monkeypatch.setattr(
         main_module,
         "get_catalog_coordinator",
@@ -365,6 +457,7 @@ async def test_output_capabilities_expose_only_luna_on_exact_openrouter_connecti
 ) -> None:
     monkeypatch.setenv("FILE_OUTPUT_ASSETS_ENABLED", "true")
     monkeypatch.setenv("CHAT_FILE_OUTPUT_TOOL_ENABLED", "true")
+    monkeypatch.setenv("FILE_ASSET_STORE_MODE", "native")
     monkeypatch.setenv(
         "LLM_GATEWAY_URL",
         "https://openrouter.ai/api/v1/chat/completions",
@@ -402,6 +495,55 @@ async def test_output_capabilities_expose_only_luna_on_exact_openrouter_connecti
     assert qwen.json()["interaction_status"] == "planned"
     assert wrong_connection.status_code == 200
     assert wrong_connection.json()["interaction_status"] == "planned"
+
+
+@pytest.mark.asyncio
+async def test_output_capabilities_follow_managed_file_qualification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FILE_OUTPUT_ASSETS_ENABLED", "true")
+    monkeypatch.setenv("CHAT_FILE_OUTPUT_TOOL_ENABLED", "true")
+    monkeypatch.setenv("FILE_ASSET_STORE_MODE", "native")
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+
+    class _ManagedControl:
+        available = True
+
+        def __init__(self, _service: object) -> None:
+            pass
+
+        @staticmethod
+        def feature_enabled() -> bool:
+            return True
+
+        def public_status(self, model_id: str, capability: str) -> SimpleNamespace:
+            assert model_id in {"openai/gpt-4o-mini", "openai/gpt-5.6-luna"}
+            assert capability == "chat_file_output"
+            return SimpleNamespace(
+                effective_mode="newapi_preferred",
+                available=self.available,
+            )
+
+    monkeypatch.setattr(file_api_module, "ProviderChatControlService", _ManagedControl)
+    monkeypatch.setattr(file_api_module, "get_model_router_service", object)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        managed = await client.get(
+            "/api/files/output-capabilities",
+            params={"purpose": "chat", "model_id": "openai/gpt-4o-mini"},
+        )
+        _ManagedControl.available = False
+        fail_closed = await client.get(
+            "/api/files/output-capabilities",
+            params={"purpose": "chat", "model_id": "openai/gpt-5.6-luna"},
+        )
+
+    assert managed.status_code == 200
+    assert managed.json()["interaction_status"] == "ready"
+    assert fail_closed.status_code == 200
+    assert fail_closed.json()["interaction_status"] == "planned"
 
 
 def test_output_reuse_binding_is_all_or_none_and_uses_exact_model(

--- a/server/tests/test_file_output_assets.py
+++ b/server/tests/test_file_output_assets.py
@@ -79,6 +79,15 @@ def test_output_capability_is_fail_closed(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert workflow.interaction_status == "ready"
     assert "reuse" not in workflow_formats["png"].actions
 
+    legacy_service = FileOutputService(
+        FileAssetService(storage_dir=tmp_path / "legacy", mode="legacy")
+    )
+    legacy = legacy_service.capabilities(
+        purpose="chat", model_id="model-1", verified_chat_tool=True
+    )
+    assert legacy.interaction_status == "disabled"
+    assert legacy.status_reason == "The unified file asset store is disabled."
+
 
 def test_publish_list_preview_download_and_delete_are_scope_safe(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/server/tests/test_provider_chat_stable_chat.py
+++ b/server/tests/test_provider_chat_stable_chat.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import sqlite3
@@ -26,6 +27,7 @@ from server.model_router.egress import ProviderEgressPolicy
 from server.model_router.schemas import (
     ProviderChatControlPolicyUpdate,
     ProviderChatControlRouteUpdate,
+    RouterConnectionUpdate,
 )
 
 
@@ -42,7 +44,11 @@ async def client():
 
 
 def _qualified_connection(
-    repository: SQLiteRouterRepository, *, name: str, kind: str
+    repository: SQLiteRouterRepository,
+    *,
+    name: str,
+    kind: str,
+    capabilities: tuple[str, ...] = ("chat_text",),
 ) -> str:
     connection = repository.create_connection(
         "local",
@@ -86,30 +92,36 @@ def _qualified_connection(
         catalog_fingerprint=f"catalog-{connection.id}",
         observed_at="2026-08-21T00:00:00+00:00",
     )
-    certification, created = repository.claim_chat_certification(
-        "local",
-        certification_id=f"cert-{connection.id}",
-        connection_id=connection.id,
-        connection_fingerprint=fingerprint,
-        contract_version="modelmirror-provider-chat-v1",
-        capability="chat_text",
-        requested_model=MODEL_ID,
-        idempotency_key_hash=hashlib.sha256(connection.id.encode()).hexdigest(),
-    )
-    assert created is True
-    repository.complete_chat_certification(
-        "local",
-        str(certification["id"]),
-        status="passed",
-        checks={"capability_verified": True},
-        warning_codes=[],
-        actual_model=MODEL_ID,
-    )
+    for capability in capabilities:
+        certification, created = repository.claim_chat_certification(
+            "local",
+            certification_id=f"cert-{capability}-{connection.id}",
+            connection_id=connection.id,
+            connection_fingerprint=fingerprint,
+            contract_version="modelmirror-provider-chat-v1",
+            capability=capability,
+            requested_model=MODEL_ID,
+            idempotency_key_hash=hashlib.sha256(
+                f"{capability}:{connection.id}".encode()
+            ).hexdigest(),
+        )
+        assert created is True
+        repository.complete_chat_certification(
+            "local",
+            str(certification["id"]),
+            status="passed",
+            checks={"capability_verified": True},
+            warning_codes=[],
+            actual_model=MODEL_ID,
+        )
     return connection.id
 
 
 def _service(
-    tmp_path: Path, *, block_primary: bool = False
+    tmp_path: Path,
+    *,
+    block_primary: bool = False,
+    capabilities: tuple[str, ...] = ("chat_text",),
 ) -> tuple[ModelRouterService, SQLiteRouterRepository, str, str]:
     repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
 
@@ -122,9 +134,17 @@ def _service(
         repository,
         egress_policy=ProviderEgressPolicy(resolver=resolve),
     )
-    newapi_id = _qualified_connection(repository, name="newAPI", kind="newapi")
+    newapi_id = _qualified_connection(
+        repository,
+        name="newAPI",
+        kind="newapi",
+        capabilities=capabilities,
+    )
     backup_id = _qualified_connection(
-        repository, name="OpenRouter", kind="openrouter"
+        repository,
+        name="OpenRouter",
+        kind="openrouter",
+        capabilities=capabilities,
     )
     ProviderChatControlService(service).update_policy(
         ProviderChatControlPolicyUpdate(
@@ -133,9 +153,10 @@ def _service(
             stable_model_ids=[MODEL_ID],
             routes=[
                 ProviderChatControlRouteUpdate(
-                    capability="chat_text",
+                    capability=capability,
                     connection_ids=[newapi_id, backup_id],
                 )
+                for capability in capabilities
             ],
         )
     )
@@ -190,6 +211,12 @@ def _fake_client(
     class FakeClient:
         def __init__(self, *args, **kwargs):
             self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, _exc_type, _exc, _tb):
+            return None
 
         def build_request(self, method, url, **kwargs):
             return {"method": method, "url": str(url), **kwargs}
@@ -553,3 +580,515 @@ async def test_disabled_flag_preserves_legacy_gateway_bytes_and_no_receipt(
     assert sent[0]["url"] == "https://legacy.example/v1/chat/completions"
     assert "event: route_receipt" not in response.text
     assert repository.list_chat_control_receipts("local")["runs"] == []
+
+
+@pytest.mark.asyncio
+async def test_preferred_tool_mode_uses_qualified_managed_route_and_receipt(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, newapi_id, _backup_id = _service(
+        tmp_path, capabilities=("chat_text", "chat_tools")
+    )
+    configure_model_router(service)
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("", ""))
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, _exc_type, _exc, _tb):
+            return None
+
+        def build_request(self, method, url, **kwargs):
+            return {"method": method, "url": str(url), **kwargs}
+
+        async def send(self, request, *, stream, follow_redirects=False):
+            sent.append({**request, "stream": stream})
+            return _FakeResponse(status_code=200, chunks=[])
+
+        async def aclose(self):
+            return None
+
+    async def fake_tool_stream(_payload, **kwargs):
+        assert kwargs["client_kwargs_override"]["trust_env"] is False
+        sender = kwargs["response_sender"]
+        assert sender is not None
+        response = await sender(
+            FakeClient(),
+            {
+                "model": MODEL_ID,
+                "messages": [{"role": "user", "content": "private tool text"}],
+            },
+        )
+        assert response.status_code == 200
+        kwargs["actual_model_observer"](MODEL_ID)
+        kwargs["usage_observer"](
+            {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3}
+        )
+        yield "managed tool final"
+
+    monkeypatch.setattr(main_module.httpx, "AsyncClient", FakeClient)
+    monkeypatch.setattr(main_module, "stream_chat_toolset_text", fake_tool_stream)
+    try:
+        response = await client.post(
+            "/api/chat",
+            json={
+                "model_id": MODEL_ID,
+                "gateway": "default",
+                "messages": [{"role": "user", "content": "private user text"}],
+                "tool_mode": "mcp_tools",
+                "tool_names": "fetch",
+            },
+        )
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 200, response.text
+    assert len(sent) == 1
+    assert sent[0]["stream"] is False
+    assert sent[0]["url"] == "https://8.8.8.8/v1/chat/completions"
+    assert sent[0]["headers"]["Host"] == "newapi.example"
+    receipt_event = next(
+        item
+        for item in response.text.split("\n\n")
+        if item.startswith("event: route_receipt")
+    )
+    receipt = json.loads(receipt_event.split("data:", 1)[1].strip())
+    assert receipt["engine"] == "newapi"
+    assert "provider_chat_chat_tools_managed" in receipt["reason_codes"]
+    stored = repository.list_chat_control_receipts("local")
+    assert stored["runs"][0]["capability"] == "chat_tools"
+    assert stored["attempts"][0]["connection_id"] == newapi_id
+    assert stored["attempts"][0]["dispatched"] == 1
+    with sqlite3.connect(repository.database_path) as database:
+        receipt_rows = repr(
+            {
+                "runs": database.execute(
+                    "SELECT * FROM provider_chat_runs"
+                ).fetchall(),
+                "attempts": database.execute(
+                    "SELECT * FROM provider_chat_attempts"
+                ).fetchall(),
+            }
+        )
+    assert "private user text" not in receipt_rows
+    assert "private tool text" not in receipt_rows
+
+
+@pytest.mark.asyncio
+async def test_preferred_tool_http_hard_failure_is_classified_and_sanitized(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, _newapi_id, _backup_id = _service(
+        tmp_path, capabilities=("chat_text", "chat_tools")
+    )
+    configure_model_router(service)
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("", ""))
+    private_error = "upstream-private-error-marker"
+
+    class FakeClient:
+        def build_request(self, method, url, **kwargs):
+            return {"method": method, "url": str(url), **kwargs}
+
+        async def send(self, _request, *, stream, follow_redirects=False):
+            return _FakeResponse(status_code=401, chunks=[])
+
+    async def failing_tool_stream(_payload, **kwargs):
+        await kwargs["response_sender"](
+            FakeClient(), {"model": MODEL_ID, "messages": []}
+        )
+        raise main_module.ChatCompletionUpstreamError(401, private_error)
+        yield "must not be reached"
+
+    monkeypatch.setattr(main_module, "stream_chat_toolset_text", failing_tool_stream)
+    caplog.set_level("WARNING")
+    try:
+        response = await client.post(
+            "/api/chat",
+            json={
+                "model_id": MODEL_ID,
+                "gateway": "default",
+                "messages": [{"role": "user", "content": "private text"}],
+                "tool_mode": "mcp_tools",
+                "tool_names": "fetch",
+            },
+        )
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 200, response.text
+    assert "provider_chat_http_401" in response.text
+    assert private_error not in response.text
+    assert private_error not in caplog.text
+    run_id = response.headers["x-modelmirror-runtime-run-id"]
+    checkpoints = await main_module.run_registry.list_checkpoints(run_id)
+    assert private_error not in repr(checkpoints)
+    receipts = repository.list_chat_control_receipts("local")
+    assert receipts["runs"][0]["hard_failure"] == 1
+    assert receipts["runs"][0]["result_class"] == "hard_failure"
+    assert receipts["attempts"][0]["error_code"] == "provider_chat_http_401"
+
+
+@pytest.mark.asyncio
+async def test_preferred_tool_client_cancel_finalizes_receipt_without_done_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, _newapi_id, _backup_id = _service(
+        tmp_path, capabilities=("chat_text", "chat_tools")
+    )
+    configure_model_router(service)
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("", ""))
+
+    class FakeClient:
+        def build_request(self, method, url, **kwargs):
+            return {"method": method, "url": str(url), **kwargs}
+
+        async def send(self, _request, *, stream, follow_redirects=False):
+            return _FakeResponse(status_code=200, chunks=[])
+
+    async def cancelled_tool_stream(_payload, **kwargs):
+        await kwargs["response_sender"](
+            FakeClient(), {"model": MODEL_ID, "messages": []}
+        )
+        raise asyncio.CancelledError
+        yield "must not be reached"
+
+    monkeypatch.setattr(main_module, "stream_chat_toolset_text", cancelled_tool_stream)
+    try:
+        request = main_module.Request(
+            {
+                "type": "http",
+                "asgi": {"version": "3.0"},
+                "http_version": "1.1",
+                "method": "POST",
+                "scheme": "http",
+                "path": "/api/chat",
+                "raw_path": b"/api/chat",
+                "query_string": b"",
+                "headers": [],
+                "client": ("127.0.0.1", 12345),
+                "server": ("testserver", 80),
+            }
+        )
+        response = await main_module.chat(
+            main_module.ChatRequest.model_validate(
+                {
+                    "model_id": MODEL_ID,
+                    "gateway": "default",
+                    "messages": [{"role": "user", "content": "private text"}],
+                    "tool_mode": "mcp_tools",
+                    "tool_names": "fetch",
+                }
+            ),
+            request,
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await anext(response.body_iterator)
+    finally:
+        configure_model_router(original_service)
+
+    receipts = repository.list_chat_control_receipts("local")
+    assert receipts["runs"][0]["status"] == "cancelled"
+    assert receipts["runs"][0]["client_cancelled"] == 1
+    assert receipts["attempts"][0]["status"] == "cancelled"
+    assert receipts["attempts"][0]["dispatched"] == 1
+
+
+@pytest.mark.asyncio
+async def test_preferred_tool_mode_blocks_second_step_after_policy_drift(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, newapi_id, backup_id = _service(
+        tmp_path, capabilities=("chat_text", "chat_tools")
+    )
+    configure_model_router(service)
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("", ""))
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, _exc_type, _exc, _tb):
+            return None
+
+        def build_request(self, method, url, **kwargs):
+            return {"method": method, "url": str(url), **kwargs}
+
+        async def send(self, request, *, stream, follow_redirects=False):
+            sent.append(request)
+            return _FakeResponse(status_code=200, chunks=[])
+
+        async def aclose(self):
+            return None
+
+    async def drifting_tool_stream(_payload, **kwargs):
+        sender = kwargs["response_sender"]
+        assert sender is not None
+        await sender(FakeClient(), {"model": MODEL_ID, "messages": []})
+        repository.update_connection(
+            "local",
+            newapi_id,
+            RouterConnectionUpdate(base_url="https://changed.example/v1"),
+        )
+        await sender(FakeClient(), {"model": MODEL_ID, "messages": []})
+        yield "must not be reached"
+
+    monkeypatch.setattr(main_module.httpx, "AsyncClient", FakeClient)
+    monkeypatch.setattr(
+        main_module, "stream_chat_toolset_text", drifting_tool_stream
+    )
+    try:
+        response = await client.post(
+            "/api/chat",
+            json={
+                "model_id": MODEL_ID,
+                "gateway": "default",
+                "messages": [{"role": "user", "content": "private user text"}],
+                "tool_mode": "mcp_tools",
+                "tool_names": "fetch",
+            },
+        )
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 200, response.text
+    assert len(sent) == 1
+    assert "provider_chat_policy_or_qualification_changed" in response.text
+    assert "event: route_receipt" in response.text
+    receipts = repository.list_chat_control_receipts("local")
+    assert len(receipts["attempts"]) == 1
+    assert receipts["attempts"][0]["connection_id"] == newapi_id
+    assert receipts["attempts"][0]["connection_id"] != backup_id
+    assert receipts["attempts"][0]["dispatched"] == 1
+    assert receipts["runs"][0]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_preferred_tool_mode_rejects_actual_model_mismatch(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, _newapi_id, _backup_id = _service(
+        tmp_path, capabilities=("chat_text", "chat_tools")
+    )
+    configure_model_router(service)
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("", ""))
+
+    class FakeClient:
+        def build_request(self, method, url, **kwargs):
+            return {"method": method, "url": str(url), **kwargs}
+
+        async def send(self, _request, *, stream, follow_redirects=False):
+            return _FakeResponse(status_code=200, chunks=[])
+
+    async def mismatched_tool_stream(_payload, **kwargs):
+        await kwargs["response_sender"](
+            FakeClient(), {"model": MODEL_ID, "messages": []}
+        )
+        kwargs["actual_model_observer"]("provider/substituted-model")
+        yield "must not be reached"
+
+    monkeypatch.setattr(
+        main_module, "stream_chat_toolset_text", mismatched_tool_stream
+    )
+    try:
+        response = await client.post(
+            "/api/chat",
+            json={
+                "model_id": MODEL_ID,
+                "gateway": "default",
+                "messages": [{"role": "user", "content": "private text"}],
+                "tool_mode": "mcp_tools",
+                "tool_names": "fetch",
+            },
+        )
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 200, response.text
+    assert "provider_chat_actual_model_mismatch" in response.text
+    assert "must not be reached" not in response.text
+    receipts = repository.list_chat_control_receipts("local")
+    assert receipts["runs"][0]["status"] == "failed"
+    assert receipts["attempts"][0]["error_code"] == (
+        "provider_chat_actual_model_mismatch"
+    )
+
+
+@pytest.mark.asyncio
+async def test_preferred_file_output_uses_managed_target_without_vendor_hint(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, _newapi_id, _backup_id = _service(
+        tmp_path, capabilities=("chat_text", "chat_file_output")
+    )
+    configure_model_router(service)
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    monkeypatch.setenv("FILE_OUTPUT_ASSETS_ENABLED", "true")
+    monkeypatch.setenv("CHAT_FILE_OUTPUT_TOOL_ENABLED", "true")
+    _disable_runtime(monkeypatch)
+    monkeypatch.setattr(main_module.httpx, "AsyncClient", _fake_client(sent))
+    try:
+        response = await client.post(
+            "/api/chat",
+            json={
+                "model_id": MODEL_ID,
+                "gateway": "default",
+                "messages": [{"role": "user", "content": "private file request"}],
+                "file_scope_id": "chat-session-1",
+                "output_mode": "allowlisted",
+                "output_context_id": "turn-1",
+            },
+        )
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 200, response.text
+    assert len(sent) == 1
+    assert sent[0]["url"] == "https://8.8.8.8/v1/chat/completions"
+    assert sent[0]["headers"]["Host"] == "newapi.example"
+    assert "provider" not in sent[0]["json"]
+    receipt_event = next(
+        item
+        for item in response.text.split("\n\n")
+        if item.startswith("event: route_receipt")
+    )
+    receipt = json.loads(receipt_event.split("data:", 1)[1].strip())
+    assert receipt["engine"] == "newapi"
+    assert "provider_chat_chat_file_output_managed" in receipt["reason_codes"]
+    stored = repository.list_chat_control_receipts("local")
+    assert stored["runs"][0]["capability"] == "chat_file_output"
+    assert stored["attempts"][0]["dispatched"] == 1
+
+
+@pytest.mark.asyncio
+async def test_preferred_file_output_preserves_managed_http_hard_failure(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, _newapi_id, _backup_id = _service(
+        tmp_path, capabilities=("chat_text", "chat_file_output")
+    )
+    configure_model_router(service)
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    monkeypatch.setenv("FILE_OUTPUT_ASSETS_ENABLED", "true")
+    monkeypatch.setenv("CHAT_FILE_OUTPUT_TOOL_ENABLED", "true")
+    _disable_runtime(monkeypatch)
+    monkeypatch.setattr(
+        main_module.httpx,
+        "AsyncClient",
+        _fake_client(sent, status_code=401),
+    )
+    try:
+        response = await client.post(
+            "/api/chat",
+            json={
+                "model_id": MODEL_ID,
+                "gateway": "default",
+                "messages": [{"role": "user", "content": "private file request"}],
+                "file_scope_id": "chat-session-1",
+                "output_mode": "allowlisted",
+                "output_context_id": "turn-1",
+            },
+        )
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 502, response.text
+    payload = response.json()
+    assert payload["code"] == "provider_chat_http_401"
+    assert payload["route_receipt"]["reason_codes"][-1] == (
+        "provider_chat_http_401"
+    )
+    receipts = repository.list_chat_control_receipts("local")
+    assert receipts["runs"][0]["hard_failure"] == 1
+    assert receipts["runs"][0]["result_class"] == "hard_failure"
+    assert receipts["attempts"][0]["error_code"] == "provider_chat_http_401"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_update",
+    [
+        {"tool_mode": "mcp_tools", "tool_names": "fetch"},
+        {
+            "output_mode": "allowlisted",
+            "file_scope_id": "chat-session-1",
+            "output_context_id": "turn-1",
+        },
+    ],
+)
+async def test_specialized_capabilities_never_borrow_text_qualification_or_legacy(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    request_update: dict[str, object],
+) -> None:
+    original_service = get_model_router_service()
+    service, repository, _newapi_id, _backup_id = _service(tmp_path)
+    configure_model_router(service)
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    monkeypatch.setenv("FILE_OUTPUT_ASSETS_ENABLED", "true")
+    monkeypatch.setenv("CHAT_FILE_OUTPUT_TOOL_ENABLED", "true")
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("https://legacy.example/v1/chat/completions", "legacy-secret"),
+    )
+    request = _request()
+    request.update(request_update)
+    try:
+        response = await client.post("/api/chat", json=request)
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 503, response.text
+    payload = response.json()
+    assert payload["code"] == "provider_chat_no_qualified_route"
+    assert payload["route_receipt"]["engine"] == "managed_chat_blocked"
+    stored = repository.list_chat_control_receipts("local")
+    assert stored["runs"][0]["capability"] in {
+        "chat_tools",
+        "chat_file_output",
+    }
+    assert all(item["dispatched"] == 0 for item in stored["attempts"])

--- a/server/tests/test_xpert_runtime_chat.py
+++ b/server/tests/test_xpert_runtime_chat.py
@@ -531,7 +531,7 @@ async def test_chat_tool_mode_answer_streams_final_text(
         "collect_chat_completion_text",
         fake_collect_chat_completion_text,
     )
-    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    monkeypatch.setattr(main_module, "chat_mcp_provider", provider)
     try:
         response = await client.post(
             "/api/chat",
@@ -572,7 +572,7 @@ async def test_chat_tool_mode_calls_runtime_toolset(
         "collect_chat_completion_text",
         fake_collect_chat_completion_text,
     )
-    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    monkeypatch.setattr(main_module, "chat_mcp_provider", provider)
     try:
         response = await client.post(
             "/api/chat",
@@ -642,7 +642,7 @@ async def test_chat_tool_mode_rejects_tool_outside_allowlist(
         "collect_chat_completion_text",
         fake_collect_chat_completion_text,
     )
-    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    monkeypatch.setattr(main_module, "chat_mcp_provider", provider)
     try:
         response = await client.post(
             "/api/chat",
@@ -703,7 +703,7 @@ async def test_chat_tool_mode_failure_records_failed_run(
         "collect_chat_completion_text",
         fake_collect_chat_completion_text,
     )
-    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    monkeypatch.setattr(main_module, "chat_mcp_provider", provider)
     try:
         response = await client.post(
             "/api/chat",
@@ -814,11 +814,13 @@ class FakeChatToolProvider:
 
 def _install_fake_chat_tool_provider():
     provider = FakeChatToolProvider()
-    original = main_module.runtime_capabilities.require("mcp_tools").implementation
-    main_module.runtime_capabilities.register("mcp_tools", provider)
+    original = main_module.runtime_capabilities.require(
+        "chat_mcp_tools"
+    ).implementation
+    main_module.runtime_capabilities.register("chat_mcp_tools", provider)
 
     def restore_provider() -> None:
-        main_module.runtime_capabilities.register("mcp_tools", original)
+        main_module.runtime_capabilities.register("chat_mcp_tools", original)
 
     return provider, restore_provider
 

--- a/server/tests/test_xpert_runtime_toolset.py
+++ b/server/tests/test_xpert_runtime_toolset.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from server.xpert_runtime import (
+    CatalogMCPToolsetProvider,
     CapabilityRegistry,
     MCPToolsetProvider,
     RuntimeTool,
@@ -141,3 +142,115 @@ def test_register_mcp_toolset_capability() -> None:
     capability = registry.require("mcp_tools")
     assert capability.implementation is provider
     assert capability.metadata["provider"] == "mcp"
+
+
+@pytest.mark.asyncio
+async def test_catalog_toolset_exposes_only_connected_chat_safe_tools() -> None:
+    service = SimpleNamespace(
+        list_adapters=lambda: {
+            "adapters": [
+                {
+                    "project_id": "time-mcp",
+                    "connected": True,
+                    "executable": True,
+                    "tool_policies": {
+                        "get_current_time": {
+                            "read_only": True,
+                            "requires_approval": False,
+                            "sensitive": False,
+                            "terminal": False,
+                            "effect": "read",
+                        },
+                        "write_time": {
+                            "read_only": False,
+                            "requires_approval": True,
+                            "sensitive": False,
+                            "terminal": False,
+                            "effect": "state-write",
+                        },
+                    },
+                },
+                {
+                    "project_id": "offline-mcp",
+                    "connected": False,
+                    "executable": True,
+                    "tool_policies": {},
+                },
+            ]
+        },
+        list_tools=AsyncMock(
+            return_value={
+                "tools": [
+                    {
+                        "name": "get_current_time",
+                        "description": "Current time",
+                        "inputSchema": {"type": "object"},
+                    },
+                    {"name": "write_time", "inputSchema": {"type": "object"}},
+                ]
+            }
+        ),
+    )
+
+    tools = await CatalogMCPToolsetProvider(service).list_tools()
+
+    assert [tool.name for tool in tools] == ["get_current_time"]
+    assert tools[0].provider == "mcp_catalog"
+    assert tools[0].server_id == "catalog:time-mcp"
+    assert tools[0].read_only is True
+    assert tools[0].requires_approval is False
+    service.list_tools.assert_awaited_once_with("time-mcp")
+
+
+@pytest.mark.asyncio
+async def test_catalog_toolset_calls_through_catalog_policy_service() -> None:
+    policy = {
+        "read_only": True,
+        "requires_approval": False,
+        "sensitive": False,
+        "terminal": False,
+        "effect": "read",
+    }
+    service = SimpleNamespace(
+        list_adapters=lambda: {
+            "adapters": [
+                {
+                    "project_id": "time-mcp",
+                    "connected": True,
+                    "executable": True,
+                    "tool_policies": {"get_current_time": policy},
+                }
+            ]
+        },
+        list_tools=AsyncMock(
+            return_value={
+                "tools": [
+                    {
+                        "name": "get_current_time",
+                        "inputSchema": {"type": "object"},
+                    }
+                ]
+            }
+        ),
+        call_tool=AsyncMock(
+            return_value={
+                "content": [{"type": "text", "text": "12:00 UTC"}],
+                "is_error": False,
+            }
+        ),
+    )
+    provider = CatalogMCPToolsetProvider(service)
+
+    result = await provider.call_tool(
+        RuntimeToolCall(
+            tool_name="get_current_time",
+            arguments={"timezone": "UTC"},
+        )
+    )
+
+    assert result.output == "12:00 UTC"
+    assert result.metadata["catalog_project_id"] == "time-mcp"
+    assert result.metadata["content_types"] == ["text"]
+    service.call_tool.assert_awaited_once_with(
+        "time-mcp", "get_current_time", {"timezone": "UTC"}
+    )

--- a/server/xpert_runtime/__init__.py
+++ b/server/xpert_runtime/__init__.py
@@ -150,6 +150,7 @@ from .toolset import (
     ToolsetProvider,
     register_mcp_toolset_capability,
 )
+from .catalog_toolset import CatalogMCPToolsetProvider
 from .tool_runner import run_tool_with_runtime
 from .hub_toolset import HubMCPToolsetProvider
 from .sandbox_api import configure_runtime_sandbox, router as runtime_sandbox_router
@@ -313,6 +314,7 @@ __all__ = [
     "validate_goal_plan",
     "InMemoryToolAuditStore",
     "MCPToolsetProvider",
+    "CatalogMCPToolsetProvider",
     "CompositeMCPToolsetProvider",
     "HubMCPToolsetProvider",
     "KnowledgeToolsetProvider",

--- a/server/xpert_runtime/catalog_toolset.py
+++ b/server/xpert_runtime/catalog_toolset.py
@@ -1,0 +1,146 @@
+"""Policy-preserving Runtime adapter for connected MCP Catalog tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .toolset import (
+    RuntimeTool,
+    RuntimeToolCall,
+    RuntimeToolError,
+    RuntimeToolResult,
+)
+
+
+class CatalogMCPToolsetProvider:
+    """Expose only connected, read-only Catalog tools without approval gates."""
+
+    def __init__(self, service: Any) -> None:
+        self.service = service
+
+    async def list_tools(self) -> list[RuntimeTool]:
+        payload = self.service.list_adapters()
+        adapters = payload.get("adapters") if isinstance(payload, dict) else []
+        tools: list[RuntimeTool] = []
+        seen: set[str] = set()
+        for adapter in adapters if isinstance(adapters, list) else []:
+            if not isinstance(adapter, dict):
+                continue
+            if not adapter.get("connected") or not adapter.get("executable"):
+                continue
+            project_id = str(adapter.get("project_id") or "").strip()
+            policies = adapter.get("tool_policies")
+            if not project_id or not isinstance(policies, dict):
+                continue
+            try:
+                discovered = await self.service.list_tools(project_id)
+            except Exception:
+                # A stale catalog session must not disable other connected tools.
+                continue
+            raw_tools = (
+                discovered.get("tools") if isinstance(discovered, dict) else []
+            )
+            for raw_tool in raw_tools if isinstance(raw_tools, list) else []:
+                if not isinstance(raw_tool, dict):
+                    continue
+                name = str(raw_tool.get("name") or "").strip()
+                policy = policies.get(name)
+                if not name or name in seen or not _chat_safe_policy(policy):
+                    continue
+                seen.add(name)
+                tools.append(
+                    RuntimeTool(
+                        name=name,
+                        description=str(raw_tool.get("description") or ""),
+                        input_schema=_dict(
+                            raw_tool.get("inputSchema")
+                            or raw_tool.get("input_schema")
+                        ),
+                        provider="mcp_catalog",
+                        server_id=f"catalog:{project_id}",
+                        metadata={
+                            "catalog_project_id": project_id,
+                            "catalog_tool_name": name,
+                            "retry_on_failure": True,
+                        },
+                        read_only=True,
+                        requires_approval=False,
+                        sensitive=False,
+                        terminal=False,
+                        parallel_safe=False,
+                        public_app_allowed=False,
+                    )
+                )
+        return tools
+
+    async def find_tool(self, tool_name: str) -> RuntimeTool | None:
+        return next(
+            (tool for tool in await self.list_tools() if tool.name == tool_name),
+            None,
+        )
+
+    async def call_tool(self, call: RuntimeToolCall) -> RuntimeToolResult:
+        tool = await self.find_tool(call.tool_name)
+        if tool is None:
+            raise RuntimeToolError(
+                call.tool_name,
+                "Catalog tool not found or is not safe for Chat Runtime",
+                code="tool_not_found",
+            )
+        project_id = str(tool.metadata.get("catalog_project_id") or "")
+        try:
+            payload = await self.service.call_tool(
+                project_id,
+                call.tool_name,
+                dict(call.arguments),
+            )
+        except Exception as exc:
+            raise RuntimeToolError(
+                call.tool_name,
+                str(exc) or exc.__class__.__name__,
+                code="catalog_tool_call_error",
+            ) from exc
+        content = [
+            dict(item)
+            for item in payload.get("content", [])
+            if isinstance(item, dict)
+        ] if isinstance(payload, dict) else []
+        output = "\n\n".join(
+            str(item.get("text") or "")
+            for item in content
+            if item.get("type") == "text" and item.get("text")
+        )
+        return RuntimeToolResult(
+            output=output,
+            content=content,
+            metadata={
+                "provider": "mcp_catalog",
+                "catalog_project_id": project_id,
+                "content_types": sorted(
+                    {str(item.get("type") or "unknown") for item in content}
+                ),
+                "retry_on_failure": True,
+            },
+            is_error=bool(
+                isinstance(payload, dict)
+                and (payload.get("is_error") or payload.get("isError"))
+            ),
+        )
+
+
+def _chat_safe_policy(value: Any) -> bool:
+    return bool(
+        isinstance(value, dict)
+        and value.get("read_only") is True
+        and value.get("requires_approval") is not True
+        and value.get("sensitive") is not True
+        and value.get("terminal") is not True
+        and value.get("effect", "read") == "read"
+    )
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+__all__ = ["CatalogMCPToolsetProvider"]


### PR DESCRIPTION
## 摘要

- 将 gateway=default 的 MCP 工具与受控文件输出分别接入 chat_tools、chat_file_output 的 Managed Provider 路由和 v15 Receipt。
- Direct Chat 只暴露已连接、只读、无需审批且非敏感的 Catalog MCP 工具；Workflow 与 Agent 的既有工具集不扩张。
- Provider 首次派发后固定同一 Managed Target，不允许跨连接、跨 Provider 或 legacy 重放；错误与 Receipt 保持脱敏。
- 文件存储未进入 shadow 或 native 时在能力投影阶段失败关闭，避免资格显示可用后才在付费调用末端失败。
- 更新设置说明、架构、部署文档和 R5D 任务卡；不改变公开 Chat/SSE、默认数据面、多模态、Auto、Canary、Agent、Workflow、RAG、Coding 或 Catalog 数量口径。

## 验证

- 最新 origin/main 交叉回归：181 passed，覆盖 R5D、MCP Hub 可信发布、Skill Hook、审批和 Workflow Agent。
- 前端：99 个测试文件、533 tests passed；typecheck 和 production build 通过。
- 后端全量：3959 passed、29 skipped、20 个既有环境失败；失败集合与基线一致。
- Core Compose、独立 newAPI Compose 和可选互联 Overlay 均通过 config --quiet。
- 独立预览器已重建到 rebased HEAD：后端健康、设置页 200、文件输出资格 qualified，数据卷和既有生成文件在重启后保留，启动日志无错误或警告。
- 真实额度验收：MCP 工具和文件输出均只产生一次 OpenRouter Provider 尝试；请求模型与实际模型一致，Receipt 与真实目标一致，无派发后回退。
- Router SQLite 和服务日志不保存用户提示、模型回复或文件正文；文件卷只保存用户明确请求的生成产物。
- git diff --check 和敏感信息扫描通过。

## 已知基线失败

- 14 项 Agency Worker：测试镜像中的独立测试挂载缺少 Worker 构建产物。
- 3 项 Expert Team Agency：同一 Worker 环境缺口。
- 1 项 Skill Finder 与 2 项 Skill semantic rerank：Python/TypeScript 索引测试环境缺口。
- 上述 20 项在 R5D 前后保持一致，不属于本 PR 回归。

## 回滚

- 将 MODEL_CONTROL_CHAT_ENABLED=false 并重启即可恢复 legacy Chat 路径。
- 保留 v15 Receipt、Router SQLite、Provider 凭据、newAPI 数据和文件卷；本 PR 不执行数据库迁移或数据删除。
- 本 PR 不批准 newAPI required 默认切换、部署上线或任何多租户/计费能力。
