### PR TITLE
feature: 完成 Provider Chat required Go/No-Go 门禁

### DIFF
--- a/client/src/components/settings/ProviderChatControlSettings.test.tsx
+++ b/client/src/components/settings/ProviderChatControlSettings.test.tsx
@@ -21,25 +21,40 @@ const policy = {
   qualifications: [],
 };
 
+const collectingGate = {
+  feature_enabled: false,
+  configured_mode: "legacy",
+  ready: false,
+  required_activation_available: false,
+  required_active: false,
+  epoch_status: "collecting",
+  hard_failure_code: null,
+  minimum_request_count: 500,
+  minimum_observed_days: 14,
+  minimum_success_rate: 0.99,
+  request_count: 0,
+  success_count: 0,
+  hard_failure_count: 0,
+  observed_days: 0,
+  success_rate: null,
+  model_progress: [],
+  required_drills: ["auth_failure"],
+  approval_recorded: false,
+  acceptance_evidence_complete: false,
+  acceptance_evidence: [],
+  blocking_reason_codes: ["provider_chat_gate_request_count_insufficient"],
+};
+
 describe("ProviderChatControlSettings", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("describes the bounded R5D data plane and saves an atomic revisioned policy", async () => {
+  it("describes the bounded R5E gate and saves an atomic revisioned policy", async () => {
     const calls: Array<[RequestInfo | URL, RequestInit | undefined]> = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       calls.push([input, init]);
       const url = String(input);
       if (url.endsWith("/chat-control/gate")) {
-        return new Response(
-          JSON.stringify({
-            ready: false,
-            required_activation_available: false,
-            request_count: 0,
-            observed_days: 0,
-            success_rate: null,
-            blocking_reason_codes: ["provider_chat_required_gate_pending_r5e"],
-          }),
-        );
+        return new Response(JSON.stringify(collectingGate));
       }
       if (url.endsWith("/connections")) {
         return new Response(
@@ -74,10 +89,10 @@ describe("ProviderChatControlSettings", () => {
     });
 
     render(<ProviderChatControlSettings csrfToken="csrf-test" />);
-    expect(await screen.findByText("R5D 稳定路由与逐能力执行")).toBeInTheDocument();
-    expect(screen.getByText(/default 普通文本、MCP 工具与受控文件输出/)).toBeInTheDocument();
-    expect(screen.getByText(/能力之间不能互借认证/)).toBeInTheDocument();
-    expect(screen.getByText(/Auto 继续沿用 Native 或 OmniRoute/)).toBeInTheDocument();
+    expect(await screen.findByText("R5E 资格证据与 required 门禁")).toBeInTheDocument();
+    expect(screen.getByText(/真实普通文本样本、逐模型成功数和故障演练证据/)).toBeInTheDocument();
+    expect(screen.getByText(/Auto、工具、文件和多模态不会计入/)).toBeInTheDocument();
+    expect(screen.getByText(/正在收集资格证据/)).toBeInTheDocument();
     expect(
       (screen.getByRole("option", { name: /newapi_required_default/ }) as HTMLOptionElement)
         .disabled,
@@ -110,6 +125,100 @@ describe("ProviderChatControlSettings", () => {
     });
     expect(put?.[1]?.headers).toMatchObject({
       "X-ModelMirror-CSRF": "csrf-test",
+    });
+  });
+
+  it("requires every Go/No-Go acknowledgement before activating required", async () => {
+    const calls: Array<[RequestInfo | URL, RequestInit | undefined]> = [];
+    const readyPolicy = {
+      ...policy,
+      feature_enabled: true,
+      configured_mode: "newapi_preferred",
+      effective_mode: "newapi_preferred",
+      revision: 7,
+      stable_model_ids: ["provider/model"],
+    };
+    const readyGate = {
+      ...collectingGate,
+      feature_enabled: true,
+      configured_mode: "newapi_preferred",
+      ready: true,
+      required_activation_available: true,
+      epoch_status: "ready",
+      request_count: 500,
+      success_count: 500,
+      observed_days: 14,
+      success_rate: 1,
+      model_progress: [
+        {
+          model_id: "provider/model",
+          success_count: 500,
+          minimum_success_count: 10,
+          ready: true,
+        },
+      ],
+      blocking_reason_codes: [],
+    };
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      calls.push([input, init]);
+      const url = String(input);
+      if (init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            ...readyGate,
+            required_activation_available: false,
+            required_active: true,
+            epoch_status: "active",
+          }),
+        );
+      }
+      if (url.endsWith("/chat-control/gate")) {
+        return new Response(JSON.stringify(readyGate));
+      }
+      if (url.endsWith("/connections")) return new Response(JSON.stringify([]));
+      return new Response(JSON.stringify(readyPolicy));
+    });
+
+    render(<ProviderChatControlSettings csrfToken="csrf-activate" />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "开始 Go/No-Go" }),
+    );
+    const activateButton = screen.getByRole("button", {
+      name: "激活 newAPI 强制默认",
+    });
+    expect(activateButton).toBeDisabled();
+
+    fireEvent.click(screen.getByText("当前没有未解决 P0/P1"));
+    fireEvent.click(screen.getByText("确认 required 的失败关闭语义"));
+    fireEvent.click(screen.getByText("故障演练：401 / 403 认证失败"));
+    fireEvent.click(screen.getByText("newAPI 额度扣减差额已核对"));
+    fireEvent.click(screen.getByText("newAPI Token 用量日志已关联"));
+    fireEvent.click(screen.getByText("newAPI 重启后持久化已验证"));
+    fireEvent.change(screen.getByLabelText("newAPI 验收关联引用"), {
+      target: { value: "acceptance-log-20260822" },
+    });
+    expect(activateButton).toBeEnabled();
+    fireEvent.click(activateButton);
+
+    await waitFor(() => {
+      expect(calls.some(([, init]) => init?.method === "POST")).toBe(true);
+    });
+    const post = calls.find(([, init]) => init?.method === "POST");
+    expect(String(post?.[0])).toContain(
+      "/api/router/chat-control/gate/activate-required",
+    );
+    expect(JSON.parse(String(post?.[1]?.body))).toMatchObject({
+      expected_revision: 7,
+      no_open_p0_p1: true,
+      acknowledge_fail_closed: true,
+      drills: { auth_failure: true },
+      newapi_correlation_reference: "acceptance-log-20260822",
+      quota_decrement_verified: true,
+      usage_log_verified: true,
+      restart_persistence_verified: true,
+    });
+    expect(post?.[1]?.headers).toMatchObject({
+      "X-ModelMirror-CSRF": "csrf-activate",
     });
   });
 });

--- a/client/src/components/settings/ProviderChatControlSettings.tsx
+++ b/client/src/components/settings/ProviderChatControlSettings.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  AlertTriangle,
   ArrowDown,
   ArrowUp,
+  CheckCircle2,
   LoaderCircle,
+  LockKeyhole,
   Plus,
   RefreshCw,
   Save,
@@ -53,13 +56,52 @@ interface PolicyResponse {
 }
 
 interface GateResponse {
+  feature_enabled: boolean;
+  configured_mode: ChatControlMode;
   ready: boolean;
   required_activation_available: boolean;
+  required_active: boolean;
+  epoch_status?: string | null;
+  hard_failure_code?: string | null;
+  minimum_request_count: number;
+  minimum_observed_days: number;
+  minimum_success_rate: number;
   request_count: number;
+  success_count: number;
+  hard_failure_count: number;
   observed_days: number;
   success_rate?: number | null;
+  model_progress: Array<{
+    model_id: string;
+    success_count: number;
+    minimum_success_count: number;
+    ready: boolean;
+  }>;
+  required_drills: string[];
+  approval_recorded: boolean;
+  acceptance_evidence_complete: boolean;
+  acceptance_evidence: Array<{
+    evidence_kind: string;
+    passed: boolean;
+    observed_at: string;
+  }>;
   blocking_reason_codes: string[];
 }
+
+const DRILL_LABELS: Record<string, string> = {
+  auth_failure: "401 / 403 认证失败",
+  http_429: "429 限流",
+  http_5xx: "5xx 上游故障",
+  connect_timeout: "连接超时",
+  read_timeout: "读取超时",
+  empty_stream: "空流",
+  invalid_sse: "非法 SSE",
+  stream_interrupted: "流中断",
+  service_restart: "服务重启",
+  credential_invalid: "凭据失效",
+  data_plane_offline: "数据面离线",
+  preferred_fallback: "preferred 派发前回退",
+};
 
 const CAPABILITIES: Array<{
   value: ChatCapability;
@@ -134,6 +176,15 @@ export default function ProviderChatControlSettings({
   );
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [activating, setActivating] = useState(false);
+  const [showActivation, setShowActivation] = useState(false);
+  const [noOpenP0P1, setNoOpenP0P1] = useState(false);
+  const [acknowledgeFailClosed, setAcknowledgeFailClosed] = useState(false);
+  const [verifiedDrills, setVerifiedDrills] = useState<Record<string, boolean>>({});
+  const [quotaDecrementVerified, setQuotaDecrementVerified] = useState(false);
+  const [usageLogVerified, setUsageLogVerified] = useState(false);
+  const [restartPersistenceVerified, setRestartPersistenceVerified] = useState(false);
+  const [correlationReference, setCorrelationReference] = useState("");
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
 
@@ -175,6 +226,28 @@ export default function ProviderChatControlSettings({
           connection.enabled && (connection.scopes ?? []).includes("chat"),
       ),
     [connections],
+  );
+
+  const activationComplete = useMemo(
+    () =>
+      Boolean(gate?.required_activation_available) &&
+      noOpenP0P1 &&
+      acknowledgeFailClosed &&
+      Boolean(gate?.required_drills.every((drill) => verifiedDrills[drill])) &&
+      quotaDecrementVerified &&
+      usageLogVerified &&
+      restartPersistenceVerified &&
+      correlationReference.trim().length >= 8,
+    [
+      acknowledgeFailClosed,
+      correlationReference,
+      gate,
+      noOpenP0P1,
+      quotaDecrementVerified,
+      restartPersistenceVerified,
+      usageLogVerified,
+      verifiedDrills,
+    ],
   );
 
   const setRouteAt = (
@@ -271,17 +344,71 @@ export default function ProviderChatControlSettings({
     }
   }, [autoEnabled, csrfToken, load, mode, policy, routes, stableModelsText]);
 
+  const activateRequired = useCallback(async () => {
+    if (!policy || !gate?.required_activation_available || !activationComplete) return;
+    setActivating(true);
+    setError("");
+    setMessage("");
+    try {
+      const response = await fetch(
+        "/api/router/chat-control/gate/activate-required",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-ModelMirror-CSRF": csrfToken,
+          },
+          body: JSON.stringify({
+            expected_revision: policy.revision,
+            no_open_p0_p1: noOpenP0P1,
+            acknowledge_fail_closed: acknowledgeFailClosed,
+            drills: Object.fromEntries(
+              gate.required_drills.map((drill) => [drill, Boolean(verifiedDrills[drill])]),
+            ),
+            newapi_correlation_reference: correlationReference.trim(),
+            quota_decrement_verified: quotaDecrementVerified,
+            usage_log_verified: usageLogVerified,
+            restart_persistence_verified: restartPersistenceVerified,
+          }),
+        },
+      );
+      if (!response.ok) throw new Error(await readError(response));
+      setCorrelationReference("");
+      setShowActivation(false);
+      setMessage(
+        "newapi_required_default 已经人工激活；普通文本硬失败将保持 required 并失败关闭，不会自动回退。",
+      );
+      await load();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "required 激活失败。");
+    } finally {
+      setActivating(false);
+    }
+  }, [
+    acknowledgeFailClosed,
+    activationComplete,
+    correlationReference,
+    csrfToken,
+    gate,
+    load,
+    noOpenP0P1,
+    policy,
+    quotaDecrementVerified,
+    restartPersistenceVerified,
+    usageLogVerified,
+    verifiedDrills,
+  ]);
+
   return (
     <section className="mb-6 overflow-hidden rounded-lg border border-cyan-300/15 bg-ink-950/82 shadow-prism">
       <div className="border-b border-white/10 bg-cyan-300/[0.04] px-5 py-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p className="text-sm font-semibold text-cyan-100">Managed Chat 控制策略</p>
-            <h2 className="mt-2 text-xl font-semibold text-white">R5D 稳定路由与逐能力执行</h2>
+            <h2 className="mt-2 text-xl font-semibold text-white">R5E 资格证据与 required 门禁</h2>
             <p className="mt-2 max-w-[78ch] text-sm leading-6 text-slate-300">
-              newapi_preferred 按独立资格接管白名单内的 default 普通文本、MCP 工具与受控文件输出；能力之间不能互借认证。
-              Auto 继续沿用 Native 或 OmniRoute 的现有选路，仅在独立门禁开启时写入脱敏运行与尝试证据。
-              工具执行和文件渲染仍由 ModelMirror Runtime 完成；多模态和 Canary 保持各自现有路径。
+              汇总当前资格纪元内的真实普通文本样本、逐模型成功数和故障演练证据。达到自动门槛后仍需人工完成 Go/No-Go，
+              才能将普通文本从 newapi_preferred 切换为失败关闭的 newapi_required_default；Auto、工具、文件和多模态不会计入该门禁。
             </p>
           </div>
           <button
@@ -317,7 +444,7 @@ export default function ProviderChatControlSettings({
                 <option value="legacy">legacy（保持现有静态路径）</option>
                 <option value="newapi_preferred">newapi_preferred（受部署总开关控制）</option>
                 <option disabled value="newapi_required_default">
-                  newapi_required_default（等待 R5E）
+                  newapi_required_default（仅通过 Go/No-Go 激活）
                 </option>
               </select>
             </label>
@@ -402,20 +529,151 @@ export default function ProviderChatControlSettings({
             </div>
           ) : null}
 
-          <div className="rounded-lg border border-amber-300/15 bg-amber-300/[0.04] p-4 text-xs text-amber-50/80">
-            <p className="font-semibold text-amber-100">required 门禁：尚不可激活</p>
-            <p className="mt-1">
-              {gate?.request_count ?? 0}/500 次 · {gate?.observed_days ?? 0}/14 天 ·
-              成功率 {gate?.success_rate == null ? "暂无样本" : `${Math.round(gate.success_rate * 1000) / 10}%`}
-            </p>
-            <p className="mt-1 break-all text-slate-500">
-              {(gate?.blocking_reason_codes ?? []).join(" · ")}
-            </p>
-          </div>
+          {gate ? (
+            <div
+              className={`rounded-lg border p-4 text-xs ${
+                gate.required_active
+                  ? "border-emerald-300/20 bg-emerald-300/[0.05]"
+                  : gate.epoch_status === "degraded"
+                    ? "border-rose-300/20 bg-rose-300/[0.05]"
+                    : "border-amber-300/15 bg-amber-300/[0.04]"
+              }`}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="flex items-center gap-2 font-semibold text-white">
+                    {gate.required_active ? (
+                      <CheckCircle2 className="h-4 w-4 text-emerald-300" />
+                    ) : gate.epoch_status === "degraded" ? (
+                      <AlertTriangle className="h-4 w-4 text-rose-300" />
+                    ) : (
+                      <LockKeyhole className="h-4 w-4 text-amber-200" />
+                    )}
+                    required 门禁：
+                    {gate.required_active
+                      ? "已人工激活"
+                      : gate.epoch_status === "degraded"
+                        ? "硬失败降级"
+                        : gate.required_activation_available
+                          ? "自动门槛已通过，等待人工 Go/No-Go"
+                          : "正在收集资格证据"}
+                  </p>
+                  <p className="mt-2 text-slate-300">
+                    {gate.request_count}/{gate.minimum_request_count} 次 · {Math.round(gate.observed_days * 10) / 10}/
+                    {gate.minimum_observed_days} 天 · 成功 {gate.success_count} 次 · 成功率 {gate.success_rate == null ? "暂无样本" : `${Math.round(gate.success_rate * 1000) / 10}%`}
+                    （门槛 {Math.round(gate.minimum_success_rate * 100)}%）
+                  </p>
+                  <p className="mt-1 text-slate-400">
+                    硬失败 {gate.hard_failure_count} 次 · 资格纪元 {gate.epoch_status ?? "未建立"}
+                    {gate.hard_failure_code ? ` · ${gate.hard_failure_code}` : ""}
+                  </p>
+                </div>
+                {gate.required_activation_available && !gate.required_active ? (
+                  <button
+                    className="rounded-full border border-amber-200/30 px-3 py-1.5 font-semibold text-amber-100"
+                    onClick={() => setShowActivation((current) => !current)}
+                    type="button"
+                  >
+                    {showActivation ? "收起 Go/No-Go" : "开始 Go/No-Go"}
+                  </button>
+                ) : null}
+              </div>
+
+              {gate.model_progress.length ? (
+                <div className="mt-3 grid gap-2 md:grid-cols-2">
+                  {gate.model_progress.map((item) => (
+                    <p className="rounded border border-white/10 px-2.5 py-2 text-slate-300" key={item.model_id}>
+                      {item.ready ? "已达标" : "待补样本"} · {item.model_id} · {item.success_count}/{item.minimum_success_count}
+                    </p>
+                  ))}
+                </div>
+              ) : null}
+
+              {gate.acceptance_evidence.length ? (
+                <p className="mt-3 text-slate-300">
+                  newAPI 有界验收：{gate.acceptance_evidence.map((item) => `${item.passed ? "通过" : "失败"} · ${item.evidence_kind}`).join("；")}
+                </p>
+              ) : null}
+
+              {gate.blocking_reason_codes.length ? (
+                <p className="mt-3 break-all text-slate-500">
+                  阻塞：{gate.blocking_reason_codes.join(" · ")}
+                </p>
+              ) : null}
+
+              {gate.epoch_status === "degraded" ? (
+                <p className="mt-3 rounded border border-rose-300/15 px-3 py-2 leading-5 text-rose-100">
+                  required 保持失败关闭，不会自动退回 preferred 或 legacy。管理员需先将策略显式退回 preferred，重新认证并建立新的资格纪元。
+                </p>
+              ) : null}
+
+              {showActivation && gate.required_activation_available && !gate.required_active ? (
+                <div className="mt-4 border-t border-white/10 pt-4">
+                  <p className="font-semibold text-white">最终人工确认</p>
+                  <p className="mt-1 max-w-[90ch] leading-5 text-amber-50/80">
+                    激活后，普通文本必须经首选 newAPI；派发前不合格或派发后失败都不会调用第二个 Provider。此操作不启用 Auto，也不改变工具、文件或多模态路径。
+                  </p>
+                  <div className="mt-3 grid gap-2 md:grid-cols-2">
+                    <label className="flex items-start gap-2 text-slate-200">
+                      <input checked={noOpenP0P1} className="mt-0.5 accent-cyan-300" onChange={(event) => setNoOpenP0P1(event.target.checked)} type="checkbox" />
+                      当前没有未解决 P0/P1
+                    </label>
+                    <label className="flex items-start gap-2 text-slate-200">
+                      <input checked={acknowledgeFailClosed} className="mt-0.5 accent-cyan-300" onChange={(event) => setAcknowledgeFailClosed(event.target.checked)} type="checkbox" />
+                      确认 required 的失败关闭语义
+                    </label>
+                    {gate.required_drills.map((drill) => (
+                      <label className="flex items-start gap-2 text-slate-300" key={drill}>
+                        <input
+                          checked={Boolean(verifiedDrills[drill])}
+                          className="mt-0.5 accent-cyan-300"
+                          onChange={(event) => setVerifiedDrills((current) => ({ ...current, [drill]: event.target.checked }))}
+                          type="checkbox"
+                        />
+                        故障演练：{DRILL_LABELS[drill] ?? drill}
+                      </label>
+                    ))}
+                    <label className="flex items-start gap-2 text-slate-300">
+                      <input checked={quotaDecrementVerified} className="mt-0.5 accent-cyan-300" onChange={(event) => setQuotaDecrementVerified(event.target.checked)} type="checkbox" />
+                      newAPI 额度扣减差额已核对
+                    </label>
+                    <label className="flex items-start gap-2 text-slate-300">
+                      <input checked={usageLogVerified} className="mt-0.5 accent-cyan-300" onChange={(event) => setUsageLogVerified(event.target.checked)} type="checkbox" />
+                      newAPI Token 用量日志已关联
+                    </label>
+                    <label className="flex items-start gap-2 text-slate-300">
+                      <input checked={restartPersistenceVerified} className="mt-0.5 accent-cyan-300" onChange={(event) => setRestartPersistenceVerified(event.target.checked)} type="checkbox" />
+                      newAPI 重启后持久化已验证
+                    </label>
+                  </div>
+                  <label className="mt-3 block max-w-2xl font-semibold text-slate-200">
+                    newAPI 验收关联引用
+                    <input
+                      autoComplete="off"
+                      className="mt-1.5 w-full rounded-lg border border-white/15 bg-slate-950 px-3 py-2 font-mono text-xs text-white"
+                      onChange={(event) => setCorrelationReference(event.target.value)}
+                      placeholder="输入可回查的验收批次或日志引用（不会保存原文）"
+                      type="password"
+                      value={correlationReference}
+                    />
+                  </label>
+                  <button
+                    className="mt-4 inline-flex items-center gap-2 rounded-full bg-rose-200 px-4 py-2 font-semibold text-rose-950 disabled:opacity-40"
+                    disabled={!activationComplete || activating}
+                    onClick={() => void activateRequired()}
+                    type="button"
+                  >
+                    {activating ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <LockKeyhole className="h-4 w-4" />}
+                    激活 newAPI 强制默认
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
 
           <button
             className="inline-flex items-center gap-2 rounded-full bg-cyan-200 px-4 py-2 text-sm font-semibold text-slate-950 disabled:opacity-45"
-            disabled={saving}
+            disabled={saving || mode === "newapi_required_default"}
             onClick={() => void save()}
             type="button"
           >

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -168,7 +168,7 @@ Round 5B 将 `gateway=default` 的白名单普通文本和已提取文本附件�
 目录、凭据或 DNS/SSRF 预检失败且尚未派发 POST 时选择显式 Managed 备用。一旦 POST
 标记派发，HTTP 错误、超时、断流和不确定结果都不得调用第二 IP、Provider、模型或
 legacy 网关。Auto、工具、受控文件输出、多模态、Canary、SSE 成功字节和默认部署值
-保持不变；`newapi_required_default` 仍等待 R5E 门禁与人工批准。
+保持不变；该阶段尚未开放 `newapi_required_default`，其门禁与人工批准由 R5E 提供。
 
 Round 5C 在不改变 Auto 选路的前提下，把 `gateway=auto` 的普通文本接入同一父运行/尝试
 证据管道。该入口由租户策略中的独立 `auto_enabled` 门禁控制，默认关闭；关闭时 Auto
@@ -185,6 +185,18 @@ ModelMirror Runtime 执行，文件规格仍由 allowlisted renderer 校验和�
 获得工具凭据或本地文件权限。多步模型调用在首次派发前固定同一连接和批准 IP，后续步骤
 重新校验策略但不得切换 Provider、模型、IP 或 legacy 路径；Receipt 只保存聚合指标和
 稳定原因码，不保存消息、工具结果或生成内容。专用多模态与 Canary 行为不变。
+
+Round 5E 在 v15 表上启用普通文本资格纪元与只读证据聚合，不新增迁移。只有真实用户、
+`gateway=default`、当前策略指纹、`chat_text`、首选 newAPI 且已派发的稳定模型运行计入
+500 次、14 天、99% 和逐模型 10 次成功门槛。Auto、Canary、认证、工具、文件、备用与
+客户端取消均被排除。自动门槛只产生“可人工激活”状态，`newapi_required_default` 只能
+由带 revision、故障演练、P0/P1 声明和 newAPI 有界验收结论的管理员操作原子激活。
+
+required 运行时重新核对批准、资格纪元、策略与连接指纹，只尝试首选 newAPI；任何阶段
+不得进入备用或 legacy。硬失败会在同一证据面关闭纪元、撤销批准并令当前资格失效，策略
+仍保持 required 并失败关闭。恢复必须先由管理员显式退回 preferred、重新认证并建立新
+纪元。数据库只保存聚合运行证据、稳定原因码和外部验收关联哈希，不保存用户内容、模型
+输出、newAPI 余额或完整 Token 日志。
 
 `/settings?section=overview|providers|routing` 共用一份 Provider 管理会话。Marble 等其他
 集成位于该门禁之外；newAPI 管理 UI 继续只通过安全外链访问，不嵌入或代理。

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -97,7 +97,7 @@ docker compose -f docker-compose.yml `
 ModelMirror 不得删除该目录。newAPI 上游为带附加条款的 AGPLv3 项目；本仓库不
 嵌入或修改其管理 UI，部署者仍需自行完成许可证与业务使用合规审查。
 
-### Provider Control Plane、v14 Catalog 与 R5D Managed Chat
+### Provider Control Plane、v14 Catalog 与 R5E Managed Chat
 
 Provider 管理面仍需外部注入至少 32 字符的
 `MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET` 和规范凭据主密钥。升级到 SQLite v14
@@ -167,6 +167,18 @@ Runtime 按既有权限执行，文件仍由 allowlisted renderer 生成，Provi
 或本地文件权限。首次 Provider 派发后，多步模型决策只能继续使用同一连接和预检批准的
 IP；连接、策略或资格漂移会失败关闭，不转向备用或 legacy。关闭
 `MODEL_CONTROL_CHAT_ENABLED` 即恢复全部旧静态路径；多模态与 Canary 不受影响。
+
+R5E 不增加环境变量，也不会因部署或样本达标自动进入 required。设置页仅在当前
+preferred 策略的资格纪元达到 500 次、14 天、99%、逐稳定模型至少 10 次成功且零硬失败
+后开放 Go/No-Go 区域。管理员还必须逐项确认故障演练、无未解决 P0/P1、失败关闭语义，
+以及 newAPI 额度扣减、Token 日志关联和重启持久化。验收关联引用仅在请求内传输，SQLite
+只保存其 SHA-256 哈希；不要输入 API Key、Token 或日志正文。
+
+激活 required 后，普通文本只允许首选 newAPI，任何预检或派发后失败都不会调用备用或
+legacy。硬失败会令 Gate 标记 degraded 并撤销批准，但不会自动改变 required 策略。
+恢复时先在设置页显式退回 `newapi_preferred`，重新完成受影响模型认证并收集新资格纪元；
+不得直接修改 SQLite、伪造 Receipt 或重开旧纪元。紧急回滚可先显式退回 preferred；必要
+时关闭 `MODEL_CONTROL_CHAT_ENABLED` 并重启以恢复 legacy 路径，同时保留 v15 表和证据。
 
 Direct Chat 可以读取已连接 MCP Catalog 中明确标记为只读、无需审批、非敏感且非终止性的
 工具；调用仍经 Catalog Service 重新执行策略校验。该接入使用独立的 Chat Runtime 能力，

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -1,7 +1,7 @@
 # Model Provider Control Plane
 
-状态：Round 0–4、Round 5A–5C 已合并；Round 5D 正在接入工具与受控文件输出；默认数据面切换未批准
-Round 5D 当前基线：`origin/main@20dd124e364701ee6ac569cc8de15d102eb1a07b`
+状态：Round 0–4、Round 5A–5D 已合并；Round 5E 正在建设资格证据与 required 人工门禁；默认数据面切换未批准
+Round 5E 当前基线：`origin/main@7e543d8c02dbb0386771bcae052d38f78c33b9ce`
 更新日期：2026-08-22
 
 ## 决策
@@ -39,6 +39,8 @@ Provider Control Plane 的会话、SQLite 或主密钥。它只加入独立外�
   Auto 接入不改变选路的独立证据管道。
 - Round 5D 只迁移 MCP 工具和受控文件输出的 Provider 选择与 Receipt；工具执行、权限、
   文件渲染和专用多模态协议仍由既有 Runtime 负责。
+- Round 5E 只实现普通文本 required 资格纪元、证据聚合、故障降级和可审核人工激活；
+  代码合并、部署或自动门槛达标均不等于批准切换。
 - newAPI 是否成为强制默认数据面由后续独立决策决定。
 - 任一门禁失败时保留现有静态数据面和 SQLite，不自动迁移或删除数据。
 
@@ -160,7 +162,7 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
 - R4 受管 Provider 不会自动配置或接管普通 `/api/chat`。当前 default Chat 仍读取
   `LLM_GATEWAY_URL/KEY` 或 `OPENROUTER_API_KEY`；迁移和 newAPI 默认门禁属于 Round 5。
 
-## Managed Chat 策略、稳定路由与 Auto 证据（Round 5A—5D）
+## Managed Chat 策略、稳定路由与 required 门禁（Round 5A—5E）
 
 - 内部契约版本为 `modelmirror-provider-chat-routing-v1`，将 `chat_text`、
   `chat_tools` 和 `chat_file_output` 分别认证和配置；普通文本认证不能证明工具或受控
@@ -172,7 +174,7 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
   `running` 在重启后标为 `uncertain` 且不重放。
 - `GET/PUT /api/router/chat-control/policy` 使用 `expected_revision` 原子更新，避免覆盖并发
   管理修改。`GET /api/router/chat-control/gate` 和 receipts 接口提供只读门禁与脱敏运行
-  证据；required 激活仍不可用。
+  证据；普通策略更新不能直接进入 required。
 - R5B 只接管 `gateway=default`、稳定模型白名单内的普通文本和已提取文本附件。
   `MODEL_CONTROL_CHAT_ENABLED` 默认 `false`；关闭开关、选择 `legacy` 或使用白名单外模型
   时继续走原有静态路径。
@@ -190,8 +192,20 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
 - 工具由 ModelMirror Runtime 执行，文件由 allowlisted renderer 校验；Provider 只接收
   既有安全模型输入，不接收 MCP 凭据或本地文件权限。需要多次模型决策时保持同一连接和
   已批准 IP，策略漂移则失败关闭，不跨 Provider 重放。
-- 多模态与 Canary 不在 R5D 接入范围；`newapi_required_default` 仍等待 R5E 的证据门禁
-  与人工批准。
+- R5E 只把当前资格纪元内真实用户发起、`gateway=default`、`chat_text`、首选 newAPI
+  实际派发的稳定模型请求计入 required。Canary、认证、Auto、工具、文件、预检备用和
+  客户端取消不计入；每个稳定模型至少需要 10 次成功样本。
+- 自动门槛固定为至少 500 次合格请求、首末跨度至少 14 天、总成功率至少 99%、零硬
+  失败。达到门槛后仍需管理员确认无未解决 P0/P1、全部故障演练、required 失败关闭语义，
+  并提供 newAPI 额度扣减、Token 日志关联及重启持久化的有界验收结论。
+- `POST /api/router/chat-control/gate/activate-required` 使用策略 revision 在同一事务中复核
+  资格并记录人工批准。验收关联引用只保存 SHA-256 哈希；不保存余额、完整 newAPI 日志、
+  Prompt、回答或引用原文。该记录证明外部数据面验收，不构成 ModelMirror 计费系统。
+- required 只使用有序文本路由的首选 newAPI。任何预检或派发后失败都失败关闭，不能调用
+  备用、第二 IP 或 legacy；401/402/403、模型不一致、非法/空 SSE 或缺少终止信号会立即
+  关闭资格纪元、撤销批准并标记 degraded，但策略保持 required，不会自动降级。
+- degraded 后管理员只能显式退回 preferred，重新认证并建立新纪元；相同失败纪元不能被
+  自动重开。瞬时失败计入成功率，但不自动关闭纪元。
 - 清理命令 `python -m server.model_router.cleanup_chat_receipts --storage-dir <path>` 默认
   dry-run；只有显式增加 `--apply` 才会删除超过保留期的运行和尝试记录，默认保留 90 天。
 

--- a/docs/task-cards/provider-chat-r5e.md
+++ b/docs/task-cards/provider-chat-r5e.md
@@ -1,0 +1,93 @@
+# 任务卡：Provider Chat R5E
+
+## 1. 单一目标
+
+- 将 v15 中已预留的资格纪元、真实请求 Receipt、故障演练与人工批准收敛为
+  `newapi_required_default` 的可审核 Go/No-Go 门禁。
+- 只实现安全激活能力；合并、预览或测试均不得自动切换 required。
+
+## 2. 已证实基线
+
+| 结论 | 证据 |
+| --- | --- |
+| 当前基线 | `origin/main@0ad98935e8b0865b2c20bf6a990dac69260d5cce` |
+| R5D 已进入主线 | 合并提交 `Merge pull request #255`，R5D 提交为其祖先 |
+| v15 已预留 Gate 表 | `server/model_router/repository.py` |
+| 当前 Gate 仍是 R5E 占位 | `ProviderChatControlService.gate()` 固定返回 pending blocker |
+| required 当前不可保存 | `update_policy()` 固定拒绝 `newapi_required_default` |
+| 受管文本/工具/文件已写入 Receipt | `chat_stable.py` 与 R5D `/api/chat` 集成 |
+| 开工基线测试 | R5D Server 镜像内 37 passed；宿主机无可用 pytest，仅属环境差异 |
+
+## 实施状态
+
+- 已实现真实资格聚合、逐模型进度、故障演练清单和 revision 保护的原子人工激活。
+- required 只允许首选 newAPI；硬失败会关闭纪元、撤销批准并保持 required 失败关闭。
+- 设置页使用内联 Go/No-Go 确认；验收关联引用只在组件内存短暂存在并以哈希入库。
+- 当前实现没有自动激活 required，也没有执行默认数据面切换；经用户逐次授权，
+  已完成一次有界真实付费普通文本验收。
+
+## 当前验证证据
+
+- R5E Repository、Service、API 与 Stable Chat 专项：30 passed。
+- R5A—R5D、Certification、Canary、Auto 与文件输出交叉回归：110 passed。
+- 前端组件专项：2 passed；typecheck 与 production build 通过。
+- 前端全量：533 passed，1 个无交叉 Skill Browser 用例在并行运行中达到 5 秒超时；
+  该文件独立重跑 2 passed。
+- 最新主线后端全量：4005 passed、29 skipped、20 failed；同一未修改基线 SHA 对失败文件复现为
+  相同 20 failed、64 passed。失败均由挂载镜像缺少 Agency Worker 构建输出或 TypeScript
+  运行依赖造成，不属于 R5E 新增失败。
+- Core、新API 与 Overlay Compose 配置通过；Overlay 使用非敏感占位 URL 注入其必填变量。
+- 隔离预览完成管理配对与未达门槛页面验收：required 选项不能直接保存、Go/No-Go 入口
+  不会提前出现、页面和控制台均未回显预览配对值，Server 日志无异常。
+- 严格证伪聚焦 required、Gate 竞态、硬失败、派发后零回退、显式回退和关联引用脱敏：
+  24 passed，22 deselected；只有 4 条既有 FastAPI 生命周期弃用警告。
+- 真实 `openai/gpt-4o-mini` 调用只新增 1 个逻辑 run、1 个 position-0 newAPI attempt 和
+  1 条 newAPI 目标模型日志；token 增量为 18 input / 9 output，Receipt 与实际模型一致。
+- Server 重启后 run、attempt、newAPI 日志和 Gate 样本计数保持不变，没有自动重放；
+  当前纪元仍为 `collecting`，只累计 1 个成功样本，没有自动升级 required。
+- Router SQLite 二进制复核未发现该次固定合成 Prompt 或模型输出正文。
+- 真实调用完成于初始 R5D 基线 `7e543d8c`；验收期间主线前进到 `0ad98935`，
+  交叉 Diff 只涉及 Coding Substrate、MCP 远程认证注册和独立文档章节。R5E Diff 已无冲突
+  恢复到最新主线，并重新通过 30 项 R5E 专项、110 项 Chat 交叉回归、前端组件专项、
+  typecheck、production build 及三组 Compose 配置检查；未为无交叉漂移重复消耗额度。
+
+## 3. 范围与风险
+
+- 允许修改：v15 Gate Repository、独立 Gate Service、Chat 控制 API/Schema、稳定
+  Managed Chat required 语义、Settings Go/No-Go 区域、专项测试和控制面文档。
+- 禁止修改：公开 Catalog 数量口径、多模态、RAG、Workflow、Agent、Coding、租户、
+  积分、充值、ModelMirror 计费、newAPI UI 与默认部署值。
+- 数据影响：不升版、不重写 v15；只向既有 Gate/Receipt 表增加运行和批准记录。
+- 依赖影响：不新增或升级生产依赖。
+- 主要风险：样本误计入、硬失败后自动恢复、激活与并发运行竞态、required 静默回退、
+  把用户正文或 newAPI 日志保存为证据。
+
+## 4. 固定门禁
+
+1. 仅统计当前资格纪元、真实用户、`chat_text`、首选 newAPI position 0 已派发、
+   非 Canary/认证/Auto/预检备用/客户端取消的请求。
+2. 至少 500 个合格请求，首末跨度至少 14 天，总成功率至少 99%。
+3. 每个稳定模型至少 10 次成功；认证错误、模型不一致、非法/空 SSE 和缺失终止为零。
+4. 硬失败立即关闭纪元并撤销批准；required 保持 required 且失败关闭，不自动降级。
+5. 新纪元必须绑定新策略/资格指纹；硬失败后的旧认证不能重新开启同一纪元。
+6. 激活要求全部固定故障演练、无未解决 P0/P1、失败关闭确认，以及一次脱敏的
+   newAPI 额度扣减、用量日志关联和重启持久化结论。
+7. 激活在单个 SQLite 事务中重新检查 revision、纪元、指标和硬失败，再保存批准并
+   切换模式；PR 合并不等于激活授权。
+
+## 5. 验收
+
+- 资格计数、14 天跨度、99% 成功率、逐模型样本和零硬失败真值表通过。
+- Auto、Canary、认证、预检备用、客户端取消和非文本能力均不计入 Gate。
+- 并发激活、revision 漂移、策略/认证变化和硬失败竞态均失败关闭。
+- preferred 仍只允许派发前备用；required 只尝试首选 newAPI，任何阶段不得进入
+  第二连接、第二 IP 或 legacy。
+- Settings 显示证据、阻塞项和人工确认，不能通过普通策略保存直接进入 required。
+- R5A—R5D、Router、认证、Canary、Auto、工具、文件和前端全量回归通过。
+- 最终完成 Compose、Diff、Git 状态和敏感信息扫描；真实付费验收另行逐次授权。
+
+## 6. 回退
+
+- 管理员可显式把策略退回 `newapi_preferred`；系统不得自动退回。
+- 必要时关闭 `MODEL_CONTROL_CHAT_ENABLED` 并重启，立即恢复 legacy 路径。
+- 保留 v15 Gate、Receipt、Provider 凭据和 newAPI 数据，不执行降级或删除。

--- a/server/model_router/api.py
+++ b/server/model_router/api.py
@@ -36,6 +36,7 @@ from .schemas import (
     ProviderChatControlPolicyUpdate,
     ProviderChatControlPublicStatus,
     ProviderChatControlReceiptsResponse,
+    ProviderChatRequiredActivationRequest,
     ProviderChatCanaryAdminResponse,
     ProviderChatCanaryPolicyUpdate,
     ProviderChatCanaryPublicStatus,
@@ -342,6 +343,22 @@ def get_chat_control_gate(
 ) -> ProviderChatControlGateResponse:
     try:
         return ProviderChatControlService(get_model_router_service()).gate()
+    except (RouterServiceError, RouterRepositoryError) as exc:
+        _raise_public_error(exc)
+
+
+@router.post(
+    "/chat-control/gate/activate-required",
+    response_model=ProviderChatControlGateResponse,
+)
+def activate_required_chat_control(
+    payload: ProviderChatRequiredActivationRequest,
+    _principal: ProviderControlPrincipal = Depends(require_provider_admin_csrf),
+) -> ProviderChatControlGateResponse:
+    try:
+        return ProviderChatControlService(
+            get_model_router_service()
+        ).activate_required(payload)
     except (RouterServiceError, RouterRepositoryError) as exc:
         _raise_public_error(exc)
 

--- a/server/model_router/chat_control.py
+++ b/server/model_router/chat_control.py
@@ -7,6 +7,15 @@ import uuid
 from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 
+from .chat_gate import (
+    MIN_PROVIDER_CHAT_GATE_DAYS,
+    MIN_PROVIDER_CHAT_GATE_MODEL_SUCCESSES,
+    MIN_PROVIDER_CHAT_GATE_REQUESTS,
+    MIN_PROVIDER_CHAT_GATE_SUCCESS_RATE,
+    REQUIRED_PROVIDER_CHAT_DRILLS,
+    evaluate_provider_chat_gate,
+    validate_provider_chat_drills,
+)
 from .chat_canary import (
     DEFAULT_PROVIDER_CHAT_CERTIFICATION_MAX_AGE_SECONDS,
     MAX_PROVIDER_CHAT_CERTIFICATION_MAX_AGE_SECONDS,
@@ -18,6 +27,8 @@ from .repository import RouterCredentialUnavailable, RouterRepositoryError
 from .schemas import (
     ProviderChatCapability,
     ProviderChatControlAttemptSummary,
+    ProviderChatGateEvidenceSummary,
+    ProviderChatGateModelProgress,
     ProviderChatControlGateResponse,
     ProviderChatControlPolicyResponse,
     ProviderChatControlPolicyUpdate,
@@ -26,6 +37,7 @@ from .schemas import (
     ProviderChatControlRouteSummary,
     ProviderChatControlRunSummary,
     ProviderChatQualificationSummary,
+    ProviderChatRequiredActivationRequest,
 )
 from .service import ModelRouterService, RouterServiceError
 
@@ -65,10 +77,11 @@ class ProviderChatControlService:
         if payload.mode == "newapi_required_default":
             raise RouterServiceError(
                 "provider_chat_required_activation_not_available",
-                "强制默认必须等待 R5E 门禁和人工批准。",
+                "强制默认只能通过 required Go/No-Go 门禁人工激活。",
                 status_code=409,
             )
 
+        current_policy = self.get_policy()
         stable_models = sorted(set(payload.stable_model_ids))
         routes_by_capability = {
             route.capability: list(route.connection_ids) for route in payload.routes
@@ -90,51 +103,88 @@ class ProviderChatControlService:
                 status_code=422,
             )
 
-        connections = {}
-        normalized_routes: list[dict[str, object]] = []
-        for capability in CHAT_CONTROL_CAPABILITIES:
-            for position, connection_id in enumerate(
-                routes_by_capability[capability]
+        normalized_routes: list[dict[str, object]] = [
+            {
+                "capability": capability,
+                "position": position,
+                "connection_id": connection_id,
+            }
+            for capability in CHAT_CONTROL_CAPABILITIES
+            for position, connection_id in enumerate(routes_by_capability[capability])
+        ]
+        rollback_only = (
+            current_policy.configured_mode == "newapi_required_default"
+            and payload.mode == "newapi_preferred"
+        )
+        if rollback_only:
+            current_routes = {
+                route.capability: list(route.connection_ids)
+                for route in current_policy.routes
+            }
+            if (
+                stable_models != current_policy.stable_model_ids
+                or bool(payload.auto_enabled) != current_policy.auto_enabled
+                or any(
+                    routes_by_capability[capability]
+                    != current_routes.get(capability, [])
+                    for capability in CHAT_CONTROL_CAPABILITIES
+                )
             ):
+                raise RouterServiceError(
+                    "provider_chat_required_rollback_scope_change_not_allowed",
+                    "从 required 回退 preferred 时只能改变模式；其他策略变更需在回退后单独保存。",
+                    status_code=409,
+                )
+            bundle = self._repository_method("get_chat_control_policy_bundle")(
+                self.router_service.tenant_id
+            )
+            qualifications = [
+                {
+                    "capability": str(item["capability"]),
+                    "connection_id": str(item["connection_id"]),
+                    "model_id": str(item["model_id"]),
+                    "certification_id": str(item["certification_id"]),
+                    "connection_fingerprint": str(item["connection_fingerprint"]),
+                    "contract_version": str(item["contract_version"]),
+                }
+                for item in list(bundle.get("qualifications") or [])
+            ]
+        else:
+            connections = {}
+            for route in normalized_routes:
+                connection_id = str(route["connection_id"])
                 connection = self.repository.get_connection(
                     self.router_service.tenant_id, connection_id
                 )
                 self._validate_route_connection(connection)
                 connections[connection_id] = connection
-                normalized_routes.append(
-                    {
-                        "capability": capability,
-                        "position": position,
-                        "connection_id": connection_id,
-                    }
-                )
 
-        if text_routes:
-            primary = connections[text_routes[0]]
-            if primary.kind != "newapi":
-                raise RouterServiceError(
-                    "provider_chat_text_primary_newapi_required",
-                    "普通文本路由的第一个目标必须是 newAPI。",
-                    status_code=422,
-                )
-
-        qualifications: list[dict[str, object]] = []
-        for route in normalized_routes:
-            capability = str(route["capability"])
-            connection_id = str(route["connection_id"])
-            for model_id in stable_models:
-                qualification, reason = self._current_qualification(
-                    connection_id=connection_id,
-                    model_id=model_id,
-                    capability=capability,
-                )
-                if qualification is None:
+            if text_routes:
+                primary = connections[text_routes[0]]
+                if primary.kind != "newapi":
                     raise RouterServiceError(
-                        reason,
-                        self._qualification_hint(reason, model_id),
-                        status_code=409,
+                        "provider_chat_text_primary_newapi_required",
+                        "普通文本路由的第一个目标必须是 newAPI。",
+                        status_code=422,
                     )
-                qualifications.append(qualification)
+
+            qualifications = []
+            for route in normalized_routes:
+                capability = str(route["capability"])
+                connection_id = str(route["connection_id"])
+                for model_id in stable_models:
+                    qualification, reason = self._current_qualification(
+                        connection_id=connection_id,
+                        model_id=model_id,
+                        capability=capability,
+                    )
+                    if qualification is None:
+                        raise RouterServiceError(
+                            reason,
+                            self._qualification_hint(reason, model_id),
+                            status_code=409,
+                        )
+                    qualifications.append(qualification)
 
         fingerprint = self._fingerprint(
             mode=payload.mode,
@@ -187,15 +237,251 @@ class ProviderChatControlService:
             blockers.append("provider_chat_control_text_route_required")
         if any(not item.valid for item in policy.qualifications):
             blockers.append("provider_chat_control_qualification_stale")
-        blockers.append("provider_chat_required_gate_pending_r5e")
+        epoch = self._repository_method("get_open_chat_control_gate_epoch")(
+            self.router_service.tenant_id,
+            policy.policy_fingerprint,
+        )
+        latest_epoch = epoch or self._repository_method(
+            "get_latest_chat_control_gate_epoch"
+        )(
+            self.router_service.tenant_id,
+            policy.policy_fingerprint,
+        )
+        summary: dict[str, object] = {}
+        if latest_epoch is not None:
+            summary = self._repository_method("summarize_chat_control_gate")(
+                self.router_service.tenant_id,
+                epoch_id=str(latest_epoch["id"]),
+            )
+        evaluation = evaluate_provider_chat_gate(
+            summary,
+            stable_model_ids=policy.stable_model_ids,
+        )
+        if epoch is None:
+            blockers.append("provider_chat_gate_epoch_unavailable")
+            if latest_epoch is not None and str(latest_epoch["status"]) == "degraded":
+                blockers.append("provider_chat_gate_hard_failure_recertification_required")
+        else:
+            blockers.extend(evaluation.blocking_reason_codes)
+        approval = self._repository_method("get_chat_control_gate_approval")(
+            self.router_service.tenant_id,
+            policy_fingerprint=policy.policy_fingerprint,
+        )
+        acceptance_evidence: list[dict[str, object]] = []
+        if latest_epoch is not None:
+            acceptance_evidence = self._repository_method(
+                "list_chat_control_acceptance_evidence"
+            )(
+                self.router_service.tenant_id,
+                policy_fingerprint=policy.policy_fingerprint,
+                epoch_id=str(latest_epoch["id"]),
+            )
+        evidence_kinds = {
+            str(item["evidence_kind"])
+            for item in acceptance_evidence
+            if bool(item["passed"])
+        }
+        required_evidence = {
+            "newapi_quota_decrement",
+            "newapi_usage_log",
+            "newapi_restart_persistence",
+        }
+        evidence_complete = required_evidence <= evidence_kinds
+        required_active = bool(
+            policy.feature_enabled
+            and policy.configured_mode == "newapi_required_default"
+            and epoch is not None
+            and str(epoch["status"]) == "active"
+            and approval is not None
+            and bool(approval.get("no_open_p0_p1"))
+            and bool(approval.get("acknowledge_fail_closed"))
+            and not validate_provider_chat_drills(
+                approval.get("drills")
+                if isinstance(approval.get("drills"), dict)
+                else {}
+            )
+            and evidence_complete
+            and all(item.valid for item in policy.qualifications)
+        )
+        automatic_ready = bool(
+            epoch is not None
+            and evaluation.ready
+            and policy.feature_enabled
+            and policy.configured_mode in {
+                "newapi_preferred",
+                "newapi_required_default",
+            }
+            and policy.stable_model_ids
+            and text_routes
+            and all(item.valid for item in policy.qualifications)
+        )
+        activation_available = bool(
+            automatic_ready
+            and policy.configured_mode == "newapi_preferred"
+            and str(epoch["status"]) in {"open", "collecting", "ready"}
+        )
+        if policy.configured_mode == "newapi_preferred" and automatic_ready:
+            blockers.append("provider_chat_required_manual_approval_pending")
+        if (
+            policy.configured_mode == "newapi_required_default"
+            and not required_active
+        ):
+            blockers.append("provider_chat_required_gate_degraded")
         return ProviderChatControlGateResponse(
             contract_version=PROVIDER_CHAT_ROUTING_CONTRACT_VERSION,
             feature_enabled=policy.feature_enabled,
             data_plane_integrated=True,
             policy_fingerprint=policy.policy_fingerprint,
             configured_mode=policy.configured_mode,
+            required_activation_available=activation_available,
+            required_active=required_active,
+            ready=automatic_ready,
+            epoch_id=(str(latest_epoch["id"]) if latest_epoch is not None else None),
+            epoch_status=(
+                str(latest_epoch["status"]) if latest_epoch is not None else None
+            ),
+            epoch_started_at=(
+                str(latest_epoch["started_at"])
+                if latest_epoch is not None
+                else None
+            ),
+            epoch_closed_at=(
+                str(latest_epoch["closed_at"])
+                if latest_epoch is not None and latest_epoch.get("closed_at")
+                else None
+            ),
+            hard_failure_code=(
+                str(latest_epoch["hard_failure_code"])
+                if latest_epoch is not None and latest_epoch.get("hard_failure_code")
+                else None
+            ),
+            minimum_request_count=MIN_PROVIDER_CHAT_GATE_REQUESTS,
+            minimum_observed_days=MIN_PROVIDER_CHAT_GATE_DAYS,
+            minimum_success_rate=MIN_PROVIDER_CHAT_GATE_SUCCESS_RATE,
+            request_count=evaluation.request_count,
+            success_count=evaluation.success_count,
+            hard_failure_count=evaluation.hard_failure_count,
+            observed_days=evaluation.observed_days,
+            success_rate=evaluation.success_rate,
+            model_progress=[
+                ProviderChatGateModelProgress(
+                    model_id=model_id,
+                    success_count=evaluation.model_successes.get(model_id, 0),
+                    minimum_success_count=MIN_PROVIDER_CHAT_GATE_MODEL_SUCCESSES,
+                    ready=(
+                        evaluation.model_successes.get(model_id, 0)
+                        >= MIN_PROVIDER_CHAT_GATE_MODEL_SUCCESSES
+                    ),
+                )
+                for model_id in policy.stable_model_ids
+            ],
+            required_drills=list(REQUIRED_PROVIDER_CHAT_DRILLS),
+            approval_recorded=approval is not None,
+            acceptance_evidence_complete=evidence_complete,
+            acceptance_evidence=[
+                ProviderChatGateEvidenceSummary(
+                    evidence_kind=str(item["evidence_kind"]),
+                    passed=bool(item["passed"]),
+                    observed_at=str(item["observed_at"]),
+                )
+                for item in acceptance_evidence
+            ],
             blocking_reason_codes=list(dict.fromkeys(blockers)),
         )
+
+    def activate_required(
+        self, payload: ProviderChatRequiredActivationRequest
+    ) -> ProviderChatControlGateResponse:
+        correlation_reference = (
+            payload.newapi_correlation_reference.get_secret_value().strip()
+        )
+        if not 8 <= len(correlation_reference) <= 512:
+            raise RouterServiceError(
+                "provider_chat_gate_correlation_reference_invalid",
+                "newAPI 验收关联引用长度必须为 8 到 512 个字符。",
+                status_code=422,
+            )
+        gate = self.gate()
+        if not gate.required_activation_available or gate.epoch_id is None:
+            code = next(
+                (
+                    item
+                    for item in gate.blocking_reason_codes
+                    if item != "provider_chat_required_manual_approval_pending"
+                ),
+                "provider_chat_required_gate_not_ready",
+            )
+            raise RouterServiceError(
+                code,
+                "当前证据尚未满足 newAPI 强制默认激活门禁。",
+                status_code=409,
+            )
+        drill_errors = validate_provider_chat_drills(payload.drills)
+        if drill_errors:
+            raise RouterServiceError(
+                drill_errors[0],
+                "必须逐项完成并确认全部 required 故障演练。",
+                status_code=422,
+            )
+        if not payload.no_open_p0_p1:
+            raise RouterServiceError(
+                "provider_chat_gate_p0_p1_attestation_required",
+                "必须确认当前无未解决 P0/P1 问题。",
+                status_code=422,
+            )
+        if not payload.acknowledge_fail_closed:
+            raise RouterServiceError(
+                "provider_chat_gate_fail_closed_ack_required",
+                "必须确认 required 模式不可用时失败关闭且不会自动回退。",
+                status_code=422,
+            )
+        evidence_checks = {
+            "newapi_quota_decrement": payload.quota_decrement_verified,
+            "newapi_usage_log": payload.usage_log_verified,
+            "newapi_restart_persistence": payload.restart_persistence_verified,
+        }
+        if not all(evidence_checks.values()):
+            raise RouterServiceError(
+                "provider_chat_gate_acceptance_evidence_required",
+                "必须完成 newAPI 额度、用量日志和重启持久化验收。",
+                status_code=422,
+            )
+        try:
+            self._repository_method("activate_chat_control_required")(
+                self.router_service.tenant_id,
+                expected_revision=payload.expected_revision,
+                policy_fingerprint=gate.policy_fingerprint,
+                epoch_id=gate.epoch_id,
+                no_open_p0_p1=payload.no_open_p0_p1,
+                drills=payload.drills,
+                acknowledge_fail_closed=payload.acknowledge_fail_closed,
+                correlation_hash=hashlib.sha256(
+                    correlation_reference.encode("utf-8")
+                ).hexdigest(),
+                evidence_checks=evidence_checks,
+            )
+        except RouterRepositoryError as exc:
+            code = str(exc)
+            status_code = 409 if code.startswith("provider_chat_gate_") or code == (
+                "provider_chat_policy_revision_conflict"
+            ) else 422
+            raise RouterServiceError(
+                code,
+                "激活前证据、策略或资格已变化，请刷新后重新审查。",
+                status_code=status_code,
+            ) from exc
+        return self.gate()
+
+    def required_runtime_allowed(
+        self, policy: ProviderChatControlPolicyResponse | None = None
+    ) -> tuple[bool, str | None]:
+        current = policy or self.get_policy()
+        if current.effective_mode != "newapi_required_default":
+            return True, None
+        gate = self.gate()
+        if gate.required_active:
+            return True, None
+        return False, "provider_chat_required_gate_degraded"
 
     def public_status(
         self, model_id: str, capability: ProviderChatCapability
@@ -536,6 +822,23 @@ class ProviderChatControlService:
             return None, "provider_chat_capability_certification_stale"
         if str(certification["contract_version"]) != PROVIDER_CHAT_CONTRACT_VERSION:
             return None, "provider_chat_capability_contract_stale"
+        hard_failure_reader = getattr(
+            self.repository,
+            "get_latest_chat_control_hard_failure",
+            None,
+        )
+        if callable(hard_failure_reader):
+            hard_failure = hard_failure_reader(
+                self.router_service.tenant_id,
+                connection_id=connection_id,
+                model_id=model_id,
+                capability=capability,
+            )
+            if hard_failure is not None and self._timestamp_at_or_after(
+                hard_failure.get("completed_at"),
+                certification.get("completed_at"),
+            ):
+                return None, "provider_chat_hard_failure_recertification_required"
         time_reason = self._certification_time_status(certification)
         if time_reason is not None:
             return None, time_reason
@@ -590,7 +893,10 @@ class ProviderChatControlService:
         )
         qualified = bool(
             policy.feature_enabled
-            and policy.configured_mode == "newapi_preferred"
+            and policy.configured_mode in {
+                "newapi_preferred",
+                "newapi_required_default",
+            }
             and policy.stable_model_ids
             and text_routes
             and expected_qualifications > 0
@@ -678,6 +984,21 @@ class ProviderChatControlService:
             "provider_chat_capability_certification_stale": "当前能力认证已因连接变化而过期。",
         }
         return f"模型 {model_id} 无法加入稳定策略：{hints.get(reason, reason)}"
+
+    @staticmethod
+    def _timestamp_at_or_after(candidate: object, baseline: object) -> bool:
+        try:
+            candidate_time = datetime.fromisoformat(
+                str(candidate or "").replace("Z", "+00:00")
+            )
+            baseline_time = datetime.fromisoformat(
+                str(baseline or "").replace("Z", "+00:00")
+            )
+        except ValueError:
+            return True
+        if candidate_time.tzinfo is None or baseline_time.tzinfo is None:
+            return True
+        return candidate_time.astimezone(UTC) >= baseline_time.astimezone(UTC)
 
     def _repository_method(self, name: str):
         method = getattr(self.repository, name, None)

--- a/server/model_router/chat_gate.py
+++ b/server/model_router/chat_gate.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+
+MIN_PROVIDER_CHAT_GATE_REQUESTS = 500
+MIN_PROVIDER_CHAT_GATE_DAYS = 14.0
+MIN_PROVIDER_CHAT_GATE_SUCCESS_RATE = 0.99
+MIN_PROVIDER_CHAT_GATE_MODEL_SUCCESSES = 10
+
+REQUIRED_PROVIDER_CHAT_DRILLS = (
+    "auth_failure",
+    "http_429",
+    "http_5xx",
+    "connect_timeout",
+    "read_timeout",
+    "empty_stream",
+    "invalid_sse",
+    "stream_interrupted",
+    "service_restart",
+    "credential_invalid",
+    "data_plane_offline",
+    "preferred_fallback",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderChatGateEvaluation:
+    ready: bool
+    request_count: int
+    success_count: int
+    hard_failure_count: int
+    observed_days: float
+    success_rate: float | None
+    model_successes: dict[str, int]
+    blocking_reason_codes: tuple[str, ...]
+
+
+def evaluate_provider_chat_gate(
+    summary: Mapping[str, object],
+    *,
+    stable_model_ids: Sequence[str],
+) -> ProviderChatGateEvaluation:
+    request_count = _integer(summary.get("request_count"))
+    success_count = _integer(summary.get("success_count"))
+    hard_failure_count = _integer(summary.get("hard_failure_count"))
+    observed_days = _float(summary.get("observed_days"))
+    success_rate = (
+        success_count / request_count if request_count > 0 else None
+    )
+    raw_model_successes = summary.get("model_successes")
+    model_successes = {
+        str(model_id): _integer(count)
+        for model_id, count in (
+            raw_model_successes.items()
+            if isinstance(raw_model_successes, Mapping)
+            else []
+        )
+    }
+    blockers: list[str] = []
+    if request_count < MIN_PROVIDER_CHAT_GATE_REQUESTS:
+        blockers.append("provider_chat_gate_request_count_insufficient")
+    if observed_days < MIN_PROVIDER_CHAT_GATE_DAYS:
+        blockers.append("provider_chat_gate_observation_window_insufficient")
+    if success_rate is None or success_rate < MIN_PROVIDER_CHAT_GATE_SUCCESS_RATE:
+        blockers.append("provider_chat_gate_success_rate_insufficient")
+    if any(
+        model_successes.get(model_id, 0)
+        < MIN_PROVIDER_CHAT_GATE_MODEL_SUCCESSES
+        for model_id in stable_model_ids
+    ):
+        blockers.append("provider_chat_gate_model_samples_insufficient")
+    if hard_failure_count:
+        blockers.append("provider_chat_gate_hard_failure_observed")
+    return ProviderChatGateEvaluation(
+        ready=not blockers,
+        request_count=request_count,
+        success_count=success_count,
+        hard_failure_count=hard_failure_count,
+        observed_days=observed_days,
+        success_rate=success_rate,
+        model_successes=model_successes,
+        blocking_reason_codes=tuple(blockers),
+    )
+
+
+def validate_provider_chat_drills(drills: Mapping[str, object]) -> list[str]:
+    unknown = sorted(set(drills) - set(REQUIRED_PROVIDER_CHAT_DRILLS))
+    if unknown:
+        return ["provider_chat_gate_unknown_drill"]
+    return [
+        f"provider_chat_gate_drill_required:{name}"
+        for name in REQUIRED_PROVIDER_CHAT_DRILLS
+        if not bool(drills.get(name))
+    ]
+
+
+def _integer(value: object) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: object) -> float:
+    try:
+        return max(0.0, float(value or 0.0))
+    except (TypeError, ValueError):
+        return 0.0

--- a/server/model_router/chat_stable.py
+++ b/server/model_router/chat_stable.py
@@ -16,6 +16,7 @@ class ProviderChatStableDispatch:
     run_id: str
     attempt_id: str
     policy_fingerprint: str
+    strategy: str
     capability: ProviderChatCapability
     requested_model: str
     target: ProviderChatTarget
@@ -56,6 +57,38 @@ class ProviderChatStableService:
             or clean_model not in policy.stable_model_ids
         ):
             return ProviderChatStablePreflight(intercepted=False)
+        runtime_allowed, runtime_error = self.control.required_runtime_allowed(policy)
+        if not runtime_allowed:
+            error_code = runtime_error or "provider_chat_required_gate_degraded"
+            run_id = f"chatrun_{uuid.uuid4().hex}"
+            self._repository_method("claim_chat_control_run")(
+                self.router_service.tenant_id,
+                run_id=run_id,
+                policy_fingerprint=policy.policy_fingerprint,
+                capability=capability,
+                requested_model=clean_model,
+                strategy=policy.effective_mode,
+                gateway="default",
+                is_real_user=True,
+                primary_newapi=True,
+            )
+            self._repository_method("complete_chat_control_run")(
+                self.router_service.tenant_id,
+                run_id,
+                status="failed",
+                result_class="preflight_failure",
+                reason_codes=[error_code],
+            )
+            return ProviderChatStablePreflight(
+                intercepted=True,
+                error_code=error_code,
+                route_receipt=self.route_receipt(
+                    None,
+                    requested_model=clean_model,
+                    reason_codes=[error_code],
+                    strategy=policy.effective_mode,
+                ),
+            )
 
         route = next(
             (item for item in policy.routes if item.capability == capability),
@@ -86,7 +119,12 @@ class ProviderChatStableService:
             if item.capability == capability and item.model_id == clean_model
         }
         failures: list[str] = []
-        for position, connection_id in enumerate(route_ids):
+        candidate_route_ids = (
+            route_ids[:1]
+            if policy.effective_mode == "newapi_required_default"
+            else route_ids
+        )
+        for position, connection_id in enumerate(candidate_route_ids):
             connection = self.repository.get_connection(
                 self.router_service.tenant_id, connection_id
             )
@@ -140,6 +178,7 @@ class ProviderChatStableService:
                     run_id=run_id,
                     attempt_id=attempt_id,
                     policy_fingerprint=policy.policy_fingerprint,
+                    strategy=policy.effective_mode,
                     capability=capability,
                     requested_model=clean_model,
                     target=target,
@@ -165,6 +204,7 @@ class ProviderChatStableService:
                 None,
                 requested_model=clean_model,
                 reason_codes=list(dict.fromkeys(failures or [error_code])),
+                strategy=policy.effective_mode,
             ),
         )
 
@@ -200,7 +240,7 @@ class ProviderChatStableService:
             None,
         )
         if (
-            policy.effective_mode != "newapi_preferred"
+            policy.effective_mode != dispatch.strategy
             or policy.policy_fingerprint != dispatch.policy_fingerprint
             or qualification is None
             or not qualification.valid
@@ -286,6 +326,7 @@ class ProviderChatStableService:
         prompt_tokens: int | None = None,
         completion_tokens: int | None = None,
         total_tokens: int | None = None,
+        strategy: str = "newapi_preferred",
     ) -> dict[str, object]:
         codes = list(dispatch.reason_codes) if dispatch is not None else []
         codes.extend(reason_codes or [])
@@ -293,7 +334,7 @@ class ProviderChatStableService:
             "requested_model": requested_model,
             "actual_model": actual_model or requested_model,
             "provider": None,
-            "strategy": "newapi_preferred",
+            "strategy": dispatch.strategy if dispatch is not None else strategy,
             "engine": (
                 dispatch.target.provider_kind
                 if dispatch is not None

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -16,6 +16,11 @@ from typing import Protocol
 
 from cryptography.fernet import Fernet, InvalidToken
 
+from .chat_gate import (
+    REQUIRED_PROVIDER_CHAT_DRILLS,
+    evaluate_provider_chat_gate,
+    validate_provider_chat_drills,
+)
 from .gate import REQUIRED_DRILLS, evaluate_native_gate, percentile
 from .omniroute_parity import ALGORITHM_VERSION, CONFIG_HASH
 from .schemas import (
@@ -1996,6 +2001,31 @@ class SQLiteRouterRepository:
                 "SELECT * FROM provider_chat_runs WHERE tenant_id = ? AND id = ?",
                 (clean_tenant, run_id),
             ).fetchone()
+            if bool(hard_failure) and row is not None and row["epoch_id"]:
+                failure_code = next(
+                    (
+                        str(item)
+                        for item in reversed(reason_codes or [])
+                        if str(item).strip()
+                    ),
+                    str(result_class or "provider_chat_hard_failure"),
+                )
+                connection.execute(
+                    """
+                    UPDATE provider_chat_gate_epochs
+                    SET status = 'degraded', hard_failure_code = ?, closed_at = ?
+                    WHERE tenant_id = ? AND id = ? AND closed_at IS NULL
+                    """,
+                    (failure_code, now, clean_tenant, row["epoch_id"]),
+                )
+                connection.execute(
+                    """
+                    UPDATE provider_chat_gate_approvals
+                    SET revoked_at = ?
+                    WHERE tenant_id = ? AND epoch_id = ? AND revoked_at IS NULL
+                    """,
+                    (now, clean_tenant, row["epoch_id"]),
+                )
         return dict(row)
 
     def list_chat_control_receipts(
@@ -2082,6 +2112,21 @@ class SQLiteRouterRepository:
                 and current is not None
                 and str(current["policy_fingerprint"]) == policy_fingerprint
             ):
+                if str(current["status"]) == "open":
+                    connection.execute(
+                        """
+                        UPDATE provider_chat_gate_epochs SET status = 'collecting'
+                        WHERE tenant_id = ? AND id = ? AND status = 'open'
+                        """,
+                        (clean_tenant, current["id"]),
+                    )
+                    current = connection.execute(
+                        """
+                        SELECT * FROM provider_chat_gate_epochs
+                        WHERE tenant_id = ? AND id = ?
+                        """,
+                        (clean_tenant, current["id"]),
+                    ).fetchone()
                 return dict(current)
             if current is not None:
                 connection.execute(
@@ -2102,6 +2147,20 @@ class SQLiteRouterRepository:
             )
             if not qualified:
                 return None
+            latest_same_policy = connection.execute(
+                """
+                SELECT * FROM provider_chat_gate_epochs
+                WHERE tenant_id = ? AND policy_fingerprint = ?
+                ORDER BY started_at DESC, id DESC
+                LIMIT 1
+                """,
+                (clean_tenant, policy_fingerprint),
+            ).fetchone()
+            if (
+                latest_same_policy is not None
+                and str(latest_same_policy["status"]) == "degraded"
+            ):
+                return None
             connection.execute(
                 """
                 INSERT INTO provider_chat_gate_epochs (
@@ -2118,6 +2177,331 @@ class SQLiteRouterRepository:
                 (clean_tenant, epoch_id),
             ).fetchone()
         return dict(row) if row is not None else None
+
+    def summarize_chat_control_gate(
+        self,
+        tenant_id: str,
+        *,
+        epoch_id: str,
+    ) -> dict[str, object]:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            return self._summarize_chat_control_gate(
+                connection,
+                tenant_id=clean_tenant,
+                epoch_id=epoch_id,
+            )
+
+    @staticmethod
+    def _summarize_chat_control_gate(
+        connection: sqlite3.Connection,
+        *,
+        tenant_id: str,
+        epoch_id: str,
+    ) -> dict[str, object]:
+        aggregate = connection.execute(
+            """
+            WITH eligible AS (
+                SELECT r.*,
+                       CASE WHEN r.hard_failure = 1 OR EXISTS (
+                           SELECT 1 FROM provider_chat_attempts AS failed_attempt
+                           WHERE failed_attempt.tenant_id = r.tenant_id
+                             AND failed_attempt.run_id = r.id
+                             AND failed_attempt.result_class = 'hard_failure'
+                       ) THEN 1 ELSE 0 END AS observed_hard_failure
+                FROM provider_chat_runs AS r
+                WHERE r.tenant_id = ? AND r.epoch_id = ?
+                  AND r.capability = 'chat_text'
+                  AND r.gateway = 'default'
+                  AND r.is_real_user = 1
+                  AND r.primary_newapi = 1
+                  AND r.client_cancelled = 0
+                  AND EXISTS (
+                      SELECT 1 FROM provider_chat_attempts AS attempt
+                      WHERE attempt.tenant_id = r.tenant_id
+                        AND attempt.run_id = r.id
+                        AND attempt.position = 0
+                        AND attempt.provider_kind = 'newapi'
+                        AND attempt.dispatched = 1
+                  )
+            )
+            SELECT COUNT(*) AS request_count,
+                   SUM(CASE WHEN status = 'succeeded' AND result_class = 'success'
+                            THEN 1 ELSE 0 END) AS success_count,
+                   SUM(observed_hard_failure)
+                       AS hard_failure_count,
+                   MIN(created_at) AS first_created_at,
+                   MAX(created_at) AS last_created_at
+            FROM eligible
+            """,
+            (tenant_id, epoch_id),
+        ).fetchone()
+        model_rows = connection.execute(
+            """
+            SELECT r.requested_model, COUNT(*) AS success_count
+            FROM provider_chat_runs AS r
+            WHERE r.tenant_id = ? AND r.epoch_id = ?
+              AND r.capability = 'chat_text'
+              AND r.gateway = 'default'
+              AND r.is_real_user = 1
+              AND r.primary_newapi = 1
+              AND r.client_cancelled = 0
+              AND r.status = 'succeeded' AND r.result_class = 'success'
+              AND EXISTS (
+                  SELECT 1 FROM provider_chat_attempts AS attempt
+                  WHERE attempt.tenant_id = r.tenant_id
+                    AND attempt.run_id = r.id
+                    AND attempt.position = 0
+                    AND attempt.provider_kind = 'newapi'
+                    AND attempt.dispatched = 1
+              )
+            GROUP BY r.requested_model
+            """,
+            (tenant_id, epoch_id),
+        ).fetchall()
+        model_successes = {
+            str(row["requested_model"]): int(row["success_count"])
+            for row in model_rows
+        }
+        observed_days = 0.0
+        if (
+            aggregate is not None
+            and aggregate["first_created_at"]
+            and aggregate["last_created_at"]
+        ):
+            try:
+                first = datetime.fromisoformat(
+                    str(aggregate["first_created_at"]).replace("Z", "+00:00")
+                )
+                last = datetime.fromisoformat(
+                    str(aggregate["last_created_at"]).replace("Z", "+00:00")
+                )
+                observed_days = max(0.0, (last - first).total_seconds() / 86400)
+            except ValueError:
+                observed_days = 0.0
+        return {
+            "request_count": int(aggregate["request_count"] or 0),
+            "success_count": int(aggregate["success_count"] or 0),
+            "hard_failure_count": int(aggregate["hard_failure_count"] or 0),
+            "observed_days": observed_days,
+            "model_successes": model_successes,
+        }
+
+    def get_chat_control_gate_approval(
+        self,
+        tenant_id: str,
+        *,
+        policy_fingerprint: str,
+    ) -> dict[str, object] | None:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM provider_chat_gate_approvals
+                WHERE tenant_id = ? AND policy_fingerprint = ?
+                  AND revoked_at IS NULL
+                """,
+                (clean_tenant, policy_fingerprint),
+            ).fetchone()
+        if row is None:
+            return None
+        result = dict(row)
+        result["no_open_p0_p1"] = bool(result["no_open_p0_p1"])
+        result["acknowledge_fail_closed"] = bool(
+            result["acknowledge_fail_closed"]
+        )
+        result["drills"] = json.loads(str(result.pop("drills_json") or "{}"))
+        return result
+
+    def list_chat_control_acceptance_evidence(
+        self,
+        tenant_id: str,
+        *,
+        policy_fingerprint: str,
+        epoch_id: str,
+    ) -> list[dict[str, object]]:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT evidence_kind, passed, observed_at
+                FROM provider_chat_acceptance_evidence
+                WHERE tenant_id = ? AND policy_fingerprint = ? AND epoch_id = ?
+                ORDER BY evidence_kind ASC, observed_at DESC
+                """,
+                (clean_tenant, policy_fingerprint, epoch_id),
+            ).fetchall()
+        return [
+            {
+                "evidence_kind": str(row["evidence_kind"]),
+                "passed": bool(row["passed"]),
+                "observed_at": str(row["observed_at"]),
+            }
+            for row in rows
+        ]
+
+    def get_latest_chat_control_hard_failure(
+        self,
+        tenant_id: str,
+        *,
+        connection_id: str,
+        model_id: str,
+        capability: str,
+    ) -> dict[str, object] | None:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT run.completed_at, run.reason_codes_json, run.epoch_id
+                FROM provider_chat_runs AS run
+                JOIN provider_chat_attempts AS attempt
+                  ON attempt.tenant_id = run.tenant_id AND attempt.run_id = run.id
+                WHERE run.tenant_id = ? AND run.capability = ?
+                  AND run.requested_model = ? AND run.hard_failure = 1
+                  AND attempt.connection_id = ? AND attempt.dispatched = 1
+                ORDER BY run.completed_at DESC, run.id DESC
+                LIMIT 1
+                """,
+                (clean_tenant, capability, model_id, connection_id),
+            ).fetchone()
+        return dict(row) if row is not None else None
+
+    def activate_chat_control_required(
+        self,
+        tenant_id: str,
+        *,
+        expected_revision: int,
+        policy_fingerprint: str,
+        epoch_id: str,
+        no_open_p0_p1: bool,
+        drills: dict[str, bool],
+        acknowledge_fail_closed: bool,
+        correlation_hash: str,
+        evidence_checks: dict[str, bool],
+    ) -> None:
+        clean_tenant = self._tenant_id(tenant_id)
+        if not no_open_p0_p1:
+            raise RouterRepositoryError("provider_chat_gate_p0_p1_attestation_required")
+        drill_errors = validate_provider_chat_drills(drills)
+        if drill_errors:
+            raise RouterRepositoryError(drill_errors[0])
+        if not acknowledge_fail_closed:
+            raise RouterRepositoryError("provider_chat_gate_fail_closed_ack_required")
+        required_evidence = {
+            "newapi_quota_decrement",
+            "newapi_usage_log",
+            "newapi_restart_persistence",
+        }
+        if set(evidence_checks) != required_evidence or not all(
+            evidence_checks.values()
+        ):
+            raise RouterRepositoryError("provider_chat_gate_acceptance_evidence_required")
+        if len(correlation_hash) != 64 or any(
+            char not in "0123456789abcdef" for char in correlation_hash
+        ):
+            raise RouterRepositoryError("provider_chat_gate_correlation_hash_invalid")
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            policy = connection.execute(
+                """
+                SELECT * FROM provider_chat_stable_policies WHERE tenant_id = ?
+                """,
+                (clean_tenant,),
+            ).fetchone()
+            if policy is None or int(policy["revision"]) != int(expected_revision):
+                raise RouterRepositoryError("provider_chat_policy_revision_conflict")
+            if str(policy["mode"]) != "newapi_preferred":
+                raise RouterRepositoryError("provider_chat_gate_preferred_mode_required")
+            if str(policy["policy_fingerprint"]) != policy_fingerprint:
+                raise RouterRepositoryError("provider_chat_gate_policy_changed")
+            epoch = connection.execute(
+                """
+                SELECT * FROM provider_chat_gate_epochs
+                WHERE tenant_id = ? AND id = ? AND policy_fingerprint = ?
+                  AND closed_at IS NULL AND status IN ('open', 'collecting', 'ready')
+                """,
+                (clean_tenant, epoch_id, policy_fingerprint),
+            ).fetchone()
+            if epoch is None:
+                raise RouterRepositoryError("provider_chat_gate_epoch_changed")
+            stable_models = [
+                str(item)
+                for item in json.loads(str(policy["stable_models_json"] or "[]"))
+            ]
+            summary = self._summarize_chat_control_gate(
+                connection,
+                tenant_id=clean_tenant,
+                epoch_id=epoch_id,
+            )
+            evaluation = evaluate_provider_chat_gate(
+                summary,
+                stable_model_ids=stable_models,
+            )
+            if not evaluation.ready:
+                raise RouterRepositoryError(evaluation.blocking_reason_codes[0])
+            connection.execute(
+                """
+                UPDATE provider_chat_stable_policies
+                SET mode = 'newapi_required_default', revision = revision + 1,
+                    updated_at = ?
+                WHERE tenant_id = ? AND revision = ?
+                """,
+                (now, clean_tenant, int(expected_revision)),
+            )
+            connection.execute(
+                """
+                UPDATE provider_chat_gate_epochs SET status = 'active'
+                WHERE tenant_id = ? AND id = ? AND closed_at IS NULL
+                """,
+                (clean_tenant, epoch_id),
+            )
+            connection.execute(
+                """
+                INSERT INTO provider_chat_gate_approvals (
+                    tenant_id, policy_fingerprint, epoch_id, no_open_p0_p1,
+                    drills_json, acknowledge_fail_closed, approved_at, revoked_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+                ON CONFLICT(tenant_id, policy_fingerprint) DO UPDATE SET
+                    epoch_id = excluded.epoch_id,
+                    no_open_p0_p1 = excluded.no_open_p0_p1,
+                    drills_json = excluded.drills_json,
+                    acknowledge_fail_closed = excluded.acknowledge_fail_closed,
+                    approved_at = excluded.approved_at,
+                    revoked_at = NULL
+                """,
+                (
+                    clean_tenant,
+                    policy_fingerprint,
+                    epoch_id,
+                    1,
+                    json.dumps(
+                        {name: True for name in REQUIRED_PROVIDER_CHAT_DRILLS},
+                        separators=(",", ":"),
+                    ),
+                    1,
+                    now,
+                ),
+            )
+            for evidence_kind in sorted(required_evidence):
+                connection.execute(
+                    """
+                    INSERT INTO provider_chat_acceptance_evidence (
+                        id, tenant_id, policy_fingerprint, epoch_id,
+                        evidence_kind, correlation_hash, passed,
+                        reason_codes_json, observed_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, 1, '[]', ?)
+                    """,
+                    (
+                        f"chatevidence_{uuid.uuid4().hex}",
+                        clean_tenant,
+                        policy_fingerprint,
+                        epoch_id,
+                        evidence_kind,
+                        correlation_hash,
+                        now,
+                    ),
+                )
 
     def cleanup_chat_control_receipts(
         self,
@@ -2232,7 +2616,24 @@ class SQLiteRouterRepository:
                 """
                 SELECT * FROM provider_chat_gate_epochs
                 WHERE tenant_id = ? AND policy_fingerprint = ?
-                  AND status = 'open' AND closed_at IS NULL
+                  AND status IN ('open', 'collecting', 'ready', 'active')
+                  AND closed_at IS NULL
+                ORDER BY started_at DESC, id DESC
+                LIMIT 1
+                """,
+                (clean_tenant, policy_fingerprint),
+            ).fetchone()
+        return dict(row) if row is not None else None
+
+    def get_latest_chat_control_gate_epoch(
+        self, tenant_id: str, policy_fingerprint: str
+    ) -> dict[str, object] | None:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM provider_chat_gate_epochs
+                WHERE tenant_id = ? AND policy_fingerprint = ?
                 ORDER BY started_at DESC, id DESC
                 LIMIT 1
                 """,

--- a/server/model_router/schemas.py
+++ b/server/model_router/schemas.py
@@ -467,6 +467,30 @@ class ProviderChatControlPolicyResponse(BaseModel):
     updated_at: str | None = None
 
 
+class ProviderChatRequiredActivationRequest(BaseModel):
+    expected_revision: int = Field(ge=0)
+    no_open_p0_p1: bool
+    acknowledge_fail_closed: bool
+    drills: dict[str, bool] = Field(default_factory=dict, max_length=16)
+    newapi_correlation_reference: SecretStr
+    quota_decrement_verified: bool
+    usage_log_verified: bool
+    restart_persistence_verified: bool
+
+
+class ProviderChatGateModelProgress(BaseModel):
+    model_id: str
+    success_count: int = 0
+    minimum_success_count: int = 10
+    ready: bool = False
+
+
+class ProviderChatGateEvidenceSummary(BaseModel):
+    evidence_kind: str
+    passed: bool
+    observed_at: str
+
+
 class ProviderChatControlGateResponse(BaseModel):
     contract_version: Literal["modelmirror-provider-chat-routing-v1"]
     feature_enabled: bool
@@ -474,10 +498,28 @@ class ProviderChatControlGateResponse(BaseModel):
     policy_fingerprint: str
     configured_mode: ProviderChatControlMode
     required_activation_available: bool = False
+    required_active: bool = False
     ready: bool = False
+    epoch_id: str | None = None
+    epoch_status: str | None = None
+    epoch_started_at: str | None = None
+    epoch_closed_at: str | None = None
+    hard_failure_code: str | None = None
+    minimum_request_count: int = 500
+    minimum_observed_days: float = 14
+    minimum_success_rate: float = 0.99
     request_count: int = 0
+    success_count: int = 0
+    hard_failure_count: int = 0
     observed_days: float = 0
     success_rate: float | None = None
+    model_progress: list[ProviderChatGateModelProgress] = Field(default_factory=list)
+    required_drills: list[str] = Field(default_factory=list)
+    approval_recorded: bool = False
+    acceptance_evidence_complete: bool = False
+    acceptance_evidence: list[ProviderChatGateEvidenceSummary] = Field(
+        default_factory=list
+    )
     blocking_reason_codes: list[str] = Field(default_factory=list)
 
 

--- a/server/tests/test_provider_chat_control_api.py
+++ b/server/tests/test_provider_chat_control_api.py
@@ -71,6 +71,11 @@ async def test_admin_policy_gate_and_receipts_require_session_and_csrf(
         assert (
             await client.get("/api/router/chat-control/receipts")
         ).status_code == 401
+        assert (
+            await client.post(
+                "/api/router/chat-control/gate/activate-required", json={}
+            )
+        ).status_code == 401
 
         paired = await client.post(
             "/api/router/admin/session", json={"pairing_secret": PAIRING_SECRET}
@@ -106,7 +111,7 @@ async def test_admin_policy_gate_and_receipts_require_session_and_csrf(
         assert "provider_chat_control_data_plane_pending_r5b" not in gate.json()[
             "blocking_reason_codes"
         ]
-        assert "provider_chat_required_gate_pending_r5e" in gate.json()[
+        assert "provider_chat_gate_epoch_unavailable" in gate.json()[
             "blocking_reason_codes"
         ]
         receipts = await client.get("/api/router/chat-control/receipts")
@@ -121,9 +126,59 @@ async def test_admin_policy_gate_and_receipts_require_session_and_csrf(
             "provider_chat_receipt_cursor_invalid"
         )
 
+        activation_payload = {
+            "expected_revision": 1,
+            "no_open_p0_p1": True,
+            "acknowledge_fail_closed": True,
+            "drills": {
+                "auth_failure": True,
+                "http_429": True,
+                "http_5xx": True,
+                "connect_timeout": True,
+                "read_timeout": True,
+                "empty_stream": True,
+                "invalid_sse": True,
+                "stream_interrupted": True,
+                "service_restart": True,
+                "credential_invalid": True,
+                "data_plane_offline": True,
+                "preferred_fallback": True,
+            },
+            "newapi_correlation_reference": "opaque-newapi-correlation",
+            "quota_decrement_verified": True,
+            "usage_log_verified": True,
+            "restart_persistence_verified": True,
+        }
+        without_csrf = await client.post(
+            "/api/router/chat-control/gate/activate-required",
+            json=activation_payload,
+        )
+        assert without_csrf.status_code == 403
+        invalid_reference = await client.post(
+            "/api/router/chat-control/gate/activate-required",
+            headers={"X-ModelMirror-CSRF": csrf},
+            json={
+                **activation_payload,
+                "newapi_correlation_reference": "leakme",
+            },
+        )
+        assert invalid_reference.status_code == 422
+        assert "leakme" not in invalid_reference.text
+        not_ready = await client.post(
+            "/api/router/chat-control/gate/activate-required",
+            headers={"X-ModelMirror-CSRF": csrf},
+            json=activation_payload,
+        )
+        assert not_ready.status_code == 409
+        assert not_ready.json()["detail"]["code"] in {
+            "provider_chat_control_feature_disabled",
+            "provider_chat_control_legacy_mode",
+            "provider_chat_control_stable_models_required",
+        }
+
 
 @pytest.mark.asyncio
-async def test_required_policy_is_rejected_until_r5e(
+async def test_required_policy_is_rejected_outside_gate_activation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/server/tests/test_provider_chat_control_repository.py
+++ b/server/tests/test_provider_chat_control_repository.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import sqlite3
+import hashlib
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -249,6 +251,35 @@ def test_gate_epoch_is_reused_then_invalidated_with_approvals(
     assert closed["closed_at"] is not None
 
 
+def test_r5d_open_gate_epoch_is_normalized_without_losing_evidence(
+    tmp_path: Path,
+) -> None:
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    with sqlite3.connect(repository.database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO provider_chat_gate_epochs (
+                id, tenant_id, policy_fingerprint, status, started_at
+            ) VALUES ('legacy-open', 'local', 'policy-open', 'open',
+                      '2026-08-01T00:00:00+00:00')
+            """
+        )
+
+    normalized = repository.sync_chat_control_gate_epoch(
+        "local",
+        epoch_id="must-not-replace",
+        policy_fingerprint="policy-open",
+        qualified=True,
+        invalidation_code="policy_changed",
+    )
+
+    assert normalized is not None
+    assert normalized["id"] == "legacy-open"
+    assert normalized["status"] == "collecting"
+    latest = repository.get_latest_chat_control_gate_epoch("local", "policy-open")
+    assert latest is not None and latest["id"] == "legacy-open"
+
+
 def test_receipt_schema_has_no_prompt_message_or_response_body_columns(
     tmp_path: Path,
 ) -> None:
@@ -271,3 +302,286 @@ def test_receipt_schema_has_no_prompt_message_or_response_body_columns(
         }
     assert not {"prompt", "messages", "model_output", "response_body"} & columns
     assert "epoch_id" in evidence_columns
+
+
+def _seed_gate_requests(
+    repository: SQLiteRouterRepository,
+    *,
+    epoch_id: str,
+    count: int = 500,
+    model_id: str = "provider/model",
+) -> None:
+    started_at = datetime(2026, 8, 1, tzinfo=UTC)
+    runs = []
+    attempts = []
+    for index in range(count):
+        observed_at = started_at + timedelta(
+            seconds=(14 * 24 * 60 * 60 * index / max(1, count - 1))
+        )
+        timestamp = observed_at.isoformat()
+        run_id = f"gate-run-{index}"
+        runs.append(
+            (
+                run_id,
+                "local",
+                "policy-1",
+                epoch_id,
+                "chat_text",
+                model_id,
+                model_id,
+                "newapi_preferred",
+                "default",
+                "succeeded",
+                "success",
+                "[]",
+                1,
+                1,
+                0,
+                0,
+                timestamp,
+                timestamp,
+                timestamp,
+            )
+        )
+        attempts.append(
+            (
+                f"gate-attempt-{index}",
+                "local",
+                run_id,
+                "chat_text",
+                0,
+                "conn-newapi",
+                "newapi",
+                1,
+                "succeeded",
+                "success",
+                model_id,
+                timestamp,
+                timestamp,
+                timestamp,
+            )
+        )
+    with sqlite3.connect(repository.database_path) as connection:
+        connection.executemany(
+            """
+            INSERT INTO provider_chat_runs (
+                id, tenant_id, policy_fingerprint, epoch_id, capability,
+                requested_model, actual_model, strategy, gateway, status,
+                result_class, reason_codes_json, is_real_user, primary_newapi,
+                client_cancelled, hard_failure, created_at, updated_at, completed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            runs,
+        )
+        connection.executemany(
+            """
+            INSERT INTO provider_chat_attempts (
+                id, tenant_id, run_id, capability, position, connection_id,
+                provider_kind, dispatched, status, result_class, actual_model,
+                created_at, updated_at, completed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            attempts,
+        )
+
+
+def test_r5e_gate_aggregates_only_primary_real_text_and_activates_atomically(
+    tmp_path: Path,
+) -> None:
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    repository.replace_chat_control_policy(
+        "local",
+        expected_revision=0,
+        mode="newapi_preferred",
+        auto_enabled=False,
+        policy_fingerprint="policy-1",
+        stable_model_ids=["provider/model"],
+        routes=[],
+        qualifications=[],
+    )
+    epoch = repository.sync_chat_control_gate_epoch(
+        "local",
+        epoch_id="epoch-1",
+        policy_fingerprint="policy-1",
+        qualified=True,
+        invalidation_code="policy_changed",
+    )
+    assert epoch is not None
+    _seed_gate_requests(repository, epoch_id="epoch-1")
+
+    summary = repository.summarize_chat_control_gate("local", epoch_id="epoch-1")
+    assert summary["request_count"] == 500
+    assert summary["success_count"] == 500
+    assert summary["hard_failure_count"] == 0
+    assert summary["observed_days"] == pytest.approx(14.0)
+    assert summary["model_successes"] == {"provider/model": 500}
+
+    drills = {
+        "auth_failure": True,
+        "http_429": True,
+        "http_5xx": True,
+        "connect_timeout": True,
+        "read_timeout": True,
+        "empty_stream": True,
+        "invalid_sse": True,
+        "stream_interrupted": True,
+        "service_restart": True,
+        "credential_invalid": True,
+        "data_plane_offline": True,
+        "preferred_fallback": True,
+    }
+    repository.activate_chat_control_required(
+        "local",
+        expected_revision=1,
+        policy_fingerprint="policy-1",
+        epoch_id="epoch-1",
+        no_open_p0_p1=True,
+        drills=drills,
+        acknowledge_fail_closed=True,
+        correlation_hash=hashlib.sha256(b"opaque-newapi-log").hexdigest(),
+        evidence_checks={
+            "newapi_quota_decrement": True,
+            "newapi_usage_log": True,
+            "newapi_restart_persistence": True,
+        },
+    )
+
+    policy = repository.get_chat_control_policy_bundle("local")["policy"]
+    assert policy["mode"] == "newapi_required_default"
+    assert policy["revision"] == 2
+    active = repository.get_open_chat_control_gate_epoch("local", "policy-1")
+    assert active is not None and active["status"] == "active"
+    approval = repository.get_chat_control_gate_approval(
+        "local", policy_fingerprint="policy-1"
+    )
+    assert approval is not None and approval["acknowledge_fail_closed"] is True
+    evidence = repository.list_chat_control_acceptance_evidence(
+        "local", policy_fingerprint="policy-1", epoch_id="epoch-1"
+    )
+    assert {item["evidence_kind"] for item in evidence} == {
+        "newapi_quota_decrement",
+        "newapi_usage_log",
+        "newapi_restart_persistence",
+    }
+    with sqlite3.connect(repository.database_path) as connection:
+        dump = "\n".join(connection.iterdump())
+    assert "opaque-newapi-log" not in dump
+
+
+def test_hard_failure_degrades_epoch_revokes_approval_and_requires_new_policy(
+    tmp_path: Path,
+) -> None:
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    repository.sync_chat_control_gate_epoch(
+        "local",
+        epoch_id="epoch-hard",
+        policy_fingerprint="policy-hard",
+        qualified=True,
+        invalidation_code="policy_changed",
+    )
+    repository.claim_chat_control_run(
+        "local",
+        run_id="run-hard",
+        policy_fingerprint="policy-hard",
+        capability="chat_text",
+        requested_model="provider/model",
+        strategy="newapi_required_default",
+        epoch_id="epoch-hard",
+        is_real_user=True,
+        primary_newapi=True,
+    )
+    repository.claim_chat_control_attempt(
+        "local",
+        attempt_id="attempt-hard",
+        run_id="run-hard",
+        capability="chat_text",
+        position=0,
+        connection_id="conn-newapi",
+        provider_kind="newapi",
+    )
+    repository.mark_chat_control_attempt_dispatched("local", "attempt-hard")
+    repository.complete_chat_control_attempt(
+        "local",
+        "attempt-hard",
+        status="failed",
+        result_class="hard_failure",
+        error_code="provider_chat_empty_stream",
+    )
+    repository.complete_chat_control_run(
+        "local",
+        "run-hard",
+        status="failed",
+        result_class="hard_failure",
+        reason_codes=["provider_chat_empty_stream"],
+        hard_failure=True,
+    )
+
+    latest = repository.get_latest_chat_control_gate_epoch(
+        "local", "policy-hard"
+    )
+    assert latest is not None
+    assert latest["status"] == "degraded"
+    assert latest["hard_failure_code"] == "provider_chat_empty_stream"
+    assert repository.get_open_chat_control_gate_epoch("local", "policy-hard") is None
+    assert repository.sync_chat_control_gate_epoch(
+        "local",
+        epoch_id="epoch-must-not-open",
+        policy_fingerprint="policy-hard",
+        qualified=True,
+        invalidation_code="qualification_changed",
+    ) is None
+    hard_failure = repository.get_latest_chat_control_hard_failure(
+        "local",
+        connection_id="conn-newapi",
+        model_id="provider/model",
+        capability="chat_text",
+    )
+    assert hard_failure is not None
+
+
+def test_gate_summary_sees_hard_attempt_before_parent_run_finishes(
+    tmp_path: Path,
+) -> None:
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    repository.sync_chat_control_gate_epoch(
+        "local",
+        epoch_id="epoch-race",
+        policy_fingerprint="policy-race",
+        qualified=True,
+        invalidation_code="policy_changed",
+    )
+    repository.claim_chat_control_run(
+        "local",
+        run_id="run-race",
+        policy_fingerprint="policy-race",
+        capability="chat_text",
+        requested_model="provider/model",
+        strategy="newapi_preferred",
+        epoch_id="epoch-race",
+        is_real_user=True,
+        primary_newapi=True,
+    )
+    repository.claim_chat_control_attempt(
+        "local",
+        attempt_id="attempt-race",
+        run_id="run-race",
+        capability="chat_text",
+        position=0,
+        connection_id="conn-newapi",
+        provider_kind="newapi",
+    )
+    repository.mark_chat_control_attempt_dispatched("local", "attempt-race")
+    repository.complete_chat_control_attempt(
+        "local",
+        "attempt-race",
+        status="failed",
+        result_class="hard_failure",
+        error_code="provider_chat_empty_stream",
+    )
+
+    summary = repository.summarize_chat_control_gate(
+        "local", epoch_id="epoch-race"
+    )
+    assert summary["request_count"] == 1
+    assert summary["success_count"] == 0
+    assert summary["hard_failure_count"] == 1

--- a/server/tests/test_provider_chat_control_service.py
+++ b/server/tests/test_provider_chat_control_service.py
@@ -5,11 +5,13 @@ import sqlite3
 
 import pytest
 
+from server.model_router.chat_gate import evaluate_provider_chat_gate
 from server.model_router.chat_control import ProviderChatControlService
 from server.model_router.repository import SQLiteRouterRepository
 from server.model_router.schemas import (
     ProviderChatControlPolicyUpdate,
     ProviderChatControlRouteUpdate,
+    ProviderChatRequiredActivationRequest,
     RouterConnectionCreate,
     RouterConnectionUpdate,
 )
@@ -305,3 +307,203 @@ def test_required_mode_cannot_be_saved_before_r5e_gate(tmp_path: Path) -> None:
             )
         )
     assert exc_info.value.code == "provider_chat_required_activation_not_available"
+
+
+def test_r5e_gate_truth_table_requires_volume_window_rate_models_and_zero_hard() -> None:
+    ready = evaluate_provider_chat_gate(
+        {
+            "request_count": 500,
+            "success_count": 495,
+            "hard_failure_count": 0,
+            "observed_days": 14,
+            "model_successes": {MODEL_ID: 495},
+        },
+        stable_model_ids=[MODEL_ID],
+    )
+    assert ready.ready is True
+    assert ready.success_rate == pytest.approx(0.99)
+
+    blocked = evaluate_provider_chat_gate(
+        {
+            "request_count": 499,
+            "success_count": 494,
+            "hard_failure_count": 1,
+            "observed_days": 13.99,
+            "model_successes": {MODEL_ID: 9},
+        },
+        stable_model_ids=[MODEL_ID],
+    )
+    assert blocked.ready is False
+    assert set(blocked.blocking_reason_codes) == {
+        "provider_chat_gate_request_count_insufficient",
+        "provider_chat_gate_observation_window_insufficient",
+        "provider_chat_gate_success_rate_insufficient",
+        "provider_chat_gate_model_samples_insufficient",
+        "provider_chat_gate_hard_failure_observed",
+    }
+
+
+def test_hard_failure_invalidates_saved_qualification_until_recertification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    service, repository = _service(tmp_path)
+    newapi_id = _connection(repository, name="newAPI", kind="newapi")
+    _certify(repository, newapi_id, "chat_text")
+    policy = service.update_policy(
+        ProviderChatControlPolicyUpdate(
+            expected_revision=0,
+            mode="newapi_preferred",
+            stable_model_ids=[MODEL_ID],
+            routes=[
+                ProviderChatControlRouteUpdate(
+                    capability="chat_text", connection_ids=[newapi_id]
+                )
+            ],
+        )
+    )
+    epoch = repository.get_open_chat_control_gate_epoch(
+        "local", policy.policy_fingerprint
+    )
+    assert epoch is not None
+    repository.claim_chat_control_run(
+        "local",
+        run_id="hard-run",
+        policy_fingerprint=policy.policy_fingerprint,
+        capability="chat_text",
+        requested_model=MODEL_ID,
+        strategy="newapi_preferred",
+        epoch_id=str(epoch["id"]),
+        is_real_user=True,
+        primary_newapi=True,
+    )
+    repository.claim_chat_control_attempt(
+        "local",
+        attempt_id="hard-attempt",
+        run_id="hard-run",
+        capability="chat_text",
+        position=0,
+        connection_id=newapi_id,
+        provider_kind="newapi",
+    )
+    repository.mark_chat_control_attempt_dispatched("local", "hard-attempt")
+    repository.complete_chat_control_attempt(
+        "local",
+        "hard-attempt",
+        status="failed",
+        result_class="hard_failure",
+        error_code="provider_chat_model_mismatch",
+    )
+    repository.complete_chat_control_run(
+        "local",
+        "hard-run",
+        status="failed",
+        result_class="hard_failure",
+        reason_codes=["provider_chat_model_mismatch"],
+        hard_failure=True,
+    )
+
+    stale = service.get_policy()
+    assert stale.qualifications[0].valid is False
+    assert stale.qualifications[0].reason_code == (
+        "provider_chat_hard_failure_recertification_required"
+    )
+    gate = service.gate()
+    assert gate.required_active is False
+    assert gate.epoch_status == "degraded"
+    assert gate.request_count == 1
+    assert gate.hard_failure_count == 1
+    assert "provider_chat_gate_hard_failure_recertification_required" in (
+        gate.blocking_reason_codes
+    )
+
+
+def test_ready_gate_requires_explicit_atomic_activation_and_hashes_correlation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
+    service, repository = _service(tmp_path)
+    newapi_id = _connection(repository, name="newAPI", kind="newapi")
+    _certify(repository, newapi_id, "chat_text")
+    policy = service.update_policy(
+        ProviderChatControlPolicyUpdate(
+            expected_revision=0,
+            mode="newapi_preferred",
+            stable_model_ids=[MODEL_ID],
+            routes=[
+                ProviderChatControlRouteUpdate(
+                    capability="chat_text", connection_ids=[newapi_id]
+                )
+            ],
+        )
+    )
+    epoch = repository.get_open_chat_control_gate_epoch(
+        "local", policy.policy_fingerprint
+    )
+    assert epoch is not None
+    with sqlite3.connect(repository.database_path) as connection:
+        connection.execute(
+            """
+            WITH RECURSIVE seq(i) AS (
+                SELECT 0 UNION ALL SELECT i + 1 FROM seq WHERE i < 499
+            )
+            INSERT INTO provider_chat_runs (
+                id, tenant_id, policy_fingerprint, epoch_id, capability,
+                requested_model, actual_model, strategy, gateway, status,
+                result_class, reason_codes_json, is_real_user, primary_newapi,
+                client_cancelled, hard_failure, created_at, updated_at, completed_at
+            )
+            SELECT 'activation-run-' || i, 'local', ?, ?, 'chat_text', ?, ?,
+                   'newapi_preferred', 'default', 'succeeded', 'success', '[]',
+                   1, 1, 0, 0,
+                   datetime('2026-08-01T00:00:00', '+' ||
+                     CAST(i * 1209600.0 / 499 AS INTEGER) || ' seconds'),
+                   datetime('2026-08-01T00:00:00', '+' ||
+                     CAST(i * 1209600.0 / 499 AS INTEGER) || ' seconds'),
+                   datetime('2026-08-01T00:00:00', '+' ||
+                     CAST(i * 1209600.0 / 499 AS INTEGER) || ' seconds')
+            FROM seq
+            """,
+            (policy.policy_fingerprint, epoch["id"], MODEL_ID, MODEL_ID),
+        )
+        connection.execute(
+            """
+            INSERT INTO provider_chat_attempts (
+                id, tenant_id, run_id, capability, position, connection_id,
+                provider_kind, dispatched, status, result_class, actual_model,
+                created_at, updated_at, completed_at
+            )
+            SELECT 'activation-attempt-' || substr(id, 16), tenant_id, id,
+                   capability, 0, ?, 'newapi', 1, 'succeeded', 'success',
+                   actual_model, created_at, updated_at, completed_at
+            FROM provider_chat_runs WHERE epoch_id = ?
+            """,
+            (newapi_id, epoch["id"]),
+        )
+
+    gate = service.gate()
+    assert gate.ready is True
+    assert gate.required_activation_available is True
+    assert gate.request_count == 500
+    activated = service.activate_required(
+        ProviderChatRequiredActivationRequest(
+            expected_revision=policy.revision,
+            no_open_p0_p1=True,
+            acknowledge_fail_closed=True,
+            drills={name: True for name in gate.required_drills},
+            newapi_correlation_reference="opaque-newapi-usage-log-reference",
+            quota_decrement_verified=True,
+            usage_log_verified=True,
+            restart_persistence_verified=True,
+        )
+    )
+    assert activated.required_active is True
+    assert activated.configured_mode == "newapi_required_default"
+    assert activated.approval_recorded is True
+    assert activated.acceptance_evidence_complete is True
+    assert activated.required_activation_available is False
+    with sqlite3.connect(repository.database_path) as connection:
+        dump = "\n".join(connection.iterdump())
+    assert "opaque-newapi-usage-log-reference" not in dump

--- a/server/tests/test_provider_chat_stable_service.py
+++ b/server/tests/test_provider_chat_stable_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
 from pathlib import Path
 
@@ -89,14 +90,19 @@ def _qualified_connection(
     return connection.id
 
 
-def _service(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def _service(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    newapi_ip: str = "10.0.0.8",
+):
     monkeypatch.setenv("MODEL_CONTROL_CHAT_ENABLED", "true")
     repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
     service = ModelRouterService(
         repository,
         egress_policy=ProviderEgressPolicy(
             resolver=lambda host, _port: (
-                ["10.0.0.8"] if host.startswith("newapi") else ["8.8.8.8"]
+                [newapi_ip] if host.startswith("newapi") else ["8.8.8.8"]
             )
         ),
     )
@@ -118,6 +124,81 @@ def _service(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         )
     )
     return ProviderChatStableService(service), repository, newapi_id, backup_id
+
+
+def _activate_required_for_test(repository: SQLiteRouterRepository) -> None:
+    policy = repository.get_chat_control_policy_bundle("local")["policy"]
+    assert policy is not None
+    epoch = repository.get_open_chat_control_gate_epoch(
+        "local", str(policy["policy_fingerprint"])
+    )
+    assert epoch is not None
+    drills = {
+        "auth_failure": True,
+        "http_429": True,
+        "http_5xx": True,
+        "connect_timeout": True,
+        "read_timeout": True,
+        "empty_stream": True,
+        "invalid_sse": True,
+        "stream_interrupted": True,
+        "service_restart": True,
+        "credential_invalid": True,
+        "data_plane_offline": True,
+        "preferred_fallback": True,
+    }
+    now = "2026-08-22T00:00:00+00:00"
+    with sqlite3.connect(repository.database_path) as connection:
+        connection.execute(
+            """
+            UPDATE provider_chat_stable_policies
+            SET mode = 'newapi_required_default', revision = revision + 1
+            WHERE tenant_id = 'local'
+            """
+        )
+        connection.execute(
+            """
+            UPDATE provider_chat_gate_epochs SET status = 'active'
+            WHERE tenant_id = 'local' AND id = ?
+            """,
+            (epoch["id"],),
+        )
+        connection.execute(
+            """
+            INSERT INTO provider_chat_gate_approvals (
+                tenant_id, policy_fingerprint, epoch_id, no_open_p0_p1,
+                drills_json, acknowledge_fail_closed, approved_at
+            ) VALUES ('local', ?, ?, 1, ?, 1, ?)
+            """,
+            (
+                policy["policy_fingerprint"],
+                epoch["id"],
+                json.dumps(drills),
+                now,
+            ),
+        )
+        for evidence_kind in (
+            "newapi_quota_decrement",
+            "newapi_usage_log",
+            "newapi_restart_persistence",
+        ):
+            connection.execute(
+                """
+                INSERT INTO provider_chat_acceptance_evidence (
+                    id, tenant_id, policy_fingerprint, epoch_id,
+                    evidence_kind, correlation_hash, passed,
+                    reason_codes_json, observed_at
+                ) VALUES (?, 'local', ?, ?, ?, ?, 1, '[]', ?)
+                """,
+                (
+                    f"evidence-{evidence_kind}",
+                    policy["policy_fingerprint"],
+                    epoch["id"],
+                    evidence_kind,
+                    hashlib.sha256(b"correlation").hexdigest(),
+                    now,
+                ),
+            )
 
 
 @pytest.mark.asyncio
@@ -240,3 +321,82 @@ async def test_feature_disabled_and_non_stable_models_use_legacy(
     assert disabled.intercepted is False
     assert outside.intercepted is False
     assert repository.list_chat_control_receipts("local")["runs"] == []
+
+
+@pytest.mark.asyncio
+async def test_required_preflight_failure_never_selects_backup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    _activate_required_for_test(repository)
+
+    result = await service.begin(MODEL_ID)
+
+    assert result.intercepted is True
+    assert result.dispatch is None
+    assert result.error_code == "provider_address_blocked"
+    assert result.route_receipt is not None
+    assert result.route_receipt["strategy"] == "newapi_required_default"
+    receipts = repository.list_chat_control_receipts("local")
+    assert [item["connection_id"] for item in receipts["attempts"]] == [newapi_id]
+    assert backup_id not in {item["connection_id"] for item in receipts["attempts"]}
+
+
+@pytest.mark.asyncio
+async def test_required_hard_failure_stays_required_and_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(
+        tmp_path,
+        monkeypatch,
+        newapi_ip="8.8.8.8",
+    )
+    _activate_required_for_test(repository)
+    first = await service.begin(MODEL_ID)
+    assert first.dispatch is not None
+    assert first.dispatch.target.connection_id == newapi_id
+    assert first.dispatch.strategy == "newapi_required_default"
+    service.mark_dispatched(first.dispatch)
+    service.complete(
+        first.dispatch,
+        status="failed",
+        result_class="hard_failure",
+        error_code="provider_chat_empty_stream",
+        hard_failure=True,
+    )
+
+    policy = service.control.get_policy()
+    assert policy.configured_mode == "newapi_required_default"
+    blocked = await service.begin(MODEL_ID)
+    assert blocked.intercepted is True
+    assert blocked.dispatch is None
+    assert blocked.error_code == "provider_chat_required_gate_degraded"
+    receipts = repository.list_chat_control_receipts("local")
+    assert len(receipts["runs"]) == 2
+    assert backup_id not in {item["connection_id"] for item in receipts["attempts"]}
+
+    current = service.control.get_policy()
+    rolled_back = service.control.update_policy(
+        ProviderChatControlPolicyUpdate(
+            expected_revision=current.revision,
+            mode="newapi_preferred",
+            auto_enabled=current.auto_enabled,
+            stable_model_ids=current.stable_model_ids,
+            routes=[
+                ProviderChatControlRouteUpdate(
+                    capability=route.capability,
+                    connection_ids=route.connection_ids,
+                )
+                for route in current.routes
+            ],
+        )
+    )
+    assert rolled_back.configured_mode == "newapi_preferred"
+    assert next(
+        item
+        for item in rolled_back.qualifications
+        if item.connection_id == newapi_id
+    ).valid is False
+    fallback = await service.begin(MODEL_ID)
+    assert fallback.dispatch is not None
+    assert fallback.dispatch.target.connection_id == backup_id


### PR DESCRIPTION
## 变更摘要

- 完成 R5E Provider Chat required Go/No-Go 门禁与原子人工激活。
- required 模式只允许首选 newAPI；硬失败保持 required 并失败关闭，不自动回退第二 Provider 或 Legacy。
- 增加资格纪元、逐模型样本、故障演练、人工证据和脱敏 Receipt 聚合。
- 设置页增加证据进度、阻塞原因、降级恢复说明及内联 Go/No-Go 确认。
- 不激活 required，不改变默认数据面，不引入多租户、积分、充值或 ModelMirror 计费。

## 验证

- R5E 专项：30 passed。
- R5A—R5D Chat 交叉回归：110 passed。
- required/竞态/硬失败/零回退证伪：24 passed。
- 前端组件：2 passed；typecheck、production build 通过。
- Core、独立 newAPI、Overlay Compose config 通过。
- 后端全量：4005 passed、29 skipped、20 failed；未修改的同 SHA 主线精确复现相同 20 failed / 64 passed，属于既有 Agency Worker 与 Node/TS 镜像环境缺口。
- 一次授权真实 newAPI 文本调用成功：只新增 1 个 run、1 个 position-0 attempt 和 1 条 newAPI 日志；零回退，重启后未重放，Router SQLite 未保存 Prompt 或模型正文。

## 回滚与限制

- 管理员可显式退回 newapi_preferred；必要时关闭 MODEL_CONTROL_CHAT_ENABLED 并重启恢复 Legacy。
- 保留 v15 Gate、Receipt 和证据表，不删除 Provider、Router SQLite 或 newAPI 数据。
- PR 合并不代表批准激活 newapi_required_default。