### PR TITLE
R6B：Engine Shadow 接入 Managed Provider 控制面

### DIFF
--- a/client/src/components/settings/ProviderWorkloadControlSettings.test.tsx
+++ b/client/src/components/settings/ProviderWorkloadControlSettings.test.tsx
@@ -81,7 +81,7 @@ describe("ProviderWorkloadControlSettings", () => {
     });
   });
 
-  it("saves exact bindings with optimistic revision while activation stays blocked in R6A", async () => {
+  it("saves exact bindings with optimistic revision while an unintegrated entry stays blocked", async () => {
     const policy = {
       contract_version: "modelmirror-provider-workload-routing-v1",
       entry_id: "agent_shadow",
@@ -112,7 +112,7 @@ describe("ProviderWorkloadControlSettings", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<ProviderWorkloadControlSettings csrfToken="csrf-value" view="routing" />);
-    await screen.findByText("R6A 入口、精确 Binding 与 Receipt 基础");
+    await screen.findByText("R6 入口、精确 Binding 与 Receipt");
     expect(screen.getByRole("button", { name: /激活 Managed/ })).toBeDisabled();
     fireEvent.click(screen.getByRole("button", { name: "添加 Binding" }));
     fireEvent.change(screen.getByLabelText("Binding 1 模型 ID"), {
@@ -135,5 +135,87 @@ describe("ProviderWorkloadControlSettings", () => {
         connection_id: connection.id,
       }],
     });
+  });
+
+  it("requires both operator acknowledgements before activating an integrated entry", async () => {
+    const policy = {
+      contract_version: "modelmirror-provider-workload-routing-v1",
+      entry_id: "agent_shadow",
+      feature_enabled: true,
+      data_plane_integrated: true,
+      configured_status: "legacy",
+      effective_status: "legacy",
+      revision: 4,
+      policy_fingerprint: "fingerprint",
+      bindings: [{
+        execution_shape: "chat_tools",
+        model_id: "openai/gpt-test",
+        connection_id: connection.id,
+        connection_name: connection.name,
+        provider_kind: connection.kind,
+        certification_id: "cert-chat-tools",
+        valid: true,
+        reason_code: "qualified",
+      }],
+      approval_valid: false,
+      blocking_reason_codes: [],
+    };
+    let activated = false;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/router/workload-control/policies" && !init) {
+        return jsonResponse({
+          policies: [activated ? {
+            ...policy,
+            configured_status: "managed_required",
+            effective_status: "managed_required",
+            revision: 5,
+            approval_valid: true,
+          } : policy],
+        });
+      }
+      if (url === "/api/router/connections") return jsonResponse([connection]);
+      if (url.startsWith("/api/router/workload-control/receipts")) {
+        return jsonResponse({ runs: [] });
+      }
+      if (
+        url === "/api/router/workload-control/policies/agent_shadow/activate"
+        && init?.method === "POST"
+      ) {
+        activated = true;
+        return jsonResponse({ ...policy, configured_status: "managed_required" });
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ProviderWorkloadControlSettings csrfToken="csrf-value" view="routing" />);
+    await screen.findByText("R6 入口、精确 Binding 与 Receipt");
+    const activateButton = screen.getByRole("button", { name: "激活 Managed 必经" });
+    expect(activateButton).toBeEnabled();
+    fireEvent.click(activateButton);
+
+    const confirmButton = screen.getByRole("button", { name: "确认激活" });
+    expect(confirmButton).toBeDisabled();
+    fireEvent.click(screen.getByLabelText("确认当前没有未解决的 P0/P1 阻塞项"));
+    expect(confirmButton).toBeDisabled();
+    fireEvent.click(screen.getByLabelText("理解并接受 Managed 不可用时失败关闭"));
+    expect(confirmButton).toBeEnabled();
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      "/api/router/workload-control/policies/agent_shadow/activate",
+      expect.objectContaining({ method: "POST" }),
+    ));
+    const call = fetchMock.mock.calls.find(([url, options]) =>
+      url === "/api/router/workload-control/policies/agent_shadow/activate"
+      && options?.method === "POST"
+    );
+    expect(JSON.parse(String(call?.[1]?.body))).toEqual({
+      expected_revision: 4,
+      no_open_p0_p1: true,
+      acknowledge_fail_closed: true,
+    });
+    await screen.findByText("Managed 必经");
   });
 });

--- a/client/src/components/settings/ProviderWorkloadControlSettings.tsx
+++ b/client/src/components/settings/ProviderWorkloadControlSettings.tsx
@@ -217,6 +217,9 @@ export default function ProviderWorkloadControlSettings({
 
   const [entryId, setEntryId] = useState<EntryId>("agent_shadow");
   const [editableBindings, setEditableBindings] = useState<EditableBinding[]>([]);
+  const [confirmActivation, setConfirmActivation] = useState(false);
+  const [confirmNoOpenP0P1, setConfirmNoOpenP0P1] = useState(false);
+  const [acknowledgeFailClosed, setAcknowledgeFailClosed] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -278,6 +281,9 @@ export default function ProviderWorkloadControlSettings({
 
   useEffect(() => {
     if (!selectedPolicy) return;
+    setConfirmActivation(false);
+    setConfirmNoOpenP0P1(false);
+    setAcknowledgeFailClosed(false);
     setEditableBindings(
       selectedPolicy.bindings.map((binding) => ({
         execution_shape: binding.execution_shape,
@@ -383,7 +389,7 @@ export default function ProviderWorkloadControlSettings({
       );
       if (!response.ok) throw new Error(await readError(response));
       setMessage(
-        "入口 Binding 已原子保存；R6A 尚未接管真实数据面，因此不会改变现有 Agent/Workflow 调用。",
+        "入口 Binding 已原子保存；只有已接入数据面的入口经过人工确认后才能激活。",
       );
       await load();
     } catch (reason) {
@@ -392,6 +398,47 @@ export default function ProviderWorkloadControlSettings({
       setBusy(false);
     }
   }, [csrfToken, editableBindings, entryId, load, selectedPolicy]);
+
+  const activate = useCallback(async () => {
+    if (!selectedPolicy || !confirmNoOpenP0P1 || !acknowledgeFailClosed) return;
+    setBusy(true);
+    setError("");
+    setMessage("");
+    try {
+      const response = await fetch(
+        `/api/router/workload-control/policies/${entryId}/activate`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-ModelMirror-CSRF": csrfToken,
+          },
+          body: JSON.stringify({
+            expected_revision: selectedPolicy.revision,
+            no_open_p0_p1: true,
+            acknowledge_fail_closed: true,
+          }),
+        },
+      );
+      if (!response.ok) throw new Error(await readError(response));
+      setMessage("该入口已激活 Managed 必经；资格漂移后将保持失败关闭。")
+      setConfirmActivation(false);
+      setConfirmNoOpenP0P1(false);
+      setAcknowledgeFailClosed(false);
+      await load();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "激活入口失败。")
+    } finally {
+      setBusy(false);
+    }
+  }, [
+    acknowledgeFailClosed,
+    confirmNoOpenP0P1,
+    csrfToken,
+    entryId,
+    load,
+    selectedPolicy,
+  ]);
 
   const deactivate = useCallback(async () => {
     if (!selectedPolicy) return;
@@ -504,8 +551,8 @@ export default function ProviderWorkloadControlSettings({
       <div className="flex flex-wrap items-start justify-between gap-3 border-b border-white/10 bg-sky-300/[0.04] px-5 py-5">
         <div>
           <p className="text-sm font-semibold text-sky-100">Managed Workload 控制策略</p>
-          <h2 className="mt-2 text-xl font-semibold text-white">R6A 入口、精确 Binding 与 Receipt 基础</h2>
-          <p className="mt-2 max-w-[80ch] text-sm leading-6 text-slate-300">当前子轮次只建设控制面，不接管真实 Agent/Workflow 调用。每个后续入口需完成独立 PR、真实 Smoke 与人工批准后才能激活。</p>
+          <h2 className="mt-2 text-xl font-semibold text-white">R6 入口、精确 Binding 与 Receipt</h2>
+          <p className="mt-2 max-w-[80ch] text-sm leading-6 text-slate-300">仅已完成对应数据面子轮次、资格有效且通过人工 fail-closed 确认的入口可以激活；其他入口继续保持 Legacy。</p>
         </div>
         <button className="inline-flex items-center gap-2 rounded-full border border-white/15 px-3 py-2 text-xs font-semibold text-slate-200" onClick={() => void load()} type="button"><RefreshCw className="h-3.5 w-3.5" />刷新</button>
       </div>
@@ -514,7 +561,7 @@ export default function ProviderWorkloadControlSettings({
           <label className="block text-sm text-slate-300">入口<select className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-white" value={entryId} onChange={(event) => setEntryId(event.target.value as EntryId)}>{Object.entries(ENTRY_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}</select></label>
           {selectedPolicy ? <div className="mt-4 rounded-lg border border-white/10 bg-white/[0.025] p-4">
             <div className="flex items-center justify-between gap-3"><span className="text-sm font-semibold text-white">{statusLabel(selectedPolicy.effective_status)}</span><span className="text-xs text-slate-400">revision {selectedPolicy.revision}</span></div>
-            <dl className="mt-3 grid gap-2 text-xs text-slate-300"><div className="flex justify-between"><dt>部署开关</dt><dd>{selectedPolicy.feature_enabled ? "开启" : "关闭"}</dd></div><div className="flex justify-between"><dt>数据面接入</dt><dd>{selectedPolicy.data_plane_integrated ? "已接入" : "R6A 未接入"}</dd></div><div className="flex justify-between"><dt>人工批准</dt><dd>{selectedPolicy.approval_valid ? "有效" : "未生效"}</dd></div></dl>
+            <dl className="mt-3 grid gap-2 text-xs text-slate-300"><div className="flex justify-between"><dt>部署开关</dt><dd>{selectedPolicy.feature_enabled ? "开启" : "关闭"}</dd></div><div className="flex justify-between"><dt>数据面接入</dt><dd>{selectedPolicy.data_plane_integrated ? "已接入" : "当前子轮次未接入"}</dd></div><div className="flex justify-between"><dt>人工批准</dt><dd>{selectedPolicy.approval_valid ? "有效" : "未生效"}</dd></div></dl>
             <div className="mt-3 space-y-1">{selectedPolicy.blocking_reason_codes.map((reason) => <p className="text-xs text-amber-100" key={reason}>· {REASON_LABELS[reason] ?? reason}</p>)}</div>
           </div> : null}
         </div>
@@ -526,10 +573,17 @@ export default function ProviderWorkloadControlSettings({
             <select aria-label={`Binding ${index + 1} 连接`} className="rounded-lg border border-white/10 bg-ink-950 px-2 py-2 text-sm text-white" value={binding.connection_id} onChange={(event) => setEditableBindings((current) => current.map((item, position) => position === index ? { ...item, connection_id: event.target.value } : item))}>{eligibleConnections.map((connection) => <option key={connection.id} value={connection.id}>{connection.name}</option>)}</select>
             <button className="rounded-full border border-rose-300/20 px-3 py-2 text-xs text-rose-100" onClick={() => setEditableBindings((current) => current.filter((_, position) => position !== index))} type="button">移除</button>
           </div>)}{!editableBindings.length ? <p className="rounded-lg border border-dashed border-white/10 p-4 text-sm text-slate-400">尚未配置；没有 Binding 时不能激活。</p> : null}</div>
-          <div className="mt-4 flex flex-wrap gap-2"><button className="rounded-full bg-sky-200 px-4 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={busy || !selectedPolicy || editableBindings.some((item) => !item.model_id.trim() || !item.connection_id)} onClick={() => void savePolicy()} type="button">保存 Binding</button>{selectedPolicy?.configured_status !== "legacy" ? <button className="rounded-full border border-white/15 px-4 py-2 text-sm text-slate-200" disabled={busy} onClick={() => void deactivate()} type="button">显式恢复 Legacy</button> : null}<button className="rounded-full border border-amber-300/20 px-4 py-2 text-sm text-amber-100 opacity-50" disabled type="button">激活 Managed（等待对应数据面子轮次）</button></div>
+          <div className="mt-4 flex flex-wrap gap-2"><button className="rounded-full bg-sky-200 px-4 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={busy || !selectedPolicy || editableBindings.some((item) => !item.model_id.trim() || !item.connection_id)} onClick={() => void savePolicy()} type="button">保存 Binding</button>{selectedPolicy?.configured_status !== "legacy" ? <button className="rounded-full border border-white/15 px-4 py-2 text-sm text-slate-200" disabled={busy} onClick={() => void deactivate()} type="button">显式恢复 Legacy</button> : <button className="rounded-full border border-amber-300/30 px-4 py-2 text-sm text-amber-100 disabled:cursor-not-allowed disabled:opacity-40" disabled={busy || !selectedPolicy.data_plane_integrated || !selectedPolicy.feature_enabled || selectedPolicy.blocking_reason_codes.length > 0} onClick={() => setConfirmActivation(true)} type="button">激活 Managed 必经</button>}</div>
         </div>
       </div>
-      <div className="border-t border-white/10 p-5"><h3 className="text-sm font-semibold text-white">最近脱敏 Receipt</h3><div className="mt-3 space-y-2">{receipts.length ? receipts.map((run) => <div className="rounded-lg border border-white/10 bg-white/[0.025] p-3" key={run.run_id}><div className="flex flex-wrap items-center justify-between gap-2"><p className="text-sm text-white">{ENTRY_LABELS[run.entry_id]} · {run.status}</p><span className="text-xs text-slate-400">{run.calls.length} 次逻辑调用</span></div><p className="mt-1 text-xs text-slate-400">仅保存模型、序号、状态、指标与用量；不保存 Prompt、消息、模型正文或工具参数。</p></div>) : <p className="rounded-lg border border-dashed border-white/10 p-4 text-sm text-slate-400">R6A 未接管数据面，因此当前没有 Workload Receipt。</p>}</div></div>
+      <div className="border-t border-white/10 p-5"><h3 className="text-sm font-semibold text-white">最近脱敏 Receipt</h3><div className="mt-3 space-y-2">{receipts.length ? receipts.map((run) => <div className="rounded-lg border border-white/10 bg-white/[0.025] p-3" key={run.run_id}><div className="flex flex-wrap items-center justify-between gap-2"><p className="text-sm text-white">{ENTRY_LABELS[run.entry_id]} · {run.status}</p><span className="text-xs text-slate-400">{run.calls.length} 次逻辑调用</span></div><p className="mt-1 text-xs text-slate-400">仅保存模型、序号、状态、指标与用量；不保存 Prompt、消息、模型正文或工具参数。</p></div>) : <p className="rounded-lg border border-dashed border-white/10 p-4 text-sm text-slate-400">当前入口尚无 Workload Receipt。</p>}</div></div>
+      {confirmActivation && selectedPolicy ? <div aria-modal="true" className="border-t border-amber-300/20 bg-amber-300/[0.05] p-5" role="dialog">
+        <p className="text-sm font-semibold text-amber-100">确认激活 {ENTRY_LABELS[entryId]} Managed 必经</p>
+        <p className="mt-2 text-sm leading-6 text-slate-300">激活后，Binding、资格、连接或凭据不合格时将失败关闭，不会自动回退 Legacy 或第二 Provider。</p>
+        <label className="mt-3 flex items-start gap-2 text-sm text-slate-200"><input checked={confirmNoOpenP0P1} className="mt-1" onChange={(event) => setConfirmNoOpenP0P1(event.target.checked)} type="checkbox" />确认当前没有未解决的 P0/P1 阻塞项</label>
+        <label className="mt-2 flex items-start gap-2 text-sm text-slate-200"><input checked={acknowledgeFailClosed} className="mt-1" onChange={(event) => setAcknowledgeFailClosed(event.target.checked)} type="checkbox" />理解并接受 Managed 不可用时失败关闭</label>
+        <div className="mt-4 flex gap-2"><button className="rounded-full bg-amber-200 px-4 py-2 text-sm font-semibold text-ink-950 disabled:cursor-not-allowed disabled:opacity-40" disabled={busy || !confirmNoOpenP0P1 || !acknowledgeFailClosed} onClick={() => void activate()} type="button">确认激活</button><button className="rounded-full border border-white/15 px-4 py-2 text-sm text-slate-200" disabled={busy} onClick={() => setConfirmActivation(false)} type="button">取消</button></div>
+      </div> : null}
       {error ? <p className="m-5 flex items-center gap-2 rounded-lg border border-rose-300/20 bg-rose-300/10 p-3 text-sm text-rose-100"><CircleAlert className="h-4 w-4" />{error}</p> : null}
       {message ? <p className="m-5 flex items-center gap-2 rounded-lg border border-emerald-300/20 bg-emerald-300/10 p-3 text-sm text-emerald-100"><BadgeCheck className="h-4 w-4" />{message}</p> : null}
     </section>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,9 +203,9 @@ Round 6A 在不接管 Agent/Workflow 数据面的前提下增加
 `entry_id + execution_shape + exact model_id` 精确绑定一个 Managed Connection；
 `chat_text`/`chat_tools` 复用 R5 资格，非流式文本、JSON Object 和原生 Fusion 使用各自
 独立资格。父运行与逻辑调用 Receipt 不保存 Prompt、消息、模型正文或工具参数，且重启后
-不重放 `uncertain` 调用。所有 R6 部署开关默认关闭，R6A 的数据面接入集合为空，因此
-Policy/Binding 可配置和审计但不能激活；现有 Agent、Workflow、Xpert 与 R5 Chat 调度均
-保持 legacy/原行为。后续入口只允许 Python 主进程解析凭据和调用 Provider，Worker 与工具
+不重放 `uncertain` 调用。所有 R6 部署开关默认关闭；R6B 只将 `agent_shadow` 加入数据面
+接入集合，其余 Policy/Binding 可配置和审计但不能激活；Workflow、Xpert 与 R5 Chat 调度均
+保持 legacy/原行为。接入入口只允许 Python 主进程解析凭据和调用 Provider，Worker 与工具
 执行器继续只处理模型消息、Tool Call 和脱敏结果。
 
 `/settings?section=overview|providers|routing` 共用一份 Provider 管理会话。Marble 等其他

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -217,10 +217,12 @@ MODEL_CONTROL_ROUTE_AGENT_ENABLED=false
 MODEL_CONTROL_TEAM_CHAT_ENABLED=false
 ```
 
-R6A 的入口数据面尚未接入，即使误开环境变量也不能激活 Managed Policy。管理员可以先完成
-新执行形态资格并保存精确 Binding，但 Agent、Workflow 和 Xpert 继续使用 legacy 路径。
-每个后续子轮次验收后才会把对应入口加入可激活集合。紧急回退先显式停用入口 Policy，再
-关闭对应开关并重启；保留 v16 表和 Receipt，旧代码可忽略这些表运行。
+R6B 仅接入 `agent_shadow` 数据面；其他 Agent、Workflow 和 Xpert 入口仍不能激活
+Managed Policy。`agent_shadow` 只有在 `MODEL_CONTROL_AGENT_SHADOW_ENABLED=true`、
+精确模型的 `chat_tools` 资格与 Binding 有效、且管理员明确批准 fail-closed 后才会接管。
+开关为 `false` 或 Policy 为 `legacy` 时继续使用原 Shadow 网关路径；已经激活但失效的
+Policy 会保持 `degraded_required`，不会自动回退。紧急回退需显式停用 Policy 或关闭该
+开关并重启 Server；保留 v16 Receipt 和 Shadow Workspace 数据。
 
 同一清理命令从 v16 起同时报告 R5 Chat 与 R6 Workload 的过期记录；第一条仍是 dry-run，
 只有第二条显式 `--apply` 才删除已完成记录。不得对正在运行的父运行或逻辑调用执行清理。

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -221,9 +221,12 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
   一个 Provider POST 和零自动重试，合成输入及响应正文不落库。
 - 管理接口以 optimistic revision 原子维护 Policy/Binding，并提供脱敏资格、Overview 和
   Receipt 查询；公共状态只返回部署开关、状态、是否在派发前阻断及稳定 reason code。
-- R6A 不接管任何 Agent、Workflow 或 Xpert 数据面。所有 R6 Feature Flag 默认 `false`，
-  `activate` 还会因入口尚未完成对应数据面子轮次而失败关闭；保存 Binding 不改变 legacy 调用。
-- 后续 R6B—R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
+- R6A 不接管任何 Agent、Workflow 或 Xpert 数据面。所有 R6 Feature Flag 默认 `false`。
+- R6B 只接入 Engine Shadow：模型别名解析为精确 invocation ID 后，使用
+  `agent_shadow + chat_tools` Binding；Worker `model.request` ID 是不可重放的逻辑调用键。
+  Flag 关闭或 Policy 为 `legacy` 时保留原 Shadow 网关；已激活策略失效后保持
+  `degraded_required` 并失败关闭。
+- 后续 R6C—R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
   只能存在于 Python 主进程内存，Worker、工具执行器和浏览器不得收到 Key、URL 或连接细节。
 - Receipt 清理命令现在同时检查 R5 Chat 与 R6 Workload 记录，仍默认 dry-run；`--apply`
   才删除超过保留期的已完成运行、尝试或调用。

--- a/docs/agent-upstream-shadow.md
+++ b/docs/agent-upstream-shadow.md
@@ -30,8 +30,10 @@ entrypoint; `PLAN.md`, scratch notes, and other inspectable workspace files are
 excluded. A later multi-file delivery round must introduce a versioned manifest
 before widening this contract.
 
-The worker receives a minimal environment and a sensitive model-lease IPC
-frame. Keys are not written to SQLite, events, error messages, or reports. Its
+The worker receives a minimal environment and a host model callback: it sends
+model messages to Python and receives only model segments plus a redacted
+outcome. Provider URLs, connection identifiers, and keys never cross into the
+worker. Keys are not written to SQLite, events, error messages, or reports. Its
 stdout is protocol-only; malformed frames, sequence gaps, duplicates, unknown
 fields, and stdout pollution fail closed.
 
@@ -52,6 +54,22 @@ The feature flag `AGENT_APP_ENGINE_SHADOW_ENABLED` defaults to `0`. When enabled
 Terminal states are `candidate_ready`, `blocked`, `budget_limited`, `stopped`,
 `interrupted`, and `failed`. Active runs become `interrupted` after server
 restart. An upstream Goal marked complete maps only to `candidate_ready`.
+
+R6B adds an independently disabled Provider control-plane path. When
+`MODEL_CONTROL_AGENT_SHADOW_ENABLED=false`, Shadow model calls retain the
+existing gateway path and do not create Workload Receipts. When the flag is on,
+only an explicitly approved `agent_shadow + chat_tools + exact model` Binding
+can activate `managed_required`. An invalidated active policy becomes
+`degraded_required` and blocks before the worker starts; it never silently
+returns to the legacy gateway.
+
+Each worker `model.request` ID is the immutable logical-call key. The Python
+host resolves one pinned Provider target, records dispatch before sending, and
+allows at most one Provider POST for that key. Cancellation, connection
+ambiguity, invalid streams, model mismatch, worker crashes, and restarts do not
+trigger a second Provider, IP, model, or legacy call. Shadow events expose only
+the managed flag, exact model, call sequence, status, and available token total;
+full redacted Receipt evidence remains in Provider Settings.
 
 ## Deliberate R3R-1 exclusions
 
@@ -89,3 +107,9 @@ Evidence created by Shadow execution.
 Rollback by setting `AGENT_APP_ENGINE_SHADOW_ENABLED=0` and rebuilding only
 `server` and `client`. Data is retained. Do not silently fall back to the
 abandoned Python AppBuild engine.
+
+To roll back only R6B routing, first deactivate the `agent_shadow` Policy or set
+`MODEL_CONTROL_AGENT_SHADOW_ENABLED=false`, then restart the Server. This
+restores the pre-R6B gateway path while retaining v16 Bindings, approvals, and
+redacted Receipts. A `degraded_required` policy remains fail-closed until the
+administrator explicitly deactivates it or restores its qualification.

--- a/server/agent_upstream/api.py
+++ b/server/agent_upstream/api.py
@@ -17,6 +17,7 @@ from .models import (
     EngineShadowRunRecord,
     EngineShadowWorkspaceEntry,
 )
+from .managed_gateway import ManagedShadowGateway
 from .service import EngineShadowService, EngineShadowServiceError
 from .store import (
     EngineShadowConflict,
@@ -58,7 +59,20 @@ def is_engine_shadow_enabled() -> bool:
 def get_engine_shadow_service() -> EngineShadowService:
     global _service
     if _service is None:
-        _service = EngineShadowService()
+        try:
+            from server.model_router.api import get_model_router_service
+            from server.model_router.workload_control import (
+                ProviderWorkloadCallService,
+            )
+        except ImportError:  # pragma: no cover - container package layout
+            from model_router.api import get_model_router_service
+            from model_router.workload_control import ProviderWorkloadCallService
+
+        _service = EngineShadowService(
+            managed_gateway=ManagedShadowGateway(
+                ProviderWorkloadCallService(get_model_router_service())
+            )
+        )
     return _service
 
 

--- a/server/agent_upstream/managed_gateway.py
+++ b/server/agent_upstream/managed_gateway.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+from typing import Any, Literal
+
+import httpx
+
+try:
+    from server.agent_workspace.gateway import (
+        DeltaCallback,
+        GatewayCapabilityError,
+        GatewayRequestError,
+        GatewayTurn,
+        OpenAICompatibleGateway,
+    )
+    from server.model_router.repository import RouterRepositoryError
+    from server.model_router.service import RouterServiceError
+    from server.model_router.workload_control import (
+        ProviderWorkloadCallService,
+        ProviderWorkloadPreparedCall,
+    )
+except ImportError:  # pragma: no cover - direct server package execution
+    from agent_workspace.gateway import (
+        DeltaCallback,
+        GatewayCapabilityError,
+        GatewayRequestError,
+        GatewayTurn,
+        OpenAICompatibleGateway,
+    )
+    from model_router.repository import RouterRepositoryError
+    from model_router.service import RouterServiceError
+    from model_router.workload_control import (
+        ProviderWorkloadCallService,
+        ProviderWorkloadPreparedCall,
+    )
+
+
+ShadowRoutingMode = Literal["legacy", "managed_required", "degraded_required"]
+
+
+class ManagedShadowRoutingError(RuntimeError):
+    def __init__(self, code: str, public_message: str) -> None:
+        super().__init__(code)
+        self.code = code
+        self.public_message = public_message
+
+
+class ManagedShadowGateway:
+    """Host-only Engine Shadow adapter for one exact managed Provider target."""
+
+    def __init__(
+        self,
+        call_service: ProviderWorkloadCallService,
+        *,
+        parser: OpenAICompatibleGateway | None = None,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self.call_service = call_service
+        self.parser = parser or OpenAICompatibleGateway()
+        self._client_factory = client_factory
+
+    def routing_mode(self) -> ShadowRoutingMode:
+        control = self.call_service.control
+        if not control.feature_enabled("agent_shadow"):
+            return "legacy"
+        policy = control.get_policy("agent_shadow")
+        if policy.configured_status == "legacy":
+            return "legacy"
+        if policy.effective_status == "managed_required":
+            return "managed_required"
+        return "degraded_required"
+
+    def resolve_exact_model(self, requested_model_id: str) -> str | None:
+        """Resolve only a currently valid exact chat_tools Binding."""
+
+        clean = requested_model_id.strip()
+        if not clean:
+            return None
+        policy = self.call_service.control.get_policy("agent_shadow")
+        if policy.effective_status != "managed_required":
+            return None
+        binding = next(
+            (
+                item
+                for item in policy.bindings
+                if item.execution_shape == "chat_tools"
+                and item.model_id == clean
+                and item.valid
+            ),
+            None,
+        )
+        return binding.model_id if binding is not None else None
+
+    def start_run(self, *, parent_run_reference: str) -> str:
+        return self.call_service.start_run(
+            "agent_shadow", parent_run_reference=parent_run_reference
+        )
+
+    async def stream_turn(
+        self,
+        *,
+        workload_run_id: str,
+        logical_call_key: str,
+        call_sequence: int,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        max_tokens: int,
+        thinking_level: str,
+        timeout_ms: int,
+        on_delta: DeltaCallback,
+    ) -> GatewayTurn:
+        prepared: ProviderWorkloadPreparedCall | None = None
+        dispatched = False
+        try:
+            prepared = await self.call_service.prepare_call(
+                run_id=workload_run_id,
+                entry_id="agent_shadow",
+                execution_shape="chat_tools",
+                model_id=model_id,
+                logical_call_key=logical_call_key,
+                call_sequence=call_sequence,
+            )
+            payload = self.parser.build_stream_payload(
+                model_id=model_id,
+                messages=messages,
+                tools=tools,
+                max_tokens=max_tokens,
+                thinking_level=thinking_level,
+            )
+            client = (
+                self._client_factory()
+                if self._client_factory is not None
+                else httpx.AsyncClient(
+                    timeout=httpx.Timeout(
+                        connect=min(15.0, timeout_ms / 1000),
+                        read=timeout_ms / 1000,
+                        write=30.0,
+                        pool=10.0,
+                    ),
+                    follow_redirects=False,
+                    trust_env=False,
+                    transport=httpx.AsyncHTTPTransport(retries=0),
+                )
+            )
+            async with client:
+                request = self.call_service.transport.build_authorized_stream_request(
+                    client,
+                    prepared.target,
+                    prepared.authorized_target,
+                    payload,
+                )
+                self.call_service.mark_dispatched(prepared)
+                dispatched = True
+                started_at = time.monotonic()
+                response = await self.call_service.transport.send_authorized_stream(
+                    client, request
+                )
+                try:
+                    turn = await self.parser.consume_stream_response(
+                        response,
+                        requested_model_id=model_id,
+                        on_delta=on_delta,
+                        started_at=started_at,
+                        require_terminal=True,
+                    )
+                finally:
+                    await response.aclose()
+            if turn.model_id != model_id:
+                raise ManagedShadowRoutingError(
+                    "provider_workload_actual_model_mismatch",
+                    "The managed Provider returned a different model than the exact Binding.",
+                )
+            self.call_service.complete_call(
+                prepared,
+                status="passed",
+                result_class="success",
+                actual_model=turn.model_id,
+                ttft_ms=turn.ttft_ms,
+                e2e_ms=turn.e2e_ms,
+                prompt_tokens=turn.prompt_tokens,
+                completion_tokens=turn.completion_tokens,
+                total_tokens=turn.total_tokens,
+            )
+            return turn
+        except asyncio.CancelledError:
+            self._complete_call_safely(
+                prepared,
+                status="cancelled",
+                result_class="client_cancelled",
+                error_code="provider_workload_call_cancelled",
+            )
+            raise
+        except ManagedShadowRoutingError as exc:
+            self._complete_call_safely(
+                prepared,
+                status="failed",
+                result_class="model_mismatch",
+                error_code=exc.code,
+            )
+            raise GatewayRequestError(exc.public_message) from exc
+        except GatewayCapabilityError:
+            self._complete_call_safely(
+                prepared,
+                status="failed",
+                result_class="capability_error",
+                error_code="provider_workload_tool_capability_failed",
+            )
+            raise
+        except GatewayRequestError:
+            self._complete_call_safely(
+                prepared,
+                status="failed",
+                result_class="provider_error" if dispatched else "preflight_error",
+                error_code=(
+                    "provider_workload_provider_request_failed"
+                    if dispatched
+                    else "provider_workload_preflight_failed"
+                ),
+            )
+            raise
+        except RouterServiceError as exc:
+            self._complete_call_safely(
+                prepared,
+                status="uncertain" if dispatched else "failed",
+                result_class="control_plane_error",
+                error_code=exc.code,
+            )
+            raise GatewayRequestError(
+                "The managed Provider route failed closed before a replay could occur."
+            ) from exc
+        except Exception as exc:
+            self._complete_call_safely(
+                prepared,
+                status="uncertain" if dispatched else "failed",
+                result_class="transport_error" if dispatched else "preflight_error",
+                error_code=(
+                    "provider_workload_dispatch_uncertain"
+                    if dispatched
+                    else "provider_workload_preflight_failed"
+                ),
+            )
+            raise GatewayRequestError(
+                "The managed Provider request failed without replay."
+            ) from exc
+
+    def finish_run(self, workload_run_id: str, shadow_status: str) -> None:
+        status = "failed"
+        result_class = "shadow_failed"
+        reason_codes = [f"agent_shadow_{shadow_status}"]
+        if shadow_status == "candidate_ready":
+            status = "passed"
+            result_class = "candidate_ready"
+            reason_codes = []
+        elif shadow_status == "stopped":
+            status = "cancelled"
+            result_class = "user_stopped"
+        elif shadow_status == "interrupted":
+            status = "uncertain"
+            result_class = "server_interrupted"
+        try:
+            self.call_service.complete_run(
+                workload_run_id,
+                status=status,
+                result_class=result_class,
+                reason_codes=reason_codes,
+            )
+        except RouterRepositoryError as exc:
+            if status == "passed" and str(exc) == (
+                "provider_workload_run_passed_without_successful_calls"
+            ):
+                self.call_service.complete_run(
+                    workload_run_id,
+                    status="failed",
+                    result_class="workload_call_failed",
+                    reason_codes=["provider_workload_call_failed"],
+                )
+                return
+            if str(exc) != "provider_workload_run_not_running":
+                raise
+
+    def _complete_call_safely(
+        self,
+        prepared: ProviderWorkloadPreparedCall | None,
+        *,
+        status: str,
+        result_class: str,
+        error_code: str,
+    ) -> None:
+        if prepared is None:
+            return
+        try:
+            self.call_service.complete_call(
+                prepared,
+                status=status,
+                result_class=result_class,
+                error_code=error_code,
+            )
+        except RouterRepositoryError:
+            # Preserve the original transport/control-plane failure. Startup
+            # reconciliation will mark any still-running receipt uncertain.
+            return

--- a/server/agent_upstream/service.py
+++ b/server/agent_upstream/service.py
@@ -42,6 +42,7 @@ from .models import (
     ResolvedShadowModel,
     TERMINAL_STATUSES,
 )
+from .managed_gateway import ManagedShadowGateway
 from .port import (
     AppBuildEnginePort,
     EnginePortError,
@@ -106,6 +107,7 @@ class EngineShadowService:
         store: EngineShadowStore | None = None,
         port: AppBuildEnginePort | None = None,
         gateway: OpenAICompatibleGateway | None = None,
+        managed_gateway: ManagedShadowGateway | None = None,
         tool_bridge: UpstreamShadowToolBridge | None = None,
         catalog_provider: CatalogProvider | None = None,
         package_root: Path | None = None,
@@ -113,15 +115,33 @@ class EngineShadowService:
         self.store = store or EngineShadowStore()
         self.port = port or NodeUpstreamEnginePort(package_root=package_root)
         self.gateway = gateway or OpenAICompatibleGateway()
+        self.managed_gateway = managed_gateway
         self.tool_bridge = tool_bridge or UpstreamShadowToolBridge()
         self._catalog_provider = catalog_provider
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._histories: dict[str, list[dict[str, Any]]] = {}
+        self._managed_runs: dict[str, str] = {}
+        self._managed_call_sequences: dict[str, int] = {}
         self._history_lock = asyncio.Lock()
+        self._managed_lock = asyncio.Lock()
         self._lifecycle_lock = asyncio.Lock()
 
     async def create_run(self, payload: EngineShadowRunCreate) -> EngineShadowRunRecord:
-        model = await self.resolve_model(payload.model_base_id)
+        managed_mode = (
+            self.managed_gateway.routing_mode()
+            if self.managed_gateway is not None
+            else "legacy"
+        )
+        if managed_mode == "degraded_required":
+            raise EngineShadowServiceError(
+                "provider_workload_agent_shadow_degraded_required",
+                "Engine Shadow 的 Managed Provider 策略已失效；请重新完成资格或显式停用策略。",
+                status_code=409,
+            )
+        model = await self.resolve_model(
+            payload.model_base_id,
+            allow_managed_exact=managed_mode == "managed_required",
+        )
         try:
             record = self.store.create_run(payload, model)
             workspace = self.store.workspace(record.run_id)
@@ -142,6 +162,28 @@ class EngineShadowService:
                 except EngineShadowStoreError:
                     pass
             raise
+
+        if managed_mode == "managed_required":
+            assert self.managed_gateway is not None
+            try:
+                workload_run_id = self.managed_gateway.start_run(
+                    parent_run_reference=record.run_id
+                )
+            except Exception as exc:
+                self.store.finish(
+                    record.run_id,
+                    "failed",
+                    error_code="provider_workload_run_start_failed",
+                    public_error="Engine Shadow Managed Provider 运行无法启动。",
+                )
+                raise EngineShadowServiceError(
+                    "provider_workload_run_start_failed",
+                    "Engine Shadow Managed Provider 运行无法启动。",
+                    status_code=409,
+                ) from exc
+            async with self._managed_lock:
+                self._managed_runs[record.run_id] = workload_run_id
+                self._managed_call_sequences[record.run_id] = 0
 
         system_prompt = self._system_prompt(record.objective)
         async with self._history_lock:
@@ -177,15 +219,25 @@ class EngineShadowService:
         )
         return self.store.get_run(record.run_id)
 
-    async def resolve_model(self, requested_base_id: str) -> ResolvedShadowModel:
+    async def resolve_model(
+        self,
+        requested_base_id: str,
+        *,
+        allow_managed_exact: bool = False,
+    ) -> ResolvedShadowModel:
         clean = requested_base_id.strip()
         if not clean:
             raise EngineShadowServiceError(
                 "model_not_found", "The requested model is not registered.", status_code=404
             )
+        managed_exact = None
+        if allow_managed_exact and self.managed_gateway is not None:
+            managed_exact = self.managed_gateway.resolve_exact_model(clean)
         try:
             catalog = await self._catalog()
         except Exception as exc:
+            if managed_exact is not None:
+                return self._managed_exact_model(clean, managed_exact)
             raise EngineShadowServiceError(
                 "model_catalog_unavailable",
                 "The model catalog is currently unavailable.",
@@ -193,6 +245,8 @@ class EngineShadowService:
             ) from exc
         models = getattr(catalog, "models", None)
         if not isinstance(models, list):
+            if managed_exact is not None:
+                return self._managed_exact_model(clean, managed_exact)
             raise EngineShadowServiceError(
                 "model_catalog_unavailable",
                 "The model catalog did not return a usable model list.",
@@ -210,6 +264,8 @@ class EngineShadowService:
             if target in keys or target == suffix:
                 matches.append(candidate)
         if not matches:
+            if managed_exact is not None:
+                return self._managed_exact_model(clean, managed_exact)
             raise EngineShadowServiceError(
                 "model_not_found", "The requested model is not registered.", status_code=404
             )
@@ -233,6 +289,17 @@ class EngineShadowService:
             invocation_id=str(candidate.invocation_id),
             context_window=max(32_000, int(candidate.context_length or 128_000)),
             max_output_tokens=max(1_024, min(int(candidate.max_output_tokens or 32_000), 32_000)),
+        )
+
+    @staticmethod
+    def _managed_exact_model(
+        requested_base_id: str, invocation_id: str
+    ) -> ResolvedShadowModel:
+        return ResolvedShadowModel(
+            requested_base_id=requested_base_id,
+            invocation_id=invocation_id,
+            context_window=128_000,
+            max_output_tokens=32_000,
         )
 
     def list_runs(self, *, limit: int = 100) -> list[EngineShadowRunRecord]:
@@ -371,6 +438,7 @@ class EngineShadowService:
                 "The upstream shadow run failed.",
             )
         finally:
+            await self._finish_managed_run(spec.run_id)
             async with self._history_lock:
                 self._histories.pop(spec.run_id, None)
 
@@ -464,23 +532,77 @@ class EngineShadowService:
                 if isinstance(delta, str):
                     thinking_parts.append(delta)
 
+        workload_run_id: str | None = None
+        call_sequence = 0
         try:
-            turn = await self.gateway.stream_turn(
-                model_id=model.invocation_id,
-                messages=messages,
-                tools=self._gateway_tools(),
-                max_tokens=model.max_output_tokens,
-                thinking_level=str(request.payload.get("thinking_level") or "medium"),
-                timeout_ms=120_000,
-                on_delta=on_delta,
+            workload_run_id, call_sequence = await self._managed_call_context(
+                request.run_id
             )
+            if workload_run_id is not None:
+                assert self.managed_gateway is not None
+                turn = await self.managed_gateway.stream_turn(
+                    workload_run_id=workload_run_id,
+                    logical_call_key=request.request_id,
+                    call_sequence=call_sequence,
+                    model_id=model.invocation_id,
+                    messages=messages,
+                    tools=self._gateway_tools(),
+                    max_tokens=model.max_output_tokens,
+                    thinking_level=str(
+                        request.payload.get("thinking_level") or "medium"
+                    ),
+                    timeout_ms=120_000,
+                    on_delta=on_delta,
+                )
+            else:
+                turn = await self.gateway.stream_turn(
+                    model_id=model.invocation_id,
+                    messages=messages,
+                    tools=self._gateway_tools(),
+                    max_tokens=model.max_output_tokens,
+                    thinking_level=str(
+                        request.payload.get("thinking_level") or "medium"
+                    ),
+                    timeout_ms=120_000,
+                    on_delta=on_delta,
+                )
+        except asyncio.CancelledError:
+            self._record_provider_route_receipt(
+                request.run_id,
+                workload_run_id=workload_run_id,
+                model_id=model.invocation_id,
+                call_sequence=call_sequence,
+                status="cancelled",
+            )
+            raise
         except GatewayNotConfiguredError:
+            self._record_provider_route_receipt(
+                request.run_id,
+                workload_run_id=workload_run_id,
+                model_id=model.invocation_id,
+                call_sequence=call_sequence,
+                status="failed",
+            )
             return self._model_failure("auth", "The LLM gateway is not configured.")
         except GatewayCapabilityError:
+            self._record_provider_route_receipt(
+                request.run_id,
+                workload_run_id=workload_run_id,
+                model_id=model.invocation_id,
+                call_sequence=call_sequence,
+                status="failed",
+            )
             return self._model_failure(
                 "failed", "The selected model does not support native Tool Calling."
             )
         except GatewayRequestError:
+            self._record_provider_route_receipt(
+                request.run_id,
+                workload_run_id=workload_run_id,
+                model_id=model.invocation_id,
+                call_sequence=call_sequence,
+                status="failed",
+            )
             return self._model_failure("failed", "The model gateway request failed.")
 
         segments = self._turn_segments(turn, thinking_parts)
@@ -489,22 +611,77 @@ class EngineShadowService:
             if request.run_id in self._histories:
                 self._histories[request.run_id].extend(converted)
                 self._histories[request.run_id].append(assistant_message)
-        input_tokens = self._estimate_tokens(messages)
-        output_tokens = self._estimate_tokens(
+        input_tokens = turn.prompt_tokens or self._estimate_tokens(messages)
+        output_tokens = turn.completion_tokens or self._estimate_tokens(
             [assistant_message, {"thinking": "".join(thinking_parts)}]
         )
+        total_tokens = turn.total_tokens or input_tokens + output_tokens
         current = self.store.get_run(request.run_id)
         self._update_if_active(request.run_id, model_turns=current.model_turns + 1)
+        self._record_provider_route_receipt(
+            request.run_id,
+            workload_run_id=workload_run_id,
+            model_id=model.invocation_id,
+            call_sequence=call_sequence,
+            status="passed",
+            total_tokens=turn.total_tokens,
+        )
         return {
             "segments": segments,
             "usage": {
                 "cache_read": 0,
                 "cache_write": 0,
                 "output": output_tokens,
-                "total": input_tokens + output_tokens,
+                "total": total_tokens,
             },
             "outcome": {"status": "completed"},
         }
+
+    async def _managed_call_context(self, run_id: str) -> tuple[str | None, int]:
+        async with self._managed_lock:
+            workload_run_id = self._managed_runs.get(run_id)
+            if workload_run_id is None:
+                return None, 0
+            sequence = self._managed_call_sequences.get(run_id, 0) + 1
+            self._managed_call_sequences[run_id] = sequence
+            return workload_run_id, sequence
+
+    def _record_provider_route_receipt(
+        self,
+        run_id: str,
+        *,
+        workload_run_id: str | None,
+        model_id: str,
+        call_sequence: int,
+        status: str,
+        total_tokens: int | None = None,
+    ) -> None:
+        if workload_run_id is None:
+            return
+        payload: dict[str, Any] = {
+            "managed": True,
+            "model_id": model_id,
+            "call_sequence": call_sequence,
+            "status": status,
+        }
+        if total_tokens is not None:
+            payload["total_tokens"] = total_tokens
+        try:
+            self.store.append_event(run_id, "provider_route_receipt", payload)
+        except EngineShadowStoreError:
+            return
+
+    async def _finish_managed_run(self, run_id: str) -> None:
+        async with self._managed_lock:
+            workload_run_id = self._managed_runs.pop(run_id, None)
+            self._managed_call_sequences.pop(run_id, None)
+        if workload_run_id is None or self.managed_gateway is None:
+            return
+        try:
+            shadow_status = self.store.get_run(run_id).status
+        except EngineShadowStoreError:
+            shadow_status = "interrupted"
+        self.managed_gateway.finish_run(workload_run_id, shadow_status)
 
     async def _catalog(self) -> Any:
         if self._catalog_provider is not None:

--- a/server/agent_workspace/gateway.py
+++ b/server/agent_workspace/gateway.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import json
 import os
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable
@@ -11,6 +12,9 @@ import httpx
 
 
 DeltaCallback = Callable[[str, dict[str, Any]], Awaitable[None] | None]
+MAX_GATEWAY_ERROR_BYTES = 1024 * 1024
+MAX_GATEWAY_SSE_EVENT_BYTES = 256 * 1024
+MAX_GATEWAY_STREAM_BYTES = 4 * 1024 * 1024
 
 
 class GatewayError(RuntimeError):
@@ -49,6 +53,11 @@ class GatewayTurn:
     tool_calls: tuple[NativeToolCall, ...]
     finish_reason: str
     model_id: str
+    ttft_ms: float | None = None
+    e2e_ms: float | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
 
 
 class OpenAICompatibleGateway:
@@ -101,6 +110,46 @@ class OpenAICompatibleGateway:
         on_delta: DeltaCallback,
     ) -> GatewayTurn:
         url, key, _ = self.configuration()
+        payload = self.build_stream_payload(
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            max_tokens=max_tokens,
+            thinking_level=thinking_level,
+        )
+        timeout = httpx.Timeout(
+            connect=min(15.0, timeout_ms / 1000),
+            read=timeout_ms / 1000,
+            write=30.0,
+            pool=10.0,
+        )
+        kwargs: dict[str, Any] = {"timeout": timeout}
+        if self._transport is not None:
+            kwargs["transport"] = self._transport
+        started_at = time.monotonic()
+        async with httpx.AsyncClient(**kwargs) as client:
+            async with client.stream(
+                "POST",
+                url,
+                headers=self._headers(key),
+                json=payload,
+            ) as response:
+                return await self.consume_stream_response(
+                    response,
+                    requested_model_id=model_id,
+                    on_delta=on_delta,
+                    started_at=started_at,
+                )
+
+    @staticmethod
+    def build_stream_payload(
+        *,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        max_tokens: int,
+        thinking_level: str,
+    ) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "model": model_id,
             "messages": messages,
@@ -112,90 +161,119 @@ class OpenAICompatibleGateway:
         }
         if thinking_level in {"low", "medium", "high", "xhigh"}:
             payload["reasoning"] = {"effort": thinking_level}
-        timeout = httpx.Timeout(
-            connect=min(15.0, timeout_ms / 1000),
-            read=timeout_ms / 1000,
-            write=30.0,
-            pool=10.0,
-        )
-        kwargs: dict[str, Any] = {"timeout": timeout}
-        if self._transport is not None:
-            kwargs["transport"] = self._transport
-        async with httpx.AsyncClient(**kwargs) as client:
-            async with client.stream(
-                "POST",
-                url,
-                headers=self._headers(key),
-                json=payload,
-            ) as response:
-                if response.status_code >= 400:
-                    body = await response.aread()
-                    self._raise_upstream(response.status_code, body)
-                content_parts: list[str] = []
-                calls: dict[int, dict[str, str]] = {}
-                finish_reason = ""
-                saw_event = False
-                async for line in response.aiter_lines():
-                    clean = line.strip()
-                    if not clean or clean.startswith(":"):
-                        continue
-                    if clean == "data: [DONE]":
-                        break
-                    raw = clean[5:].strip() if clean.startswith("data:") else clean
-                    try:
-                        event = json.loads(raw)
-                    except json.JSONDecodeError:
-                        continue
-                    saw_event = True
-                    if isinstance(event, dict) and isinstance(event.get("error"), dict):
-                        message = str(event["error"].get("message") or "模型流返回错误")
-                        self._raise_message(message)
-                    choices = event.get("choices") if isinstance(event, dict) else None
-                    if not isinstance(choices, list) or not choices:
-                        continue
-                    choice = choices[0] if isinstance(choices[0], dict) else {}
-                    finish_reason = str(choice.get("finish_reason") or finish_reason)
-                    delta = choice.get("delta")
-                    if not isinstance(delta, dict):
-                        message = choice.get("message")
-                        if isinstance(message, dict):
-                            delta = message
-                        else:
-                            continue
-                    text = self._text(delta.get("content"))
-                    if text:
-                        content_parts.append(text)
-                        await self._emit(on_delta, "text_delta", {"delta": text})
-                    thought = self._text(
-                        delta.get("reasoning_content", delta.get("reasoning"))
+        return payload
+
+    async def consume_stream_response(
+        self,
+        response: httpx.Response,
+        *,
+        requested_model_id: str,
+        on_delta: DeltaCallback,
+        started_at: float | None = None,
+        require_terminal: bool = False,
+    ) -> GatewayTurn:
+        if response.status_code >= 400:
+            body = bytearray()
+            async for chunk in response.aiter_bytes():
+                if len(body) + len(chunk) > MAX_GATEWAY_ERROR_BYTES:
+                    raise GatewayRequestError("模型服务错误响应超过安全上限。")
+                body.extend(chunk)
+            self._raise_upstream(response.status_code, bytes(body))
+        started = started_at if started_at is not None else time.monotonic()
+        first_delta_at: float | None = None
+        content_parts: list[str] = []
+        calls: dict[int, dict[str, str]] = {}
+        finish_reason = ""
+        actual_model = ""
+        prompt_tokens: int | None = None
+        completion_tokens: int | None = None
+        total_tokens: int | None = None
+        saw_event = False
+        saw_done = False
+        stream_bytes = 0
+        async for line in response.aiter_lines():
+            clean = line.strip()
+            if not clean or clean.startswith(":"):
+                continue
+            if clean == "data: [DONE]":
+                saw_done = True
+                break
+            encoded_size = len(clean.encode("utf-8"))
+            stream_bytes += encoded_size
+            if encoded_size > MAX_GATEWAY_SSE_EVENT_BYTES:
+                raise GatewayRequestError("模型流事件超过安全上限。")
+            if stream_bytes > MAX_GATEWAY_STREAM_BYTES:
+                raise GatewayRequestError("模型流响应超过安全上限。")
+            raw = clean[5:].strip() if clean.startswith("data:") else clean
+            try:
+                event = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            saw_event = True
+            if isinstance(event, dict) and isinstance(event.get("error"), dict):
+                message = str(event["error"].get("message") or "模型流返回错误")
+                self._raise_message(message)
+            if isinstance(event, dict):
+                if event.get("model"):
+                    actual_model = str(event["model"])
+                usage = event.get("usage")
+                if isinstance(usage, dict):
+                    prompt_tokens = self._optional_int(usage.get("prompt_tokens"))
+                    completion_tokens = self._optional_int(
+                        usage.get("completion_tokens")
                     )
-                    if thought:
-                        await self._emit(on_delta, "thinking_delta", {"delta": thought})
-                    raw_calls = delta.get("tool_calls")
-                    if isinstance(raw_calls, list):
-                        for raw_call in raw_calls:
-                            if not isinstance(raw_call, dict):
-                                continue
-                            index = int(raw_call.get("index") or 0)
-                            accumulated = calls.setdefault(
-                                index, {"id": "", "name": "", "arguments": ""}
+                    total_tokens = self._optional_int(usage.get("total_tokens"))
+            choices = event.get("choices") if isinstance(event, dict) else None
+            if not isinstance(choices, list) or not choices:
+                continue
+            choice = choices[0] if isinstance(choices[0], dict) else {}
+            finish_reason = str(choice.get("finish_reason") or finish_reason)
+            delta = choice.get("delta")
+            if not isinstance(delta, dict):
+                message = choice.get("message")
+                if isinstance(message, dict):
+                    delta = message
+                else:
+                    continue
+            text = self._text(delta.get("content"))
+            if text:
+                first_delta_at = first_delta_at or time.monotonic()
+                content_parts.append(text)
+                await self._emit(on_delta, "text_delta", {"delta": text})
+            thought = self._text(
+                delta.get("reasoning_content", delta.get("reasoning"))
+            )
+            if thought:
+                first_delta_at = first_delta_at or time.monotonic()
+                await self._emit(on_delta, "thinking_delta", {"delta": thought})
+            raw_calls = delta.get("tool_calls")
+            if isinstance(raw_calls, list):
+                for raw_call in raw_calls:
+                    if not isinstance(raw_call, dict):
+                        continue
+                    first_delta_at = first_delta_at or time.monotonic()
+                    index = int(raw_call.get("index") or 0)
+                    accumulated = calls.setdefault(
+                        index, {"id": "", "name": "", "arguments": ""}
+                    )
+                    if raw_call.get("id"):
+                        accumulated["id"] = str(raw_call["id"])
+                    function = raw_call.get("function")
+                    if isinstance(function, dict):
+                        if function.get("name"):
+                            accumulated["name"] += str(function["name"])
+                        if function.get("arguments"):
+                            argument_delta = str(function["arguments"])
+                            accumulated["arguments"] += argument_delta
+                            await self._emit(
+                                on_delta,
+                                "tool_call_delta",
+                                {"index": index, "delta": argument_delta},
                             )
-                            if raw_call.get("id"):
-                                accumulated["id"] = str(raw_call["id"])
-                            function = raw_call.get("function")
-                            if isinstance(function, dict):
-                                if function.get("name"):
-                                    accumulated["name"] += str(function["name"])
-                                if function.get("arguments"):
-                                    argument_delta = str(function["arguments"])
-                                    accumulated["arguments"] += argument_delta
-                                    await self._emit(
-                                        on_delta,
-                                        "tool_call_delta",
-                                        {"index": index, "delta": argument_delta},
-                                    )
         if not saw_event:
             raise GatewayRequestError("模型没有返回可解析的流式响应。")
+        if require_terminal and not saw_done and not finish_reason:
+            raise GatewayRequestError("模型流没有返回安全终止信号。")
         tool_calls: list[NativeToolCall] = []
         for index in sorted(calls):
             item = calls[index]
@@ -214,7 +292,16 @@ class OpenAICompatibleGateway:
             content="".join(content_parts),
             tool_calls=tuple(tool_calls),
             finish_reason=finish_reason or ("tool_calls" if tool_calls else "stop"),
-            model_id=model_id,
+            model_id=actual_model or requested_model_id,
+            ttft_ms=(
+                round((first_delta_at - started) * 1000, 3)
+                if first_delta_at is not None
+                else None
+            ),
+            e2e_ms=round((time.monotonic() - started) * 1000, 3),
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
         )
 
     async def describe_image(
@@ -325,3 +412,10 @@ class OpenAICompatibleGateway:
         if isinstance(value, dict) and isinstance(value.get("text"), str):
             return value["text"]
         return ""
+
+    @staticmethod
+    def _optional_int(value: Any) -> int | None:
+        try:
+            return int(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None

--- a/server/model_router/workload_control.py
+++ b/server/model_router/workload_control.py
@@ -99,7 +99,9 @@ ENTRY_ALLOWED_SHAPES: dict[
 
 # R6A deliberately provides only the control-plane foundation. Each later data-plane
 # PR adds its entry here after its dedicated tests and real smoke are complete.
-DATA_PLANE_INTEGRATED_ENTRIES: frozenset[ProviderWorkloadEntryId] = frozenset()
+DATA_PLANE_INTEGRATED_ENTRIES: frozenset[ProviderWorkloadEntryId] = frozenset(
+    {"agent_shadow"}
+)
 
 
 def _enabled(value: str | None, *, default: bool = False) -> bool:
@@ -1424,7 +1426,7 @@ class ProviderWorkloadPreparedCall:
 
 
 class ProviderWorkloadCallService:
-    """Future data-plane seam: exact target plus one-dispatch receipt guard."""
+    """Exact managed target and one-dispatch receipt guard for R6 data planes."""
 
     def __init__(self, router_service: ModelRouterService) -> None:
         self.router_service = router_service
@@ -1607,6 +1609,50 @@ class ProviderWorkloadCallService:
                     status_code=409,
                 ) from exc
             raise
+
+    def complete_call(
+        self,
+        prepared: ProviderWorkloadPreparedCall,
+        *,
+        status: str,
+        result_class: str | None = None,
+        error_code: str | None = None,
+        actual_model: str | None = None,
+        ttft_ms: float | None = None,
+        e2e_ms: float | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+    ) -> None:
+        self.repository.complete_workload_call(
+            self.router_service.tenant_id,
+            prepared.call_id,
+            status=status,
+            result_class=result_class,
+            error_code=error_code,
+            actual_model=actual_model,
+            ttft_ms=ttft_ms,
+            e2e_ms=e2e_ms,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+        )
+
+    def complete_run(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        result_class: str | None = None,
+        reason_codes: list[str] | None = None,
+    ) -> None:
+        self.repository.complete_workload_run(
+            self.router_service.tenant_id,
+            run_id,
+            status=status,
+            result_class=result_class,
+            reason_codes=reason_codes,
+        )
 
     @staticmethod
     def _ensure_active(policy: ProviderWorkloadPolicyResponse) -> None:

--- a/server/tests/test_agent_upstream_managed_gateway.py
+++ b/server/tests/test_agent_upstream_managed_gateway.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from server.agent_upstream.managed_gateway import ManagedShadowGateway
+from server.model_router.egress import ProviderEgressPolicy
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import (
+    ProviderWorkloadActivationRequest,
+    ProviderWorkloadBindingUpdate,
+    ProviderWorkloadPolicyUpdate,
+    RouterConnectionCreate,
+)
+from server.model_router.service import ModelRouterService
+from server.model_router.workload_control import (
+    ProviderWorkloadCallService,
+    ProviderWorkloadControlService,
+)
+from server.agent_workspace.gateway import GatewayRequestError
+
+
+MODEL_ID = "provider/tool-model"
+PROVIDER_SECRET = "managed-shadow-provider-secret"
+
+
+def _qualified_router(tmp_path: Path) -> tuple[ModelRouterService, str]:
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Shadow Provider",
+            kind="openai_compatible",
+            base_url="https://shadow-provider.example/v1",
+            api_key=PROVIDER_SECRET,
+            scopes=["chat"],
+        ),
+    )
+    repository.save_test_result(
+        "local",
+        connection.id,
+        health="online",
+        model_count=1,
+        checked_at="2026-08-23T00:00:00+00:00",
+    )
+    fingerprint = repository.connection_config_fingerprint("local", connection.id)
+    refresh_id = f"refresh-{connection.id}"
+    repository.claim_catalog_refresh(
+        "local",
+        refresh_id=refresh_id,
+        connection_id=connection.id,
+        connection_fingerprint=fingerprint,
+    )
+    repository.complete_catalog_refresh(
+        "local",
+        refresh_id,
+        connection_id=connection.id,
+        models=[
+            {
+                "model_id": MODEL_ID,
+                "normalized_model_id": MODEL_ID,
+                "capability_state": "declared",
+            }
+        ],
+        offerings=[],
+        model_count=1,
+        truncated=False,
+        catalog_fingerprint="shadow-catalog",
+        observed_at="2026-08-23T00:00:00+00:00",
+    )
+    certification, created = repository.claim_chat_certification(
+        "local",
+        certification_id="shadow-tools-certification",
+        connection_id=connection.id,
+        connection_fingerprint=fingerprint,
+        contract_version="modelmirror-provider-chat-v1",
+        capability="chat_tools",
+        requested_model=MODEL_ID,
+        idempotency_key_hash=hashlib.sha256(b"shadow-tools").hexdigest(),
+    )
+    assert created is True
+    repository.complete_chat_certification(
+        "local",
+        str(certification["id"]),
+        status="passed",
+        checks={"capability_verified": True},
+        warning_codes=[],
+        actual_model=MODEL_ID,
+    )
+    service = ModelRouterService(
+        repository,
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+    return service, connection.id
+
+
+def _activate_shadow_policy(service: ModelRouterService, connection_id: str) -> None:
+    control = ProviderWorkloadControlService(service)
+    saved = control.update_policy(
+        "agent_shadow",
+        ProviderWorkloadPolicyUpdate(
+            expected_revision=0,
+            bindings=[
+                ProviderWorkloadBindingUpdate(
+                    execution_shape="chat_tools",
+                    model_id=MODEL_ID,
+                    connection_id=connection_id,
+                )
+            ],
+        ),
+    )
+    active = control.activate(
+        "agent_shadow",
+        ProviderWorkloadActivationRequest(
+            expected_revision=saved.revision,
+            no_open_p0_p1=True,
+            acknowledge_fail_closed=True,
+        ),
+    )
+    assert active.effective_status == "managed_required"
+
+
+@pytest.mark.asyncio
+async def test_managed_shadow_exact_binding_dispatches_once_and_records_no_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_AGENT_SHADOW_ENABLED", "true")
+    _activate_shadow_policy(service, connection_id)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        payload = json.loads(request.content)
+        assert payload["model"] == MODEL_ID
+        assert payload["tool_choice"] == "auto"
+        assert request.headers["host"] == "shadow-provider.example"
+        assert request.headers["authorization"] == f"Bearer {PROVIDER_SECRET}"
+        body = "\n".join(
+            [
+                "data: "
+                + json.dumps(
+                    {
+                        "model": MODEL_ID,
+                        "choices": [
+                            {
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "call-1",
+                                            "function": {
+                                                "name": "read_file",
+                                                "arguments": '{"file_path":"README.md"}',
+                                            },
+                                        }
+                                    ]
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ],
+                        "usage": {
+                            "prompt_tokens": 10,
+                            "completion_tokens": 4,
+                            "total_tokens": 14,
+                        },
+                    }
+                ),
+                "data: [DONE]",
+                "",
+            ]
+        )
+        return httpx.Response(
+            200,
+            text=body,
+            headers={"Content-Type": "text/event-stream"},
+        )
+
+    call_service = ProviderWorkloadCallService(service)
+    gateway = ManagedShadowGateway(
+        call_service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=False,
+            trust_env=False,
+        ),
+    )
+    assert gateway.routing_mode() == "managed_required"
+    assert gateway.resolve_exact_model(MODEL_ID) == MODEL_ID
+    assert gateway.resolve_exact_model("provider/other-model") is None
+    run_id = gateway.start_run(parent_run_reference="shadow-run-1")
+    turn = await gateway.stream_turn(
+        workload_run_id=run_id,
+        logical_call_key="worker-model-request-1",
+        call_sequence=1,
+        model_id=MODEL_ID,
+        messages=[{"role": "user", "content": "private prompt"}],
+        tools=[{"type": "function", "function": {"name": "read_file"}}],
+        max_tokens=128,
+        thinking_level="medium",
+        timeout_ms=30_000,
+        on_delta=lambda *_args: None,
+    )
+
+    assert turn.model_id == MODEL_ID
+    assert turn.tool_calls[0].name == "read_file"
+    assert turn.total_tokens == 14
+    with pytest.raises(GatewayRequestError):
+        await gateway.stream_turn(
+            workload_run_id=run_id,
+            logical_call_key="worker-model-request-1",
+            call_sequence=2,
+            model_id=MODEL_ID,
+            messages=[{"role": "user", "content": "private prompt"}],
+            tools=[],
+            max_tokens=128,
+            thinking_level="medium",
+            timeout_ms=30_000,
+            on_delta=lambda *_args: None,
+        )
+    gateway.finish_run(run_id, "candidate_ready")
+
+    assert len(requests) == 1
+    receipts = service.repository.list_workload_receipts("local")
+    assert len(receipts["runs"]) == 1
+    assert len(receipts["calls"]) == 1
+    assert receipts["runs"][0]["parent_run_reference"] == "shadow-run-1"
+    assert receipts["runs"][0]["status"] == "passed"
+    assert receipts["calls"][0]["status"] == "passed"
+    assert receipts["calls"][0]["dispatched"] == 1
+    assert receipts["calls"][0]["actual_model"] == MODEL_ID
+    database = service.repository.database_path.read_bytes()
+    assert b"private prompt" not in database
+    assert b"README.md" not in database
+    assert PROVIDER_SECRET.encode() not in database
+
+
+@pytest.mark.asyncio
+async def test_managed_shadow_model_mismatch_fails_without_second_post(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_AGENT_SHADOW_ENABLED", "true")
+    _activate_shadow_policy(service, connection_id)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"model":"provider/other","choices":[{"delta":{"content":"x"},'
+                '"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n'
+            ),
+            headers={"Content-Type": "text/event-stream"},
+        )
+
+    gateway = ManagedShadowGateway(
+        ProviderWorkloadCallService(service),
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), trust_env=False
+        ),
+    )
+    run_id = gateway.start_run(parent_run_reference="shadow-run-mismatch")
+    with pytest.raises(GatewayRequestError, match="different model"):
+        await gateway.stream_turn(
+            workload_run_id=run_id,
+            logical_call_key="model-1",
+            call_sequence=1,
+            model_id=MODEL_ID,
+            messages=[{"role": "user", "content": "private prompt"}],
+            tools=[],
+            max_tokens=128,
+            thinking_level="medium",
+            timeout_ms=30_000,
+            on_delta=lambda *_args: None,
+        )
+    gateway.finish_run(run_id, "failed")
+
+    assert len(requests) == 1
+    receipt = service.repository.list_workload_receipts("local")["calls"][0]
+    assert receipt["status"] == "failed"
+    assert receipt["error_code"] == "provider_workload_actual_model_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_managed_shadow_cancellation_after_dispatch_is_not_replayed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_AGENT_SHADOW_ENABLED", "true")
+    _activate_shadow_policy(service, connection_id)
+    call_service = ProviderWorkloadCallService(service)
+    dispatch_started = asyncio.Event()
+    never_finishes = asyncio.Event()
+    sends = 0
+
+    async def stalled_send(_client, _request):
+        nonlocal sends
+        sends += 1
+        dispatch_started.set()
+        await never_finishes.wait()
+        raise AssertionError("cancelled dispatch must not resume")
+
+    monkeypatch.setattr(
+        call_service.transport, "send_authorized_stream", stalled_send
+    )
+    gateway = ManagedShadowGateway(call_service)
+    run_id = gateway.start_run(parent_run_reference="shadow-run-cancel")
+    task = asyncio.create_task(
+        gateway.stream_turn(
+            workload_run_id=run_id,
+            logical_call_key="model-cancel-1",
+            call_sequence=1,
+            model_id=MODEL_ID,
+            messages=[{"role": "user", "content": "private prompt"}],
+            tools=[],
+            max_tokens=128,
+            thinking_level="medium",
+            timeout_ms=30_000,
+            on_delta=lambda *_args: None,
+        )
+    )
+    await asyncio.wait_for(dispatch_started.wait(), 2)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    with pytest.raises(GatewayRequestError):
+        await gateway.stream_turn(
+            workload_run_id=run_id,
+            logical_call_key="model-cancel-1",
+            call_sequence=2,
+            model_id=MODEL_ID,
+            messages=[{"role": "user", "content": "private prompt"}],
+            tools=[],
+            max_tokens=128,
+            thinking_level="medium",
+            timeout_ms=30_000,
+            on_delta=lambda *_args: None,
+        )
+    gateway.finish_run(run_id, "stopped")
+
+    assert sends == 1
+    receipt = service.repository.list_workload_receipts("local")["calls"][0]
+    assert receipt["dispatched"] == 1
+    assert receipt["status"] == "cancelled"
+    assert receipt["error_code"] == "provider_workload_call_cancelled"
+
+
+@pytest.mark.asyncio
+async def test_managed_shadow_incomplete_stream_fails_closed_after_one_post(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_AGENT_SHADOW_ENABLED", "true")
+    _activate_shadow_policy(service, connection_id)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"model":"provider/tool-model",'
+                '"choices":[{"delta":{"content":"partial"},"finish_reason":null}]}\n\n'
+            ),
+            headers={"Content-Type": "text/event-stream"},
+        )
+
+    gateway = ManagedShadowGateway(
+        ProviderWorkloadCallService(service),
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), trust_env=False
+        ),
+    )
+    run_id = gateway.start_run(parent_run_reference="shadow-run-incomplete")
+    with pytest.raises(GatewayRequestError, match="终止信号"):
+        await gateway.stream_turn(
+            workload_run_id=run_id,
+            logical_call_key="model-incomplete-1",
+            call_sequence=1,
+            model_id=MODEL_ID,
+            messages=[{"role": "user", "content": "private prompt"}],
+            tools=[],
+            max_tokens=128,
+            thinking_level="medium",
+            timeout_ms=30_000,
+            on_delta=lambda *_args: None,
+        )
+    gateway.finish_run(run_id, "failed")
+
+    assert len(requests) == 1
+    receipt = service.repository.list_workload_receipts("local")["calls"][0]
+    assert receipt["dispatched"] == 1
+    assert receipt["status"] == "failed"
+    assert receipt["error_code"] == "provider_workload_provider_request_failed"

--- a/server/tests/test_agent_upstream_port.py
+++ b/server/tests/test_agent_upstream_port.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 import json
 import os
 import sys
@@ -13,6 +14,7 @@ from server.agent_upstream.models import ENGINE_PROTOCOL, UPSTREAM_REVISION
 from server.agent_upstream.port import (
     EngineProtocolError,
     EngineShadowRunSpec,
+    EngineUnavailableError,
     NodeUpstreamEnginePort,
 )
 from server.agent_upstream.tools import SHADOW_TOOL_DEFINITIONS, UpstreamShadowToolBridge
@@ -129,12 +131,65 @@ print(json.dumps({{"protocol": {ENGINE_PROTOCOL!r}, "seq": 2, "type": "worker.he
         )
 
 
+@pytest.mark.asyncio
+async def test_started_worker_crash_after_model_request_is_never_restarted(
+    tmp_path: Path,
+) -> None:
+    script = tmp_path / "post-then-crash-worker.py"
+    marker = tmp_path / "worker-starts.txt"
+    _write_worker(
+        script,
+        f'''import json, pathlib, sys
+protocol = {ENGINE_PROTOCOL!r}
+revision = {UPSTREAM_REVISION!r}
+marker = pathlib.Path({str(marker)!r})
+marker.write_text(marker.read_text() + "start\\n" if marker.exists() else "start\\n")
+seq = 1
+def send(kind, payload):
+    global seq
+    print(json.dumps({{"protocol": protocol, "seq": seq, "type": kind, "payload": payload}}), flush=True)
+    seq += 1
+send("worker.hello", {{"node_version": "v24.19.0", "upstream_revision": revision, "capabilities": ["read_file", "write_file", "edit_file"]}})
+for line in sys.stdin:
+    frame = json.loads(line)
+    if frame["type"] == "run.start":
+        run_id = frame["payload"]["run_id"]
+        send("run.started", {{"run_id": run_id}})
+        send("model.request", {{"run_id": run_id, "request_id": "model-once", "new_messages": []}})
+    elif frame["type"] == "model.response":
+        raise SystemExit(23)
+''',
+    )
+    port = NodeUpstreamEnginePort(
+        package_root=tmp_path,
+        command_factory=_command(script),
+    )
+    spec = replace(_spec(tmp_path, run_id="post-then-crash"), max_prestart_retries=3)
+    model_requests: list[str] = []
+
+    async def execute_model(request):
+        model_requests.append(request.request_id)
+        return {"segments": [], "usage": {}, "outcome": {"status": "completed"}}
+
+    with pytest.raises(EngineUnavailableError):
+        await port.start_run(
+            spec,
+            on_event=lambda _kind, _payload: None,
+            execute_model=execute_model,
+            execute_tool=lambda _request: {},
+        )
+
+    assert model_requests == ["model-once"]
+    assert marker.read_text(encoding="utf-8").splitlines() == ["start"]
+
+
 def test_worker_environment_excludes_gateway_and_service_secrets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("PATH", "safe-path")
     monkeypatch.setenv("LLM_GATEWAY_KEY", "must-not-cross")
     monkeypatch.setenv("OPENROUTER_API_KEY", "must-not-cross")
+    monkeypatch.setenv("MODEL_MIRROR_CREDENTIAL_MASTER_KEY", "must-not-cross")
     monkeypatch.setenv("DATABASE_URL", "must-not-cross")
 
     environment = NodeUpstreamEnginePort()._minimal_environment()
@@ -142,6 +197,7 @@ def test_worker_environment_excludes_gateway_and_service_secrets(
     assert environment["PATH"] == "safe-path"
     assert "LLM_GATEWAY_KEY" not in environment
     assert "OPENROUTER_API_KEY" not in environment
+    assert "MODEL_MIRROR_CREDENTIAL_MASTER_KEY" not in environment
     assert "DATABASE_URL" not in environment
 
 

--- a/server/tests/test_agent_upstream_service.py
+++ b/server/tests/test_agent_upstream_service.py
@@ -52,6 +52,49 @@ class _FakeGateway:
         )
 
 
+class _FakeManagedGateway:
+    def __init__(
+        self,
+        mode: str = "managed_required",
+        *,
+        exact_model_ids: set[str] | None = None,
+    ) -> None:
+        self.mode = mode
+        self.exact_model_ids = exact_model_ids or set()
+        self.started: list[str] = []
+        self.calls: list[dict[str, object]] = []
+        self.finished: list[tuple[str, str]] = []
+
+    def routing_mode(self) -> str:
+        return self.mode
+
+    def resolve_exact_model(self, requested_model_id: str) -> str | None:
+        return (
+            requested_model_id
+            if requested_model_id in self.exact_model_ids
+            else None
+        )
+
+    def start_run(self, *, parent_run_reference: str) -> str:
+        self.started.append(parent_run_reference)
+        return f"managed-{parent_run_reference}"
+
+    async def stream_turn(self, **kwargs) -> GatewayTurn:
+        self.calls.append(kwargs)
+        return GatewayTurn(
+            content="managed private output",
+            tool_calls=(),
+            finish_reason="stop",
+            model_id=str(kwargs["model_id"]),
+            prompt_tokens=10,
+            completion_tokens=2,
+            total_tokens=12,
+        )
+
+    def finish_run(self, workload_run_id: str, shadow_status: str) -> None:
+        self.finished.append((workload_run_id, shadow_status))
+
+
 class _CandidatePort:
     def __init__(self) -> None:
         self.stopped: list[str] = []
@@ -227,6 +270,142 @@ async def test_shadow_service_produces_host_verified_candidate_without_transcrip
     assert b"private-model-output-that-must-stay-in-memory" not in raw_database
     events = service.list_events(created.run_id)
     assert all("content" not in str(event.payload).lower() for event in events)
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shadow_service_uses_exact_managed_binding_after_alias_resolution(
+    tmp_path: Path,
+) -> None:
+    legacy = _FakeGateway()
+    managed = _FakeManagedGateway()
+    service = EngineShadowService(
+        store=EngineShadowStore(tmp_path / "agent-workspace"),
+        port=_CandidatePort(),
+        gateway=legacy,
+        managed_gateway=managed,  # type: ignore[arg-type]
+        catalog_provider=_catalog,
+    )
+
+    created = await service.create_run(
+        EngineShadowRunCreate(
+            objective="Build through the exact managed model",
+            model_base_id="deepseek-v4-pro-0813",
+        )
+    )
+    finished = await _wait_terminal(service, created.run_id)
+
+    assert finished.status == "candidate_ready"
+    assert legacy.messages == []
+    assert managed.started == [created.run_id]
+    assert len(managed.calls) == 1
+    assert managed.calls[0]["workload_run_id"] == f"managed-{created.run_id}"
+    assert managed.calls[0]["logical_call_key"] == "model-1"
+    assert managed.calls[0]["call_sequence"] == 1
+    assert managed.calls[0]["model_id"] == "deepseek/deepseek-v4-pro-0813"
+    assert managed.finished == [
+        (f"managed-{created.run_id}", "candidate_ready")
+    ]
+    route_event = next(
+        event
+        for event in service.list_events(created.run_id)
+        if event.type == "provider_route_receipt"
+    )
+    assert route_event.payload == {
+        "managed": True,
+        "model_id": "deepseek/deepseek-v4-pro-0813",
+        "call_sequence": 1,
+        "status": "passed",
+        "total_tokens": 12,
+    }
+    assert b"managed private output" not in service.store.database_path.read_bytes()
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shadow_service_accepts_valid_exact_managed_binding_when_legacy_catalog_is_empty(
+    tmp_path: Path,
+) -> None:
+    exact_model_id = "openai/gpt-4o-mini"
+    legacy = _FakeGateway()
+    managed = _FakeManagedGateway(exact_model_ids={exact_model_id})
+    service = EngineShadowService(
+        store=EngineShadowStore(tmp_path / "agent-workspace"),
+        port=_CandidatePort(),
+        gateway=legacy,
+        managed_gateway=managed,  # type: ignore[arg-type]
+        catalog_provider=lambda: SimpleNamespace(models=[]),
+    )
+
+    created = await service.create_run(
+        EngineShadowRunCreate(
+            objective="Build through an exact managed-only model",
+            model_base_id=exact_model_id,
+        )
+    )
+    finished = await _wait_terminal(service, created.run_id)
+
+    assert finished.status == "candidate_ready"
+    assert created.resolved_model_id == exact_model_id
+    assert legacy.messages == []
+    assert len(managed.calls) == 1
+    assert managed.calls[0]["model_id"] == exact_model_id
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shadow_service_degraded_required_fails_before_workspace_or_worker(
+    tmp_path: Path,
+) -> None:
+    managed = _FakeManagedGateway("degraded_required")
+    service = EngineShadowService(
+        store=EngineShadowStore(tmp_path / "agent-workspace"),
+        port=_CandidatePort(),
+        gateway=_FakeGateway(),
+        managed_gateway=managed,  # type: ignore[arg-type]
+        catalog_provider=_catalog,
+    )
+
+    with pytest.raises(EngineShadowServiceError) as captured:
+        await service.create_run(
+            EngineShadowRunCreate(objective="Must fail before managed dispatch")
+        )
+
+    assert captured.value.code == (
+        "provider_workload_agent_shadow_degraded_required"
+    )
+    assert service.list_runs() == []
+    assert managed.started == []
+
+
+@pytest.mark.asyncio
+async def test_shadow_service_legacy_mode_does_not_touch_managed_receipts(
+    tmp_path: Path,
+) -> None:
+    legacy = _FakeGateway()
+    managed = _FakeManagedGateway("legacy")
+    service = EngineShadowService(
+        store=EngineShadowStore(tmp_path / "agent-workspace"),
+        port=_CandidatePort(),
+        gateway=legacy,
+        managed_gateway=managed,  # type: ignore[arg-type]
+        catalog_provider=_catalog,
+    )
+
+    created = await service.create_run(
+        EngineShadowRunCreate(objective="Keep the existing gateway path")
+    )
+    finished = await _wait_terminal(service, created.run_id)
+
+    assert finished.status == "candidate_ready"
+    assert len(legacy.messages) == 1
+    assert managed.started == []
+    assert managed.calls == []
+    assert managed.finished == []
+    assert not any(
+        event.type == "provider_route_receipt"
+        for event in service.list_events(created.run_id)
+    )
     await service.shutdown()
 
 


### PR DESCRIPTION
## 改动摘要

- 将 Engine Shadow 接入 R6 Workload Managed Provider 控制面，精确绑定 `agent_shadow + chat_tools + model_id`。
- Provider POST 使用单连接、单批准 IP、零自动重试；派发后禁止切换 Provider、第二 IP 或 legacy 路径。
- 统一并强化 OpenAI-compatible SSE/Tool Calling 解析、响应关闭、usage 与 TTFT/E2E 采集。
- 补齐 Engine Shadow 数据面集成标记、脱敏 Receipt、Settings 人工激活流程与架构/部署文档。
- 修复 Managed 精确 Binding 有效但旧 Catalog 为空时被本地误判 `model_not_found` 的问题；legacy 解析语义保持不变。

## 验证

- 后端聚焦回归：30 passed。
- R6 Agent 受影响回归：81 passed；R5 回归：124 passed。
- Settings 组件：3 passed。
- 前端全量：570 passed、1 个无关 Skill Browser 用例超时；该文件单独重跑 2 passed。
- TypeScript typecheck 与 production build 通过；仅保留既有 chunk size 警告。
- `git diff --check` 与敏感信息扫描通过。
- 独立预览真实 Smoke：`openai/gpt-4o-mini`，6/6 Managed 调用成功，单连接、无重试/回退，候选达到 `candidate_ready`；Router SQLite 与日志未发现目标正文、候选正文或认证头。

## 边界与回滚

- Feature Flag 默认关闭；PR 合并不代表生产启用。
- 普通 Agent Workbench、R5 Chat、多模态、RAG、Workflow、Xpert、Coding 与计费均不在本 PR 范围。
- 回滚时显式停用 `agent_shadow` Policy 或关闭 `MODEL_CONTROL_AGENT_SHADOW_ENABLED`，保留 v16 Receipt 与 Shadow Workspace 数据。
- 未执行 Merge 或部署。