### PR TITLE
feature: 完成 Skill 触发验证工作台闭环

### DIFF
--- a/client/src/components/skill-creator/SkillResourceBuildPanel.tsx
+++ b/client/src/components/skill-creator/SkillResourceBuildPanel.tsx
@@ -324,7 +324,7 @@ export default function SkillResourceBuildPanel({
   if (!build || !buildMatchesCurrentPlan) {
     return (
       <section className="rounded-lg border border-white/10 bg-surface-900/80 p-5 sm:p-6" aria-labelledby="resource-build-start-heading">
-        <h2 className="text-xl font-semibold text-white" id="resource-build-start-heading">
+        <h2 className="text-xl font-semibold text-white focus:outline-none" id="resource-build-start-heading" tabIndex={-1}>
           {build ? "按新方案重新生成" : "准备生成内容"}
         </h2>
         <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">点击后会立即生成第一项内容。每项完成基础检查后只请你确认一次，不会用内部生成片段反复打扰。</p>
@@ -359,7 +359,7 @@ export default function SkillResourceBuildPanel({
       <div className="border-y border-white/10 py-5">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
-            <h2 className="text-xl font-semibold text-white" id="resource-build-heading">逐项生成内容</h2>
+            <h2 className="text-xl font-semibold text-white focus:outline-none" id="resource-build-heading" tabIndex={-1}>逐项生成内容</h2>
             <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">{activeTarget ? `正在处理：${activeTarget}` : "辅助内容已完成，准备整理最终使用说明。"}</p>
           </div>
           <div className="flex flex-wrap gap-2 text-xs">

--- a/client/src/components/skill-creator/SkillResourcePlanPanel.test.tsx
+++ b/client/src/components/skill-creator/SkillResourcePlanPanel.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -9,9 +10,9 @@ import type {
 } from "../../utils/skillCreatorApi";
 import SkillResourcePlanPanel from "./SkillResourcePlanPanel";
 
-function jsonResponse(payload: unknown) {
+function jsonResponse(payload: unknown, responseStatus = 200) {
   return Promise.resolve(new Response(JSON.stringify(payload), {
-    status: 200,
+    status: responseStatus,
     headers: { "Content-Type": "application/json" },
   }));
 }
@@ -86,6 +87,11 @@ const session: SkillCreatorSession = {
   updated_at: 2,
 };
 
+function Harness({ initial, currentStatus = status }: { initial: SkillCreatorSession; currentStatus?: SkillCreatorStatus }) {
+  const [current, setCurrent] = useState(initial);
+  return <SkillResourcePlanPanel onSession={setCurrent} session={current} status={currentStatus} />;
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
@@ -99,6 +105,76 @@ describe("SkillResourcePlanPanel", () => {
     expect(screen.getByRole("heading", { name: "遇到信息不足时" })).toBeVisible();
     expect(screen.getByText(/Mark missing facts as unconfirmed\./)).toBeVisible();
     expect(screen.getByText("共 4 步执行流程")).toBeVisible();
+  });
+
+  it("keeps plan confirmation disabled until a required trigger check passes", () => {
+    render(<SkillResourcePlanPanel
+      onSession={vi.fn()}
+      session={{ ...session, trigger_required: true, trigger_stale_reason: "skill_trigger_suite_required" }}
+      status={{
+        ...status,
+        trigger_optimization_enabled: true,
+        trigger_optimizer_available: false,
+        trigger_store_available: true,
+      }}
+    />);
+
+    expect(screen.getByRole("button", { name: "先完成触发检查" })).toBeDisabled();
+    expect(screen.getByRole("heading", { name: "先确认什么时候该使用这个 Skill" })).toBeVisible();
+  });
+
+  it("requires unsaved plan edits to be saved before trigger mutations are available", async () => {
+    const triggerSession = {
+      ...session,
+      trigger_required: true,
+      trigger_stale_reason: "skill_trigger_suite_required",
+    };
+    const savedPlan = {
+      ...plan,
+      revision: plan.revision + 1,
+      digest: "9".repeat(64),
+      skill_description: "Review incidents from evidence; do not use for ordinary summaries.",
+    };
+    const savedSession = {
+      ...triggerSession,
+      session_revision: triggerSession.session_revision + 1,
+      resource_plan: savedPlan,
+    };
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse({ session: savedSession, resource_plan: savedPlan }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<Harness
+      currentStatus={{
+        ...status,
+        trigger_optimization_enabled: true,
+        trigger_optimizer_available: true,
+        trigger_store_available: true,
+      }}
+      initial={triggerSession}
+    />);
+    await userEvent.click(screen.getByRole("button", { name: "手工填写" }));
+    const unsavedTriggerCase = screen.getByRole("textbox", { name: "应该触发用例 1" });
+    await userEvent.type(unsavedTriggerCase, "，并列出证据缺口");
+    await userEvent.click(screen.getByText("查看并调整完整方案（可选）"));
+    const description = screen.getByRole("textbox", { name: "能力、触发场景与边界" });
+    await userEvent.clear(description);
+    await userEvent.type(description, savedPlan.skill_description);
+
+    expect(screen.getByText("先保存方案调整")).toBeVisible();
+    expect(screen.getByRole("heading", { name: "先确认什么时候该使用这个 Skill" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "AI 提出测试边界" })).toBeDisabled();
+    expect(unsavedTriggerCase).toBeDisabled();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "保存我的调整" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(String(fetchMock.mock.calls[0][0])).toMatch(/\/resource-plan$/);
+    expect(await screen.findByRole("heading", { name: "先确认什么时候该使用这个 Skill" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "AI 提出测试边界" })).toBeEnabled();
+    expect(screen.getByRole("textbox", { name: "应该触发用例 1" })).toHaveValue("Turn this incident log into a review.，并列出证据缺口");
   });
 
   it("generates a plan without writing resource files", async () => {
@@ -212,5 +288,48 @@ describe("SkillResourcePlanPanel", () => {
       path: "scripts/check_release.py",
       action: "update",
     });
+  });
+
+  it("moves forward only after the resource plan is confirmed successfully", async () => {
+    const confirmedSession = {
+      ...session,
+      session_revision: 4,
+      resource_plan: { ...plan, revision: 3, state: "confirmed" as const },
+    };
+    vi.stubGlobal("fetch", vi.fn(() => jsonResponse({
+      session: confirmedSession,
+      resource_plan: confirmedSession.resource_plan,
+    })));
+    const onSession = vi.fn();
+    const onPlanConfirmed = vi.fn();
+
+    render(<SkillResourcePlanPanel
+      onPlanConfirmed={onPlanConfirmed}
+      onSession={onSession}
+      session={session}
+      status={status}
+    />);
+    await userEvent.click(screen.getByRole("button", { name: "确认方案，进入生成" }));
+
+    await waitFor(() => expect(onSession).toHaveBeenCalledWith(confirmedSession));
+    expect(onPlanConfirmed).toHaveBeenCalledWith(confirmedSession);
+  });
+
+  it("does not move forward when plan confirmation fails", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => jsonResponse({
+      detail: { code: "skill_creator_revision_conflict", message: "Creator session changed." },
+    }, 409)));
+    const onPlanConfirmed = vi.fn();
+
+    render(<SkillResourcePlanPanel
+      onPlanConfirmed={onPlanConfirmed}
+      onSession={vi.fn()}
+      session={session}
+      status={status}
+    />);
+    await userEvent.click(screen.getByRole("button", { name: "确认方案，进入生成" }));
+
+    expect(await screen.findByText("会话或方案已更新，请重新加载页面后再继续。")).toBeVisible();
+    expect(onPlanConfirmed).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/skill-creator/SkillResourcePlanPanel.tsx
+++ b/client/src/components/skill-creator/SkillResourcePlanPanel.tsx
@@ -20,11 +20,13 @@ import {
   confirmSkillCreatorResourcePlan,
   generateSkillCreatorResourcePlan,
   patchSkillCreatorResourcePlan,
+  SkillCreatorApiError,
   type SkillCreatorSession,
   type SkillCreatorStatus,
   type SkillResourcePlanItem,
   type SkillResourceHookPlanItem,
 } from "../../utils/skillCreatorApi";
+import SkillTriggerOptimizationPanel, { skillTriggerGateReady } from "./SkillTriggerOptimizationPanel";
 
 
 const KIND_LABELS = {
@@ -56,17 +58,21 @@ interface Props {
   session: SkillCreatorSession;
   status: SkillCreatorStatus;
   onSession: (session: SkillCreatorSession) => void | Promise<void>;
+  onPlanConfirmed?: (session: SkillCreatorSession) => void;
 }
 
 function errorMessage(value: unknown, fallback: string) {
-  return value instanceof Error && value.message ? value.message : fallback;
+  if (value instanceof SkillCreatorApiError && value.status === 409) {
+    return "会话或方案已更新，请重新加载页面后再继续。";
+  }
+  return fallback;
 }
 
 function summaryItem(value: string) {
   return value.replace(/^\s*[-•]\s*/, "").trim();
 }
 
-export default function SkillResourcePlanPanel({ session, status, onSession }: Props) {
+export default function SkillResourcePlanPanel({ session, status, onSession, onPlanConfirmed }: Props) {
   const plan = session.resource_plan ?? null;
   const legacyFlow = session.authoring_flow !== "resource";
   const [busy, setBusy] = useState("");
@@ -101,6 +107,7 @@ export default function SkillResourcePlanPanel({ session, status, onSession }: P
   const hookEditingLocked = plan?.state === "confirmed" || !hookAuthoringEnabled;
   const planEditingLocked = plan?.state === "confirmed"
     || (!hookAuthoringEnabled && hooks.length > 0);
+  const triggerGateReady = skillTriggerGateReady(session, status);
 
   async function run(label: string, operation: () => Promise<SkillCreatorSession>, success: string) {
     setBusy(label);
@@ -168,11 +175,16 @@ export default function SkillResourcePlanPanel({ session, status, onSession }: P
       setError("请先保存当前修改，再确认资源计划。");
       return;
     }
-    await run(
+    if (!triggerGateReady) {
+      setError("请先完成下方的触发检查，再确认资源计划。");
+      return;
+    }
+    const updated = await run(
       "confirm",
       () => confirmSkillCreatorResourcePlan(session),
       "资源计划已冻结。后续生成只能使用这些已确认路径和来源。",
     );
+    if (updated) onPlanConfirmed?.(updated);
   }
 
   function updateResource(index: number, changes: Partial<SkillResourcePlanItem>) {
@@ -586,6 +598,22 @@ export default function SkillResourcePlanPanel({ session, status, onSession }: P
             </div>
           </details>
 
+          {planDirty ? (
+            <div className="rounded-md border border-amber-300/25 bg-amber-300/[0.08] p-4" id="creator-plan-save-before-trigger" role="status">
+              <p className="text-sm font-semibold text-amber-100">先保存方案调整</p>
+              <p className="mt-1 text-xs leading-5 text-amber-100/75">
+                当前名称、描述或资源还有未保存内容。保存后再做触发检查，避免验证旧描述或覆盖你的修改。
+              </p>
+            </div>
+          ) : null}
+          <fieldset
+            aria-describedby={planDirty ? "creator-plan-save-before-trigger" : undefined}
+            className={`m-0 min-w-0 border-0 p-0 ${planDirty || busy ? "opacity-60" : ""}`}
+            disabled={planDirty || Boolean(busy)}
+          >
+            <SkillTriggerOptimizationPanel onSession={onSession} session={session} status={status} />
+          </fieldset>
+
           {plan.state === "confirmed" ? (
             <div className="rounded-md border border-emerald-300/20 bg-emerald-300/[0.08] p-4">
               <p className="flex items-center gap-2 text-sm font-semibold text-emerald-100"><CheckCircle2 aria-hidden="true" size={17} />方案已确认</p>
@@ -594,7 +622,7 @@ export default function SkillResourcePlanPanel({ session, status, onSession }: P
           ) : (
             <div className="flex flex-wrap justify-end gap-3 border-t border-white/10 pt-4">
               <button className="min-h-11 rounded-full border border-white/15 px-5 py-2 text-sm font-semibold text-white disabled:opacity-40" disabled={planEditingLocked || !planDirty || Boolean(busy)} onClick={() => void savePlan()} type="button">{busy === "save" ? "正在保存…" : "保存我的调整"}</button>
-              <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={planEditingLocked || planDirty || Boolean(busy)} onClick={() => void confirmPlan()} type="button"><CheckCircle2 aria-hidden="true" size={16} />{busy === "confirm" ? "正在确认…" : "方案没问题，开始生成"}</button>
+              <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={planEditingLocked || planDirty || !triggerGateReady || Boolean(busy)} onClick={() => void confirmPlan()} type="button"><CheckCircle2 aria-hidden="true" size={16} />{busy === "confirm" ? "正在确认…" : triggerGateReady ? "确认方案，进入生成" : "先完成触发检查"}</button>
             </div>
           )}
         </div>

--- a/client/src/components/skill-creator/SkillTriggerOptimizationPanel.test.tsx
+++ b/client/src/components/skill-creator/SkillTriggerOptimizationPanel.test.tsx
@@ -1,0 +1,531 @@
+import { useState } from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  SkillCreatorSession,
+  SkillCreatorStatus,
+  SkillResourcePlan,
+  SkillTriggerDescriptionAttempt,
+  SkillTriggerReceipt,
+  SkillTriggerSuite,
+} from "../../utils/skillCreatorApi";
+import SkillTriggerOptimizationPanel, { skillTriggerGateReady } from "./SkillTriggerOptimizationPanel";
+
+function jsonResponse(payload: unknown, status = 200) {
+  return Promise.resolve(new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  }));
+}
+
+const plan: SkillResourcePlan = {
+  plan_id: "resourceplan_1",
+  session_id: "creator_1",
+  revision: 2,
+  digest: "b".repeat(64),
+  state: "ready",
+  session_revision: 3,
+  skill_name: "review-incidents",
+  skill_description: "整理事故事实并生成可追溯复盘，不用于普通文字润色。",
+  workflow_steps: [{ step_id: "review", instruction: "Review evidence." }],
+  output_contract: ["Return a factual report."],
+  failure_modes: ["Mark unknown facts."],
+  resources: [],
+  clarifications: [],
+  clarification_answers: {},
+  created_at: 1,
+  updated_at: 2,
+};
+
+const baseSession: SkillCreatorSession = {
+  session_id: "creator_1",
+  session_revision: 3,
+  draft_state_revision: 1,
+  authoring_flow: "resource",
+  mode: "blank",
+  assistant_agent_id: "skill-creator-assistant-v1",
+  intent: "把事故记录整理成可追溯复盘。",
+  positive_examples: ["根据部署日志整理事故复盘"],
+  near_miss_examples: ["润色这段普通文字"],
+  expected_output: "事实复盘",
+  success_criteria: ["不编造原因"],
+  selected_evidence: [],
+  evidence_confirmed: true,
+  state: "editing_draft",
+  resource_plan: plan,
+  trigger_required: true,
+  trigger_stale_reason: "skill_trigger_suite_required",
+  created_at: 1,
+  updated_at: 2,
+};
+
+const status: SkillCreatorStatus = {
+  enabled: true,
+  version: "skill-creator-v2",
+  model_available: true,
+  assistant_agent_id: "skill-creator-assistant-v1",
+  supported_sources: ["blank"],
+  resource_authoring_enabled: true,
+  resource_planner_available: true,
+  trigger_optimization_enabled: true,
+  trigger_optimizer_available: false,
+  trigger_store_available: true,
+};
+
+const suite: SkillTriggerSuite = {
+  suite_id: "triggersuite_1",
+  version: "skill-trigger-suite-v1",
+  suite_revision: 2,
+  suite_digest: "c".repeat(64),
+  session_id: baseSession.session_id,
+  session_revision: baseSession.session_revision,
+  definition_digest: "d".repeat(64),
+  skill_name: plan.skill_name,
+  state: "confirmed",
+  cases: [
+    ["positive-1", "should_trigger", "根据部署日志整理事故复盘"],
+    ["positive-2", "should_trigger", "从事件时间线生成根因待确认清单"],
+    ["negative-1", "should_not_trigger", "润色这段普通文字"],
+    ["negative-2", "should_not_trigger", "概括一篇新闻"],
+  ].map(([case_id, kind, text]) => ({
+    case_id,
+    kind: kind as "should_trigger" | "should_not_trigger",
+    text,
+    source: "user" as const,
+    case_hash: "e".repeat(64),
+  })),
+  change_reason: "用户确认边界",
+  created_at: 3,
+};
+
+const attempt: SkillTriggerDescriptionAttempt = {
+  attempt_id: "triggerattempt_1",
+  version: "skill-trigger-description-attempt-v1",
+  revision: 1,
+  digest: "f".repeat(64),
+  session_id: baseSession.session_id,
+  session_revision: baseSession.session_revision,
+  plan_id: plan.plan_id,
+  plan_revision: plan.revision,
+  plan_digest: plan.digest,
+  suite_id: suite.suite_id,
+  suite_revision: suite.suite_revision,
+  suite_digest: suite.suite_digest,
+  state: "evaluated",
+  candidates: [{
+    description: "用于根据事故日志生成可追溯复盘；普通润色或新闻摘要不应使用。",
+    description_digest: "1".repeat(64),
+    receipt_id: "triggerreceipt_1",
+    passed: true,
+    worst_positive_rank: 2,
+    positive_rank_sum: 3,
+    negative_safety_distance: 19,
+  }],
+  recommended_description_digest: "1".repeat(64),
+  created_at: 4,
+};
+
+const receipt: SkillTriggerReceipt = {
+  receipt_id: "triggerreceipt_1",
+  version: "skill-trigger-receipt-v1",
+  suite_id: suite.suite_id,
+  suite_revision: suite.suite_revision,
+  suite_digest: suite.suite_digest,
+  session_id: baseSession.session_id,
+  skill_name: plan.skill_name,
+  description_digest: "1".repeat(64),
+  ranker_version: "skill-need-local-v3",
+  runtime_index_fingerprint: "2".repeat(64),
+  directory_fingerprint: "3".repeat(64),
+  trust_index_fingerprint: "4".repeat(64),
+  candidate_fingerprint: "5".repeat(64),
+  candidate_set_fingerprint: "6".repeat(64),
+  passed: true,
+  case_results: suite.cases.map((item) => ({
+    case_id: item.case_id,
+    case_hash: item.case_hash,
+    kind: item.kind,
+    passed: true,
+    finder: {
+      rank_top_6: item.kind === "should_trigger" ? 2 : null,
+      rank_top_24: item.kind === "should_trigger" ? 2 : null,
+      in_top_6: item.kind === "should_trigger",
+      in_top_24: item.kind === "should_trigger",
+      reasons: [{ reason_type: "term", origin: "description", matched_terms: ["事故", "复盘"] }],
+      competitors: [{ candidate_id: "generic-summary", candidate_fingerprint: "7".repeat(64), rank: 1 }],
+    },
+    router: {
+      rank_top_6: item.kind === "should_trigger" ? 1 : null,
+      rank_top_24: item.kind === "should_trigger" ? 1 : null,
+      in_top_6: item.kind === "should_trigger",
+      in_top_24: item.kind === "should_trigger",
+      reasons: [],
+      competitors: [],
+    },
+  })),
+  created_at: 5,
+};
+
+function Harness({ initial, currentStatus = status }: { initial: SkillCreatorSession; currentStatus?: SkillCreatorStatus }) {
+  const [session, setSession] = useState(initial);
+  return <SkillTriggerOptimizationPanel onSession={setSession} session={session} status={currentStatus} />;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("SkillTriggerOptimizationPanel", () => {
+  it("fails closed when a required trigger Store status is missing", () => {
+    const confirmedSession = {
+      ...baseSession,
+      trigger_suite: suite,
+      trigger_attempt: { ...attempt, state: "confirmed" as const },
+      trigger_receipt: receipt,
+      trigger_stale_reason: null,
+    };
+
+    expect(skillTriggerGateReady(confirmedSession, {
+      ...status,
+      trigger_store_available: undefined,
+    })).toBe(false);
+  });
+
+  it("does not retroactively block a legacy session when the trigger Store is unavailable", () => {
+    expect(skillTriggerGateReady({
+      ...baseSession,
+      trigger_required: false,
+    }, {
+      ...status,
+      trigger_store_available: false,
+    })).toBe(true);
+  });
+
+  it("labels an optional legacy session as not enabled instead of passed", () => {
+    render(<Harness initial={{ ...baseSession, trigger_required: false }} />);
+
+    expect(screen.getByText("尚未启用")).toBeVisible();
+    expect(screen.queryByText("已通过")).not.toBeInTheDocument();
+  });
+
+  it("prevents no-op suite revisions but keeps the confirmed next action available", () => {
+    render(<Harness initial={{
+      ...baseSession,
+      trigger_suite: { ...suite, state: "draft" },
+    }} />);
+
+    expect(screen.getByRole("button", { name: "保存测试边界" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "边界没问题，继续" })).toBeEnabled();
+  });
+
+  it("completes the no-key path from manual cases through local description confirmation", async () => {
+    const draftSuite = { ...suite, state: "draft" as const };
+    const manualInitial = {
+      ...baseSession,
+      positive_examples: ["根据部署日志整理事故复盘"],
+      near_miss_examples: ["润色这段普通文字"],
+    };
+    const draftSession = { ...manualInitial, trigger_suite: draftSuite };
+    const confirmedSuite = {
+      ...suite,
+      suite_revision: suite.suite_revision + 1,
+      suite_digest: "9".repeat(64),
+      state: "confirmed" as const,
+    };
+    const evaluatedAttempt = {
+      ...attempt,
+      suite_revision: confirmedSuite.suite_revision,
+      suite_digest: confirmedSuite.suite_digest,
+    };
+    const evaluatedReceipt = {
+      ...receipt,
+      suite_revision: confirmedSuite.suite_revision,
+      suite_digest: confirmedSuite.suite_digest,
+    };
+    const suiteConfirmedSession = {
+      ...manualInitial,
+      trigger_suite: confirmedSuite,
+      trigger_stale_reason: "description_unconfirmed",
+    };
+    const evaluatedSession = {
+      ...suiteConfirmedSession,
+      trigger_attempt: evaluatedAttempt,
+      trigger_receipt: evaluatedReceipt,
+    };
+    const confirmedAttempt = {
+      ...evaluatedAttempt,
+      revision: 2,
+      state: "confirmed" as const,
+      selected_description_digest: evaluatedAttempt.candidates[0].description_digest,
+    };
+    const completedSession = {
+      ...evaluatedSession,
+      resource_plan: {
+        ...plan,
+        revision: 3,
+        digest: "8".repeat(64),
+        skill_description: evaluatedAttempt.candidates[0].description,
+      },
+      trigger_attempt: confirmedAttempt,
+      trigger_stale_reason: null,
+    };
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/trigger-suite") && init?.method === "PATCH") {
+        return jsonResponse({ session: draftSession, resource_plan: plan, trigger_required: true, trigger_suite: draftSuite, trigger_stale_reason: "skill_trigger_suite_required" });
+      }
+      if (url.endsWith("/trigger-suite/confirm")) {
+        return jsonResponse({ session: suiteConfirmedSession, resource_plan: plan, trigger_required: true, trigger_suite: confirmedSuite, trigger_stale_reason: "description_unconfirmed" });
+      }
+      if (url.endsWith("/trigger-descriptions/evaluate")) {
+        return jsonResponse({ session: evaluatedSession, resource_plan: plan, trigger_required: true, trigger_suite: confirmedSuite, trigger_attempt: evaluatedAttempt, trigger_receipt: evaluatedReceipt, trigger_stale_reason: "description_unconfirmed" });
+      }
+      return jsonResponse({ session: completedSession, resource_plan: completedSession.resource_plan, trigger_required: true, trigger_suite: confirmedSuite, trigger_attempt: confirmedAttempt, trigger_receipt: evaluatedReceipt, trigger_stale_reason: null });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<Harness initial={manualInitial} />);
+    await userEvent.click(screen.getByRole("button", { name: "手工填写" }));
+    const positiveGroup = screen.getByRole("group", { name: /应该触发/ });
+    const negativeGroup = screen.getByRole("group", { name: /不该触发/ });
+    await userEvent.click(within(positiveGroup).getByRole("button", { name: "再加一条" }));
+    await userEvent.type(screen.getByRole("textbox", { name: "应该触发用例 2" }), "根据告警与变更记录复盘服务中断");
+    await userEvent.click(within(negativeGroup).getByRole("button", { name: "再加一条" }));
+    await userEvent.type(screen.getByRole("textbox", { name: "不该触发用例 2" }), "总结一篇行业新闻");
+    expect(screen.getByRole("button", { name: "保存测试边界" })).toBeEnabled();
+    await userEvent.click(screen.getByRole("button", { name: "保存测试边界" }));
+    await userEvent.click(await screen.findByRole("button", { name: "边界没问题，继续" }));
+    await userEvent.click(await screen.findByRole("button", { name: "验证这条描述" }));
+    await userEvent.click(await screen.findByRole("button", { name: "采用第 1 条描述" }));
+
+    expect(await screen.findByText("触发检查通过")).toBeVisible();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body.cases).toEqual(expect.arrayContaining([
+      { kind: "should_trigger", text: "根据告警与变更记录复盘服务中断" },
+      { kind: "should_not_trigger", text: "总结一篇行业新闻" },
+    ]));
+    expect(body.change_reason).toContain("手工定义");
+    expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual(expect.arrayContaining([
+      expect.stringMatching(/\/trigger-suite$/),
+      expect.stringMatching(/\/trigger-suite\/confirm$/),
+      expect.stringMatching(/\/trigger-descriptions\/evaluate$/),
+      expect.stringMatching(/\/trigger-descriptions\/triggerattempt_1\/confirm$/),
+    ]));
+    const confirmSuiteCall = fetchMock.mock.calls.find(([input]) => String(input).endsWith("/trigger-suite/confirm"));
+    expect(JSON.parse(String(confirmSuiteCall?.[1]?.body))).toMatchObject({
+      expected_suite_revision: draftSuite.suite_revision,
+      expected_suite_digest: draftSuite.suite_digest,
+    });
+    const evaluateCall = fetchMock.mock.calls.find(([input]) => String(input).endsWith("/trigger-descriptions/evaluate"));
+    expect(JSON.parse(String(evaluateCall?.[1]?.body))).toMatchObject({
+      expected_suite_revision: confirmedSuite.suite_revision,
+      expected_suite_digest: confirmedSuite.suite_digest,
+    });
+  });
+
+  it("locks suite inputs while a save is in flight", async () => {
+    let resolveSave!: (response: Response) => void;
+    const pendingSave = new Promise<Response>((resolve) => { resolveSave = resolve; });
+    vi.stubGlobal("fetch", vi.fn(() => pendingSave));
+    const draftSuite = { ...suite, state: "draft" as const };
+    render(<Harness initial={{ ...baseSession, trigger_suite: draftSuite }} />);
+
+    const firstCase = screen.getByRole("textbox", { name: "应该触发用例 1" });
+    await userEvent.type(firstCase, "，并标记证据缺口");
+    await userEvent.click(screen.getByRole("button", { name: "保存测试边界" }));
+
+    expect(screen.getByRole("button", { name: "正在保存…" })).toBeDisabled();
+    expect(firstCase).toBeDisabled();
+    for (const button of screen.getAllByRole("button", { name: "再加一条" })) {
+      expect(button).toBeDisabled();
+    }
+    resolveSave(await jsonResponse({
+      session: { ...baseSession, trigger_suite: draftSuite },
+      resource_plan: plan,
+      trigger_required: true,
+      trigger_suite: draftSuite,
+      trigger_stale_reason: "skill_trigger_suite_required",
+    }));
+    await waitFor(() => expect(screen.queryByRole("button", { name: "正在保存…" })).not.toBeInTheDocument());
+  });
+
+  it("shows one recommendation, diagnostics on demand, and adopts only a passing description", async () => {
+    const evaluated = {
+      ...baseSession,
+      trigger_suite: suite,
+      trigger_attempt: attempt,
+      trigger_receipt: receipt,
+      trigger_stale_reason: "description_unconfirmed",
+    };
+    const confirmedAttempt = { ...attempt, revision: 2, state: "confirmed" as const, selected_description_digest: attempt.candidates[0].description_digest };
+    const confirmed = {
+      ...evaluated,
+      resource_plan: { ...plan, revision: 3, digest: "8".repeat(64), skill_description: attempt.candidates[0].description },
+      trigger_attempt: confirmedAttempt,
+      trigger_stale_reason: null,
+    };
+    const fetchMock = vi.fn((input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/trigger-descriptions/optimize")) {
+        return jsonResponse({ session: evaluated, resource_plan: plan, trigger_required: true, trigger_suite: suite, trigger_attempt: attempt, trigger_receipt: receipt, trigger_stale_reason: "description_unconfirmed" });
+      }
+      return jsonResponse({ session: confirmed, resource_plan: confirmed.resource_plan, trigger_required: true, trigger_suite: suite, trigger_attempt: confirmedAttempt, trigger_receipt: receipt, trigger_stale_reason: null });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<Harness currentStatus={{ ...status, trigger_optimizer_available: true }} initial={{ ...baseSession, trigger_suite: suite, trigger_stale_reason: "description_unconfirmed" }} />);
+    await userEvent.click(screen.getByRole("button", { name: "AI 优化并实测描述" }));
+
+    expect(await screen.findByText(attempt.candidates[0].description)).toBeVisible();
+    expect(screen.getByText("推荐 · 通过")).toBeVisible();
+    const diagnosticSummary = screen.getByText("查看排名与竞争候选（诊断）");
+    expect(diagnosticSummary.closest("details")).not.toHaveAttribute("open");
+    await userEvent.click(diagnosticSummary);
+    expect(diagnosticSummary.closest("details")).toHaveAttribute("open");
+    expect(screen.getAllByText(/主要竞争：generic-summary/)[0]).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "采用第 1 条描述" }));
+
+    expect(await screen.findByText("触发检查通过")).toBeVisible();
+    expect(screen.getByText("应该触发：2/2 命中 · 不该触发：2/2 避开")).toBeVisible();
+    const confirmCall = fetchMock.mock.calls.find(([input]) => String(input).includes(`/trigger-descriptions/${attempt.attempt_id}/confirm`));
+    expect(confirmCall).toBeTruthy();
+    expect(JSON.parse(String(confirmCall?.[1]?.body))).toMatchObject({
+      expected_attempt_revision: 1,
+      expected_attempt_digest: attempt.digest,
+      selected_description_digest: attempt.candidates[0].description_digest,
+    });
+  });
+
+  it("does not offer adoption when every description fails the hard gate", () => {
+    const failedAttempt = {
+      ...attempt,
+      candidates: attempt.candidates.map((candidate) => ({ ...candidate, passed: false })),
+      recommended_description_digest: null,
+    };
+    render(<Harness initial={{
+      ...baseSession,
+      trigger_suite: suite,
+      trigger_attempt: failedAttempt,
+      trigger_receipt: { ...receipt, passed: false },
+      trigger_stale_reason: "description_unconfirmed",
+    }} />);
+
+    expect(screen.queryByRole("button", { name: /采用第 \d+ 条描述/ })).not.toBeInTheDocument();
+    expect(screen.getByText(/没有候选通过/)).toBeVisible();
+    expect(screen.getByRole("button", { name: "手工改写并重试" })).toBeVisible();
+  });
+
+  it("translates conflicts into a reload action instead of exposing backend English", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => jsonResponse({
+      detail: { code: "skill_creator_revision_conflict", message: "Creator session changed." },
+    }, 409)));
+
+    render(<Harness currentStatus={{ ...status, trigger_optimizer_available: true }} initial={baseSession} />);
+    await userEvent.click(screen.getByRole("button", { name: "AI 提出测试边界" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText(/请先复制未保存内容，再重新加载继续/)).toBeVisible();
+    expect(alert).not.toHaveTextContent("Creator session changed");
+
+    await userEvent.click(screen.getByRole("button", { name: "手工填写" }));
+    await userEvent.click(screen.getByRole("button", { name: "保存测试边界" }));
+    expect(await screen.findByText(/都至少需要 2 条非空用例/)).toBeVisible();
+    expect(screen.queryByRole("button", { name: "重新加载会话" })).not.toBeInTheDocument();
+  });
+
+  it("reloads the latest server session after a revision conflict", async () => {
+    const latest = {
+      ...baseSession,
+      session_revision: 4,
+      positive_examples: ["使用最新部署记录生成复盘"],
+      near_miss_examples: ["只润色一句普通文字"],
+    };
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      if (String(input).endsWith(`/sessions/${baseSession.session_id}`)) {
+        return jsonResponse({
+          session: latest,
+          resource_plan: plan,
+          trigger_required: true,
+          trigger_stale_reason: "skill_trigger_suite_required",
+        });
+      }
+      return jsonResponse({
+        detail: { code: "skill_creator_revision_conflict", message: "Creator session changed." },
+      }, 409);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<Harness currentStatus={{ ...status, trigger_optimizer_available: true }} initial={baseSession} />);
+    await userEvent.click(screen.getByRole("button", { name: "AI 提出测试边界" }));
+    await userEvent.click(await screen.findByRole("button", { name: "重新加载会话" }));
+
+    expect(await screen.findByText("已加载服务端最新状态。")).toBeVisible();
+    expect(screen.queryByRole("button", { name: "重新加载会话" })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "手工填写" }));
+    expect(screen.getByRole("textbox", { name: "应该触发用例 1" })).toHaveValue("使用最新部署记录生成复盘");
+    expect(fetchMock.mock.calls.some(([input]) => String(input).endsWith(`/sessions/${baseSession.session_id}`))).toBe(true);
+  });
+
+  it("uses Chinese recovery copy for a network failure", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new TypeError("Failed to fetch"))));
+
+    render(<Harness currentStatus={{ ...status, trigger_optimizer_available: true }} initial={baseSession} />);
+    await userEvent.click(screen.getByRole("button", { name: "AI 提出测试边界" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("触发检查失败，请重试");
+    expect(alert).not.toHaveTextContent("Failed to fetch");
+  });
+
+  it("offers a deterministic reload path when the local trigger index is unavailable", async () => {
+    const unavailable = {
+      ...baseSession,
+      trigger_suite: suite,
+      trigger_attempt: {
+        ...attempt,
+        revision: 2,
+        state: "confirmed" as const,
+        selected_description_digest: attempt.candidates[0].description_digest,
+      },
+      trigger_receipt: null,
+      trigger_stale_reason: "skill_trigger_index_unavailable",
+    };
+    const restored = {
+      ...unavailable,
+      trigger_receipt: receipt,
+      trigger_stale_reason: null,
+    };
+    vi.stubGlobal("fetch", vi.fn(() => jsonResponse({
+      session: restored,
+      resource_plan: plan,
+      trigger_required: true,
+      trigger_suite: suite,
+      trigger_attempt: restored.trigger_attempt,
+      trigger_receipt: receipt,
+      trigger_stale_reason: null,
+    })));
+
+    render(<Harness initial={unavailable} />);
+
+    expect(screen.getByText("本地 Skill 索引暂不可用")).toBeVisible();
+    expect(screen.queryByRole("button", { name: "AI 优化并实测描述" })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "重新加载会话" }));
+
+    expect(await screen.findByText("触发检查通过")).toBeVisible();
+  });
+
+  it("disables both assisted and manual entry when the trigger Store is unavailable", () => {
+    render(<Harness currentStatus={{
+      ...status,
+      trigger_optimizer_available: true,
+      trigger_store_available: false,
+    }} initial={baseSession} />);
+
+    expect(screen.getByText(/触发验证 Store 暂不可用/)).toBeVisible();
+    expect(screen.getByRole("button", { name: "AI 提出测试边界" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "手工填写" })).toBeDisabled();
+  });
+});

--- a/client/src/components/skill-creator/SkillTriggerOptimizationPanel.tsx
+++ b/client/src/components/skill-creator/SkillTriggerOptimizationPanel.tsx
@@ -1,0 +1,477 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  CheckCircle2,
+  ChevronRight,
+  CircleAlert,
+  LoaderCircle,
+  Plus,
+  RefreshCw,
+  Sparkles,
+  Target,
+  Trash2,
+} from "lucide-react";
+
+import {
+  confirmSkillCreatorTriggerDescription,
+  confirmSkillCreatorTriggerSuite,
+  evaluateSkillCreatorTriggerDescription,
+  generateSkillCreatorTriggerSuite,
+  optimizeSkillCreatorTriggerDescriptions,
+  readSkillCreatorSession,
+  saveSkillCreatorTriggerSuite,
+  SkillCreatorApiError,
+  type SkillCreatorSession,
+  type SkillCreatorStatus,
+} from "../../utils/skillCreatorApi";
+
+interface Props {
+  session: SkillCreatorSession;
+  status: SkillCreatorStatus;
+  onSession: (session: SkillCreatorSession) => void | Promise<void>;
+}
+
+const ERROR_COPY: Record<string, { message: string; action: string }> = {
+  skill_trigger_suite_required: {
+    message: "需要先确认哪些任务应该触发、哪些相似任务不该触发。",
+    action: "补全并确认测试边界",
+  },
+  skill_trigger_suite_stale: {
+    message: "需求或 Skill 名称已经变化，原测试边界不再适用。",
+    action: "按当前需求重新生成",
+  },
+  skill_trigger_suite_invalid: {
+    message: "测试边界不完整或存在重复。正例和反例都至少需要 2 条。",
+    action: "检查用例后重新保存",
+  },
+  skill_trigger_optimizer_unconfigured: {
+    message: "模型网关未配置，仍可手工填写用例和描述并在本地验证。",
+    action: "改用手工验证",
+  },
+  skill_trigger_optimizer_invalid: {
+    message: "AI 没有返回可用的触发描述，现有方案未被修改。",
+    action: "重试或手工填写描述",
+  },
+  skill_trigger_description_invalid: {
+    message: "描述需要是一行清晰文字，说明能力、使用时机和关键边界。",
+    action: "修改描述后重新验证",
+  },
+  skill_trigger_evaluation_failed: {
+    message: "当前描述还不能稳定命中目标任务并避开相似任务。",
+    action: "换一个描述再验证",
+  },
+  skill_trigger_receipt_stale: {
+    message: "目录或排序版本已变化，需要按当前索引重新验证。",
+    action: "重新验证当前描述",
+  },
+  skill_trigger_gate_required: {
+    message: "触发验证尚未完成，资源计划暂时不能确认。",
+    action: "完成当前触发检查",
+  },
+  skill_trigger_index_unavailable: {
+    message: "本地 Skill 索引暂不可用，无法给出可信的触发结论。",
+    action: "恢复索引后重新加载",
+  },
+};
+
+function presentError(value: unknown, fallback: string) {
+  if (value instanceof SkillCreatorApiError) {
+    const known = ERROR_COPY[value.code];
+    if (known) return `${known.message} ${known.action}。`;
+    if (value.status === 409) return "会话或方案已在其他位置更新。请先复制未保存内容，再重新加载继续。";
+    return fallback;
+  }
+  return fallback;
+}
+
+function minimumCases(values: string[]) {
+  return values.map((item) => item.trim()).filter(Boolean).length >= 2;
+}
+
+function rankLabel(rank: number | null | undefined) {
+  return rank == null ? "未进入 Top 24" : `第 ${rank} 名`;
+}
+
+export default function SkillTriggerOptimizationPanel({ session, status, onSession }: Props) {
+  const plan = session.resource_plan ?? null;
+  const suite = session.trigger_suite ?? null;
+  const attempt = session.trigger_attempt ?? null;
+  const receipt = session.trigger_receipt ?? null;
+  const enabled = status.trigger_optimization_enabled === true;
+  const [busy, setBusy] = useState("");
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+  const [reloadSuggested, setReloadSuggested] = useState(false);
+  const [manualOpen, setManualOpen] = useState(false);
+  const [positiveCases, setPositiveCases] = useState<string[]>([]);
+  const [negativeCases, setNegativeCases] = useState<string[]>([]);
+  const [description, setDescription] = useState("");
+  const [caseDirty, setCaseDirty] = useState(false);
+  const positiveExamplesKey = JSON.stringify(session.positive_examples);
+  const negativeExamplesKey = JSON.stringify(session.near_miss_examples);
+
+  useEffect(() => {
+    const positives = suite?.cases.filter((item) => item.kind === "should_trigger").map((item) => item.text)
+      ?? session.positive_examples;
+    const negatives = suite?.cases.filter((item) => item.kind === "should_not_trigger").map((item) => item.text)
+      ?? session.near_miss_examples;
+    setPositiveCases(positives.length ? positives : [""]);
+    setNegativeCases(negatives.length ? negatives : [""]);
+    setCaseDirty(false);
+  }, [negativeExamplesKey, positiveExamplesKey, suite?.suite_digest]);
+
+  useEffect(() => {
+    setDescription(plan?.skill_description ?? "");
+  }, [plan?.skill_description]);
+
+  const gateReady = Boolean(
+    status.trigger_store_available
+      && session.trigger_required
+      && receipt?.passed
+      && attempt?.state === "confirmed"
+      && !session.trigger_stale_reason
+  );
+  const counts = useMemo(() => {
+    const results = receipt?.case_results ?? [];
+    const positives = results.filter((item) => item.kind === "should_trigger");
+    const negatives = results.filter((item) => item.kind === "should_not_trigger");
+    return {
+      positivePassed: positives.filter((item) => item.passed).length,
+      positiveTotal: positives.length,
+      negativePassed: negatives.filter((item) => item.passed).length,
+      negativeTotal: negatives.length,
+    };
+  }, [receipt]);
+
+  if (!enabled || !plan || plan.stale || !["ready", "confirmed"].includes(plan.state)) return null;
+
+  async function run(
+    label: string,
+    operation: () => Promise<SkillCreatorSession>,
+    success: string,
+  ) {
+    setBusy(label);
+    setError("");
+    setNotice("");
+    setReloadSuggested(false);
+    try {
+      const updated = await operation();
+      await onSession(updated);
+      setNotice(success);
+      return updated;
+    } catch (caught) {
+      setError(presentError(caught, "触发检查失败，请重试。"));
+      setReloadSuggested(
+        caught instanceof SkillCreatorApiError
+          && (
+            caught.status === 409
+            || caught.code === "skill_trigger_receipt_stale"
+            || caught.code === "skill_trigger_index_unavailable"
+          ),
+      );
+      return null;
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function reloadSession() {
+    setBusy("reload");
+    setError("");
+    try {
+      await onSession(await readSkillCreatorSession(session.session_id));
+      setReloadSuggested(false);
+      setNotice("已加载服务端最新状态。");
+    } catch (caught) {
+      setError(presentError(caught, "重新加载失败，请稍后重试。"));
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function generateSuite() {
+    await run(
+      "suite-generate",
+      () => generateSkillCreatorTriggerSuite(session),
+      "AI 已提出测试边界，请确认它们是否符合你的真实使用场景。",
+    );
+  }
+
+  async function saveSuite() {
+    if (!minimumCases(positiveCases) || !minimumCases(negativeCases)) {
+      setNotice("");
+      setReloadSuggested(false);
+      setError("“应该触发”和“不该触发”都至少需要 2 条非空用例。");
+      return;
+    }
+    const existingSmoke = suite?.cases.filter((item) => item.kind === "exact_name_smoke") ?? [];
+    const cases = [
+      ...positiveCases.filter((item) => item.trim()).map((text) => ({ kind: "should_trigger" as const, text })),
+      ...negativeCases.filter((item) => item.trim()).map((text) => ({ kind: "should_not_trigger" as const, text })),
+      ...existingSmoke.map((item) => ({ kind: item.kind, text: item.text })),
+    ];
+    const updated = await run(
+      "suite-save",
+      () => saveSkillCreatorTriggerSuite(
+        session,
+        cases,
+        suite ? "用户调整触发测试边界。" : "用户手工定义触发测试边界。",
+      ),
+      "测试边界已保存。",
+    );
+    if (updated) setManualOpen(false);
+  }
+
+  async function confirmSuite() {
+    if (caseDirty) {
+      setNotice("");
+      setReloadSuggested(false);
+      setError("输入框中还有未保存的修改，请先保存测试边界。");
+      return;
+    }
+    await run(
+      "suite-confirm",
+      () => confirmSkillCreatorTriggerSuite(session),
+      "测试边界已冻结。下一步验证 Skill 描述。",
+    );
+  }
+
+  function updateCase(kind: "positive" | "negative", index: number, value: string) {
+    const setter = kind === "positive" ? setPositiveCases : setNegativeCases;
+    setter((current) => current.map((item, itemIndex) => itemIndex === index ? value : item));
+    setCaseDirty(true);
+  }
+
+  function removeCase(kind: "positive" | "negative", index: number) {
+    const setter = kind === "positive" ? setPositiveCases : setNegativeCases;
+    setter((current) => current.filter((_, itemIndex) => itemIndex !== index));
+    setCaseDirty(true);
+  }
+
+  function addCase(kind: "positive" | "negative") {
+    const setter = kind === "positive" ? setPositiveCases : setNegativeCases;
+    setter((current) => current.length >= 6 ? current : [...current, ""]);
+    setCaseDirty(true);
+  }
+
+  const suiteConfirmed = suite?.state === "confirmed";
+  const canEditSuite = plan.state !== "confirmed" && !suiteConfirmed;
+  const suiteStale = [
+    "skill_trigger_suite_required",
+    "skill_trigger_suite_stale",
+    "definition_changed",
+    "skill_name_changed",
+  ].includes(session.trigger_stale_reason ?? "") && Boolean(suite?.state === "confirmed");
+  const descriptionStale = [
+    "description_unconfirmed",
+    "description_failed",
+    "skill_trigger_receipt_stale",
+  ].includes(session.trigger_stale_reason ?? "");
+  const indexUnavailable = session.trigger_stale_reason === "skill_trigger_index_unavailable";
+  const primaryNext = indexUnavailable
+    ? "recover-index"
+    : !session.trigger_required || !suite || suiteStale
+    ? "suite"
+    : !suiteConfirmed
+      ? "confirm-suite"
+      : !attempt
+        ? "description"
+        : attempt.state !== "confirmed"
+          ? "confirm-description"
+          : descriptionStale
+            ? "description"
+            : "done";
+
+  return (
+    <section className="border-t border-white/10 pt-5" aria-labelledby="creator-trigger-heading">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-white">
+            <Target aria-hidden="true" size={17} />
+            <h4 className="text-sm font-semibold" id="creator-trigger-heading">先确认什么时候该使用这个 Skill</h4>
+          </div>
+          <p className="mt-1 max-w-3xl text-xs leading-5 text-slate-400">
+            用真实需求和相似任务检查描述，避免该出现时找不到、不该出现时频繁打扰。
+          </p>
+        </div>
+        <span className={`rounded-full border px-3 py-1 text-xs ${gateReady ? "border-emerald-300/20 text-emerald-100" : "border-amber-300/20 text-amber-100"}`}>
+          {!session.trigger_required ? "尚未启用" : gateReady ? "已通过" : "待完成"}
+        </span>
+      </div>
+
+      {error ? <div className="mt-4 rounded-md border border-red-400/25 bg-red-400/10 px-3 py-2" role="alert"><p className="text-sm leading-6 text-red-100">{error}</p>{reloadSuggested ? <button className="mt-2 inline-flex min-h-11 items-center gap-2 rounded-full border border-red-200/25 px-3 text-xs font-semibold text-red-50 disabled:opacity-40" disabled={Boolean(busy)} onClick={() => void reloadSession()} type="button"><RefreshCw aria-hidden="true" size={14} />重新加载会话</button> : null}</div> : null}
+      {notice ? <p className="mt-4 rounded-md border border-emerald-400/20 bg-emerald-400/10 px-3 py-2 text-sm leading-6 text-emerald-100" role="status">{notice}</p> : null}
+      {!status.trigger_store_available ? (
+        <p className="mt-4 rounded-md border border-red-400/25 bg-red-400/10 px-3 py-2 text-sm leading-6 text-red-100" role="alert">
+          {session.trigger_required
+            ? "触发验证 Store 暂不可用。为避免错误放行，当前方案不能确认；恢复后请重新加载。"
+            : "触发验证 Store 暂不可用。当前旧流程仍可继续；恢复后才能主动启用触发验证。"}
+        </p>
+      ) : null}
+
+      {primaryNext === "recover-index" ? (
+        <div className="mt-4 rounded-md border border-amber-300/25 bg-amber-300/[0.08] p-4" role="alert">
+          <p className="flex items-center gap-2 text-sm font-semibold text-amber-100">
+            <CircleAlert aria-hidden="true" size={16} />
+            本地 Skill 索引暂不可用
+          </p>
+          <p className="mt-1 text-xs leading-5 text-amber-100/75">
+            当前描述不能形成可信触发凭据。恢复索引后重新加载会话，系统会按最新候选重新验证。
+          </p>
+          <button className="mt-3 inline-flex min-h-11 items-center gap-2 rounded-full border border-amber-200/30 px-4 text-xs font-semibold text-amber-50 disabled:opacity-40" disabled={Boolean(busy)} onClick={() => void reloadSession()} type="button">
+            <RefreshCw aria-hidden="true" size={14} />
+            {busy === "reload" ? "正在重新加载…" : "重新加载会话"}
+          </button>
+        </div>
+      ) : null}
+
+      {primaryNext === "suite" && !(plan.state === "confirmed" && !session.trigger_required) ? (
+        <div className="mt-4 rounded-md border border-brand-300/20 bg-brand-300/[0.04] p-4">
+          <p className="text-sm text-slate-200">
+            {suiteStale
+              ? "需求或 Skill 名称已变化，需要按当前内容重新确认测试边界。"
+              : session.trigger_required
+              ? "先生成一组正反例，再由你确认边界。"
+              : "这是旧会话，现有流程不会被追溯阻断。你可以主动启用触发验证。"}
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {status.trigger_optimizer_available ? (
+              <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={Boolean(busy) || !status.trigger_store_available} onClick={() => void generateSuite()} type="button">
+                {busy === "suite-generate" ? <LoaderCircle className="animate-spin motion-reduce:animate-none" aria-hidden="true" size={16} /> : <Sparkles aria-hidden="true" size={16} />}
+                {suiteStale ? "重新生成测试边界" : session.trigger_required ? "AI 提出测试边界" : "启用并生成测试边界"}
+              </button>
+            ) : null}
+            <button className="min-h-11 rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-white disabled:opacity-40" disabled={Boolean(busy) || !status.trigger_store_available} onClick={() => setManualOpen(true)} type="button">
+              手工填写
+            </button>
+          </div>
+          {!status.trigger_optimizer_available ? <p className="mt-2 text-xs leading-5 text-amber-100">模型网关未配置。手工填写至少 2 条正例、2 条反例后，仍可使用同一套本地排序验证。</p> : null}
+        </div>
+      ) : null}
+
+      {plan.state === "confirmed" && !session.trigger_required ? (
+        <p className="mt-4 rounded-md border border-white/10 bg-ink-950/25 p-4 text-xs leading-5 text-slate-400">
+          这个旧会话的资源计划已经冻结，不会被追溯阻断。如需启用触发验证，请复制为新会话后再调整。
+        </p>
+      ) : null}
+
+      {(manualOpen || (suite && !suiteConfirmed)) && canEditSuite ? (
+        <div className="mt-4 grid gap-4 lg:grid-cols-2">
+          {([
+            ["positive", "应该触发", positiveCases, "例如：根据故障日志整理可追溯的事故复盘"],
+            ["negative", "不该触发", negativeCases, "例如：把一段普通文字改得更通顺"],
+          ] as const).map(([kind, title, values, placeholder]) => (
+            <fieldset className="min-w-0 rounded-md border border-white/10 bg-ink-950/35 p-4" key={kind}>
+              <legend className="px-1 text-sm font-semibold text-white">{title}（{values.filter((item) => item.trim()).length}/2–6）</legend>
+              <div className="mt-2 space-y-2">
+                {values.map((value, index) => (
+                  <div className="flex min-w-0 items-start gap-2" key={`${kind}-${index}`}>
+                    <textarea aria-label={`${title}用例 ${index + 1}`} className="min-h-20 min-w-0 flex-1 resize-y rounded-md border border-white/10 bg-ink-950/75 px-3 py-2 text-sm leading-6 text-white focus:border-brand-300/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-300/40 disabled:opacity-50" disabled={Boolean(busy)} maxLength={500} onChange={(event) => updateCase(kind, index, event.target.value)} placeholder={placeholder} value={value} />
+                    <button aria-label={`删除${title}用例 ${index + 1}`} className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md p-2 text-slate-400 hover:bg-white/10 hover:text-red-100 disabled:opacity-30" disabled={Boolean(busy) || values.length <= 1} onClick={() => removeCase(kind, index)} type="button"><Trash2 aria-hidden="true" size={15} /></button>
+                  </div>
+                ))}
+              </div>
+              <button className="mt-2 inline-flex min-h-11 items-center gap-2 rounded-full px-3 text-xs font-semibold text-brand-100 hover:bg-white/5 disabled:opacity-30" disabled={Boolean(busy) || values.length >= 6} onClick={() => addCase(kind)} type="button"><Plus aria-hidden="true" size={14} />再加一条</button>
+            </fieldset>
+          ))}
+          <div className="flex flex-wrap justify-end gap-2 lg:col-span-2">
+            <button className="min-h-11 rounded-full border border-white/15 px-5 py-2 text-sm font-semibold text-white disabled:opacity-40" disabled={Boolean(busy) || (Boolean(suite) && !caseDirty)} onClick={() => void saveSuite()} type="button">{busy === "suite-save" ? "正在保存…" : "保存测试边界"}</button>
+            {suite ? <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={caseDirty || Boolean(busy)} onClick={() => void confirmSuite()} type="button"><CheckCircle2 aria-hidden="true" size={16} />{busy === "suite-confirm" ? "正在确认…" : "边界没问题，继续"}</button> : null}
+          </div>
+        </div>
+      ) : null}
+
+      {suiteConfirmed && primaryNext === "description" ? (
+        <div className="mt-4 rounded-md border border-brand-300/20 bg-brand-300/[0.04] p-4">
+          <p className="text-sm text-slate-200">{descriptionStale ? "目录或描述已变化，需要重新验证当前触发效果。" : "测试边界已确认。现在用生产 Finder 与 Router 排序验证一条清晰描述。"}</p>
+          {status.trigger_optimizer_available ? <div className="mt-3 flex flex-wrap gap-2">
+            <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={Boolean(busy)} onClick={() => void run("optimize", () => optimizeSkillCreatorTriggerDescriptions(session), "已生成并实测描述候选。") } type="button">{busy === "optimize" ? <LoaderCircle className="animate-spin motion-reduce:animate-none" aria-hidden="true" size={16} /> : <Sparkles aria-hidden="true" size={16} />}{busy === "optimize" ? "正在实测…" : "AI 优化并实测描述"}</button>
+            <button className="min-h-11 rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-white" disabled={Boolean(busy)} onClick={() => setManualOpen(true)} type="button">手工验证描述</button>
+          </div> : null}
+          {!status.trigger_optimizer_available ? <p className="mt-2 text-xs text-amber-100">无模型也可直接验证当前描述。</p> : null}
+        </div>
+      ) : null}
+
+      {suiteConfirmed && (manualOpen || (!status.trigger_optimizer_available && !attempt)) && (attempt?.state !== "confirmed" || descriptionStale) ? (
+        <div className="mt-4 rounded-md border border-white/10 bg-ink-950/35 p-4">
+          <label className="block">
+            <span className="text-sm font-semibold text-white">Skill 描述</span>
+            <span className="mt-1 block text-xs leading-5 text-slate-400">用一行说明它能做什么、什么时候用，以及不适用的边界（最多 600 字符）。</span>
+            <textarea className="mt-3 min-h-24 w-full resize-y rounded-md border border-white/10 bg-ink-950/75 px-3 py-2 text-sm leading-6 text-white focus:border-brand-300/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-300/40 disabled:opacity-50" disabled={Boolean(busy)} maxLength={600} onChange={(event) => setDescription(event.target.value)} value={description} />
+          </label>
+          <div className="mt-3 flex justify-end">
+            <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={!description.trim() || Boolean(busy)} onClick={() => void run("evaluate", () => evaluateSkillCreatorTriggerDescription(session, description), "描述已完成本地验证。") } type="button">{busy === "evaluate" ? <LoaderCircle className="animate-spin motion-reduce:animate-none" aria-hidden="true" size={16} /> : <Target aria-hidden="true" size={16} />}{busy === "evaluate" ? "正在验证…" : "验证这条描述"}</button>
+          </div>
+        </div>
+      ) : null}
+
+      {attempt && attempt.state !== "confirmed" ? (
+        <div className="mt-4 space-y-3">
+          <p className="text-sm font-semibold text-white">选择一条已通过的描述</p>
+          {attempt.candidates.map((candidate, index) => {
+            const recommended = candidate.description_digest === attempt.recommended_description_digest;
+            return (
+              <article className={`min-w-0 rounded-md border p-4 ${candidate.passed ? "border-emerald-300/30 bg-emerald-300/[0.04]" : "border-red-300/25 bg-red-300/[0.035]"}`} key={candidate.description_digest}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <p className="min-w-0 flex-1 break-words text-sm leading-6 text-slate-200">{candidate.description}</p>
+                  <span className={`rounded-full px-2.5 py-1 text-[11px] ${candidate.passed ? "bg-emerald-300/10 text-emerald-100" : "bg-red-300/10 text-red-100"}`}>{recommended ? "推荐 · " : ""}{candidate.passed ? "通过" : "未通过"}</span>
+                </div>
+                <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+                  <p className="text-xs text-slate-400">最弱正例名次 {candidate.worst_positive_rank || "—"} · 反例安全距离 {candidate.negative_safety_distance}</p>
+                  {candidate.passed ? <button aria-label={`采用第 ${index + 1} 条描述`} className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-4 py-2 text-xs font-semibold text-ink-950 disabled:opacity-40" disabled={Boolean(busy)} onClick={() => void run("confirm-description", () => confirmSkillCreatorTriggerDescription(session, candidate.description_digest), "推荐描述已写入方案，触发检查通过。") } type="button">{busy === "confirm-description" ? <LoaderCircle className="animate-spin motion-reduce:animate-none" aria-hidden="true" size={15} /> : null}{busy === "confirm-description" ? "正在采用…" : "采用这条描述"}{busy !== "confirm-description" ? <ChevronRight aria-hidden="true" size={15} /> : null}</button> : null}
+                </div>
+              </article>
+            );
+          })}
+          {!attempt.candidates.some((item) => item.passed) ? <p className="rounded-md border border-amber-300/20 bg-amber-300/[0.07] px-3 py-2 text-xs leading-5 text-amber-100">没有候选通过。请手工改写描述后重新验证，或重新运行 AI 优化；资源计划尚未被修改。</p> : null}
+          <button className="min-h-11 rounded-full px-3 text-xs font-semibold text-brand-100 hover:bg-white/5" onClick={() => setManualOpen(true)} type="button">手工改写并重试</button>
+        </div>
+      ) : null}
+
+      {attempt?.state === "confirmed" && receipt ? (
+        <div className={`mt-4 rounded-md border p-4 ${receipt.passed && !session.trigger_stale_reason ? "border-emerald-300/30 bg-emerald-300/[0.04]" : "border-amber-300/30 bg-amber-300/[0.04]"}`}>
+          <p className="flex items-center gap-2 text-sm font-semibold text-white">
+            {receipt.passed && !session.trigger_stale_reason ? <CheckCircle2 className="text-emerald-200" aria-hidden="true" size={17} /> : <CircleAlert className="text-amber-200" aria-hidden="true" size={17} />}
+            {receipt.passed && !session.trigger_stale_reason ? "触发检查通过" : "需要重新验证"}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-300">
+            应该触发：{counts.positivePassed}/{counts.positiveTotal} 命中 · 不该触发：{counts.negativePassed}/{counts.negativeTotal} 避开
+          </p>
+          {session.trigger_stale_reason ? <p className="mt-2 text-xs leading-5 text-amber-100">{ERROR_COPY[session.trigger_stale_reason]?.message ?? "当前验证凭据已过期。"}</p> : null}
+        </div>
+      ) : null}
+
+      {receipt ? (
+        <details className="mt-4 border-t border-white/10 pt-3">
+          <summary className="flex min-h-11 cursor-pointer items-center text-xs font-semibold text-slate-400 hover:text-slate-200">查看排名与竞争候选（诊断）</summary>
+          <div className="mt-3 space-y-3">
+            {receipt.case_results.map((result) => {
+              const testCase = suite?.cases.find((item) => item.case_id === result.case_id);
+              const terms = [...result.finder.reasons, ...result.router.reasons].flatMap((item) => item.matched_terms);
+              return (
+                <article className="min-w-0 rounded-md border border-white/8 bg-ink-950/30 p-3" key={result.case_id}>
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <p className="min-w-0 flex-1 break-words text-xs leading-5 text-slate-300">{testCase?.text ?? result.case_id}</p>
+                    <span className={result.passed ? "text-xs text-emerald-200" : "text-xs text-red-200"}>{result.passed ? "通过" : "未通过"}</span>
+                  </div>
+                  <p className="mt-2 text-[11px] leading-5 text-slate-500">Finder {rankLabel(result.finder.rank_top_24)} · Router {rankLabel(result.router.rank_top_24)}{terms.length ? ` · 匹配：${[...new Set(terms)].slice(0, 8).join("、")}` : ""}</p>
+                  {result.finder.competitors.length || result.router.competitors.length ? <p className="text-[11px] leading-5 text-slate-500">主要竞争：{[...result.finder.competitors, ...result.router.competitors].slice(0, 6).map((item) => item.candidate_id).join("、")}</p> : null}
+                </article>
+              );
+            })}
+          </div>
+        </details>
+      ) : null}
+    </section>
+  );
+}
+
+export function skillTriggerGateReady(session: SkillCreatorSession, status: SkillCreatorStatus) {
+  if (!status.trigger_optimization_enabled) return true;
+  if (!session.trigger_required) return true;
+  if (status.trigger_store_available !== true) return false;
+  return Boolean(
+    session.trigger_attempt?.state === "confirmed"
+      && session.trigger_receipt?.passed
+      && !session.trigger_stale_reason,
+  );
+}

--- a/client/src/pages/SkillCreatorPages.test.tsx
+++ b/client/src/pages/SkillCreatorPages.test.tsx
@@ -98,10 +98,34 @@ function creatorProposal(
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
 describe("Skill Creator pages", () => {
+  it("resets preserved page scroll when a Creator session opens", async () => {
+    vi.spyOn(window, "scrollX", "get").mockReturnValue(0);
+    vi.spyOn(window, "scrollY", "get").mockReturnValue(240);
+    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/skills/creator/status") return jsonResponse(status);
+      if (url === "/api/skills/creator/sessions/creator_1") return jsonResponse({ session: baseSession });
+      return jsonResponse({ detail: `not found: ${url}` }, 404);
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/skills/create/creator_1"]}>
+        <Routes>
+          <Route element={<SkillCreatorStudioPage />} path="/skills/create/:sessionId" />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole("heading", { name: "把你的做法变成可复用的 Skill" });
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, left: 0, behavior: "auto" });
+  });
+
   it("opens trusted workflow evidence after saving the handoff requirement", async () => {
     let currentSession: SkillCreatorSession = {
       ...baseSession,
@@ -565,6 +589,74 @@ describe("Skill Creator pages", () => {
     expect(await screen.findByRole("button", { name: "批准并写入草稿" })).toBeVisible();
     expect(screen.queryByRole("heading", { name: "准备生成内容" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "按新方案开始生成" })).not.toBeInTheDocument();
+  });
+
+  it("enters the resource build step only after plan confirmation succeeds", async () => {
+    let currentScrollY = 0;
+    vi.spyOn(window, "scrollX", "get").mockReturnValue(0);
+    vi.spyOn(window, "scrollY", "get").mockImplementation(() => currentScrollY);
+    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {
+      currentScrollY = 0;
+    });
+    const readyPlan: SkillResourcePlan = {
+      plan_id: "plan_ready_to_confirm",
+      session_id: baseSession.session_id,
+      revision: 2,
+      digest: "9".repeat(64),
+      state: "ready",
+      session_revision: baseSession.session_revision,
+      skill_name: "compare-pdf",
+      skill_description: "比较 PDF 并保留证据页码。",
+      workflow_steps: [{ step_id: "collect", instruction: "Collect cited evidence." }],
+      output_contract: ["Return a cited comparison."],
+      failure_modes: ["Mark missing evidence."],
+      resources: [],
+      clarifications: [],
+      clarification_answers: {},
+      created_at: 1,
+      updated_at: 2,
+    };
+    const readySession: SkillCreatorSession = {
+      ...baseSession,
+      authoring_flow: "resource",
+      evidence_confirmed: true,
+      resource_plan: readyPlan,
+    };
+    const confirmedSession: SkillCreatorSession = {
+      ...readySession,
+      session_revision: readySession.session_revision + 1,
+      resource_plan: { ...readyPlan, revision: 3, state: "confirmed" },
+    };
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/skills/creator/status") return jsonResponse({
+        ...status,
+        resource_authoring_enabled: true,
+        resource_builder_available: true,
+      });
+      if (url === "/api/skills/creator/sessions/creator_1" && !init?.method) {
+        return jsonResponse({ session: readySession, resource_plan: readyPlan });
+      }
+      if (url.endsWith("/resource-plan/confirm") && init?.method === "POST") {
+        return jsonResponse({ session: confirmedSession, resource_plan: confirmedSession.resource_plan });
+      }
+      return jsonResponse({ detail: `not found: ${url}` }, 404);
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/skills/create/creator_1"]}>
+        <Routes><Route element={<SkillCreatorStudioPage />} path="/skills/create/:sessionId" /></Routes>
+      </MemoryRouter>,
+    );
+
+    const confirmButton = await screen.findByRole("button", { name: "确认方案，进入生成" });
+    currentScrollY = 620;
+    await userEvent.click(confirmButton);
+
+    const buildHeading = await screen.findByRole("heading", { name: "准备生成内容" });
+    expect(screen.getByText("当前步骤 3/6")).toBeVisible();
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 0, left: 0, behavior: "auto" });
+    expect(buildHeading).toHaveFocus();
   });
 
   it("restores the latest resource-build proposal instead of an older approved session proposal", async () => {

--- a/client/src/pages/SkillCreatorStudioPage.tsx
+++ b/client/src/pages/SkillCreatorStudioPage.tsx
@@ -13,7 +13,7 @@ import {
   ShieldCheck,
   Sparkles,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import PageContainer from "../components/PageContainer";
 import SkillCreatorFinish from "../components/skill-creator/SkillCreatorFinish";
@@ -258,6 +258,7 @@ export default function SkillCreatorStudioPage() {
   const [sourcePreview, setSourcePreview] = useState<SkillCreatorSourcePreview | null>(null);
   const [selectedEvidence, setSelectedEvidence] = useState<Set<string>>(new Set());
   const [activeStep, setActiveStep] = useState(0);
+  const previousActiveStepRef = useRef(activeStep);
   const [intent, setIntent] = useState("");
   const [positiveExamples, setPositiveExamples] = useState("");
   const [nearMissExamples, setNearMissExamples] = useState("");
@@ -369,6 +370,18 @@ export default function SkillCreatorStudioPage() {
       document.removeEventListener("visibilitychange", refreshVisibleSession);
     };
   }, [loadSession, status]);
+
+  useLayoutEffect(() => {
+    const stepChanged = previousActiveStepRef.current !== activeStep;
+    if (window.scrollX !== 0 || window.scrollY !== 0) {
+      window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+    }
+    if (stepChanged && activeStep === 2) {
+      document.getElementById("resource-build-start-heading")?.focus();
+      document.getElementById("resource-build-heading")?.focus();
+    }
+    previousActiveStepRef.current = activeStep;
+  }, [activeStep, sessionId]);
 
   const intentComplete = definitionMode === "simple"
     ? Boolean(intent.trim())
@@ -884,7 +897,12 @@ export default function SkillCreatorStudioPage() {
               )}
 
               {status.resource_authoring_enabled ? (
-                <SkillResourcePlanPanel onSession={acceptHydratedSession} session={session} status={status} />
+                <SkillResourcePlanPanel
+                  onPlanConfirmed={() => setActiveStep(2)}
+                  onSession={acceptHydratedSession}
+                  session={session}
+                  status={status}
+                />
               ) : null}
 
               {!resourceFlow && proposal?.status !== "pending" ? (

--- a/client/src/utils/skillCreatorApi.ts
+++ b/client/src/utils/skillCreatorApi.ts
@@ -666,6 +666,116 @@ export interface SkillResourceBuild {
   updated_at: number;
 }
 
+export type SkillTriggerCaseKind = "should_trigger" | "should_not_trigger" | "exact_name_smoke";
+
+export interface SkillTriggerCase {
+  case_id: string;
+  kind: SkillTriggerCaseKind;
+  text: string;
+  source: "model" | "user" | "migrated";
+  case_hash: string;
+}
+
+export interface SkillTriggerSuite {
+  suite_id: string;
+  version: string;
+  suite_revision: number;
+  suite_digest: string;
+  session_id: string;
+  session_revision: number;
+  definition_digest: string;
+  skill_name: string;
+  state: "draft" | "confirmed";
+  cases: SkillTriggerCase[];
+  change_reason: string;
+  based_on_revision?: number | null;
+  confirmed_actor_id?: string | null;
+  confirmed_at?: number | null;
+  created_at: number;
+}
+
+export interface SkillTriggerMatchReason {
+  reason_type: string;
+  origin: string;
+  matched_terms: string[];
+}
+
+export interface SkillTriggerCompetitor {
+  candidate_id: string;
+  candidate_fingerprint: string;
+  rank: number;
+}
+
+export interface SkillTriggerDomainResult {
+  rank_top_6?: number | null;
+  rank_top_24?: number | null;
+  in_top_6: boolean;
+  in_top_24: boolean;
+  score?: number | null;
+  reasons: SkillTriggerMatchReason[];
+  competitors: SkillTriggerCompetitor[];
+}
+
+export interface SkillTriggerCaseResult {
+  case_id: string;
+  case_hash: string;
+  kind: SkillTriggerCaseKind;
+  finder: SkillTriggerDomainResult;
+  router: SkillTriggerDomainResult;
+  passed: boolean;
+}
+
+export interface SkillTriggerReceipt {
+  receipt_id: string;
+  version: string;
+  suite_id: string;
+  suite_revision: number;
+  suite_digest: string;
+  session_id: string;
+  skill_name: string;
+  description_digest: string;
+  ranker_version: string;
+  runtime_index_fingerprint: string;
+  directory_fingerprint: string;
+  trust_index_fingerprint: string;
+  candidate_fingerprint: string;
+  candidate_set_fingerprint: string;
+  passed: boolean;
+  case_results: SkillTriggerCaseResult[];
+  created_at: number;
+}
+
+export interface SkillTriggerDescriptionCandidate {
+  description: string;
+  description_digest: string;
+  receipt_id: string;
+  passed: boolean;
+  worst_positive_rank: number;
+  positive_rank_sum: number;
+  negative_safety_distance: number;
+}
+
+export interface SkillTriggerDescriptionAttempt {
+  attempt_id: string;
+  version: string;
+  revision: number;
+  digest: string;
+  session_id: string;
+  session_revision: number;
+  plan_id: string;
+  plan_revision: number;
+  plan_digest: string;
+  suite_id: string;
+  suite_revision: number;
+  suite_digest: string;
+  state: "evaluated" | "confirmed";
+  candidates: SkillTriggerDescriptionCandidate[];
+  recommended_description_digest?: string | null;
+  selected_description_digest?: string | null;
+  created_at: number;
+  confirmed_at?: number | null;
+}
+
 export interface SkillCreatorSession {
   session_id: string;
   session_revision: number;
@@ -717,6 +827,11 @@ export interface SkillCreatorSession {
   evaluation_suite?: SkillEvaluationSuite | null;
   evolution_plan?: SkillEvolutionPlan | SkillUnavailableProjection | null;
   regression_governance?: SkillRegressionGovernance | null;
+  trigger_required?: boolean;
+  trigger_suite?: SkillTriggerSuite | null;
+  trigger_attempt?: SkillTriggerDescriptionAttempt | null;
+  trigger_receipt?: SkillTriggerReceipt | null;
+  trigger_stale_reason?: string | null;
   created_at: number;
   updated_at: number;
 }
@@ -747,6 +862,10 @@ export interface SkillCreatorStatus {
   hook_manifest_version?: string | null;
   hook_result_version?: string | null;
   hook_runtimes?: string[];
+  trigger_optimization_enabled?: boolean;
+  trigger_optimization_version?: string | null;
+  trigger_optimizer_available?: boolean;
+  trigger_store_available?: boolean;
 }
 
 export interface SkillCreatorListResponse {
@@ -841,6 +960,11 @@ function unwrapSession(
         evaluation_suite?: SkillEvaluationSuite | null;
         evolution_plan?: SkillEvolutionPlan | SkillUnavailableProjection | null;
         regression_governance?: SkillRegressionGovernance | null;
+        trigger_required?: boolean;
+        trigger_suite?: SkillTriggerSuite | null;
+        trigger_attempt?: SkillTriggerDescriptionAttempt | null;
+        trigger_receipt?: SkillTriggerReceipt | null;
+        trigger_stale_reason?: string | null;
       },
 ): SkillCreatorSession {
   if (!("session" in payload)) return payload;
@@ -856,6 +980,11 @@ function unwrapSession(
     evaluation_suite: payload.evaluation_suite ?? payload.session.evaluation_suite,
     evolution_plan: payload.evolution_plan ?? payload.session.evolution_plan,
     regression_governance: payload.regression_governance ?? payload.session.regression_governance,
+    trigger_required: payload.trigger_required ?? payload.session.trigger_required,
+    trigger_suite: payload.trigger_suite ?? payload.session.trigger_suite,
+    trigger_attempt: payload.trigger_attempt ?? payload.session.trigger_attempt,
+    trigger_receipt: payload.trigger_receipt ?? payload.session.trigger_receipt,
+    trigger_stale_reason: payload.trigger_stale_reason ?? payload.session.trigger_stale_reason,
   };
 }
 
@@ -1368,6 +1497,115 @@ function resourcePlanWritePayload(session: SkillCreatorSession, plan: SkillResou
     expected_plan_revision: plan.revision,
     expected_plan_digest: plan.digest,
   };
+}
+
+function triggerSessionResponse(payload: SkillCreatorSession | {
+  session: SkillCreatorSession;
+  resource_plan?: SkillResourcePlan | null;
+  trigger_required?: boolean;
+  trigger_suite?: SkillTriggerSuite | null;
+  trigger_attempt?: SkillTriggerDescriptionAttempt | null;
+  trigger_receipt?: SkillTriggerReceipt | null;
+  trigger_stale_reason?: string | null;
+}) {
+  return unwrapSession(payload);
+}
+
+function triggerSuitePayload(session: SkillCreatorSession) {
+  const plan = session.resource_plan;
+  if (!plan) throw new Error("Resource plan is unavailable.");
+  const suite = session.trigger_suite;
+  return {
+    ...resourcePlanWritePayload(session, plan),
+    expected_suite_revision: suite?.suite_revision ?? null,
+    expected_suite_digest: suite?.suite_digest ?? null,
+  };
+}
+
+function confirmedTriggerSuitePayload(session: SkillCreatorSession) {
+  const suite = session.trigger_suite;
+  if (!suite || suite.state !== "confirmed") {
+    throw new Error("Trigger suite is not confirmed.");
+  }
+  return {
+    ...triggerSuitePayload(session),
+    suite_id: suite.suite_id,
+    expected_suite_revision: suite.suite_revision,
+    expected_suite_digest: suite.suite_digest,
+  };
+}
+
+export async function generateSkillCreatorTriggerSuite(session: SkillCreatorSession) {
+  return triggerSessionResponse(await request<Parameters<typeof triggerSessionResponse>[0]>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/trigger-suite/generate`,
+    jsonRequest("POST", triggerSuitePayload(session)),
+  ));
+}
+
+export async function saveSkillCreatorTriggerSuite(
+  session: SkillCreatorSession,
+  cases: Array<Pick<SkillTriggerCase, "kind" | "text">>,
+  changeReason: string,
+) {
+  return triggerSessionResponse(await request<Parameters<typeof triggerSessionResponse>[0]>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/trigger-suite`,
+    jsonRequest("PATCH", {
+      ...triggerSuitePayload(session),
+      cases: cases.map((item) => ({ kind: item.kind, text: item.text.trim() })),
+      change_reason: changeReason.trim(),
+    }),
+  ));
+}
+
+export async function confirmSkillCreatorTriggerSuite(session: SkillCreatorSession) {
+  const suite = session.trigger_suite;
+  if (!suite) throw new Error("Trigger suite is unavailable.");
+  return triggerSessionResponse(await request<Parameters<typeof triggerSessionResponse>[0]>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/trigger-suite/confirm`,
+    jsonRequest("POST", {
+      ...triggerSuitePayload(session),
+      suite_id: suite.suite_id,
+      expected_suite_revision: suite.suite_revision,
+      expected_suite_digest: suite.suite_digest,
+    }),
+  ));
+}
+
+export async function optimizeSkillCreatorTriggerDescriptions(session: SkillCreatorSession) {
+  return triggerSessionResponse(await request<Parameters<typeof triggerSessionResponse>[0]>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/trigger-descriptions/optimize`,
+    jsonRequest("POST", confirmedTriggerSuitePayload(session)),
+  ));
+}
+
+export async function evaluateSkillCreatorTriggerDescription(
+  session: SkillCreatorSession,
+  description: string,
+) {
+  return triggerSessionResponse(await request<Parameters<typeof triggerSessionResponse>[0]>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/trigger-descriptions/evaluate`,
+    jsonRequest("POST", {
+      ...confirmedTriggerSuitePayload(session),
+      description: description.trim(),
+    }),
+  ));
+}
+
+export async function confirmSkillCreatorTriggerDescription(
+  session: SkillCreatorSession,
+  descriptionDigest: string,
+) {
+  const attempt = session.trigger_attempt;
+  if (!attempt) throw new Error("Trigger description attempt is unavailable.");
+  return triggerSessionResponse(await request<Parameters<typeof triggerSessionResponse>[0]>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/trigger-descriptions/${encodeURIComponent(attempt.attempt_id)}/confirm`,
+    jsonRequest("POST", {
+      ...confirmedTriggerSuitePayload(session),
+      expected_attempt_revision: attempt.revision,
+      expected_attempt_digest: attempt.digest,
+      selected_description_digest: descriptionDigest,
+    }),
+  ));
 }
 
 export async function answerSkillCreatorResourcePlan(

--- a/docs/SKILL_INTEGRATION.md
+++ b/docs/SKILL_INTEGRATION.md
@@ -253,7 +253,7 @@ curl -X DELETE http://localhost:8000/api/skills/anthropics-skills-skills-pdf
 
 触发描述闭环由 `SkillTriggerSuiteV1`、`SkillTriggerReceiptV1` 和纯本地 `SkillTriggerEvaluator` 提供。验证器把 Creator 草稿作为内存中的 `workspace_draft` 候选，直接复用生产 Finder/Router 的 Top 6 与 Top 24 词典排序，不写入安装目录或全局索引；凭据绑定套件、描述、ranker 及 Runtime/Trust/目录指纹。固定私有 Trigger Optimizer 只接收 Creator 意图、冻结正反例、当前描述和有界公共竞争候选摘要，使用 `toolMode=none` 一次提出最多三个描述；模型不能提交名次、候选 ID、指纹或门禁结论。服务端逐项重跑生产排序并按最差正例名次、正例名次总和、反例安全距离、长度和摘要确定稳定推荐项。
 
-用户也可在没有模型 Key 时手工维护正反例与单行描述，再调用同一个本地验证器。主动进入该流程的 Session 必须先确认一个通过描述，随后资源计划确认、资源构建提案和 Workspace draft 安装会在服务端重新验证；资源内容变化但 Skill 名称、描述与触发套件不变时可复用确认，描述或合同变化则失效。旧 Session、既有 Creator 安装、Git、本地导入和插件不追溯阻断。`SKILL_CREATOR_TRIGGER_OPTIMIZATION_ENABLED` 在本批仍默认 `false`，因此尚不改变默认 Creator 体验；正式工作台与新 Session 默认迁移留给下一批。
+用户也可在没有模型 Key 时手工维护正反例与单行描述，再调用同一个本地验证器。新建资源化 Creator Session 默认必须先确认一个通过描述，随后资源计划确认、资源构建提案和 Workspace draft 安装都会在服务端重新验证；资源内容变化但 Skill 名称、描述与触发套件不变时可复用确认，描述或合同变化则失效。Step 2 默认只展示正例命中、反例避开与唯一下一步，Top 6/24、匹配词和竞争候选收进折叠诊断。旧 Session 只有用户主动启用时才迁移，既有 Creator 安装、Git、本地导入和插件不追溯阻断。`SKILL_CREATOR_TRIGGER_OPTIMIZATION_ENABLED=false` 可完整回退原 Creator 流程，已保存的触发 Store 数据不会删除。
 
 社区资源卡片同时显示原始来源与收录索引。安装第三方条目只会复制目录，不会在安装阶段自动执行脚本；用户仍需在激活前检查依赖、外部服务和凭据要求。
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -35,8 +35,8 @@ SKILL_CREATOR_MIDDLEWARE_V2_ENABLED=true
 SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED=true
 # 私有 Creator 默认启用可复用套件、资源级进化和跨版本回归；设为 false 可回退旧三例流程。
 SKILL_CREATOR_EVOLUTION_V2_ENABLED=true
-# 触发合同与生产排序验证器已可审计；描述优化和 Creator 门禁在后续批次接入前保持关闭。
-SKILL_CREATOR_TRIGGER_OPTIMIZATION_ENABLED=false
+# 新建资源化 Creator Session 默认执行正反例触发验证；设为 false 可完整回退，旧 Store 数据保留。
+SKILL_CREATOR_TRIGGER_OPTIMIZATION_ENABLED=true
 # 第三方 Git Skill 信任门默认 enforce：确定恶意或不可安装内容会被阻断；
 # 其余风险需确认精确凭据，可疑项不进入 Agent Router。可切回 audit 或 off 即时回退。
 SKILL_TRUST_GATE_MODE=enforce

--- a/server/main.py
+++ b/server/main.py
@@ -1944,6 +1944,9 @@ skill_creator_trigger_optimization_service = SkillCreatorTriggerOptimizationServ
     SkillTriggerEvaluator(SkillFinder(skill_manager=get_skill_manager())),
     actor_id=authoring_service.local_console_actor_id,
 )
+skill_creator_service.resource_trigger_required = (
+    skill_creator_trigger_optimization_service.enabled
+)
 skill_creator_resource_planning_service.confirmation_gate = (
     skill_creator_trigger_optimization_service.require_plan_gate
 )
@@ -1999,28 +2002,28 @@ def require_creator_trigger_proposal_approval(proposal) -> None:
         return
     if proposal.source_type != "skill_creator" or not proposal.creator_session_id:
         return
-    session = skill_creator_session_store.require(proposal.creator_session_id)
-    if not skill_trigger_optimization_store.is_required(session.session_id):
-        return
-    plan = skill_creator_resource_plan_store.current_for_session(session.session_id)
-    resource_binding = proposal.payload.get("creator_resource_build")
-    skill_payload = proposal.payload.get("skill")
-    if (
-        plan is None
-        or plan.state != "confirmed"
-        or not isinstance(resource_binding, dict)
-        or resource_binding.get("plan_id") != plan.plan_id
-        or resource_binding.get("plan_digest") != plan.digest
-        or not isinstance(skill_payload, dict)
-        or skill_payload.get("name") != plan.skill_name
-        or skill_payload.get("slug") != plan.skill_name
-        or skill_payload.get("description") != plan.skill_description
-    ):
-        raise AuthoringProposalValidationError(
-            "The Creator proposal no longer matches its trigger-gated resource plan.",
-            code="skill_trigger_receipt_stale",
-        )
     try:
+        session = skill_creator_session_store.require(proposal.creator_session_id)
+        if not skill_creator_trigger_optimization_service.requires_trigger(session):
+            return
+        plan = skill_creator_resource_plan_store.current_for_session(session.session_id)
+        resource_binding = proposal.payload.get("creator_resource_build")
+        skill_payload = proposal.payload.get("skill")
+        if (
+            plan is None
+            or plan.state != "confirmed"
+            or not isinstance(resource_binding, dict)
+            or resource_binding.get("plan_id") != plan.plan_id
+            or resource_binding.get("plan_digest") != plan.digest
+            or not isinstance(skill_payload, dict)
+            or skill_payload.get("name") != plan.skill_name
+            or skill_payload.get("slug") != plan.skill_name
+            or skill_payload.get("description") != plan.skill_description
+        ):
+            raise AuthoringProposalValidationError(
+                "The Creator proposal no longer matches its trigger-gated resource plan.",
+                code="skill_trigger_receipt_stale",
+            )
         _, draft = skill_creator_service.get_session(session.session_id)
         skill_creator_trigger_optimization_service.require_plan_gate(
             session, plan, draft

--- a/server/skills/creator_api.py
+++ b/server/skills/creator_api.py
@@ -753,7 +753,9 @@ def _session_response(
         except SkillCreatorStorageError:
             response.update(
                 {
-                    "trigger_required": False,
+                    "trigger_required": bool(
+                        getattr(session, "trigger_required", False)
+                    ),
                     "trigger_suite": None,
                     "trigger_attempt": None,
                     "trigger_receipt": None,

--- a/server/skills/creator_service.py
+++ b/server/skills/creator_service.py
@@ -126,6 +126,7 @@ class SkillCreatorService:
         enabled: bool | None = None,
         source_provider: CreatorSourceProvider | None = None,
         generation_executor: CreatorGenerationExecutor | None = None,
+        resource_trigger_required: bool = False,
     ) -> None:
         self.session_store = session_store
         self.draft_store = draft_store
@@ -138,6 +139,7 @@ class SkillCreatorService:
         )
         self.source_provider = source_provider
         self.generation_executor = generation_executor
+        self.resource_trigger_required = bool(resource_trigger_required)
         self._generation_locks_guard = threading.RLock()
         self._generation_locks: dict[str, asyncio.Lock] = {}
 
@@ -212,6 +214,9 @@ class SkillCreatorService:
                 source_conversation_id=source_conversation_id,
                 source_message_id=source_message_id,
                 authoring_flow=authoring_flow,
+                trigger_required=(
+                    self.resource_trigger_required and authoring_flow == "resource"
+                ),
             )
         return self.session_store.create(
             mode=mode,
@@ -227,6 +232,9 @@ class SkillCreatorService:
             source_conversation_id=source_conversation_id,
             source_message_id=source_message_id,
             authoring_flow=authoring_flow,
+            trigger_required=(
+                self.resource_trigger_required and authoring_flow == "resource"
+            ),
         )
 
     def create_or_get_workflow_handoff(
@@ -262,6 +270,7 @@ class SkillCreatorService:
             success_criteria=success_criteria,
             source_task_id=source.source_task_id,
             source_run_id=source.source_run_id,
+            trigger_required=self.resource_trigger_required,
         )
 
     def list_sessions(self, *, limit: int) -> list[SkillCreatorSession]:

--- a/server/skills/creator_store.py
+++ b/server/skills/creator_store.py
@@ -61,6 +61,7 @@ class SkillCreatorSession:
     mode: CreatorMode = "blank"
     assistant_agent_id: str = CREATOR_ASSISTANT_AGENT_ID
     authoring_flow: CreatorAuthoringFlow = "legacy"
+    trigger_required: bool = False
     intent: str = ""
     positive_examples: list[str] = field(default_factory=list)
     near_miss_examples: list[str] = field(default_factory=list)
@@ -99,7 +100,8 @@ class SkillCreatorSession:
 class SkillCreatorSessionStore:
     """Atomic, fail-closed persistence for recoverable Creator sessions."""
 
-    SCHEMA_VERSION = 1
+    SCHEMA_VERSION = 2
+    READABLE_SCHEMA_VERSIONS = frozenset({1, SCHEMA_VERSION})
     MAX_SESSIONS = 500
     MAX_TEXT_BYTES = 64 * 1024
 
@@ -134,6 +136,7 @@ class SkillCreatorSessionStore:
         source_conversation_id: str | None = None,
         source_message_id: str | None = None,
         authoring_flow: CreatorAuthoringFlow = "legacy",
+        trigger_required: bool = False,
     ) -> SkillCreatorSession:
         session = self._new_session(
             mode=mode,
@@ -149,6 +152,7 @@ class SkillCreatorSessionStore:
             source_conversation_id=source_conversation_id,
             source_message_id=source_message_id,
             authoring_flow=authoring_flow,
+            trigger_required=trigger_required,
         )
         with self._lock:
             self._insert_unlocked(session)
@@ -164,6 +168,7 @@ class SkillCreatorSessionStore:
         success_criteria: list[str],
         source_task_id: str,
         source_run_id: str,
+        trigger_required: bool = False,
     ) -> SkillCreatorSession:
         """Atomically create one resource-authoring session per trusted run.
 
@@ -183,6 +188,7 @@ class SkillCreatorSessionStore:
             source_task_id=source_task_id,
             source_run_id=source_run_id,
             authoring_flow="resource",
+            trigger_required=trigger_required,
         )
         with self._lock:
             self._ensure_writable_unlocked()
@@ -204,6 +210,7 @@ class SkillCreatorSessionStore:
                 if self._is_pristine_run_capture(existing):
                     previous = self._copy(existing)
                     existing.authoring_flow = "resource"
+                    existing.trigger_required = candidate.trigger_required
                     existing.intent = candidate.intent
                     existing.positive_examples = candidate.positive_examples
                     existing.near_miss_examples = candidate.near_miss_examples
@@ -239,6 +246,7 @@ class SkillCreatorSessionStore:
         source_conversation_id: str | None = None,
         source_message_id: str | None = None,
         authoring_flow: CreatorAuthoringFlow = "legacy",
+        trigger_required: bool = False,
     ) -> SkillCreatorSession:
         """Make the existing completed-run capture API idempotent by source."""
 
@@ -256,6 +264,7 @@ class SkillCreatorSessionStore:
             source_conversation_id=source_conversation_id,
             source_message_id=source_message_id,
             authoring_flow=authoring_flow,
+            trigger_required=trigger_required,
         )
         with self._lock:
             self._ensure_writable_unlocked()
@@ -296,11 +305,19 @@ class SkillCreatorSessionStore:
         source_conversation_id: str | None = None,
         source_message_id: str | None = None,
         authoring_flow: CreatorAuthoringFlow = "legacy",
+        trigger_required: bool = False,
     ) -> SkillCreatorSession:
+        if not isinstance(trigger_required, bool):
+            raise SkillCreatorValidationError("trigger_required must be boolean.")
+        if trigger_required and authoring_flow != "resource":
+            raise SkillCreatorValidationError(
+                "Only resource Creator sessions can require trigger validation."
+            )
         session = SkillCreatorSession(
             session_id=f"skillcreator_{uuid.uuid4().hex}",
             mode=self._mode(mode),
             authoring_flow=self._authoring_flow(authoring_flow),
+            trigger_required=trigger_required,
             intent=self._text(intent, "intent", maximum=8_000),
             positive_examples=self._text_list(
                 positive_examples or [], "positive_examples", maximum_items=10
@@ -401,6 +418,8 @@ class SkillCreatorSessionStore:
     def _is_pristine_run_capture(item: SkillCreatorSession) -> bool:
         return (
             item.mode == "run"
+            and item.authoring_flow == "legacy"
+            and not item.trigger_required
             and item.session_revision == 1
             and not item.intent
             and not item.positive_examples
@@ -1066,12 +1085,12 @@ class SkillCreatorSessionStore:
                 return
             if (
                 not isinstance(raw, dict)
-                or raw.get("version") != self.SCHEMA_VERSION
+                or raw.get("version") not in self.READABLE_SCHEMA_VERSIONS
                 or not isinstance(raw.get("items"), list)
             ):
                 self._load_error = "Skill Creator storage has an unsupported structure."
                 return
-            sanitized = False
+            sanitized = raw["version"] != self.SCHEMA_VERSION
             for index, record in enumerate(raw["items"]):
                 try:
                     item = self._decode_item(record)
@@ -1103,6 +1122,10 @@ class SkillCreatorSessionStore:
             raise ValueError("Creator assistant identity is immutable.")
         item.mode = self._mode(item.mode)
         item.authoring_flow = self._authoring_flow(item.authoring_flow)
+        if not isinstance(item.trigger_required, bool):
+            raise ValueError("Invalid Creator trigger requirement.")
+        if item.trigger_required and item.authoring_flow != "resource":
+            raise ValueError("Legacy Creator sessions cannot require trigger validation.")
         item.source_kind = self._source_kind(item.source_kind)
         item.quality_mode = self._quality_mode(item.quality_mode)
         item.review_state = self._review_state(item.review_state)

--- a/server/skills/creator_trigger_service.py
+++ b/server/skills/creator_trigger_service.py
@@ -24,7 +24,6 @@ from .creator_store import (
     SkillCreatorValidationError,
 )
 from .draft_store import WorkspaceSkillDraft
-from .finder import RANKER_VERSION
 from .package_validation import scan_skill_package_credentials
 from .trigger_contract import (
     SkillTriggerEvaluator,
@@ -142,6 +141,48 @@ class SkillTriggerOptimizationStore:
             attempts = [items[-1] for items in self._attempts.values() if items and items[-1].session_id == clean]
             attempts.sort(key=lambda item: (item.created_at, item.attempt_id), reverse=True)
             return copy.deepcopy(attempts[0]) if attempts else None
+
+    def current_for_scope(
+        self,
+        *,
+        session_id: str,
+        plan_id: str,
+        plan_revision: int,
+        plan_digest: str,
+        suite_id: str,
+        suite_revision: int,
+        suite_digest: str,
+    ) -> SkillTriggerDescriptionAttempt | None:
+        expected = (
+            _identifier(session_id, "session_id"),
+            _identifier(plan_id, "plan_id"),
+            int(plan_revision),
+            _digest(plan_digest, "plan_digest"),
+            _identifier(suite_id, "suite_id"),
+            int(suite_revision),
+            _digest(suite_digest, "suite_digest"),
+        )
+        with self._lock:
+            self._ensure_readable_unlocked()
+            matches = [
+                items[-1]
+                for items in self._attempts.values()
+                if items
+                and (
+                    items[-1].session_id,
+                    items[-1].plan_id,
+                    items[-1].plan_revision,
+                    items[-1].plan_digest,
+                    items[-1].suite_id,
+                    items[-1].suite_revision,
+                    items[-1].suite_digest,
+                )
+                == expected
+            ]
+            matches.sort(
+                key=lambda item: (item.created_at, item.attempt_id), reverse=True
+            )
+            return copy.deepcopy(matches[0]) if matches else None
 
     def require(self, attempt_id: str) -> SkillTriggerDescriptionAttempt:
         clean = _identifier(attempt_id, "attempt_id")
@@ -388,6 +429,17 @@ class SkillCreatorTriggerOptimizationService:
                 "Skill trigger optimization is disabled.",
                 code="skill_trigger_gate_required",
             )
+
+    def requires_trigger(self, session: SkillCreatorSession) -> bool:
+        """Resolve the atomic new-session fact before legacy opt-in state."""
+
+        if session.trigger_required:
+            return True
+        if self.optimization_store.is_required(session.session_id):
+            return True
+        if self.optimization_store.current_for_session(session.session_id) is not None:
+            return True
+        return self.trigger_store.current_for_session(session.session_id) is not None
 
     def status(self) -> dict[str, Any]:
         try:
@@ -667,7 +719,7 @@ class SkillCreatorTriggerOptimizationService:
     ) -> SkillTriggerReceiptV1 | None:
         if not self.enabled:
             return None
-        if not self.optimization_store.is_required(session.session_id):
+        if not self.requires_trigger(session):
             return None
         suite = self._current_confirmed_suite(session, skill_name=plan.skill_name)
         self._require_confirmed_description(
@@ -687,13 +739,18 @@ class SkillCreatorTriggerOptimizationService:
     def require_draft_install_gate(self, draft: WorkspaceSkillDraft) -> SkillTriggerReceiptV1 | None:
         if not self.enabled:
             return None
-        sessions = [item for item in self.creator_service.session_store.list(limit=500) if item.draft_id == draft.draft_id]
-        if not sessions:
+        if draft.creator_session_id is None:
             return None
-        if len(sessions) != 1:
-            raise SkillCreatorConflictError("Multiple Creator sessions reference this draft.")
-        session = sessions[0]
-        if not self.optimization_store.is_required(session.session_id):
+        session, bound_draft = self.creator_service.get_session(draft.creator_session_id)
+        if (
+            session.draft_id != draft.draft_id
+            or bound_draft is None
+            or bound_draft.draft_id != draft.draft_id
+        ):
+            raise SkillCreatorConflictError(
+                "The Creator draft no longer matches its owning session."
+            )
+        if not self.requires_trigger(session):
             return None
         suite = self._current_confirmed_suite(session, skill_name=draft.slug)
         plan = self.planning_service.plan_store.current_for_session(session.session_id)
@@ -755,9 +812,9 @@ class SkillCreatorTriggerOptimizationService:
                 "trigger_receipt": None,
                 "trigger_stale_reason": None,
             }
-        required = self.optimization_store.is_required(session.session_id)
+        required = self.requires_trigger(session)
         suite = self.trigger_store.current_for_session(session.session_id)
-        attempt = self.optimization_store.current_for_session(session.session_id)
+        attempt = None
         stale_reason = None
         receipt = None
         if required and suite is None:
@@ -783,26 +840,33 @@ class SkillCreatorTriggerOptimizationService:
                 )
                 if confirmation is None:
                     stale_reason = "description_unconfirmed"
-                else:
-                    candidate = next(
-                        item
-                        for item in confirmation.candidates
-                        if item.description_digest == description_digest
+                    attempt = self.optimization_store.current_for_scope(
+                        session_id=session.session_id,
+                        plan_id=plan.plan_id,
+                        plan_revision=plan.revision,
+                        plan_digest=plan.digest,
+                        suite_id=suite.suite_id,
+                        suite_revision=suite.suite_revision,
+                        suite_digest=suite.suite_digest,
                     )
-                    receipt = self.trigger_store.require_receipt(candidate.receipt_id)
-                    metadata = self.evaluator.finder.index_metadata()
-                    if (
-                        receipt.ranker_version != RANKER_VERSION
-                        or receipt.runtime_index_fingerprint
-                        != metadata["runtimeIndexFingerprint"]
-                        or receipt.directory_fingerprint
-                        != metadata["directoryFingerprint"]
-                        or receipt.trust_index_fingerprint
-                        != metadata["trustIndexFingerprint"]
-                    ):
-                        receipt = self._evaluate_and_save(
-                            suite, plan.skill_name, plan.skill_description
+                    if attempt is not None and attempt.candidates:
+                        diagnostic = next(
+                            (
+                                item
+                                for item in attempt.candidates
+                                if item.description_digest
+                                == attempt.recommended_description_digest
+                            ),
+                            attempt.candidates[0],
                         )
+                        receipt = self.trigger_store.require_receipt(
+                            diagnostic.receipt_id
+                        )
+                else:
+                    attempt = confirmation
+                    receipt = self._evaluate_and_save(
+                        suite, plan.skill_name, plan.skill_description
+                    )
                     if not receipt.passed:
                         stale_reason = "description_failed"
             except SkillCreatorError as exc:

--- a/server/skills/trigger_contract.py
+++ b/server/skills/trigger_contract.py
@@ -151,7 +151,7 @@ class SkillTriggerReceiptV1:
 
 
 def trigger_optimization_enabled() -> bool:
-    return os.getenv("SKILL_CREATOR_TRIGGER_OPTIMIZATION_ENABLED", "false").strip().lower() in {
+    return os.getenv("SKILL_CREATOR_TRIGGER_OPTIMIZATION_ENABLED", "true").strip().lower() in {
         "1",
         "true",
         "yes",
@@ -725,8 +725,11 @@ def _evaluate_domain(
     target_id: str,
     router: bool,
 ) -> SkillTriggerDomainResult:
-    top_6 = finder.find(query, limit=MAX_RESULTS, router_eligible_only=router)["results"]
     top_24 = finder.recall(query, limit=MAX_RECALL_RESULTS, router_eligible_only=router)["results"]
+    # Finder and recall share the same stable production ranker; the public
+    # Top 6 window is the prefix of the diagnostic Top 24 window. Reusing the
+    # single ranking pass avoids doubling every suite evaluation.
+    top_6 = top_24[:MAX_RESULTS]
     top_6_rank = next((index for index, item in enumerate(top_6, 1) if item["candidateId"] == target_id), None)
     top_24_rank = next((index for index, item in enumerate(top_24, 1) if item["candidateId"] == target_id), None)
     target = next((item for item in top_24 if item["candidateId"] == target_id), None)

--- a/server/tests/test_skill_creator_sessions.py
+++ b/server/tests/test_skill_creator_sessions.py
@@ -187,6 +187,155 @@ def _confirm_blank_evidence(service: SkillCreatorService, session):
     )
 
 
+def test_resource_trigger_requirement_is_atomic_without_secondary_store(
+    tmp_path: Path,
+) -> None:
+    creator, _authoring, _drafts = _services(tmp_path)
+    creator.resource_trigger_required = True
+
+    created = creator.create_session(
+        mode="blank",
+        intent="Create a reusable checklist.",
+        positive_examples=[],
+        near_miss_examples=[],
+        expected_output="",
+        success_criteria=[],
+        authoring_flow="resource",
+    )
+    restored = SkillCreatorSessionStore(
+        creator.session_store.storage_dir
+    ).require(created.session_id)
+
+    assert restored.trigger_required is True
+    assert restored.authoring_flow == "resource"
+
+
+def test_resource_trigger_requirement_is_atomic_for_runtime_sources(
+    tmp_path: Path,
+) -> None:
+    creator, _authoring, _drafts = _services(tmp_path)
+    creator.source_provider = SimpleNamespace(validate_source=lambda _source: None)
+    creator.resource_trigger_required = True
+    definition = {
+        "intent": "Turn a completed run into a reusable review.",
+        "positive_examples": ["Review the completed workflow output."],
+        "near_miss_examples": ["Rewrite unrelated prose."],
+        "expected_output": "A bounded review.",
+        "success_criteria": ["Do not invent evidence."],
+    }
+
+    captured = creator.create_session(
+        mode="run",
+        source_kind="workflow_classic",
+        source_task_id="task-atomic-capture",
+        source_run_id="run-atomic-capture",
+        authoring_flow="resource",
+        **definition,
+    )
+    captured_again = creator.create_session(
+        mode="run",
+        source_kind="workflow_classic",
+        source_task_id="task-atomic-capture",
+        source_run_id="run-atomic-capture",
+        authoring_flow="resource",
+        **definition,
+    )
+    handed_off = creator.create_or_get_workflow_handoff(
+        source_task_id="task-atomic-handoff",
+        source_run_id="run-atomic-handoff",
+        **definition,
+    )
+    handed_off_again = creator.create_or_get_workflow_handoff(
+        source_task_id="task-atomic-handoff",
+        source_run_id="run-atomic-handoff",
+        **definition,
+    )
+
+    assert captured_again.session_id == captured.session_id
+    assert handed_off_again.session_id == handed_off.session_id
+    assert captured.trigger_required is True
+    assert handed_off.trigger_required is True
+
+
+def test_invalid_persisted_trigger_requirement_is_quarantined(tmp_path: Path) -> None:
+    store = SkillCreatorSessionStore(tmp_path / "sessions")
+    created = store.create(
+        intent="Create a reusable checklist.",
+        authoring_flow="resource",
+        trigger_required=True,
+    )
+    payload = json.loads(store.snapshot_path.read_text(encoding="utf-8"))
+    payload["items"][0]["trigger_required"] = "false"
+    store.snapshot_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    restored = SkillCreatorSessionStore(tmp_path / "sessions")
+    assert restored.list() == []
+    assert restored.list_quarantined()[0]["reason_code"] == "blocked_or_invalid_session"
+    with pytest.raises(SkillCreatorValidationError):
+        store.create(
+            intent="Invalid legacy requirement.",
+            authoring_flow="legacy",
+            trigger_required=True,
+        )
+    assert created.trigger_required is True
+
+
+def test_workflow_handoff_cannot_downgrade_existing_required_resource_session(
+    tmp_path: Path,
+) -> None:
+    creator, _authoring, _drafts = _services(tmp_path)
+    creator.source_provider = SimpleNamespace(validate_source=lambda _source: None)
+    creator.resource_trigger_required = True
+    existing = creator.create_session(
+        mode="run",
+        source_kind="workflow_classic",
+        source_task_id="task-required-empty",
+        source_run_id="run-required-empty",
+        intent="",
+        positive_examples=[],
+        near_miss_examples=[],
+        expected_output="",
+        success_criteria=[],
+        authoring_flow="resource",
+    )
+    creator.resource_trigger_required = False
+
+    with pytest.raises(SkillCreatorConflictError):
+        creator.create_or_get_workflow_handoff(
+            source_task_id="task-required-empty",
+            source_run_id="run-required-empty",
+            intent="Turn the run into a reusable review.",
+            positive_examples=["Review the completed workflow output."],
+            near_miss_examples=["Rewrite unrelated prose."],
+            expected_output="A bounded review.",
+            success_criteria=["Do not invent evidence."],
+        )
+
+    restored = creator.session_store.require(existing.session_id)
+    assert restored.authoring_flow == "resource"
+    assert restored.trigger_required is True
+
+
+def test_disabled_trigger_feature_persists_no_requirement_on_new_resource_session(
+    tmp_path: Path,
+) -> None:
+    creator, _authoring, _drafts = _services(tmp_path)
+    creator.resource_trigger_required = False
+
+    created = creator.create_session(
+        mode="blank",
+        intent="Create a reusable checklist.",
+        positive_examples=[],
+        near_miss_examples=[],
+        expected_output="",
+        success_criteria=[],
+        authoring_flow="resource",
+    )
+
+    assert created.authoring_flow == "resource"
+    assert created.trigger_required is False
+
+
 def test_session_store_is_atomic_fail_closed_and_secret_safe(tmp_path: Path) -> None:
     store = SkillCreatorSessionStore(tmp_path / "sessions")
     session = store.create(intent="Draft a reusable review workflow.")
@@ -224,6 +373,37 @@ def test_session_store_is_atomic_fail_closed_and_secret_safe(tmp_path: Path) -> 
     with pytest.raises(SkillCreatorStorageError):
         corrupt.create(intent="must not overwrite")
     assert (corrupt_dir / "skill_creator_sessions.json").read_text() == "{not-json"
+
+
+def test_session_store_migrates_v1_and_preserves_unknown_schema_snapshot(
+    tmp_path: Path,
+) -> None:
+    storage_dir = tmp_path / "schema-migration"
+    store = SkillCreatorSessionStore(storage_dir)
+    created = store.create(
+        intent="Draft a reusable review workflow.",
+        authoring_flow="resource",
+    )
+    payload = json.loads(store.snapshot_path.read_text(encoding="utf-8"))
+    payload["version"] = 1
+    payload["items"][0].pop("trigger_required")
+    store.snapshot_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    migrated = SkillCreatorSessionStore(storage_dir)
+
+    assert migrated.require(created.session_id).trigger_required is False
+    migrated_payload = json.loads(store.snapshot_path.read_text(encoding="utf-8"))
+    assert migrated_payload["version"] == SkillCreatorSessionStore.SCHEMA_VERSION
+    assert migrated_payload["items"][0]["trigger_required"] is False
+
+    unsupported = {**migrated_payload, "version": 999}
+    unsupported_bytes = json.dumps(unsupported).encode("utf-8")
+    store.snapshot_path.write_bytes(unsupported_bytes)
+    future = SkillCreatorSessionStore(storage_dir)
+
+    with pytest.raises(SkillCreatorStorageError):
+        future.list()
+    assert store.snapshot_path.read_bytes() == unsupported_bytes
 
 
 def test_legacy_session_resource_authoring_opt_in_is_explicit_and_durable(

--- a/server/tests/test_skill_trigger_contract.py
+++ b/server/tests/test_skill_trigger_contract.py
@@ -97,11 +97,11 @@ def confirmed_suite(store: SkillTriggerStore, *, session_id: str = "session-one"
     )
 
 
-def test_trigger_flag_defaults_off(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_trigger_flag_defaults_on_with_explicit_rollback(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("SKILL_CREATOR_TRIGGER_OPTIMIZATION_ENABLED", raising=False)
-    assert trigger_optimization_enabled() is False
-    monkeypatch.setenv("SKILL_CREATOR_TRIGGER_OPTIMIZATION_ENABLED", "true")
     assert trigger_optimization_enabled() is True
+    monkeypatch.setenv("SKILL_CREATOR_TRIGGER_OPTIMIZATION_ENABLED", "false")
+    assert trigger_optimization_enabled() is False
 
 
 @pytest.mark.parametrize(
@@ -389,6 +389,42 @@ def test_evaluator_uses_production_finder_and_router_windows(tmp_path: Path) -> 
     with pytest.raises(SkillTriggerNotFoundError):
         non_finite.require_receipt(stored.receipt_id)
     assert non_finite.status()["quarantine_count"] == 3
+
+
+def test_evaluator_uses_one_ranking_pass_per_case_and_domain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SkillTriggerStore(tmp_path)
+    suite = confirmed_suite(store)
+    evaluator = SkillTriggerEvaluator(
+        SkillFinder(index_path=INDEX_PATH, skill_manager=StubSkillManager())
+    )
+    recall_calls: list[tuple[str, bool]] = []
+    original_recall = SkillFinder.recall
+
+    def counting_recall(self, query, *, limit=24, router_eligible_only=False):
+        recall_calls.append((query, router_eligible_only))
+        return original_recall(
+            self,
+            query,
+            limit=limit,
+            router_eligible_only=router_eligible_only,
+        )
+
+    monkeypatch.setattr(SkillFinder, "recall", counting_recall)
+    evaluator.evaluate(
+        suite=suite,
+        skill_id="incident-timeline-guide",
+        skill_name=SKILL_NAME,
+        description=DESCRIPTION,
+    )
+
+    assert recall_calls == [
+        (case.text, router)
+        for case in suite.cases
+        for router in (False, True)
+    ]
 
 
 def test_evaluator_exposes_top_24_diagnostics_without_weakening_top_6_gate(

--- a/server/tests/test_skill_trigger_optimizer.py
+++ b/server/tests/test_skill_trigger_optimizer.py
@@ -13,8 +13,12 @@ from server.skills import api as skills_api
 from server.skills import creator_api
 from server.skills.creator_resource_plan import SkillResourcePlanStore
 from server.skills.creator_resource_service import SkillCreatorResourcePlanningService
+from server.skills.creator_service import SkillCreatorService
 from server.skills.creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorNotFoundError,
     SkillCreatorSession,
+    SkillCreatorSessionStore,
     SkillCreatorStorageError,
     SkillCreatorValidationError,
 )
@@ -31,7 +35,7 @@ from server.skills.creator_trigger_service import (
     validate_trigger_description,
 )
 from server.skills.finder import SkillFinder
-from server.skills.skill_manager import SkillManager, SkillValidationError
+from server.skills.skill_manager import InstalledSkill, SkillManager, SkillValidationError
 from server.skills.trigger_contract import SkillTriggerEvaluator, SkillTriggerStore
 from server.xpert_runtime.authoring_service import AuthoringService
 from server.xpert_runtime.authoring_store import (
@@ -102,8 +106,11 @@ def plan_payload(description: str = "整理事故信息并输出报告，普通�
 
 
 class StubSkillManager:
+    def __init__(self) -> None:
+        self.installed: list[InstalledSkill] = []
+
     def list_installed_skills(self):
-        return []
+        return list(self.installed)
 
 
 class StubSessionStore:
@@ -117,11 +124,12 @@ class StubSessionStore:
 class StubCreatorService:
     def __init__(self, session: SkillCreatorSession) -> None:
         self.session = session
+        self.draft = None
         self.session_store = StubSessionStore(session)
 
     def get_session(self, session_id: str):
         assert session_id == self.session.session_id
-        return self.session, None
+        return self.session, self.draft
 
     @staticmethod
     def require_enabled() -> None:
@@ -241,6 +249,9 @@ async def test_suite_optimize_confirm_and_plan_gate_form_one_closed_loop(tmp_pat
     assert len(attempt.candidates) == 1
     assert attempt.candidates[0].passed is True
     assert attempt.recommended_description_digest == attempt.candidates[0].description_digest
+    diagnostic_projection = service.projection(session, plan)
+    assert diagnostic_projection["trigger_stale_reason"] == "description_unconfirmed"
+    assert diagnostic_projection["trigger_receipt"]["receipt_id"] == attempt.candidates[0].receipt_id
 
     confirmed, updated_plan = service.confirm_description(
         session.session_id,
@@ -259,14 +270,55 @@ async def test_suite_optimize_confirm_and_plan_gate_form_one_closed_loop(tmp_pat
     assert updated_plan.skill_description == PASSING_DESCRIPTION
     assert service.require_plan_gate(session, updated_plan).passed is True
     session.draft_id = "skilldraft-trigger-test"
+    draft = SimpleNamespace(
+        draft_id=session.draft_id,
+        creator_session_id=session.session_id,
+        slug=SKILL_NAME,
+        description=PASSING_DESCRIPTION,
+    )
+    service.creator_service.draft = draft  # type: ignore[attr-defined]
     install_receipt = service.require_draft_install_gate(
-        SimpleNamespace(
-            draft_id=session.draft_id,
-            slug=SKILL_NAME,
-            description=PASSING_DESCRIPTION,
-        )
+        draft
     )
     assert install_receipt is not None and install_receipt.passed is True
+    service.creator_service.draft = None  # type: ignore[attr-defined]
+    later_attempt = service.evaluate_description(
+        session.session_id,
+        description="将任意输入原样返回，不执行分析或报告。",
+        expected_session_revision=session.session_revision,
+        plan_id=updated_plan.plan_id,
+        expected_plan_revision=updated_plan.revision,
+        expected_plan_digest=updated_plan.digest,
+        expected_suite_revision=suite.suite_revision,
+        expected_suite_digest=suite.suite_digest,
+    )
+    assert later_attempt.created_at >= confirmed.created_at
+    stable_projection = service.projection(session, updated_plan)
+    assert stable_projection["trigger_attempt"]["attempt_id"] == confirmed.attempt_id
+    assert stable_projection["trigger_receipt"]["passed"] is True
+    assert stable_projection["trigger_stale_reason"] is None
+
+    old_receipt_id = stable_projection["trigger_receipt"]["receipt_id"]
+    manager = service.evaluator.finder.skill_manager
+    assert isinstance(manager, StubSkillManager)
+    manager.installed.append(
+        InstalledSkill(
+            skill_id="unrelated-release-notes",
+            name="unrelated-release-notes",
+            description="Format product release notes without incident analysis.",
+            repo_url="workspace://draft/unrelated-release-notes",
+            sub_path="unrelated-release-notes",
+            installed_at=0.0,
+            source_kind="workspace_draft",
+            source_id="unrelated-session",
+            content_digest="1" * 64,
+            package_subpath="unrelated-release-notes",
+        )
+    )
+    refreshed_projection = service.projection(session, updated_plan)
+    assert refreshed_projection["trigger_receipt"]["receipt_id"] != old_receipt_id
+    assert refreshed_projection["trigger_receipt"]["passed"] is True
+    assert refreshed_projection["trigger_stale_reason"] is None
     assert executor.suite_context == {
         "session_id": session.session_id,
         "skill_name": SKILL_NAME,
@@ -354,6 +406,83 @@ def test_manual_path_requires_confirmation_but_reuses_it_after_resource_only_cha
     assert stale.value.code == "skill_trigger_gate_required"
 
 
+def test_projection_drops_attempt_from_superseded_suite(tmp_path: Path) -> None:
+    service, session, plan = make_service(tmp_path)
+    draft_suite = service.save_suite(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        plan_id=plan.plan_id,
+        expected_plan_revision=plan.revision,
+        expected_plan_digest=plan.digest,
+        cases=trigger_cases(),
+        expected_suite_revision=None,
+        expected_suite_digest=None,
+        change_reason="Initial trigger boundary.",
+    )
+    suite = service.confirm_suite(
+        session.session_id,
+        suite_id=draft_suite.suite_id,
+        expected_session_revision=session.session_revision,
+        plan_id=plan.plan_id,
+        expected_plan_revision=plan.revision,
+        expected_plan_digest=plan.digest,
+        expected_suite_revision=draft_suite.suite_revision,
+        expected_suite_digest=draft_suite.suite_digest,
+    )
+    attempt = service.evaluate_description(
+        session.session_id,
+        description=PASSING_DESCRIPTION,
+        expected_session_revision=session.session_revision,
+        plan_id=plan.plan_id,
+        expected_plan_revision=plan.revision,
+        expected_plan_digest=plan.digest,
+        expected_suite_revision=suite.suite_revision,
+        expected_suite_digest=suite.suite_digest,
+    )
+    _confirmed_attempt, current_plan = service.confirm_description(
+        session.session_id,
+        attempt_id=attempt.attempt_id,
+        selected_description_digest=attempt.candidates[0].description_digest,
+        expected_attempt_revision=attempt.revision,
+        expected_attempt_digest=attempt.digest,
+        expected_session_revision=session.session_revision,
+        plan_id=plan.plan_id,
+        expected_plan_revision=plan.revision,
+        expected_plan_digest=plan.digest,
+        expected_suite_revision=suite.suite_revision,
+        expected_suite_digest=suite.suite_digest,
+    )
+
+    session.intent = "根据故障记录生成复盘，并明确标注待确认事实"
+    revised_suite = service.save_suite(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        plan_id=current_plan.plan_id,
+        expected_plan_revision=current_plan.revision,
+        expected_plan_digest=current_plan.digest,
+        cases=trigger_cases(),
+        expected_suite_revision=suite.suite_revision,
+        expected_suite_digest=suite.suite_digest,
+        change_reason="The Creator intent changed.",
+    )
+    confirmed_revision = service.confirm_suite(
+        session.session_id,
+        suite_id=revised_suite.suite_id,
+        expected_session_revision=session.session_revision,
+        plan_id=current_plan.plan_id,
+        expected_plan_revision=current_plan.revision,
+        expected_plan_digest=current_plan.digest,
+        expected_suite_revision=revised_suite.suite_revision,
+        expected_suite_digest=revised_suite.suite_digest,
+    )
+
+    projection = service.projection(session, current_plan)
+    assert projection["trigger_suite"]["suite_revision"] == confirmed_revision.suite_revision
+    assert projection["trigger_attempt"] is None
+    assert projection["trigger_receipt"] is None
+    assert projection["trigger_stale_reason"] == "description_unconfirmed"
+
+
 def test_failed_description_has_no_recommendation_and_cannot_change_plan(tmp_path: Path) -> None:
     service, session, plan = make_service(tmp_path)
     draft_suite = service.save_suite(
@@ -409,6 +538,7 @@ def test_failed_description_has_no_recommendation_and_cannot_change_plan(tmp_pat
 
 def test_disabled_flag_bypasses_existing_required_session_without_deleting_state(tmp_path: Path) -> None:
     service, session, plan = make_service(tmp_path)
+    session.trigger_required = True
     service.optimization_store.mark_required(session.session_id)
     session.draft_id = "skilldraft-trigger-disabled"
     service.enabled = False
@@ -428,7 +558,92 @@ def test_disabled_flag_bypasses_existing_required_session_without_deleting_state
         "trigger_receipt": None,
         "trigger_stale_reason": None,
     }
+    assert session.trigger_required is True
     assert service.optimization_store.is_required(session.session_id) is True
+    service.enabled = True
+    assert service.requires_trigger(session) is True
+
+
+def test_install_gate_rejects_mismatched_creator_session_binding(tmp_path: Path) -> None:
+    service, session, _plan = make_service(tmp_path)
+    session.trigger_required = True
+    session.draft_id = "skilldraft-owned"
+    service.creator_service.draft = SimpleNamespace(  # type: ignore[attr-defined]
+        draft_id="skilldraft-owned",
+    )
+    mismatched = SimpleNamespace(
+        draft_id="skilldraft-other",
+        creator_session_id=session.session_id,
+        slug=SKILL_NAME,
+        description=PASSING_DESCRIPTION,
+    )
+
+    with pytest.raises(SkillCreatorConflictError):
+        service.require_draft_install_gate(mismatched)
+
+
+def test_non_creator_install_bypasses_trigger_gate_even_when_store_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    service, _session, _plan = make_service(tmp_path)
+    service.optimization_store.storage_dir.mkdir(parents=True, exist_ok=True)
+    service.optimization_store.snapshot_path.write_text("{broken", encoding="utf-8")
+    service.optimization_store = SkillTriggerOptimizationStore(
+        service.optimization_store.storage_dir
+    )
+
+    assert service.require_draft_install_gate(
+        SimpleNamespace(
+            draft_id="skilldraft-non-creator",
+            creator_session_id=None,
+            slug=SKILL_NAME,
+            description=PASSING_DESCRIPTION,
+        )
+    ) is None
+
+
+def test_missing_creator_session_blocks_install_before_trust_evaluation(
+    tmp_path: Path,
+) -> None:
+    runtime_dir = tmp_path / "runtime"
+    drafts = WorkspaceSkillDraftStore(runtime_dir)
+    authoring = AuthoringService(
+        AuthoringProposalStore(runtime_dir),
+        XpertStore(tmp_path / "xperts"),
+        drafts,
+        local_console_actor_id="console-test",
+    )
+    creator = SkillCreatorService(
+        SkillCreatorSessionStore(runtime_dir),
+        drafts,
+        authoring,
+        enabled=True,
+    )
+    service, _session, _plan = make_service(tmp_path / "trigger-service")
+    service.creator_service = creator
+
+    with pytest.raises(SkillCreatorNotFoundError):
+        service.require_draft_install_gate(
+            SimpleNamespace(
+                draft_id="skilldraft-missing-owner",
+                creator_session_id="skillcreator_missing_owner",
+                slug=SKILL_NAME,
+                description=PASSING_DESCRIPTION,
+            )
+        )
+
+
+def test_atomic_session_requirement_cannot_be_bypassed_by_missing_marker(
+    tmp_path: Path,
+) -> None:
+    service, session, plan = make_service(tmp_path)
+    session.trigger_required = True
+
+    assert service.optimization_store.is_required(session.session_id) is False
+    assert service.requires_trigger(session) is True
+    with pytest.raises(SkillCreatorValidationError) as blocked:
+        service.require_plan_gate(session, plan)
+    assert blocked.value.code == "skill_trigger_suite_required"
 
 
 def test_resource_plan_confirmation_calls_server_gate_before_state_change(tmp_path: Path) -> None:
@@ -550,6 +765,102 @@ def test_description_validation_rejects_injection_secrets_and_keyword_stuffing(d
     with pytest.raises(SkillCreatorValidationError) as error:
         validate_trigger_description(description)
     assert error.value.code == "skill_trigger_description_invalid"
+
+
+def test_corrupt_optimization_store_cannot_rollback_atomic_session_or_open_gate(
+    tmp_path: Path,
+) -> None:
+    runtime_dir = tmp_path / "runtime"
+    drafts = WorkspaceSkillDraftStore(runtime_dir)
+    authoring = AuthoringService(
+        AuthoringProposalStore(runtime_dir),
+        XpertStore(tmp_path / "xperts"),
+        drafts,
+        local_console_actor_id="console-test",
+    )
+    creator = SkillCreatorService(
+        SkillCreatorSessionStore(runtime_dir),
+        drafts,
+        authoring,
+        enabled=True,
+        resource_trigger_required=True,
+    )
+    session = creator.create_session(
+        mode="blank",
+        intent="根据软件故障记录生成无责事故复盘",
+        positive_examples=["线上故障时间线"],
+        near_miss_examples=["普通摘要"],
+        expected_output="一份有证据边界的事故复盘",
+        success_criteria=["不编造缺失事实"],
+        authoring_flow="resource",
+    )
+    plan_store = SkillResourcePlanStore(tmp_path / "plans")
+    plan = plan_store.save_generated(
+        session_id=session.session_id,
+        session_revision=session.session_revision,
+        draft_id=None,
+        draft_revision=None,
+        draft_digest=None,
+        payload=plan_payload(),
+        allowed_source_ids=SOURCE_IDS,
+    )
+    trigger_store = SkillTriggerStore(tmp_path / "triggers")
+    optimization_store = SkillTriggerOptimizationStore(tmp_path / "attempts")
+    service = SkillCreatorTriggerOptimizationService(
+        creator,
+        StubPlanningService(plan_store),  # type: ignore[arg-type]
+        trigger_store,
+        optimization_store,
+        SkillTriggerEvaluator(
+            SkillFinder(index_path=INDEX_PATH, skill_manager=StubSkillManager())
+        ),
+        actor_id="local-console-instance",
+        enabled=True,
+    )
+    draft_suite = service.save_suite(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        plan_id=plan.plan_id,
+        expected_plan_revision=plan.revision,
+        expected_plan_digest=plan.digest,
+        cases=trigger_cases(),
+        expected_suite_revision=None,
+        expected_suite_digest=None,
+        change_reason="Define deterministic trigger boundaries.",
+    )
+    service.confirm_suite(
+        session.session_id,
+        suite_id=draft_suite.suite_id,
+        expected_session_revision=session.session_revision,
+        plan_id=plan.plan_id,
+        expected_plan_revision=plan.revision,
+        expected_plan_digest=plan.digest,
+        expected_suite_revision=draft_suite.suite_revision,
+        expected_suite_digest=draft_suite.suite_digest,
+    )
+
+    optimization_store.snapshot_path.write_text("{broken", encoding="utf-8")
+    service.optimization_store = SkillTriggerOptimizationStore(
+        optimization_store.storage_dir
+    )
+    survivor = creator.create_session(
+        mode="blank",
+        intent="Create another reusable checklist.",
+        positive_examples=[],
+        near_miss_examples=[],
+        expected_output="",
+        success_criteria=[],
+        authoring_flow="resource",
+    )
+
+    assert survivor.trigger_required is True
+    assert creator.session_store.require(survivor.session_id).trigger_required is True
+    assert service.status()["optimization_store"]["available"] is False
+    projection = service.projection(session, plan)
+    assert projection["trigger_required"] is True
+    assert projection["trigger_stale_reason"] == "skill_trigger_index_unavailable"
+    with pytest.raises(SkillCreatorStorageError):
+        service.require_plan_gate(session, plan)
 
 
 def test_optimization_store_fails_closed_on_top_level_corruption(tmp_path: Path) -> None:


### PR DESCRIPTION
## 摘要

- 新建资源化 Creator Session 默认启用 should-trigger / should-not-trigger 触发门，旧 Session 仅主动迁移后启用。
- 在 Step 2 提供正反例生成、无 Key 手工路径、描述优化与生产 Finder/Router 本地验证，并投影结构化恢复状态。
- 资源计划确认、提案与安装继续由服务端重新验证触发凭据；目录或排序变化失败关闭，既有安装不追溯阻断。
- 将 trigger_required 原子持久化到 Creator Session，并升级 Store schema v2，兼容迁移 v1且保证旧二进制回滚失败关闭。
- 修复未保存计划与触发编辑并行时的静默覆盖和输入重置；默认开关改为启用，保留 false 即时回退。

## 验证

- 前端完整 Vitest：107 files / 605 tests passed（固定 4 workers）。
- Trigger/Resource Plan 组件回归：22 passed。
- 后端 Creator/Trigger/Middleware 回归：71 passed。
- Resource Build、Evaluation/Evolution、Lifecycle、Finder/Router、Semantic、Hook 与集成回归：138 passed。
- npm.cmd run build 通过；仅保留仓库既有大 chunk 告警。
- 独立预览 client 15201 与 server 18201 均返回 200；未重建或重启共享 Docker。

## 回退与边界

- 设置 SKILL_CREATOR_TRIGGER_OPTIMIZATION_ENABLED=false 可恢复原 Creator 流程，已保存的 Trigger Store 数据保留。
- Git、本地导入、插件、既有 Creator 安装与旧 Session 不受追溯门禁影响。
- 最终微调后的自动浏览器刷新受本地 URL 安全策略限制；组件回归与生产构建已覆盖，独立预览进程保持可用。