### PR TITLE
fix: 收紧 V20 Harness 生命周期与评测准入

### DIFF
--- a/docker-compose.coding-worker-v20-evaluation.yml
+++ b/docker-compose.coding-worker-v20-evaluation.yml
@@ -44,7 +44,7 @@ services:
           create_host_path: false
       - coding_worker_acp_evaluation_socket:/run/modelmirror-coding-evaluation
     healthcheck:
-      test: ["CMD", "python", "-c", "import json,os,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-coding-evaluation/driver.sock'); s.sendall((json.dumps({'token':os.environ['CODING_WORKER_EVALUATION_TOKEN'],'action':'health'})+'\\n').encode()); assert json.loads(s.recv(65536))['ok']"]
+      test: ["CMD", "python", "-c", "import json,os,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-coding-evaluation/driver.sock'); s.sendall((json.dumps({'token':os.environ['CODING_WORKER_EVALUATION_TOKEN'],'action':'health'})+'\\n').encode()); response=json.loads(s.recv(65536)); assert response['ok'] and response['result']['available']"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -76,7 +76,7 @@ services:
           create_host_path: false
       - coding_worker_codex_evaluation_socket:/run/modelmirror-coding-evaluation
     healthcheck:
-      test: ["CMD", "python", "-c", "import json,os,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-coding-evaluation/driver.sock'); s.sendall((json.dumps({'token':os.environ['CODING_WORKER_EVALUATION_TOKEN'],'action':'health'})+'\\n').encode()); assert json.loads(s.recv(65536))['ok']"]
+      test: ["CMD", "python", "-c", "import json,os,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-coding-evaluation/driver.sock'); s.sendall((json.dumps({'token':os.environ['CODING_WORKER_EVALUATION_TOKEN'],'action':'health'})+'\\n').encode()); response=json.loads(s.recv(65536)); assert response['ok'] and response['result']['available']"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/tasks/CODING_WORKER_V20.md
+++ b/docs/tasks/CODING_WORKER_V20.md
@@ -96,3 +96,13 @@ PR C 最终自动证据：Coding Worker `463 passed, 5 skipped`；Agent Workspac
 在 #261 rebase 阶段首次把前后端全量并行运行时，既有 Chat/OCR 交互测试未展开面板，模型路由 p95 微基准以 `10.165ms` 略过 `10ms` 阈值。两者与 PR C Diff 无交集；停止并发后，OCR 单文件 `5/5` 通过，路由微基准连续 `3/3` 通过，随后前端和后端各自独立全量均通过。最终 #262/#263 基线上再次独立全量通过；未修改这两个模块、未放宽阈值，也未用单项绿测替代最终全量证据。
 
 本阶段没有调用真实模型、没有运行另行授权的四次真实任务、校准或认证。因此当前只证明自动工程门禁与 evaluation conformance/准入边界完成；不能使用 V20 最终交付结论，也不形成任何能力提升、接近或等效表述。
+
+## 10. 合并后证伪修复状态
+
+严格反例审查发现，原自动门禁仍允许 pending request 在 turn 完成、interrupt 或 resume 时成为孤儿；失败事件还会提前消耗 Driver sequence，JSON-RPC 数字与字符串 ID 会发生相关性碰撞。修复后，一个 turn 同时只能存在一个未结算请求，退出前必须精确结算；sequence 和 pending 状态仅在生命周期核接受后提交，供应商 ID 同时绑定原始类型。ACP permission 现在接受规范 `_meta`，但只允许最多 16 个结构完整、ID 唯一的官方类型选项；回复必须选择原请求实际提供的 option，cancel 必须先结算全部 pending permission。
+
+镜像级审查同时推翻了“health 即 Driver 可用”的假设：当前 evaluation sidecar 仅实现鉴权 health 与静态 adapter 装载，尚未承载 ACP/Codex 实时协议传输。sidecar 现会校验固定命令和镜像内实际 Schema 摘要，并明确返回 `available=false`、`reason=protocol_transport_unavailable`、`image_attestation=external_required`；Compose 健康检查据此 fail-closed。只有外部控制器完成真实镜像身份验证且实现协议传输后，evaluation profile 才能转为可用。
+
+本轮修复后的专项为 `52 passed`；受影响后端回归为 `912 passed, 14 skipped`；两套 evaluation 镜像重新构建并确认 UID/GID `65532:65532` 与固定 Schema 摘要。V18 compile 与 Fake smoke 通过，Fake smoke 摘要仍为 `472b88ae9de93f3816de84bc40d07e7c192ec82c4eca6cb67ef2f56dc60a1df3`。前端 production build 通过；完整前端套件两次均有同一个既有 Chat/OCR 时序用例失败（单文件 `5/5` 通过），因此不得记录为全量前端绿测。后端全量首个失败是隔离镜像缺少 Agency Worker 构建产物，受影响集合无失败。
+
+结论仍为 Experimental：未调用真实模型、未运行四次真实任务、校准或认证；ACP/Codex evaluation profile 尚不可用，V20 最终交付结论仍不得使用。

--- a/docs/tasks/CODING_WORKER_V20.md
+++ b/docs/tasks/CODING_WORKER_V20.md
@@ -103,6 +103,6 @@ PR C 最终自动证据：Coding Worker `463 passed, 5 skipped`；Agent Workspac
 
 镜像级审查同时推翻了“health 即 Driver 可用”的假设：当前 evaluation sidecar 仅实现鉴权 health 与静态 adapter 装载，尚未承载 ACP/Codex 实时协议传输。sidecar 现会校验固定命令和镜像内实际 Schema 摘要，并明确返回 `available=false`、`reason=protocol_transport_unavailable`、`image_attestation=external_required`；Compose 健康检查据此 fail-closed。只有外部控制器完成真实镜像身份验证且实现协议传输后，evaluation profile 才能转为可用。
 
-本轮修复后的专项为 `52 passed`；受影响后端回归为 `912 passed, 14 skipped`；两套 evaluation 镜像重新构建并确认 UID/GID `65532:65532` 与固定 Schema 摘要。V18 compile 与 Fake smoke 通过，Fake smoke 摘要仍为 `472b88ae9de93f3816de84bc40d07e7c192ec82c4eca6cb67ef2f56dc60a1df3`。前端 production build 通过；完整前端套件两次均有同一个既有 Chat/OCR 时序用例失败（单文件 `5/5` 通过），因此不得记录为全量前端绿测。后端全量首个失败是隔离镜像缺少 Agency Worker 构建产物，受影响集合无失败。
+证伪修复最终重放到包含 #269 的主线 `bdd1dcda`，range-diff 与原四个逻辑提交一致。后端全量在紧邻主线 `e6a59117` 为 `4219 passed, 29 skipped`；主线继续合入 #267/#268 后，覆盖 Coding Worker、Coding Runtime、Agent Workspace 与 Project Host 的回归为 `962 passed, 14 skipped`，#269 仅修改前端竞态。最终基线专项为 `52 passed`，前端完整套件为 `104 files / 572 tests`，production build 通过。两套 evaluation 镜像重新构建并确认 UID/GID `65532:65532`，ACP 与 Codex Schema 摘要分别为 `998c6427fa78bf6cd39f442bf164c6172234ebdf1c04298af57c40fa716ce267` 和 `02a4c63a638fdae4a5f6c3ad32a41a377b642c66f3abc84f6fc47c7f3d6074df`。主/评测 Compose 静态展开、V18 compile 与 Fake smoke 通过，Fake smoke 摘要仍为 `472b88ae9de93f3816de84bc40d07e7c192ec82c4eca6cb67ef2f56dc60a1df3`。
 
 结论仍为 Experimental：未调用真实模型、未运行四次真实任务、校准或认证；ACP/Codex evaluation profile 尚不可用，V20 最终交付结论仍不得使用。

--- a/server/coding_worker/acp_driver.py
+++ b/server/coding_worker/acp_driver.py
@@ -92,10 +92,13 @@ class AcpV1HarnessDriver(StandardEvaluationDriver):
         )
         self.broker_mcp = broker_mcp
         self._prompt_request_id: str | None = None
+        self._permission_options: dict[
+            str, tuple[object, frozenset[str]]
+        ] = {}
 
     def initialize(self, frame: Mapping[str, Any]) -> None:
         _, params = require_jsonrpc_method(frame, "initialize", notification=False)
-        require_exact_keys(
+        self._require_acp_keys(
             params,
             required={"protocolVersion"},
             optional={"clientCapabilities", "clientInfo"},
@@ -121,7 +124,7 @@ class AcpV1HarnessDriver(StandardEvaluationDriver):
         request_id, params = require_jsonrpc_method(
             frame, "session/prompt", notification=False
         )
-        require_exact_keys(params, required={"sessionId", "prompt"})
+        self._require_acp_keys(params, required={"sessionId", "prompt"})
         self._require_supplier_session(params["sessionId"])
         prompt = params["prompt"]
         if not isinstance(prompt, list) or not prompt:
@@ -142,7 +145,7 @@ class AcpV1HarnessDriver(StandardEvaluationDriver):
         _, params = require_jsonrpc_method(
             frame, "session/update", notification=True
         )
-        require_exact_keys(params, required={"sessionId", "update"})
+        self._require_acp_keys(params, required={"sessionId", "update"})
         self._require_supplier_session(params["sessionId"])
         update = params["update"]
         if not isinstance(update, Mapping):
@@ -172,7 +175,7 @@ class AcpV1HarnessDriver(StandardEvaluationDriver):
         request_id, params = require_jsonrpc_method(
             frame, "session/request_permission", notification=False
         )
-        require_exact_keys(
+        self._require_acp_keys(
             params,
             required={"sessionId", "toolCall", "options"},
         )
@@ -181,45 +184,100 @@ class AcpV1HarnessDriver(StandardEvaluationDriver):
         options = params["options"]
         if not isinstance(tool_call, Mapping) or not isinstance(options, list):
             raise EvaluationDriverError("ACP permission request is invalid")
-        if not options or any(not isinstance(option, Mapping) for option in options):
+        if (
+            not options
+            or len(options) > 16
+            or any(not isinstance(option, Mapping) for option in options)
+        ):
             raise EvaluationDriverError("ACP permission options are invalid")
+        option_ids: list[str] = []
+        for option in options:
+            try:
+                self._require_acp_keys(
+                    option,
+                    required={"optionId", "name", "kind"},
+                )
+            except EvaluationDriverError as exc:
+                raise EvaluationDriverError(
+                    "ACP permission options are invalid"
+                ) from exc
+            option_id = option.get("optionId")
+            name = option.get("name")
+            option_kind = option.get("kind")
+            if (
+                not isinstance(option_id, str)
+                or not option_id
+                or len(option_id) > 128
+                or not isinstance(name, str)
+                or len(name) > 512
+                or option_kind
+                not in {
+                    "allow_once",
+                    "allow_always",
+                    "reject_once",
+                    "reject_always",
+                }
+            ):
+                raise EvaluationDriverError("ACP permission options are invalid")
+            option_ids.append(option_id)
+        if len(set(option_ids)) != len(option_ids):
+            raise EvaluationDriverError("ACP permission option id was repeated")
         assert request_id is not None
-        return self.request(
+        event = self.request(
             supplier_request_id=request_id,
             kind=HarnessRequestKind.APPROVAL,
             payload={
                 "tool_call_id": str(tool_call.get("toolCallId") or "")[:128],
                 "title": str(tool_call.get("title") or "")[:256],
                 "kind": str(tool_call.get("kind") or "")[:64],
-                "option_ids": [
-                    str(option.get("optionId") or "")[:128]
-                    for option in options[:16]
-                ],
+                "option_ids": option_ids,
             },
         )
+        self._permission_options[canonical_supplier_id(request_id)] = (
+            request_id,
+            frozenset(option_ids),
+        )
+        return event
 
     def reply_permission(self, frame: Mapping[str, Any]) -> HarnessResponse:
         request_id = frame.get("id")
         result = frame.get("result")
         if request_id is None or not isinstance(result, Mapping):
             raise EvaluationDriverError("ACP permission reply is invalid")
+        self._require_acp_keys(result, required={"outcome"})
         outcome = result.get("outcome")
         if not isinstance(outcome, Mapping):
             raise EvaluationDriverError("ACP permission outcome is invalid")
-        selected = outcome.get("outcome") == "selected"
-        return self.resolve(
+        request_key = canonical_supplier_id(request_id)
+        registered = self._permission_options.get(request_key)
+        if registered is None:
+            raise EvaluationDriverError("evaluation request is not pending")
+        _, offered_options = registered
+        outcome_kind = outcome.get("outcome")
+        if outcome_kind == "selected":
+            self._require_acp_keys(
+                outcome, required={"outcome", "optionId"}
+            )
+            option_id = outcome.get("optionId")
+            if not isinstance(option_id, str) or option_id not in offered_options:
+                raise EvaluationDriverError(
+                    "ACP permission option was not offered"
+                )
+            response_outcome = HarnessResponseOutcome.APPROVED
+            response_payload = {"option_id": option_id[:128]}
+        elif outcome_kind == "cancelled":
+            self._require_acp_keys(outcome, required={"outcome"})
+            response_outcome = HarnessResponseOutcome.CANCELLED
+            response_payload = {"option_id": ""}
+        else:
+            raise EvaluationDriverError("ACP permission outcome is invalid")
+        response = self.resolve(
             supplier_request_id=request_id,
-            outcome=(
-                HarnessResponseOutcome.APPROVED
-                if selected
-                else HarnessResponseOutcome.DECLINED
-            ),
-            payload={
-                "option_id": str(outcome.get("optionId") or "")[:128]
-                if selected
-                else "",
-            },
+            outcome=response_outcome,
+            payload=response_payload,
         )
+        self._permission_options.pop(request_key)
+        return response
 
     def complete_turn(self, frame: Mapping[str, Any]) -> HarnessEventEnvelope:
         request_id = frame.get("id")
@@ -230,7 +288,7 @@ class AcpV1HarnessDriver(StandardEvaluationDriver):
             or not isinstance(result, Mapping)
         ):
             raise EvaluationDriverError("ACP prompt response is not correlated")
-        require_exact_keys(result, required={"stopReason"})
+        self._require_acp_keys(result, required={"stopReason"})
         stop_reason = str(result["stopReason"])
         self._prompt_request_id = None
         return self.emit(
@@ -239,14 +297,28 @@ class AcpV1HarnessDriver(StandardEvaluationDriver):
             payload={"stop_reason": stop_reason[:64]},
         )
 
-    def cancel_turn(self, frame: Mapping[str, Any]) -> None:
+    def cancel_turn(
+        self, frame: Mapping[str, Any]
+    ) -> tuple[HarnessResponse, ...]:
         _, params = require_jsonrpc_method(
             frame, "session/cancel", notification=True
         )
-        require_exact_keys(params, required={"sessionId"})
+        self._require_acp_keys(params, required={"sessionId"})
         self._require_supplier_session(params["sessionId"])
+        cancelled: list[HarnessResponse] = []
+        for request_key, (supplier_request_id, _) in tuple(
+            self._permission_options.items()
+        ):
+            cancelled.append(
+                self.resolve(
+                    supplier_request_id=supplier_request_id,
+                    outcome=HarnessResponseOutcome.CANCELLED,
+                )
+            )
+            self._permission_options.pop(request_key)
         self._prompt_request_id = None
         self.interrupt()
+        return tuple(cancelled)
 
     def resume_session(
         self,
@@ -265,7 +337,7 @@ class AcpV1HarnessDriver(StandardEvaluationDriver):
         _, params = require_jsonrpc_method(
             frame, "session/close", notification=False
         )
-        require_exact_keys(params, required={"sessionId"})
+        self._require_acp_keys(params, required={"sessionId"})
         self._require_supplier_session(params["sessionId"])
         self.close()
 
@@ -275,7 +347,7 @@ class AcpV1HarnessDriver(StandardEvaluationDriver):
         required = {"cwd", "mcpServers"}
         if resume:
             required.add("sessionId")
-        require_exact_keys(
+        self._require_acp_keys(
             params,
             required=required,
             optional={"additionalDirectories"},
@@ -287,6 +359,22 @@ class AcpV1HarnessDriver(StandardEvaluationDriver):
             raise EvaluationDriverError("ACP additional directories are unavailable")
         if params["mcpServers"] != [self.broker_mcp.acp_config()]:
             raise EvaluationDriverError("ACP arbitrary MCP configuration is unavailable")
+
+    @staticmethod
+    def _require_acp_keys(
+        payload: Mapping[str, Any],
+        *,
+        required: set[str],
+        optional: set[str] | None = None,
+    ) -> None:
+        require_exact_keys(
+            payload,
+            required=required,
+            optional=set(optional or ()) | {"_meta"},
+        )
+        metadata = payload.get("_meta")
+        if metadata is not None and not isinstance(metadata, Mapping):
+            raise EvaluationDriverError("ACP metadata is invalid")
 
     def _require_supplier_session(self, value: object) -> None:
         session = self.require_session()

--- a/server/coding_worker/evaluation_driver.py
+++ b/server/coding_worker/evaluation_driver.py
@@ -205,10 +205,10 @@ class StandardEvaluationDriver:
         request: HarnessRequestRef | None = None,
     ) -> HarnessEventEnvelope:
         session = self.require_session()
-        self.sequence += 1
+        next_sequence = self.sequence + 1
         envelope = HarnessEventEnvelope(
             event_id=safe_supplier_id("event", supplier_event_id),
-            sequence=self.sequence,
+            sequence=next_sequence,
             session=session,
             turn=self.turn,
             request=request,
@@ -216,6 +216,7 @@ class StandardEvaluationDriver:
             payload=dict(payload or {}),
         )
         self._kernel_call(self.kernel.accept_event, envelope)
+        self.sequence = next_sequence
         if kind is HarnessEventKind.TURN_COMPLETED:
             self.turn = None
         return envelope
@@ -253,7 +254,7 @@ class StandardEvaluationDriver:
         payload: Mapping[str, Any] | None = None,
     ) -> HarnessResponse:
         request_key = canonical_supplier_id(supplier_request_id)
-        request = self._pending.pop(request_key, None)
+        request = self._pending.get(request_key)
         if request is None:
             raise EvaluationDriverError("evaluation request is not pending")
         response = HarnessResponse(
@@ -262,6 +263,7 @@ class StandardEvaluationDriver:
             payload=dict(payload or {}),
         )
         self._kernel_call(self.kernel.resolve_request, response)
+        self._pending.pop(request_key)
         return response
 
     def steer(self) -> None:
@@ -325,7 +327,8 @@ def canonical_supplier_id(value: object) -> str:
     text = str(value)
     if not text or len(text) > 256:
         raise EvaluationDriverError("supplier correlation id is invalid")
-    return text
+    kind = "string" if isinstance(value, str) else "integer"
+    return f"{kind}:{text}"
 
 
 def safe_supplier_id(prefix: str, value: object) -> str:

--- a/server/coding_worker/evaluation_sidecar.py
+++ b/server/coding_worker/evaluation_sidecar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import importlib.metadata
 import json
 import os
@@ -20,6 +21,21 @@ from .evaluation_loader import (
 
 
 MAX_REQUEST_BYTES = 64 * 1024
+MAX_SCHEMA_BYTES = 16 * 1024 * 1024
+_SCHEMA_PATHS = {
+    "acp_v1": Path(
+        "/usr/share/modelmirror-coding-evaluation/schemas/acp-schema-v1.19.json"
+    ),
+    "codex_app_server": Path(
+        "/usr/share/modelmirror-coding-evaluation/schemas/"
+        "codex-app-server-0.149.0.schemas.json"
+    ),
+}
+_ACP_SIDECAR_COMMAND = (
+    "/usr/local/bin/python",
+    "-m",
+    "coding_worker.evaluation_sidecar",
+)
 
 
 class EvaluationSidecarError(RuntimeError):
@@ -42,6 +58,7 @@ class EvaluationSidecar:
         observed_image_digest: str,
         observed_command: Sequence[str],
         token: str,
+        schema_path: Path | None = None,
         environment: Mapping[str, str] | None = None,
     ) -> None:
         if len(token) < 32:
@@ -62,6 +79,7 @@ class EvaluationSidecar:
         self.driver_class.validate_manifest(self.manifest)
         self.driver_id = driver_id
         self.token = token
+        self._verify_schema(schema_path or _SCHEMA_PATHS[driver_id])
         self._verify_runtime_package()
 
     def safe_descriptor(self) -> dict[str, Any]:
@@ -74,6 +92,9 @@ class EvaluationSidecar:
             "tool_ownership": self.manifest.tool_ownership.value,
             "persistence": self.manifest.persistence.value,
             "production_route": False,
+            "available": False,
+            "reason": "protocol_transport_unavailable",
+            "image_attestation": "external_required",
         }
 
     async def serve_unix(self, socket_path: Path) -> None:
@@ -122,6 +143,8 @@ class EvaluationSidecar:
         else:
             package = "@openai/codex"
         if package == "agent-client-protocol":
+            if tuple(self.manifest.command) != _ACP_SIDECAR_COMMAND:
+                raise EvaluationSidecarError("ACP executable is not fixed")
             try:
                 version = importlib.metadata.version(package)
             except importlib.metadata.PackageNotFoundError as exc:
@@ -147,6 +170,21 @@ class EvaluationSidecar:
                 raise EvaluationSidecarError(
                     "Codex runtime version does not match"
                 )
+
+    def _verify_schema(self, schema_path: Path) -> None:
+        if not schema_path.is_absolute():
+            raise EvaluationSidecarError("evaluation schema path must be absolute")
+        try:
+            metadata = schema_path.lstat()
+            if schema_path.is_symlink() or not stat.S_ISREG(metadata.st_mode):
+                raise EvaluationSidecarError("evaluation schema path is unsafe")
+            if metadata.st_size <= 0 or metadata.st_size > MAX_SCHEMA_BYTES:
+                raise EvaluationSidecarError("evaluation schema path is unsafe")
+            digest = hashlib.sha256(schema_path.read_bytes()).hexdigest()
+        except OSError as exc:
+            raise EvaluationSidecarError("evaluation schema is unavailable") from exc
+        if digest != self.manifest.schema_sha256:
+            raise EvaluationSidecarError("evaluation schema digest does not match")
 
 
 def _from_environment() -> tuple[EvaluationSidecar, Path]:

--- a/server/coding_worker/harness_driver.py
+++ b/server/coding_worker/harness_driver.py
@@ -86,7 +86,7 @@ class ProviderV4HarnessTranslator:
             raise HarnessDriverProtocolError(
                 "provider event kind is unavailable to the V20 harness"
             )
-        self._sequence += 1
+        next_sequence = self._sequence + 1
         payload = {"provider_kind": event.kind.value, "data": event.data}
         digest = hashlib.sha256(
             json.dumps(
@@ -94,7 +94,7 @@ class ProviderV4HarnessTranslator:
                     "task_id": self.session.binding.task_id,
                     "session_id": self.session.session_id,
                     "turn_id": turn_id,
-                    "sequence": self._sequence,
+                    "sequence": next_sequence,
                     "payload": payload,
                 },
                 sort_keys=True,
@@ -103,7 +103,7 @@ class ProviderV4HarnessTranslator:
         ).hexdigest()
         envelope = HarnessEventEnvelope(
             event_id=f"event_{digest[:32]}",
-            sequence=self._sequence,
+            sequence=next_sequence,
             session=self.session,
             turn=self._turn,
             kind=kind,
@@ -115,6 +115,7 @@ class ProviderV4HarnessTranslator:
             raise HarnessDriverProtocolError(
                 "provider event violated the V20 Harness contract"
             ) from exc
+        self._sequence = next_sequence
         if kind is HarnessEventKind.TURN_COMPLETED:
             self._turn = None
         return envelope

--- a/server/coding_worker/harness_protocol.py
+++ b/server/coding_worker/harness_protocol.py
@@ -262,7 +262,19 @@ class HarnessLifecycleKernel:
             raise HarnessProtocolError("harness event was replayed")
         if event.turn is not None:
             self._require_turn(event.turn)
+        if (
+            event.kind is HarnessEventKind.TURN_COMPLETED
+            and event.turn is not None
+            and self._has_pending_for_turn(event.turn)
+        ):
+            raise HarnessProtocolError(
+                "pending request must settle before harness turn completion"
+            )
         if event.request is not None:
+            if self._has_pending_for_turn(event.request.turn):
+                raise HarnessProtocolError(
+                    "pending request must settle before another harness request"
+                )
             request_key = self._request_key(event.request)
             if (
                 request_key in self._pending_requests
@@ -290,6 +302,10 @@ class HarnessLifecycleKernel:
 
     def interrupt(self, turn: HarnessTurnRef) -> None:
         self._require_turn(turn)
+        if self._has_pending_for_turn(turn):
+            raise HarnessProtocolError(
+                "pending request must settle before harness turn interruption"
+            )
         self._turns.pop(self._session_key(turn.session), None)
 
     def resume_session(self, previous: HarnessSessionRef, resumed: HarnessSessionRef) -> None:
@@ -307,6 +323,12 @@ class HarnessLifecycleKernel:
         previous_key = self._session_key(previous)
         if previous_key in self._turns:
             raise HarnessProtocolError("active turn must be interrupted before resume")
+        if any(
+            ref.turn.session == previous for ref in self._pending_requests.values()
+        ):
+            raise HarnessProtocolError(
+                "pending request must settle before harness session resume"
+            )
         self._sessions.pop(previous_key)
         self._sessions[self._session_key(resumed)] = resumed
 
@@ -332,6 +354,9 @@ class HarnessLifecycleKernel:
         self._require_session(turn.session)
         if self._turns.get(self._session_key(turn.session)) != turn:
             raise HarnessProtocolError("harness turn is stale or not active")
+
+    def _has_pending_for_turn(self, turn: HarnessTurnRef) -> bool:
+        return any(ref.turn == turn for ref in self._pending_requests.values())
 
     @staticmethod
     def _session_key(session: HarnessSessionRef) -> tuple[str, str]:

--- a/server/tests/test_coding_worker_evaluation_isolation.py
+++ b/server/tests/test_coding_worker_evaluation_isolation.py
@@ -34,7 +34,7 @@ from server.coding_worker.harness_protocol import (
 
 
 IMAGE_DIGEST = "sha256:" + "a" * 64
-ACP_COMMAND = ("/usr/local/bin/python", "-m", "modelmirror_acp_fixture_agent")
+ACP_COMMAND = ("/usr/local/bin/python", "-m", "coding_worker.evaluation_sidecar")
 CODEX_COMMAND = ("/usr/local/bin/codex", "app-server")
 ACP_WHEEL_SHA256 = (
     "233626748034896214de118f5cf5a319484ad2186705fd595219afee92237ccc"
@@ -49,6 +49,13 @@ CODEX_INTEGRITY = (
 CODEX_SCHEMA_SHA256 = (
     "02a4c63a638fdae4a5f6c3ad32a41a377b642c66f3abc84f6fc47c7f3d6074df"
 )
+SCHEMA_ROOT = Path(__file__).resolve().parent / "fixtures/coding_worker_v20_schemas"
+
+
+def _schema_path(driver_id: str) -> Path:
+    if driver_id == "acp_v1":
+        return SCHEMA_ROOT / "acp-schema-v1.19.json"
+    return SCHEMA_ROOT / "codex-app-server-0.149.0.schemas.json"
 
 
 def _manifest(driver_id: str) -> EvaluationDriverManifest:
@@ -193,6 +200,7 @@ def test_sidecar_requires_exactly_one_profile_and_emits_safe_health(
             observed_image_digest=IMAGE_DIGEST,
             observed_command=ACP_COMMAND,
             token="t" * 32,
+            schema_path=_schema_path("acp_v1"),
             environment={
                 "CODING_WORKER_ACP_EVALUATION_ENABLED": "true",
                 "CODING_WORKER_CODEX_EVALUATION_ENABLED": "true",
@@ -204,6 +212,7 @@ def test_sidecar_requires_exactly_one_profile_and_emits_safe_health(
         observed_image_digest=IMAGE_DIGEST,
         observed_command=ACP_COMMAND,
         token="t" * 32,
+        schema_path=_schema_path("acp_v1"),
         environment={"CODING_WORKER_ACP_EVALUATION_ENABLED": "true"},
     )
     descriptor = sidecar.safe_descriptor()
@@ -217,7 +226,13 @@ def test_sidecar_requires_exactly_one_profile_and_emits_safe_health(
         "tool_ownership",
         "persistence",
         "production_route",
+        "available",
+        "reason",
+        "image_attestation",
     }
+    assert descriptor["available"] is False
+    assert descriptor["reason"] == "protocol_transport_unavailable"
+    assert descriptor["image_attestation"] == "external_required"
     incompatible = _manifest("acp_v1").model_copy(
         update={"package_integrity": "sha256:" + "f" * 64}
     )
@@ -232,6 +247,7 @@ def test_sidecar_requires_exactly_one_profile_and_emits_safe_health(
             observed_image_digest=IMAGE_DIGEST,
             observed_command=ACP_COMMAND,
             token="t" * 32,
+            schema_path=_schema_path("acp_v1"),
             environment={"CODING_WORKER_ACP_EVALUATION_ENABLED": "true"},
         )
 
@@ -251,6 +267,7 @@ def test_codex_sidecar_verifies_fixed_runtime_version(tmp_path: Path, monkeypatc
         observed_image_digest=IMAGE_DIGEST,
         observed_command=CODEX_COMMAND,
         token="t" * 32,
+        schema_path=_schema_path("codex_app_server"),
         environment={"CODING_WORKER_CODEX_EVALUATION_ENABLED": "true"},
     )
     assert sidecar.safe_descriptor()["tool_ownership"] == "unknown"
@@ -265,6 +282,7 @@ def test_sidecar_refuses_to_replace_a_regular_file(tmp_path: Path, monkeypatch) 
         observed_image_digest=IMAGE_DIGEST,
         observed_command=ACP_COMMAND,
         token="t" * 32,
+        schema_path=_schema_path("acp_v1"),
         environment={"CODING_WORKER_ACP_EVALUATION_ENABLED": "true"},
     )
     socket_path = tmp_path / "driver.sock"
@@ -272,3 +290,43 @@ def test_sidecar_refuses_to_replace_a_regular_file(tmp_path: Path, monkeypatch) 
     with pytest.raises(EvaluationSidecarError, match="unsafe"):
         asyncio.run(sidecar.serve_unix(socket_path))
     assert socket_path.read_text(encoding="utf-8") == "do not delete"
+
+
+def test_sidecar_rejects_unregistered_acp_executable_and_schema_bytes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(importlib.metadata, "version", lambda package: "0.12.0")
+    wrong_command = ("/missing/acp-agent",)
+    wrong_manifest = _manifest("acp_v1").model_copy(
+        update={
+            "command": wrong_command,
+            "command_sha256": command_sha256(wrong_command),
+        }
+    )
+    wrong_manifest_path = tmp_path / "wrong-command.json"
+    wrong_manifest_path.write_text(
+        json.dumps(wrong_manifest.model_dump(mode="json")), encoding="utf-8"
+    )
+    with pytest.raises(EvaluationSidecarError, match="ACP executable is not fixed"):
+        EvaluationSidecar(
+            driver_id="acp_v1",
+            manifest_path=wrong_manifest_path,
+            observed_image_digest=IMAGE_DIGEST,
+            observed_command=wrong_command,
+            token="t" * 32,
+            schema_path=_schema_path("acp_v1"),
+            environment={"CODING_WORKER_ACP_EVALUATION_ENABLED": "true"},
+        )
+
+    corrupt_schema = tmp_path / "schema.json"
+    corrupt_schema.write_text("{}", encoding="utf-8")
+    with pytest.raises(EvaluationSidecarError, match="schema digest does not match"):
+        EvaluationSidecar(
+            driver_id="acp_v1",
+            manifest_path=_write_manifest(tmp_path, "acp_v1"),
+            observed_image_digest=IMAGE_DIGEST,
+            observed_command=ACP_COMMAND,
+            token="t" * 32,
+            schema_path=corrupt_schema,
+            environment={"CODING_WORKER_ACP_EVALUATION_ENABLED": "true"},
+        )

--- a/server/tests/test_coding_worker_evaluation_supply_chain.py
+++ b/server/tests/test_coding_worker_evaluation_supply_chain.py
@@ -75,6 +75,8 @@ def test_evaluation_compose_has_no_production_or_host_escape() -> None:
         token_setting = service["environment"]["CODING_WORKER_EVALUATION_TOKEN"]
         assert token_setting.startswith("${CODING_WORKER_")
         assert token_setting.endswith("_EVALUATION_TOKEN:-}")
+        healthcheck = service["healthcheck"]["test"]
+        assert any("['available']" in item for item in healthcheck)
 
     acp = payload["services"]["coding-worker-acp-evaluation"]["environment"]
     codex = payload["services"]["coding-worker-codex-evaluation"]["environment"]

--- a/server/tests/test_coding_worker_harness_protocol.py
+++ b/server/tests/test_coding_worker_harness_protocol.py
@@ -352,6 +352,114 @@ def test_kernel_settles_each_request_exactly_once() -> None:
         )
 
 
+def test_pending_request_blocks_turn_exit_until_exactly_settled() -> None:
+    descriptor = _descriptor()
+    session = _session(descriptor)
+    turn = HarnessTurnRef(session=session, turn_id="turn_pending")
+    request = HarnessRequestRef(
+        turn=turn,
+        request_id="request_pending",
+        kind=HarnessRequestKind.APPROVAL,
+    )
+    kernel = HarnessLifecycleKernel()
+    kernel.initialize(descriptor)
+    kernel.open_session(session)
+    kernel.start_turn(turn)
+    kernel.accept_event(
+        HarnessEventEnvelope(
+            event_id="event_request_pending",
+            sequence=1,
+            session=session,
+            turn=turn,
+            request=request,
+            kind=HarnessEventKind.REQUEST,
+        )
+    )
+
+    with pytest.raises(HarnessProtocolError, match="pending request"):
+        kernel.accept_event(
+            HarnessEventEnvelope(
+                event_id="event_complete_early",
+                sequence=2,
+                session=session,
+                turn=turn,
+                kind=HarnessEventKind.TURN_COMPLETED,
+            )
+        )
+    with pytest.raises(HarnessProtocolError, match="pending request"):
+        kernel.interrupt(turn)
+
+    kernel.resolve_request(
+        HarnessResponse(
+            ref=request,
+            outcome=HarnessResponseOutcome.CANCELLED,
+        )
+    )
+    kernel.interrupt(turn)
+    resumed = _session(descriptor, generation=2)
+    kernel.resume_session(session, resumed)
+    kernel.close_session(resumed)
+
+
+def test_only_one_request_can_park_a_turn_at_a_time() -> None:
+    descriptor = _descriptor()
+    session = _session(descriptor)
+    turn = HarnessTurnRef(session=session, turn_id="turn_single_barrier")
+    first = HarnessRequestRef(
+        turn=turn,
+        request_id="request_first",
+        kind=HarnessRequestKind.APPROVAL,
+    )
+    second = HarnessRequestRef(
+        turn=turn,
+        request_id="request_second",
+        kind=HarnessRequestKind.USER_INPUT,
+    )
+    kernel = HarnessLifecycleKernel()
+    kernel.initialize(descriptor)
+    kernel.open_session(session)
+    kernel.start_turn(turn)
+    kernel.accept_event(
+        HarnessEventEnvelope(
+            event_id="event_first",
+            sequence=1,
+            session=session,
+            turn=turn,
+            request=first,
+            kind=HarnessEventKind.REQUEST,
+        )
+    )
+
+    with pytest.raises(HarnessProtocolError, match="pending request"):
+        kernel.accept_event(
+            HarnessEventEnvelope(
+                event_id="event_second_early",
+                sequence=2,
+                session=session,
+                turn=turn,
+                request=second,
+                kind=HarnessEventKind.REQUEST,
+            )
+        )
+
+    kernel.resolve_request(
+        HarnessResponse(
+            ref=first,
+            outcome=HarnessResponseOutcome.APPROVED,
+        )
+    )
+    kernel.accept_event(
+        HarnessEventEnvelope(
+            event_id="event_second_after_settlement",
+            sequence=2,
+            session=session,
+            turn=turn,
+            request=second,
+            kind=HarnessEventKind.REQUEST,
+        )
+    )
+
+
 def test_event_and_request_deduplication_is_scoped_to_the_exact_binding() -> None:
     descriptor = _descriptor()
     first_session = _session(

--- a/server/tests/test_coding_worker_standard_drivers.py
+++ b/server/tests/test_coding_worker_standard_drivers.py
@@ -29,7 +29,9 @@ from server.coding_worker.evaluation_driver import (
     EvaluationBrokerMcp,
     EvaluationDriverError,
     EvaluationDriverManifest,
+    canonical_supplier_id,
     command_sha256,
+    safe_supplier_id,
 )
 from server.coding_worker.harness_protocol import (
     HarnessBinding,
@@ -311,6 +313,216 @@ def test_acp_v1_full_lifecycle_normalizes_without_native_side_effects() -> None:
             "session/cancel", {"sessionId": "acp-session-1"}, None
         )
     )
+    resumed = _binding(_manifest("acp"), ACP_CAPABILITIES, generation=2)
+    driver.resume_session(
+        _acp_frame(
+            "session/resume",
+            {
+                "sessionId": "acp-session-1",
+                "cwd": "/workspace",
+                "mcpServers": [driver.broker_mcp.acp_config()],
+            },
+            5,
+        ),
+        resumed_binding=resumed,
+    )
+    driver.close_session(
+        _acp_frame("session/close", {"sessionId": "acp-session-1"}, 6)
+    )
+
+
+def test_supplier_correlation_preserves_json_rpc_id_type() -> None:
+    assert canonical_supplier_id(1) != canonical_supplier_id("1")
+    assert safe_supplier_id("request", 1) != safe_supplier_id("request", "1")
+
+
+def test_rejected_event_does_not_poison_driver_sequence() -> None:
+    driver = _acp_driver()
+    _initialize_acp(driver)
+    driver.start_turn(
+        _acp_frame(
+            "session/prompt",
+            {
+                "sessionId": "acp-session-1",
+                "prompt": [{"type": "text", "text": "Inspect."}],
+            },
+            3,
+        ),
+        platform_turn_id="turn-sequence",
+    )
+    first = driver.emit(
+        supplier_event_id="same-event",
+        kind=HarnessEventKind.MESSAGE,
+    )
+    with pytest.raises(EvaluationDriverError):
+        driver.emit(
+            supplier_event_id="same-event",
+            kind=HarnessEventKind.MESSAGE,
+        )
+    recovered = driver.emit(
+        supplier_event_id="fresh-event",
+        kind=HarnessEventKind.MESSAGE,
+    )
+    assert first.sequence == 1
+    assert recovered.sequence == 2
+
+
+def test_acp_accepts_meta_and_rejects_unoffered_permission_option() -> None:
+    driver = _acp_driver()
+    driver.initialize(
+        _acp_frame(
+            "initialize",
+            {
+                "protocolVersion": 1,
+                "clientCapabilities": {},
+                "_meta": {"trace": "safe"},
+            },
+        )
+    )
+    driver.open(
+        _acp_frame(
+            "session/new",
+            {
+                "cwd": "/workspace",
+                "mcpServers": [driver.broker_mcp.acp_config()],
+                "_meta": {"trace": "safe"},
+            },
+            2,
+        ),
+        supplier_session_id="acp-session-1",
+    )
+    driver.start_turn(
+        _acp_frame(
+            "session/prompt",
+            {
+                "sessionId": "acp-session-1",
+                "prompt": [{"type": "text", "text": "Inspect."}],
+                "_meta": {"trace": "safe"},
+            },
+            3,
+        ),
+        platform_turn_id="turn-permission",
+    )
+    driver.request_permission(
+        _acp_frame(
+            "session/request_permission",
+            {
+                "sessionId": "acp-session-1",
+                "toolCall": {"toolCallId": "tool-1"},
+                "options": [
+                    {"optionId": "deny", "name": "Deny", "kind": "reject_once"}
+                ],
+                "_meta": {"trace": "safe"},
+            },
+            4,
+        )
+    )
+    with pytest.raises(EvaluationDriverError, match="not offered"):
+        driver.reply_permission(
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "result": {
+                    "outcome": {
+                        "outcome": "selected",
+                        "optionId": "admin-unlock",
+                    }
+                },
+            }
+        )
+    accepted = driver.reply_permission(
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "result": {
+                "outcome": {"outcome": "selected", "optionId": "deny"}
+            },
+        }
+    )
+    assert accepted.outcome is HarnessResponseOutcome.APPROVED
+
+
+@pytest.mark.parametrize(
+    "options",
+    (
+        [{"optionId": "allow", "kind": "allow_once"}],
+        [{"optionId": "allow", "name": "Allow", "kind": "invented"}],
+        [
+            {
+                "optionId": f"option-{index}",
+                "name": "Allow",
+                "kind": "allow_once",
+            }
+            for index in range(17)
+        ],
+    ),
+)
+def test_acp_permission_options_are_schema_bounded(
+    options: list[dict[str, str]],
+) -> None:
+    driver = _acp_driver()
+    _initialize_acp(driver)
+    driver.start_turn(
+        _acp_frame(
+            "session/prompt",
+            {
+                "sessionId": "acp-session-1",
+                "prompt": [{"type": "text", "text": "Inspect."}],
+            },
+            3,
+        ),
+        platform_turn_id="turn-invalid-options",
+    )
+    with pytest.raises(EvaluationDriverError, match="permission options"):
+        driver.request_permission(
+            _acp_frame(
+                "session/request_permission",
+                {
+                    "sessionId": "acp-session-1",
+                    "toolCall": {"toolCallId": "tool-1"},
+                    "options": options,
+                },
+                4,
+            )
+        )
+
+
+def test_acp_cancel_settles_pending_permission_before_resume() -> None:
+    driver = _acp_driver()
+    _initialize_acp(driver)
+    driver.start_turn(
+        _acp_frame(
+            "session/prompt",
+            {
+                "sessionId": "acp-session-1",
+                "prompt": [{"type": "text", "text": "Inspect."}],
+            },
+            3,
+        ),
+        platform_turn_id="turn-cancel",
+    )
+    driver.request_permission(
+        _acp_frame(
+            "session/request_permission",
+            {
+                "sessionId": "acp-session-1",
+                "toolCall": {"toolCallId": "tool-1"},
+                "options": [
+                    {"optionId": "deny", "name": "Deny", "kind": "reject_once"}
+                ],
+            },
+            4,
+        )
+    )
+    cancelled = driver.cancel_turn(
+        _acp_frame(
+            "session/cancel",
+            {"sessionId": "acp-session-1", "_meta": {"trace": "safe"}},
+            None,
+        )
+    )
+    assert len(cancelled) == 1
+    assert cancelled[0].outcome is HarnessResponseOutcome.CANCELLED
     resumed = _binding(_manifest("acp"), ACP_CAPABILITIES, generation=2)
     driver.resume_session(
         _acp_frame(


### PR DESCRIPTION
本 PR 收口 V20 证伪审查发现的三类缺口：阻止 pending request 在 turn 完成、interrupt 或 resume 时成为孤儿，并使 sequence/pending 变更只在生命周期核接受后提交；收紧 ACP permission 的 _meta、选项结构、精确回复与 cancel 结算；让 ACP/Codex evaluation sidecar 校验固定命令和 Schema 摘要，并明确以 protocol_transport_unavailable fail-closed，Compose 不再把静态 health 误报为 Driver 可用。验证：V20 专项 52/52；相关后端 962 passed、14 skipped；紧邻主线后端全量 4219 passed、29 skipped；最终前端 104 files / 572 tests；production build、主/评测 Compose、V18 compile/Fake smoke、Python 编译、镜像非 root/Schema、Diff/秘密/禁止产物扫描通过。未调用真实模型，未启动四次真实任务、校准或认证；ACP/Codex evaluation profile 仍不可用，结论保持 Experimental，不宣称能力提升或等效。