### PR TITLE
R6E: 统一 Workflow Agent Managed Provider 路由

### DIFF
--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -450,7 +450,9 @@ export interface ProviderRouteReceipt {
   entry_id:
     | "meta_agent"
     | "workflow_interactive_llm"
-    | "workflow_deployment_llm";
+    | "workflow_deployment_llm"
+    | "workflow_interactive_agent"
+    | "workflow_deployment_agent";
   routing_mode: "managed_required";
   run_reference: string;
   status: "running" | "passed" | "failed" | "uncertain" | "cancelled";

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -218,6 +218,16 @@ Round 6D 将 Classic Workflow 的交互 `llm`、`parameter_extractor`、
 自动重放。Provider 错误在 Managed 模式失败关闭，不调用第二连接、第二 IP 或 legacy；专用
 多模态、RAG、Agent、Xpert 和 `/workflow-native` 仍不属于 R6D。
 
+Round 6E 进一步把 Classic Workflow 的 `agent` 与 `workflow_agent` 模型轮次接入独立的
+`workflow_interactive_agent` / `workflow_deployment_agent` Policy。直接回答与 ReAct 使用
+`chat_text`，原生 Function Calling 使用 `chat_tools`，结构化生成、修复和 LLM Tool Selector
+使用 `chat_json_object`；每个计划内模型轮次拥有单调调用序号。Managed `auto` 在首个 POST
+前根据当前精确 Binding 选择 Function Calling 或 ReAct，不再通过真实失败探测策略。已配置
+`retryOnFailure` 或 `fallbackModelId` 的节点会在派发前阻断；任一轮派发后不切换连接、模型、
+IP 或 legacy。HITL 审批和替换复用已保存输出，只有显式 revise 才创建新的模型轮次和稳定运行
+阶段。工具执行、权限、中间件和 Workflow 编排仍由现有 Runtime 负责；Published Xpert、RAG、
+多模态与 `/workflow-native` 仍未纳入 R6E。
+
 接入入口只允许 Python 主进程解析凭据和调用 Provider，Worker 与
 工具执行器继续只处理模型消息、Tool Call 和脱敏结果。
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -218,7 +218,8 @@ MODEL_CONTROL_TEAM_CHAT_ENABLED=false
 ```
 
 R6B 接入 `agent_shadow`，R6C 接入两个 Meta Agent 生成入口，R6D 接入 Classic Workflow
-交互与部署 LLM；其他 Workflow Agent 和 Xpert 入口仍不能激活 Managed Policy。`agent_shadow` 只有在
+交互与部署 LLM，R6E 接入 Classic Workflow 的 `agent` 与 `workflow_agent`；Xpert 等后续入口
+仍不能激活 Managed Policy。`agent_shadow` 只有在
 `MODEL_CONTROL_AGENT_SHADOW_ENABLED=true`、
 精确模型的 `chat_tools` 资格与 Binding 有效、且管理员明确批准 fail-closed 后才会接管。
 开关为 `false` 或 Policy 为 `legacy` 时继续使用原 Shadow 网关路径；已经激活但失效的
@@ -237,6 +238,14 @@ Classic Workflow 交互接管要求 `MODEL_CONTROL_WORKFLOW_LLM_ENABLED=true`，
 各自的 Policy。关闭对应开关并重启可恢复 legacy；已经激活但资格或 Binding 漂移时保持
 `degraded_required` 并失败关闭。恢复部署执行不得自动重放已有模型节点；应由操作者确认后
 创建显式新执行。交互节点仅显示脱敏摘要，完整调用证据在管理员 Settings 查看。
+
+Workflow Agent 接管要求 `MODEL_CONTROL_WORKFLOW_AGENT_ENABLED=true`；部署执行还同时要求
+`MODEL_CONTROL_WORKFLOW_DEPLOYMENT_ENABLED=true`。交互与部署入口须分别批准精确模型的
+`chat_text`、`chat_tools` 或 `chat_json_object` Binding。Managed 节点不得保留
+`retryOnFailure` 或 `fallbackModelId`，否则在第一个 Provider POST 前失败关闭。`auto` 策略只
+依据当前资格选择 Function Calling 或 ReAct，不通过真实失败探测；派发后不重试、不切换模型、
+连接、IP 或 legacy。HITL approve/replace 不产生新调用，只有 revise 创建新模型轮次。关闭 Agent
+开关并重启会恢复该入口的 legacy 路径；已激活但资格漂移时保持 `degraded_required`。
 
 同一清理命令从 v16 起同时报告 R5 Chat 与 R6 Workload 的过期记录；第一条仍是 dry-run，
 只有第二条显式 `--apply` 才删除已完成记录。不得对正在运行的父运行或逻辑调用执行清理。

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -236,7 +236,13 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
   自动恢复遇到既有派发或不确定证据时失败关闭，显式新执行才可创建新的可计费调用。
   缺省 `modelId` 在 Managed 模式规范化为现有 `TEXT_FALLBACK_MODEL`，仍须具备该精确模型的
   Inventory、资格和 Binding。Provider 失败不再返回旧 `{}` 或默认分类；legacy 模式保持原行为。
-- 后续 R6E—R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
+- R6E 接入 Classic Workflow 的 `agent` 与 `workflow_agent`。交互和部署使用独立 Policy；
+  直接回答/ReAct、Function Calling、结构化输出及中间模型调用分别要求 `chat_text`、
+  `chat_tools`、`chat_json_object` 精确 Binding。`auto` 在派发前按资格确定策略，Managed 模式
+  禁止 `retryOnFailure`、`fallbackModelId` 和 Function Calling 失败后转 ReAct。HITL 恢复复用
+  已保存输出，只有显式 revise 创建新的稳定阶段和模型轮次。工具调用仍由 Runtime 执行，Receipt
+  不保存工具参数、Prompt 或模型正文。
+- 后续 R6F—R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
   只能存在于 Python 主进程内存，Worker、工具执行器和浏览器不得收到 Key、URL 或连接细节。
 - Receipt 清理命令现在同时检查 R5 Chat 与 R6 Workload 记录，仍默认 dry-run；`--apply`
   才删除超过保留期的已完成运行、尝试或调用。

--- a/server/main.py
+++ b/server/main.py
@@ -1281,12 +1281,14 @@ except ModuleNotFoundError:
 try:
     from server.model_router.workflow_gateway import (
         ManagedWorkflowGateway,
+        ManagedWorkflowAgentRun,
         ManagedWorkflowNodeRun,
         ManagedWorkflowRoutingError,
     )
 except ModuleNotFoundError:
     from model_router.workflow_gateway import (
         ManagedWorkflowGateway,
+        ManagedWorkflowAgentRun,
         ManagedWorkflowNodeRun,
         ManagedWorkflowRoutingError,
     )
@@ -9001,11 +9003,25 @@ async def _run_workflow_response(
     workflow_managed_mode = workflow_managed_gateway.routing_mode(
         trusted_source_kind
     )
+    workflow_agent_managed_mode = workflow_managed_gateway.agent_routing_mode(
+        trusted_source_kind
+    )
     requires_legacy_model = any(
-        (node.data.get("kind") if isinstance(node.data.get("kind"), str) else node.type)
-        == "workflow_agent"
+        (
+            (
+                node.data.get("kind")
+                if isinstance(node.data.get("kind"), str)
+                else node.type
+            )
+            in {"agent", "workflow_agent"}
+            and workflow_agent_managed_mode == "legacy"
+        )
         or (
-            (node.data.get("kind") if isinstance(node.data.get("kind"), str) else node.type)
+            (
+                node.data.get("kind")
+                if isinstance(node.data.get("kind"), str)
+                else node.type
+            )
             == "llm"
             and workflow_managed_mode == "legacy"
         )
@@ -9399,8 +9415,41 @@ async def _run_workflow_response(
                 node_id=node_id,
             )
 
+        def start_managed_agent_run(
+            node_id: str,
+            *,
+            logical_phase: str = "initial",
+        ) -> ManagedWorkflowAgentRun | None:
+            if workflow_agent_managed_mode == "legacy":
+                return None
+            entry_id = workflow_managed_gateway.agent_entry_id(trusted_source_kind)
+            if entry_id is None:
+                return None
+            if workflow_agent_managed_mode == "degraded_required":
+                code = "provider_workload_workflow_agent_degraded_required"
+                raise ManagedWorkflowRoutingError(
+                    code,
+                    "Workflow Agent 的 Managed Provider 策略已失效，当前节点失败关闭。",
+                    status_code=409,
+                    receipt=workflow_managed_gateway.blocked_receipt(entry_id, code),
+                )
+            execution_reference = (
+                str(
+                    run_metadata.get("workflow_deployment_execution_id")
+                    or task_id
+                )
+                if trusted_source_kind == "workflow_deployment"
+                else task_id
+            )
+            return workflow_managed_gateway.start_agent_run(
+                source_kind=trusted_source_kind,  # type: ignore[arg-type]
+                execution_reference=execution_reference,
+                node_id=node_id,
+                logical_phase=logical_phase,
+            )
+
         def finish_managed_node_failure(
-            managed_run: ManagedWorkflowNodeRun,
+            managed_run: ManagedWorkflowNodeRun | ManagedWorkflowAgentRun,
             code: str,
         ) -> dict[str, Any]:
             status = "failed"
@@ -11509,6 +11558,7 @@ async def _run_workflow_response(
             selector_spec: RuntimeMiddlewareSpec | None = None,
             history_messages: list[dict[str, Any]] | None = None,
             actual_model_observer: Callable[[str], None] | None = None,
+            managed_agent_run: ManagedWorkflowAgentRun | None = None,
         ) -> AgentStrategyResult:
             runtime_metadata = dict(task_state.get("runtime_metadata") or {})
             agent_max_tokens = workflow_agent_token_budget(runtime_metadata)
@@ -11542,6 +11592,24 @@ async def _run_workflow_response(
                 middleware_specs=middleware_specs,
                 apply_policy_filter=selector_spec is not None,
             )
+            resolved_strategy = strategy
+            if managed_agent_run is not None:
+                if selector_spec is not None and available_tools:
+                    selector_model_id = str(
+                        selector_spec.config.get("selector_model_id") or model_id
+                    ).strip() or model_id
+                    managed_agent_run.require_shape(
+                        selector_model_id,
+                        "chat_json_object",
+                    )
+                    # The selector may conservatively return no tools. Preflight
+                    # the direct text shape before paying for the selector call.
+                    managed_agent_run.require_shape(model_id, "chat_text")
+                resolved_strategy = managed_agent_run.resolve_strategy(
+                    requested_strategy=strategy,
+                    model_id=model_id,
+                    has_tools=bool(available_tools),
+                )
             selector_skills_spec = middleware_spec(
                 middleware_specs or [], "skills_runtime"
             )
@@ -11632,24 +11700,53 @@ async def _run_workflow_response(
                         20,
                     ),
                     required_tools=required_tools,
-                    model_text=middleware_model_text,
+                    model_text=(
+                        (
+                            lambda selected_model_id, messages, selected_max_tokens: (
+                                managed_agent_run.complete_json_object(
+                                    purpose="tool_selector",
+                                    model_id=selected_model_id,
+                                    messages=messages,
+                                    temperature=0,
+                                    max_tokens=selected_max_tokens,
+                                    cancel_event=task_state["provider_cancel_event"],
+                                )
+                            )
+                        )
+                        if managed_agent_run is not None
+                        else middleware_model_text
+                    ),
                 )
                 if middleware_context is not None:
                     middleware_context.metadata["tool_selection"] = selector_metadata
 
-            gateway_url, gateway_key = get_llm_gateway_config()
-            if not gateway_url:
-                raise ValueError(LLM_GATEWAY_NOT_CONFIGURED_MESSAGE)
-            base_model_client = OpenAICompatibleAgentModelClient(
-                endpoint=gateway_url,
-                headers=llm_gateway_headers(gateway_key),
-                client_kwargs=llm_client_kwargs(),
-            )
+            if managed_agent_run is not None:
+                if not available_tools:
+                    managed_agent_run.require_shape(model_id, "chat_text")
+                base_model_client = managed_agent_run
+            else:
+                gateway_url, gateway_key = get_llm_gateway_config()
+                if not gateway_url:
+                    raise ValueError(LLM_GATEWAY_NOT_CONFIGURED_MESSAGE)
+                base_model_client = OpenAICompatibleAgentModelClient(
+                    endpoint=gateway_url,
+                    headers=llm_gateway_headers(gateway_key),
+                    client_kwargs=llm_client_kwargs(),
+                )
+
+            async def complete_base_model(**kwargs: Any) -> AgentModelTurn:
+                if managed_agent_run is not None:
+                    return await managed_agent_run.complete(
+                        **kwargs,
+                        purpose="agent_strategy_model_round",
+                        cancel_event=task_state["provider_cancel_event"],
+                    )
+                return await base_model_client.complete(**kwargs)
 
             class MiddlewareAgentModelClient:
                 async def complete(self, **kwargs: Any) -> AgentModelTurn:
                     if pipeline is None or middleware_context is None:
-                        turn = await base_model_client.complete(**kwargs)
+                        turn = await complete_base_model(**kwargs)
                         if actual_model_observer is not None:
                             raw_model = turn.raw.get("model")
                             actual_model_observer(
@@ -11662,7 +11759,7 @@ async def _run_workflow_response(
                     async def handler(request: ModelCallRequest) -> ModelCallResponse:
                         nonlocal captured_turn, observed_turn
                         params = dict(request.params or {})
-                        captured_turn = await base_model_client.complete(
+                        captured_turn = await complete_base_model(
                             model_id=request.model_id,
                             messages=list(request.messages),
                             temperature=float(
@@ -11743,7 +11840,11 @@ async def _run_workflow_response(
                     raise AgentStrategyError(
                         "模型没有返回直接回答。", code="empty_model_response"
                     )
-                active_strategy = "react" if strategy == "react" else "function_calling"
+                active_strategy = (
+                    resolved_strategy
+                    if resolved_strategy in {"function_calling", "react"}
+                    else "function_calling"
+                )
                 result = AgentStrategyResult(
                     answer=answer,
                     strategy=active_strategy,
@@ -11880,7 +11981,7 @@ async def _run_workflow_response(
                     model_id=model_id,
                     system_prompt=system_prompt,
                     user_prompt=user_prompt,
-                    strategy=strategy,  # type: ignore[arg-type]
+                    strategy=resolved_strategy,  # type: ignore[arg-type]
                     max_iterations=max_iterations,
                     temperature=temperature,
                     max_tokens=agent_max_tokens,
@@ -11955,6 +12056,7 @@ async def _run_workflow_response(
             resume_state: dict[str, Any] | None = None,
             actual_model_observer: Callable[[str], None] | None = None,
             usage_observer: Callable[[dict[str, int]], None] | None = None,
+            managed_agent_run: ManagedWorkflowAgentRun | None = None,
         ) -> tuple[str, list[dict[str, Any]]]:
             max_tool_concurrency = min(max(int(max_tool_concurrency), 1), 8)
             max_tool_calls = min(max(int(max_tool_calls), 1), 50)
@@ -11995,6 +12097,16 @@ async def _run_workflow_response(
                 middleware_specs=middleware_specs,
                 apply_policy_filter=selector_spec is not None,
             )
+            if managed_agent_run is not None:
+                managed_agent_run.require_shape(model_id, "chat_text")
+                if selector_spec is not None and available_tools:
+                    selector_model_id = str(
+                        selector_spec.config.get("selector_model_id") or model_id
+                    ).strip() or model_id
+                    managed_agent_run.require_shape(
+                        selector_model_id,
+                        "chat_json_object",
+                    )
             if selector_spec is not None and available_tools:
                 required_tools = (
                     {"todo_list", "todo_create", "todo_update"}
@@ -12058,7 +12170,22 @@ async def _run_workflow_response(
                         20,
                     ),
                     required_tools=required_tools,
-                    model_text=middleware_model_text,
+                    model_text=(
+                        (
+                            lambda selected_model_id, messages, selected_max_tokens: (
+                                managed_agent_run.complete_json_object(
+                                    purpose="tool_selector",
+                                    model_id=selected_model_id,
+                                    messages=messages,
+                                    temperature=0,
+                                    max_tokens=selected_max_tokens,
+                                    cancel_event=task_state["provider_cancel_event"],
+                                )
+                            )
+                        )
+                        if managed_agent_run is not None
+                        else middleware_model_text
+                    ),
                 )
                 if middleware_context is not None:
                     middleware_context.metadata["tool_selection"] = selector_metadata
@@ -12111,34 +12238,65 @@ async def _run_workflow_response(
                     if usage_observer is not None:
                         usage_observer(reported_usage)
 
-                if pipeline is None or middleware_context is None:
+                async def invoke_provider(
+                    call_model_id: str,
+                    call_messages: list[ChatMessage],
+                    *,
+                    call_temperature: float,
+                    call_max_tokens: int,
+                ) -> str:
+                    if managed_agent_run is not None:
+                        text = await managed_agent_run.complete_text(
+                            purpose="react_model_round",
+                            model_id=call_model_id,
+                            messages=[message.model_dump() for message in call_messages],
+                            temperature=call_temperature,
+                            max_tokens=call_max_tokens,
+                            cancel_event=task_state["provider_cancel_event"],
+                        )
+                        receipt = managed_agent_run.calls[-1]
+                        capture_actual_model(receipt.actual_model or call_model_id)
+                        capture_usage(
+                            {
+                                "prompt_tokens": receipt.prompt_tokens or 0,
+                                "completion_tokens": receipt.completion_tokens or 0,
+                                "total_tokens": receipt.total_tokens or 0,
+                            }
+                        )
+                        return text
                     return await collect_chat_completion_text(
-                        model_id,
-                        messages,
-                        temperature=temperature,
-                        max_tokens=agent_max_tokens,
+                        call_model_id,
+                        call_messages,
+                        temperature=call_temperature,
+                        max_tokens=call_max_tokens,
                         actual_model_observer=capture_actual_model,
                         usage_observer=capture_usage,
                     )
 
+                if pipeline is None or middleware_context is None:
+                    return await invoke_provider(
+                        model_id,
+                        messages,
+                        call_temperature=temperature,
+                        call_max_tokens=agent_max_tokens,
+                    )
+
                 async def handler(request: ModelCallRequest) -> ModelCallResponse:
-                    text = await collect_chat_completion_text(
+                    text = await invoke_provider(
                         request.model_id,
                         [
                             ChatMessage.model_validate(message)
                             for message in request.messages
                         ],
-                        temperature=float(
+                        call_temperature=float(
                             request.params.get("temperature", temperature)
                         ),
-                        max_tokens=int(
+                        call_max_tokens=int(
                             request.params.get(
                                 "max_tokens",
                                 agent_max_tokens,
                             )
                         ),
-                        actual_model_observer=capture_actual_model,
-                        usage_observer=capture_usage,
                     )
                     return ModelCallResponse(
                         text=text,
@@ -14488,7 +14646,9 @@ async def _run_workflow_response(
 
                 chosen_handle: str | None = None
                 output = ""
-                node_provider_run: ManagedWorkflowNodeRun | None = None
+                node_provider_run: (
+                    ManagedWorkflowNodeRun | ManagedWorkflowAgentRun | None
+                ) = None
                 node_provider_receipt: dict[str, Any] | None = None
 
                 if kind == "input":
@@ -17015,8 +17175,26 @@ async def _run_workflow_response(
                             parallel_tool_calls = workflow_truthy(
                                 node.data.get("parallelToolCalls")
                             )
+                            if workflow_agent_managed_mode != "legacy":
+                                node_provider_run = start_managed_agent_run(node.id)
 
                             async def run_direct_agent() -> str:
+                                if isinstance(
+                                    node_provider_run,
+                                    ManagedWorkflowAgentRun,
+                                ):
+                                    return await node_provider_run.complete_text(
+                                        purpose="agent_direct",
+                                        model_id=model_id,
+                                        messages=[
+                                            {"role": "user", "content": instruction}
+                                        ],
+                                        temperature=temperature,
+                                        max_tokens=WORKFLOW_AGENT_MAX_TOKENS,
+                                        cancel_event=task_state[
+                                            "provider_cancel_event"
+                                        ],
+                                    )
                                 if not get_llm_gateway_config()[0]:
                                     raise ValueError(LLM_GATEWAY_NOT_CONFIGURED_MESSAGE)
                                 return await collect_chat_completion_text(
@@ -17057,6 +17235,14 @@ async def _run_workflow_response(
                                             output_variable=output_variable,
                                             run_id=workflow_run.run_id,
                                             checkpoint_prefix="agent",
+                                            managed_agent_run=(
+                                                node_provider_run
+                                                if isinstance(
+                                                    node_provider_run,
+                                                    ManagedWorkflowAgentRun,
+                                                )
+                                                else None
+                                            ),
                                         )
                                     except AgentStrategyError as strategy_exc:
                                         for agent_event in agent_strategy_node_events(
@@ -17092,6 +17278,14 @@ async def _run_workflow_response(
                                         max_iterations=max_iterations,
                                         temperature=temperature,
                                         output_variable=output_variable,
+                                        managed_agent_run=(
+                                            node_provider_run
+                                            if isinstance(
+                                                node_provider_run,
+                                                ManagedWorkflowAgentRun,
+                                            )
+                                            else None
+                                        ),
                                     )
                                 variables[output_variable] = output
                                 for agent_event in agent_events:
@@ -17108,7 +17302,25 @@ async def _run_workflow_response(
                                 )
                             else:
                                 raise ValueError(f"Agent 模式不支持：{agent_mode}")
+                            if isinstance(node_provider_run, ManagedWorkflowAgentRun):
+                                node_provider_run.finish("passed")
+                                node_provider_receipt = (
+                                    node_provider_run.receipt_summary()
+                                )
+                    except ManagedWorkflowRoutingError as exc:
+                        if isinstance(node_provider_run, ManagedWorkflowAgentRun):
+                            node_provider_receipt = finish_managed_node_failure(
+                                node_provider_run,
+                                exc.code,
+                            )
+                            exc.receipt = node_provider_receipt
+                        raise
                     except Exception as exc:
+                        if isinstance(node_provider_run, ManagedWorkflowAgentRun):
+                            node_provider_receipt = finish_managed_node_failure(
+                                node_provider_run,
+                                "provider_workload_agent_runtime_failed",
+                            )
                         logger.warning("Workflow agent node failed: %s", exc)
                         output = ""
                         variables[output_variable] = output
@@ -17134,6 +17346,61 @@ async def _run_workflow_response(
                         model_id = str(
                             node.data.get("modelId") or TEXT_FALLBACK_MODEL
                         ).strip() or TEXT_FALLBACK_MODEL
+                        managed_agent_phase = "initial"
+                        restored_agent_state = task_state.get("agent_resume_state")
+                        if (
+                            workflow_agent_managed_mode != "legacy"
+                            and isinstance(restored_agent_state, dict)
+                            and restored_agent_state
+                        ):
+                            resolved = task_state.get("resolved_approval")
+                            phase_material = json.dumps(
+                                {
+                                    "type": restored_agent_state.get("type"),
+                                    "approval_id": (
+                                        resolved.get("approval_id")
+                                        if isinstance(resolved, dict)
+                                        else None
+                                    ),
+                                    "revision_round": restored_agent_state.get(
+                                        "revision_round"
+                                    ),
+                                },
+                                sort_keys=True,
+                                separators=(",", ":"),
+                            )
+                            managed_agent_phase = (
+                                "resume:"
+                                + hashlib.sha256(
+                                    phase_material.encode("utf-8")
+                                ).hexdigest()[:16]
+                            )
+                            restored_receipt = restored_agent_state.get(
+                                "provider_route_receipts"
+                            )
+                            if isinstance(restored_receipt, dict):
+                                node_provider_receipt = dict(restored_receipt)
+
+                        def ensure_workflow_agent_provider_run(
+                        ) -> ManagedWorkflowAgentRun | None:
+                            nonlocal node_provider_run
+                            if workflow_agent_managed_mode == "legacy":
+                                return None
+                            if node_provider_run is None:
+                                node_provider_run = start_managed_agent_run(
+                                    node.id,
+                                    logical_phase=managed_agent_phase,
+                                )
+                            if not isinstance(
+                                node_provider_run,
+                                ManagedWorkflowAgentRun,
+                            ):
+                                raise ManagedWorkflowRoutingError(
+                                    "provider_workload_agent_run_type_invalid",
+                                    "Workflow Agent 的 Managed Provider 运行状态无效。",
+                                    status_code=500,
+                                )
+                            return node_provider_run
                         agent_specs = agent_middleware_specs(node.id)
                         todo_spec = middleware_spec(agent_specs, "todo_planner")
                         sandbox_files_spec = middleware_spec(
@@ -17702,6 +17969,29 @@ async def _run_workflow_response(
                         fallback_model_id = str(
                             node.data.get("fallbackModelId") or ""
                         ).strip()
+                        if workflow_agent_managed_mode != "legacy" and (
+                            retry_on_failure or fallback_model_id
+                        ):
+                            entry_id = workflow_managed_gateway.agent_entry_id(
+                                trusted_source_kind
+                            )
+                            code = "provider_workload_legacy_retry_fallback_configured"
+                            raise ManagedWorkflowRoutingError(
+                                code,
+                                (
+                                    "Managed Workflow Agent 禁止派发后重试或备用模型；"
+                                    "请先关闭 retryOnFailure 并移除 fallbackModelId。"
+                                ),
+                                status_code=409,
+                                receipt=(
+                                    workflow_managed_gateway.blocked_receipt(
+                                        entry_id,
+                                        code,
+                                    )
+                                    if entry_id is not None
+                                    else None
+                                ),
+                            )
                         exception_handling = str(
                             node.data.get("exceptionHandling") or "none"
                         ).strip() or "none"
@@ -18096,6 +18386,7 @@ async def _run_workflow_response(
                             max_tokens: int,
                             *,
                             temperature: float = 0.7,
+                            execution_shape: str = "chat_text",
                         ) -> str:
                             async def handler(
                                 request: ModelCallRequest,
@@ -18103,24 +18394,73 @@ async def _run_workflow_response(
                                 def capture_actual_model(reported_model_id: str) -> None:
                                     observe_actual_model(reported_model_id)
 
-                                text = await collect_chat_completion_text(
-                                    request.model_id,
-                                    [
-                                        ChatMessage.model_validate(message)
-                                        for message in request.messages
-                                    ],
-                                    temperature=float(
+                                managed_run = ensure_workflow_agent_provider_run()
+                                if managed_run is not None:
+                                    call_temperature = float(
                                         request.params.get(
                                             "temperature",
                                             temperature,
                                         )
-                                    ),
-                                    max_tokens=int(
+                                    )
+                                    call_max_tokens = int(
                                         request.params.get("max_tokens", max_tokens)
-                                    ),
-                                    actual_model_observer=capture_actual_model,
-                                    usage_observer=observe_token_usage,
-                                )
+                                    )
+                                    if execution_shape == "chat_json_object":
+                                        text = await managed_run.complete_json_object(
+                                            purpose="structured_model_round",
+                                            model_id=request.model_id,
+                                            messages=list(request.messages),
+                                            temperature=call_temperature,
+                                            max_tokens=call_max_tokens,
+                                            cancel_event=task_state[
+                                                "provider_cancel_event"
+                                            ],
+                                        )
+                                    else:
+                                        text = await managed_run.complete_text(
+                                            purpose="agent_text_model_round",
+                                            model_id=request.model_id,
+                                            messages=list(request.messages),
+                                            temperature=call_temperature,
+                                            max_tokens=call_max_tokens,
+                                            cancel_event=task_state[
+                                                "provider_cancel_event"
+                                            ],
+                                        )
+                                    receipt = managed_run.calls[-1]
+                                    capture_actual_model(
+                                        receipt.actual_model or request.model_id
+                                    )
+                                    observe_token_usage(
+                                        {
+                                            "prompt_tokens": receipt.prompt_tokens or 0,
+                                            "completion_tokens": (
+                                                receipt.completion_tokens or 0
+                                            ),
+                                            "total_tokens": receipt.total_tokens or 0,
+                                        }
+                                    )
+                                else:
+                                    text = await collect_chat_completion_text(
+                                        request.model_id,
+                                        [
+                                            ChatMessage.model_validate(message)
+                                            for message in request.messages
+                                        ],
+                                        temperature=float(
+                                            request.params.get(
+                                                "temperature",
+                                                temperature,
+                                            )
+                                        ),
+                                        max_tokens=int(
+                                            request.params.get(
+                                                "max_tokens", max_tokens
+                                            )
+                                        ),
+                                        actual_model_observer=capture_actual_model,
+                                        usage_observer=observe_token_usage,
+                                    )
                                 return ModelCallResponse(
                                     text=text,
                                     metadata={"model_id": request.model_id},
@@ -18151,6 +18491,7 @@ async def _run_workflow_response(
                                     messages,
                                     max_tokens,
                                     temperature=0,
+                                    execution_shape="chat_json_object",
                                 )
                             )
 
@@ -18392,6 +18733,11 @@ async def _run_workflow_response(
                                             attempt_model_id,
                                             direct_messages,
                                             direct_agent_max_tokens,
+                                            execution_shape=(
+                                                "chat_json_object"
+                                                if structured_spec is not None
+                                                else "chat_text"
+                                            ),
                                         )
                                         if (
                                             content_policy_output_enabled
@@ -18427,7 +18773,34 @@ async def _run_workflow_response(
                                             ChatMessage.model_validate(message)
                                             for message in prepared_request.messages
                                         ]
-                                        if (
+                                        managed_run = (
+                                            ensure_workflow_agent_provider_run()
+                                        )
+                                        if managed_run is not None:
+                                            model_stream = managed_run.stream_text(
+                                                purpose="agent_direct_stream",
+                                                model_id=prepared_request.model_id,
+                                                messages=[
+                                                    message.model_dump()
+                                                    for message in prepared_messages
+                                                ],
+                                                temperature=float(
+                                                    prepared_request.params.get(
+                                                        "temperature",
+                                                        agent_temperature,
+                                                    )
+                                                ),
+                                                max_tokens=int(
+                                                    prepared_request.params.get(
+                                                        "max_tokens",
+                                                        direct_agent_max_tokens,
+                                                    )
+                                                ),
+                                                cancel_event=task_state[
+                                                    "provider_cancel_event"
+                                                ],
+                                            )
+                                        elif (
                                             direct_agent_max_tokens
                                             != WORKFLOW_AGENT_MAX_TOKENS
                                         ):
@@ -18476,6 +18849,28 @@ async def _run_workflow_response(
                                         )
                                         if isinstance(stream_usage, dict) and stream_usage:
                                             observe_token_usage(stream_usage)
+                                        elif (
+                                            managed_run is not None
+                                            and managed_run.calls
+                                        ):
+                                            receipt = managed_run.calls[-1]
+                                            observe_actual_model(
+                                                receipt.actual_model
+                                                or prepared_request.model_id
+                                            )
+                                            observe_token_usage(
+                                                {
+                                                    "prompt_tokens": (
+                                                        receipt.prompt_tokens or 0
+                                                    ),
+                                                    "completion_tokens": (
+                                                        receipt.completion_tokens or 0
+                                                    ),
+                                                    "total_tokens": (
+                                                        receipt.total_tokens or 0
+                                                    ),
+                                                }
+                                            )
                                         await agent_pipeline.after_model(
                                             ModelCallResponse(
                                                 text=output,
@@ -18547,6 +18942,9 @@ async def _run_workflow_response(
                                                 selector_spec=selector_spec,
                                                 history_messages=history_messages,
                                                 actual_model_observer=observe_actual_model,
+                                                managed_agent_run=(
+                                                    ensure_workflow_agent_provider_run()
+                                                ),
                                             )
                                         except AgentStrategyError as strategy_exc:
                                             failure_events = agent_strategy_node_events(
@@ -18638,6 +19036,9 @@ async def _run_workflow_response(
                                             ),
                                             actual_model_observer=observe_actual_model,
                                             usage_observer=observe_token_usage,
+                                            managed_agent_run=(
+                                                ensure_workflow_agent_provider_run()
+                                            ),
                                         )
                                     agent_events = guard_agent_visible_events(agent_events)
                                     output = guard_agent_visible_text(output)
@@ -18743,6 +19144,9 @@ async def _run_workflow_response(
                                             history_messages=history_messages,
                                             actual_model_observer=observe_actual_model,
                                             usage_observer=observe_token_usage,
+                                            managed_agent_run=(
+                                                ensure_workflow_agent_provider_run()
+                                            ),
                                         )
                                         ralph_events.extend(next_events)
                                         return guard_agent_visible_text(next_output)
@@ -19237,14 +19641,59 @@ async def _run_workflow_response(
                                 ),
                             },
                         )
-                    except RuntimeInterrupt:
+                        if isinstance(node_provider_run, ManagedWorkflowAgentRun):
+                            node_provider_run.finish("passed")
+                            node_provider_receipt = (
+                                node_provider_run.receipt_summary()
+                            )
+                    except RuntimeInterrupt as interrupt:
+                        if isinstance(node_provider_run, ManagedWorkflowAgentRun):
+                            if any(
+                                call.status == "passed"
+                                for call in node_provider_run.calls
+                            ):
+                                node_provider_run.finish("passed")
+                            else:
+                                node_provider_run.finish(
+                                    "failed",
+                                    reason_code=(
+                                        "provider_workload_agent_interrupted_before_call"
+                                    ),
+                                )
+                            node_provider_receipt = (
+                                node_provider_run.receipt_summary()
+                            )
+                            continuation_state = dict(
+                                interrupt.continuation.get("agent_state") or {}
+                            )
+                            continuation_state["provider_route_receipts"] = (
+                                node_provider_receipt
+                            )
+                            interrupt.continuation["agent_state"] = (
+                                continuation_state
+                            )
                         if agent_context is not None:
                             for hook_event in drain_skill_hook_status_events(
                                 agent_context
                             ):
                                 yield sse_payload(hook_event)
                         raise
+                    except ManagedWorkflowRoutingError as exc:
+                        if isinstance(node_provider_run, ManagedWorkflowAgentRun):
+                            node_provider_receipt = finish_managed_node_failure(
+                                node_provider_run,
+                                exc.code,
+                            )
+                            exc.receipt = node_provider_receipt
+                        elif exc.receipt is not None:
+                            node_provider_receipt = exc.receipt
+                        raise
                     except ContentPolicyError as exc:
+                        if isinstance(node_provider_run, ManagedWorkflowAgentRun):
+                            node_provider_receipt = finish_managed_node_failure(
+                                node_provider_run,
+                                exc.code,
+                            )
                         if workflow_agent_run is not None:
                             safe_error = f"{exc.code}: phase={exc.phase or 'input'}"
                             if exc.rule_id:
@@ -19275,6 +19724,11 @@ async def _run_workflow_response(
                                 )
                         raise
                     except Exception as exc:
+                        if isinstance(node_provider_run, ManagedWorkflowAgentRun):
+                            node_provider_receipt = finish_managed_node_failure(
+                                node_provider_run,
+                                "provider_workload_agent_runtime_failed",
+                            )
                         if runtime_run_type == "skill_evaluation":
                             logger.exception(
                                 "Skill evaluation workflow_agent node failed: %s",
@@ -21372,6 +21826,9 @@ async def _run_workflow_response(
                 "rule_id": exc.rule_id or None,
                 "message": safe_message,
             }
+            provider_receipt = locals().get("node_provider_receipt")
+            if isinstance(provider_receipt, dict):
+                error_event["provider_route_receipts"] = provider_receipt
             try:
                 workflow_execution_store.fail(task_id, error=failure_error)
                 workflow_execution_store.append_event(task_id, error_event)

--- a/server/model_router/workflow_gateway.py
+++ b/server/model_router/workflow_gateway.py
@@ -17,12 +17,27 @@ from .workload_control import (
     ProviderWorkloadCallService,
     ProviderWorkloadPreparedCall,
 )
+try:
+    from server.xpert_runtime.agent_strategy.models import (
+        AgentModelTurn,
+        AgentToolCall,
+        AgentUsage,
+    )
+except ImportError:  # pragma: no cover - direct server package execution
+    from xpert_runtime.agent_strategy.models import (
+        AgentModelTurn,
+        AgentToolCall,
+        AgentUsage,
+    )
 
 
 WorkflowRoutingMode = Literal["legacy", "managed_required", "degraded_required"]
 WorkflowSourceKind = Literal["workflow_classic", "workflow_deployment"]
 WorkflowEntryId = Literal[
-    "workflow_interactive_llm", "workflow_deployment_llm"
+    "workflow_interactive_llm",
+    "workflow_deployment_llm",
+    "workflow_interactive_agent",
+    "workflow_deployment_agent",
 ]
 WorkflowCallStatus = Literal[
     "passed", "failed", "uncertain", "cancelled"
@@ -86,12 +101,23 @@ class _StreamEvidence:
     total_tokens: int | None = None
 
 
+@dataclass(slots=True)
+class _AgentStreamEvidence(_StreamEvidence):
+    content_parts: list[str] = field(default_factory=list)
+    tool_calls: dict[int, dict[str, str]] = field(default_factory=dict)
+    finish_reason: str | None = None
+
+
 class ManagedWorkflowGateway:
     """Classic Workflow adapter for one exact managed Provider target."""
 
     _ENTRY_BY_SOURCE: dict[WorkflowSourceKind, WorkflowEntryId] = {
         "workflow_classic": "workflow_interactive_llm",
         "workflow_deployment": "workflow_deployment_llm",
+    }
+    _AGENT_ENTRY_BY_SOURCE: dict[WorkflowSourceKind, WorkflowEntryId] = {
+        "workflow_classic": "workflow_interactive_agent",
+        "workflow_deployment": "workflow_deployment_agent",
     }
 
     def __init__(
@@ -129,9 +155,29 @@ class ManagedWorkflowGateway:
             return "managed_required"
         return "degraded_required"
 
+    def agent_routing_mode(self, source_kind: str | None) -> WorkflowRoutingMode:
+        entry_id = self.agent_entry_id(source_kind)
+        if entry_id is None:
+            return "legacy"
+        control = self.call_service.control
+        if not control.feature_enabled(entry_id):
+            return "legacy"
+        policy = control.get_policy(entry_id)
+        if policy.configured_status == "legacy":
+            return "legacy"
+        if policy.effective_status == "managed_required":
+            return "managed_required"
+        return "degraded_required"
+
     @classmethod
     def entry_id(cls, source_kind: str | None) -> WorkflowEntryId | None:
         return cls._ENTRY_BY_SOURCE.get(str(source_kind or ""))  # type: ignore[arg-type]
+
+    @classmethod
+    def agent_entry_id(cls, source_kind: str | None) -> WorkflowEntryId | None:
+        return cls._AGENT_ENTRY_BY_SOURCE.get(  # type: ignore[arg-type]
+            str(source_kind or "")
+        )
 
     def start_node_run(
         self,
@@ -172,6 +218,50 @@ class ManagedWorkflowGateway:
                 receipt=self.blocked_receipt(entry_id, exc.code),
             ) from exc
         return ManagedWorkflowNodeRun(self, entry_id, run_id)
+
+    def start_agent_run(
+        self,
+        *,
+        source_kind: WorkflowSourceKind,
+        execution_reference: str,
+        node_id: str,
+        logical_phase: str = "initial",
+    ) -> ManagedWorkflowAgentRun:
+        entry_id = self._AGENT_ENTRY_BY_SOURCE[source_kind]
+        if self.agent_routing_mode(source_kind) != "managed_required":
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_policy_not_active",
+                "Workflow Agent 的 Managed Provider 策略未就绪，当前节点失败关闭。",
+                status_code=409,
+            )
+        clean_execution = execution_reference.strip()
+        clean_node = node_id.strip()
+        clean_phase = logical_phase.strip()
+        if not clean_execution or not clean_node or not clean_phase:
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_workflow_reference_required",
+                "Workflow Agent 缺少稳定执行引用。",
+                status_code=409,
+            )
+        parent_reference = (
+            f"{'interactive' if source_kind == 'workflow_classic' else 'deployment'}:"
+            f"{clean_execution}:{clean_node}:agent:{clean_phase}"
+        )
+        try:
+            run_id = self.call_service.start_stable_run(
+                entry_id,
+                parent_run_reference=parent_reference,
+            )
+        except RouterServiceError as exc:
+            raise ManagedWorkflowRoutingError(
+                exc.code,
+                "Workflow Agent 已有执行证据或资格已失效，系统不会自动重放。",
+                status_code=exc.status_code,
+                receipt=self.blocked_receipt(entry_id, exc.code),
+            ) from exc
+        return ManagedWorkflowAgentRun(
+            ManagedWorkflowNodeRun(self, entry_id, run_id)
+        )
 
     @staticmethod
     def blocked_receipt(entry_id: WorkflowEntryId, reason_code: str) -> dict[str, Any]:
@@ -394,6 +484,230 @@ class ManagedWorkflowNodeRun:
             require_json_object=False,
             cancel_event=cancel_event,
         )
+
+    async def complete_agent_turn(
+        self,
+        *,
+        logical_call_key: str,
+        call_sequence: int,
+        execution_shape: Literal["chat_text", "chat_tools"],
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
+        parallel_tool_calls: bool | None = None,
+        cancel_event: asyncio.Event | None = None,
+    ) -> AgentModelTurn:
+        prepared: ProviderWorkloadPreparedCall | None = None
+        dispatched = False
+        started = time.perf_counter()
+        evidence = _AgentStreamEvidence()
+        try:
+            if execution_shape == "chat_tools" and tools is None:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_tools_required",
+                    "Managed Workflow Agent 的 Tool Calling 轮次缺少工具定义。",
+                    status_code=409,
+                )
+            if execution_shape == "chat_text" and tools is not None:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_execution_shape_mismatch",
+                    "Managed Workflow Agent 的文本轮次不得携带工具定义。",
+                    status_code=409,
+                )
+            prepared = await self.gateway.call_service.prepare_call(
+                run_id=self.run_id,
+                entry_id=self.entry_id,
+                execution_shape=execution_shape,
+                model_id=model_id,
+                logical_call_key=logical_call_key,
+                call_sequence=call_sequence,
+            )
+            payload: dict[str, Any] = {
+                "model": model_id,
+                "messages": messages,
+                "stream": True,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            }
+            if tools is not None:
+                payload["tools"] = tools
+                payload["tool_choice"] = tool_choice or "auto"
+                if parallel_tool_calls is not None:
+                    payload["parallel_tool_calls"] = bool(parallel_tool_calls)
+            async with self._client() as client:
+                request = self.gateway.call_service.transport.build_authorized_stream_request(
+                    client,
+                    prepared.target,
+                    prepared.authorized_target,
+                    payload,
+                )
+                self.gateway.call_service.mark_dispatched(prepared)
+                dispatched = True
+                response = await self.gateway.call_service.transport.send_authorized_stream(
+                    client, request
+                )
+                try:
+                    self._validate_status(response.status_code)
+                    async for event in self._iter_sse_events(response, cancel_event):
+                        self._consume_agent_stream_event(
+                            event,
+                            evidence,
+                            requested_model=model_id,
+                            started=started,
+                        )
+                finally:
+                    await response.aclose()
+            if not evidence.content_observed and not evidence.tool_calls:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_empty_stream",
+                    "Managed Provider 没有返回 Workflow Agent 可用的文本或 Tool Call。",
+                )
+            if not evidence.terminal_observed:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_missing_terminal",
+                    "Managed Provider 的 Workflow Agent 流缺少安全终止信号。",
+                )
+            if execution_shape == "chat_text" and evidence.tool_calls:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_execution_shape_mismatch",
+                    "Managed Provider 在纯文本 Workflow Agent 轮次返回了 Tool Call。",
+                )
+            tool_calls: list[AgentToolCall] = []
+            for index in sorted(evidence.tool_calls):
+                item = evidence.tool_calls[index]
+                if not item["id"] or not item["name"]:
+                    raise ManagedWorkflowRoutingError(
+                        "provider_workload_incomplete_tool_call",
+                        "Managed Provider 返回了不完整的 Workflow Agent Tool Call。",
+                    )
+                tool_calls.append(
+                    AgentToolCall(
+                        call_id=item["id"],
+                        name=item["name"],
+                        raw_arguments=item["arguments"] or "{}",
+                    )
+                )
+            if evidence.finish_reason == "tool_calls" and not tool_calls:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_incomplete_tool_call",
+                    "Managed Provider 声明了 Tool Call，但未返回可执行参数。",
+                )
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            self.gateway.call_service.complete_call(
+                prepared,
+                status="passed",
+                result_class="success",
+                actual_model=evidence.actual_model,
+                ttft_ms=evidence.ttft_ms,
+                e2e_ms=elapsed_ms,
+                prompt_tokens=evidence.prompt_tokens,
+                completion_tokens=evidence.completion_tokens,
+                total_tokens=evidence.total_tokens,
+            )
+            self.calls.append(
+                WorkflowProviderCallReceipt(
+                    call_sequence=call_sequence,
+                    model_id=model_id,
+                    actual_model=evidence.actual_model,
+                    dispatched=True,
+                    status="passed",
+                    prompt_tokens=evidence.prompt_tokens,
+                    completion_tokens=evidence.completion_tokens,
+                    total_tokens=evidence.total_tokens,
+                )
+            )
+            return AgentModelTurn(
+                content="".join(evidence.content_parts),
+                tool_calls=tool_calls,
+                finish_reason=evidence.finish_reason,
+                usage=AgentUsage(
+                    prompt_tokens=evidence.prompt_tokens or 0,
+                    completion_tokens=evidence.completion_tokens or 0,
+                    total_tokens=evidence.total_tokens or 0,
+                ),
+                raw={"model": evidence.actual_model or model_id},
+            )
+        except asyncio.CancelledError:
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status="cancelled",
+                result_class="client_cancelled",
+                code="provider_workload_call_cancelled",
+            )
+            raise
+        except ManagedWorkflowRoutingError as exc:
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status="failed",
+                result_class="provider_error" if dispatched else "preflight_error",
+                code=exc.code,
+            )
+            exc.receipt = self.receipt_summary()
+            raise
+        except RouterServiceError as exc:
+            status: WorkflowCallStatus = "uncertain" if dispatched else "failed"
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                result_class="control_plane_error",
+                code=exc.code,
+            )
+            raise self._closed_error(exc.code, dispatched) from exc
+        except (httpx.TimeoutException, TimeoutError) as exc:
+            status = "uncertain" if dispatched else "failed"
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                result_class="transport_error",
+                code="provider_workload_timeout",
+            )
+            raise self._closed_error("provider_workload_timeout", dispatched) from exc
+        except httpx.HTTPError as exc:
+            status = "uncertain" if dispatched else "failed"
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                result_class="transport_error",
+                code="provider_workload_transport_error",
+            )
+            raise self._closed_error(
+                "provider_workload_transport_error", dispatched
+            ) from exc
+        except Exception as exc:
+            status = "uncertain" if dispatched else "failed"
+            code = (
+                "provider_workload_dispatch_uncertain"
+                if dispatched
+                else "provider_workload_preflight_failed"
+            )
+            self._record_failure(
+                prepared,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=dispatched,
+                status=status,
+                result_class="unexpected_error",
+                code=code,
+            )
+            raise self._closed_error(code, dispatched) from exc
 
     async def complete_json_object(
         self,
@@ -778,6 +1092,105 @@ class ManagedWorkflowNodeRun:
                 deltas.append(content)
         return deltas
 
+    def _consume_agent_stream_event(
+        self,
+        event: str,
+        evidence: _AgentStreamEvidence,
+        *,
+        requested_model: str,
+        started: float,
+    ) -> None:
+        data_lines: list[str] = []
+        for line in event.split("\n"):
+            if not line or line.startswith(":"):
+                continue
+            if line.startswith("data:"):
+                data_lines.append(line[5:].lstrip())
+                continue
+            if line.startswith(("event:", "id:", "retry:")):
+                continue
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_invalid_sse",
+                "Managed Provider 返回了无效的 Workflow Agent SSE。",
+            )
+        if not data_lines:
+            return
+        data = "\n".join(data_lines)
+        if data == "[DONE]":
+            evidence.terminal_observed = True
+            return
+        try:
+            payload = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_invalid_sse",
+                "Managed Provider 返回了无效的 Workflow Agent SSE。",
+            ) from exc
+        if not isinstance(payload, dict) or isinstance(payload.get("error"), dict):
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_invalid_sse",
+                "Managed Provider 返回了无效的 Workflow Agent SSE。",
+            )
+        self._read_usage(payload, evidence)
+        actual_model = payload.get("model")
+        if isinstance(actual_model, str) and actual_model.strip():
+            clean_model = actual_model.strip()
+            if clean_model != requested_model:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_actual_model_mismatch",
+                    "Managed Provider 返回的实际模型与 Workflow Agent Binding 不一致。",
+                )
+            evidence.actual_model = clean_model
+        choices = payload.get("choices")
+        if not isinstance(choices, list):
+            return
+        for choice in choices:
+            if not isinstance(choice, dict):
+                continue
+            finish_reason = choice.get("finish_reason")
+            if finish_reason:
+                evidence.finish_reason = str(finish_reason)
+                evidence.terminal_observed = True
+            delta = choice.get("delta")
+            if not isinstance(delta, dict):
+                delta = choice.get("message")
+            if not isinstance(delta, dict):
+                continue
+            content = self._content_text(delta.get("content"))
+            if content:
+                if evidence.ttft_ms is None:
+                    evidence.ttft_ms = (time.perf_counter() - started) * 1000
+                evidence.content_observed = True
+                evidence.content_parts.append(content)
+            raw_calls = delta.get("tool_calls")
+            if not isinstance(raw_calls, list):
+                continue
+            for fallback_index, raw_call in enumerate(raw_calls):
+                if not isinstance(raw_call, dict):
+                    continue
+                raw_index = raw_call.get("index", fallback_index)
+                try:
+                    index = int(raw_index)
+                except (TypeError, ValueError):
+                    raise ManagedWorkflowRoutingError(
+                        "provider_workload_invalid_tool_call",
+                        "Managed Provider 返回了无效的 Workflow Agent Tool Call。",
+                    )
+                accumulated = evidence.tool_calls.setdefault(
+                    index,
+                    {"id": "", "name": "", "arguments": ""},
+                )
+                if raw_call.get("id"):
+                    accumulated["id"] = str(raw_call["id"])
+                function = raw_call.get("function")
+                if isinstance(function, dict):
+                    if function.get("name"):
+                        accumulated["name"] += str(function["name"])
+                    if function.get("arguments"):
+                        accumulated["arguments"] += str(function["arguments"])
+                if evidence.ttft_ms is None:
+                    evidence.ttft_ms = (time.perf_counter() - started) * 1000
+
     async def _read_with_cancel(
         self,
         response: httpx.Response,
@@ -962,3 +1375,211 @@ class ManagedWorkflowNodeRun:
             ),
             receipt=self.receipt_summary(),
         )
+
+
+class ManagedWorkflowAgentRun:
+    """One stable Agent node run with monotonically ordered Provider calls."""
+
+    def __init__(self, node_run: ManagedWorkflowNodeRun) -> None:
+        self._node_run = node_run
+        self._call_sequence = 0
+
+    @property
+    def entry_id(self) -> WorkflowEntryId:
+        return self._node_run.entry_id
+
+    @property
+    def run_id(self) -> str:
+        return self._node_run.run_id
+
+    @property
+    def status(self) -> str:
+        return self._node_run.status
+
+    @property
+    def calls(self) -> list[WorkflowProviderCallReceipt]:
+        return self._node_run.calls
+
+    def supports(self, model_id: str, execution_shape: str) -> bool:
+        try:
+            policy = self._node_run.gateway.call_service.control.get_policy(
+                self.entry_id
+            )
+        except Exception:
+            return False
+        return bool(
+            policy.effective_status == "managed_required"
+            and any(
+                item.valid
+                and item.model_id == model_id
+                and item.execution_shape == execution_shape
+                for item in policy.bindings
+            )
+        )
+
+    def resolve_strategy(
+        self,
+        *,
+        requested_strategy: str,
+        model_id: str,
+        has_tools: bool,
+    ) -> Literal["function_calling", "react"]:
+        clean = requested_strategy.strip() or "auto"
+        if clean not in {"auto", "function_calling", "react"}:
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_agent_strategy_invalid",
+                "Workflow Agent 策略无效。",
+                status_code=422,
+                receipt=self.receipt_summary(),
+            )
+        if clean == "function_calling":
+            if not has_tools:
+                raise ManagedWorkflowRoutingError(
+                    "provider_workload_agent_tools_required",
+                    "显式 Function Calling 策略缺少可用 Runtime 工具。",
+                    status_code=409,
+                    receipt=self.receipt_summary(),
+                )
+            self.require_shape(model_id, "chat_tools")
+            return "function_calling"
+        if not has_tools:
+            self.require_shape(model_id, "chat_text")
+            return "react"
+        if clean == "react":
+            self.require_shape(model_id, "chat_text")
+            return "react"
+        if self.supports(model_id, "chat_tools"):
+            return "function_calling"
+        if self.supports(model_id, "chat_text"):
+            return "react"
+        self.require_shape(model_id, "chat_tools")
+        raise AssertionError("unreachable")
+
+    def require_shape(self, model_id: str, execution_shape: str) -> None:
+        if self.supports(model_id, execution_shape):
+            return
+        raise ManagedWorkflowRoutingError(
+            "provider_workload_binding_missing",
+            "Workflow Agent 缺少精确模型与执行形态的合格 Binding。",
+            status_code=409,
+            receipt=self.receipt_summary(),
+        )
+
+    async def stream_text(
+        self,
+        *,
+        purpose: str,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        cancel_event: asyncio.Event | None = None,
+    ) -> AsyncIterator[str]:
+        self.require_shape(model_id, "chat_text")
+        call_sequence, logical_call_key = self._next_call(purpose)
+        async for delta in self._node_run.stream_text(
+            logical_call_key=logical_call_key,
+            call_sequence=call_sequence,
+            model_id=model_id,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            cancel_event=cancel_event,
+        ):
+            yield delta
+
+    async def complete_text(
+        self,
+        *,
+        purpose: str,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        cancel_event: asyncio.Event | None = None,
+    ) -> str:
+        turn = await self.complete(
+            model_id=model_id,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            purpose=purpose,
+            cancel_event=cancel_event,
+        )
+        if not turn.content.strip():
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_empty_response",
+                "Managed Provider 没有返回 Workflow Agent 所需文本。",
+                receipt=self.receipt_summary(),
+            )
+        return turn.content
+
+    async def complete_json_object(
+        self,
+        *,
+        purpose: str,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        cancel_event: asyncio.Event | None = None,
+    ) -> str:
+        self.require_shape(model_id, "chat_json_object")
+        call_sequence, logical_call_key = self._next_call(purpose)
+        return await self._node_run.complete_json_object(
+            logical_call_key=logical_call_key,
+            call_sequence=call_sequence,
+            model_id=model_id,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            cancel_event=cancel_event,
+        )
+
+    async def complete(
+        self,
+        *,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
+        parallel_tool_calls: bool | None = None,
+        purpose: str = "agent_model_round",
+        cancel_event: asyncio.Event | None = None,
+    ) -> AgentModelTurn:
+        execution_shape: Literal["chat_text", "chat_tools"] = (
+            "chat_tools" if tools is not None else "chat_text"
+        )
+        self.require_shape(model_id, execution_shape)
+        call_sequence, logical_call_key = self._next_call(purpose)
+        return await self._node_run.complete_agent_turn(
+            logical_call_key=logical_call_key,
+            call_sequence=call_sequence,
+            execution_shape=execution_shape,
+            model_id=model_id,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            tool_choice=tool_choice,
+            parallel_tool_calls=parallel_tool_calls,
+            cancel_event=cancel_event,
+        )
+
+    def finish(
+        self,
+        status: Literal["passed", "failed", "uncertain", "cancelled"],
+        *,
+        reason_code: str | None = None,
+    ) -> None:
+        self._node_run.finish(status, reason_code=reason_code)
+
+    def receipt_summary(self) -> dict[str, Any]:
+        return self._node_run.receipt_summary()
+
+    def _next_call(self, purpose: str) -> tuple[int, str]:
+        self._call_sequence += 1
+        clean_purpose = purpose.strip() or "agent_model_round"
+        return self._call_sequence, f"{clean_purpose}:{self._call_sequence}"

--- a/server/model_router/workload_control.py
+++ b/server/model_router/workload_control.py
@@ -105,6 +105,8 @@ DATA_PLANE_INTEGRATED_ENTRIES: frozenset[ProviderWorkloadEntryId] = frozenset(
         "meta_agent",
         "workflow_interactive_llm",
         "workflow_deployment_llm",
+        "workflow_interactive_agent",
+        "workflow_deployment_agent",
     }
 )
 

--- a/server/tests/test_workflow_managed_gateway.py
+++ b/server/tests/test_workflow_managed_gateway.py
@@ -88,31 +88,36 @@ def _qualified_router(tmp_path: Path) -> tuple[ModelRouterService, str]:
         catalog_fingerprint="workflow-catalog",
         observed_at="2026-08-23T00:00:00+00:00",
     )
-    chat_cert, created = repository.claim_chat_certification(
-        "local",
-        certification_id="workflow-chat-text-cert",
-        connection_id=connection.id,
-        connection_fingerprint=fingerprint,
-        contract_version=PROVIDER_CHAT_CONTRACT_VERSION,
-        capability="chat_text",
-        requested_model=MODEL_ID,
-        idempotency_key_hash=hashlib.sha256(b"workflow-chat-text").hexdigest(),
-    )
-    assert created is True
-    repository.complete_chat_certification(
-        "local",
-        str(chat_cert["id"]),
-        status="passed",
-        checks={
-            "catalog_contains_model": True,
-            "http_2xx": True,
-            "content_observed": True,
-            "response_complete": True,
-            "terminal_observed": True,
-        },
-        warning_codes=[],
-        actual_model=MODEL_ID,
-    )
+    for capability in ("chat_text", "chat_tools"):
+        chat_cert, created = repository.claim_chat_certification(
+            "local",
+            certification_id=f"workflow-{capability}-cert",
+            connection_id=connection.id,
+            connection_fingerprint=fingerprint,
+            contract_version=PROVIDER_CHAT_CONTRACT_VERSION,
+            capability=capability,
+            requested_model=MODEL_ID,
+            idempotency_key_hash=hashlib.sha256(
+                f"workflow-{capability}".encode("utf-8")
+            ).hexdigest(),
+        )
+        assert created is True
+        repository.complete_chat_certification(
+            "local",
+            str(chat_cert["id"]),
+            status="passed",
+            checks={
+                "catalog_contains_model": True,
+                "http_2xx": True,
+                "content_observed": True,
+                "response_complete": True,
+                "terminal_observed": True,
+                "tool_call_observed": capability == "chat_tools",
+                "tool_call_arguments_valid": capability == "chat_tools",
+            },
+            warning_codes=[],
+            actual_model=MODEL_ID,
+        )
     for execution_shape in ("chat_text_unary", "chat_json_object"):
         profile, profile_fingerprint = _profile(execution_shape)
         certification, created = repository.claim_workload_certification(
@@ -155,6 +160,12 @@ def _activate(
     service: ModelRouterService,
     connection_id: str,
     entry_id: str,
+    *,
+    shapes: tuple[str, ...] = (
+        "chat_text",
+        "chat_text_unary",
+        "chat_json_object",
+    ),
 ) -> None:
     control = ProviderWorkloadControlService(service)
     saved = control.update_policy(
@@ -167,7 +178,7 @@ def _activate(
                     model_id=MODEL_ID,
                     connection_id=connection_id,
                 )
-                for shape in ("chat_text", "chat_text_unary", "chat_json_object")
+                for shape in shapes
             ],
         ),
     )
@@ -202,6 +213,250 @@ def qualified_interactive(
     )
     _activate(service, connection_id, "workflow_interactive_llm")
     return service, connection_id
+
+
+@pytest.fixture
+def qualified_interactive_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[ModelRouterService, str]:
+    service, connection_id = _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_WORKFLOW_AGENT_ENABLED", "true")
+    _activate(
+        service,
+        connection_id,
+        "workflow_interactive_agent",
+        shapes=("chat_text", "chat_tools", "chat_json_object"),
+    )
+    return service, connection_id
+
+
+@pytest.mark.asyncio
+async def test_agent_run_resolves_auto_before_dispatch_and_records_each_round(
+    qualified_interactive_agent: tuple[ModelRouterService, str],
+) -> None:
+    service, _ = qualified_interactive_agent
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        body = json.loads(request.content)
+        if body.get("response_format") == {"type": "json_object"}:
+            return httpx.Response(
+                200,
+                json={
+                    "model": MODEL_ID,
+                    "choices": [{"message": {"content": '{"ok":true}'}}],
+                },
+            )
+        if body.get("tools"):
+            return httpx.Response(
+                200,
+                content=(
+                    b'data: {"model":"provider/workflow-model","choices":'
+                    b'[{"delta":{"tool_calls":[{"index":0,"id":"call_1",'
+                    b'"function":{"name":"lookup","arguments":"{\\"q\\":"}}]},'
+                    b'"finish_reason":null}]}\n\n'
+                    b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,'
+                    b'"function":{"arguments":"\\"value\\"}"}}]},'
+                    b'"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":8,'
+                    b'"completion_tokens":3,"total_tokens":11}}\n\n'
+                    b"data: [DONE]\n\n"
+                ),
+            )
+        return httpx.Response(
+            200,
+            content=(
+                b'data: {"model":"provider/workflow-model","choices":'
+                b'[{"delta":{"content":"final answer"},"finish_reason":"stop"}],'
+                b'"usage":{"prompt_tokens":5,"completion_tokens":2,'
+                b'"total_tokens":7}}\n\n'
+                b"data: [DONE]\n\n"
+            ),
+        )
+
+    gateway = ManagedWorkflowGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=False,
+            trust_env=False,
+        ),
+    )
+    run = gateway.start_agent_run(
+        source_kind="workflow_classic",
+        execution_reference="agent-task-1",
+        node_id="agent-node",
+    )
+
+    assert run.resolve_strategy(
+        requested_strategy="auto", model_id=MODEL_ID, has_tools=True
+    ) == "function_calling"
+    tool_turn = await run.complete(
+        model_id=MODEL_ID,
+        messages=[{"role": "user", "content": "private tool prompt"}],
+        temperature=0.2,
+        max_tokens=128,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    )
+    text_turn = await run.complete(
+        model_id=MODEL_ID,
+        messages=[{"role": "user", "content": "private react prompt"}],
+        temperature=0.2,
+        max_tokens=128,
+    )
+    json_text = await run.complete_json_object(
+        purpose="structured_repair",
+        model_id=MODEL_ID,
+        messages=[{"role": "user", "content": "private json prompt"}],
+        temperature=0,
+        max_tokens=128,
+    )
+    run.finish("passed")
+
+    assert tool_turn.tool_calls[0].name == "lookup"
+    assert json.loads(tool_turn.tool_calls[0].raw_arguments) == {"q": "value"}
+    assert text_turn.content == "final answer"
+    assert json.loads(json_text) == {"ok": True}
+    assert [item.call_sequence for item in run.calls] == [1, 2, 3]
+    assert len(requests) == 3
+    assert all(json.loads(item.content)["stream"] is (index < 2) for index, item in enumerate(requests))
+    database = service.repository.database_path.read_bytes()
+    assert b"private tool prompt" not in database
+    assert b"private react prompt" not in database
+    assert b"private json prompt" not in database
+    assert PROVIDER_SECRET.encode() not in database
+
+
+def test_agent_auto_uses_only_prequalified_shape_without_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_WORKFLOW_AGENT_ENABLED", "true")
+    _activate(
+        service,
+        connection_id,
+        "workflow_interactive_agent",
+        shapes=("chat_text",),
+    )
+    run = ManagedWorkflowGateway.for_router(service).start_agent_run(
+        source_kind="workflow_classic",
+        execution_reference="agent-task-react",
+        node_id="agent-node",
+    )
+
+    assert run.resolve_strategy(
+        requested_strategy="auto", model_id=MODEL_ID, has_tools=True
+    ) == "react"
+    with pytest.raises(ManagedWorkflowRoutingError) as blocked:
+        run.resolve_strategy(
+            requested_strategy="function_calling",
+            model_id=MODEL_ID,
+            has_tools=True,
+        )
+    run.finish("failed", reason_code=blocked.value.code)
+
+    assert blocked.value.code == "provider_workload_binding_missing"
+    assert run.receipt_summary()["call_count"] == 0
+
+    with pytest.raises(ManagedWorkflowRoutingError) as no_tools:
+        run.resolve_strategy(
+            requested_strategy="function_calling",
+            model_id=MODEL_ID,
+            has_tools=False,
+        )
+    assert no_tools.value.code == "provider_workload_agent_tools_required"
+    assert run.receipt_summary()["call_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_agent_text_shape_rejects_unrequested_tool_call(
+    qualified_interactive_agent: tuple[ModelRouterService, str],
+) -> None:
+    service, _ = qualified_interactive_agent
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            content=(
+                b'data: {"model":"provider/workflow-model","choices":'
+                b'[{"delta":{"tool_calls":[{"index":0,"id":"call_1",'
+                b'"function":{"name":"lookup","arguments":"{}"}}]},'
+                b'"finish_reason":"tool_calls"}]}\n\n'
+                b"data: [DONE]\n\n"
+            ),
+        )
+
+    run = ManagedWorkflowGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=False,
+            trust_env=False,
+        ),
+    ).start_agent_run(
+        source_kind="workflow_classic",
+        execution_reference="agent-text-shape",
+        node_id="agent-node",
+    )
+
+    with pytest.raises(ManagedWorkflowRoutingError) as blocked:
+        await run.complete_text(
+            purpose="agent_text",
+            model_id=MODEL_ID,
+            messages=[{"role": "user", "content": "plain text only"}],
+            temperature=0,
+            max_tokens=64,
+        )
+    run.finish("failed", reason_code=blocked.value.code)
+
+    assert blocked.value.code == "provider_workload_execution_shape_mismatch"
+    assert len(requests) == 1
+    assert run.receipt_summary()["call_count"] == 1
+    assert run.receipt_summary()["calls"][0]["dispatched"] is True
+
+
+def test_agent_phase_blocks_implicit_replay_but_allows_explicit_revision(
+    qualified_interactive_agent: tuple[ModelRouterService, str],
+) -> None:
+    service, _ = qualified_interactive_agent
+    gateway = ManagedWorkflowGateway.for_router(service)
+    initial = gateway.start_agent_run(
+        source_kind="workflow_classic",
+        execution_reference="agent-task-hitl",
+        node_id="agent-node",
+        logical_phase="initial",
+    )
+    initial.finish("failed", reason_code="test_pause")
+
+    with pytest.raises(ManagedWorkflowRoutingError) as replay:
+        gateway.start_agent_run(
+            source_kind="workflow_classic",
+            execution_reference="agent-task-hitl",
+            node_id="agent-node",
+            logical_phase="initial",
+        )
+    revision = gateway.start_agent_run(
+        source_kind="workflow_classic",
+        execution_reference="agent-task-hitl",
+        node_id="agent-node",
+        logical_phase="revision:1",
+    )
+    revision.finish("failed", reason_code="test_no_paid_call")
+
+    assert replay.value.code == "provider_workload_logical_run_replay_blocked"
+    assert len(service.repository.list_workload_receipts("local")["runs"]) == 2
 
 
 def test_stable_node_run_blocks_recovery_replay(

--- a/server/tests/test_workflow_managed_runtime.py
+++ b/server/tests/test_workflow_managed_runtime.py
@@ -2,20 +2,63 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from fastapi.responses import StreamingResponse
 
 import server.main as main_module
-from server.model_router.workflow_gateway import ManagedWorkflowRoutingError
+from server.model_router.workflow_gateway import (
+    ManagedWorkflowAgentRun,
+    ManagedWorkflowRoutingError,
+)
+from server.xpert_runtime.agent_strategy.models import (
+    AgentModelTurn,
+    AgentToolCall,
+    AgentUsage,
+)
 from server.xpert_runtime.execution_store import WorkflowExecutionStore
+from server.xpert_runtime.approval_store import RuntimeApprovalStore
+from server.xpert_runtime.toolset import RuntimeTool, RuntimeToolResult
 
 
 MODEL_ID = "provider/workflow-model"
 
 
-class FakeManagedNodeRun:
+class FakeManagedNodeRun(ManagedWorkflowAgentRun):
+    @property
+    def entry_id(self) -> str:
+        return self._fake_entry_id
+
+    @entry_id.setter
+    def entry_id(self, value: str) -> None:
+        self._fake_entry_id = value
+
+    @property
+    def run_id(self) -> str:
+        return self._fake_run_id
+
+    @run_id.setter
+    def run_id(self, value: str) -> None:
+        self._fake_run_id = value
+
+    @property
+    def status(self) -> str:
+        return self._fake_status
+
+    @status.setter
+    def status(self, value: str) -> None:
+        self._fake_status = value
+
+    @property
+    def calls(self) -> list[Any]:
+        return self._fake_calls
+
+    @calls.setter
+    def calls(self, value: list[Any]) -> None:
+        self._fake_calls = value
+
     def __init__(self, entry_id: str) -> None:
         self.entry_id = entry_id
         self.run_id = "workrun_fake"
@@ -23,9 +66,20 @@ class FakeManagedNodeRun:
         self.calls: list[Any] = []
         self.invocations: list[dict[str, Any]] = []
         self.json_outputs: list[str] = []
+        self.agent_turns: list[AgentModelTurn] = []
 
     async def stream_text(self, **kwargs: Any):
+        kwargs.setdefault("call_sequence", len(self.invocations) + 1)
         self.invocations.append({"shape": "chat_text", **kwargs})
+        self.calls.append(
+            SimpleNamespace(
+                status="passed",
+                actual_model=kwargs["model_id"],
+                prompt_tokens=3,
+                completion_tokens=2,
+                total_tokens=5,
+            )
+        )
         yield "managed "
         yield "answer"
 
@@ -34,10 +88,57 @@ class FakeManagedNodeRun:
         return '{"categoryId":"category_2"}'
 
     async def complete_json_object(self, **kwargs: Any) -> str:
+        kwargs.setdefault("call_sequence", len(self.invocations) + 1)
         self.invocations.append({"shape": "chat_json_object", **kwargs})
+        self.calls.append(
+            SimpleNamespace(
+                status="passed",
+                actual_model=kwargs["model_id"],
+                prompt_tokens=3,
+                completion_tokens=2,
+                total_tokens=5,
+            )
+        )
         if self.json_outputs:
             return self.json_outputs.pop(0)
         return '{"order_id":"A-1"}'
+
+    def require_shape(self, _model_id: str, _execution_shape: str) -> None:
+        return None
+
+    def resolve_strategy(
+        self, *, requested_strategy: str, model_id: str, has_tools: bool
+    ) -> str:
+        del model_id
+        if requested_strategy == "react":
+            return "react"
+        return "function_calling" if has_tools else "react"
+
+    async def complete_text(self, **kwargs: Any) -> str:
+        turn = await self.complete(**kwargs)
+        return turn.content
+
+    async def complete(self, **kwargs: Any) -> AgentModelTurn:
+        kwargs.setdefault("call_sequence", len(self.invocations) + 1)
+        shape = "chat_tools" if kwargs.get("tools") is not None else "chat_text"
+        self.invocations.append({"shape": shape, **kwargs})
+        self.calls.append(
+            SimpleNamespace(
+                status="passed",
+                actual_model=kwargs["model_id"],
+                prompt_tokens=3,
+                completion_tokens=2,
+                total_tokens=5,
+            )
+        )
+        if self.agent_turns:
+            return self.agent_turns.pop(0)
+        return AgentModelTurn(
+            content="managed answer",
+            finish_reason="stop",
+            usage=AgentUsage(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+            raw={"model": kwargs["model_id"]},
+        )
 
     def finish(self, status: str, *, reason_code: str | None = None) -> None:
         self.status = status
@@ -74,6 +175,8 @@ class FakeManagedNodeRun:
 
 class FakeManagedWorkflowGateway:
     instances: list[FakeManagedWorkflowGateway] = []
+    agent_mode = "legacy"
+    agent_turns: list[AgentModelTurn] = []
 
     def __init__(self) -> None:
         self.started: list[dict[str, str]] = []
@@ -92,6 +195,13 @@ class FakeManagedWorkflowGateway:
         }.get(str(source_kind or ""))
 
     @staticmethod
+    def agent_entry_id(source_kind: str | None) -> str | None:
+        return {
+            "workflow_classic": "workflow_interactive_agent",
+            "workflow_deployment": "workflow_deployment_agent",
+        }.get(str(source_kind or ""))
+
+    @staticmethod
     def blocked_receipt(entry_id: str, reason_code: str) -> dict[str, Any]:
         return {
             "contract_version": "modelmirror-provider-workload-routing-v1",
@@ -107,11 +217,23 @@ class FakeManagedWorkflowGateway:
     def routing_mode(self, source_kind: str | None) -> str:
         return "managed_required" if self.entry_id(source_kind) else "legacy"
 
+    def agent_routing_mode(self, source_kind: str | None) -> str:
+        return self.agent_mode if self.agent_entry_id(source_kind) else "legacy"
+
     def start_node_run(self, **kwargs: str) -> FakeManagedNodeRun:
         self.started.append(dict(kwargs))
         entry_id = self.entry_id(kwargs["source_kind"])
         assert entry_id is not None
         run = FakeManagedNodeRun(entry_id)
+        self.runs.append(run)
+        return run
+
+    def start_agent_run(self, **kwargs: str) -> FakeManagedNodeRun:
+        self.started.append(dict(kwargs))
+        entry_id = self.agent_entry_id(kwargs["source_kind"])
+        assert entry_id is not None
+        run = FakeManagedNodeRun(entry_id)
+        run.agent_turns = list(self.agent_turns)
         self.runs.append(run)
         return run
 
@@ -150,6 +272,8 @@ def _isolated_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     FakeManagedWorkflowGateway.instances = []
+    FakeManagedWorkflowGateway.agent_mode = "legacy"
+    FakeManagedWorkflowGateway.agent_turns = []
     monkeypatch.setattr(
         main_module, "ManagedWorkflowGateway", FakeManagedWorkflowGateway
     )
@@ -568,6 +692,744 @@ async def test_deployment_binding_uses_stable_execution_id() -> None:
             "node_id": "llm",
         }
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("node_kind", ["agent", "workflow_agent"])
+async def test_managed_agent_nodes_do_not_read_legacy_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+    node_kind: str,
+) -> None:
+    FakeManagedWorkflowGateway.agent_mode = "managed_required"
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_ENABLED", True)
+
+    def legacy_must_not_run(*_args: Any, **_kwargs: Any):
+        raise AssertionError("legacy Agent gateway must not run")
+
+    monkeypatch.setattr(main_module, "collect_chat_completion_text", legacy_must_not_run)
+    monkeypatch.setattr(main_module, "stream_workflow_llm_text", legacy_must_not_run)
+    monkeypatch.setattr(main_module, "stream_workflow_llm_messages", legacy_must_not_run)
+    node_data = (
+        {
+            "kind": "agent",
+            "agentMode": "direct",
+            "modelId": MODEL_ID,
+            "instruction": "Handle {{user_input}}",
+            "outputVariable": "answer",
+        }
+        if node_kind == "agent"
+        else {
+            "kind": "workflow_agent",
+            "agentName": "managed-agent",
+            "modelId": MODEL_ID,
+            "rolePrompt": "You are a managed agent.",
+            "taskInput": "Handle {{user_input}}",
+            "toolMode": "none",
+            "outputVariable": "answer",
+        }
+    )
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {"id": "agent-node", "type": node_kind, "data": node_data},
+                {
+                    "id": "output",
+                    "type": "output",
+                    "data": {"kind": "output", "outputVariable": "answer"},
+                },
+            ],
+            [
+                {"id": "e1", "source": "input", "target": "agent-node"},
+                {"id": "e2", "source": "agent-node", "target": "output"},
+            ],
+        ),
+        None,
+        runtime_execution_source_kind="workflow_classic",
+        runtime_task_id=f"managed-{node_kind}-task",
+    )
+    events = await _events(response)
+
+    agent_end = next(
+        item
+        for item in events
+        if item.get("event") == "node_end" and item.get("node_id") == "agent-node"
+    )
+    receipt = agent_end["provider_route_receipts"]
+    assert receipt["entry_id"] == "workflow_interactive_agent"
+    assert receipt["call_count"] == 1
+    assert receipt["calls"][0]["model_id"] == MODEL_ID
+    assert not [item for item in events if item.get("event") == "error"]
+    assert FakeManagedWorkflowGateway.instances[0].started == [
+        {
+            "source_kind": "workflow_classic",
+            "execution_reference": f"managed-{node_kind}-task",
+            "node_id": "agent-node",
+            "logical_phase": "initial",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_managed_deployment_agent_uses_stable_execution_id() -> None:
+    FakeManagedWorkflowGateway.agent_mode = "managed_required"
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {
+                    "id": "agent-node",
+                    "type": "workflow_agent",
+                    "data": {
+                        "kind": "workflow_agent",
+                        "agentName": "managed-deployment-agent",
+                        "modelId": MODEL_ID,
+                        "rolePrompt": "You are a managed agent.",
+                        "taskInput": "Handle {{user_input}}",
+                        "toolMode": "none",
+                    },
+                },
+            ],
+            [{"id": "e1", "source": "input", "target": "agent-node"}],
+        ),
+        None,
+        runtime_execution_source_kind="workflow_deployment",
+        runtime_metadata={
+            "workflow_deployment_execution_id": "deployment-agent-execution-1"
+        },
+        runtime_task_id="deployment-agent-task-id",
+    )
+    events = await _events(response)
+
+    agent_end = next(
+        item
+        for item in events
+        if item.get("event") == "node_end" and item.get("node_id") == "agent-node"
+    )
+    assert agent_end["provider_route_receipts"]["entry_id"] == (
+        "workflow_deployment_agent"
+    )
+    assert FakeManagedWorkflowGateway.instances[0].started == [
+        {
+            "source_kind": "workflow_deployment",
+            "execution_reference": "deployment-agent-execution-1",
+            "node_id": "agent-node",
+            "logical_phase": "initial",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_managed_workflow_agent_structured_output_uses_json_qualification() -> None:
+    FakeManagedWorkflowGateway.agent_mode = "managed_required"
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {
+                    "id": "agent-node",
+                    "type": "workflow_agent",
+                    "data": {
+                        "kind": "workflow_agent",
+                        "agentName": "managed-structured-agent",
+                        "modelId": MODEL_ID,
+                        "rolePrompt": "Return JSON.",
+                        "taskInput": "Extract {{user_input}}",
+                        "toolMode": "none",
+                        "outputVariable": "answer",
+                    },
+                },
+                {
+                    "id": "structured",
+                    "type": "runtime_middleware",
+                    "data": {
+                        "kind": "runtime_middleware",
+                        "runtimeMiddlewareId": "structured_output",
+                        "runtimeMiddlewareKind": "runtime_middleware.structured_output",
+                        "middlewarePriority": "20",
+                        "runtimeMiddlewareConfig": {
+                            "schema_json": {
+                                "type": "object",
+                                "required": ["order_id"],
+                                "properties": {"order_id": {"type": "string"}},
+                                "additionalProperties": False,
+                            },
+                            "repair_attempts": 0,
+                        },
+                    },
+                },
+            ],
+            [
+                {"id": "e1", "source": "input", "target": "agent-node"},
+                {
+                    "id": "bind-structured",
+                    "source": "structured",
+                    "target": "agent-node",
+                    "sourceHandle": "middleware-binding",
+                    "targetHandle": "middleware",
+                },
+            ],
+        ),
+        None,
+        runtime_execution_source_kind="workflow_classic",
+        runtime_task_id="managed-structured-agent-task",
+    )
+    events = await _events(response)
+
+    agent_end = next(
+        item
+        for item in events
+        if item.get("event") == "node_end" and item.get("node_id") == "agent-node"
+    )
+    managed_run = FakeManagedWorkflowGateway.instances[0].runs[0]
+    assert json.loads(agent_end["output"]) == {"order_id": "A-1"}
+    assert [item["shape"] for item in managed_run.invocations] == [
+        "chat_json_object"
+    ]
+    assert agent_end["provider_route_receipts"]["call_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_managed_agent_provider_failure_never_calls_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeManagedWorkflowGateway.agent_mode = "managed_required"
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_ENABLED", True)
+    legacy_calls: list[str] = []
+
+    async def legacy_must_not_run(*_args: Any, **_kwargs: Any) -> str:
+        legacy_calls.append("legacy")
+        return "legacy answer"
+
+    async def fail_after_dispatch(
+        self: FakeManagedNodeRun, **kwargs: Any
+    ) -> AgentModelTurn:
+        kwargs.setdefault("call_sequence", len(self.invocations) + 1)
+        self.invocations.append({"shape": "chat_text", **kwargs})
+        self.calls.append(
+            SimpleNamespace(
+                status="uncertain",
+                actual_model=None,
+                prompt_tokens=None,
+                completion_tokens=None,
+                total_tokens=None,
+            )
+        )
+        error = ManagedWorkflowRoutingError(
+            "provider_workload_transport_error",
+            "Managed Provider dispatch failed closed.",
+        )
+        error.receipt = self.receipt_summary()
+        raise error
+
+    monkeypatch.setattr(
+        main_module, "collect_chat_completion_text", legacy_must_not_run
+    )
+    monkeypatch.setattr(FakeManagedNodeRun, "complete", fail_after_dispatch)
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {
+                    "id": "agent-node",
+                    "type": "agent",
+                    "data": {
+                        "kind": "agent",
+                        "agentMode": "direct",
+                        "modelId": MODEL_ID,
+                        "instruction": "Handle {{user_input}}",
+                    },
+                },
+            ],
+            [{"id": "e1", "source": "input", "target": "agent-node"}],
+        ),
+        None,
+        runtime_execution_source_kind="workflow_classic",
+        runtime_task_id="managed-agent-failure-task",
+    )
+    events = await _events(response)
+
+    error = next(item for item in events if item.get("event") == "error")
+    assert error["code"] == "provider_workload_transport_error"
+    assert error["provider_route_receipts"]["call_count"] == 1
+    assert error["provider_route_receipts"]["calls"][0]["dispatched"] is True
+    assert legacy_calls == []
+    assert len(FakeManagedWorkflowGateway.instances[0].runs[0].invocations) == 1
+
+
+@pytest.mark.asyncio
+async def test_managed_agent_runtime_failure_finalizes_provider_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeManagedWorkflowGateway.agent_mode = "managed_required"
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_ENABLED", True)
+
+    async def fail_after_model_turn(
+        self: FakeManagedNodeRun, **kwargs: Any
+    ) -> AgentModelTurn:
+        kwargs.setdefault("call_sequence", len(self.invocations) + 1)
+        self.invocations.append({"shape": "chat_text", **kwargs})
+        self.calls.append(
+            SimpleNamespace(
+                status="passed",
+                actual_model=kwargs["model_id"],
+                prompt_tokens=3,
+                completion_tokens=2,
+                total_tokens=5,
+            )
+        )
+        raise RuntimeError("synthetic runtime post-processing failure")
+
+    monkeypatch.setattr(FakeManagedNodeRun, "complete", fail_after_model_turn)
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {
+                    "id": "agent-node",
+                    "type": "agent",
+                    "data": {
+                        "kind": "agent",
+                        "agentMode": "direct",
+                        "modelId": MODEL_ID,
+                        "instruction": "Handle {{user_input}}",
+                    },
+                },
+            ],
+            [{"id": "e1", "source": "input", "target": "agent-node"}],
+        ),
+        None,
+        runtime_execution_source_kind="workflow_classic",
+        runtime_task_id="managed-agent-runtime-failure",
+    )
+    events = await _events(response)
+
+    managed_run = FakeManagedWorkflowGateway.instances[0].runs[0]
+    assert managed_run.status == "failed"
+    node_end = next(
+        item
+        for item in events
+        if item.get("event") == "node_end" and item.get("node_id") == "agent-node"
+    )
+    assert node_end["provider_route_receipts"]["status"] == "failed"
+    assert node_end["provider_route_receipts"]["call_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_managed_output_policy_block_finalizes_provider_run() -> None:
+    FakeManagedWorkflowGateway.agent_mode = "managed_required"
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {
+                    "id": "agent-node",
+                    "type": "workflow_agent",
+                    "data": {
+                        "kind": "workflow_agent",
+                        "agentName": "managed-policy-agent",
+                        "modelId": MODEL_ID,
+                        "rolePrompt": "You are a managed agent.",
+                        "taskInput": "Handle {{user_input}}",
+                        "toolMode": "none",
+                    },
+                },
+                {
+                    "id": "content-policy",
+                    "type": "runtime_middleware",
+                    "data": {
+                        "kind": "runtime_middleware",
+                        "runtimeMiddlewareId": "content_policy",
+                        "runtimeMiddlewareKind": "runtime_middleware.content_policy",
+                        "middlewarePriority": "100",
+                        "runtimeMiddlewareConfig": {
+                            "phase": "output",
+                            "rules": [
+                                {
+                                    "id": "rule_1",
+                                    "label": "Synthetic block",
+                                    "detector": "literal_terms",
+                                    "action": "block",
+                                    "terms": ["managed answer"],
+                                    "caseSensitive": False,
+                                }
+                            ],
+                        },
+                    },
+                },
+            ],
+            [
+                {"id": "e1", "source": "input", "target": "agent-node"},
+                {
+                    "id": "bind-policy",
+                    "source": "content-policy",
+                    "target": "agent-node",
+                    "sourceHandle": "middleware-binding",
+                    "targetHandle": "middleware",
+                },
+            ],
+        ),
+        None,
+        runtime_execution_source_kind="workflow_classic",
+        runtime_task_id="managed-agent-policy-block",
+    )
+    events = await _events(response)
+
+    managed_run = FakeManagedWorkflowGateway.instances[0].runs[0]
+    assert managed_run.status == "failed"
+    error = next(item for item in events if item.get("event") == "error")
+    assert error["provider_route_receipts"]["status"] == "failed"
+    assert error["provider_route_receipts"]["call_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_managed_workflow_agent_blocks_legacy_retry_before_dispatch() -> None:
+    FakeManagedWorkflowGateway.agent_mode = "managed_required"
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {
+                    "id": "agent-node",
+                    "type": "workflow_agent",
+                    "data": {
+                        "kind": "workflow_agent",
+                        "agentName": "managed-agent",
+                        "modelId": MODEL_ID,
+                        "rolePrompt": "You are a managed agent.",
+                        "taskInput": "Handle {{user_input}}",
+                        "toolMode": "none",
+                        "retryOnFailure": True,
+                        "fallbackModelId": "provider/fallback-model",
+                    },
+                },
+            ],
+            [{"id": "e1", "source": "input", "target": "agent-node"}],
+        ),
+        None,
+        runtime_execution_source_kind="workflow_classic",
+        runtime_task_id="managed-agent-retry-block",
+    )
+    events = await _events(response)
+
+    error = next(item for item in events if item.get("event") == "error")
+    assert error["code"] == "provider_workload_legacy_retry_fallback_configured"
+    assert error["provider_route_receipts"]["call_count"] == 0
+    assert FakeManagedWorkflowGateway.instances[0].started == []
+    assert not any(
+        item.get("event") == "node_end" and item.get("node_id") == "agent-node"
+        for item in events
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("requested_strategy", "model_text", "expected_shape", "expected_output"),
+    [
+        (
+            "auto",
+            "managed function answer",
+            "chat_tools",
+            "managed function answer",
+        ),
+        (
+            "react",
+            "FinalAnswer: managed react answer",
+            "chat_text",
+            "managed react answer",
+        ),
+    ],
+)
+async def test_managed_agent_strategy_is_selected_before_first_post(
+    monkeypatch: pytest.MonkeyPatch,
+    requested_strategy: str,
+    model_text: str,
+    expected_shape: str,
+    expected_output: str,
+) -> None:
+    FakeManagedWorkflowGateway.agent_mode = "managed_required"
+    FakeManagedWorkflowGateway.agent_turns = [
+        AgentModelTurn(
+            content=model_text,
+            finish_reason="stop",
+            usage=AgentUsage(prompt_tokens=4, completion_tokens=2, total_tokens=6),
+            raw={"model": MODEL_ID},
+        )
+    ]
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_ENABLED", True)
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", True)
+
+    class OneToolProvider:
+        async def list_tools(self) -> list[RuntimeTool]:
+            return [
+                RuntimeTool(
+                    name="lookup",
+                    description="Read-only lookup",
+                    input_schema={"type": "object", "properties": {}},
+                )
+            ]
+
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", OneToolProvider())
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {
+                    "id": "agent-node",
+                    "type": "agent",
+                    "data": {
+                        "kind": "agent",
+                        "agentMode": "tool_first",
+                        "agentStrategy": requested_strategy,
+                        "modelId": MODEL_ID,
+                        "instruction": "Handle {{user_input}}",
+                        "outputVariable": "answer",
+                    },
+                },
+            ],
+            [{"id": "e1", "source": "input", "target": "agent-node"}],
+        ),
+        None,
+        runtime_execution_source_kind="workflow_classic",
+        runtime_task_id=f"managed-agent-{requested_strategy}",
+    )
+    events = await _events(response)
+
+    agent_end = next(
+        item
+        for item in events
+        if item.get("event") == "node_end" and item.get("node_id") == "agent-node"
+    )
+    managed_run = FakeManagedWorkflowGateway.instances[0].runs[0]
+    assert [item["shape"] for item in managed_run.invocations] == [expected_shape]
+    assert agent_end["provider_route_receipts"]["call_count"] == 1
+    assert agent_end["output"] == expected_output
+
+
+@pytest.mark.asyncio
+async def test_managed_function_calling_records_each_model_round_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeManagedWorkflowGateway.agent_mode = "managed_required"
+    FakeManagedWorkflowGateway.agent_turns = [
+        AgentModelTurn(
+            content="",
+            tool_calls=[
+                AgentToolCall(
+                    call_id="call_lookup_1",
+                    name="lookup",
+                    raw_arguments='{"q":"value"}',
+                )
+            ],
+            finish_reason="tool_calls",
+            usage=AgentUsage(prompt_tokens=4, completion_tokens=2, total_tokens=6),
+            raw={"model": MODEL_ID},
+        ),
+        AgentModelTurn(
+            content="managed tool answer",
+            finish_reason="stop",
+            usage=AgentUsage(prompt_tokens=6, completion_tokens=3, total_tokens=9),
+            raw={"model": MODEL_ID},
+        ),
+    ]
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_ENABLED", True)
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", True)
+
+    class ToolProvider:
+        def __init__(self) -> None:
+            self.tool = RuntimeTool(
+                name="lookup",
+                description="Read-only lookup",
+                input_schema={
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                    "required": ["q"],
+                },
+                read_only=True,
+            )
+            self.calls: list[Any] = []
+
+        async def list_tools(self) -> list[RuntimeTool]:
+            return [self.tool]
+
+        async def find_tool(self, tool_name: str) -> RuntimeTool | None:
+            return self.tool if tool_name == self.tool.name else None
+
+        async def call_tool(self, call: Any) -> RuntimeToolResult:
+            self.calls.append(call)
+            return RuntimeToolResult(
+                output="lookup result",
+                content=[{"type": "text", "text": "lookup result"}],
+                metadata={"content_types": ["text"]},
+                is_error=False,
+            )
+
+    provider = ToolProvider()
+    original_provider = main_module.runtime_capabilities.require(
+        "mcp_tools"
+    ).implementation
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    main_module.runtime_capabilities.register("mcp_tools", provider)
+    try:
+        response = await main_module._run_workflow_response(
+            _workflow(
+                [
+                    {"id": "input", "type": "input", "data": {"kind": "input"}},
+                    {
+                        "id": "agent-node",
+                        "type": "agent",
+                        "data": {
+                            "kind": "agent",
+                            "agentMode": "tool_first",
+                            "agentStrategy": "function_calling",
+                            "modelId": MODEL_ID,
+                            "instruction": "Use lookup for {{user_input}}",
+                            "toolNames": "lookup",
+                            "outputVariable": "answer",
+                        },
+                    },
+                ],
+                [{"id": "e1", "source": "input", "target": "agent-node"}],
+            ),
+            None,
+            runtime_execution_source_kind="workflow_classic",
+            runtime_task_id="managed-agent-tool-loop",
+        )
+        events = await _events(response)
+    finally:
+        main_module.runtime_capabilities.register("mcp_tools", original_provider)
+
+    agent_end = next(
+        item
+        for item in events
+        if item.get("event") == "node_end" and item.get("node_id") == "agent-node"
+    )
+    managed_run = FakeManagedWorkflowGateway.instances[0].runs[0]
+    assert agent_end["output"] == "managed tool answer"
+    assert [item["shape"] for item in managed_run.invocations] == [
+        "chat_tools",
+        "chat_tools",
+    ]
+    assert agent_end["provider_route_receipts"]["call_count"] == 2
+    assert [
+        item["call_sequence"]
+        for item in agent_end["provider_route_receipts"]["calls"]
+    ] == [1, 2]
+    assert len(provider.calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", ["replace", "revise"])
+async def test_managed_hitl_resume_dispatches_only_explicit_revision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    decision: str,
+) -> None:
+    FakeManagedWorkflowGateway.agent_mode = "managed_required"
+    approvals = RuntimeApprovalStore(tmp_path / "approvals")
+    executions = WorkflowExecutionStore(tmp_path / "hitl-executions")
+    monkeypatch.setattr(main_module, "runtime_approval_store", approvals)
+    monkeypatch.setattr(main_module, "workflow_execution_store", executions)
+    workflow = _workflow(
+        [
+            {"id": "input", "type": "input", "data": {"kind": "input"}},
+            {
+                "id": "agent-node",
+                "type": "workflow_agent",
+                "data": {
+                    "kind": "workflow_agent",
+                    "agentName": "managed-agent",
+                    "modelId": MODEL_ID,
+                    "rolePrompt": "You are a managed agent.",
+                    "taskInput": "Handle {{user_input}}",
+                    "toolMode": "none",
+                    "outputVariable": "answer",
+                },
+            },
+            {
+                "id": "hitl",
+                "type": "runtime_middleware",
+                "data": {
+                    "kind": "runtime_middleware",
+                    "runtimeMiddlewareId": "human_in_the_loop",
+                    "runtimeMiddlewareKind": "runtime_middleware.human_in_the_loop",
+                    "middlewarePriority": "40",
+                    "runtimeMiddlewareConfig": {
+                        "interrupt_on_tools": "",
+                        "final_confirmation": True,
+                        "max_revision_rounds": 1,
+                        "timeout_seconds": 3600,
+                    },
+                },
+            },
+            {
+                "id": "output",
+                "type": "output",
+                "data": {"kind": "output", "outputVariable": "answer"},
+            },
+        ],
+        [
+            {"id": "e1", "source": "input", "target": "agent-node"},
+            {"id": "e2", "source": "agent-node", "target": "output"},
+            {
+                "id": "bind-hitl",
+                "source": "hitl",
+                "target": "agent-node",
+                "sourceHandle": "middleware-binding",
+                "targetHandle": "middleware",
+            },
+        ],
+    )
+    response = await main_module._run_workflow_response(
+        workflow,
+        None,
+        runtime_execution_source_kind="workflow_classic",
+        runtime_task_id="managed-hitl-task",
+    )
+    events = await _events(response)
+    pending = next(
+        item for item in events if item.get("event") == "runtime_approval_pending"
+    )
+    approval = approvals.require(pending["approval_id"])
+    decided = approvals.decide(
+        approval.approval_id,
+        revision=approval.revision,
+        decision=decision,
+        operator="tester",
+        replacement_text="approved answer" if decision == "replace" else None,
+        message="revise once" if decision == "revise" else None,
+    )
+    executions.mark_ready(pending["task_id"], approval_id=approval.approval_id)
+    claimed = executions.claim(pending["task_id"], worker_id="test-worker")
+    await main_module.resume_runtime_approval_execution(claimed, decided)
+
+    completed = executions.require(pending["task_id"])
+    assert len(FakeManagedWorkflowGateway.instances) == 2
+    assert len(FakeManagedWorkflowGateway.instances[0].runs) == 1
+    if decision == "replace":
+        agent_end = next(
+            item
+            for item in completed.events
+            if item.get("event") == "node_end"
+            and item.get("node_id") == "agent-node"
+        )
+        assert completed.status == "completed"
+        assert completed.result == "approved answer"
+        assert agent_end["provider_route_receipts"]["call_count"] == 1
+        assert FakeManagedWorkflowGateway.instances[1].started == []
+    else:
+        assert completed.status == "waiting"
+        assert len(FakeManagedWorkflowGateway.instances[1].runs) == 1
+        resumed_run = FakeManagedWorkflowGateway.instances[1].runs[0]
+        assert resumed_run.receipt_summary()["call_count"] == 1
+        assert FakeManagedWorkflowGateway.instances[1].started[0][
+            "logical_phase"
+        ].startswith("resume:")
+        assert sum(
+            1
+            for item in completed.events
+            if item.get("event") == "runtime_approval_pending"
+        ) == 2
 
 
 def test_durable_event_sanitizes_provider_receipt(tmp_path: Path) -> None:


### PR DESCRIPTION
## 概要

- 接入 `workflow_interactive_agent` 与 `workflow_deployment_agent` 的 Managed Provider 控制面。
- 统一 `chat_text`、`chat_tools`、`chat_json_object` 的精确 Binding、资格校验与脱敏 Receipt。
- Provider POST 派发后禁止自动重试、备用连接和 legacy 回退；工具执行、权限与 HITL 仍由 Workflow Runtime 负责。
- 补充策略分流、结构化输出、Ralph 中间调用、恢复/中断和失败关闭回归测试，并同步架构与部署文档。

## 验证

- R6E 专项：98 passed（整合主线前）。
- R5/控制面回归：92 passed。
- 后端全量：4431 passed, 29 skipped。
- 前端全量：108 files / 619 tests passed；typecheck 与 production build 通过。
- 最新 `origin/main@bea9849c` 交叉回归：后端 80 passed；前端 Workflow 22 passed；typecheck 与 py_compile 通过。
- Core、独立 newAPI、Overlay Compose 配置验证通过。
- 真实交互 Workflow Agent：1 个 Provider POST，59 tokens，模型与 Receipt 一致，无重试/回退。
- 真实部署 Workflow Agent：1 个 Provider POST，87 tokens，执行完成，模型与 Receipt 一致，无重试/回退。
- `git diff --check` 与敏感信息扫描通过。

## 边界与风险

- R6F-R6I、普通 Agent Workbench、RAG、多模态、Coding、多租户和计费均不在本 PR。
- Feature Flags 默认关闭；合并不等于生产启用。
- 预览环境未配置可选 File Output Service，相关 503 属于本轮排除的文件输出路径，不影响已验收的纯文本 Agent 路径。
- 不改变 R5 Chat、Catalog 数量口径、提示词选择器或多模态协议。
