### PR TITLE
feat: 接入 Meta Agent Managed Provider 控制面

### DIFF
--- a/client/src/components/meta/MetaPlannerV2.test.tsx
+++ b/client/src/components/meta/MetaPlannerV2.test.tsx
@@ -1,0 +1,145 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+
+import { plannerModelOptions } from "../../pages/MetaAgentPage";
+import MetaPlannerV2, { candidateGenerationOutcome } from "./MetaPlannerV2";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Meta Planner managed compatibility", () => {
+  it("does not hide eligible text models behind an arbitrary catalog cap", () => {
+    expect(plannerModelOptions.length).toBeGreaterThan(120);
+    expect(plannerModelOptions.some((model) => model.id === "openai/gpt-4o-mini")).toBe(
+      true,
+    );
+  });
+
+  it("does not present an unresolved repaired candidate as successful", () => {
+    expect(candidateGenerationOutcome({ valid: false }, true)).toEqual({
+      error: "候选已保留，但一次定向修复后仍未通过验证，需要人工修复。",
+      notice: "",
+    });
+  });
+
+  it("preserves the paid-call receipt when the follow-up proposal load fails", async () => {
+    const receipt = {
+      contract_version: "modelmirror-provider-workload-routing-v1",
+      entry_id: "meta_agent",
+      routing_mode: "managed_required",
+      run_reference: "workrun_receipt_preserved",
+      status: "passed",
+      call_count: 1,
+      reason_codes: [],
+      calls: [
+        {
+          call_sequence: 1,
+          model_id: "openai/gpt-4o-mini",
+          dispatched: true,
+          status: "passed",
+          total_tokens: 17,
+        },
+      ],
+    };
+    const jsonResponse = (body: unknown, status = 200) =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url === "/api/meta-agent/capabilities") {
+          return jsonResponse({
+            version: "test-snapshot-v1",
+            snapshot_hash: "snapshot-hash",
+            generated_at: 1,
+            nodes: [],
+            middleware: [],
+            external_xperts: [],
+            knowledge_bases: [],
+            toolsets: [],
+            plugins: [],
+            prompt_profiles: [],
+            default_scope: {
+              allowed_node_kinds: [],
+              external_xpert_ids: [],
+              knowledge_base_ids: [],
+              toolset_ids: [],
+              plugin_ids: [],
+              prompt_profile_ids: [],
+              middleware_ids: [],
+            },
+          });
+        }
+        if (url.startsWith("/api/xperts?")) {
+          return jsonResponse({ items: [], total: 0 });
+        }
+        if (url.startsWith("/api/runtime/authoring-proposals?")) {
+          return jsonResponse({ items: [] });
+        }
+        if (
+          url === "/api/meta-agent/generate-xpert-candidate" &&
+          init?.method === "POST"
+        ) {
+          return jsonResponse({
+            proposal_id: "proposal_receipt_test",
+            proposal_revision: 1,
+            mode: "create",
+            target_xpert_id: null,
+            base_revision: null,
+            plan: { summary: "Test plan", assumptions: [], tasks: [] },
+            candidate: {
+              name: "Receipt candidate",
+              description: "Test candidate",
+              tags: [],
+              starters: [],
+              draft: {
+                workflow: {
+                  id: "workflow_receipt_test",
+                  title: "Receipt test",
+                  nodes: [],
+                  edges: [],
+                },
+              },
+            },
+            validation: { valid: true, stages: [] },
+            warnings: [],
+            repair_used: false,
+            capability_snapshot_version: "test-snapshot-v1",
+            capability_snapshot_hash: "snapshot-hash",
+            provider_route_receipts: receipt,
+          });
+        }
+        if (url === "/api/runtime/authoring-proposals/proposal_receipt_test") {
+          return jsonResponse({ detail: "proposal reload failed" }, 500);
+        }
+        throw new Error(`Unexpected request: ${url}`);
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <MemoryRouter>
+        <MetaPlannerV2 />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("test-snapshot-v1");
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "例如：构建一个负责研究、事实核查与审稿协作的智能体",
+      ),
+      { target: { value: "Generate a bounded candidate for receipt testing." } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "生成候选智能体" }));
+
+    await screen.findByText("proposal reload failed");
+    await waitFor(() => {
+      expect(screen.getByText("已纳管")).toBeInTheDocument();
+      expect(screen.getByText("1 次模型调用")).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/meta/MetaPlannerV2.tsx
+++ b/client/src/components/meta/MetaPlannerV2.tsx
@@ -5,6 +5,9 @@ import { models } from "../../data/models";
 import { type WorkflowDefinition } from "../../types/workflow";
 import { type XpertDraft, type XpertSummary } from "../../types/xpert";
 import { listXperts, toXpertDraftWorkflow } from "../../utils/xpertApi";
+import ProviderRouteReceiptSummary, {
+  type ProviderRouteReceipt,
+} from "./ProviderRouteReceiptSummary";
 import WorkflowEditor from "../workflow/WorkflowEditor";
 
 type ScopeKey =
@@ -103,6 +106,8 @@ interface MetaPlannerResponse {
   repair_used: boolean;
   capability_snapshot_version: string;
   capability_snapshot_hash: string;
+  run_id?: string | null;
+  provider_route_receipts?: ProviderRouteReceipt | null;
 }
 
 interface AuthoringProposal {
@@ -138,6 +143,24 @@ function readError(payload: unknown, fallback: string) {
     if (typeof error === "string") return error;
   }
   return fallback;
+}
+
+export function candidateGenerationOutcome(
+  validation: Record<string, unknown>,
+  repairUsed: boolean,
+) {
+  if (validation.valid === false) {
+    return {
+      error: "候选已保留，但一次定向修复后仍未通过验证，需要人工修复。",
+      notice: "",
+    };
+  }
+  return {
+    error: "",
+    notice: repairUsed
+      ? "候选已生成并完成一次定向修复。"
+      : "候选已生成并写入审批提案。",
+  };
 }
 
 function candidateFromProposal(proposal: AuthoringProposal): CandidateXpert {
@@ -273,6 +296,7 @@ export default function MetaPlannerV2() {
   const [warnings, setWarnings] = useState<string[]>([]);
   const [repairUsed, setRepairUsed] = useState(false);
   const [snapshotHash, setSnapshotHash] = useState("");
+  const [routeReceipt, setRouteReceipt] = useState<ProviderRouteReceipt | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isGenerating, setIsGenerating] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -324,7 +348,12 @@ export default function MetaPlannerV2() {
     };
   }, []);
 
-  async function loadProposal(proposalId: string, showNotice = true) {
+  async function loadProposal(
+    proposalId: string,
+    showNotice = true,
+    clearRouteReceipt = true,
+  ) {
+    if (clearRouteReceipt) setRouteReceipt(null);
     const response = await fetch(`/api/runtime/authoring-proposals/${proposalId}`);
     const payload = (await response.json().catch(() => null)) as
       | AuthoringProposal
@@ -379,6 +408,7 @@ export default function MetaPlannerV2() {
     setIsGenerating(true);
     setError("");
     setNotice("");
+    setRouteReceipt(null);
     try {
       const response = await fetch("/api/meta-agent/generate-xpert-candidate", {
         method: "POST",
@@ -396,9 +426,14 @@ export default function MetaPlannerV2() {
       });
       const payload = (await response.json().catch(() => null)) as
         | MetaPlannerResponse
-        | { detail?: string }
+        | {
+            detail?: string;
+            error?: string;
+            provider_route_receipts?: ProviderRouteReceipt | null;
+          }
         | null;
       if (!response.ok || !payload || !("proposal_id" in payload)) {
+        setRouteReceipt(payload?.provider_route_receipts ?? null);
         throw new Error(readError(payload, "Meta Planner 生成失败。"));
       }
       const generated = payload as MetaPlannerResponse;
@@ -407,12 +442,14 @@ export default function MetaPlannerV2() {
       setWarnings(generated.warnings);
       setRepairUsed(generated.repair_used);
       setSnapshotHash(generated.capability_snapshot_hash);
-      await loadProposal(generated.proposal_id, false);
-      setNotice(
-        generated.repair_used
-          ? "候选已生成并完成一次定向修复。"
-          : "候选已生成并写入审批提案。",
+      setRouteReceipt(generated.provider_route_receipts ?? null);
+      await loadProposal(generated.proposal_id, false, false);
+      const outcome = candidateGenerationOutcome(
+        generated.validation,
+        generated.repair_used,
       );
+      setError(outcome.error);
+      setNotice(outcome.notice);
     } catch (generateError) {
       setError(
         generateError instanceof Error ? generateError.message : "Meta Planner 生成失败。",
@@ -909,6 +946,9 @@ export default function MetaPlannerV2() {
             <div className="rounded-lg border border-emerald-300/20 bg-emerald-300/10 px-3 py-2 text-sm text-emerald-100">
               {notice}
             </div>
+          ) : null}
+          {routeReceipt ? (
+            <ProviderRouteReceiptSummary receipt={routeReceipt} />
           ) : null}
           {error ? (
             <div className="rounded-lg border border-rose-300/25 bg-rose-300/10 px-3 py-2 text-sm text-rose-100">

--- a/client/src/components/meta/ProviderRouteReceiptSummary.test.tsx
+++ b/client/src/components/meta/ProviderRouteReceiptSummary.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ProviderRouteReceiptSummary from "./ProviderRouteReceiptSummary";
+
+describe("ProviderRouteReceiptSummary", () => {
+  it("shows only redacted managed call evidence", () => {
+    render(
+      <ProviderRouteReceiptSummary
+        receipt={{
+          contract_version: "modelmirror-provider-workload-routing-v1",
+          entry_id: "meta_agent",
+          routing_mode: "managed_required",
+          run_reference: "workrun_1234567890abcdef",
+          status: "passed",
+          call_count: 2,
+          reason_codes: [],
+          calls: [
+            {
+              call_sequence: 1,
+              model_id: "provider/meta-model",
+              actual_model: "provider/meta-model",
+              status: "passed",
+              total_tokens: 12,
+            },
+            {
+              call_sequence: 2,
+              model_id: "provider/meta-model",
+              actual_model: "provider/meta-model",
+              status: "passed",
+              total_tokens: 18,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("已纳管")).toBeInTheDocument();
+    expect(screen.getByText("2 次模型调用")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("2 次模型调用"));
+    expect(screen.getByText("调用 1")).toBeInTheDocument();
+    expect(screen.getByText("18 tokens")).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain("connection_id");
+    expect(document.body.textContent).not.toContain("api_key");
+    expect(document.body.textContent).not.toContain("private prompt");
+  });
+
+  it("does not describe a blocked preflight as a model call", () => {
+    render(
+      <ProviderRouteReceiptSummary
+        receipt={{
+          contract_version: "modelmirror-provider-workload-routing-v1",
+          entry_id: "meta_agent",
+          routing_mode: "managed_required",
+          run_reference: "workrun_preflight_only",
+          status: "failed",
+          call_count: 0,
+          reason_codes: ["provider_workload_binding_missing"],
+          calls: [
+            {
+              call_sequence: 1,
+              model_id: "provider/unbound-model",
+              dispatched: false,
+              status: "failed",
+              error_code: "provider_workload_binding_missing",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("0 次模型调用")).toBeInTheDocument();
+    expect(screen.getByText("0 个精确模型")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("0 次模型调用"));
+    expect(screen.getByText("预检 1")).toBeInTheDocument();
+    expect(screen.getByText("未派发")).toBeInTheDocument();
+    expect(screen.queryByText("调用 1")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/meta/ProviderRouteReceiptSummary.tsx
+++ b/client/src/components/meta/ProviderRouteReceiptSummary.tsx
@@ -1,0 +1,104 @@
+export interface ProviderRouteCallReceipt {
+  call_sequence: number;
+  model_id: string;
+  actual_model?: string | null;
+  dispatched?: boolean;
+  status: "passed" | "failed" | "uncertain" | "cancelled";
+  error_code?: string | null;
+  prompt_tokens?: number | null;
+  completion_tokens?: number | null;
+  total_tokens?: number | null;
+}
+
+export interface ProviderRouteReceipt {
+  contract_version: string;
+  entry_id: "meta_agent";
+  routing_mode: "managed_required";
+  run_reference: string;
+  status: "running" | "passed" | "failed" | "uncertain" | "cancelled";
+  call_count: number;
+  reason_codes: string[];
+  calls: ProviderRouteCallReceipt[];
+}
+
+const statusLabels: Record<ProviderRouteReceipt["status"], string> = {
+  running: "调用中",
+  passed: "已纳管",
+  failed: "纳管调用失败",
+  uncertain: "调用结果待确认",
+  cancelled: "调用已取消",
+};
+
+const callStatusLabels: Record<ProviderRouteCallReceipt["status"], string> = {
+  passed: "成功",
+  failed: "失败",
+  uncertain: "待确认",
+  cancelled: "已取消",
+};
+
+function statusClass(status: ProviderRouteReceipt["status"]) {
+  if (status === "passed") return "border-emerald-300/25 bg-emerald-300/10 text-emerald-100";
+  if (status === "uncertain") return "border-amber-300/25 bg-amber-300/10 text-amber-100";
+  if (status === "running") return "border-cyan-300/25 bg-cyan-300/10 text-cyan-100";
+  return "border-rose-300/25 bg-rose-300/10 text-rose-100";
+}
+
+export default function ProviderRouteReceiptSummary({
+  receipt,
+}: {
+  receipt: ProviderRouteReceipt | null | undefined;
+}) {
+  if (!receipt) return null;
+  const modelCount = new Set(
+    receipt.calls
+      .filter((call) => call.dispatched !== false)
+      .map((call) => call.model_id),
+  ).size;
+
+  return (
+    <details className="rounded-lg border border-white/10 bg-white/[0.035] text-xs text-slate-300">
+      <summary className="flex cursor-pointer list-none flex-wrap items-center gap-2 px-3 py-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/50">
+        <span className={`rounded-full border px-2 py-0.5 font-semibold ${statusClass(receipt.status)}`}>
+          {statusLabels[receipt.status]}
+        </span>
+        <span>{receipt.call_count} 次模型调用</span>
+        <span className="text-slate-500">{modelCount} 个精确模型</span>
+        <span className="ml-auto font-mono text-[10px] text-slate-500">
+          {receipt.run_reference.slice(-12)}
+        </span>
+      </summary>
+      <div className="border-t border-white/10 px-3 py-2.5">
+        <p className="mb-2 text-slate-400">
+          仅显示脱敏路由结果。连接、凭据和完整证据仅在设置中查看。
+        </p>
+        <div className="space-y-1.5">
+          {receipt.calls.map((call) => (
+            <div
+              className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md bg-slate-950/35 px-2.5 py-2"
+              key={`${call.call_sequence}-${call.model_id}`}
+            >
+              <span className="font-semibold text-slate-200">
+                {call.dispatched === false ? "预检" : "调用"} {call.call_sequence}
+              </span>
+              <span className="min-w-0 truncate font-mono text-[10px] text-slate-400">
+                {call.model_id}
+              </span>
+              <span>{callStatusLabels[call.status]}</span>
+              {call.dispatched === false ? (
+                <span className="text-amber-200">未派发</span>
+              ) : null}
+              {call.total_tokens != null ? (
+                <span className="ml-auto text-slate-500">{call.total_tokens} tokens</span>
+              ) : null}
+              {call.error_code ? (
+                <span className="w-full font-mono text-[10px] text-rose-200">
+                  {call.error_code}
+                </span>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/client/src/pages/MetaAgentPage.tsx
+++ b/client/src/pages/MetaAgentPage.tsx
@@ -10,6 +10,9 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import PageContainer from "../components/PageContainer";
 import MetaPlannerV2 from "../components/meta/MetaPlannerV2";
+import ProviderRouteReceiptSummary, {
+  type ProviderRouteReceipt,
+} from "../components/meta/ProviderRouteReceiptSummary";
 import RuntimeApprovalPanel from "../components/runtime/RuntimeApprovalPanel";
 import BrowserSessionPanel from "../components/runtime/BrowserSessionPanel";
 import ClientToolPanel from "../components/runtime/ClientToolPanel";
@@ -76,6 +79,8 @@ interface MetaAgentGenerateResponse {
   workflow: WorkflowDefinition;
   warnings: string[];
   validation: MetaAgentValidation;
+  run_id?: string | null;
+  provider_route_receipts?: ProviderRouteReceipt | null;
 }
 
 interface AgentTaskSummary {
@@ -133,14 +138,12 @@ const goalTemplates = [
   },
 ];
 
-const plannerModelOptions = models
-  .filter(
-    (model) =>
-      model.active &&
-      model.input_modalities.includes("text") &&
-      model.capabilities.includes("text"),
-  )
-  .slice(0, 120);
+export const plannerModelOptions = models.filter(
+  (model) =>
+    model.active &&
+    model.input_modalities.includes("text") &&
+    model.capabilities.includes("text"),
+);
 
 const defaultPlannerModel =
   plannerModelOptions.find((model) => model.id === "openai/gpt-5.6-sol")?.id ??
@@ -323,6 +326,7 @@ export default function MetaAgentPage() {
   const [temperature, setTemperature] = useState(0.3);
   const [maxTasks, setMaxTasks] = useState(5);
   const [result, setResult] = useState<MetaAgentGenerateResponse | null>(null);
+  const [routeReceipt, setRouteReceipt] = useState<ProviderRouteReceipt | null>(null);
   const [error, setError] = useState("");
   const [isGenerating, setIsGenerating] = useState(false);
   const [agentTasks, setAgentTasks] = useState<AgentTaskSummary[]>([]);
@@ -788,6 +792,7 @@ export default function MetaAgentPage() {
     }
 
     setError("");
+    setRouteReceipt(null);
     setIsGenerating(true);
     try {
       const response = await fetch("/api/meta-agent/generate-workflow", {
@@ -802,13 +807,19 @@ export default function MetaAgentPage() {
       });
       const payload = (await response.json().catch(() => null)) as
         | MetaAgentGenerateResponse
-        | { error?: string; detail?: unknown }
+        | {
+            error?: string;
+            detail?: unknown;
+            provider_route_receipts?: ProviderRouteReceipt | null;
+          }
         | null;
       if (!response.ok) {
+        setRouteReceipt(payload?.provider_route_receipts ?? null);
         throw new Error(errorMessage(payload, "生成失败，请检查模型网关配置。"));
       }
       const generated = payload as MetaAgentGenerateResponse;
       setResult(generated);
+      setRouteReceipt(generated.provider_route_receipts ?? null);
       await createAgentTaskForResult(generated, trimmedGoal);
     } catch (generateError) {
       setError(generateError instanceof Error ? generateError.message : "生成失败。");
@@ -975,6 +986,11 @@ export default function MetaAgentPage() {
           {error ? (
             <div className="mt-4 rounded-lg border border-rose-300/25 bg-rose-300/10 px-3 py-2 text-sm leading-6 text-rose-100">
               {error}
+            </div>
+          ) : null}
+          {routeReceipt ? (
+            <div className="mt-4">
+              <ProviderRouteReceiptSummary receipt={routeReceipt} />
             </div>
           ) : null}
         </section>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,10 +203,14 @@ Round 6A 在不接管 Agent/Workflow 数据面的前提下增加
 `entry_id + execution_shape + exact model_id` 精确绑定一个 Managed Connection；
 `chat_text`/`chat_tools` 复用 R5 资格，非流式文本、JSON Object 和原生 Fusion 使用各自
 独立资格。父运行与逻辑调用 Receipt 不保存 Prompt、消息、模型正文或工具参数，且重启后
-不重放 `uncertain` 调用。所有 R6 部署开关默认关闭；R6B 只将 `agent_shadow` 加入数据面
-接入集合，其余 Policy/Binding 可配置和审计但不能激活；Workflow、Xpert 与 R5 Chat 调度均
-保持 legacy/原行为。接入入口只允许 Python 主进程解析凭据和调用 Provider，Worker 与工具
-执行器继续只处理模型消息、Tool Call 和脱敏结果。
+不重放 `uncertain` 调用。所有 R6 部署开关默认关闭；R6B 将 `agent_shadow` 加入数据面，
+R6C 将两个 Meta Agent 生成入口加入数据面。Meta Agent 使用精确
+`meta_agent + chat_json_object + model_id` Binding，任务规划、蓝图和最多一次语义修复分别
+记录为独立逻辑调用；任一调用派发后都不重试、不切换 Provider，也不进入 legacy。
+`MODEL_CONTROL_META_AGENT_ENABLED=false` 或 Policy 为 `legacy` 时保留原生成路径；已激活
+Policy 失效后保持 `degraded_required` 并在 POST 前失败关闭。其他 Workflow、Xpert 与 R5
+Chat 调度仍保持原行为。接入入口只允许 Python 主进程解析凭据和调用 Provider，Worker 与
+工具执行器继续只处理模型消息、Tool Call 和脱敏结果。
 
 `/settings?section=overview|providers|routing` 共用一份 Provider 管理会话。Marble 等其他
 集成位于该门禁之外；newAPI 管理 UI 继续只通过安全外链访问，不嵌入或代理。

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -217,12 +217,19 @@ MODEL_CONTROL_ROUTE_AGENT_ENABLED=false
 MODEL_CONTROL_TEAM_CHAT_ENABLED=false
 ```
 
-R6B 仅接入 `agent_shadow` 数据面；其他 Agent、Workflow 和 Xpert 入口仍不能激活
-Managed Policy。`agent_shadow` 只有在 `MODEL_CONTROL_AGENT_SHADOW_ENABLED=true`、
+R6B 接入 `agent_shadow`，R6C 接入两个 Meta Agent 生成入口；其他 Workflow 和 Xpert 入口
+仍不能激活 Managed Policy。`agent_shadow` 只有在
+`MODEL_CONTROL_AGENT_SHADOW_ENABLED=true`、
 精确模型的 `chat_tools` 资格与 Binding 有效、且管理员明确批准 fail-closed 后才会接管。
 开关为 `false` 或 Policy 为 `legacy` 时继续使用原 Shadow 网关路径；已经激活但失效的
 Policy 会保持 `degraded_required`，不会自动回退。紧急回退需显式停用 Policy 或关闭该
 开关并重启 Server；保留 v16 Receipt 和 Shadow Workspace 数据。
+
+Meta Agent 只有在 `MODEL_CONTROL_META_AGENT_ENABLED=true`、精确模型的
+`chat_json_object` 资格与 Binding 有效、且管理员批准 fail-closed 后才会接管。关闭开关或
+显式停用 `meta_agent` Policy 会恢复原静态网关路径；已经激活但资格失效时保持失败关闭。
+两个生成接口在 managed 模式均返回脱敏 `provider_route_receipts`，不得从中推断或输出
+连接、URL、凭据、Prompt 或模型正文。
 
 同一清理命令从 v16 起同时报告 R5 Chat 与 R6 Workload 的过期记录；第一条仍是 dry-run，
 只有第二条显式 `--apply` 才删除已完成记录。不得对正在运行的父运行或逻辑调用执行清理。

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -226,7 +226,11 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
   `agent_shadow + chat_tools` Binding；Worker `model.request` ID 是不可重放的逻辑调用键。
   Flag 关闭或 Policy 为 `legacy` 时保留原 Shadow 网关；已激活策略失效后保持
   `degraded_required` 并失败关闭。
-- 后续 R6C—R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
+- R6C 接入 `/api/meta-agent/generate-workflow` 与
+  `/api/meta-agent/generate-xpert-candidate`。两者使用 `chat_json_object` 精确 Binding；规划、
+  蓝图和最多一次修复分别记录调用序号。派发后不重试、不换 IP、连接、模型或 legacy；响应
+  只加法返回运行引用、模型、调用序号、状态和可用 usage，不返回内部连接或生成正文。
+- 后续 R6D—R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
   只能存在于 Python 主进程内存，Worker、工具执行器和浏览器不得收到 Key、URL 或连接细节。
 - Receipt 清理命令现在同时检查 R5 Chat 与 R6 Workload 记录，仍默认 dry-run；`--apply`
   才删除超过保留期的已完成运行、尝试或调用。

--- a/server/main.py
+++ b/server/main.py
@@ -553,6 +553,9 @@ try:
     from server.meta_agent import (
         MetaAgentGenerateRequest,
         MetaAgentGenerateResponse,
+        ManagedMetaAgentGateway,
+        ManagedMetaAgentRoutingError,
+        ManagedMetaAgentRun,
         MetaPlannerGenerateRequest,
         MetaPlannerGenerateResponse,
         MetaPlannerScope,
@@ -634,6 +637,9 @@ except ModuleNotFoundError:
     from meta_agent import (
         MetaAgentGenerateRequest,
         MetaAgentGenerateResponse,
+        ManagedMetaAgentGateway,
+        ManagedMetaAgentRoutingError,
+        ManagedMetaAgentRun,
         MetaPlannerGenerateRequest,
         MetaPlannerGenerateResponse,
         MetaPlannerScope,
@@ -7843,11 +7849,6 @@ async def generate_meta_planner_xpert_candidate(
     payload: MetaPlannerGenerateRequest,
     request: Request,
 ):
-    if not get_llm_gateway_config()[0]:
-        return JSONResponse(
-            status_code=500,
-            content={"error": LLM_GATEWAY_NOT_CONFIGURED_MESSAGE},
-        )
     try:
         rate_limit_or_raise(client_ip(request))
         validate_plain_message(payload.goal)
@@ -7871,6 +7872,24 @@ async def generate_meta_planner_xpert_candidate(
             content={"error": "Create mode cannot set target_xpert_id."},
         )
 
+    managed_gateway = ManagedMetaAgentGateway.for_router(
+        get_model_router_service()
+    )
+    routing_mode = managed_gateway.routing_mode()
+    if routing_mode == "legacy" and not get_llm_gateway_config()[0]:
+        return JSONResponse(
+            status_code=500,
+            content={"error": LLM_GATEWAY_NOT_CONFIGURED_MESSAGE},
+        )
+    if routing_mode == "degraded_required":
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": "Meta Agent 的 Managed Provider 策略已失效，当前入口失败关闭。",
+                "code": "provider_workload_meta_agent_degraded_required",
+            },
+        )
+
     run = await run_registry.create_run(
         "meta_planner",
         f"Meta Planner: {payload.goal[:80]}",
@@ -7890,6 +7909,29 @@ async def generate_meta_planner_xpert_candidate(
         metadata={"mode": payload.mode},
     )
 
+    managed_run: ManagedMetaAgentRun | None = None
+    if routing_mode == "managed_required":
+        try:
+            managed_run = managed_gateway.start_run(
+                parent_run_reference=run.run_id
+            )
+        except RouterServiceError as exc:
+            await run_registry.update_run(
+                run.run_id,
+                status="failed",
+                error="Managed Provider route failed before dispatch.",
+            )
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={
+                    "error": "Meta Agent 的 Managed Provider 路由已失败关闭。",
+                    "code": exc.code,
+                    "run_id": run.run_id,
+                },
+            )
+
+    call_sequence = 0
+
     async def complete(
         model_id: str,
         system_prompt: str,
@@ -7897,6 +7939,18 @@ async def generate_meta_planner_xpert_candidate(
         temperature: float,
         max_tokens: int,
     ) -> str:
+        nonlocal call_sequence
+        if managed_run is not None:
+            call_sequence += 1
+            return await managed_run.complete_json(
+                logical_call_key=f"{run.run_id}:meta-planner:{call_sequence}",
+                call_sequence=call_sequence,
+                model_id=model_id,
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
         return await collect_chat_completion_text(
             model_id,
             [
@@ -7920,6 +7974,22 @@ async def generate_meta_planner_xpert_candidate(
             target=target,
             source_run_id=run.run_id,
         )
+        if managed_run is not None:
+            if response.validation.get("valid") is True:
+                managed_run.finish("passed")
+            else:
+                managed_run.finish(
+                    "failed",
+                    reason_code="provider_workload_meta_agent_validation_failed",
+                )
+        response = response.model_copy(
+            update={
+                "run_id": run.run_id,
+                "provider_route_receipts": (
+                    managed_run.receipt_summary() if managed_run is not None else None
+                ),
+            }
+        )
         await run_registry.record_checkpoint(
             run.run_id,
             event_type="meta_planner.completed",
@@ -7938,13 +8008,82 @@ async def generate_meta_planner_xpert_candidate(
             metadata={"proposal_id": response.proposal_id},
         )
         return response
+    except asyncio.CancelledError:
+        if managed_run is not None:
+            managed_run.finish(
+                "cancelled", reason_code="provider_workload_call_cancelled"
+            )
+        await run_registry.update_run(
+            run.run_id,
+            status="cancelled",
+            error="Meta Agent request was cancelled.",
+        )
+        raise
+    except ManagedMetaAgentRoutingError as exc:
+        if managed_run is not None:
+            failure_status = (
+                "uncertain"
+                if any(item.status == "uncertain" for item in managed_run.calls)
+                else "failed"
+            )
+            managed_run.finish(failure_status, reason_code=exc.code)
+        await run_registry.update_run(
+            run.run_id,
+            status="failed",
+            error="Managed Provider route failed closed.",
+        )
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={
+                "error": exc.public_message,
+                "code": exc.code,
+                "run_id": run.run_id,
+                "provider_route_receipts": (
+                    managed_run.receipt_summary().model_dump(mode="json")
+                    if managed_run is not None
+                    else None
+                ),
+            },
+        )
     except ValueError as exc:
-        await run_registry.update_run(run.run_id, status="failed", error=str(exc)[:500])
-        return JSONResponse(status_code=422, content={"error": str(exc)})
+        if managed_run is not None:
+            managed_run.finish(
+                "failed", reason_code="provider_workload_meta_agent_invalid_output"
+            )
+            error_message = "Managed Provider 未生成可验证的 Meta Agent 结构化结果。"
+            error_code = "provider_workload_meta_agent_invalid_output"
+        else:
+            error_message = str(exc)
+            error_code = None
+        await run_registry.update_run(
+            run.run_id, status="failed", error=error_message[:500]
+        )
+        content: dict[str, Any] = {"error": error_message, "run_id": run.run_id}
+        if error_code:
+            content["code"] = error_code
+            content["provider_route_receipts"] = managed_run.receipt_summary().model_dump(
+                mode="json"
+            )
+        return JSONResponse(status_code=422, content=content)
     except Exception as exc:
         logger.exception("Meta Planner V2 candidate generation failed")
-        await run_registry.update_run(run.run_id, status="failed", error=str(exc)[:500])
-        return JSONResponse(status_code=500, content={"error": str(exc)})
+        if managed_run is not None:
+            managed_run.finish(
+                "failed", reason_code="provider_workload_meta_agent_internal_error"
+            )
+            error_message = "Meta Agent 生成失败；Managed Provider 调用不会自动重放。"
+        else:
+            error_message = str(exc)
+        await run_registry.update_run(
+            run.run_id, status="failed", error=error_message[:500]
+        )
+        content: dict[str, Any] = {"error": error_message, "run_id": run.run_id}
+        if managed_run is not None:
+            content["code"] = "provider_workload_meta_agent_internal_error"
+            content["provider_route_receipts"] = managed_run.receipt_summary().model_dump(
+                mode="json"
+            )
+        return JSONResponse(status_code=500, content=content)
 
 
 @app.post("/api/meta-agent/generate-workflow", response_model=MetaAgentGenerateResponse)
@@ -7952,29 +8091,79 @@ async def generate_meta_agent_workflow(
     payload: MetaAgentGenerateRequest,
     request: Request,
 ):
-    if not get_llm_gateway_config()[0]:
-        return JSONResponse(
-            status_code=500,
-            content={"error": LLM_GATEWAY_NOT_CONFIGURED_MESSAGE},
-        )
-
     try:
         rate_limit_or_raise(client_ip(request))
         validate_plain_message(payload.goal)
     except HTTPException as exc:
         return JSONResponse(status_code=exc.status_code, content={"error": str(exc.detail)})
 
+    managed_gateway = ManagedMetaAgentGateway.for_router(
+        get_model_router_service()
+    )
+    routing_mode = managed_gateway.routing_mode()
+    if routing_mode == "legacy" and not get_llm_gateway_config()[0]:
+        return JSONResponse(
+            status_code=500,
+            content={"error": LLM_GATEWAY_NOT_CONFIGURED_MESSAGE},
+        )
+    if routing_mode == "degraded_required":
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": "Meta Agent 的 Managed Provider 策略已失效，当前入口失败关闭。",
+                "code": "provider_workload_meta_agent_degraded_required",
+            },
+        )
+
+    run = await run_registry.create_run(
+        "meta_planner",
+        f"Meta Agent workflow: {payload.goal[:80]}",
+        status="running",
+        metadata={"model_id": payload.model_id, "max_tasks": payload.max_tasks},
+    )
+    managed_run: ManagedMetaAgentRun | None = None
+    if routing_mode == "managed_required":
+        try:
+            managed_run = managed_gateway.start_run(
+                parent_run_reference=run.run_id
+            )
+        except RouterServiceError as exc:
+            await run_registry.update_run(
+                run.run_id,
+                status="failed",
+                error="Managed Provider route failed before dispatch.",
+            )
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={
+                    "error": "Meta Agent 的 Managed Provider 路由已失败关闭。",
+                    "code": exc.code,
+                    "run_id": run.run_id,
+                },
+            )
+
     try:
         prompt = build_meta_agent_prompt(payload.goal, payload.max_tasks)
-        raw_plan = await collect_chat_completion_text(
-            payload.model_id,
-            [
-                ChatMessage(role="system", content=META_AGENT_SYSTEM_PROMPT),
-                ChatMessage(role="user", content=prompt),
-            ],
-            temperature=payload.temperature,
-            max_tokens=4096,
-        )
+        if managed_run is not None:
+            raw_plan = await managed_run.complete_json(
+                logical_call_key=f"{run.run_id}:workflow-plan:1",
+                call_sequence=1,
+                model_id=payload.model_id,
+                system_prompt=META_AGENT_SYSTEM_PROMPT,
+                user_prompt=prompt,
+                temperature=payload.temperature,
+                max_tokens=4096,
+            )
+        else:
+            raw_plan = await collect_chat_completion_text(
+                payload.model_id,
+                [
+                    ChatMessage(role="system", content=META_AGENT_SYSTEM_PROMPT),
+                    ChatMessage(role="user", content=prompt),
+                ],
+                temperature=payload.temperature,
+                max_tokens=4096,
+            )
         plan = parse_meta_agent_plan(raw_plan, max_tasks=payload.max_tasks)
         workflow, warnings = build_workflow_from_plan(
             goal=payload.goal,
@@ -7993,18 +8182,101 @@ async def generate_meta_agent_workflow(
                 }
             )
         )
-        return MetaAgentGenerateResponse(
+        if managed_run is not None:
+            if validation.valid:
+                managed_run.finish("passed")
+            else:
+                managed_run.finish(
+                    "failed",
+                    reason_code="provider_workload_meta_agent_validation_failed",
+                )
+        response = MetaAgentGenerateResponse(
             goal=payload.goal,
             plan=plan,
             workflow=workflow,
             warnings=warnings,
             validation=validation.model_dump(mode="json"),
+            run_id=run.run_id,
+            provider_route_receipts=(
+                managed_run.receipt_summary() if managed_run is not None else None
+            ),
+        )
+        await run_registry.update_run(run.run_id, status="completed")
+        return response
+    except asyncio.CancelledError:
+        if managed_run is not None:
+            managed_run.finish(
+                "cancelled", reason_code="provider_workload_call_cancelled"
+            )
+        await run_registry.update_run(
+            run.run_id,
+            status="cancelled",
+            error="Meta Agent request was cancelled.",
+        )
+        raise
+    except ManagedMetaAgentRoutingError as exc:
+        if managed_run is not None:
+            failure_status = (
+                "uncertain"
+                if any(item.status == "uncertain" for item in managed_run.calls)
+                else "failed"
+            )
+            managed_run.finish(failure_status, reason_code=exc.code)
+        await run_registry.update_run(
+            run.run_id,
+            status="failed",
+            error="Managed Provider route failed closed.",
+        )
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={
+                "error": exc.public_message,
+                "code": exc.code,
+                "run_id": run.run_id,
+                "provider_route_receipts": (
+                    managed_run.receipt_summary().model_dump(mode="json")
+                    if managed_run is not None
+                    else None
+                ),
+            },
         )
     except ValueError as exc:
-        return JSONResponse(status_code=422, content={"error": str(exc)})
+        if managed_run is not None:
+            managed_run.finish(
+                "failed", reason_code="provider_workload_meta_agent_invalid_output"
+            )
+            error_message = "Managed Provider 未生成可验证的 Meta Agent 工作流计划。"
+        else:
+            error_message = str(exc)
+        await run_registry.update_run(
+            run.run_id, status="failed", error=error_message[:500]
+        )
+        content: dict[str, Any] = {"error": error_message, "run_id": run.run_id}
+        if managed_run is not None:
+            content["code"] = "provider_workload_meta_agent_invalid_output"
+            content["provider_route_receipts"] = managed_run.receipt_summary().model_dump(
+                mode="json"
+            )
+        return JSONResponse(status_code=422, content=content)
     except Exception as exc:
         logger.exception("Meta-agent workflow generation failed")
-        return JSONResponse(status_code=500, content={"error": str(exc)})
+        if managed_run is not None:
+            managed_run.finish(
+                "failed", reason_code="provider_workload_meta_agent_internal_error"
+            )
+            error_message = "Meta Agent 生成失败；Managed Provider 调用不会自动重放。"
+        else:
+            error_message = str(exc)
+        await run_registry.update_run(
+            run.run_id, status="failed", error=error_message[:500]
+        )
+        content: dict[str, Any] = {"error": error_message, "run_id": run.run_id}
+        if managed_run is not None:
+            content["code"] = "provider_workload_meta_agent_internal_error"
+            content["provider_route_receipts"] = managed_run.receipt_summary().model_dump(
+                mode="json"
+            )
+        return JSONResponse(status_code=500, content=content)
 
 
 @dataclass(slots=True)

--- a/server/meta_agent/__init__.py
+++ b/server/meta_agent/__init__.py
@@ -15,8 +15,15 @@ from .schemas import (
     MetaPlannerGenerateResponse,
     MetaPlannerPreviewResponse,
     MetaPlannerScope,
+    ProviderRouteCallReceipt,
+    ProviderRouteReceiptSummary,
 )
 from .capabilities import build_capability_snapshot
+from .managed_gateway import (
+    ManagedMetaAgentGateway,
+    ManagedMetaAgentRoutingError,
+    ManagedMetaAgentRun,
+)
 from .meta_planner_v2 import MetaPlannerV2Service
 
 __all__ = [
@@ -28,6 +35,11 @@ __all__ = [
     "MetaPlannerPreviewResponse",
     "MetaPlannerScope",
     "MetaPlannerV2Service",
+    "ManagedMetaAgentGateway",
+    "ManagedMetaAgentRoutingError",
+    "ManagedMetaAgentRun",
+    "ProviderRouteCallReceipt",
+    "ProviderRouteReceiptSummary",
     "build_capability_snapshot",
     "build_meta_agent_prompt",
     "build_workflow_from_plan",

--- a/server/meta_agent/managed_gateway.py
+++ b/server/meta_agent/managed_gateway.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import Callable
+from typing import Any, Literal
+
+import httpx
+
+try:
+    from server.model_router.repository import RouterRepositoryError
+    from server.model_router.service import ModelRouterService, RouterServiceError
+    from server.model_router.workload_control import (
+        PROVIDER_WORKLOAD_CONTRACT_VERSION,
+        ProviderWorkloadCallService,
+        ProviderWorkloadPreparedCall,
+    )
+except ImportError:  # pragma: no cover - direct server package execution
+    from model_router.repository import RouterRepositoryError
+    from model_router.service import ModelRouterService, RouterServiceError
+    from model_router.workload_control import (
+        PROVIDER_WORKLOAD_CONTRACT_VERSION,
+        ProviderWorkloadCallService,
+        ProviderWorkloadPreparedCall,
+    )
+
+from .schemas import ProviderRouteCallReceipt, ProviderRouteReceiptSummary
+
+
+MetaAgentRoutingMode = Literal["legacy", "managed_required", "degraded_required"]
+MAX_META_AGENT_RESPONSE_BYTES = 1024 * 1024
+
+
+class ManagedMetaAgentRoutingError(RuntimeError):
+    def __init__(self, code: str, public_message: str, *, status_code: int = 502) -> None:
+        super().__init__(code)
+        self.code = code
+        self.public_message = public_message
+        self.status_code = status_code
+
+
+class ManagedMetaAgentGateway:
+    """Host-only managed JSON completion adapter for both Meta Agent entries."""
+
+    def __init__(
+        self,
+        call_service: ProviderWorkloadCallService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self.call_service = call_service
+        self._client_factory = client_factory
+
+    @classmethod
+    def for_router(
+        cls,
+        router_service: ModelRouterService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> ManagedMetaAgentGateway:
+        return cls(
+            ProviderWorkloadCallService(router_service),
+            client_factory=client_factory,
+        )
+
+    def routing_mode(self) -> MetaAgentRoutingMode:
+        control = self.call_service.control
+        if not control.feature_enabled("meta_agent"):
+            return "legacy"
+        policy = control.get_policy("meta_agent")
+        if policy.configured_status == "legacy":
+            return "legacy"
+        if policy.effective_status == "managed_required":
+            return "managed_required"
+        return "degraded_required"
+
+    def start_run(self, *, parent_run_reference: str) -> ManagedMetaAgentRun:
+        return ManagedMetaAgentRun(
+            self,
+            self.call_service.start_run(
+                "meta_agent", parent_run_reference=parent_run_reference
+            ),
+        )
+
+
+class ManagedMetaAgentRun:
+    def __init__(self, gateway: ManagedMetaAgentGateway, run_id: str) -> None:
+        self.gateway = gateway
+        self.run_id = run_id
+        self.status: Literal[
+            "running", "passed", "failed", "uncertain", "cancelled"
+        ] = "running"
+        self.reason_codes: list[str] = []
+        self.calls: list[ProviderRouteCallReceipt] = []
+
+    async def complete_json(
+        self,
+        *,
+        logical_call_key: str,
+        call_sequence: int,
+        model_id: str,
+        system_prompt: str,
+        user_prompt: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> str:
+        prepared: ProviderWorkloadPreparedCall | None = None
+        dispatched = False
+        started = time.perf_counter()
+        try:
+            prepared = await self.gateway.call_service.prepare_call(
+                run_id=self.run_id,
+                entry_id="meta_agent",
+                execution_shape="chat_json_object",
+                model_id=model_id,
+                logical_call_key=logical_call_key,
+                call_sequence=call_sequence,
+            )
+            request_payload = {
+                "model": model_id,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                "stream": False,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "response_format": {"type": "json_object"},
+            }
+            client = (
+                self.gateway._client_factory()
+                if self.gateway._client_factory is not None
+                else httpx.AsyncClient(
+                    **self.gateway.call_service.transport.client_kwargs(
+                        certification=True
+                    )
+                )
+            )
+            async with asyncio.timeout(60):
+                async with client:
+                    request = self.gateway.call_service.transport.build_authorized_stream_request(
+                        client,
+                        prepared.target,
+                        prepared.authorized_target,
+                        request_payload,
+                    )
+                    self.gateway.call_service.mark_dispatched(prepared)
+                    dispatched = True
+                    response = await self.gateway.call_service.transport.send_authorized_stream(
+                        client, request
+                    )
+                    try:
+                        payload = await self._read_response(response)
+                    finally:
+                        await response.aclose()
+            text, actual_model, usage = self._completion_payload(
+                payload, requested_model=model_id
+            )
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            self.gateway.call_service.complete_call(
+                prepared,
+                status="passed",
+                result_class="success",
+                actual_model=actual_model,
+                ttft_ms=elapsed_ms,
+                e2e_ms=elapsed_ms,
+                prompt_tokens=usage.get("prompt_tokens"),
+                completion_tokens=usage.get("completion_tokens"),
+                total_tokens=usage.get("total_tokens"),
+            )
+            self.calls.append(
+                ProviderRouteCallReceipt(
+                    call_sequence=call_sequence,
+                    model_id=model_id,
+                    actual_model=actual_model,
+                    dispatched=True,
+                    status="passed",
+                    prompt_tokens=usage.get("prompt_tokens"),
+                    completion_tokens=usage.get("completion_tokens"),
+                    total_tokens=usage.get("total_tokens"),
+                )
+            )
+            return text
+        except asyncio.CancelledError:
+            self._complete_call_safely(
+                prepared,
+                status="cancelled",
+                result_class="client_cancelled",
+                error_code="provider_workload_call_cancelled",
+            )
+            self._append_failure(
+                call_sequence,
+                model_id,
+                "cancelled",
+                "provider_workload_call_cancelled",
+                dispatched=dispatched,
+            )
+            raise
+        except ManagedMetaAgentRoutingError as exc:
+            self._complete_call_safely(
+                prepared,
+                status="failed",
+                result_class="provider_error" if dispatched else "preflight_error",
+                error_code=exc.code,
+            )
+            self._append_failure(
+                call_sequence,
+                model_id,
+                "failed",
+                exc.code,
+                dispatched=dispatched,
+            )
+            raise
+        except RouterServiceError as exc:
+            status = "uncertain" if dispatched else "failed"
+            self._complete_call_safely(
+                prepared,
+                status=status,
+                result_class="control_plane_error",
+                error_code=exc.code,
+            )
+            self._append_failure(
+                call_sequence,
+                model_id,
+                status,
+                exc.code,
+                dispatched=dispatched,
+            )
+            raise ManagedMetaAgentRoutingError(
+                exc.code,
+                "Meta Agent 的 Managed Provider 路由已失败关闭。",
+                status_code=exc.status_code,
+            ) from exc
+        except (httpx.TimeoutException, TimeoutError) as exc:
+            code = "provider_workload_timeout"
+            status = "uncertain" if dispatched else "failed"
+            self._complete_call_safely(
+                prepared,
+                status=status,
+                result_class="transport_error",
+                error_code=code,
+            )
+            self._append_failure(
+                call_sequence,
+                model_id,
+                status,
+                code,
+                dispatched=dispatched,
+            )
+            raise ManagedMetaAgentRoutingError(
+                code, "Meta Agent 的 Managed Provider 请求超时，系统未重放。"
+            ) from exc
+        except httpx.HTTPError as exc:
+            code = "provider_workload_transport_error"
+            status = "uncertain" if dispatched else "failed"
+            self._complete_call_safely(
+                prepared,
+                status=status,
+                result_class="transport_error",
+                error_code=code,
+            )
+            self._append_failure(
+                call_sequence,
+                model_id,
+                status,
+                code,
+                dispatched=dispatched,
+            )
+            raise ManagedMetaAgentRoutingError(
+                code, "Meta Agent 的 Managed Provider 请求失败，系统未重放。"
+            ) from exc
+        except Exception as exc:
+            code = "provider_workload_dispatch_uncertain" if dispatched else (
+                "provider_workload_preflight_failed"
+            )
+            status = "uncertain" if dispatched else "failed"
+            self._complete_call_safely(
+                prepared,
+                status=status,
+                result_class="unexpected_error",
+                error_code=code,
+            )
+            self._append_failure(
+                call_sequence,
+                model_id,
+                status,
+                code,
+                dispatched=dispatched,
+            )
+            raise ManagedMetaAgentRoutingError(
+                code, "Meta Agent 的 Managed Provider 调用失败，系统未重放。"
+            ) from exc
+
+    def finish(
+        self,
+        status: Literal["passed", "failed", "uncertain", "cancelled"],
+        *,
+        reason_code: str | None = None,
+    ) -> None:
+        if self.status != "running":
+            return
+        reason_codes = [reason_code] if reason_code else []
+        try:
+            self.gateway.call_service.complete_run(
+                self.run_id,
+                status=status,
+                result_class=f"meta_agent_{status}",
+                reason_codes=reason_codes,
+            )
+        except RouterRepositoryError as exc:
+            if str(exc) != "provider_workload_run_not_running":
+                raise
+        self.status = status
+        self.reason_codes = reason_codes
+
+    def receipt_summary(self) -> ProviderRouteReceiptSummary:
+        return ProviderRouteReceiptSummary(
+            contract_version=PROVIDER_WORKLOAD_CONTRACT_VERSION,
+            entry_id="meta_agent",
+            routing_mode="managed_required",
+            run_reference=self.run_id,
+            status=self.status,
+            call_count=sum(1 for call in self.calls if call.dispatched),
+            reason_codes=list(self.reason_codes),
+            calls=list(self.calls),
+        )
+
+    @staticmethod
+    async def _read_response(response: httpx.Response) -> dict[str, Any]:
+        if response.status_code < 200 or response.status_code >= 300:
+            code = {
+                401: "provider_workload_http_401",
+                402: "provider_workload_http_402",
+                403: "provider_workload_http_403",
+                404: "provider_workload_http_404",
+                429: "provider_workload_http_429",
+            }.get(
+                response.status_code,
+                "provider_workload_http_5xx"
+                if response.status_code >= 500
+                else "provider_workload_http_error",
+            )
+            raise ManagedMetaAgentRoutingError(
+                code, "Managed Provider 拒绝或未能完成 Meta Agent 请求。"
+            )
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in response.aiter_bytes(chunk_size=64 * 1024):
+            total += len(chunk)
+            if total > MAX_META_AGENT_RESPONSE_BYTES:
+                raise ManagedMetaAgentRoutingError(
+                    "provider_workload_response_too_large",
+                    "Managed Provider 的 Meta Agent 响应超过安全上限。",
+                )
+            chunks.append(chunk)
+        try:
+            payload = json.loads(b"".join(chunks))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise ManagedMetaAgentRoutingError(
+                "provider_workload_invalid_json_response",
+                "Managed Provider 返回了无效的响应格式。",
+            ) from exc
+        if not isinstance(payload, dict):
+            raise ManagedMetaAgentRoutingError(
+                "provider_workload_invalid_json_response",
+                "Managed Provider 返回了无效的响应格式。",
+            )
+        return payload
+
+    @staticmethod
+    def _completion_payload(
+        payload: dict[str, Any], *, requested_model: str
+    ) -> tuple[str, str | None, dict[str, int]]:
+        actual_model = payload.get("model")
+        actual_model = actual_model.strip() if isinstance(actual_model, str) else None
+        if actual_model and actual_model != requested_model:
+            raise ManagedMetaAgentRoutingError(
+                "provider_workload_actual_model_mismatch",
+                "Managed Provider 返回的实际模型与精确 Binding 不一致。",
+            )
+        choices = payload.get("choices")
+        first = choices[0] if isinstance(choices, list) and choices else None
+        message = first.get("message") if isinstance(first, dict) else None
+        content = message.get("content") if isinstance(message, dict) else None
+        if not isinstance(content, str) or not content.strip():
+            raise ManagedMetaAgentRoutingError(
+                "provider_workload_empty_response",
+                "Managed Provider 未返回 Meta Agent 所需的 JSON 内容。",
+            )
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise ManagedMetaAgentRoutingError(
+                "provider_workload_json_object_invalid",
+                "Managed Provider 未返回有效 JSON Object。",
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise ManagedMetaAgentRoutingError(
+                "provider_workload_json_object_invalid",
+                "Managed Provider 未返回有效 JSON Object。",
+            )
+        raw_usage = payload.get("usage")
+        usage: dict[str, int] = {}
+        if isinstance(raw_usage, dict):
+            for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+                value = raw_usage.get(key)
+                if (
+                    isinstance(value, (int, float))
+                    and not isinstance(value, bool)
+                    and value >= 0
+                ):
+                    usage[key] = int(value)
+        return content, actual_model, usage
+
+    def _append_failure(
+        self,
+        call_sequence: int,
+        model_id: str,
+        status: Literal["failed", "uncertain", "cancelled"],
+        error_code: str,
+        *,
+        dispatched: bool,
+    ) -> None:
+        self.calls.append(
+            ProviderRouteCallReceipt(
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                error_code=error_code,
+            )
+        )
+
+    def _complete_call_safely(
+        self,
+        prepared: ProviderWorkloadPreparedCall | None,
+        *,
+        status: str,
+        result_class: str,
+        error_code: str,
+    ) -> None:
+        if prepared is None:
+            return
+        try:
+            self.gateway.call_service.complete_call(
+                prepared,
+                status=status,
+                result_class=result_class,
+                error_code=error_code,
+            )
+        except RouterRepositoryError:
+            return

--- a/server/meta_agent/meta_planner_v2.py
+++ b/server/meta_agent/meta_planner_v2.py
@@ -83,6 +83,7 @@ Use only IDs and middleware listed in the authorized capability snapshot.
 Compile the task DAG into explicit typed IR nodes, control edges, resource bindings,
 middleware bindings, and one explicit final output. A node may cover multiple tasks
 and a task may require multiple nodes. Bindings must target a workflow_agent node ref.
+Respect the supplied typed_ir_constraints, including its workflow-agent node limit.
 Never invent credentials, tools, resource IDs, node kinds, versions, or private content.
 """
 
@@ -91,6 +92,7 @@ REPAIR_SYSTEM_PROMPT = """\
 You repair a ModelMirror Meta Planner blueprint. Return one strict JSON object only.
 Make the smallest changes required by the structured validation issues. Do not add
 capabilities outside the supplied authorized snapshot. This is the only repair pass.
+Return the complete blueprint and obey every supplied typed_ir_constraint.
 """
 
 
@@ -122,10 +124,71 @@ def _safe_identifier(value: str, fallback: str) -> str:
     return normalized[:120]
 
 
+def _typed_ir_prompt_constraints(
+    request: MetaPlannerGenerateRequest,
+    plan: MetaPlannerTaskPlan,
+) -> dict[str, Any]:
+    children: dict[str, list[str]] = defaultdict(list)
+    indegree = {task.task_id: len(task.depends_on) for task in plan.tasks}
+    for task in plan.tasks:
+        for dependency in task.depends_on:
+            children[dependency].append(task.task_id)
+    queue = deque(sorted(task_id for task_id, count in indegree.items() if count == 0))
+    topological_order: list[str] = []
+    while queue:
+        current = queue.popleft()
+        topological_order.append(current)
+        for child in sorted(children[current]):
+            indegree[child] -= 1
+            if indegree[child] == 0:
+                queue.append(child)
+
+    suggested_groups: list[list[str]] = []
+    can_group_by_order = all(
+        not task.agent_id and not task.method_skill_ids for task in plan.tasks
+    )
+    if can_group_by_order and topological_order:
+        group_count = min(request.max_agents, len(topological_order))
+        for index in range(group_count):
+            start = index * len(topological_order) // group_count
+            end = (index + 1) * len(topological_order) // group_count
+            suggested_groups.append(topological_order[start:end])
+
+    return {
+        "max_workflow_agent_nodes": request.max_agents,
+        "required_task_ids": [task.task_id for task in plan.tasks],
+        "topological_task_order": topological_order,
+        "suggested_task_groups": suggested_groups,
+        "task_dependencies": {
+            task.task_id: list(task.depends_on) for task in plan.tasks
+        },
+        "task_agent_bindings": {
+            task.task_id: task.agent_id for task in plan.tasks
+        },
+        "authorized_agent_ids": list(request.scope.agent_ids),
+        "workflow_agent_config_allowed_fields": list(
+            MetaPlannerWorkflowAgentConfig.model_fields
+        ),
+        "workflow_agent_config_forbidden_fields": ["agent_id"],
+        "rules": [
+            "Every required task_id must appear in at least one node.task_ids entry.",
+            "When the plan has more tasks than the node limit, group compatible task_ids into shared workflow_agent nodes.",
+            "Use suggested_task_groups when present unless a stricter task binding requires separate nodes.",
+            "Represent every dependency between tasks assigned to different nodes with a control edge.",
+            "Control edges must follow topological_task_order and must never form a cycle.",
+            "Node inputs may reference only user_input, conversation_history, or outputs from ancestor nodes.",
+            "Set source_agent_id only to the exact non-null task_agent_binding; otherwise omit it.",
+            "workflow_agent config accepts only workflow_agent_config_allowed_fields; agent_id belongs to the task plan and must not appear in node.config.",
+            "Return a complete typed blueprint, not a patch or partial fragment.",
+        ],
+    }
+
+
 def validate_task_plan(
     plan: MetaPlannerTaskPlan,
     *,
     max_agents: int,
+    authorized_agent_ids: set[str] | None = None,
 ) -> list[str]:
     issues: list[str] = []
     interaction_ids = [
@@ -140,6 +203,21 @@ def validate_task_plan(
     if len(task_ids) != len(set(task_ids)):
         issues.append("Task IDs must be unique.")
     known = set(task_ids)
+    assigned_agent_ids = {
+        task.agent_id for task in plan.tasks if task.agent_id is not None
+    }
+    if len(assigned_agent_ids) > max_agents:
+        issues.append(
+            f"Task plan assigns {len(assigned_agent_ids)} experts; "
+            f"max_agents={max_agents}."
+        )
+    if authorized_agent_ids is not None:
+        for task in plan.tasks:
+            if task.agent_id and task.agent_id not in authorized_agent_ids:
+                issues.append(
+                    f"Task {task.task_id} binds unauthorized expert "
+                    f"{task.agent_id}."
+                )
     graph: dict[str, list[str]] = {task_id: [] for task_id in task_ids}
     indegree = {task_id: 0 for task_id in task_ids}
     for task in plan.tasks:
@@ -372,7 +450,11 @@ def validate_blueprint_authorization(
     blueprint: MetaPlannerBlueprint | MetaPlannerTypedBlueprintV2,
     snapshot: MetaPlannerCapabilitySnapshot,
 ) -> list[str]:
-    issues = validate_task_plan(plan, max_agents=request.max_agents)
+    issues = validate_task_plan(
+        plan,
+        max_agents=request.max_agents,
+        authorized_agent_ids=set(request.scope.agent_ids),
+    )
     try:
         typed = _typed_blueprint(plan, blueprint)
     except (KeyError, ValueError, ValidationError) as exc:
@@ -1364,6 +1446,43 @@ def _validation_report(
     }
 
 
+def _authoritative_validation_report(
+    validation: dict[str, Any],
+    proposal: AuthoringProposal,
+) -> dict[str, Any]:
+    """Combine local checks with the persisted Proposal validation verdict."""
+
+    proposal_validation = (
+        proposal.validation if isinstance(proposal.validation, dict) else {}
+    )
+    authoring_valid = proposal_validation.get("valid") is True
+    raw_issues = proposal_validation.get("issues")
+    authoring_issues = (
+        [dict(issue) for issue in raw_issues[:20] if isinstance(issue, dict)]
+        if isinstance(raw_issues, list)
+        else []
+    )
+    stages = [
+        *list(validation.get("stages") or []),
+        {
+            "id": "authoring_proposal",
+            "valid": authoring_valid,
+            "issues": authoring_issues,
+        },
+    ]
+    return {
+        **validation,
+        "valid": validation.get("valid") is True and authoring_valid,
+        "stages": stages,
+        "issues": [
+            issue
+            for stage in stages
+            for issue in stage.get("issues", [])
+            if issue.get("severity", "error") == "error"
+        ],
+    }
+
+
 class MetaPlannerV2Service:
     def __init__(
         self,
@@ -1416,7 +1535,11 @@ class MetaPlannerV2Service:
             plan = MetaPlannerTaskPlan.model_validate(_json_payload(raw_plan))
         except Exception as exc:
             raise ValueError(_safe_exception_message(exc)) from exc
-        plan_issues = validate_task_plan(plan, max_agents=request.max_agents)
+        plan_issues = validate_task_plan(
+            plan,
+            max_agents=request.max_agents,
+            authorized_agent_ids=set(request.scope.agent_ids),
+        )
         if plan_issues:
             raise ValueError("; ".join(plan_issues))
 
@@ -1545,6 +1668,7 @@ class MetaPlannerV2Service:
             proposal.proposal_id,
             revision=proposal.revision,
         )
+        validation = _authoritative_validation_report(validation, proposal)
         return self._response(
             request=request,
             plan=plan,
@@ -1582,7 +1706,11 @@ class MetaPlannerV2Service:
                     + ", ".join(unsupported)
                     + "."
                 )
-        plan_issues = validate_task_plan(plan, max_agents=request.max_agents)
+        plan_issues = validate_task_plan(
+            plan,
+            max_agents=request.max_agents,
+            authorized_agent_ids=set(request.scope.agent_ids),
+        )
         blueprint_issues = validate_blueprint_authorization(
             request, plan, blueprint, snapshot
         )
@@ -1721,7 +1849,14 @@ class MetaPlannerV2Service:
                 "mode": request.mode,
                 "max_tasks": 8,
                 "max_workflow_agents": request.max_agents,
+                "authorized_agent_ids": list(request.scope.agent_ids),
                 "required_schema": required_schema,
+                "rules": [
+                    "agent_id may only use an exact value from authorized_agent_ids.",
+                    "When authorized_agent_ids is empty, omit agent_id or set it to null for every task.",
+                    "Never invent descriptive role names as agent_id values.",
+                    "Use no more than max_workflow_agents distinct non-null agent_id values.",
+                ],
             },
             ensure_ascii=False,
         )
@@ -1751,6 +1886,7 @@ class MetaPlannerV2Service:
                 "capability_snapshot": snapshot.model_dump(mode="json"),
                 "target_xpert": target_summary,
                 "required_schema": MetaPlannerTypedBlueprintV2.model_json_schema(),
+                "typed_ir_constraints": _typed_ir_prompt_constraints(request, plan),
                 "rules": [
                     "Use only executable node kinds marked compilable in the snapshot.",
                     "A workflow_agent may cover multiple task_ids and a task may use multiple nodes.",
@@ -1777,6 +1913,7 @@ class MetaPlannerV2Service:
             {
                 "goal": request.goal,
                 "task_plan": plan.model_dump(mode="json"),
+                "default_agent_model_id": request.default_agent_model_id,
                 "authorized_scope": request.scope.model_dump(mode="json"),
                 "capability_snapshot_hash": snapshot.snapshot_hash,
                 "available_resources": {
@@ -1790,6 +1927,7 @@ class MetaPlannerV2Service:
                 "invalid_blueprint": raw_blueprint[:30_000],
                 "validation_issues": issues[:30],
                 "required_schema": MetaPlannerTypedBlueprintV2.model_json_schema(),
+                "typed_ir_constraints": _typed_ir_prompt_constraints(request, plan),
             },
             ensure_ascii=False,
         )

--- a/server/meta_agent/schemas.py
+++ b/server/meta_agent/schemas.py
@@ -47,12 +47,37 @@ class MetaAgentPlan(BaseModel):
     sub_tasks: list[MetaAgentSubTask] = Field(default_factory=list, max_length=8)
 
 
+class ProviderRouteCallReceipt(BaseModel):
+    call_sequence: int = Field(ge=1)
+    model_id: str
+    actual_model: str | None = None
+    dispatched: bool = True
+    status: Literal["passed", "failed", "uncertain", "cancelled"]
+    error_code: str | None = None
+    prompt_tokens: int | None = Field(default=None, ge=0)
+    completion_tokens: int | None = Field(default=None, ge=0)
+    total_tokens: int | None = Field(default=None, ge=0)
+
+
+class ProviderRouteReceiptSummary(BaseModel):
+    contract_version: str
+    entry_id: Literal["meta_agent"] = "meta_agent"
+    routing_mode: Literal["managed_required"] = "managed_required"
+    run_reference: str
+    status: Literal["running", "passed", "failed", "uncertain", "cancelled"]
+    call_count: int = Field(ge=0)
+    reason_codes: list[str] = Field(default_factory=list, max_length=20)
+    calls: list[ProviderRouteCallReceipt] = Field(default_factory=list, max_length=8)
+
+
 class MetaAgentGenerateResponse(BaseModel):
     goal: str
     plan: MetaAgentPlan
     workflow: dict[str, Any]
     warnings: list[str] = Field(default_factory=list)
     validation: dict[str, Any]
+    run_id: str | None = None
+    provider_route_receipts: ProviderRouteReceiptSummary | None = None
 
 
 class MetaPlannerScope(BaseModel):
@@ -310,3 +335,5 @@ class MetaPlannerGenerateResponse(BaseModel):
     repair_used: bool = False
     capability_snapshot_version: str
     capability_snapshot_hash: str
+    run_id: str | None = None
+    provider_route_receipts: ProviderRouteReceiptSummary | None = None

--- a/server/model_router/workload_control.py
+++ b/server/model_router/workload_control.py
@@ -100,7 +100,7 @@ ENTRY_ALLOWED_SHAPES: dict[
 # R6A deliberately provides only the control-plane foundation. Each later data-plane
 # PR adds its entry here after its dedicated tests and real smoke are complete.
 DATA_PLANE_INTEGRATED_ENTRIES: frozenset[ProviderWorkloadEntryId] = frozenset(
-    {"agent_shadow"}
+    {"agent_shadow", "meta_agent"}
 )
 
 

--- a/server/tests/test_meta_agent_managed_endpoints.py
+++ b/server/tests/test_meta_agent_managed_endpoints.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server import main as main_module
+from server.main import app
+from server.meta_agent.schemas import (
+    MetaPlannerIRFinalOutput,
+    MetaPlannerIRInputBinding,
+    MetaPlannerIRNode,
+    MetaPlannerIROutputBinding,
+    MetaPlannerTask,
+    MetaPlannerTaskPlan,
+    MetaPlannerTypedBlueprintV2,
+    MetaPlannerWorkflowAgentConfig,
+    ProviderRouteCallReceipt,
+    ProviderRouteReceiptSummary,
+)
+
+
+MODEL_ID = "deepseek/deepseek-chat"
+
+
+@pytest_asyncio.fixture
+async def client():
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
+
+
+class FakeManagedRun:
+    def __init__(self, outputs: list[str]) -> None:
+        self.outputs = list(outputs)
+        self.calls: list[ProviderRouteCallReceipt] = []
+        self.status = "running"
+        self.run_id = "workrun_meta_test"
+        self.parent_run_reference = ""
+
+    async def complete_json(self, **kwargs) -> str:
+        sequence = int(kwargs["call_sequence"])
+        model_id = str(kwargs["model_id"])
+        self.calls.append(
+            ProviderRouteCallReceipt(
+                call_sequence=sequence,
+                model_id=model_id,
+                actual_model=model_id,
+                status="passed",
+                total_tokens=sequence,
+            )
+        )
+        return self.outputs.pop(0)
+
+    def finish(self, status, *, reason_code=None) -> None:
+        self.status = status
+        self.reason_codes = [reason_code] if reason_code else []
+
+    def receipt_summary(self) -> ProviderRouteReceiptSummary:
+        return ProviderRouteReceiptSummary(
+            contract_version="modelmirror-provider-workload-routing-v1",
+            run_reference=self.run_id,
+            status=self.status,
+            call_count=len(self.calls),
+            reason_codes=getattr(self, "reason_codes", []),
+            calls=self.calls,
+        )
+
+
+class FakeManagedGateway:
+    def __init__(self, run: FakeManagedRun, mode: str = "managed_required") -> None:
+        self.run = run
+        self.mode = mode
+
+    def routing_mode(self) -> str:
+        return self.mode
+
+    def start_run(self, *, parent_run_reference: str) -> FakeManagedRun:
+        self.run.parent_run_reference = parent_run_reference
+        return self.run
+
+
+def _install_gateway(monkeypatch: pytest.MonkeyPatch, gateway: FakeManagedGateway) -> None:
+    monkeypatch.setattr(
+        main_module.ManagedMetaAgentGateway,
+        "for_router",
+        staticmethod(lambda _router_service: gateway),
+    )
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+
+
+def _classic_plan_json() -> str:
+    return json.dumps(
+        {
+            "thought": "Create one bounded delivery task.",
+            "sub_tasks": [
+                {
+                    "name": "deliver",
+                    "description": "Produce the requested delivery.",
+                    "inputs": [{"name": "goal", "type": "string"}],
+                    "outputs": [{"name": "answer", "type": "string"}],
+                    "agent": {
+                        "name": "delivery_agent",
+                        "prompt": "Use {goal}.\n\n## answer\nReturn the answer.",
+                        "tool_names": [],
+                    },
+                }
+            ],
+        }
+    )
+
+
+def _planner_outputs() -> list[str]:
+    plan = MetaPlannerTaskPlan(
+        summary="Produce one bounded candidate.",
+        tasks=[
+            MetaPlannerTask(
+                task_id="deliver",
+                title="Deliver",
+                objective="Produce the final answer.",
+                output_contract="Final answer.",
+            )
+        ],
+    )
+    blueprint = MetaPlannerTypedBlueprintV2(
+        name="Managed Meta Agent",
+        description="A bounded managed candidate.",
+        nodes=[
+            MetaPlannerIRNode(
+                ref="writer",
+                kind="workflow_agent",
+                title="Writer",
+                task_ids=["deliver"],
+                inputs=[
+                    MetaPlannerIRInputBinding(
+                        port="request", variable="user_input", value_type="string"
+                    )
+                ],
+                outputs=[
+                    MetaPlannerIROutputBinding(
+                        port="result", variable="answer", value_type="string"
+                    )
+                ],
+                config=MetaPlannerWorkflowAgentConfig(
+                    role_prompt="Produce the requested final answer.",
+                    task_input="{{user_input}}",
+                ).model_dump(mode="json"),
+            )
+        ],
+        final_output=MetaPlannerIRFinalOutput(node_ref="writer", variable="answer"),
+    )
+    return [
+        plan.model_dump_json(),
+        json.dumps({"name": "invalid"}),
+        blueprint.model_dump_json(),
+    ]
+
+
+def _unresolved_planner_outputs() -> list[str]:
+    outputs = _planner_outputs()
+    outputs[-1] = json.dumps({"name": "still invalid"})
+    return outputs
+
+
+@pytest.mark.asyncio
+async def test_classic_workflow_endpoint_uses_one_managed_call_and_returns_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    managed_run = FakeManagedRun([_classic_plan_json()])
+    _install_gateway(monkeypatch, FakeManagedGateway(managed_run))
+
+    async def legacy_completion(*_args, **_kwargs):
+        raise AssertionError("managed_required must not call the legacy gateway")
+
+    monkeypatch.setattr(
+        main_module, "collect_chat_completion_text", legacy_completion
+    )
+    response = await client.post(
+        "/api/meta-agent/generate-workflow",
+        json={
+            "goal": "Generate a bounded workflow for a managed Meta Agent test.",
+            "model_id": MODEL_ID,
+            "temperature": 0.2,
+            "max_tasks": 3,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["run_id"] == managed_run.parent_run_reference
+    assert payload["provider_route_receipts"]["status"] == "passed"
+    assert payload["provider_route_receipts"]["call_count"] == 1
+    assert len(managed_run.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_classic_invalid_workflow_marks_managed_receipt_failed(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = json.loads(_classic_plan_json())
+    duplicate = dict(plan["sub_tasks"][0])
+    duplicate["description"] = "A second task with the same generated node id."
+    plan["sub_tasks"].append(duplicate)
+    managed_run = FakeManagedRun([json.dumps(plan)])
+    _install_gateway(monkeypatch, FakeManagedGateway(managed_run))
+
+    async def legacy_completion(*_args, **_kwargs):
+        raise AssertionError("managed_required must not call the legacy gateway")
+
+    monkeypatch.setattr(
+        main_module, "collect_chat_completion_text", legacy_completion
+    )
+    response = await client.post(
+        "/api/meta-agent/generate-workflow",
+        json={
+            "goal": "Generate a workflow whose duplicate task names fail validation.",
+            "model_id": MODEL_ID,
+            "temperature": 0.2,
+            "max_tasks": 3,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["validation"]["valid"] is False
+    assert payload["provider_route_receipts"]["status"] == "failed"
+    assert payload["provider_route_receipts"]["reason_codes"] == [
+        "provider_workload_meta_agent_validation_failed"
+    ]
+    assert payload["provider_route_receipts"]["call_count"] == 1
+    assert len(managed_run.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_xpert_candidate_endpoint_records_plan_blueprint_and_one_repair(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    managed_run = FakeManagedRun(_planner_outputs())
+    _install_gateway(monkeypatch, FakeManagedGateway(managed_run))
+
+    async def legacy_completion(*_args, **_kwargs):
+        raise AssertionError("managed_required must not call the legacy gateway")
+
+    monkeypatch.setattr(
+        main_module, "collect_chat_completion_text", legacy_completion
+    )
+    response = await client.post(
+        "/api/meta-agent/generate-xpert-candidate",
+        json={
+            "goal": "Generate a bounded Xpert candidate for managed routing.",
+            "mode": "create",
+            "planner_model_id": MODEL_ID,
+            "default_agent_model_id": MODEL_ID,
+            "temperature": 0.2,
+            "max_agents": 3,
+            "scope": {},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["run_id"] == managed_run.parent_run_reference
+    assert payload["repair_used"] is True
+    assert payload["validation"]["valid"] is True
+    assert payload["provider_route_receipts"]["call_count"] == 3
+    assert [item.call_sequence for item in managed_run.calls] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_xpert_candidate_validation_failure_marks_managed_run_failed(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    managed_run = FakeManagedRun(_unresolved_planner_outputs())
+    _install_gateway(monkeypatch, FakeManagedGateway(managed_run))
+
+    response = await client.post(
+        "/api/meta-agent/generate-xpert-candidate",
+        json={
+            "goal": "Generate a candidate that remains invalid after repair.",
+            "mode": "create",
+            "planner_model_id": MODEL_ID,
+            "default_agent_model_id": MODEL_ID,
+            "temperature": 0.2,
+            "max_agents": 3,
+            "scope": {},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    receipt = payload["provider_route_receipts"]
+    assert payload["validation"]["valid"] is False
+    assert receipt["status"] == "failed"
+    assert receipt["reason_codes"] == [
+        "provider_workload_meta_agent_validation_failed"
+    ]
+    assert receipt["call_count"] == 3
+    assert all(item.status == "passed" for item in managed_run.calls)
+
+
+@pytest.mark.asyncio
+async def test_degraded_meta_agent_fails_before_legacy_or_managed_call(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    managed_run = FakeManagedRun([_classic_plan_json()])
+    _install_gateway(
+        monkeypatch, FakeManagedGateway(managed_run, mode="degraded_required")
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("degraded_required must not inspect the legacy gateway")
+        ),
+    )
+    response = await client.post(
+        "/api/meta-agent/generate-workflow",
+        json={
+            "goal": "Generate a bounded workflow for degraded routing behavior.",
+            "model_id": MODEL_ID,
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["code"] == (
+        "provider_workload_meta_agent_degraded_required"
+    )
+    assert managed_run.calls == []

--- a/server/tests/test_meta_agent_managed_gateway.py
+++ b/server/tests/test_meta_agent_managed_gateway.py
@@ -1,0 +1,468 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from server.meta_agent.managed_gateway import (
+    ManagedMetaAgentGateway,
+    ManagedMetaAgentRoutingError,
+)
+from server.model_router.egress import ProviderEgressPolicy
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import (
+    ProviderWorkloadActivationRequest,
+    ProviderWorkloadBindingUpdate,
+    ProviderWorkloadPolicyUpdate,
+    RouterConnectionCreate,
+)
+from server.model_router.service import ModelRouterService
+from server.model_router.workload_control import (
+    PROVIDER_WORKLOAD_CONTRACT_VERSION,
+    ProviderWorkloadCallService,
+    ProviderWorkloadControlService,
+)
+
+
+MODEL_ID = "provider/meta-model"
+PROVIDER_SECRET = "managed-meta-provider-secret"
+
+
+async def _qualified_router(
+    tmp_path: Path,
+) -> tuple[ModelRouterService, str]:
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Meta Provider",
+            kind="openai_compatible",
+            base_url="https://meta-provider.example/v1",
+            api_key=PROVIDER_SECRET,
+            scopes=["chat"],
+        ),
+    )
+    repository.save_test_result(
+        "local",
+        connection.id,
+        health="online",
+        model_count=1,
+        checked_at="2026-08-23T00:00:00+00:00",
+    )
+    fingerprint = repository.connection_config_fingerprint("local", connection.id)
+    refresh_id = f"refresh-{connection.id}"
+    repository.claim_catalog_refresh(
+        "local",
+        refresh_id=refresh_id,
+        connection_id=connection.id,
+        connection_fingerprint=fingerprint,
+    )
+    repository.complete_catalog_refresh(
+        "local",
+        refresh_id,
+        connection_id=connection.id,
+        models=[
+            {
+                "model_id": MODEL_ID,
+                "normalized_model_id": MODEL_ID,
+                "capability_state": "declared",
+            }
+        ],
+        offerings=[],
+        model_count=1,
+        truncated=False,
+        catalog_fingerprint="meta-catalog",
+        observed_at="2026-08-23T00:00:00+00:00",
+    )
+    service = ModelRouterService(
+        repository,
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+
+    profile = {
+        "execution_shape": "chat_json_object",
+        "model_id": MODEL_ID,
+        "candidate_model_ids": [],
+        "judge_model_id": None,
+    }
+    profile_fingerprint = hashlib.sha256(
+        json.dumps(profile, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    certification, created = repository.claim_workload_certification(
+        "local",
+        certification_id="meta-json-certification",
+        connection_id=connection.id,
+        connection_fingerprint=fingerprint,
+        contract_version=PROVIDER_WORKLOAD_CONTRACT_VERSION,
+        execution_shape="chat_json_object",
+        requested_model=MODEL_ID,
+        profile=profile,
+        profile_fingerprint=profile_fingerprint,
+        idempotency_key_hash=hashlib.sha256(b"meta-json-certification").hexdigest(),
+    )
+    assert created is True
+    repository.complete_workload_certification(
+        "local",
+        str(certification["id"]),
+        status="passed",
+        checks={"json_object_verified": True, "actual_model_verified": True},
+        warning_codes=[],
+        actual_model=MODEL_ID,
+    )
+    return service, connection.id
+
+
+def _activate_policy(service: ModelRouterService, connection_id: str) -> None:
+    control = ProviderWorkloadControlService(service)
+    saved = control.update_policy(
+        "meta_agent",
+        ProviderWorkloadPolicyUpdate(
+            expected_revision=0,
+            bindings=[
+                ProviderWorkloadBindingUpdate(
+                    execution_shape="chat_json_object",
+                    model_id=MODEL_ID,
+                    connection_id=connection_id,
+                )
+            ],
+        ),
+    )
+    active = control.activate(
+        "meta_agent",
+        ProviderWorkloadActivationRequest(
+            expected_revision=saved.revision,
+            no_open_p0_p1=True,
+            acknowledge_fail_closed=True,
+        ),
+    )
+    assert active.effective_status == "managed_required"
+
+
+@pytest.mark.asyncio
+async def test_managed_meta_agent_records_each_json_call_without_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = await _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_META_AGENT_ENABLED", "true")
+    _activate_policy(service, connection_id)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        body = json.loads(request.content)
+        assert body["response_format"] == {"type": "json_object"}
+        assert body["stream"] is False
+        assert body["model"] == MODEL_ID
+        return httpx.Response(
+            200,
+            json={
+                "model": MODEL_ID,
+                "choices": [{"message": {"content": '{"result":"ok"}'}}],
+                "usage": {
+                    "prompt_tokens": 11,
+                    "completion_tokens": 4,
+                    "total_tokens": 15,
+                },
+            },
+        )
+
+    gateway = ManagedMetaAgentGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=False,
+            trust_env=False,
+        ),
+    )
+    assert gateway.routing_mode() == "managed_required"
+    run = gateway.start_run(parent_run_reference="meta-parent-run")
+    first = await run.complete_json(
+        logical_call_key="task-plan",
+        call_sequence=1,
+        model_id=MODEL_ID,
+        system_prompt="private system prompt",
+        user_prompt="private user goal",
+        temperature=0.2,
+        max_tokens=4096,
+    )
+    second = await run.complete_json(
+        logical_call_key="blueprint",
+        call_sequence=2,
+        model_id=MODEL_ID,
+        system_prompt="private blueprint prompt",
+        user_prompt="private capability snapshot",
+        temperature=0.2,
+        max_tokens=8192,
+    )
+    run.finish("passed")
+
+    assert json.loads(first) == {"result": "ok"}
+    assert json.loads(second) == {"result": "ok"}
+    assert len(requests) == 2
+    summary = run.receipt_summary()
+    assert summary.status == "passed"
+    assert summary.call_count == 2
+    assert [item.call_sequence for item in summary.calls] == [1, 2]
+    assert all(item.total_tokens == 15 for item in summary.calls)
+    receipts = service.repository.list_workload_receipts("local")
+    assert receipts["runs"][0]["parent_run_reference"] == "meta-parent-run"
+    assert [item["status"] for item in receipts["calls"]] == ["passed", "passed"]
+    database = service.repository.database_path.read_bytes()
+    assert b"private user goal" not in database
+    assert b"private capability snapshot" not in database
+    assert b'{"result":"ok"}' not in database
+    assert PROVIDER_SECRET.encode() not in database
+
+
+@pytest.mark.asyncio
+async def test_managed_meta_agent_preflight_failure_is_not_counted_as_dispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = await _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_META_AGENT_ENABLED", "true")
+    _activate_policy(service, connection_id)
+    post_count = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal post_count
+        post_count += 1
+        raise AssertionError("missing binding must fail before Provider dispatch")
+
+    gateway = ManagedMetaAgentGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), trust_env=False
+        ),
+    )
+    run = gateway.start_run(parent_run_reference="meta-preflight")
+    with pytest.raises(ManagedMetaAgentRoutingError) as blocked:
+        await run.complete_json(
+            logical_call_key="unbound-plan",
+            call_sequence=1,
+            model_id="provider/unbound-model",
+            system_prompt="private prompt",
+            user_prompt="private goal",
+            temperature=0.2,
+            max_tokens=4096,
+        )
+    run.finish("failed", reason_code=blocked.value.code)
+
+    assert blocked.value.code == "provider_workload_binding_missing"
+    assert post_count == 0
+    summary = run.receipt_summary()
+    assert summary.call_count == 0
+    assert len(summary.calls) == 1
+    assert summary.calls[0].dispatched is False
+    assert service.repository.list_workload_receipts("local")["calls"] == []
+
+
+@pytest.mark.asyncio
+async def test_managed_meta_agent_model_mismatch_fails_after_one_post(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = await _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_META_AGENT_ENABLED", "true")
+    _activate_policy(service, connection_id)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "model": "provider/other-model",
+                "choices": [{"message": {"content": '{"result":"wrong"}'}}],
+            },
+        )
+
+    gateway = ManagedMetaAgentGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), trust_env=False
+        ),
+    )
+    run = gateway.start_run(parent_run_reference="meta-mismatch")
+    with pytest.raises(ManagedMetaAgentRoutingError) as mismatch:
+        await run.complete_json(
+            logical_call_key="task-plan",
+            call_sequence=1,
+            model_id=MODEL_ID,
+            system_prompt="private prompt",
+            user_prompt="private goal",
+            temperature=0.2,
+            max_tokens=4096,
+        )
+    run.finish("failed", reason_code=mismatch.value.code)
+
+    assert mismatch.value.code == "provider_workload_actual_model_mismatch"
+    assert len(requests) == 1
+    receipt = service.repository.list_workload_receipts("local")["calls"][0]
+    assert receipt["dispatched"] == 1
+    assert receipt["status"] == "failed"
+    assert receipt["error_code"] == "provider_workload_actual_model_mismatch"
+    summary = run.receipt_summary()
+    assert summary.call_count == 1
+    assert summary.calls[0].dispatched is True
+
+
+@pytest.mark.asyncio
+async def test_managed_meta_agent_duplicate_logical_call_is_not_replayed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = await _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_META_AGENT_ENABLED", "true")
+    _activate_policy(service, connection_id)
+    post_count = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal post_count
+        post_count += 1
+        return httpx.Response(
+            200,
+            json={
+                "model": MODEL_ID,
+                "choices": [{"message": {"content": '{"result":"ok"}'}}],
+            },
+        )
+
+    gateway = ManagedMetaAgentGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), trust_env=False
+        ),
+    )
+    run = gateway.start_run(parent_run_reference="meta-no-replay")
+    await run.complete_json(
+        logical_call_key="same-call",
+        call_sequence=1,
+        model_id=MODEL_ID,
+        system_prompt="private prompt",
+        user_prompt="private goal",
+        temperature=0.2,
+        max_tokens=4096,
+    )
+    with pytest.raises(ManagedMetaAgentRoutingError) as replay:
+        await run.complete_json(
+            logical_call_key="same-call",
+            call_sequence=2,
+            model_id=MODEL_ID,
+            system_prompt="private prompt",
+            user_prompt="private goal",
+            temperature=0.2,
+            max_tokens=4096,
+        )
+    run.finish("failed", reason_code=replay.value.code)
+
+    assert replay.value.code == "provider_workload_logical_call_replay_blocked"
+    assert post_count == 1
+    receipts = service.repository.list_workload_receipts("local")
+    assert len(receipts["calls"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_managed_meta_agent_invalid_json_fails_without_second_post(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = await _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_META_AGENT_ENABLED", "true")
+    _activate_policy(service, connection_id)
+    post_count = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal post_count
+        post_count += 1
+        return httpx.Response(
+            200,
+            json={
+                "model": MODEL_ID,
+                "choices": [{"message": {"content": "not-json"}}],
+            },
+        )
+
+    gateway = ManagedMetaAgentGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), trust_env=False
+        ),
+    )
+    run = gateway.start_run(parent_run_reference="meta-invalid-json")
+    with pytest.raises(ManagedMetaAgentRoutingError) as invalid:
+        await run.complete_json(
+            logical_call_key="task-plan",
+            call_sequence=1,
+            model_id=MODEL_ID,
+            system_prompt="private prompt",
+            user_prompt="private goal",
+            temperature=0.2,
+            max_tokens=4096,
+        )
+    run.finish("failed", reason_code=invalid.value.code)
+
+    assert invalid.value.code == "provider_workload_json_object_invalid"
+    assert post_count == 1
+    receipt = service.repository.list_workload_receipts("local")["calls"][0]
+    assert receipt["status"] == "failed"
+    assert receipt["error_code"] == "provider_workload_json_object_invalid"
+    assert run.receipt_summary().calls[0].dispatched is True
+
+
+@pytest.mark.asyncio
+async def test_managed_meta_agent_cancellation_after_dispatch_is_not_replayed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = await _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_META_AGENT_ENABLED", "true")
+    _activate_policy(service, connection_id)
+    call_service = ProviderWorkloadCallService(service)
+    dispatch_started = asyncio.Event()
+    never_finishes = asyncio.Event()
+    send_count = 0
+
+    async def stalled_send(_client, _request):
+        nonlocal send_count
+        send_count += 1
+        dispatch_started.set()
+        await never_finishes.wait()
+        raise AssertionError("cancelled dispatch must not resume")
+
+    monkeypatch.setattr(
+        call_service.transport, "send_authorized_stream", stalled_send
+    )
+    run = ManagedMetaAgentGateway(call_service).start_run(
+        parent_run_reference="meta-cancelled"
+    )
+    task = asyncio.create_task(
+        run.complete_json(
+            logical_call_key="task-plan",
+            call_sequence=1,
+            model_id=MODEL_ID,
+            system_prompt="private prompt",
+            user_prompt="private goal",
+            temperature=0.2,
+            max_tokens=4096,
+        )
+    )
+    await asyncio.wait_for(dispatch_started.wait(), 2)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    run.finish("cancelled", reason_code="provider_workload_call_cancelled")
+
+    assert send_count == 1
+    receipt = service.repository.list_workload_receipts("local")["calls"][0]
+    assert receipt["dispatched"] == 1
+    assert receipt["status"] == "cancelled"
+    assert receipt["error_code"] == "provider_workload_call_cancelled"
+    assert run.receipt_summary().calls[0].dispatched is True

--- a/server/tests/test_meta_planner_v2.py
+++ b/server/tests/test_meta_planner_v2.py
@@ -84,6 +84,81 @@ def test_generic_meta_planner_keeps_hitl_scoped_to_expert_team():
     assert "output_variable" not in task_properties
 
 
+def test_task_plan_rejects_unscoped_expert_bindings_before_blueprint():
+    plan = _plan().model_copy(deep=True)
+    plan.tasks[0].agent_id = "invented_release_architect"
+
+    issues = validate_task_plan(
+        plan,
+        max_agents=3,
+        authorized_agent_ids=set(),
+    )
+
+    assert issues == [
+        "Task research binds unauthorized expert invented_release_architect."
+    ]
+
+
+def test_blueprint_and_repair_prompts_expose_typed_ir_agent_constraints():
+    request = _request()
+    plan = _plan()
+    snapshot = _snapshot()
+    plan_prompt = json.loads(MetaPlannerV2Service._plan_prompt(request))
+
+    blueprint_prompt = json.loads(
+        MetaPlannerV2Service._blueprint_prompt(request, plan, snapshot, None)
+    )
+    repair_prompt = json.loads(
+        MetaPlannerV2Service._repair_prompt(
+            request,
+            plan,
+            snapshot,
+            '{"ir_version": 2}',
+            ["Typed IR exceeds max_agents=3."],
+        )
+    )
+
+    for prompt in (blueprint_prompt, repair_prompt):
+        constraints = prompt["typed_ir_constraints"]
+        assert constraints["max_workflow_agent_nodes"] == request.max_agents
+        assert constraints["required_task_ids"] == [
+            task.task_id for task in plan.tasks
+        ]
+        assert sorted(
+            task_id
+            for group in constraints["suggested_task_groups"]
+            for task_id in group
+        ) == sorted(task.task_id for task in plan.tasks)
+        assert len(constraints["suggested_task_groups"]) <= request.max_agents
+        assert constraints["task_dependencies"] == {
+            task.task_id: task.depends_on for task in plan.tasks
+        }
+        assert constraints["task_agent_bindings"] == {
+            task.task_id: task.agent_id for task in plan.tasks
+        }
+        assert constraints["authorized_agent_ids"] == request.scope.agent_ids
+        assert constraints["workflow_agent_config_allowed_fields"] == list(
+            MetaPlannerWorkflowAgentConfig.model_fields
+        )
+        assert constraints["workflow_agent_config_forbidden_fields"] == [
+            "agent_id"
+        ]
+        assert any(
+            "group compatible task_ids" in rule
+            for rule in constraints["rules"]
+        )
+        assert prompt["default_agent_model_id"] == request.default_agent_model_id
+
+    assert repair_prompt["validation_issues"] == [
+        "Typed IR exceeds max_agents=3."
+    ]
+    assert plan_prompt["authorized_agent_ids"] == request.scope.agent_ids
+    assert any(
+        "omit agent_id or set it to null" in rule
+        for rule in plan_prompt["rules"]
+    )
+
+
 def _resource(
     resource_id: str,
     name: str,
@@ -639,6 +714,64 @@ async def test_failed_repair_persists_unapprovable_candidate_until_human_edit(
         revision=edited.revision,
     )
     assert validated.validation["valid"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_revision_drift_uses_final_proposal_validation(
+    tmp_path: Path,
+):
+    proposal_store = AuthoringProposalStore(tmp_path / "runtime")
+    xpert_store = XpertStore(tmp_path / "xperts")
+    skill_store = WorkspaceSkillDraftStore(tmp_path / "skills")
+    target = xpert_store.create_xpert(name="Revision drift target")
+
+    def preflight(candidate):
+        result = validate_xpert_definition(candidate)
+        return result, candidate.draft.workflow, []
+
+    authoring = AuthoringService(
+        proposal_store,
+        xpert_store,
+        skill_store,
+        xpert_preflight=preflight,
+    )
+    original_validate = authoring.validate
+
+    def validate_after_revision_drift(proposal_id: str, *, revision: int):
+        current = xpert_store.get_xpert(target.id)
+        xpert_store.update_xpert(
+            target.id,
+            {"draft": current.draft.model_dump(mode="json")},
+        )
+        return original_validate(proposal_id, revision=revision)
+
+    authoring.validate = validate_after_revision_drift  # type: ignore[method-assign]
+    outputs = [_plan().model_dump_json(), _typed_blueprint().model_dump_json()]
+
+    async def complete(model_id, system_prompt, user_prompt, temperature, max_tokens):
+        return outputs.pop(0)
+
+    service = MetaPlannerV2Service(
+        authoring_service=authoring,
+        preflight=preflight,
+        completion=complete,
+    )
+    request = _request().model_copy(
+        update={"mode": "update", "target_xpert_id": target.id}
+    )
+
+    response = await service.generate(request, _snapshot(), target=target)
+
+    proposal = proposal_store.require(response.proposal_id)
+    assert proposal.validation["valid"] is False
+    assert response.validation["valid"] is False
+    authoring_stage = next(
+        stage
+        for stage in response.validation["stages"]
+        if stage["id"] == "authoring_proposal"
+    )
+    assert authoring_stage["valid"] is False
+    assert authoring_stage["issues"]
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_provider_workload_control.py
+++ b/server/tests/test_provider_workload_control.py
@@ -1096,7 +1096,7 @@ async def test_workload_admin_api_is_session_and_csrf_protected_and_public_redac
         )
         assert saved.status_code == 200
         assert saved.json()["revision"] == 1
-        assert saved.json()["data_plane_integrated"] is False
+        assert saved.json()["data_plane_integrated"] is True
         activation = await client.post(
             "/api/router/workload-control/policies/meta_agent/activate",
             headers={"X-ModelMirror-CSRF": csrf},


### PR DESCRIPTION
## 范围

完成 Round 6C：将 generate-workflow 与 generate-xpert-candidate 接入 Meta Agent Managed Provider 控制面，增加精确模型 Binding、脱敏 Receipt、稳定父运行引用、前端摘要和最终 Proposal 权威校验。本 PR 不接管 Workflow 执行、Agent Runtime、RAG、多模态、Coding 或其他 R6 入口，不改变 Catalog 与模型数量口径。

## 安全语义

- MODEL_CONTROL_META_AGENT_ENABLED 默认关闭；legacy 路径保持兼容。
- managed_required 下资格不合格时发送前失败关闭；每个逻辑调用最多一个 Provider POST；派发后不重试或切换 Provider。
- Key、Prompt、消息、模型输出与完整上游错误不进入客户端、Receipt、SQLite 或日志。
- 本地最终校验失败会令父 Receipt 失败；预检阻断不计作付费调用。

## 验证

- 后端专项：41 passed；R6C/R20 交叉：218 passed。
- 最新主线后端全量：4314 passed, 29 skipped, 6 warnings。
- 前端：定向 5 passed；全量 106 files / 586 passed；typecheck、production build 通过。
- Core、独立 newAPI、Overlay Compose config 通过。
- 独立预览器健康、Managed 状态与最新静态资源探针通过。
- diff check、范围复核和敏感信息扫描通过。

## 真实付费验收

所有调用均逐次授权且无自动重跑：Classic Workflow 以 gpt-4o-mini 单 POST 通过；Xpert Candidate 最终以 gpt-5.6-sol 两次计划内 POST 通过，未触发第三次 Repair。严格证伪发现的问题均已最小修复并补回归。

## 非阻塞边界与发布状态

- 未派发预检不写 provider_workload_calls；未来若需刷新后还原逐条预检详情，应另扩展存储契约。
- 无效 Classic Workflow 仍兼容返回可编辑草案，但 Managed Receipt 失败且运行入口被阻断。
- npm ci 报告基线已有 5 项依赖审计问题；本 PR 未改依赖或锁文件。
- Feature Flag 保持默认关闭；PR 合并不等于启用，未部署或切换生产流量。
- 不实现多租户账户、积分、充值、账本或 ModelMirror 自有计费。