### PR TITLE
fix: 防止 Workload 初始同步覆盖用户操作

### DIFF
--- a/client/src/components/settings/ProviderWorkloadControlSettings.tsx
+++ b/client/src/components/settings/ProviderWorkloadControlSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import {
   BadgeCheck,
   CircleAlert,
@@ -279,7 +279,7 @@ export default function ProviderWorkloadControlSettings({
     [entryId, policies],
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!selectedPolicy) return;
     setConfirmActivation(false);
     setConfirmNoOpenP0P1(false);


### PR DESCRIPTION
修复 Provider Workload 控制面首屏初始化竞态：将策略到本地编辑/确认状态的同步移到浏览器绘制前，避免延迟 effect 覆盖用户刚添加的 Binding 或刚打开的激活确认。范围仅 1 个前端文件。验证：目标测试连续 5 轮共 15/15 通过；前端全量 104 files / 572 tests 通过；production build 通过；git diff --check 通过。无后端、数据库、配置或部署变更。