### PR TITLE
feature: R6D 统一 Classic Workflow Managed Provider 控制面

### DIFF
--- a/client/src/components/meta/ProviderRouteReceiptSummary.test.tsx
+++ b/client/src/components/meta/ProviderRouteReceiptSummary.test.tsx
@@ -75,4 +75,34 @@ describe("ProviderRouteReceiptSummary", () => {
     expect(screen.getByText("未派发")).toBeInTheDocument();
     expect(screen.queryByText("调用 1")).not.toBeInTheDocument();
   });
+
+  it("renders a compact workflow-safe summary without internal evidence", () => {
+    render(
+      <ProviderRouteReceiptSummary
+        compact
+        receipt={{
+          contract_version: "modelmirror-provider-workload-routing-v1",
+          entry_id: "workflow_interactive_llm",
+          routing_mode: "managed_required",
+          run_reference: "workrun_internal_reference",
+          status: "failed",
+          call_count: 0,
+          reason_codes: ["provider_workload_binding_missing"],
+          calls: [{
+            call_sequence: 1,
+            model_id: "provider/unbound-model",
+            dispatched: false,
+            status: "failed",
+            error_code: "provider_workload_binding_missing",
+          }],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("发送前已阻断")).toBeInTheDocument();
+    expect(screen.getByText("调用 1")).toBeInTheDocument();
+    expect(screen.getByText("provider/unbound-model")).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain("workrun_internal_reference");
+    expect(document.body.textContent).not.toContain("provider_workload_binding_missing");
+  });
 });

--- a/client/src/components/meta/ProviderRouteReceiptSummary.tsx
+++ b/client/src/components/meta/ProviderRouteReceiptSummary.tsx
@@ -1,25 +1,9 @@
-export interface ProviderRouteCallReceipt {
-  call_sequence: number;
-  model_id: string;
-  actual_model?: string | null;
-  dispatched?: boolean;
-  status: "passed" | "failed" | "uncertain" | "cancelled";
-  error_code?: string | null;
-  prompt_tokens?: number | null;
-  completion_tokens?: number | null;
-  total_tokens?: number | null;
-}
+import type {
+  ProviderRouteCallReceipt,
+  ProviderRouteReceipt,
+} from "../../types/workflow";
 
-export interface ProviderRouteReceipt {
-  contract_version: string;
-  entry_id: "meta_agent";
-  routing_mode: "managed_required";
-  run_reference: string;
-  status: "running" | "passed" | "failed" | "uncertain" | "cancelled";
-  call_count: number;
-  reason_codes: string[];
-  calls: ProviderRouteCallReceipt[];
-}
+export type { ProviderRouteCallReceipt, ProviderRouteReceipt } from "../../types/workflow";
 
 const statusLabels: Record<ProviderRouteReceipt["status"], string> = {
   running: "调用中",
@@ -45,8 +29,10 @@ function statusClass(status: ProviderRouteReceipt["status"]) {
 
 export default function ProviderRouteReceiptSummary({
   receipt,
+  compact = false,
 }: {
   receipt: ProviderRouteReceipt | null | undefined;
+  compact?: boolean;
 }) {
   if (!receipt) return null;
   const modelCount = new Set(
@@ -54,6 +40,31 @@ export default function ProviderRouteReceiptSummary({
       .filter((call) => call.dispatched !== false)
       .map((call) => call.model_id),
   ).size;
+
+  if (compact) {
+    const summaryLabel = receipt.call_count === 0 && receipt.status === "failed"
+      ? "发送前已阻断"
+      : statusLabels[receipt.status];
+    return (
+      <div className="rounded-md border border-white/10 bg-slate-950/35 px-2.5 py-2 text-[11px] text-slate-300">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className={`rounded-full border px-2 py-0.5 font-semibold ${statusClass(receipt.status)}`}>
+            {summaryLabel}
+          </span>
+          {receipt.calls.map((call) => (
+            <span className="flex min-w-0 items-center gap-1.5" key={`${call.call_sequence}-${call.model_id}`}>
+              <span>调用 {call.call_sequence}</span>
+              <span className="max-w-48 truncate font-mono text-[10px] text-slate-400">
+                {call.model_id}
+              </span>
+              <span>{callStatusLabels[call.status]}</span>
+              {call.total_tokens != null ? <span className="text-slate-500">{call.total_tokens} tokens</span> : null}
+            </span>
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <details className="rounded-lg border border-white/10 bg-white/[0.035] text-xs text-slate-300">

--- a/client/src/components/settings/ProviderWorkloadControlSettings.test.tsx
+++ b/client/src/components/settings/ProviderWorkloadControlSettings.test.tsx
@@ -218,4 +218,65 @@ describe("ProviderWorkloadControlSettings", () => {
     });
     await screen.findByText("Managed 必经");
   });
+
+  it("keeps connection and call evidence in the authenticated settings view", async () => {
+    const policy = {
+      contract_version: "modelmirror-provider-workload-routing-v1",
+      entry_id: "workflow_interactive_llm",
+      feature_enabled: true,
+      data_plane_integrated: true,
+      configured_status: "managed_required",
+      effective_status: "managed_required",
+      revision: 2,
+      policy_fingerprint: "fingerprint",
+      bindings: [],
+      approval_valid: true,
+      blocking_reason_codes: [],
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/router/workload-control/policies") {
+        return jsonResponse({ policies: [policy] });
+      }
+      if (url === "/api/router/connections") return jsonResponse([connection]);
+      if (url.startsWith("/api/router/workload-control/receipts")) {
+        return jsonResponse({ runs: [{
+          run_id: "workrun-1",
+          entry_id: "workflow_interactive_llm",
+          status: "passed",
+          parent_run_reference: "interactive:task-1:node-1",
+          result_class: "workflow_node_passed",
+          reason_codes: [],
+          created_at: "2026-08-23T00:00:00Z",
+          calls: [{
+            call_id: "call-1",
+            execution_shape: "chat_text",
+            model_id: "openai/gpt-test",
+            actual_model: "openai/gpt-test",
+            connection_id: "connection-internal-ref",
+            call_sequence: 1,
+            dispatched: true,
+            status: "passed",
+            result_class: "provider_workload_success",
+            ttft_ms: 125,
+            e2e_ms: 480,
+            total_tokens: 17,
+          }],
+        }] });
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ProviderWorkloadControlSettings csrfToken="csrf-value" view="routing" />);
+    await screen.findByText("R6 入口、精确 Binding 与 Receipt");
+    fireEvent.click(screen.getByText("Workflow 交互 LLM · passed"));
+
+    expect(screen.getByText("请求模型：openai/gpt-test")).toBeInTheDocument();
+    expect(screen.getByText("连接引用：connection-internal-ref")).toBeInTheDocument();
+    expect(screen.getByText("TTFT 125 ms")).toBeInTheDocument();
+    expect(screen.getByText("17 tokens")).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain("private prompt");
+    expect(document.body.textContent).not.toContain("api_key");
+  });
 });

--- a/client/src/components/settings/ProviderWorkloadControlSettings.tsx
+++ b/client/src/components/settings/ProviderWorkloadControlSettings.tsx
@@ -85,9 +85,17 @@ interface ReceiptCall {
   call_id: string;
   execution_shape: ExecutionShape;
   model_id: string;
+  actual_model?: string | null;
+  connection_id?: string | null;
   call_sequence: number;
   dispatched: boolean;
   status: string;
+  result_class?: string | null;
+  error_code?: string | null;
+  ttft_ms?: number | null;
+  e2e_ms?: number | null;
+  prompt_tokens?: number | null;
+  completion_tokens?: number | null;
   total_tokens?: number | null;
 }
 
@@ -95,6 +103,9 @@ interface ReceiptRun {
   run_id: string;
   entry_id: EntryId;
   status: string;
+  parent_run_reference?: string | null;
+  result_class?: string | null;
+  reason_codes?: string[];
   created_at: string;
   calls: ReceiptCall[];
 }
@@ -576,7 +587,46 @@ export default function ProviderWorkloadControlSettings({
           <div className="mt-4 flex flex-wrap gap-2"><button className="rounded-full bg-sky-200 px-4 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={busy || !selectedPolicy || editableBindings.some((item) => !item.model_id.trim() || !item.connection_id)} onClick={() => void savePolicy()} type="button">保存 Binding</button>{selectedPolicy?.configured_status !== "legacy" ? <button className="rounded-full border border-white/15 px-4 py-2 text-sm text-slate-200" disabled={busy} onClick={() => void deactivate()} type="button">显式恢复 Legacy</button> : <button className="rounded-full border border-amber-300/30 px-4 py-2 text-sm text-amber-100 disabled:cursor-not-allowed disabled:opacity-40" disabled={busy || !selectedPolicy.data_plane_integrated || !selectedPolicy.feature_enabled || selectedPolicy.blocking_reason_codes.length > 0} onClick={() => setConfirmActivation(true)} type="button">激活 Managed 必经</button>}</div>
         </div>
       </div>
-      <div className="border-t border-white/10 p-5"><h3 className="text-sm font-semibold text-white">最近脱敏 Receipt</h3><div className="mt-3 space-y-2">{receipts.length ? receipts.map((run) => <div className="rounded-lg border border-white/10 bg-white/[0.025] p-3" key={run.run_id}><div className="flex flex-wrap items-center justify-between gap-2"><p className="text-sm text-white">{ENTRY_LABELS[run.entry_id]} · {run.status}</p><span className="text-xs text-slate-400">{run.calls.length} 次逻辑调用</span></div><p className="mt-1 text-xs text-slate-400">仅保存模型、序号、状态、指标与用量；不保存 Prompt、消息、模型正文或工具参数。</p></div>) : <p className="rounded-lg border border-dashed border-white/10 p-4 text-sm text-slate-400">当前入口尚无 Workload Receipt。</p>}</div></div>
+      <div className="border-t border-white/10 p-5">
+        <h3 className="text-sm font-semibold text-white">最近脱敏 Receipt</h3>
+        <p className="mt-1 text-xs text-slate-400">管理视图显示内部连接引用与逐调用指标；不保存 Prompt、消息、模型正文、凭据或工具参数。</p>
+        <div className="mt-3 space-y-2">
+          {receipts.length ? receipts.map((run) => (
+            <details className="rounded-lg border border-white/10 bg-white/[0.025]" key={run.run_id}>
+              <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-2 p-3">
+                <span className="text-sm text-white">{ENTRY_LABELS[run.entry_id]} · {run.status}</span>
+                <span className="text-xs text-slate-400">{run.calls.length} 次逻辑调用</span>
+              </summary>
+              <div className="space-y-2 border-t border-white/10 p-3 text-xs text-slate-300">
+                <p className="break-all font-mono text-[10px] text-slate-500">运行 {run.run_id}</p>
+                {run.parent_run_reference ? <p className="break-all text-slate-400">父运行：{run.parent_run_reference}</p> : null}
+                {run.result_class ? <p>结果分类：{run.result_class}</p> : null}
+                {run.reason_codes?.length ? <p className="text-amber-100">原因：{run.reason_codes.join("、")}</p> : null}
+                {run.calls.map((call) => (
+                  <div className="rounded-md bg-slate-950/35 p-2.5" key={call.call_id}>
+                    <div className="flex flex-wrap gap-x-3 gap-y-1">
+                      <span className="font-semibold text-slate-100">调用 {call.call_sequence}</span>
+                      <span>{SHAPE_LABELS[call.execution_shape]}</span>
+                      <span>{call.dispatched ? "已派发" : "发送前阻断"}</span>
+                      <span>{call.status}</span>
+                    </div>
+                    <p className="mt-1 break-all font-mono text-[10px] text-slate-400">请求模型：{call.model_id}</p>
+                    {call.actual_model ? <p className="mt-1 break-all font-mono text-[10px] text-slate-400">实际模型：{call.actual_model}</p> : null}
+                    {call.connection_id ? <p className="mt-1 break-all font-mono text-[10px] text-slate-500">连接引用：{call.connection_id}</p> : null}
+                    <div className="mt-1 flex flex-wrap gap-x-3 text-slate-500">
+                      {call.ttft_ms != null ? <span>TTFT {Math.round(call.ttft_ms)} ms</span> : null}
+                      {call.e2e_ms != null ? <span>E2E {Math.round(call.e2e_ms)} ms</span> : null}
+                      {call.total_tokens != null ? <span>{call.total_tokens} tokens</span> : null}
+                      {call.result_class ? <span>{call.result_class}</span> : null}
+                      {call.error_code ? <span className="text-rose-200">{call.error_code}</span> : null}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </details>
+          )) : <p className="rounded-lg border border-dashed border-white/10 p-4 text-sm text-slate-400">当前入口尚无 Workload Receipt。</p>}
+        </div>
+      </div>
       {confirmActivation && selectedPolicy ? <div aria-modal="true" className="border-t border-amber-300/20 bg-amber-300/[0.05] p-5" role="dialog">
         <p className="text-sm font-semibold text-amber-100">确认激活 {ENTRY_LABELS[entryId]} Managed 必经</p>
         <p className="mt-2 text-sm leading-6 text-slate-300">激活后，Binding、资格、连接或凭据不合格时将失败关闭，不会自动回退 Legacy 或第二 Provider。</p>

--- a/client/src/components/workflow/WorkflowRun.handoff-recovery.test.ts
+++ b/client/src/components/workflow/WorkflowRun.handoff-recovery.test.ts
@@ -79,6 +79,44 @@ describe("WorkflowRun handoff recovery pointer", () => {
     expect(steps.some((step) => step.status === "running")).toBe(false);
   });
 
+  it("keeps a redacted managed receipt on its node and does not overwrite an error", () => {
+    const receipt = {
+      contract_version: "modelmirror-provider-workload-routing-v1",
+      entry_id: "workflow_interactive_llm" as const,
+      routing_mode: "managed_required" as const,
+      run_reference: "workrun-safe",
+      status: "failed" as const,
+      call_count: 0,
+      reason_codes: ["provider_workload_binding_missing"],
+      calls: [],
+    };
+    const steps = buildRunSteps([
+      {
+        event: "error",
+        node_id: "llm-1",
+        node_title: "LLM",
+        node_type: "llm",
+        message: "发送前已阻断。",
+        provider_route_receipts: receipt,
+      },
+      {
+        event: "node_end",
+        node_id: "llm-1",
+        node_title: "LLM",
+        node_type: "llm",
+        output: "",
+      },
+    ]);
+
+    expect(steps).toEqual([
+      expect.objectContaining({
+        id: "llm-1",
+        status: "error",
+        providerRouteReceipt: receipt,
+      }),
+    ]);
+  });
+
   it("stores only bounded task and run ids for page refresh recovery", () => {
     const taskId = "a".repeat(32);
     const runId = "123e4567-e89b-42d3-a456-426614174000";

--- a/client/src/components/workflow/WorkflowRun.tsx
+++ b/client/src/components/workflow/WorkflowRun.tsx
@@ -17,6 +17,7 @@ import SkillApplicationCard, {
 import SkillHookApplicationCard, {
   hookSkillIdsFromWorkflowNodes,
 } from "../skill-runtime/SkillHookApplicationCard";
+import ProviderRouteReceiptSummary from "../meta/ProviderRouteReceiptSummary";
 import { useSkillCreatorStatus } from "../../hooks/useSkillCreatorStatus";
 import {
   fetchFileOutputs,
@@ -27,6 +28,7 @@ import {
   type NodeRunStatus,
   type WorkflowDefinition,
   type WorkflowRunEvent,
+  type ProviderRouteReceipt,
   type WorkflowValue,
   type WorkflowVariableDeclaration,
 } from "../../types/workflow";
@@ -225,6 +227,7 @@ interface WorkflowRunStep {
   status: RunStepStatus;
   output: string;
   variable?: string;
+  providerRouteReceipt?: ProviderRouteReceipt;
 }
 
 function serializeWorkflow(definition: WorkflowDefinition) {
@@ -585,8 +588,9 @@ export function buildRunSteps(events: WorkflowRunEvent[]) {
       return;
     }
     if (event.event === "node_end") {
-      step.status = "done";
+      if (step.status !== "error") step.status = "done";
       step.variable = event.variable ?? step.variable;
+      step.providerRouteReceipt = event.provider_route_receipts ?? step.providerRouteReceipt;
       if (!step.output) {
         step.output = appendStepOutput(step.output, event.output, step.type);
       }
@@ -595,6 +599,7 @@ export function buildRunSteps(events: WorkflowRunEvent[]) {
     if (event.event === "error") {
       step.status = "error";
       step.output = appendStepOutput(step.output, event.message, step.type);
+      step.providerRouteReceipt = event.provider_route_receipts ?? step.providerRouteReceipt;
     }
   });
 
@@ -2069,13 +2074,13 @@ export default function WorkflowRun({
             </div>
           ) : (
             runSteps.map((step) => (
-              <button
-                className="w-full rounded-lg border border-white/10 bg-white/[0.045] px-3 py-2 text-left transition hover:border-brand-300/40 hover:bg-white/[0.07]"
-                key={step.id}
-                onClick={() => onStepSelect?.(step.id)}
-                title="在画布上定位该节点"
-                type="button"
-              >
+              <div className="rounded-lg border border-white/10 bg-white/[0.045]" key={step.id}>
+                <button
+                  className="w-full px-3 py-2 text-left transition hover:bg-white/[0.025]"
+                  onClick={() => onStepSelect?.(step.id)}
+                  title="在画布上定位该节点"
+                  type="button"
+                >
                 <div className="flex items-center justify-between gap-3">
                   <div className="min-w-0">
                     <p className="truncate text-xs font-semibold text-slate-200">
@@ -2099,7 +2104,13 @@ export default function WorkflowRun({
                     </p>
                   </>
                 ) : null}
-              </button>
+                </button>
+                {step.providerRouteReceipt ? (
+                  <div className="px-3 pb-2">
+                    <ProviderRouteReceiptSummary compact receipt={step.providerRouteReceipt} />
+                  </div>
+                ) : null}
+              </div>
             ))
           )}
         </div>

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -431,6 +431,32 @@ export interface WorkflowDefinition {
   updatedAt: string;
 }
 
+export interface ProviderRouteCallReceipt {
+  call_sequence: number;
+  model_id: string;
+  actual_model?: string | null;
+  dispatched?: boolean;
+  status: "passed" | "failed" | "uncertain" | "cancelled";
+  error_code?: string | null;
+  prompt_tokens?: number | null;
+  completion_tokens?: number | null;
+  total_tokens?: number | null;
+}
+
+export interface ProviderRouteReceipt {
+  contract_version: string;
+  entry_id:
+    | "meta_agent"
+    | "workflow_interactive_llm"
+    | "workflow_deployment_llm";
+  routing_mode: "managed_required";
+  run_reference: string;
+  status: "running" | "passed" | "failed" | "uncertain" | "cancelled";
+  call_count: number;
+  reason_codes: string[];
+  calls: ProviderRouteCallReceipt[];
+}
+
 export interface WorkflowRunEvent {
   event:
     | "workflow_meta"
@@ -512,4 +538,5 @@ export interface WorkflowRunEvent {
   resource_paths?: string[];
   source_ref?: string;
   result_count?: number;
+  provider_route_receipts?: ProviderRouteReceipt;
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -209,7 +209,16 @@ R6C 将两个 Meta Agent 生成入口加入数据面。Meta Agent 使用精确
 记录为独立逻辑调用；任一调用派发后都不重试、不切换 Provider，也不进入 legacy。
 `MODEL_CONTROL_META_AGENT_ENABLED=false` 或 Policy 为 `legacy` 时保留原生成路径；已激活
 Policy 失效后保持 `degraded_required` 并在 POST 前失败关闭。其他 Workflow、Xpert 与 R5
-Chat 调度仍保持原行为。接入入口只允许 Python 主进程解析凭据和调用 Provider，Worker 与
+Chat 调度仍保持原行为。
+
+Round 6D 将 Classic Workflow 的交互 `llm`、`parameter_extractor`、
+`question_classifier` 模型回退以及对应部署执行接入独立的
+`workflow_interactive_llm` / `workflow_deployment_llm` Policy。规则分类命中不调用模型；
+模型节点使用稳定的 task/execution + node 运行身份，恢复时已有派发、完成或不确定证据均不
+自动重放。Provider 错误在 Managed 模式失败关闭，不调用第二连接、第二 IP 或 legacy；专用
+多模态、RAG、Agent、Xpert 和 `/workflow-native` 仍不属于 R6D。
+
+接入入口只允许 Python 主进程解析凭据和调用 Provider，Worker 与
 工具执行器继续只处理模型消息、Tool Call 和脱敏结果。
 
 `/settings?section=overview|providers|routing` 共用一份 Provider 管理会话。Marble 等其他

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -217,8 +217,8 @@ MODEL_CONTROL_ROUTE_AGENT_ENABLED=false
 MODEL_CONTROL_TEAM_CHAT_ENABLED=false
 ```
 
-R6B 接入 `agent_shadow`，R6C 接入两个 Meta Agent 生成入口；其他 Workflow 和 Xpert 入口
-仍不能激活 Managed Policy。`agent_shadow` 只有在
+R6B 接入 `agent_shadow`，R6C 接入两个 Meta Agent 生成入口，R6D 接入 Classic Workflow
+交互与部署 LLM；其他 Workflow Agent 和 Xpert 入口仍不能激活 Managed Policy。`agent_shadow` 只有在
 `MODEL_CONTROL_AGENT_SHADOW_ENABLED=true`、
 精确模型的 `chat_tools` 资格与 Binding 有效、且管理员明确批准 fail-closed 后才会接管。
 开关为 `false` 或 Policy 为 `legacy` 时继续使用原 Shadow 网关路径；已经激活但失效的
@@ -230,6 +230,13 @@ Meta Agent 只有在 `MODEL_CONTROL_META_AGENT_ENABLED=true`、精确模型的
 显式停用 `meta_agent` Policy 会恢复原静态网关路径；已经激活但资格失效时保持失败关闭。
 两个生成接口在 managed 模式均返回脱敏 `provider_route_receipts`，不得从中推断或输出
 连接、URL、凭据、Prompt 或模型正文。
+
+Classic Workflow 交互接管要求 `MODEL_CONTROL_WORKFLOW_LLM_ENABLED=true`，部署执行还要求
+`MODEL_CONTROL_WORKFLOW_DEPLOYMENT_ENABLED=true`。两类入口须分别配置并批准精确模型的
+`chat_text`、`chat_text_unary`、`chat_json_object` Binding；只启用部署开关不能绕过交互/部署
+各自的 Policy。关闭对应开关并重启可恢复 legacy；已经激活但资格或 Binding 漂移时保持
+`degraded_required` 并失败关闭。恢复部署执行不得自动重放已有模型节点；应由操作者确认后
+创建显式新执行。交互节点仅显示脱敏摘要，完整调用证据在管理员 Settings 查看。
 
 同一清理命令从 v16 起同时报告 R5 Chat 与 R6 Workload 的过期记录；第一条仍是 dry-run，
 只有第二条显式 `--apply` 才删除已完成记录。不得对正在运行的父运行或逻辑调用执行清理。

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -230,7 +230,13 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
   `/api/meta-agent/generate-xpert-candidate`。两者使用 `chat_json_object` 精确 Binding；规划、
   蓝图和最多一次修复分别记录调用序号。派发后不重试、不换 IP、连接、模型或 legacy；响应
   只加法返回运行引用、模型、调用序号、状态和可用 usage，不返回内部连接或生成正文。
-- 后续 R6D—R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
+- R6D 接入受信任的 Classic Workflow 交互与部署执行。`llm`、参数提取和分类模型回退分别
+  使用 `chat_text`、`chat_json_object` 和 `chat_text_unary` 精确 Binding；规则命中不创建
+  Provider 调用。每个模型节点以入口、Workflow task/部署 execution 和 node ID 形成稳定运行，
+  自动恢复遇到既有派发或不确定证据时失败关闭，显式新执行才可创建新的可计费调用。
+  缺省 `modelId` 在 Managed 模式规范化为现有 `TEXT_FALLBACK_MODEL`，仍须具备该精确模型的
+  Inventory、资格和 Binding。Provider 失败不再返回旧 `{}` 或默认分类；legacy 模式保持原行为。
+- 后续 R6E—R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
   只能存在于 Python 主进程内存，Worker、工具执行器和浏览器不得收到 Key、URL 或连接细节。
 - Receipt 清理命令现在同时检查 R5 Chat 与 R6 Workload 记录，仍默认 dry-run；`--apply`
   才删除超过保留期的已完成运行、尝试或调用。

--- a/server/main.py
+++ b/server/main.py
@@ -1257,6 +1257,19 @@ except ModuleNotFoundError:
     from model_router.api import get_catalog_coordinator
 
 try:
+    from server.model_router.workflow_gateway import (
+        ManagedWorkflowGateway,
+        ManagedWorkflowNodeRun,
+        ManagedWorkflowRoutingError,
+    )
+except ModuleNotFoundError:
+    from model_router.workflow_gateway import (
+        ManagedWorkflowGateway,
+        ManagedWorkflowNodeRun,
+        ManagedWorkflowRoutingError,
+    )
+
+try:
     from server.context_engine import (
         estimate_messages_tokens,
         estimate_text_tokens,
@@ -8928,12 +8941,23 @@ async def _run_workflow_response(
             resume_execution=resume_execution,
         )
     )
-    requires_model = any(
+    workflow_managed_gateway = ManagedWorkflowGateway.for_router(
+        get_model_router_service()
+    )
+    workflow_managed_mode = workflow_managed_gateway.routing_mode(
+        trusted_source_kind
+    )
+    requires_legacy_model = any(
         (node.data.get("kind") if isinstance(node.data.get("kind"), str) else node.type)
-        in {"llm", "workflow_agent"}
+        == "workflow_agent"
+        or (
+            (node.data.get("kind") if isinstance(node.data.get("kind"), str) else node.type)
+            == "llm"
+            and workflow_managed_mode == "legacy"
+        )
         for node in payload.workflow.nodes
     )
-    model_gateway_missing = requires_model and not get_llm_gateway_config()[0]
+    model_gateway_missing = requires_legacy_model and not get_llm_gateway_config()[0]
     nodes_by_id = {node.id: node for node in payload.workflow.nodes}
     input_block_policy_can_stop_before_model = False
     input_content_policy_redactors = []
@@ -9205,6 +9229,7 @@ async def _run_workflow_response(
             else None
         ),
         "runtime_trigger_event": dict(runtime_trigger_event or {}),
+        "provider_cancel_event": asyncio.Event(),
         "private_http_event": bool(
             isinstance(runtime_trigger_event, dict)
             and runtime_trigger_event.get("type") == "http_event"
@@ -9266,6 +9291,46 @@ async def _run_workflow_response(
         queued: set[str] = task_state["queued"]
         executed: set[str] = task_state["executed"]
         final_output = ""
+
+        def start_managed_node_run(node_id: str) -> ManagedWorkflowNodeRun | None:
+            if workflow_managed_mode == "legacy":
+                return None
+            entry_id = workflow_managed_gateway.entry_id(trusted_source_kind)
+            if entry_id is None:
+                return None
+            if workflow_managed_mode == "degraded_required":
+                code = "provider_workload_workflow_degraded_required"
+                raise ManagedWorkflowRoutingError(
+                    code,
+                    "Workflow 的 Managed Provider 策略已失效，当前节点失败关闭。",
+                    status_code=409,
+                    receipt=workflow_managed_gateway.blocked_receipt(entry_id, code),
+                )
+            execution_reference = (
+                str(
+                    run_metadata.get("workflow_deployment_execution_id")
+                    or task_id
+                )
+                if trusted_source_kind == "workflow_deployment"
+                else task_id
+            )
+            return workflow_managed_gateway.start_node_run(
+                source_kind=trusted_source_kind,  # type: ignore[arg-type]
+                execution_reference=execution_reference,
+                node_id=node_id,
+            )
+
+        def finish_managed_node_failure(
+            managed_run: ManagedWorkflowNodeRun,
+            code: str,
+        ) -> dict[str, Any]:
+            status = "failed"
+            if any(item.status == "uncertain" for item in managed_run.calls):
+                status = "uncertain"
+            elif any(item.status == "cancelled" for item in managed_run.calls):
+                status = "cancelled"
+            managed_run.finish(status, reason_code=code)  # type: ignore[arg-type]
+            return managed_run.receipt_summary()
 
         def safe_content_policy_value(value: Any) -> Any:
             if not input_content_policy_redactors:
@@ -14295,6 +14360,8 @@ async def _run_workflow_response(
 
                 chosen_handle: str | None = None
                 output = ""
+                node_provider_run: ManagedWorkflowNodeRun | None = None
+                node_provider_receipt: dict[str, Any] | None = None
 
                 if kind == "input":
                     variable_name = str(node.data.get("variableName") or "user_input")
@@ -14377,22 +14444,67 @@ async def _run_workflow_response(
                         if isinstance(active_system_prompt, str)
                         else None
                     )
-                    async for delta in stream_workflow_llm_text(
-                        model_id,
-                        prompt,
-                        system_prompt=system_prompt,
-                    ):
-                        output += delta
-                        yield sse_payload(
-                            {
-                                "event": "node_delta",
-                                "node_id": node.id,
-                                "node_title": title,
-                                "node_type": kind,
-                                "output": delta,
-                                "variable": output_variable,
-                            }
-                        )
+                    node_provider_run = start_managed_node_run(node.id)
+                    try:
+                        if node_provider_run is None:
+                            stream = stream_workflow_llm_text(
+                                model_id,
+                                prompt,
+                                system_prompt=system_prompt,
+                            )
+                        else:
+                            managed_messages: list[dict[str, Any]] = []
+                            if system_prompt and system_prompt.strip():
+                                managed_messages.append(
+                                    {
+                                        "role": "system",
+                                        "content": system_prompt.strip(),
+                                    }
+                                )
+                            managed_messages.append(
+                                {"role": "user", "content": prompt}
+                            )
+                            stream = node_provider_run.stream_text(
+                                logical_call_key="llm:primary",
+                                call_sequence=1,
+                                model_id=model_id,
+                                messages=managed_messages,
+                                temperature=0.7,
+                                max_tokens=2048,
+                                cancel_event=task_state["provider_cancel_event"],
+                            )
+                        async for delta in stream:
+                            output += delta
+                            yield sse_payload(
+                                {
+                                    "event": "node_delta",
+                                    "node_id": node.id,
+                                    "node_title": title,
+                                    "node_type": kind,
+                                    "output": delta,
+                                    "variable": output_variable,
+                                }
+                            )
+                        if node_provider_run is not None:
+                            node_provider_run.finish("passed")
+                            node_provider_receipt = (
+                                node_provider_run.receipt_summary()
+                            )
+                    except asyncio.CancelledError:
+                        if node_provider_run is not None:
+                            node_provider_receipt = finish_managed_node_failure(
+                                node_provider_run,
+                                "provider_workload_call_cancelled",
+                            )
+                        raise
+                    except ManagedWorkflowRoutingError as exc:
+                        if node_provider_run is not None:
+                            node_provider_receipt = finish_managed_node_failure(
+                                node_provider_run,
+                                exc.code,
+                            )
+                            exc.receipt = node_provider_receipt
+                        raise
                     variables[output_variable] = output
 
                 elif kind == "condition":
@@ -15283,27 +15395,52 @@ async def _run_workflow_response(
                                 "Parameter extractor contractVersion must be 1 or 2.",
                             )
                         if is_typed_ai_v2(node.data):
-                            if not get_llm_gateway_config()[0]:
+                            extractor_config = (
+                                {
+                                    **node.data,
+                                    "modelId": model_id,
+                                }
+                                if workflow_managed_mode != "legacy"
+                                and not str(node.data.get("modelId") or "").strip()
+                                else node.data
+                            )
+                            typed_schema = validate_parameter_extractor_v2_config(
+                                extractor_config
+                            )
+                            node_provider_run = start_managed_node_run(node.id)
+                            if (
+                                node_provider_run is None
+                                and not get_llm_gateway_config()[0]
+                            ):
                                 raise WorkflowTypedAIError(
                                     "parameter_extractor_gateway_unavailable",
                                     "Parameter extractor V2 requires a configured LLM gateway.",
                                 )
-                            typed_schema = validate_parameter_extractor_v2_config(
-                                node.data
+                            initial_prompt = parameter_extractor_prompt(
+                                input_text,
+                                typed_schema,
                             )
-                            raw_text = await collect_chat_completion_text(
-                                model_id,
-                                [
-                                    ChatMessage(
-                                        role="user",
-                                        content=parameter_extractor_prompt(
-                                            input_text,
-                                            typed_schema,
-                                        ),
-                                    )
-                                ],
-                                temperature=0,
-                                max_tokens=2048,
+                            raw_text = (
+                                await node_provider_run.complete_json_object(
+                                    logical_call_key="parameter_extractor:initial",
+                                    call_sequence=1,
+                                    model_id=model_id,
+                                    messages=[
+                                        {"role": "user", "content": initial_prompt}
+                                    ],
+                                    temperature=0,
+                                    max_tokens=2048,
+                                    cancel_event=task_state[
+                                        "provider_cancel_event"
+                                    ],
+                                )
+                                if node_provider_run is not None
+                                else await collect_chat_completion_text(
+                                    model_id,
+                                    [ChatMessage(role="user", content=initial_prompt)],
+                                    temperature=0,
+                                    max_tokens=2048,
+                                )
                             )
                             try:
                                 typed_output = parse_and_validate_extractor_output(
@@ -15313,19 +15450,39 @@ async def _run_workflow_response(
                             except WorkflowTypedAIError:
                                 if int(node.data.get("repairAttempts") or 0) != 1:
                                     raise
-                                repaired_text = await collect_chat_completion_text(
-                                    model_id,
-                                    [
-                                        ChatMessage(
-                                            role="user",
-                                            content=parameter_extractor_repair_prompt(
-                                                raw_text,
-                                                typed_schema,
-                                            ),
-                                        )
-                                    ],
-                                    temperature=0,
-                                    max_tokens=2048,
+                                repair_prompt = parameter_extractor_repair_prompt(
+                                    raw_text,
+                                    typed_schema,
+                                )
+                                repaired_text = (
+                                    await node_provider_run.complete_json_object(
+                                        logical_call_key="parameter_extractor:repair:1",
+                                        call_sequence=2,
+                                        model_id=model_id,
+                                        messages=[
+                                            {
+                                                "role": "user",
+                                                "content": repair_prompt,
+                                            }
+                                        ],
+                                        temperature=0,
+                                        max_tokens=2048,
+                                        cancel_event=task_state[
+                                            "provider_cancel_event"
+                                        ],
+                                    )
+                                    if node_provider_run is not None
+                                    else await collect_chat_completion_text(
+                                        model_id,
+                                        [
+                                            ChatMessage(
+                                                role="user",
+                                                content=repair_prompt,
+                                            )
+                                        ],
+                                        temperature=0,
+                                        max_tokens=2048,
+                                    )
                                 )
                                 typed_output = parse_and_validate_extractor_output(
                                     repaired_text,
@@ -15352,69 +15509,113 @@ async def _run_workflow_response(
                                     "contract_version": 2,
                                 }
                             )
-                        elif not get_llm_gateway_config()[0]:
-                            schema = str(node.data.get("schema") or "")
-                            output = "{}"
-                            variables[output_variable] = output
-                            yield sse_payload(
-                                {
-                                    "event": "node_delta",
-                                    "node_id": node.id,
-                                    "node_title": title,
-                                    "node_type": kind,
-                                    "output": "LLM gateway not configured; returned {}",
-                                    "variable": output_variable,
-                                }
-                            )
+                            if node_provider_run is not None:
+                                node_provider_run.finish("passed")
+                                node_provider_receipt = (
+                                    node_provider_run.receipt_summary()
+                                )
                         else:
                             schema = str(node.data.get("schema") or "")
-                            prompt = (
-                                "请从以下文本中严格按 JSON 格式返回指定字段 "
-                                f"{schema}；若无法提取则返回空对象 {{}}。\n\n"
-                                f"文本：\n{input_text}"
-                            )
-                            raw_text = await collect_chat_completion_text(
-                                model_id,
-                                [ChatMessage(role="user", content=prompt)],
-                                temperature=0.3,
-                                max_tokens=1024,
-                            )
-                            json_text = extract_json_object_text(raw_text)
-                            if json_text:
-                                try:
-                                    parsed = json.loads(json_text)
-                                    output = json.dumps(parsed, ensure_ascii=False)
-                                except ValueError:
+                            node_provider_run = start_managed_node_run(node.id)
+                            if (
+                                node_provider_run is None
+                                and not get_llm_gateway_config()[0]
+                            ):
+                                output = "{}"
+                                variables[output_variable] = output
+                                yield sse_payload(
+                                    {
+                                        "event": "node_delta",
+                                        "node_id": node.id,
+                                        "node_title": title,
+                                        "node_type": kind,
+                                        "output": "LLM gateway not configured; returned {}",
+                                        "variable": output_variable,
+                                    }
+                                )
+                            else:
+                                prompt = (
+                                    "请从以下文本中严格按 JSON 格式返回指定字段 "
+                                    f"{schema}；若无法提取则返回空对象 {{}}。\n\n"
+                                    f"文本：\n{input_text}"
+                                )
+                                raw_text = (
+                                    await node_provider_run.complete_json_object(
+                                        logical_call_key="parameter_extractor:initial",
+                                        call_sequence=1,
+                                        model_id=model_id,
+                                        messages=[
+                                            {"role": "user", "content": prompt}
+                                        ],
+                                        temperature=0.3,
+                                        max_tokens=1024,
+                                        cancel_event=task_state[
+                                            "provider_cancel_event"
+                                        ],
+                                    )
+                                    if node_provider_run is not None
+                                    else await collect_chat_completion_text(
+                                        model_id,
+                                        [ChatMessage(role="user", content=prompt)],
+                                        temperature=0.3,
+                                        max_tokens=1024,
+                                    )
+                                )
+                                json_text = extract_json_object_text(raw_text)
+                                if json_text:
+                                    try:
+                                        parsed = json.loads(json_text)
+                                        output = json.dumps(parsed, ensure_ascii=False)
+                                    except ValueError:
+                                        output = raw_text
+                                        yield sse_payload(
+                                            {
+                                                "event": "error",
+                                                "node_id": node.id,
+                                                "message": "参数提取返回 JSON 解析失败，已保留原文。",
+                                            }
+                                        )
+                                else:
                                     output = raw_text
                                     yield sse_payload(
                                         {
                                             "event": "error",
                                             "node_id": node.id,
-                                            "message": "参数提取返回 JSON 解析失败，已保留原文。",
+                                            "message": "参数提取未找到 JSON 对象，已保留原文。",
                                         }
                                     )
-                            else:
-                                output = raw_text
+                                variables[output_variable] = output
                                 yield sse_payload(
                                     {
-                                        "event": "error",
+                                        "event": "node_delta",
                                         "node_id": node.id,
-                                        "message": "参数提取未找到 JSON 对象，已保留原文。",
+                                        "node_title": title,
+                                        "node_type": kind,
+                                        "output": output,
+                                        "variable": output_variable,
                                     }
                                 )
-                            variables[output_variable] = output
-                            yield sse_payload(
-                                {
-                                    "event": "node_delta",
-                                    "node_id": node.id,
-                                    "node_title": title,
-                                    "node_type": kind,
-                                    "output": output,
-                                    "variable": output_variable,
-                                }
+                                if node_provider_run is not None:
+                                    node_provider_run.finish("passed")
+                                    node_provider_receipt = (
+                                        node_provider_run.receipt_summary()
+                                    )
+                    except ManagedWorkflowRoutingError as exc:
+                        if node_provider_run is not None:
+                            node_provider_receipt = finish_managed_node_failure(
+                                node_provider_run,
+                                exc.code,
                             )
+                            exc.receipt = node_provider_receipt
+                        raise
                     except Exception as exc:
                         logger.warning("Workflow parameter_extractor node failed: %s", exc)
+                        if node_provider_run is not None:
+                            node_provider_receipt = finish_managed_node_failure(
+                                node_provider_run,
+                                "provider_workload_workflow_output_invalid",
+                            )
+                            raise
                         if typed_ai_contract_version(node.data) != 1:
                             raise
                         variables[
@@ -16255,12 +16456,22 @@ async def _run_workflow_response(
                                     "question_classifier_disabled",
                                     "Question classifier execution is disabled.",
                                 )
-                            categories = validate_question_classifier_v2_config(
-                                node.data
-                            )
                             mode = str(
                                 node.data.get("classificationMode") or "rules_only"
                             ).strip()
+                            classifier_config = (
+                                {
+                                    **node.data,
+                                    "modelId": TEXT_FALLBACK_MODEL,
+                                }
+                                if workflow_managed_mode != "legacy"
+                                and mode in {"rules_then_model", "model_only"}
+                                and not str(node.data.get("modelId") or "").strip()
+                                else node.data
+                            )
+                            categories = validate_question_classifier_v2_config(
+                                classifier_config
+                            )
                             selection = None
                             if mode != "model_only":
                                 selection = select_question_classifier_rule(
@@ -16274,25 +16485,56 @@ async def _run_workflow_response(
                                 "rules_then_model",
                                 "model_only",
                             }:
-                                if not get_llm_gateway_config()[0]:
+                                model_id = str(
+                                    node.data.get("modelId")
+                                    or (
+                                        TEXT_FALLBACK_MODEL
+                                        if workflow_managed_mode != "legacy"
+                                        else ""
+                                    )
+                                ).strip()
+                                node_provider_run = start_managed_node_run(node.id)
+                                if (
+                                    node_provider_run is None
+                                    and not get_llm_gateway_config()[0]
+                                ):
                                     raise WorkflowTypedAIError(
                                         "question_classifier_gateway_unavailable",
                                         "Question classifier model mode requires a configured LLM gateway.",
                                     )
-                                model_id = str(node.data.get("modelId") or "").strip()
-                                raw_decision = await collect_chat_completion_text(
-                                    model_id,
-                                    [
-                                        ChatMessage(
-                                            role="user",
-                                            content=question_classifier_prompt(
-                                                text,
-                                                categories,
-                                            ),
-                                        )
-                                    ],
-                                    temperature=0,
-                                    max_tokens=64,
+                                classifier_prompt = question_classifier_prompt(
+                                    text,
+                                    categories,
+                                )
+                                raw_decision = (
+                                    await node_provider_run.complete_text_unary(
+                                        logical_call_key="question_classifier:model_fallback",
+                                        call_sequence=1,
+                                        model_id=model_id,
+                                        messages=[
+                                            {
+                                                "role": "user",
+                                                "content": classifier_prompt,
+                                            }
+                                        ],
+                                        temperature=0,
+                                        max_tokens=64,
+                                        cancel_event=task_state[
+                                            "provider_cancel_event"
+                                        ],
+                                    )
+                                    if node_provider_run is not None
+                                    else await collect_chat_completion_text(
+                                        model_id,
+                                        [
+                                            ChatMessage(
+                                                role="user",
+                                                content=classifier_prompt,
+                                            )
+                                        ],
+                                        temperature=0,
+                                        max_tokens=64,
+                                    )
                                 )
                                 selection = parse_question_classifier_model_output(
                                     raw_decision,
@@ -16323,6 +16565,11 @@ async def _run_workflow_response(
                                 "contract_version": 2,
                             }
                             yield sse_payload(delta_event)
+                            if node_provider_run is not None:
+                                node_provider_run.finish("passed")
+                                node_provider_receipt = (
+                                    node_provider_run.receipt_summary()
+                                )
                         elif not WORKFLOW_QUESTION_CLASSIFIER_ENABLED:
                             variables[output_variable] = default_category
                             output = default_category
@@ -16356,7 +16603,14 @@ async def _run_workflow_response(
                                 .lower()
                                 == "true"
                             )
-                            model_id = str(node.data.get("modelId") or "").strip()
+                            model_id = str(
+                                node.data.get("modelId")
+                                or (
+                                    TEXT_FALLBACK_MODEL
+                                    if workflow_managed_mode != "legacy"
+                                    else ""
+                                )
+                            ).strip()
                             try:
                                 raw_categories = json.loads(categories_json)
                             except ValueError as exc:
@@ -16423,7 +16677,14 @@ async def _run_workflow_response(
                                     f"已分类：{selected}（关键词命中：{matched_keyword}）"
                                 )
                             elif use_llm_fallback:
-                                if not get_llm_gateway_config()[0] or not model_id:
+                                node_provider_run = start_managed_node_run(node.id)
+                                if (
+                                    (
+                                        node_provider_run is None
+                                        and not get_llm_gateway_config()[0]
+                                    )
+                                    or not model_id
+                                ):
                                     raise ValueError(
                                         "LLM 回退未配置网关或 modelId。"
                                     )
@@ -16444,7 +16705,21 @@ async def _run_workflow_response(
                                         f"{text}"
                                     )
                                 selected = (
-                                    await collect_chat_completion_text(
+                                    await node_provider_run.complete_text_unary(
+                                        logical_call_key="question_classifier:model_fallback",
+                                        call_sequence=1,
+                                        model_id=model_id,
+                                        messages=[
+                                            {"role": "user", "content": prompt}
+                                        ],
+                                        temperature=0,
+                                        max_tokens=20,
+                                        cancel_event=task_state[
+                                            "provider_cancel_event"
+                                        ],
+                                    )
+                                    if node_provider_run is not None
+                                    else await collect_chat_completion_text(
                                         model_id,
                                         [ChatMessage(role="user", content=prompt)],
                                         temperature=0,
@@ -16484,8 +16759,27 @@ async def _run_workflow_response(
                                     "variable": output_variable,
                                 }
                             )
+                            if node_provider_run is not None:
+                                node_provider_run.finish("passed")
+                                node_provider_receipt = (
+                                    node_provider_run.receipt_summary()
+                                )
+                    except ManagedWorkflowRoutingError as exc:
+                        if node_provider_run is not None:
+                            node_provider_receipt = finish_managed_node_failure(
+                                node_provider_run,
+                                exc.code,
+                            )
+                            exc.receipt = node_provider_receipt
+                        raise
                     except Exception as exc:
                         logger.warning("Workflow question_classifier node failed: %s", exc)
+                        if node_provider_run is not None:
+                            node_provider_receipt = finish_managed_node_failure(
+                                node_provider_run,
+                                "provider_workload_workflow_output_invalid",
+                            )
+                            raise
                         if typed_ai_contract_version(node.data) != 1:
                             raise
                         output = default_category
@@ -20056,6 +20350,8 @@ async def _run_workflow_response(
                     "node_type": kind,
                     "status": "completed",
                 }
+                if node_provider_receipt is not None:
+                    node_end_event["provider_route_receipts"] = node_provider_receipt
                 workflow_execution_store.append_event(task_id, node_end_event)
                 yield sse_payload(
                     {
@@ -20859,7 +21155,27 @@ async def _run_workflow_response(
                 logger.warning("Failed to persist content policy failure", exc_info=True)
             yield sse_payload(error_event)
         except Exception as exc:
-            logger.exception("Workflow run failed workflow=%s", payload.workflow.id)
+            managed_error = (
+                exc if isinstance(exc, ManagedWorkflowRoutingError) else None
+            )
+            if managed_error is not None:
+                logger.warning(
+                    "Managed Workflow run failed workflow=%s code=%s",
+                    payload.workflow.id,
+                    managed_error.code,
+                )
+            else:
+                logger.exception(
+                    "Workflow run failed workflow=%s", payload.workflow.id
+                )
+            public_error = (
+                managed_error.public_message if managed_error is not None else str(exc)
+            )
+            provider_receipt = (
+                managed_error.receipt
+                if managed_error is not None and managed_error.receipt is not None
+                else locals().get("node_provider_receipt")
+            )
             failed_node_id = str(locals().get("node_id") or "").strip() or None
             failed_node = nodes_by_id.get(failed_node_id) if failed_node_id else None
             failed_node_title = (
@@ -20869,35 +21185,40 @@ async def _run_workflow_response(
                 await run_registry.update_run(
                     workflow_run.run_id,
                     status="failed",
-                    error=str(exc),
+                    error=public_error,
                 )
             except Exception:
                 logger.warning("Failed to update workflow run status", exc_info=True)
             try:
-                workflow_execution_store.fail(task_id, error=str(exc))
-                workflow_execution_store.append_event(
-                    task_id,
-                    {
-                        "event": "error",
-                        "task_id": task_id,
-                        "run_id": workflow_run.run_id,
-                        "node_id": failed_node_id,
-                        "node_title": failed_node_title,
-                        "message": str(exc),
-                    },
-                )
-            except Exception:
-                logger.warning("Failed to persist workflow failure", exc_info=True)
-            yield sse_payload(
-                {
+                workflow_execution_store.fail(task_id, error=public_error)
+                error_event = {
                     "event": "error",
                     "task_id": task_id,
                     "run_id": workflow_run.run_id,
                     "node_id": failed_node_id,
                     "node_title": failed_node_title,
-                    "message": str(exc),
+                    "message": public_error,
                 }
-            )
+                if managed_error is not None:
+                    error_event["code"] = managed_error.code
+                if isinstance(provider_receipt, dict):
+                    error_event["provider_route_receipts"] = provider_receipt
+                workflow_execution_store.append_event(task_id, error_event)
+            except Exception:
+                logger.warning("Failed to persist workflow failure", exc_info=True)
+            error_event = {
+                "event": "error",
+                "task_id": task_id,
+                "run_id": workflow_run.run_id,
+                "node_id": failed_node_id,
+                "node_title": failed_node_title,
+                "message": public_error,
+            }
+            if managed_error is not None:
+                error_event["code"] = managed_error.code
+            if isinstance(provider_receipt, dict):
+                error_event["provider_route_receipts"] = provider_receipt
+            yield sse_payload(error_event)
         finally:
             durable_execution = workflow_execution_store.get(task_id)
             if durable_execution is None or durable_execution.status != "waiting":
@@ -20945,6 +21266,9 @@ async def cancel_workflow_task(task_id: str, request: Request):
     task = workflow_task_store.get(task_id)
     if task is not None:
         task["cancel_requested"] = True
+        provider_cancel_event = task.get("provider_cancel_event")
+        if isinstance(provider_cancel_event, asyncio.Event):
+            provider_cancel_event.set()
         pause_event = task.get("pause_event")
         if isinstance(pause_event, asyncio.Event):
             pause_event.set()

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -3193,6 +3193,50 @@ class SQLiteRouterRepository:
             ).fetchone()
         return dict(row)
 
+    def claim_stable_workload_run(
+        self,
+        tenant_id: str,
+        *,
+        run_id: str,
+        entry_id: str,
+        policy_fingerprint: str,
+        parent_run_reference: str,
+    ) -> tuple[dict[str, object], bool]:
+        """Atomically reserve a deterministic workload run.
+
+        Workflow deployment recovery can revisit the same model node after a
+        process restart.  A deterministic primary key makes that revisit
+        observable without reopening or replaying the original Provider call.
+        """
+
+        clean_tenant = self._tenant_id(tenant_id)
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                """
+                INSERT OR IGNORE INTO provider_workload_runs (
+                    id, tenant_id, entry_id, policy_fingerprint,
+                    parent_run_reference, status, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, 'running', ?, ?)
+                """,
+                (
+                    run_id,
+                    clean_tenant,
+                    entry_id,
+                    policy_fingerprint,
+                    parent_run_reference,
+                    now,
+                    now,
+                ),
+            )
+            row = connection.execute(
+                "SELECT * FROM provider_workload_runs WHERE tenant_id = ? AND id = ?",
+                (clean_tenant, run_id),
+            ).fetchone()
+        if row is None:  # pragma: no cover - protected by the transaction above
+            raise RouterRepositoryError("provider_workload_run_not_found")
+        return dict(row), cursor.rowcount == 1
+
     def claim_workload_call(
         self,
         tenant_id: str,

--- a/server/model_router/workflow_gateway.py
+++ b/server/model_router/workflow_gateway.py
@@ -1,0 +1,964 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import time
+from collections.abc import AsyncIterator, Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import httpx
+
+from .repository import RouterRepositoryError
+from .service import ModelRouterService, RouterServiceError
+from .workload_control import (
+    PROVIDER_WORKLOAD_CONTRACT_VERSION,
+    ProviderWorkloadCallService,
+    ProviderWorkloadPreparedCall,
+)
+
+
+WorkflowRoutingMode = Literal["legacy", "managed_required", "degraded_required"]
+WorkflowSourceKind = Literal["workflow_classic", "workflow_deployment"]
+WorkflowEntryId = Literal[
+    "workflow_interactive_llm", "workflow_deployment_llm"
+]
+WorkflowCallStatus = Literal[
+    "passed", "failed", "uncertain", "cancelled"
+]
+
+MAX_RESPONSE_BYTES = 1024 * 1024
+MAX_STREAM_BYTES = 4 * 1024 * 1024
+MAX_SSE_EVENT_BYTES = 256 * 1024
+
+
+class ManagedWorkflowRoutingError(RuntimeError):
+    def __init__(
+        self,
+        code: str,
+        public_message: str,
+        *,
+        status_code: int = 502,
+        receipt: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(code)
+        self.code = code
+        self.public_message = public_message
+        self.status_code = status_code
+        self.receipt = receipt
+
+
+@dataclass(slots=True)
+class WorkflowProviderCallReceipt:
+    call_sequence: int
+    model_id: str
+    actual_model: str | None = None
+    dispatched: bool = False
+    status: WorkflowCallStatus = "failed"
+    error_code: str | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "call_sequence": self.call_sequence,
+            "model_id": self.model_id,
+            "actual_model": self.actual_model,
+            "dispatched": self.dispatched,
+            "status": self.status,
+            "error_code": self.error_code,
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+        }
+
+
+@dataclass(slots=True)
+class _StreamEvidence:
+    content_observed: bool = False
+    terminal_observed: bool = False
+    actual_model: str | None = None
+    ttft_ms: float | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+
+
+class ManagedWorkflowGateway:
+    """Classic Workflow adapter for one exact managed Provider target."""
+
+    _ENTRY_BY_SOURCE: dict[WorkflowSourceKind, WorkflowEntryId] = {
+        "workflow_classic": "workflow_interactive_llm",
+        "workflow_deployment": "workflow_deployment_llm",
+    }
+
+    def __init__(
+        self,
+        call_service: ProviderWorkloadCallService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self.call_service = call_service
+        self._client_factory = client_factory
+
+    @classmethod
+    def for_router(
+        cls,
+        router_service: ModelRouterService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> ManagedWorkflowGateway:
+        return cls(
+            ProviderWorkloadCallService(router_service),
+            client_factory=client_factory,
+        )
+
+    def routing_mode(self, source_kind: str | None) -> WorkflowRoutingMode:
+        entry_id = self.entry_id(source_kind)
+        if entry_id is None:
+            return "legacy"
+        control = self.call_service.control
+        if not control.feature_enabled(entry_id):
+            return "legacy"
+        policy = control.get_policy(entry_id)
+        if policy.configured_status == "legacy":
+            return "legacy"
+        if policy.effective_status == "managed_required":
+            return "managed_required"
+        return "degraded_required"
+
+    @classmethod
+    def entry_id(cls, source_kind: str | None) -> WorkflowEntryId | None:
+        return cls._ENTRY_BY_SOURCE.get(str(source_kind or ""))  # type: ignore[arg-type]
+
+    def start_node_run(
+        self,
+        *,
+        source_kind: WorkflowSourceKind,
+        execution_reference: str,
+        node_id: str,
+    ) -> ManagedWorkflowNodeRun:
+        entry_id = self._ENTRY_BY_SOURCE[source_kind]
+        if self.routing_mode(source_kind) != "managed_required":
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_policy_not_active",
+                "Workflow 的 Managed Provider 策略未就绪，当前节点失败关闭。",
+                status_code=409,
+            )
+        clean_execution = execution_reference.strip()
+        clean_node = node_id.strip()
+        if not clean_execution or not clean_node:
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_workflow_reference_required",
+                "Workflow 模型节点缺少稳定执行引用。",
+                status_code=409,
+            )
+        parent_reference = (
+            f"{'interactive' if source_kind == 'workflow_classic' else 'deployment'}:"
+            f"{clean_execution}:{clean_node}"
+        )
+        try:
+            run_id = self.call_service.start_stable_run(
+                entry_id,
+                parent_run_reference=parent_reference,
+            )
+        except RouterServiceError as exc:
+            raise ManagedWorkflowRoutingError(
+                exc.code,
+                "Workflow 模型节点已有执行证据或资格已失效，系统不会自动重放。",
+                status_code=exc.status_code,
+                receipt=self.blocked_receipt(entry_id, exc.code),
+            ) from exc
+        return ManagedWorkflowNodeRun(self, entry_id, run_id)
+
+    @staticmethod
+    def blocked_receipt(entry_id: WorkflowEntryId, reason_code: str) -> dict[str, Any]:
+        return {
+            "contract_version": PROVIDER_WORKLOAD_CONTRACT_VERSION,
+            "entry_id": entry_id,
+            "routing_mode": "managed_required",
+            "run_reference": "blocked_before_dispatch",
+            "status": "failed",
+            "call_count": 0,
+            "reason_codes": [reason_code],
+            "calls": [],
+        }
+
+
+class ManagedWorkflowNodeRun:
+    def __init__(
+        self,
+        gateway: ManagedWorkflowGateway,
+        entry_id: WorkflowEntryId,
+        run_id: str,
+    ) -> None:
+        self.gateway = gateway
+        self.entry_id = entry_id
+        self.run_id = run_id
+        self.status: Literal[
+            "running", "passed", "failed", "uncertain", "cancelled"
+        ] = "running"
+        self.reason_codes: list[str] = []
+        self.calls: list[WorkflowProviderCallReceipt] = []
+
+    async def stream_text(
+        self,
+        *,
+        logical_call_key: str,
+        call_sequence: int,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        cancel_event: asyncio.Event | None = None,
+    ) -> AsyncIterator[str]:
+        prepared: ProviderWorkloadPreparedCall | None = None
+        dispatched = False
+        started = time.perf_counter()
+        evidence = _StreamEvidence()
+        try:
+            prepared = await self.gateway.call_service.prepare_call(
+                run_id=self.run_id,
+                entry_id=self.entry_id,
+                execution_shape="chat_text",
+                model_id=model_id,
+                logical_call_key=logical_call_key,
+                call_sequence=call_sequence,
+            )
+            payload = {
+                "model": model_id,
+                "messages": messages,
+                "stream": True,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            }
+            async with self._client() as client:
+                request = self.gateway.call_service.transport.build_authorized_stream_request(
+                    client,
+                    prepared.target,
+                    prepared.authorized_target,
+                    payload,
+                )
+                self.gateway.call_service.mark_dispatched(prepared)
+                dispatched = True
+                response = await self.gateway.call_service.transport.send_authorized_stream(
+                    client, request
+                )
+                try:
+                    self._validate_status(response.status_code)
+                    async for event in self._iter_sse_events(response, cancel_event):
+                        for delta in self._consume_stream_event(
+                            event,
+                            evidence,
+                            requested_model=model_id,
+                            started=started,
+                        ):
+                            yield delta
+                finally:
+                    await response.aclose()
+            if not evidence.content_observed:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_empty_stream",
+                    "Managed Provider 没有返回可用的 Workflow 文本流。",
+                )
+            if not evidence.terminal_observed:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_missing_terminal",
+                    "Managed Provider 的 Workflow 文本流缺少安全终止信号。",
+                )
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            self.gateway.call_service.complete_call(
+                prepared,
+                status="passed",
+                result_class="success",
+                actual_model=evidence.actual_model,
+                ttft_ms=evidence.ttft_ms,
+                e2e_ms=elapsed_ms,
+                prompt_tokens=evidence.prompt_tokens,
+                completion_tokens=evidence.completion_tokens,
+                total_tokens=evidence.total_tokens,
+            )
+            self.calls.append(
+                WorkflowProviderCallReceipt(
+                    call_sequence=call_sequence,
+                    model_id=model_id,
+                    actual_model=evidence.actual_model,
+                    dispatched=True,
+                    status="passed",
+                    prompt_tokens=evidence.prompt_tokens,
+                    completion_tokens=evidence.completion_tokens,
+                    total_tokens=evidence.total_tokens,
+                )
+            )
+        except asyncio.CancelledError:
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status="cancelled",
+                result_class="client_cancelled",
+                code="provider_workload_call_cancelled",
+            )
+            raise
+        except ManagedWorkflowRoutingError as exc:
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status="failed",
+                result_class="provider_error" if dispatched else "preflight_error",
+                code=exc.code,
+            )
+            exc.receipt = self.receipt_summary()
+            raise
+        except RouterServiceError as exc:
+            status: WorkflowCallStatus = "uncertain" if dispatched else "failed"
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                result_class="control_plane_error",
+                code=exc.code,
+            )
+            raise self._closed_error(exc.code, dispatched) from exc
+        except (httpx.TimeoutException, TimeoutError) as exc:
+            status = "uncertain" if dispatched else "failed"
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                result_class="transport_error",
+                code="provider_workload_timeout",
+            )
+            raise self._closed_error("provider_workload_timeout", dispatched) from exc
+        except httpx.HTTPError as exc:
+            status = "uncertain" if dispatched else "failed"
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                result_class="transport_error",
+                code="provider_workload_transport_error",
+            )
+            raise self._closed_error(
+                "provider_workload_transport_error", dispatched
+            ) from exc
+        except Exception as exc:
+            status = "uncertain" if dispatched else "failed"
+            code = (
+                "provider_workload_dispatch_uncertain"
+                if dispatched
+                else "provider_workload_preflight_failed"
+            )
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                result_class="unexpected_error",
+                code=code,
+            )
+            raise self._closed_error(code, dispatched) from exc
+
+    async def complete_text_unary(
+        self,
+        *,
+        logical_call_key: str,
+        call_sequence: int,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        cancel_event: asyncio.Event | None = None,
+    ) -> str:
+        return await self._complete_unary(
+            logical_call_key=logical_call_key,
+            call_sequence=call_sequence,
+            execution_shape="chat_text_unary",
+            model_id=model_id,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            response_format=None,
+            require_json_object=False,
+            cancel_event=cancel_event,
+        )
+
+    async def complete_json_object(
+        self,
+        *,
+        logical_call_key: str,
+        call_sequence: int,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        cancel_event: asyncio.Event | None = None,
+    ) -> str:
+        return await self._complete_unary(
+            logical_call_key=logical_call_key,
+            call_sequence=call_sequence,
+            execution_shape="chat_json_object",
+            model_id=model_id,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            response_format={"type": "json_object"},
+            require_json_object=True,
+            cancel_event=cancel_event,
+        )
+
+    async def _complete_unary(
+        self,
+        *,
+        logical_call_key: str,
+        call_sequence: int,
+        execution_shape: Literal["chat_text_unary", "chat_json_object"],
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        response_format: dict[str, str] | None,
+        require_json_object: bool,
+        cancel_event: asyncio.Event | None,
+    ) -> str:
+        prepared: ProviderWorkloadPreparedCall | None = None
+        dispatched = False
+        started = time.perf_counter()
+        try:
+            prepared = await self.gateway.call_service.prepare_call(
+                run_id=self.run_id,
+                entry_id=self.entry_id,
+                execution_shape=execution_shape,
+                model_id=model_id,
+                logical_call_key=logical_call_key,
+                call_sequence=call_sequence,
+            )
+            payload: dict[str, Any] = {
+                "model": model_id,
+                "messages": messages,
+                "stream": False,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            }
+            if response_format is not None:
+                payload["response_format"] = response_format
+            async with self._client() as client:
+                request = self.gateway.call_service.transport.build_authorized_stream_request(
+                    client,
+                    prepared.target,
+                    prepared.authorized_target,
+                    payload,
+                )
+                self.gateway.call_service.mark_dispatched(prepared)
+                dispatched = True
+                response = await self.gateway.call_service.transport.send_authorized_stream(
+                    client, request
+                )
+                try:
+                    self._validate_status(response.status_code)
+                    raw = await self._read_with_cancel(response, cancel_event)
+                finally:
+                    await response.aclose()
+            payload_body = self._decode_completion(raw)
+            text, actual_model, usage = self._completion_text(
+                payload_body,
+                requested_model=model_id,
+                require_json_object=require_json_object,
+            )
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            self.gateway.call_service.complete_call(
+                prepared,
+                status="passed",
+                result_class="success",
+                actual_model=actual_model,
+                ttft_ms=elapsed_ms,
+                e2e_ms=elapsed_ms,
+                prompt_tokens=usage.get("prompt_tokens"),
+                completion_tokens=usage.get("completion_tokens"),
+                total_tokens=usage.get("total_tokens"),
+            )
+            self.calls.append(
+                WorkflowProviderCallReceipt(
+                    call_sequence=call_sequence,
+                    model_id=model_id,
+                    actual_model=actual_model,
+                    dispatched=True,
+                    status="passed",
+                    prompt_tokens=usage.get("prompt_tokens"),
+                    completion_tokens=usage.get("completion_tokens"),
+                    total_tokens=usage.get("total_tokens"),
+                )
+            )
+            return text
+        except asyncio.CancelledError:
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status="cancelled",
+                result_class="client_cancelled",
+                code="provider_workload_call_cancelled",
+            )
+            raise
+        except ManagedWorkflowRoutingError as exc:
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status="failed",
+                result_class="provider_error" if dispatched else "preflight_error",
+                code=exc.code,
+            )
+            exc.receipt = self.receipt_summary()
+            raise
+        except RouterServiceError as exc:
+            status: WorkflowCallStatus = "uncertain" if dispatched else "failed"
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                result_class="control_plane_error",
+                code=exc.code,
+            )
+            raise self._closed_error(exc.code, dispatched) from exc
+        except (httpx.TimeoutException, TimeoutError) as exc:
+            status = "uncertain" if dispatched else "failed"
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                result_class="transport_error",
+                code="provider_workload_timeout",
+            )
+            raise self._closed_error("provider_workload_timeout", dispatched) from exc
+        except httpx.HTTPError as exc:
+            status = "uncertain" if dispatched else "failed"
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                result_class="transport_error",
+                code="provider_workload_transport_error",
+            )
+            raise self._closed_error(
+                "provider_workload_transport_error", dispatched
+            ) from exc
+        except Exception as exc:
+            status = "uncertain" if dispatched else "failed"
+            code = (
+                "provider_workload_dispatch_uncertain"
+                if dispatched
+                else "provider_workload_preflight_failed"
+            )
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                result_class="unexpected_error",
+                code=code,
+            )
+            raise self._closed_error(code, dispatched) from exc
+
+    def finish(
+        self,
+        status: Literal["passed", "failed", "uncertain", "cancelled"],
+        *,
+        reason_code: str | None = None,
+    ) -> None:
+        if self.status != "running":
+            return
+        reason_codes = [reason_code] if reason_code else []
+        try:
+            self.gateway.call_service.complete_run(
+                self.run_id,
+                status=status,
+                result_class=f"workflow_node_{status}",
+                reason_codes=reason_codes,
+            )
+        except RouterRepositoryError as exc:
+            if str(exc) != "provider_workload_run_not_running":
+                raise
+        self.status = status
+        self.reason_codes = reason_codes
+
+    def receipt_summary(self) -> dict[str, Any]:
+        return {
+            "contract_version": PROVIDER_WORKLOAD_CONTRACT_VERSION,
+            "entry_id": self.entry_id,
+            "routing_mode": "managed_required",
+            "run_reference": self.run_id,
+            "status": self.status,
+            "call_count": sum(1 for call in self.calls if call.dispatched),
+            "reason_codes": list(self.reason_codes),
+            "calls": [call.as_dict() for call in self.calls],
+        }
+
+    def _client(self) -> httpx.AsyncClient:
+        if self.gateway._client_factory is not None:
+            return self.gateway._client_factory()
+        return httpx.AsyncClient(
+            **self.gateway.call_service.transport.client_kwargs()
+        )
+
+    async def _iter_sse_events(
+        self,
+        response: httpx.Response,
+        cancel_event: asyncio.Event | None,
+    ) -> AsyncIterator[str]:
+        buffer = b""
+        total = 0
+        async for chunk in self._iter_response_bytes(response, cancel_event):
+            total += len(chunk)
+            if total > MAX_STREAM_BYTES:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_stream_too_large",
+                    "Managed Provider 的 Workflow 文本流超过安全上限。",
+                )
+            buffer += chunk
+            while True:
+                delimiters = [
+                    (index, delimiter)
+                    for delimiter in (b"\n\n", b"\r\n\r\n", b"\r\r")
+                    if (index := buffer.find(delimiter)) >= 0
+                ]
+                if not delimiters:
+                    break
+                index, delimiter = min(delimiters, key=lambda item: item[0])
+                raw_event = buffer[:index]
+                buffer = buffer[index + len(delimiter) :]
+                yield self._decode_sse_event(raw_event)
+            if len(buffer) > MAX_SSE_EVENT_BYTES:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_sse_event_too_large",
+                    "Managed Provider 的 Workflow 流事件超过安全上限。",
+                )
+        if buffer.strip():
+            yield self._decode_sse_event(buffer)
+
+    async def _iter_response_bytes(
+        self,
+        response: httpx.Response,
+        cancel_event: asyncio.Event | None,
+    ) -> AsyncIterator[bytes]:
+        # Preserve upstream SSE chunk delivery. A fixed 64 KiB chunk size makes
+        # httpx buffer short streams until EOF, delaying both TTFT and cancel.
+        iterator = response.aiter_bytes().__aiter__()
+        while True:
+            next_chunk = asyncio.create_task(anext(iterator))
+            cancel_wait = (
+                asyncio.create_task(cancel_event.wait())
+                if cancel_event is not None
+                else None
+            )
+            waiters = {next_chunk}
+            if cancel_wait is not None:
+                waiters.add(cancel_wait)
+            done, _ = await asyncio.wait(waiters, return_when=asyncio.FIRST_COMPLETED)
+            if cancel_wait is not None and cancel_wait in done and cancel_event.is_set():
+                next_chunk.cancel()
+                with contextlib.suppress(asyncio.CancelledError, StopAsyncIteration):
+                    await next_chunk
+                raise asyncio.CancelledError
+            if cancel_wait is not None:
+                cancel_wait.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await cancel_wait
+            try:
+                yield next_chunk.result()
+            except StopAsyncIteration:
+                return
+
+    @staticmethod
+    def _decode_sse_event(raw: bytes) -> str:
+        if len(raw) > MAX_SSE_EVENT_BYTES:
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_sse_event_too_large",
+                "Managed Provider 的 Workflow 流事件超过安全上限。",
+            )
+        try:
+            return raw.decode("utf-8").replace("\r\n", "\n").replace("\r", "\n")
+        except UnicodeDecodeError as exc:
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_invalid_sse",
+                "Managed Provider 返回了无效的 Workflow SSE。",
+            ) from exc
+
+    def _consume_stream_event(
+        self,
+        event: str,
+        evidence: _StreamEvidence,
+        *,
+        requested_model: str,
+        started: float,
+    ) -> list[str]:
+        data_lines: list[str] = []
+        for line in event.split("\n"):
+            if not line or line.startswith(":"):
+                continue
+            if line.startswith("data:"):
+                data_lines.append(line[5:].lstrip())
+                continue
+            if line.startswith(("event:", "id:", "retry:")):
+                continue
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_invalid_sse",
+                "Managed Provider 返回了无效的 Workflow SSE。",
+            )
+        if not data_lines:
+            return []
+        data = "\n".join(data_lines)
+        if data == "[DONE]":
+            evidence.terminal_observed = True
+            return []
+        try:
+            payload = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_invalid_sse",
+                "Managed Provider 返回了无效的 Workflow SSE。",
+            ) from exc
+        if not isinstance(payload, dict) or isinstance(payload.get("error"), dict):
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_invalid_sse",
+                "Managed Provider 返回了无效的 Workflow SSE。",
+            )
+        self._read_usage(payload, evidence)
+        actual_model = payload.get("model")
+        if isinstance(actual_model, str) and actual_model.strip():
+            clean_model = actual_model.strip()
+            if clean_model != requested_model:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_actual_model_mismatch",
+                    "Managed Provider 返回的实际模型与 Workflow Binding 不一致。",
+                )
+            evidence.actual_model = clean_model
+        choices = payload.get("choices")
+        if not isinstance(choices, list):
+            return []
+        deltas: list[str] = []
+        for choice in choices:
+            if not isinstance(choice, dict):
+                continue
+            if choice.get("finish_reason"):
+                evidence.terminal_observed = True
+            content_source = choice.get("delta")
+            if not isinstance(content_source, dict):
+                content_source = choice.get("message")
+            content = (
+                self._content_text(content_source.get("content"))
+                if isinstance(content_source, dict)
+                else ""
+            )
+            if content:
+                if evidence.ttft_ms is None:
+                    evidence.ttft_ms = (time.perf_counter() - started) * 1000
+                evidence.content_observed = True
+                deltas.append(content)
+        return deltas
+
+    async def _read_with_cancel(
+        self,
+        response: httpx.Response,
+        cancel_event: asyncio.Event | None,
+    ) -> bytes:
+        read_task = asyncio.create_task(response.aread())
+        cancel_wait = (
+            asyncio.create_task(cancel_event.wait()) if cancel_event is not None else None
+        )
+        waiters = {read_task}
+        if cancel_wait is not None:
+            waiters.add(cancel_wait)
+        done, _ = await asyncio.wait(waiters, return_when=asyncio.FIRST_COMPLETED)
+        if cancel_wait is not None and cancel_wait in done and cancel_event.is_set():
+            read_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await read_task
+            raise asyncio.CancelledError
+        if cancel_wait is not None:
+            cancel_wait.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await cancel_wait
+        raw = read_task.result()
+        if len(raw) > MAX_RESPONSE_BYTES:
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_response_too_large",
+                "Managed Provider 的 Workflow 响应超过安全上限。",
+            )
+        return raw
+
+    @staticmethod
+    def _decode_completion(raw: bytes) -> dict[str, Any]:
+        try:
+            payload = json.loads(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_invalid_json_response",
+                "Managed Provider 返回了无效的 Workflow 响应。",
+            ) from exc
+        if not isinstance(payload, dict):
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_invalid_json_response",
+                "Managed Provider 返回了无效的 Workflow 响应。",
+            )
+        return payload
+
+    @classmethod
+    def _completion_text(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        requested_model: str,
+        require_json_object: bool,
+    ) -> tuple[str, str | None, dict[str, int]]:
+        actual_model = payload.get("model")
+        actual_model = actual_model.strip() if isinstance(actual_model, str) else None
+        if actual_model and actual_model != requested_model:
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_actual_model_mismatch",
+                "Managed Provider 返回的实际模型与 Workflow Binding 不一致。",
+            )
+        choices = payload.get("choices")
+        first = choices[0] if isinstance(choices, list) and choices else None
+        message = first.get("message") if isinstance(first, dict) else None
+        text = (
+            cls._content_text(message.get("content"))
+            if isinstance(message, dict)
+            else ""
+        )
+        if not text.strip():
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_empty_response",
+                "Managed Provider 没有返回 Workflow 所需内容。",
+            )
+        if require_json_object:
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_json_object_invalid",
+                    "Managed Provider 没有返回有效的 JSON Object。",
+                ) from exc
+            if not isinstance(parsed, dict):
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_json_object_invalid",
+                    "Managed Provider 没有返回有效的 JSON Object。",
+                )
+        usage: dict[str, int] = {}
+        raw_usage = payload.get("usage")
+        if isinstance(raw_usage, dict):
+            for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+                value = raw_usage.get(key)
+                if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                    usage[key] = value
+        return text, actual_model, usage
+
+    @staticmethod
+    def _content_text(value: Any) -> str:
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            parts: list[str] = []
+            for item in value:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, dict) and isinstance(item.get("text"), str):
+                    parts.append(item["text"])
+            return "".join(parts)
+        if isinstance(value, dict) and isinstance(value.get("text"), str):
+            return value["text"]
+        return ""
+
+    @staticmethod
+    def _read_usage(payload: Mapping[str, Any], evidence: _StreamEvidence) -> None:
+        usage = payload.get("usage")
+        if not isinstance(usage, dict):
+            return
+        for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+            value = usage.get(key)
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                setattr(evidence, key, value)
+
+    @staticmethod
+    def _validate_status(status_code: int) -> None:
+        if 200 <= status_code < 300:
+            return
+        code = {
+            401: "provider_workload_http_401",
+            402: "provider_workload_http_402",
+            403: "provider_workload_http_403",
+            404: "provider_workload_http_404",
+            429: "provider_workload_http_429",
+        }.get(
+            status_code,
+            "provider_workload_http_5xx"
+            if status_code >= 500
+            else "provider_workload_http_error",
+        )
+        raise ManagedWorkflowRoutingError(
+            code,
+            "Managed Provider 拒绝或未能完成 Workflow 请求。",
+        )
+
+    def _record_failure(
+        self,
+        prepared: ProviderWorkloadPreparedCall | None,
+        *,
+        call_sequence: int,
+        model_id: str,
+        dispatched: bool,
+        status: WorkflowCallStatus,
+        result_class: str,
+        code: str,
+    ) -> None:
+        if prepared is not None:
+            try:
+                self.gateway.call_service.complete_call(
+                    prepared,
+                    status=status,
+                    result_class=result_class,
+                    error_code=code,
+                )
+            except RouterRepositoryError:
+                pass
+        self.calls.append(
+            WorkflowProviderCallReceipt(
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                error_code=code,
+            )
+        )
+
+    def _closed_error(self, code: str, dispatched: bool) -> ManagedWorkflowRoutingError:
+        return ManagedWorkflowRoutingError(
+            code,
+            (
+                "Workflow 的 Managed Provider 调用结果不确定，系统未重放。"
+                if dispatched
+                else "Workflow 的 Managed Provider 路由在发送前失败关闭。"
+            ),
+            receipt=self.receipt_summary(),
+        )

--- a/server/model_router/workload_control.py
+++ b/server/model_router/workload_control.py
@@ -100,7 +100,12 @@ ENTRY_ALLOWED_SHAPES: dict[
 # R6A deliberately provides only the control-plane foundation. Each later data-plane
 # PR adds its entry here after its dedicated tests and real smoke are complete.
 DATA_PLANE_INTEGRATED_ENTRIES: frozenset[ProviderWorkloadEntryId] = frozenset(
-    {"agent_shadow", "meta_agent"}
+    {
+        "agent_shadow",
+        "meta_agent",
+        "workflow_interactive_llm",
+        "workflow_deployment_llm",
+    }
 )
 
 
@@ -1450,6 +1455,57 @@ class ProviderWorkloadCallService:
             policy_fingerprint=policy.policy_fingerprint,
             parent_run_reference=parent_run_reference,
         )
+        return run_id
+
+    def start_stable_run(
+        self,
+        entry_id: ProviderWorkloadEntryId,
+        *,
+        parent_run_reference: str,
+    ) -> str:
+        """Claim one durable logical run and reject every later replay."""
+
+        clean_parent = parent_run_reference.strip()
+        if not clean_parent:
+            raise RouterServiceError(
+                "provider_workload_parent_run_reference_required",
+                "Workload 稳定运行缺少父执行引用。",
+                status_code=422,
+            )
+        policy = self.control.get_policy(entry_id)
+        self._ensure_active(policy)
+        material = json.dumps(
+            {
+                "tenant_id": self.router_service.tenant_id,
+                "entry_id": entry_id,
+                "parent_run_reference": clean_parent,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        run_id = f"workrun_{hashlib.sha256(material.encode('utf-8')).hexdigest()}"
+        row, created = self.repository.claim_stable_workload_run(
+            self.router_service.tenant_id,
+            run_id=run_id,
+            entry_id=entry_id,
+            policy_fingerprint=policy.policy_fingerprint,
+            parent_run_reference=clean_parent,
+        )
+        if (
+            str(row["entry_id"]) != entry_id
+            or str(row["parent_run_reference"] or "") != clean_parent
+        ):
+            raise RouterServiceError(
+                "provider_workload_stable_run_collision",
+                "Workload 稳定运行引用发生冲突，系统不会派发 Provider 请求。",
+                status_code=409,
+            )
+        if not created:
+            raise RouterServiceError(
+                "provider_workload_logical_run_replay_blocked",
+                "该 Workflow 模型节点已有执行证据，系统不会自动重放。",
+                status_code=409,
+            )
         return run_id
 
     async def prepare_call(

--- a/server/tests/test_workflow_managed_gateway.py
+++ b/server/tests/test_workflow_managed_gateway.py
@@ -1,0 +1,563 @@
+import hashlib
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from server.model_router.egress import ProviderEgressPolicy
+from server.model_router.provider_chat import PROVIDER_CHAT_CONTRACT_VERSION
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import (
+    ProviderWorkloadActivationRequest,
+    ProviderWorkloadBindingUpdate,
+    ProviderWorkloadPolicyUpdate,
+    RouterConnectionCreate,
+)
+from server.model_router.service import ModelRouterService
+from server.model_router.workflow_gateway import (
+    ManagedWorkflowGateway,
+    ManagedWorkflowRoutingError,
+)
+from server.model_router.workload_control import (
+    PROVIDER_WORKLOAD_CONTRACT_VERSION,
+    ProviderWorkloadControlService,
+)
+import server.model_router.workload_control as workload_control_module
+
+
+MODEL_ID = "provider/workflow-model"
+PROVIDER_SECRET = "workflow-provider-secret"
+
+
+def _profile(execution_shape: str) -> tuple[dict[str, object], str]:
+    value: dict[str, object] = {
+        "execution_shape": execution_shape,
+        "model_id": MODEL_ID,
+        "candidate_model_ids": [],
+        "judge_model_id": None,
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return value, fingerprint
+
+
+def _qualified_router(tmp_path: Path) -> tuple[ModelRouterService, str]:
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Workflow Provider",
+            kind="openai_compatible",
+            base_url="https://workflow-provider.example/v1",
+            api_key=PROVIDER_SECRET,
+            scopes=["chat"],
+        ),
+    )
+    repository.save_test_result(
+        "local",
+        connection.id,
+        health="online",
+        model_count=1,
+        checked_at="2026-08-23T00:00:00+00:00",
+    )
+    fingerprint = repository.connection_config_fingerprint("local", connection.id)
+    refresh_id = f"refresh-{connection.id}"
+    repository.claim_catalog_refresh(
+        "local",
+        refresh_id=refresh_id,
+        connection_id=connection.id,
+        connection_fingerprint=fingerprint,
+    )
+    repository.complete_catalog_refresh(
+        "local",
+        refresh_id,
+        connection_id=connection.id,
+        models=[
+            {
+                "model_id": MODEL_ID,
+                "normalized_model_id": MODEL_ID,
+                "capability_state": "declared",
+            }
+        ],
+        offerings=[],
+        model_count=1,
+        truncated=False,
+        catalog_fingerprint="workflow-catalog",
+        observed_at="2026-08-23T00:00:00+00:00",
+    )
+    chat_cert, created = repository.claim_chat_certification(
+        "local",
+        certification_id="workflow-chat-text-cert",
+        connection_id=connection.id,
+        connection_fingerprint=fingerprint,
+        contract_version=PROVIDER_CHAT_CONTRACT_VERSION,
+        capability="chat_text",
+        requested_model=MODEL_ID,
+        idempotency_key_hash=hashlib.sha256(b"workflow-chat-text").hexdigest(),
+    )
+    assert created is True
+    repository.complete_chat_certification(
+        "local",
+        str(chat_cert["id"]),
+        status="passed",
+        checks={
+            "catalog_contains_model": True,
+            "http_2xx": True,
+            "content_observed": True,
+            "response_complete": True,
+            "terminal_observed": True,
+        },
+        warning_codes=[],
+        actual_model=MODEL_ID,
+    )
+    for execution_shape in ("chat_text_unary", "chat_json_object"):
+        profile, profile_fingerprint = _profile(execution_shape)
+        certification, created = repository.claim_workload_certification(
+            "local",
+            certification_id=f"workflow-{execution_shape}-cert",
+            connection_id=connection.id,
+            connection_fingerprint=fingerprint,
+            contract_version=PROVIDER_WORKLOAD_CONTRACT_VERSION,
+            execution_shape=execution_shape,
+            requested_model=MODEL_ID,
+            profile=profile,
+            profile_fingerprint=profile_fingerprint,
+            idempotency_key_hash=hashlib.sha256(
+                f"workflow-{execution_shape}".encode("utf-8")
+            ).hexdigest(),
+        )
+        assert created is True
+        repository.complete_workload_certification(
+            "local",
+            str(certification["id"]),
+            status="passed",
+            checks={
+                "content_observed": True,
+                "actual_model_verified": True,
+                "json_object_verified": execution_shape == "chat_json_object",
+            },
+            warning_codes=[],
+            actual_model=MODEL_ID,
+        )
+    service = ModelRouterService(
+        repository,
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+    return service, connection.id
+
+
+def _activate(
+    service: ModelRouterService,
+    connection_id: str,
+    entry_id: str,
+) -> None:
+    control = ProviderWorkloadControlService(service)
+    saved = control.update_policy(
+        entry_id,  # type: ignore[arg-type]
+        ProviderWorkloadPolicyUpdate(
+            expected_revision=0,
+            bindings=[
+                ProviderWorkloadBindingUpdate(
+                    execution_shape=shape,  # type: ignore[arg-type]
+                    model_id=MODEL_ID,
+                    connection_id=connection_id,
+                )
+                for shape in ("chat_text", "chat_text_unary", "chat_json_object")
+            ],
+        ),
+    )
+    active = control.activate(
+        entry_id,  # type: ignore[arg-type]
+        ProviderWorkloadActivationRequest(
+            expected_revision=saved.revision,
+            no_open_p0_p1=True,
+            acknowledge_fail_closed=True,
+        ),
+    )
+    assert active.effective_status == "managed_required"
+
+
+@pytest.fixture
+def qualified_interactive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[ModelRouterService, str]:
+    service, connection_id = _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_WORKFLOW_LLM_ENABLED", "true")
+    monkeypatch.setattr(
+        workload_control_module,
+        "DATA_PLANE_INTEGRATED_ENTRIES",
+        frozenset(
+            {
+                "agent_shadow",
+                "meta_agent",
+                "workflow_interactive_llm",
+            }
+        ),
+    )
+    _activate(service, connection_id, "workflow_interactive_llm")
+    return service, connection_id
+
+
+def test_stable_node_run_blocks_recovery_replay(
+    qualified_interactive: tuple[ModelRouterService, str],
+) -> None:
+    service, _ = qualified_interactive
+    gateway = ManagedWorkflowGateway.for_router(service)
+
+    first = gateway.start_node_run(
+        source_kind="workflow_classic",
+        execution_reference="workflow-task-1",
+        node_id="llm-node",
+    )
+    first.finish("failed", reason_code="test_preflight_stop")
+    with pytest.raises(ManagedWorkflowRoutingError) as replay:
+        gateway.start_node_run(
+            source_kind="workflow_classic",
+            execution_reference="workflow-task-1",
+            node_id="llm-node",
+        )
+
+    assert replay.value.code == "provider_workload_logical_run_replay_blocked"
+    assert replay.value.receipt is not None
+    assert replay.value.receipt["call_count"] == 0
+    receipts = service.repository.list_workload_receipts("local")
+    assert len(receipts["runs"]) == 1
+    assert receipts["runs"][0]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_workflow_gateway_streams_and_records_all_execution_shapes(
+    qualified_interactive: tuple[ModelRouterService, str],
+) -> None:
+    service, _ = qualified_interactive
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        body = json.loads(request.content)
+        if body["stream"]:
+            return httpx.Response(
+                200,
+                content=(
+                    b'data: {"model":"provider/workflow-model","choices":'
+                    b'[{"delta":{"content":"hello "},"finish_reason":null}]}\n\n'
+                    b'data: {"choices":[{"delta":{"content":"world"},'
+                    b'"finish_reason":"stop"}],"usage":{"prompt_tokens":7,'
+                    b'"completion_tokens":2,"total_tokens":9}}\n\n'
+                    b"data: [DONE]\n\n"
+                ),
+            )
+        content = (
+            '{"value":"ok"}'
+            if body.get("response_format") == {"type": "json_object"}
+            else "category-a"
+        )
+        return httpx.Response(
+            200,
+            json={
+                "model": MODEL_ID,
+                "choices": [{"message": {"content": content}}],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 1,
+                    "total_tokens": 6,
+                },
+            },
+        )
+
+    gateway = ManagedWorkflowGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=False,
+            trust_env=False,
+        ),
+    )
+    stream_run = gateway.start_node_run(
+        source_kind="workflow_classic",
+        execution_reference="workflow-task-stream",
+        node_id="llm-node",
+    )
+    chunks = [
+        item
+        async for item in stream_run.stream_text(
+            logical_call_key="llm:primary",
+            call_sequence=1,
+            model_id=MODEL_ID,
+            messages=[{"role": "user", "content": "private prompt"}],
+            temperature=0.7,
+            max_tokens=128,
+        )
+    ]
+    stream_run.finish("passed")
+
+    unary_run = gateway.start_node_run(
+        source_kind="workflow_classic",
+        execution_reference="workflow-task-unary",
+        node_id="classifier-node",
+    )
+    unary = await unary_run.complete_text_unary(
+        logical_call_key="question_classifier:model_fallback",
+        call_sequence=1,
+        model_id=MODEL_ID,
+        messages=[{"role": "user", "content": "private classifier input"}],
+        temperature=0,
+        max_tokens=64,
+    )
+    unary_run.finish("passed")
+
+    json_run = gateway.start_node_run(
+        source_kind="workflow_classic",
+        execution_reference="workflow-task-json",
+        node_id="extractor-node",
+    )
+    extracted = await json_run.complete_json_object(
+        logical_call_key="parameter_extractor:initial",
+        call_sequence=1,
+        model_id=MODEL_ID,
+        messages=[{"role": "user", "content": "private extraction input"}],
+        temperature=0,
+        max_tokens=128,
+    )
+    json_run.finish("passed")
+
+    assert chunks == ["hello ", "world"]
+    assert unary == "category-a"
+    assert json.loads(extracted) == {"value": "ok"}
+    assert len(requests) == 3
+    assert stream_run.receipt_summary()["calls"][0]["total_tokens"] == 9
+    assert unary_run.receipt_summary()["call_count"] == 1
+    assert json_run.receipt_summary()["call_count"] == 1
+    database = service.repository.database_path.read_bytes()
+    assert b"private prompt" not in database
+    assert b"private classifier input" not in database
+    assert b"private extraction input" not in database
+    assert PROVIDER_SECRET.encode() not in database
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response", "expected_code"),
+    [
+        (
+            httpx.Response(401, json={"error": {"message": "secret upstream body"}}),
+            "provider_workload_http_401",
+        ),
+        (
+            httpx.Response(
+                200,
+                content=(
+                    b'data: {"model":"different/model","choices":'
+                    b'[{"delta":{"content":"wrong"},"finish_reason":"stop"}]}\n\n'
+                    b"data: [DONE]\n\n"
+                ),
+            ),
+            "provider_workload_actual_model_mismatch",
+        ),
+        (
+            httpx.Response(
+                200,
+                content=b'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n',
+            ),
+            "provider_workload_missing_terminal",
+        ),
+    ],
+)
+async def test_stream_failure_is_one_post_and_never_replayed(
+    qualified_interactive: tuple[ModelRouterService, str],
+    response: httpx.Response,
+    expected_code: str,
+) -> None:
+    service, _ = qualified_interactive
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return response
+
+    gateway = ManagedWorkflowGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=False,
+            trust_env=False,
+        ),
+    )
+    run = gateway.start_node_run(
+        source_kind="workflow_classic",
+        execution_reference=f"failure-{expected_code}",
+        node_id="llm-node",
+    )
+    with pytest.raises(ManagedWorkflowRoutingError) as failure:
+        _ = [
+            item
+            async for item in run.stream_text(
+                logical_call_key="llm:primary",
+                call_sequence=1,
+                model_id=MODEL_ID,
+                messages=[{"role": "user", "content": "private"}],
+                temperature=0.7,
+                max_tokens=128,
+            )
+        ]
+    run.finish("failed", reason_code=failure.value.code)
+
+    assert failure.value.code == expected_code
+    assert len(requests) == 1
+    assert run.receipt_summary()["call_count"] == 1
+    with pytest.raises(ManagedWorkflowRoutingError) as replay:
+        gateway.start_node_run(
+            source_kind="workflow_classic",
+            execution_reference=f"failure-{expected_code}",
+            node_id="llm-node",
+        )
+    assert replay.value.code == "provider_workload_logical_run_replay_blocked"
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_cancel_closes_one_post_and_blocks_replay(
+    qualified_interactive: tuple[ModelRouterService, str],
+) -> None:
+    service, _ = qualified_interactive
+    requests: list[httpx.Request] = []
+    release = asyncio.Event()
+
+    class BlockingStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield (
+                b'data: {"model":"provider/workflow-model","choices":'
+                b'[{"delta":{"content":"first"},"finish_reason":null}]}\n\n'
+            )
+            await release.wait()
+            yield b"data: [DONE]\n\n"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, stream=BlockingStream())
+
+    gateway = ManagedWorkflowGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=False,
+            trust_env=False,
+        ),
+    )
+    run = gateway.start_node_run(
+        source_kind="workflow_classic",
+        execution_reference="cancelled-stream",
+        node_id="llm-node",
+    )
+    cancel_event = asyncio.Event()
+    stream = run.stream_text(
+        logical_call_key="llm:primary",
+        call_sequence=1,
+        model_id=MODEL_ID,
+        messages=[{"role": "user", "content": "private"}],
+        temperature=0.7,
+        max_tokens=128,
+        cancel_event=cancel_event,
+    )
+    assert await anext(stream) == "first"
+    cancel_event.set()
+    with pytest.raises(asyncio.CancelledError):
+        await anext(stream)
+    run.finish("cancelled", reason_code="provider_workload_call_cancelled")
+
+    assert len(requests) == 1
+    receipt = run.receipt_summary()
+    assert receipt["status"] == "cancelled"
+    assert receipt["calls"][0]["status"] == "cancelled"
+    assert receipt["calls"][0]["dispatched"] is True
+    with pytest.raises(ManagedWorkflowRoutingError) as replay:
+        gateway.start_node_run(
+            source_kind="workflow_classic",
+            execution_reference="cancelled-stream",
+            node_id="llm-node",
+        )
+    assert replay.value.code == "provider_workload_logical_run_replay_blocked"
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_deployment_restart_blocks_completed_call_before_node_end(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_WORKFLOW_LLM_ENABLED", "true")
+    monkeypatch.setenv("MODEL_CONTROL_WORKFLOW_DEPLOYMENT_ENABLED", "true")
+    _activate(service, connection_id, "workflow_deployment_llm")
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            content=(
+                b'data: {"model":"provider/workflow-model","choices":'
+                b'[{"delta":{"content":"completed upstream"},'
+                b'"finish_reason":"stop"}]}\n\n'
+                b"data: [DONE]\n\n"
+            ),
+        )
+
+    gateway = ManagedWorkflowGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=False,
+            trust_env=False,
+        ),
+    )
+    interrupted = gateway.start_node_run(
+        source_kind="workflow_deployment",
+        execution_reference="deployment-execution-1",
+        node_id="llm-node",
+    )
+    chunks = [
+        item
+        async for item in interrupted.stream_text(
+            logical_call_key="llm:primary",
+            call_sequence=1,
+            model_id=MODEL_ID,
+            messages=[{"role": "user", "content": "private deployment input"}],
+            temperature=0.7,
+            max_tokens=128,
+        )
+    ]
+    assert chunks == ["completed upstream"]
+    assert interrupted.status == "running"
+    assert len(requests) == 1
+
+    restarted_repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    restarted_service = ModelRouterService(
+        restarted_repository,
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+    restarted = ManagedWorkflowGateway.for_router(restarted_service)
+    with pytest.raises(ManagedWorkflowRoutingError) as replay:
+        restarted.start_node_run(
+            source_kind="workflow_deployment",
+            execution_reference="deployment-execution-1",
+            node_id="llm-node",
+        )
+    assert replay.value.code == "provider_workload_logical_run_replay_blocked"
+    assert len(requests) == 1
+
+    fresh = restarted.start_node_run(
+        source_kind="workflow_deployment",
+        execution_reference="deployment-execution-2",
+        node_id="llm-node",
+    )
+    fresh.finish("failed", reason_code="test_no_paid_rerun")
+    assert len(requests) == 1

--- a/server/tests/test_workflow_managed_runtime.py
+++ b/server/tests/test_workflow_managed_runtime.py
@@ -1,0 +1,653 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.responses import StreamingResponse
+
+import server.main as main_module
+from server.model_router.workflow_gateway import ManagedWorkflowRoutingError
+from server.xpert_runtime.execution_store import WorkflowExecutionStore
+
+
+MODEL_ID = "provider/workflow-model"
+
+
+class FakeManagedNodeRun:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+        self.run_id = "workrun_fake"
+        self.status = "running"
+        self.calls: list[Any] = []
+        self.invocations: list[dict[str, Any]] = []
+        self.json_outputs: list[str] = []
+
+    async def stream_text(self, **kwargs: Any):
+        self.invocations.append({"shape": "chat_text", **kwargs})
+        yield "managed "
+        yield "answer"
+
+    async def complete_text_unary(self, **kwargs: Any) -> str:
+        self.invocations.append({"shape": "chat_text_unary", **kwargs})
+        return '{"categoryId":"category_2"}'
+
+    async def complete_json_object(self, **kwargs: Any) -> str:
+        self.invocations.append({"shape": "chat_json_object", **kwargs})
+        if self.json_outputs:
+            return self.json_outputs.pop(0)
+        return '{"order_id":"A-1"}'
+
+    def finish(self, status: str, *, reason_code: str | None = None) -> None:
+        self.status = status
+        self.reason_code = reason_code
+
+    def receipt_summary(self) -> dict[str, Any]:
+        calls = [
+            {
+                "call_sequence": int(item["call_sequence"]),
+                "model_id": str(item["model_id"]),
+                "actual_model": str(item["model_id"]),
+                "dispatched": True,
+                "status": "passed" if self.status == "passed" else "failed",
+                "error_code": getattr(self, "reason_code", None),
+                "prompt_tokens": 3,
+                "completion_tokens": 2,
+                "total_tokens": 5,
+            }
+            for item in self.invocations
+        ]
+        return {
+            "contract_version": "modelmirror-provider-workload-routing-v1",
+            "entry_id": self.entry_id,
+            "routing_mode": "managed_required",
+            "run_reference": self.run_id,
+            "status": self.status,
+            "call_count": len(calls),
+            "reason_codes": (
+                [self.reason_code] if getattr(self, "reason_code", None) else []
+            ),
+            "calls": calls,
+        }
+
+
+class FakeManagedWorkflowGateway:
+    instances: list[FakeManagedWorkflowGateway] = []
+
+    def __init__(self) -> None:
+        self.started: list[dict[str, str]] = []
+        self.runs: list[FakeManagedNodeRun] = []
+        self.__class__.instances.append(self)
+
+    @classmethod
+    def for_router(cls, _service: Any) -> FakeManagedWorkflowGateway:
+        return cls()
+
+    @staticmethod
+    def entry_id(source_kind: str | None) -> str | None:
+        return {
+            "workflow_classic": "workflow_interactive_llm",
+            "workflow_deployment": "workflow_deployment_llm",
+        }.get(str(source_kind or ""))
+
+    @staticmethod
+    def blocked_receipt(entry_id: str, reason_code: str) -> dict[str, Any]:
+        return {
+            "contract_version": "modelmirror-provider-workload-routing-v1",
+            "entry_id": entry_id,
+            "routing_mode": "managed_required",
+            "run_reference": "blocked_before_dispatch",
+            "status": "failed",
+            "call_count": 0,
+            "reason_codes": [reason_code],
+            "calls": [],
+        }
+
+    def routing_mode(self, source_kind: str | None) -> str:
+        return "managed_required" if self.entry_id(source_kind) else "legacy"
+
+    def start_node_run(self, **kwargs: str) -> FakeManagedNodeRun:
+        self.started.append(dict(kwargs))
+        entry_id = self.entry_id(kwargs["source_kind"])
+        assert entry_id is not None
+        run = FakeManagedNodeRun(entry_id)
+        self.runs.append(run)
+        return run
+
+
+def _workflow(nodes: list[dict[str, Any]], edges: list[dict[str, Any]]) -> Any:
+    return main_module.WorkflowRunRequest.model_validate(
+        {
+            "workflow": {
+                "id": "managed-workflow-test",
+                "title": "Managed Workflow Test",
+                "nodes": nodes,
+                "edges": edges,
+            },
+            "inputs": {"user_input": "private workflow input"},
+        }
+    )
+
+
+async def _events(response: Any) -> list[dict[str, Any]]:
+    assert isinstance(response, StreamingResponse)
+    payloads: list[dict[str, Any]] = []
+    buffer = ""
+    async for chunk in response.body_iterator:
+        buffer += chunk.decode("utf-8") if isinstance(chunk, bytes) else str(chunk)
+        while "\n\n" in buffer:
+            frame, buffer = buffer.split("\n\n", 1)
+            for line in frame.splitlines():
+                if line.startswith("data:"):
+                    payloads.append(json.loads(line[5:].strip()))
+    return payloads
+
+
+@pytest.fixture(autouse=True)
+def _isolated_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeManagedWorkflowGateway.instances = []
+    monkeypatch.setattr(
+        main_module, "ManagedWorkflowGateway", FakeManagedWorkflowGateway
+    )
+    monkeypatch.setattr(
+        main_module,
+        "workflow_execution_store",
+        WorkflowExecutionStore(tmp_path / "executions"),
+    )
+    monkeypatch.setattr(main_module, "workflow_task_store", {})
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("", ""))
+
+
+@pytest.mark.asyncio
+async def test_managed_llm_runs_without_legacy_gateway_and_adds_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def legacy_must_not_run(*_args: Any, **_kwargs: Any):
+        raise AssertionError("legacy workflow stream must not run")
+
+    monkeypatch.setattr(main_module, "stream_workflow_llm_text", legacy_must_not_run)
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {
+                    "id": "llm",
+                    "type": "llm",
+                    "data": {
+                        "kind": "llm",
+                        "modelId": MODEL_ID,
+                        "prompt": "{{user_input}}",
+                        "outputVariable": "answer",
+                    },
+                },
+                {
+                    "id": "output",
+                    "type": "output",
+                    "data": {"kind": "output", "outputVariable": "answer"},
+                },
+            ],
+            [
+                {"id": "e1", "source": "input", "target": "llm"},
+                {"id": "e2", "source": "llm", "target": "output"},
+            ],
+        ),
+        None,
+        runtime_execution_source_kind="workflow_classic",
+        runtime_task_id="interactive-task",
+    )
+    events = await _events(response)
+
+    llm_end = next(
+        item
+        for item in events
+        if item.get("event") == "node_end" and item.get("node_id") == "llm"
+    )
+    receipt = llm_end["provider_route_receipts"]
+    assert receipt["entry_id"] == "workflow_interactive_llm"
+    assert receipt["call_count"] == 1
+    assert receipt["calls"][0]["model_id"] == MODEL_ID
+    assert [
+        item["output"]
+        for item in events
+        if item.get("event") == "node_delta" and item.get("node_id") == "llm"
+    ] == ["managed ", "answer"]
+    assert FakeManagedWorkflowGateway.instances[0].started == [
+        {
+            "source_kind": "workflow_classic",
+            "execution_reference": "interactive-task",
+            "node_id": "llm",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_excluded_runtime_source_keeps_legacy_llm_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    async def legacy_stream(model_id: str, prompt: str, **_kwargs: Any):
+        calls.append((model_id, prompt))
+        yield "legacy answer"
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("https://legacy.example/v1/chat/completions", "legacy-key"),
+    )
+    monkeypatch.setattr(main_module, "stream_workflow_llm_text", legacy_stream)
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {
+                    "id": "llm",
+                    "type": "llm",
+                    "data": {
+                        "kind": "llm",
+                        "modelId": MODEL_ID,
+                        "prompt": "{{user_input}}",
+                        "outputVariable": "answer",
+                    },
+                },
+            ],
+            [{"id": "e1", "source": "input", "target": "llm"}],
+        ),
+        None,
+        runtime_run_type="xpert",
+        runtime_execution_source_kind="xpert_chat",
+        runtime_task_id="excluded-xpert-task",
+    )
+    events = await _events(response)
+
+    assert calls == [(MODEL_ID, "private workflow input")]
+    assert FakeManagedWorkflowGateway.instances[0].started == []
+    llm_end = next(
+        item for item in events
+        if item.get("event") == "node_end" and item.get("node_id") == "llm"
+    )
+    assert "provider_route_receipts" not in llm_end
+
+
+@pytest.mark.asyncio
+async def test_classifier_rule_hit_creates_no_managed_run() -> None:
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {
+                    "id": "classifier",
+                    "type": "question_classifier",
+                    "data": {
+                        "kind": "question_classifier",
+                        "contractVersion": 2,
+                        "inputVariable": "user_input",
+                        "outputVariable": "category",
+                        "classificationMode": "rules_then_model",
+                        "caseSensitive": False,
+                        "modelId": MODEL_ID,
+                        "defaultLabel": "其他",
+                        "categoriesV2": [
+                            {
+                                "id": "category_1",
+                                "label": "Private",
+                                "description": "Rule hit",
+                                "keywords": ["private"],
+                                "matchMode": "contains_any",
+                            }
+                        ],
+                    },
+                },
+            ],
+            [{"id": "e1", "source": "input", "target": "classifier"}],
+        ),
+        None,
+        runtime_execution_source_kind="workflow_classic",
+        runtime_task_id="classifier-rule-task",
+    )
+    events = await _events(response)
+
+    assert FakeManagedWorkflowGateway.instances[0].started == []
+    classifier_end = next(
+        item for item in events if item.get("event") == "node_end"
+    )
+    assert "provider_route_receipts" not in classifier_end
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("node_kind", "node_data", "expected_shape"),
+    [
+        (
+            "parameter_extractor",
+            {
+                "contractVersion": 2,
+                "inputVariable": "user_input",
+                "outputVariable": "parameters",
+                "schemaMode": "fields",
+                "outputShape": "object",
+                "fields": [
+                    {
+                        "id": "field_1",
+                        "name": "order_id",
+                        "description": "Order identifier",
+                        "valueType": "string",
+                        "required": True,
+                        "nullable": False,
+                    }
+                ],
+                "repairAttempts": 0,
+            },
+            "chat_json_object",
+        ),
+        (
+            "question_classifier",
+            {
+                "contractVersion": 2,
+                "inputVariable": "user_input",
+                "outputVariable": "category",
+                "classificationMode": "model_only",
+                "caseSensitive": False,
+                "defaultLabel": "其他",
+                "categoriesV2": [
+                    {
+                        "id": "category_1",
+                        "label": "A",
+                        "description": "A",
+                        "keywords": [],
+                        "matchMode": "contains_any",
+                    },
+                    {
+                        "id": "category_2",
+                        "label": "B",
+                        "description": "B",
+                        "keywords": [],
+                        "matchMode": "contains_any",
+                    },
+                ],
+            },
+            "chat_text_unary",
+        ),
+    ],
+)
+async def test_managed_v2_missing_model_uses_exact_text_fallback_binding(
+    node_kind: str,
+    node_data: dict[str, Any],
+    expected_shape: str,
+) -> None:
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {
+                    "id": "model-node",
+                    "type": node_kind,
+                    "data": {"kind": node_kind, **node_data},
+                },
+            ],
+            [{"id": "e1", "source": "input", "target": "model-node"}],
+        ),
+        None,
+        runtime_execution_source_kind="workflow_classic",
+        runtime_task_id=f"fallback-{node_kind}",
+    )
+    events = await _events(response)
+
+    assert not [item for item in events if item.get("event") == "error"]
+    managed_run = FakeManagedWorkflowGateway.instances[0].runs[0]
+    assert managed_run.invocations[0]["shape"] == expected_shape
+    assert managed_run.invocations[0]["model_id"] == main_module.TEXT_FALLBACK_MODEL
+
+
+@pytest.mark.asyncio
+async def test_parameter_extractor_repair_is_two_planned_calls() -> None:
+    original_start = FakeManagedWorkflowGateway.start_node_run
+
+    def start_with_repair(
+        self: FakeManagedWorkflowGateway, **kwargs: str
+    ) -> FakeManagedNodeRun:
+        run = original_start(self, **kwargs)
+        run.json_outputs = ['{"order_id":3}', '{"order_id":"A-2"}']
+        return run
+
+    FakeManagedWorkflowGateway.start_node_run = start_with_repair
+    try:
+        response = await main_module._run_workflow_response(
+            _workflow(
+                [
+                    {"id": "input", "type": "input", "data": {"kind": "input"}},
+                    {
+                        "id": "extractor",
+                        "type": "parameter_extractor",
+                        "data": {
+                            "kind": "parameter_extractor",
+                            "contractVersion": 2,
+                            "inputVariable": "user_input",
+                            "modelId": MODEL_ID,
+                            "outputVariable": "parameters",
+                            "schemaMode": "fields",
+                            "outputShape": "object",
+                            "fields": [
+                                {
+                                    "id": "field_1",
+                                    "name": "order_id",
+                                    "description": "Order identifier",
+                                    "valueType": "string",
+                                    "required": True,
+                                    "nullable": False,
+                                }
+                            ],
+                            "jsonSchema": {},
+                            "repairAttempts": 1,
+                        },
+                    },
+                ],
+                [{"id": "e1", "source": "input", "target": "extractor"}],
+            ),
+            None,
+            runtime_execution_source_kind="workflow_classic",
+            runtime_task_id="extractor-repair-task",
+        )
+        events = await _events(response)
+    finally:
+        FakeManagedWorkflowGateway.start_node_run = original_start
+
+    extractor_end = next(
+        item
+        for item in events
+        if item.get("event") == "node_end" and item.get("node_id") == "extractor"
+    )
+    receipt = extractor_end["provider_route_receipts"]
+    assert receipt["call_count"] == 2
+    assert [item["call_sequence"] for item in receipt["calls"]] == [1, 2]
+    assert [
+        item["logical_call_key"]
+        for item in FakeManagedWorkflowGateway.instances[0].runs[0].invocations
+    ] == ["parameter_extractor:initial", "parameter_extractor:repair:1"]
+
+
+@pytest.mark.asyncio
+async def test_managed_v1_provider_failure_does_not_return_legacy_empty_object(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    original_complete = FakeManagedNodeRun.complete_json_object
+
+    async def fail_closed(self: FakeManagedNodeRun, **kwargs: Any) -> str:
+        self.invocations.append({"shape": "chat_json_object", **kwargs})
+        error = ManagedWorkflowRoutingError(
+            "provider_workload_http_503",
+            "Workflow Managed Provider failed closed.",
+        )
+        error.receipt = self.receipt_summary()
+        try:
+            raise RuntimeError(
+                "private prompt https://private-provider.example secret-key"
+            )
+        except RuntimeError as cause:
+            raise error from cause
+
+    FakeManagedNodeRun.complete_json_object = fail_closed
+    try:
+        response = await main_module._run_workflow_response(
+            _workflow(
+                [
+                    {"id": "input", "type": "input", "data": {"kind": "input"}},
+                    {
+                        "id": "extractor",
+                        "type": "parameter_extractor",
+                        "data": {
+                            "kind": "parameter_extractor",
+                            "contractVersion": 1,
+                            "inputVariable": "user_input",
+                            "modelId": MODEL_ID,
+                            "outputVariable": "parameters",
+                            "schema": "order_id:string",
+                        },
+                    },
+                ],
+                [{"id": "e1", "source": "input", "target": "extractor"}],
+            ),
+            None,
+            runtime_execution_source_kind="workflow_classic",
+            runtime_task_id="v1-fail-closed-task",
+        )
+        events = await _events(response)
+    finally:
+        FakeManagedNodeRun.complete_json_object = original_complete
+
+    error = next(item for item in events if item.get("event") == "error")
+    assert error["code"] == "provider_workload_http_503"
+    assert error["provider_route_receipts"]["entry_id"] == (
+        "workflow_interactive_llm"
+    )
+    assert not any(
+        item.get("event") == "node_end" and item.get("node_id") == "extractor"
+        for item in events
+    )
+    assert not any(item.get("output") == "{}" for item in events)
+    assert "private prompt" not in caplog.text
+    assert "private-provider.example" not in caplog.text
+    assert "secret-key" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_deployment_binding_uses_stable_execution_id() -> None:
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {
+                    "id": "llm",
+                    "type": "llm",
+                    "data": {
+                        "kind": "llm",
+                        "modelId": MODEL_ID,
+                        "prompt": "{{user_input}}",
+                    },
+                },
+            ],
+            [{"id": "e1", "source": "input", "target": "llm"}],
+        ),
+        None,
+        runtime_execution_source_kind="workflow_deployment",
+        runtime_metadata={
+            "workflow_deployment_execution_id": "deployment-execution-1"
+        },
+        runtime_task_id="deployment-task-id",
+    )
+    await _events(response)
+
+    assert FakeManagedWorkflowGateway.instances[0].started == [
+        {
+            "source_kind": "workflow_deployment",
+            "execution_reference": "deployment-execution-1",
+            "node_id": "llm",
+        }
+    ]
+
+
+def test_durable_event_sanitizes_provider_receipt(tmp_path: Path) -> None:
+    store = WorkflowExecutionStore(tmp_path / "durable")
+    store.create(
+        task_id="task",
+        run_id="run",
+        run_type="workflow",
+        workflow={"id": "wf", "title": "WF"},
+        inputs={},
+        source_kind="workflow_classic",
+    )
+    store.append_event(
+        "task",
+        {
+            "event": "node_end",
+            "node_id": "llm",
+            "provider_route_receipts": {
+                "entry_id": "workflow_interactive_llm",
+                "status": "passed",
+                "run_reference": "workrun-safe",
+                "connection_id": "must-not-survive",
+                "prompt": "private prompt",
+                "reason_codes": [],
+                "calls": [
+                    {
+                        "call_sequence": 1,
+                        "model_id": MODEL_ID,
+                        "actual_model": MODEL_ID,
+                        "dispatched": True,
+                        "status": "passed",
+                        "total_tokens": 5,
+                        "connection_id": "must-not-survive",
+                        "output": "private output",
+                    }
+                ],
+            },
+        },
+    )
+
+    receipt = store.require("task").events[0]["provider_route_receipts"]
+    assert receipt["call_count"] == 1
+    assert receipt["calls"][0]["model_id"] == MODEL_ID
+    serialized = json.dumps(receipt)
+    assert "connection_id" not in serialized
+    assert "private prompt" not in serialized
+    assert "private output" not in serialized
+
+
+def test_durable_event_bounds_malformed_provider_receipt_numbers(
+    tmp_path: Path,
+) -> None:
+    store = WorkflowExecutionStore(tmp_path / "durable-malformed")
+    store.create(
+        task_id="task-malformed",
+        run_id="run-malformed",
+        run_type="workflow",
+        workflow={"id": "wf", "title": "WF"},
+        inputs={},
+        source_kind="workflow_classic",
+    )
+    store.append_event(
+        "task-malformed",
+        {
+            "event": "node_end",
+            "node_id": "llm",
+            "provider_route_receipts": {
+                "entry_id": "workflow_interactive_llm",
+                "status": "passed",
+                "calls": [
+                    {
+                        "call_sequence": "not-a-number",
+                        "model_id": MODEL_ID,
+                        "dispatched": True,
+                        "status": "passed",
+                    }
+                ],
+            },
+        },
+    )
+
+    receipt = store.require("task-malformed").events[0]["provider_route_receipts"]
+    assert receipt["calls"][0]["call_sequence"] == 1

--- a/server/xpert_runtime/execution_store.py
+++ b/server/xpert_runtime/execution_store.py
@@ -518,6 +518,7 @@ class WorkflowExecutionStore:
             "request_status",
             "host_id",
             "session_id",
+            "code",
             "error_code",
             "tool_name",
             "status",
@@ -535,6 +536,7 @@ class WorkflowExecutionStore:
             "message",
             "final_output",
             "variable",
+            "provider_route_receipts",
         }
         if agency_execution:
             allowed.update(
@@ -561,9 +563,15 @@ class WorkflowExecutionStore:
                 }
             )
         clean = {key: value for key, value in event.items() if key in allowed}
-        for key in ("session_id", "error_code"):
+        for key in ("session_id", "code", "error_code"):
             if key in clean:
                 clean[key] = str(clean[key] or "")[:200]
+        if "provider_route_receipts" in clean:
+            clean["provider_route_receipts"] = (
+                WorkflowExecutionStore._safe_provider_route_receipt(
+                    clean["provider_route_receipts"]
+                )
+            )
         for key in ("skill_id", "skill_version_id"):
             if key in clean:
                 clean[key] = str(clean[key] or "")[:200]
@@ -659,6 +667,94 @@ class WorkflowExecutionStore:
                 "reworked": bool(raw_verification.get("reworked")),
             }
         return clean
+
+    @staticmethod
+    def _safe_provider_route_receipt(value: Any) -> dict[str, Any]:
+        raw = value if isinstance(value, dict) else {}
+
+        def bounded_integer(
+            candidate: Any,
+            *,
+            default: int,
+            minimum: int,
+            maximum: int,
+        ) -> int:
+            if isinstance(candidate, bool):
+                return default
+            try:
+                parsed = int(candidate)
+            except (TypeError, ValueError, OverflowError):
+                return default
+            return max(minimum, min(parsed, maximum))
+
+        allowed_entries = {
+            "workflow_interactive_llm",
+            "workflow_deployment_llm",
+        }
+        allowed_statuses = {
+            "running",
+            "passed",
+            "failed",
+            "uncertain",
+            "cancelled",
+        }
+        entry_id = str(raw.get("entry_id") or "")
+        status = str(raw.get("status") or "failed")
+        calls: list[dict[str, Any]] = []
+        raw_calls = raw.get("calls")
+        for item in raw_calls[:8] if isinstance(raw_calls, list) else []:
+            if not isinstance(item, dict):
+                continue
+            call_status = str(item.get("status") or "failed")
+            clean_call: dict[str, Any] = {
+                "call_sequence": bounded_integer(
+                    item.get("call_sequence"),
+                    default=1,
+                    minimum=1,
+                    maximum=100,
+                ),
+                "model_id": str(item.get("model_id") or "")[:300],
+                "actual_model": (
+                    str(item.get("actual_model") or "")[:300] or None
+                ),
+                "dispatched": bool(item.get("dispatched")),
+                "status": (
+                    call_status if call_status in allowed_statuses else "failed"
+                ),
+                "error_code": str(item.get("error_code") or "")[:200] or None,
+            }
+            for token_key in (
+                "prompt_tokens",
+                "completion_tokens",
+                "total_tokens",
+            ):
+                token_value = item.get(token_key)
+                clean_call[token_key] = (
+                    min(1_000_000_000, max(0, int(token_value)))
+                    if isinstance(token_value, (int, float))
+                    and not isinstance(token_value, bool)
+                    else None
+                )
+            calls.append(clean_call)
+        reason_codes = raw.get("reason_codes")
+        return {
+            "contract_version": "modelmirror-provider-workload-routing-v1",
+            "entry_id": entry_id if entry_id in allowed_entries else "",
+            "routing_mode": "managed_required",
+            "run_reference": str(raw.get("run_reference") or "")[:200],
+            "status": status if status in allowed_statuses else "failed",
+            "call_count": min(
+                8,
+                sum(1 for item in calls if item["dispatched"]),
+            ),
+            "reason_codes": [
+                str(item)[:200]
+                for item in (
+                    reason_codes[:20] if isinstance(reason_codes, list) else []
+                )
+            ],
+            "calls": calls,
+        }
 
     @staticmethod
     def _is_skill_creator(item: WorkflowExecution) -> bool:


### PR DESCRIPTION
## 变更摘要

- 将 Classic Workflow 的交互与部署 LLM 节点接入 R6 Managed Provider 控制面。
- 为 chat_text、chat_text_unary、chat_json_object 建立精确模型 Binding、fail-closed 调度和脱敏 Receipt。
- 阻止同一逻辑调用在失败、取消、断流或重启恢复后重复派发 Provider POST。
- 在 Workflow 运行界面和 Settings 中展示脱敏的纳管状态、调用序号、模型与用量。
- 保持 R5 Chat、Workflow 编排、多模态和 legacy 路径兼容；Feature Flag 默认关闭。

## 验证

- 后端交叉专项：115 passed。
- 后端全量：4414 passed, 29 skipped。
- 前端专项：13 passed。
- 前端全量：619 passed。
- npm run typecheck 通过。
- npm run build 通过。
- Core、独立 newAPI 与 Overlay Compose 配置验证通过。
- git diff --cached --check 与敏感信息扫描通过。
- 独立预览器完成一次真实交互式参数提取调用：仅一个 Provider POST，Receipt 与实际模型和 usage 一致，无 legacy 或第二 Provider 回退。

## 边界与回滚

- 本 PR 不启用生产策略，不迁移 Workflow Agent、RAG、多模态、Coding 或计费系统。
- 部署入口的真实 Provider 调用留作正式启用前验收；自动化已覆盖重启和防重放。
- 回滚时显式停用入口 Policy，或关闭 MODEL_CONTROL_WORKFLOW_LLM_ENABLED / MODEL_CONTROL_WORKFLOW_DEPLOYMENT_ENABLED；保留 v16 脱敏证据。