### PR TITLE
feature: 纳管 Xpert 与 Xpert App 模型调用

### DIFF
--- a/client/src/pages/XpertAppPage.receipt-state.test.tsx
+++ b/client/src/pages/XpertAppPage.receipt-state.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import XpertAppPage from "./XpertAppPage";
+
+const APP_SLUG = "receipt-state-app";
+const TOKEN_KEY = `modelmirror-xpert-app:${APP_SLUG}:access`;
+const scrollToDescriptor = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "scrollTo",
+);
+
+function jsonResponse(payload: unknown) {
+  return Promise.resolve(new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  }));
+}
+
+function streamResponse() {
+  const receipt = {
+    contract_version: "modelmirror-provider-workload-routing-v1",
+    entry_id: "xpert_app",
+    routing_mode: "managed_required",
+    run_reference: "workrun-receipt-state",
+    status: "passed",
+    call_count: 1,
+    reason_codes: [],
+    calls: [{
+      call_sequence: 1,
+      model_id: "provider/test-model",
+      actual_model: "provider/test-model",
+      dispatched: true,
+      status: "passed",
+      error_code: null,
+      prompt_tokens: 1,
+      completion_tokens: 1,
+      total_tokens: 2,
+    }],
+  };
+  const payload = {
+    choices: [{ delta: { content: "done" } }],
+    modelmirror: { provider_route_receipts: receipt },
+  };
+  const body = `data: ${JSON.stringify(payload)}\n\ndata: [DONE]\n\n`;
+  return Promise.resolve(new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  }));
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/apps/${APP_SLUG}`]}>
+      <Routes>
+        <Route element={<XpertAppPage />} path="/apps/:appSlug" />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+async function produceReceipt() {
+  await screen.findByText("Receipt State App");
+  fireEvent.change(screen.getByPlaceholderText("输入消息，Enter 发送"), {
+    target: { value: "hello" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "发送" }));
+  await screen.findByText("已纳管");
+}
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+    configurable: true,
+    value: vi.fn(),
+  });
+  sessionStorage.setItem(TOKEN_KEY, "mmshare_test");
+  vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input) === `/api/apps/${APP_SLUG}/manifest`) {
+      return jsonResponse({
+        object: "xpert.app",
+        slug: APP_SLUG,
+        name: "Receipt State App",
+        description: "state test",
+        starters: [],
+        version: 1,
+        deployment_revision: 1,
+        visibility: "unlisted",
+      });
+    }
+    if (
+      String(input) === `/api/v1/xpert-apps/${APP_SLUG}/chat/completions`
+      && init?.method === "POST"
+    ) {
+      return streamResponse();
+    }
+    throw new Error(`Unexpected fetch: ${String(input)}`);
+  }));
+});
+
+afterEach(() => {
+  if (scrollToDescriptor) {
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", scrollToDescriptor);
+  } else {
+    delete (HTMLElement.prototype as { scrollTo?: unknown }).scrollTo;
+  }
+  sessionStorage.clear();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe("XpertAppPage provider receipt state", () => {
+  it("clears the previous receipt with the conversation", async () => {
+    renderPage();
+    await produceReceipt();
+
+    fireEvent.click(screen.getByRole("button", { name: "清空对话" }));
+
+    expect(screen.queryByText("已纳管")).not.toBeInTheDocument();
+    expect(screen.getByText("从一个问题开始")).toBeInTheDocument();
+  });
+
+  it("does not restore a receipt after leaving and reopening the share", async () => {
+    renderPage();
+    await produceReceipt();
+
+    fireEvent.click(screen.getByRole("button", { name: "退出分享" }));
+    expect(await screen.findByText("打开未列出的 Agent App")).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText("mmshare_..."), {
+      target: { value: "mmshare_test" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "验证访问" }));
+
+    await waitFor(() => expect(screen.getByText("Receipt State App")).toBeInTheDocument());
+    expect(screen.queryByText("已纳管")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/pages/XpertAppPage.test.ts
+++ b/client/src/pages/XpertAppPage.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { xpertAppProviderReceipt } from "./XpertAppPage";
+
+describe("xpertAppProviderReceipt", () => {
+  it("reads the additive sanitized receipt envelope", () => {
+    const receipt = {
+      contract_version: "modelmirror-provider-workload-routing-v1",
+      entry_id: "xpert_app",
+      routing_mode: "managed_required",
+      run_reference: "workrun-app",
+      status: "passed",
+      call_count: 1,
+      reason_codes: [],
+      calls: [],
+    };
+
+    expect(xpertAppProviderReceipt({
+      modelmirror: { provider_route_receipts: receipt },
+    })).toEqual(receipt);
+    expect(xpertAppProviderReceipt({ choices: [] })).toBeNull();
+  });
+});

--- a/client/src/pages/XpertAppPage.tsx
+++ b/client/src/pages/XpertAppPage.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import ProviderRouteReceiptSummary, {
+  type ProviderRouteReceipt,
+} from "../components/meta/ProviderRouteReceiptSummary";
 import { type XpertAppManifest } from "../types/xpert";
 
 interface AppMessage {
@@ -26,6 +29,16 @@ function readError(payload: unknown, fallback: string) {
   return fallback;
 }
 
+export function xpertAppProviderReceipt(payload: unknown): ProviderRouteReceipt | null {
+  if (!payload || typeof payload !== "object") return null;
+  const modelmirror = (payload as { modelmirror?: unknown }).modelmirror;
+  if (!modelmirror || typeof modelmirror !== "object") return null;
+  const receipt = (modelmirror as { provider_route_receipts?: unknown })
+    .provider_route_receipts;
+  if (!receipt || typeof receipt !== "object") return null;
+  return receipt as ProviderRouteReceipt;
+}
+
 export default function XpertAppPage() {
   const { appSlug = "" } = useParams();
   const [manifest, setManifest] = useState<XpertAppManifest | null>(null);
@@ -36,6 +49,7 @@ export default function XpertAppPage() {
   const [loading, setLoading] = useState(true);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState("");
+  const [providerReceipt, setProviderReceipt] = useState<ProviderRouteReceipt | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -111,6 +125,13 @@ export default function XpertAppPage() {
     setAccessDraft("");
     setManifest(null);
     setError("");
+    setProviderReceipt(null);
+  }
+
+  function clearConversation() {
+    setMessages([]);
+    setProviderReceipt(null);
+    localStorage.removeItem(historyKey(appSlug));
   }
 
   async function sendMessage(value = input) {
@@ -123,6 +144,7 @@ export default function XpertAppPage() {
     setInput("");
     setRunning(true);
     setError("");
+    setProviderReceipt(null);
     try {
       const response = await fetch(`/api/v1/xpert-apps/${appSlug}/chat/completions`, {
         method: "POST",
@@ -161,7 +183,10 @@ export default function XpertAppPage() {
             const payload = JSON.parse(raw) as {
               error?: { message?: string };
               choices?: Array<{ delta?: { content?: string } }>;
+              modelmirror?: { provider_route_receipts?: ProviderRouteReceipt | null };
             };
+            const receipt = xpertAppProviderReceipt(payload);
+            if (receipt) setProviderReceipt(receipt);
             if (payload.error) throw new Error(payload.error.message || "App 运行失败");
             const delta = payload.choices?.[0]?.delta?.content || "";
             if (!delta) continue;
@@ -229,7 +254,7 @@ export default function XpertAppPage() {
             <p className="mt-1 line-clamp-2 max-w-3xl text-xs leading-5 text-slate-400">{manifest.description || "已发布的模镜 Agent App"}</p>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            <button className="rounded-md border border-white/10 px-3 py-2 text-xs text-slate-300 hover:bg-white/[0.05]" onClick={() => { setMessages([]); localStorage.removeItem(historyKey(appSlug)); }} type="button">清空对话</button>
+            <button className="rounded-md border border-white/10 px-3 py-2 text-xs text-slate-300 hover:bg-white/[0.05]" onClick={clearConversation} type="button">清空对话</button>
             <button className="rounded-md px-3 py-2 text-xs text-slate-500 hover:text-slate-200" onClick={resetAccess} type="button">退出分享</button>
           </div>
         </header>
@@ -275,6 +300,11 @@ export default function XpertAppPage() {
 
         <footer className="border-t border-white/10 bg-ink-950/55 p-4 sm:px-6">
           <div className="mx-auto max-w-3xl">
+            {providerReceipt ? (
+              <div className="mb-2">
+                <ProviderRouteReceiptSummary compact receipt={providerReceipt} />
+              </div>
+            ) : null}
             {error ? <p className="mb-2 text-xs text-rose-200">{error}</p> : null}
             <div className="flex items-end gap-2">
               <textarea

--- a/client/src/pages/XpertChatPage.file-assets.test.ts
+++ b/client/src/pages/XpertChatPage.file-assets.test.ts
@@ -6,6 +6,7 @@ import {
   consumeSelectedXpertFiles,
   fileOutputsForRun,
   isCurrentXpertConversationRequest,
+  latestXpertProviderReceipt,
   parseXpertWorkflowEvents,
   selectedXpertFilesAfterConversationRestore,
   selectedXpertFilesAfterRefresh,
@@ -15,6 +16,29 @@ import {
   xpertMessageInputLocked,
   xpertOutputScopeId,
 } from "./XpertChatPage";
+
+describe("latestXpertProviderReceipt", () => {
+  it("returns the latest sanitized route receipt without touching message storage", () => {
+    const receipt = {
+      contract_version: "modelmirror-provider-workload-routing-v1",
+      entry_id: "xpert" as const,
+      routing_mode: "managed_required" as const,
+      run_reference: "workrun-1",
+      status: "passed" as const,
+      call_count: 1,
+      reason_codes: [],
+      calls: [],
+    };
+
+    expect(latestXpertProviderReceipt([
+      { event: "workflow_meta" },
+      { event: "node_end", provider_route_receipts: receipt },
+      { event: "workflow_end" },
+    ])).toEqual(receipt);
+    expect(latestXpertProviderReceipt([])).toBeNull();
+    expect(latestXpertProviderReceipt([{ event: "workflow_end" }])).toBeNull();
+  });
+});
 
 afterEach(() => {
   vi.unstubAllGlobals();

--- a/client/src/pages/XpertChatPage.tsx
+++ b/client/src/pages/XpertChatPage.tsx
@@ -9,6 +9,9 @@ import SandboxWorkspacePanel from "../components/runtime/SandboxWorkspacePanel";
 import DataXResultCard from "../components/datax/DataXResultCard";
 import FileOutputTray from "../components/FileOutputTray";
 import FileMemoryPanel from "../components/xpert/FileMemoryPanel";
+import ProviderRouteReceiptSummary, {
+  type ProviderRouteReceipt,
+} from "../components/meta/ProviderRouteReceiptSummary";
 import SkillApplicationCard, {
   requiredSkillIdsFromWorkflowNodes,
 } from "../components/skill-runtime/SkillApplicationCard";
@@ -89,6 +92,18 @@ interface XpertRunEvent {
   sequence?: number;
   suggestions?: string[];
   conversation_title?: string;
+  provider_route_receipts?: ProviderRouteReceipt;
+}
+
+export function latestXpertProviderReceipt(
+  events: XpertRunEvent[],
+): ProviderRouteReceipt | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    if (events[index]?.provider_route_receipts) {
+      return events[index].provider_route_receipts ?? null;
+    }
+  }
+  return null;
 }
 
 export function selectedXpertFilesAfterConversationRestore(
@@ -337,6 +352,7 @@ export default function XpertChatPage() {
   const [messages, setMessages] = useState<XpertConversationMessage[]>([]);
   const [input, setInput] = useState("");
   const [events, setEvents] = useState<XpertRunEvent[]>([]);
+  const [providerReceipt, setProviderReceipt] = useState<ProviderRouteReceipt | null>(null);
   const [runId, setRunId] = useState("");
   const [taskId, setTaskId] = useState("");
   const [trace, setTrace] = useState<TraceBundle | null>(null);
@@ -538,6 +554,7 @@ export default function XpertChatPage() {
     setFileOutputs([]);
     setSelectedFileIds([]);
     setEvents([]);
+    setProviderReceipt(null);
     setContextLoading(true);
     setError("");
     try {
@@ -577,7 +594,8 @@ export default function XpertChatPage() {
             `/api/workflow/run/${encodeURIComponent(linkedMessage.source_task_id)}/stream?after_sequence=0`,
           );
           if (response.ok) {
-            const restored = parseXpertWorkflowEvents(await response.text())
+            const restoredEvents = parseXpertWorkflowEvents(await response.text());
+            const restored = restoredEvents
               .filter((event) => ["skill_runtime_status", "skill_hook_status"].includes(event.event))
               .slice(-80);
             if (isCurrentXpertConversationRequest(
@@ -585,7 +603,10 @@ export default function XpertChatPage() {
               conversationRequestTokenRef.current,
               nextConversationId,
               conversationIdRef.current,
-            )) setEvents(restored);
+            )) {
+              setEvents(restored);
+              setProviderReceipt(latestXpertProviderReceipt(restoredEvents));
+            }
           }
         } catch {
           // Historical Skill status is best-effort; the conversation stays usable.
@@ -1039,6 +1060,7 @@ export default function XpertChatPage() {
     setInput("");
     setSelectedFileIds(nextSelectedFileIds);
     setEvents([]);
+    setProviderReceipt(null);
     setTrace(null);
     setRunId("");
     setTaskId("");
@@ -1078,6 +1100,9 @@ export default function XpertChatPage() {
           if (!raw) continue;
           const event = JSON.parse(raw) as XpertRunEvent;
           setEvents((current) => [...current.slice(-79), event]);
+          if (event.provider_route_receipts) {
+            setProviderReceipt(event.provider_route_receipts);
+          }
           if (event.run_id) {
             nextRunId = event.run_id;
             setRunId(event.run_id);
@@ -1160,6 +1185,7 @@ export default function XpertChatPage() {
       let finalSuggestions: string[] = [];
       let finalConversationTitle = "";
       setEvents([]);
+      setProviderReceipt(null);
 
       const processBlock = (block: string) => {
         for (const line of block.split(/\r?\n/)) {
@@ -1168,6 +1194,9 @@ export default function XpertChatPage() {
           if (!raw) continue;
           const event = JSON.parse(raw) as XpertRunEvent;
           setEvents((current) => [...current.slice(-79), event]);
+          if (event.provider_route_receipts) {
+            setProviderReceipt(event.provider_route_receipts);
+          }
           if (event.run_id) {
             nextRunId = event.run_id;
             setRunId(event.run_id);
@@ -1595,6 +1624,12 @@ export default function XpertChatPage() {
             <div className="rounded-lg border border-white/10 bg-white/[0.04] p-3"><dt className="text-slate-500">状态</dt><dd className="mt-1 font-semibold text-white">{running ? "运行中" : trace?.run?.status ?? "待运行"}</dd></div>
             <div className="col-span-2 rounded-lg border border-white/10 bg-white/[0.04] p-3"><dt className="text-slate-500">Run ID</dt><dd className="mt-1 break-all font-mono text-[11px] text-slate-300">{runId || "-"}</dd></div>
           </dl>
+
+          {providerReceipt ? (
+            <div className="mt-3">
+              <ProviderRouteReceiptSummary compact receipt={providerReceipt} />
+            </div>
+          ) : null}
 
           <SkillApplicationCard
             className="mt-3"

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -452,7 +452,9 @@ export interface ProviderRouteReceipt {
     | "workflow_interactive_llm"
     | "workflow_deployment_llm"
     | "workflow_interactive_agent"
-    | "workflow_deployment_agent";
+    | "workflow_deployment_agent"
+    | "xpert"
+    | "xpert_app";
   routing_mode: "managed_required";
   run_reference: string;
   status: "running" | "passed" | "failed" | "uncertain" | "cancelled";

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -228,6 +228,14 @@ IP 或 legacy。HITL 审批和替换复用已保存输出，只有显式 revise 
 阶段。工具执行、权限、中间件和 Workflow 编排仍由现有 Runtime 负责；Published Xpert、RAG、
 多模态与 `/workflow-native` 仍未纳入 R6E。
 
+Round 6F 复用同一执行服务，将直接 Published Xpert 与已部署 Xpert App 分别接入 `xpert` /
+`xpert_app` Policy。Xpert 工作流内的文本、Tool Calling 与结构化模型轮次仍按
+`chat_text`、`chat_tools`、`chat_json_object` 精确 Binding 执行；用户侧只显示脱敏 Receipt，
+回答正文和会话存储不改变。主 Xpert 发起的受控子 Xpert 与自动 Handoff 显式继承 `xpert`
+上下文；Managed Handoff 失败不会进入现有自动重试。Automation、Goal、评测、进化、记忆候选
+和 Skill 流程不携带该上下文，继续使用原路径。文件仅在既有抽取流程转成文本后进入 R6F；
+视觉、音频及其他专用操作仍由原 Adapter 执行。
+
 接入入口只允许 Python 主进程解析凭据和调用 Provider，Worker 与
 工具执行器继续只处理模型消息、Tool Call 和脱敏结果。
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -218,8 +218,8 @@ MODEL_CONTROL_TEAM_CHAT_ENABLED=false
 ```
 
 R6B 接入 `agent_shadow`，R6C 接入两个 Meta Agent 生成入口，R6D 接入 Classic Workflow
-交互与部署 LLM，R6E 接入 Classic Workflow 的 `agent` 与 `workflow_agent`；Xpert 等后续入口
-仍不能激活 Managed Policy。`agent_shadow` 只有在
+交互与部署 LLM，R6E 接入 Classic Workflow 的 `agent` 与 `workflow_agent`，R6F 接入直接
+Published Xpert 与已部署 Xpert App。`agent_shadow` 只有在
 `MODEL_CONTROL_AGENT_SHADOW_ENABLED=true`、
 精确模型的 `chat_tools` 资格与 Binding 有效、且管理员明确批准 fail-closed 后才会接管。
 开关为 `false` 或 Policy 为 `legacy` 时继续使用原 Shadow 网关路径；已经激活但失效的
@@ -246,6 +246,13 @@ Workflow Agent 接管要求 `MODEL_CONTROL_WORKFLOW_AGENT_ENABLED=true`；部署
 依据当前资格选择 Function Calling 或 ReAct，不通过真实失败探测；派发后不重试、不切换模型、
 连接、IP 或 legacy。HITL approve/replace 不产生新调用，只有 revise 创建新模型轮次。关闭 Agent
 开关并重启会恢复该入口的 legacy 路径；已激活但资格漂移时保持 `degraded_required`。
+
+Published Xpert 与 Xpert App 必须分别配置并批准 `xpert`、`xpert_app` Policy，且对应
+`MODEL_CONTROL_XPERT_ENABLED` / `MODEL_CONTROL_XPERT_APP_ENABLED` 为 `true`。两者不得共享
+批准，Binding 或资格漂移后各自保持 `degraded_required`。主 Xpert 的受控子 Xpert/Handoff
+继承 `xpert` 上下文；Managed Handoff 失败直接进入不可自动重放状态。独立 Automation、Goal、
+评测、进化、记忆候选、后台增强和 Skill 流程仍未纳管。关闭对应 Flag 并重启只恢复该入口
+legacy，不删除 v16 Receipt、Xpert 会话、App 部署或 Provider 配置。
 
 同一清理命令从 v16 起同时报告 R5 Chat 与 R6 Workload 的过期记录；第一条仍是 dry-run，
 只有第二条显式 `--apply` 才删除已完成记录。不得对正在运行的父运行或逻辑调用执行清理。

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -242,7 +242,12 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
   禁止 `retryOnFailure`、`fallbackModelId` 和 Function Calling 失败后转 ReAct。HITL 恢复复用
   已保存输出，只有显式 revise 创建新的稳定阶段和模型轮次。工具调用仍由 Runtime 执行，Receipt
   不保存工具参数、Prompt 或模型正文。
-- 后续 R6F—R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
+- R6F 接入直接 Published Xpert 与已部署 Xpert App，分别使用 `xpert`、`xpert_app` Policy。
+  工作流内文本、工具与结构化轮次复用 R6E Call Service；Xpert Chat 和 App 响应只增加脱敏
+  Receipt，不改变回答正文或会话历史。受控子 Xpert/Handoff 显式继承 `xpert` 上下文，Managed
+  失败不自动重放；Automation、Goal、评测、进化、记忆候选、后台增强与 Skill 流程保持排除。
+  文件仅使用既有抽取文本，多模态继续专用 Adapter。
+- 后续 R6G—R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
   只能存在于 Python 主进程内存，Worker、工具执行器和浏览器不得收到 Key、URL 或连接细节。
 - Receipt 清理命令现在同时检查 R5 Chat 与 R6 Workload 记录，仍默认 dry-run；`--apply`
   才删除超过保留期的已完成运行、尝试或调用。

--- a/server/main.py
+++ b/server/main.py
@@ -1496,6 +1496,7 @@ AUTOMATION_COORDINATOR_MAX_CONCURRENCY = env_int(
     "AUTOMATION_COORDINATOR_MAX_CONCURRENCY", 2, 1
 )
 HANDOFF_MAX_DELEGATION_DEPTH = 5
+_PROVIDER_WORKLOAD_SOURCE_METADATA_KEY = "provider_workload_source_kind"
 MAX_IMAGE_DATA_URL_BYTES = 5 * 1024 * 1024
 AGENTS_DATA_PATH = Path(__file__).parent / "data" / "agents.json"
 MAX_AGENT_PROMPT_CHARS = 6000
@@ -8929,7 +8930,7 @@ def _trusted_workflow_execution_source_kind(
     *,
     runtime_run_type: str,
     resume_execution: WorkflowExecution | None,
-) -> Literal["workflow_classic", "xpert_chat"] | None:
+) -> Literal["workflow_classic", "xpert_chat", "xpert_app"] | None:
     if resume_execution is not None:
         return resume_execution.source_kind
     if request is None:
@@ -9162,6 +9163,13 @@ async def _run_workflow_response(
         if resume_execution is not None
         else (runtime_metadata or {})
     )
+    # Only trusted Published Xpert and Xpert App entries may pass their managed
+    # routing context to child Xperts and handoffs. Never accept this marker
+    # from caller-provided runtime metadata or from excluded Xpert workloads.
+    if trusted_source_kind in {"xpert_chat", "xpert_app"}:
+        run_metadata[_PROVIDER_WORKLOAD_SOURCE_METADATA_KEY] = trusted_source_kind
+    else:
+        run_metadata.pop(_PROVIDER_WORKLOAD_SOURCE_METADATA_KEY, None)
     workflow_run = (
         await run_registry.get_run(resume_execution.run_id)
         if resume_execution is not None
@@ -10601,6 +10609,9 @@ async def _run_workflow_response(
                         "run_id": effective_context.metadata.get("run_id"),
                         "workflow_id": run_context.get("workflow_id"),
                         "runtime_run_type": runtime_run_type,
+                        _PROVIDER_WORKLOAD_SOURCE_METADATA_KEY: run_context.get(
+                            _PROVIDER_WORKLOAD_SOURCE_METADATA_KEY
+                        ),
                         "xpert_id": run_context.get("xpert_id"),
                         "xpert_slug": run_context.get("xpert_slug"),
                         "xpert_version": run_context.get("xpert_version"),
@@ -19971,6 +19982,9 @@ async def _run_workflow_response(
                                 "result_variable": result_variable,
                                 "wait_timeout_seconds": wait_timeout_seconds,
                                 "ready_for_execution": False,
+                                _PROVIDER_WORKLOAD_SOURCE_METADATA_KEY: run_metadata.get(
+                                    _PROVIDER_WORKLOAD_SOURCE_METADATA_KEY
+                                ),
                                 "handoff_depth": int(
                                     run_metadata.get("handoff_depth") or 0
                                 ),
@@ -20209,6 +20223,9 @@ async def _run_workflow_response(
                                 "result_variable": result_variable,
                                 "wait_timeout_seconds": wait_timeout_seconds,
                                 "ready_for_execution": False,
+                                _PROVIDER_WORKLOAD_SOURCE_METADATA_KEY: run_metadata.get(
+                                    _PROVIDER_WORKLOAD_SOURCE_METADATA_KEY
+                                ),
                                 "handoff_depth": int(
                                     run_metadata.get("handoff_depth") or 0
                                 ),
@@ -21990,12 +22007,14 @@ class WorkflowStreamFailure(RuntimeError):
         run_id: str | None = None,
         failed_node_id: str | None = None,
         failed_node_title: str | None = None,
+        provider_route_receipts: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(message)
         self.task_id = task_id
         self.run_id = run_id
         self.failed_node_id = failed_node_id
         self.failed_node_title = failed_node_title
+        self.provider_route_receipts = provider_route_receipts
 
 
 async def consume_workflow_stream(response: Any) -> dict[str, Any]:
@@ -22009,6 +22028,12 @@ async def consume_workflow_stream(response: Any) -> dict[str, Any]:
             str(message or "Xpert workflow could not start."),
             task_id=response.headers.get("X-ModelMirror-Runtime-Task-Id"),
             run_id=response.headers.get("X-ModelMirror-Runtime-Run-Id"),
+            provider_route_receipts=(
+                dict(payload.get("provider_route_receipts"))
+                if isinstance(payload, dict)
+                and isinstance(payload.get("provider_route_receipts"), dict)
+                else None
+            ),
         )
     if not isinstance(response, StreamingResponse):
         raise RuntimeError("Xpert workflow returned an unsupported response.")
@@ -22021,6 +22046,7 @@ async def consume_workflow_stream(response: Any) -> dict[str, Any]:
     error_run_id: str | None = None
     failed_node_id: str | None = None
     failed_node_title: str | None = None
+    provider_route_receipts: dict[str, Any] | None = None
     buffer = ""
     async for chunk in response.body_iterator:
         if isinstance(chunk, bytes):
@@ -22045,6 +22071,10 @@ async def consume_workflow_stream(response: Any) -> dict[str, Any]:
                     failed_node_title = (
                         str(event.get("node_title") or "").strip() or None
                     )
+                    if isinstance(event.get("provider_route_receipts"), dict):
+                        provider_route_receipts = dict(
+                            event["provider_route_receipts"]
+                        )
                 elif event.get("event") == "workflow_end":
                     final_event = event
                 elif event.get("event") == "runtime_approval_pending":
@@ -22062,6 +22092,7 @@ async def consume_workflow_stream(response: Any) -> dict[str, Any]:
             run_id=error_run_id,
             failed_node_id=failed_node_id,
             failed_node_title=failed_node_title,
+            provider_route_receipts=provider_route_receipts,
         )
     if pending_wait_event is not None:
         return pending_wait_event
@@ -22584,6 +22615,12 @@ async def execute_external_xpert_resource(
         runtime_source_id=prepared.xpert.id,
         runtime_metadata=prepared.runtime_metadata,
         runtime_parent_run_id=parent_run_id,
+        runtime_execution_source_kind=(
+            str(call.metadata.get(_PROVIDER_WORKLOAD_SOURCE_METADATA_KEY))
+            if call.metadata.get(_PROVIDER_WORKLOAD_SOURCE_METADATA_KEY)
+            in {"xpert_chat", "xpert_app"}
+            else None
+        ),
     )
     final_event = await consume_workflow_stream(response)
     if final_event.get("event") in {
@@ -22688,6 +22725,13 @@ async def execute_xpert_handoff_target(
             "handoff_depth": source_depth,
         },
     )
+    managed_parent_source = str(
+        handoff.metadata.get(_PROVIDER_WORKLOAD_SOURCE_METADATA_KEY) or ""
+    )
+    managed_parent_entry = {
+        "xpert_chat": "xpert",
+        "xpert_app": "xpert_app",
+    }.get(managed_parent_source)
     response = await _run_workflow_response(
         prepared.request,
         None,
@@ -22700,8 +22744,23 @@ async def execute_xpert_handoff_target(
             "source_agent": handoff.source_agent,
         },
         runtime_parent_run_id=handoff_run_id,
+        runtime_execution_source_kind=(
+            managed_parent_source if managed_parent_entry is not None else None
+        ),
     )
-    final_event = await consume_workflow_stream(response)
+    try:
+        final_event = await consume_workflow_stream(response)
+    except WorkflowStreamFailure as exc:
+        receipt = exc.provider_route_receipts
+        if (
+            managed_parent_entry is not None
+            and isinstance(receipt, dict)
+            and receipt.get("entry_id") == managed_parent_entry
+        ):
+            raise HandoffPermanentError(
+                "Managed Xpert handoff failed; automatic replay is disabled."
+            ) from exc
+        raise
     if final_event.get("event") == "runtime_approval_pending":
         return HandoffExecutionResult(
             output="",
@@ -23690,6 +23749,7 @@ async def run_deployed_xpert_app(
             "file_count": 0,
             "memory_write_enabled": False,
         },
+        runtime_execution_source_kind="xpert_app",
     )
 
 
@@ -25640,6 +25700,9 @@ async def create_agent_handoff(task_id: str, payload: dict[str, Any]):
         "execution_mode": execution_mode,
         "ready_for_execution": False,
     }
+    # The managed-parent marker is server-owned.  Public handoff callers may
+    # not opt an otherwise excluded workload into the Xpert control plane.
+    handoff_metadata.pop(_PROVIDER_WORKLOAD_SOURCE_METADATA_KEY, None)
     handoff = await agent_task_store.create_handoff(
         task_id,
         source_agent=source_agent or "workflow",

--- a/server/model_router/workflow_gateway.py
+++ b/server/model_router/workflow_gateway.py
@@ -32,12 +32,19 @@ except ImportError:  # pragma: no cover - direct server package execution
 
 
 WorkflowRoutingMode = Literal["legacy", "managed_required", "degraded_required"]
-WorkflowSourceKind = Literal["workflow_classic", "workflow_deployment"]
+WorkflowSourceKind = Literal[
+    "workflow_classic",
+    "workflow_deployment",
+    "xpert_chat",
+    "xpert_app",
+]
 WorkflowEntryId = Literal[
     "workflow_interactive_llm",
     "workflow_deployment_llm",
     "workflow_interactive_agent",
     "workflow_deployment_agent",
+    "xpert",
+    "xpert_app",
 ]
 WorkflowCallStatus = Literal[
     "passed", "failed", "uncertain", "cancelled"
@@ -114,10 +121,20 @@ class ManagedWorkflowGateway:
     _ENTRY_BY_SOURCE: dict[WorkflowSourceKind, WorkflowEntryId] = {
         "workflow_classic": "workflow_interactive_llm",
         "workflow_deployment": "workflow_deployment_llm",
+        "xpert_chat": "xpert",
+        "xpert_app": "xpert_app",
     }
     _AGENT_ENTRY_BY_SOURCE: dict[WorkflowSourceKind, WorkflowEntryId] = {
         "workflow_classic": "workflow_interactive_agent",
         "workflow_deployment": "workflow_deployment_agent",
+        "xpert_chat": "xpert",
+        "xpert_app": "xpert_app",
+    }
+    _SOURCE_PREFIX: dict[WorkflowSourceKind, str] = {
+        "workflow_classic": "interactive",
+        "workflow_deployment": "deployment",
+        "xpert_chat": "xpert",
+        "xpert_app": "xpert_app",
     }
 
     def __init__(
@@ -202,8 +219,7 @@ class ManagedWorkflowGateway:
                 status_code=409,
             )
         parent_reference = (
-            f"{'interactive' if source_kind == 'workflow_classic' else 'deployment'}:"
-            f"{clean_execution}:{clean_node}"
+            f"{self._SOURCE_PREFIX[source_kind]}:{clean_execution}:{clean_node}"
         )
         try:
             run_id = self.call_service.start_stable_run(
@@ -244,8 +260,8 @@ class ManagedWorkflowGateway:
                 status_code=409,
             )
         parent_reference = (
-            f"{'interactive' if source_kind == 'workflow_classic' else 'deployment'}:"
-            f"{clean_execution}:{clean_node}:agent:{clean_phase}"
+            f"{self._SOURCE_PREFIX[source_kind]}:{clean_execution}:{clean_node}:"
+            f"agent:{clean_phase}"
         )
         try:
             run_id = self.call_service.start_stable_run(

--- a/server/model_router/workload_control.py
+++ b/server/model_router/workload_control.py
@@ -107,6 +107,8 @@ DATA_PLANE_INTEGRATED_ENTRIES: frozenset[ProviderWorkloadEntryId] = frozenset(
         "workflow_deployment_llm",
         "workflow_interactive_agent",
         "workflow_deployment_agent",
+        "xpert",
+        "xpert_app",
     }
 )
 

--- a/server/tests/test_workflow_managed_gateway.py
+++ b/server/tests/test_workflow_managed_gateway.py
@@ -193,6 +193,99 @@ def _activate(
     assert active.effective_status == "managed_required"
 
 
+def test_xpert_sources_use_separate_integrated_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_XPERT_ENABLED", "true")
+    monkeypatch.setenv("MODEL_CONTROL_XPERT_APP_ENABLED", "true")
+    for entry_id in ("xpert", "xpert_app"):
+        _activate(
+            service,
+            connection_id,
+            entry_id,
+            shapes=("chat_text", "chat_tools", "chat_json_object"),
+        )
+
+    gateway = ManagedWorkflowGateway.for_router(service)
+    xpert_run = gateway.start_agent_run(
+        source_kind="xpert_chat",
+        execution_reference="xpert-task-1",
+        node_id="agent-node",
+    )
+    app_run = gateway.start_agent_run(
+        source_kind="xpert_app",
+        execution_reference="app-task-1",
+        node_id="agent-node",
+    )
+    xpert_record = service.repository.get_workload_run("local", xpert_run.run_id)
+    app_record = service.repository.get_workload_run("local", app_run.run_id)
+
+    assert gateway.entry_id("xpert_chat") == "xpert"
+    assert gateway.agent_entry_id("xpert_chat") == "xpert"
+    assert gateway.entry_id("xpert_app") == "xpert_app"
+    assert gateway.agent_entry_id("xpert_app") == "xpert_app"
+    assert xpert_record["parent_run_reference"] == (
+        "xpert:xpert-task-1:agent-node:agent:initial"
+    )
+    assert app_record["parent_run_reference"] == (
+        "xpert_app:app-task-1:agent-node:agent:initial"
+    )
+    xpert_run.finish("failed", reason_code="test_complete")
+    app_run.finish("failed", reason_code="test_complete")
+
+
+@pytest.mark.asyncio
+async def test_managed_xpert_failure_dispatches_exactly_one_provider_post(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, connection_id = _qualified_router(tmp_path)
+    monkeypatch.setenv("MODEL_CONTROL_XPERT_ENABLED", "true")
+    _activate(
+        service,
+        connection_id,
+        "xpert",
+        shapes=("chat_text",),
+    )
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(503, json={"error": "private upstream failure"})
+
+    run = ManagedWorkflowGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=False,
+            trust_env=False,
+        ),
+    ).start_agent_run(
+        source_kind="xpert_chat",
+        execution_reference="xpert-failed-task",
+        node_id="agent-node",
+    )
+
+    with pytest.raises(ManagedWorkflowRoutingError):
+        await run.complete_text(
+            purpose="agent_text",
+            model_id=MODEL_ID,
+            messages=[{"role": "user", "content": "private xpert prompt"}],
+            temperature=0,
+            max_tokens=64,
+        )
+    run.finish("failed", reason_code="provider_workload_upstream_http_error")
+
+    receipt = run.receipt_summary()
+    assert len(requests) == 1
+    assert receipt["entry_id"] == "xpert"
+    assert receipt["call_count"] == 1
+    assert receipt["calls"][0]["dispatched"] is True
+    assert b"private xpert prompt" not in service.repository.database_path.read_bytes()
+
+
 @pytest.fixture
 def qualified_interactive(
     tmp_path: Path,

--- a/server/tests/test_workflow_managed_runtime.py
+++ b/server/tests/test_workflow_managed_runtime.py
@@ -192,6 +192,8 @@ class FakeManagedWorkflowGateway:
         return {
             "workflow_classic": "workflow_interactive_llm",
             "workflow_deployment": "workflow_deployment_llm",
+            "xpert_chat": "xpert",
+            "xpert_app": "xpert_app",
         }.get(str(source_kind or ""))
 
     @staticmethod
@@ -199,6 +201,8 @@ class FakeManagedWorkflowGateway:
         return {
             "workflow_classic": "workflow_interactive_agent",
             "workflow_deployment": "workflow_deployment_agent",
+            "xpert_chat": "xpert",
+            "xpert_app": "xpert_app",
         }.get(str(source_kind or ""))
 
     @staticmethod
@@ -250,6 +254,29 @@ def _workflow(nodes: list[dict[str, Any]], edges: list[dict[str, Any]]) -> Any:
             "inputs": {"user_input": "private workflow input"},
         }
     )
+
+
+def test_only_direct_published_xpert_route_derives_managed_context() -> None:
+    direct_request = main_module.Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/xperts/xpert-1/run",
+            "headers": [],
+            "route": SimpleNamespace(path="/api/xperts/{xpert_id}/run"),
+        }
+    )
+
+    assert main_module._trusted_workflow_execution_source_kind(
+        direct_request,
+        runtime_run_type="xpert",
+        resume_execution=None,
+    ) == "xpert_chat"
+    assert main_module._trusted_workflow_execution_source_kind(
+        None,
+        runtime_run_type="xpert",
+        resume_execution=None,
+    ) is None
 
 
 async def _events(response: Any) -> list[dict[str, Any]]:
@@ -349,7 +376,7 @@ async def test_managed_llm_runs_without_legacy_gateway_and_adds_receipt(
 
 
 @pytest.mark.asyncio
-async def test_excluded_runtime_source_keeps_legacy_llm_path(
+async def test_independent_xpert_runtime_without_control_context_keeps_legacy_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[tuple[str, str]] = []
@@ -383,7 +410,6 @@ async def test_excluded_runtime_source_keeps_legacy_llm_path(
         ),
         None,
         runtime_run_type="xpert",
-        runtime_execution_source_kind="xpert_chat",
         runtime_task_id="excluded-xpert-task",
     )
     events = await _events(response)
@@ -395,6 +421,77 @@ async def test_excluded_runtime_source_keeps_legacy_llm_path(
         if item.get("event") == "node_end" and item.get("node_id") == "llm"
     )
     assert "provider_route_receipts" not in llm_end
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("source_kind", "run_type", "entry_id"),
+    [
+        ("xpert_chat", "xpert", "xpert"),
+        ("xpert_app", "xpert_app", "xpert_app"),
+        ("xpert_app", "xpert", "xpert_app"),
+    ],
+)
+async def test_xpert_control_context_uses_managed_provider_and_persists_source(
+    source_kind: str,
+    run_type: str,
+    entry_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def legacy_must_not_run(*_args: Any, **_kwargs: Any):
+        raise AssertionError("legacy Xpert stream must not run")
+
+    monkeypatch.setattr(main_module, "stream_workflow_llm_text", legacy_must_not_run)
+    task_id = f"{entry_id}-managed-task"
+    response = await main_module._run_workflow_response(
+        _workflow(
+            [
+                {"id": "input", "type": "input", "data": {"kind": "input"}},
+                {
+                    "id": "llm",
+                    "type": "llm",
+                    "data": {
+                        "kind": "llm",
+                        "modelId": MODEL_ID,
+                        "prompt": "{{user_input}}",
+                        "outputVariable": "answer",
+                    },
+                },
+                {
+                    "id": "output",
+                    "type": "output",
+                    "data": {"kind": "output", "outputVariable": "answer"},
+                },
+            ],
+            [
+                {"id": "e1", "source": "input", "target": "llm"},
+                {"id": "e2", "source": "llm", "target": "output"},
+            ],
+        ),
+        None,
+        runtime_run_type=run_type,
+        runtime_execution_source_kind=source_kind,
+        runtime_task_id=task_id,
+    )
+    events = await _events(response)
+    llm_end = next(
+        item
+        for item in events
+        if item.get("event") == "node_end" and item.get("node_id") == "llm"
+    )
+    execution = main_module.workflow_execution_store.get(task_id)
+
+    assert llm_end["provider_route_receipts"]["entry_id"] == entry_id
+    assert llm_end["provider_route_receipts"]["call_count"] == 1
+    assert execution is not None
+    assert execution.source_kind == source_kind
+    assert FakeManagedWorkflowGateway.instances[0].started == [
+        {
+            "source_kind": source_kind,
+            "execution_reference": task_id,
+            "node_id": "llm",
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -1513,3 +1610,29 @@ def test_durable_event_bounds_malformed_provider_receipt_numbers(
 
     receipt = store.require("task-malformed").events[0]["provider_route_receipts"]
     assert receipt["calls"][0]["call_sequence"] == 1
+
+
+@pytest.mark.parametrize(
+    "entry_id",
+    [
+        "workflow_interactive_agent",
+        "workflow_deployment_agent",
+        "xpert",
+        "xpert_app",
+    ],
+)
+def test_durable_event_preserves_integrated_workload_entry_ids(
+    tmp_path: Path,
+    entry_id: str,
+) -> None:
+    receipt = WorkflowExecutionStore._safe_provider_route_receipt(
+        {
+            "entry_id": entry_id,
+            "status": "passed",
+            "connection_id": "must-not-survive",
+            "calls": [],
+        }
+    )
+
+    assert receipt["entry_id"] == entry_id
+    assert "connection_id" not in json.dumps(receipt)

--- a/server/tests/test_workflow_resource_nodes.py
+++ b/server/tests/test_workflow_resource_nodes.py
@@ -6,6 +6,7 @@ from typing import Any
 import httpx
 import pytest
 import pytest_asyncio
+from fastapi.responses import StreamingResponse
 
 import server.main as main_module
 from server.main import app, workflow_topological_order
@@ -537,6 +538,73 @@ async def test_external_xpert_runs_in_process_and_registers_child_trace(
     }
     assert "external_xpert.started" in checkpoint_types
     assert "external_xpert.completed" in checkpoint_types
+
+
+@pytest.mark.asyncio
+async def test_external_xpert_only_inherits_trusted_published_xpert_control(
+    resource_stores,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    xpert_store, _ = resource_stores
+    specialist = xpert_store.create_xpert(name="Controlled Child")
+    xpert_store.publish_xpert(
+        specialist.id,
+        expected_revision=specialist.draft_revision,
+    )
+    captured: list[str | None] = []
+
+    async def fake_run(*_args, **kwargs):
+        captured.append(kwargs.get("runtime_execution_source_kind"))
+
+        async def body():
+            yield main_module.sse_payload(
+                {"event": "workflow_end", "final_output": "done", "run_id": "child"}
+            )
+
+        return StreamingResponse(body(), media_type="text/event-stream")
+
+    monkeypatch.setattr(main_module, "_run_workflow_response", fake_run)
+    resource = {
+        "xpert_id": specialist.id,
+        "pinned_version": 1,
+    }
+    base_metadata = {
+        "external_xpert_depth": 0,
+        "external_xpert_path": [],
+        "xpert_id": "parent",
+    }
+
+    await main_module.execute_external_xpert_resource(
+        resource,
+        "legacy task",
+        RuntimeToolCall(tool_name="child", arguments={}, metadata=base_metadata),
+    )
+    await main_module.execute_external_xpert_resource(
+        resource,
+        "managed task",
+        RuntimeToolCall(
+            tool_name="child",
+            arguments={},
+            metadata={
+                **base_metadata,
+                "provider_workload_source_kind": "xpert_chat",
+            },
+        ),
+    )
+    await main_module.execute_external_xpert_resource(
+        resource,
+        "managed app task",
+        RuntimeToolCall(
+            tool_name="child",
+            arguments={},
+            metadata={
+                **base_metadata,
+                "provider_workload_source_kind": "xpert_app",
+            },
+        ),
+    )
+
+    assert captured == [None, "xpert_chat", "xpert_app"]
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_xpert_app_api.py
+++ b/server/tests/test_xpert_app_api.py
@@ -9,8 +9,10 @@ from typing import Any
 import httpx
 import pytest
 import pytest_asyncio
+from fastapi.responses import StreamingResponse
 
 import server.main as main_module
+import server.xperts.app_api as app_api_module
 from server.main import app
 from server.xperts import (
     XpertAppStore,
@@ -75,6 +77,152 @@ async def _create_deployed_app(
     )
     assert deploy.status_code == 200, deploy.text
     return created, deploy.json()["app"], created_app["share_token"]
+
+
+@pytest.mark.asyncio
+async def test_public_app_forwards_only_sanitized_provider_receipt(
+    client: httpx.AsyncClient,
+    stores,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    xpert_store, _ = stores
+    _, deployed, share_token = await _create_deployed_app(
+        client,
+        xpert_store,
+        slug="managed-receipt-app",
+    )
+    receipt = {
+        "contract_version": "modelmirror-provider-workload-routing-v1",
+        "entry_id": "xpert_app",
+        "routing_mode": "managed_required",
+        "run_reference": "workrun-public-safe",
+        "status": "passed",
+        "call_count": 1,
+        "reason_codes": [],
+        "connection_id": "must-not-survive",
+        "base_url": "https://private-provider.invalid/v1",
+        "prompt": "private prompt",
+        "calls": [
+            {
+                "call_sequence": 1,
+                "model_id": "provider/public-model",
+                "actual_model": "provider/public-model",
+                "dispatched": True,
+                "status": "passed",
+                "error_code": None,
+                "prompt_tokens": 3,
+                "completion_tokens": 2,
+                "total_tokens": 5,
+                "connection_id": "must-not-survive",
+                "output": "private model output",
+            }
+        ],
+    }
+
+    async def fake_runtime(*_args: Any, **_kwargs: Any) -> StreamingResponse:
+        async def body():
+            for event in (
+                {"event": "workflow_meta", "run_id": "run-public-safe"},
+                {
+                    "event": "node_end",
+                    "node_id": "agent",
+                    "provider_route_receipts": receipt,
+                },
+                {
+                    "event": "workflow_end",
+                    "run_id": "run-public-safe",
+                    "final_output": "public managed answer",
+                },
+            ):
+                yield "data: " + json.dumps(event) + "\n\n"
+
+        return StreamingResponse(body(), media_type="text/event-stream")
+
+    monkeypatch.setattr(app_api_module, "_runtime_callback", fake_runtime)
+    headers = {"X-ModelMirror-App-Token": share_token}
+    non_stream = await client.post(
+        f"/api/v1/xpert-apps/{deployed['slug']}/chat/completions",
+        headers=headers,
+        json={"messages": [{"role": "user", "content": "hello"}]},
+    )
+    streamed = await client.post(
+        f"/api/v1/xpert-apps/{deployed['slug']}/chat/completions",
+        headers=headers,
+        json={
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+
+    assert non_stream.status_code == 200, non_stream.text
+    public_receipt = non_stream.json()["modelmirror"]["provider_route_receipts"]
+    assert non_stream.json()["modelmirror"]["run_id"] == "run-public-safe"
+    assert public_receipt["entry_id"] == "xpert_app"
+    assert public_receipt["calls"][0]["model_id"] == "provider/public-model"
+    assert streamed.status_code == 200, streamed.text
+    assert '"entry_id": "xpert_app"' in streamed.text
+    for forbidden in (
+        "connection_id",
+        "base_url",
+        "private-provider",
+        "private prompt",
+        "private model output",
+    ):
+        assert forbidden not in json.dumps(non_stream.json())
+        assert forbidden not in streamed.text
+
+
+@pytest.mark.asyncio
+async def test_public_app_non_stream_failure_preserves_sanitized_provider_receipt(
+    client: httpx.AsyncClient,
+    stores,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    xpert_store, _ = stores
+    _, deployed, share_token = await _create_deployed_app(
+        client,
+        xpert_store,
+        slug="managed-failure-receipt-app",
+    )
+    receipt = {
+        "entry_id": "xpert_app",
+        "status": "failed",
+        "reason_codes": ["provider_workload_policy_not_active"],
+        "connection_id": "must-not-survive",
+        "calls": [],
+    }
+
+    async def fake_runtime(*_args: Any, **_kwargs: Any) -> StreamingResponse:
+        async def body():
+            yield "data: " + json.dumps(
+                {"event": "workflow_meta", "run_id": "run-public-failed"}
+            ) + "\n\n"
+            yield "data: " + json.dumps(
+                {
+                    "event": "error",
+                    "message": "Managed Provider policy blocked the call.",
+                    "provider_route_receipts": receipt,
+                }
+            ) + "\n\n"
+
+        return StreamingResponse(body(), media_type="text/event-stream")
+
+    monkeypatch.setattr(app_api_module, "_runtime_callback", fake_runtime)
+    response = await client.post(
+        f"/api/v1/xpert-apps/{deployed['slug']}/chat/completions",
+        headers={"X-ModelMirror-App-Token": share_token},
+        json={"messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    assert response.status_code == 500, response.text
+    payload = response.json()
+    assert payload["modelmirror"]["run_id"] == "run-public-failed"
+    public_receipt = payload["modelmirror"]["provider_route_receipts"]
+    assert public_receipt["entry_id"] == "xpert_app"
+    assert public_receipt["reason_codes"] == [
+        "provider_workload_policy_not_active"
+    ]
+    assert "connection_id" not in json.dumps(payload)
 
 
 def test_xpert_app_store_persists_hashes_deployments_and_rollback(

--- a/server/tests/test_xpert_handoff_executor.py
+++ b/server/tests/test_xpert_handoff_executor.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 import pytest
+from fastapi.responses import StreamingResponse
 
 import server.main as main_module
 from server.main import app
@@ -96,6 +97,118 @@ async def test_handoff_claim_is_atomic_and_manual_targets_are_not_executable() -
     with pytest.raises(ValueError, match="already leased"):
         await store.claim_handoff(automatic.handoff_id, worker_id="worker-b")
     assert await store.list_executable_handoffs() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("source_kind", "entry_id"),
+    (("xpert_chat", "xpert"), ("xpert_app", "xpert_app")),
+)
+async def test_managed_handoff_failure_is_permanent_and_inherits_xpert_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source_kind: str,
+    entry_id: str,
+) -> None:
+    xpert_store = XpertStore(tmp_path / "xperts-managed-handoff")
+    task_store = AgentTaskStore(storage_dir=tmp_path / "managed-handoff-tasks")
+    set_xpert_store_for_tests(xpert_store)
+    monkeypatch.setattr(main_module, "agent_task_store", task_store)
+    specialist = xpert_store.create_xpert(name="Specialist", slug="specialist")
+    xpert_store.publish_xpert(
+        specialist.id,
+        expected_revision=specialist.draft_revision,
+    )
+    task = await task_store.create_task("Managed handoff", "private task")
+    handoff = await task_store.create_handoff(
+        task.task_id,
+        "manager",
+        "xpert:specialist",
+        "delegate",
+        metadata={
+            "execution_mode": "xpert_auto",
+            "ready_for_execution": True,
+            "provider_workload_source_kind": source_kind,
+        },
+    )
+    captured: dict[str, Any] = {}
+
+    async def fake_run(*_args: Any, **kwargs: Any) -> StreamingResponse:
+        captured.update(kwargs)
+
+        async def body():
+            yield main_module.sse_payload(
+                {
+                    "event": "error",
+                    "message": "Managed Provider call failed.",
+                    "provider_route_receipts": {
+                        "contract_version": "modelmirror-provider-workload-routing-v1",
+                        "entry_id": entry_id,
+                        "routing_mode": "managed_required",
+                        "run_reference": "workrun-managed-handoff",
+                        "status": "uncertain",
+                        "call_count": 1,
+                        "reason_codes": ["provider_workload_stream_interrupted"],
+                        "calls": [],
+                    },
+                }
+            )
+
+        return StreamingResponse(body(), media_type="text/event-stream")
+
+    monkeypatch.setattr(main_module, "_run_workflow_response", fake_run)
+    try:
+        with pytest.raises(
+            HandoffPermanentError,
+            match="automatic replay is disabled",
+        ):
+            await main_module.execute_xpert_handoff_target(handoff, task, None)
+        assert captured["runtime_execution_source_kind"] == source_kind
+    finally:
+        set_xpert_store_for_tests(None)
+
+
+@pytest.mark.asyncio
+async def test_excluded_handoff_does_not_inherit_managed_xpert_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    xpert_store = XpertStore(tmp_path / "xperts-legacy-handoff")
+    task_store = AgentTaskStore(storage_dir=tmp_path / "legacy-handoff-tasks")
+    set_xpert_store_for_tests(xpert_store)
+    monkeypatch.setattr(main_module, "agent_task_store", task_store)
+    specialist = xpert_store.create_xpert(name="Legacy Specialist", slug="legacy-specialist")
+    xpert_store.publish_xpert(
+        specialist.id,
+        expected_revision=specialist.draft_revision,
+    )
+    task = await task_store.create_task("Legacy handoff", "private")
+    handoff = await task_store.create_handoff(
+        task.task_id,
+        "automation",
+        "xpert:legacy-specialist",
+        "delegate",
+        metadata={"execution_mode": "xpert_auto", "ready_for_execution": True},
+    )
+    captured: dict[str, Any] = {}
+
+    async def fake_run(*_args: Any, **kwargs: Any) -> StreamingResponse:
+        captured.update(kwargs)
+
+        async def body():
+            yield main_module.sse_payload(
+                {"event": "workflow_end", "final_output": "legacy result"}
+            )
+
+        return StreamingResponse(body(), media_type="text/event-stream")
+
+    monkeypatch.setattr(main_module, "_run_workflow_response", fake_run)
+    try:
+        result = await main_module.execute_xpert_handoff_target(handoff, task, None)
+        assert result.output == "legacy result"
+        assert captured["runtime_execution_source_kind"] is None
+    finally:
+        set_xpert_store_for_tests(None)
 
 
 @pytest.mark.asyncio

--- a/server/xpert_runtime/execution_store.py
+++ b/server/xpert_runtime/execution_store.py
@@ -23,6 +23,7 @@ WorkflowExecutionSourceKind = Literal[
     "workflow_classic",
     "workflow_deployment",
     "xpert_chat",
+    "xpert_app",
     "expert_team_agency",
 ]
 
@@ -690,6 +691,10 @@ class WorkflowExecutionStore:
         allowed_entries = {
             "workflow_interactive_llm",
             "workflow_deployment_llm",
+            "workflow_interactive_agent",
+            "workflow_deployment_agent",
+            "xpert",
+            "xpert_app",
         }
         allowed_statuses = {
             "running",
@@ -784,12 +789,15 @@ class WorkflowExecutionStore:
         if not clean:
             return None
         expected_run_types = {
-            "workflow_classic": "workflow",
-            "workflow_deployment": "workflow",
-            "xpert_chat": "xpert",
-            "expert_team_agency": "expert_team",
+            "workflow_classic": {"workflow"},
+            "workflow_deployment": {"workflow"},
+            "xpert_chat": {"xpert"},
+            # A root App run uses xpert_app; a server-controlled child Xpert
+            # keeps its xpert run type while inheriting the App control plane.
+            "xpert_app": {"xpert_app", "xpert"},
+            "expert_team_agency": {"expert_team"},
         }
-        if clean not in expected_run_types or expected_run_types[clean] != str(run_type):
+        if clean not in expected_run_types or str(run_type) not in expected_run_types[clean]:
             if strict:
                 raise WorkflowExecutionConflictError(
                     "Workflow execution source kind does not match its run type."

--- a/server/xperts/app_api.py
+++ b/server/xperts/app_api.py
@@ -31,8 +31,10 @@ from .models import XpertConversationMessage, XpertRunRequest, XpertVersion
 from .store import XpertNotFoundError, XpertStoreError
 
 try:
+    from server.xpert_runtime.execution_store import WorkflowExecutionStore
     from server.xpert_runtime.middleware_registry import runtime_middleware_registry
 except ModuleNotFoundError:
+    from xpert_runtime.execution_store import WorkflowExecutionStore
     from xpert_runtime.middleware_registry import runtime_middleware_registry
 
 
@@ -40,6 +42,19 @@ router = APIRouter(tags=["xpert-apps"])
 _app_store: XpertAppStore | None = None
 _access_controller: XpertAppAccessController | None = None
 _runtime_callback: Callable[..., Awaitable[Any]] | None = None
+
+
+class _XpertAppExecutionFailure(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        run_id: str,
+        provider_receipt: dict[str, Any] | None,
+    ) -> None:
+        super().__init__(message)
+        self.run_id = run_id
+        self.provider_receipt = provider_receipt
 
 
 class XpertAppCreateRequest(BaseModel):
@@ -668,11 +683,18 @@ async def _iter_internal_events(response: Any) -> AsyncIterator[dict[str, Any]]:
                     yield event
 
 
-async def _consume_final_output(response: Any) -> tuple[str, str]:
+async def _consume_final_output(
+    response: Any,
+) -> tuple[str, str, dict[str, Any] | None]:
     final_output = ""
     run_id = ""
     error = ""
+    provider_receipt: dict[str, Any] | None = None
     async for event in _iter_internal_events(response):
+        if isinstance(event.get("provider_route_receipts"), dict):
+            provider_receipt = WorkflowExecutionStore._safe_provider_route_receipt(
+                event["provider_route_receipts"]
+            )
         if event.get("event") == "workflow_meta":
             run_id = str(event.get("run_id") or "")
         elif event.get("event") == "workflow_end":
@@ -680,11 +702,16 @@ async def _consume_final_output(response: Any) -> tuple[str, str]:
             run_id = str(event.get("run_id") or run_id)
         elif event.get("event") == "error":
             error = str(event.get("message") or "Xpert App execution failed.")
+            run_id = str(event.get("run_id") or run_id)
     if error:
-        raise RuntimeError(error)
+        raise _XpertAppExecutionFailure(
+            error,
+            run_id=run_id,
+            provider_receipt=provider_receipt,
+        )
     if not final_output:
         raise RuntimeError("Xpert App completed without a final answer.")
-    return final_output, run_id
+    return final_output, run_id, provider_receipt
 
 
 def _prepare_openai_run(payload: OpenAIChatCompletionsRequest, version: int) -> XpertRunRequest:
@@ -970,7 +997,9 @@ async def run_public_xpert_app(
                 headers["X-ModelMirror-Runtime-Run-Id"] = internal_run_id
         if not payload.stream:
             try:
-                output, run_id = await _consume_final_output(internal_response)
+                output, run_id, provider_receipt = await _consume_final_output(
+                    internal_response
+                )
             finally:
                 await controller.release(grant)
                 grant = None
@@ -989,6 +1018,10 @@ async def run_public_xpert_app(
                         }
                     ],
                     "usage": None,
+                    "modelmirror": {
+                        "run_id": run_id,
+                        "provider_route_receipts": provider_receipt,
+                    },
                 },
                 headers=headers,
             )
@@ -996,6 +1029,7 @@ async def run_public_xpert_app(
         async def stream_openai() -> AsyncIterator[str]:
             run_id = ""
             completed = False
+            provider_receipt: dict[str, Any] | None = None
             try:
                 yield "data: " + json.dumps(
                     {
@@ -1010,6 +1044,12 @@ async def run_public_xpert_app(
                     ensure_ascii=False,
                 ) + "\n\n"
                 async for event in _iter_internal_events(internal_response):
+                    if isinstance(event.get("provider_route_receipts"), dict):
+                        provider_receipt = (
+                            WorkflowExecutionStore._safe_provider_route_receipt(
+                                event["provider_route_receipts"]
+                            )
+                        )
                     if event.get("event") == "workflow_meta":
                         run_id = str(event.get("run_id") or run_id)
                     elif event.get("event") == "error":
@@ -1019,7 +1059,11 @@ async def run_public_xpert_app(
                                 "type": "modelmirror_app_error",
                                 "param": None,
                                 "code": "app_execution_failed",
-                            }
+                            },
+                            "modelmirror": {
+                                "run_id": run_id,
+                                "provider_route_receipts": provider_receipt,
+                            },
                         }
                         yield "data: " + json.dumps(error_payload, ensure_ascii=False) + "\n\n"
                         yield "data: [DONE]\n\n"
@@ -1038,7 +1082,10 @@ async def run_public_xpert_app(
                                     "choices": [
                                         {"index": 0, "delta": {"content": output}, "finish_reason": None}
                                     ],
-                                    "modelmirror": {"run_id": run_id},
+                                    "modelmirror": {
+                                        "run_id": run_id,
+                                        "provider_route_receipts": provider_receipt,
+                                    },
                                 },
                                 ensure_ascii=False,
                             ) + "\n\n"
@@ -1065,7 +1112,10 @@ async def run_public_xpert_app(
                         "choices": [
                             {"index": 0, "delta": {}, "finish_reason": "stop"}
                         ],
-                        "modelmirror": {"run_id": run_id},
+                        "modelmirror": {
+                            "run_id": run_id,
+                            "provider_route_receipts": provider_receipt,
+                        },
                     },
                     ensure_ascii=False,
                 ) + "\n\n"
@@ -1088,6 +1138,18 @@ async def run_public_xpert_app(
         response = _openai_error(str(exc), status_code=429, code="rate_limit_exceeded")
         response.headers["Retry-After"] = "60"
         return response
+    except _XpertAppExecutionFailure as exc:
+        response = _openai_error(
+            str(exc),
+            status_code=500,
+            code="app_execution_failed",
+        )
+        payload = json.loads(bytes(response.body).decode("utf-8"))
+        payload["modelmirror"] = {
+            "run_id": exc.run_id,
+            "provider_route_receipts": exc.provider_receipt,
+        }
+        return JSONResponse(status_code=response.status_code, content=payload)
     except (XpertNotFoundError, XpertStoreError, RuntimeError) as exc:
         return _openai_error(str(exc), status_code=500, code="app_execution_failed")
     finally:


### PR DESCRIPTION
## 范围

- 将 Published Xpert 与 Xpert App 接入 R6 Managed Provider 控制面，并保持部署开关默认关闭。
- 为 Xpert 子调用与 Handoff 传播服务端拥有的控制面上下文，确保模型 Route Plan、单次派发和脱敏 Receipt 一致。
- 补齐 Xpert App 非流式失败 Receipt、运行持久化兼容和前端 Receipt 状态清理。
- 更新架构、部署与 Provider Control Plane 文档；不扩大到 Agent Workbench、RAG、多模态、计费或多租户。

## 验证

- 后端聚焦测试：47 passed。
- 后端受影响范围回归：91 passed；最终持久化/子调用补测：7 passed。
- 前端聚焦测试：13 passed；前端全量：629 passed。
- 前端生产构建通过；隔离 Linux 容器内 `tsc -b --pretty false` 通过。
- 后端全量：4494 passed, 29 skipped, 1 failed。唯一失败为既有 Candidate Hot Planner p95 性能阈值波动（11.066 ms）；相关实现与测试无本轮 Diff，隔离重跑通过（1 passed）。
- `git diff --check`、staged 敏感信息扫描通过。
- 独立预览器已从本提交源码重建：前端 15141、后端 18141 均返回 200；独立数据卷、Provider 配置、Binding 与脱敏运行证据保留，启动日志无错误。
- 修复前已完成 Xpert/Xpert App 两项授权真实 Smoke；修复后未重复发起付费调用。

## 安全边界

- Provider Key 不进入 Worker、客户端、Receipt 或持久化运行正文。
- Managed POST 派发后不回退第二连接、第二模型或 legacy。
- Feature Flag 与入口 Policy 默认不启用；合并不等于生产启用或部署授权。

## 回滚

- 显式停用 `xpert` / `xpert_app` Policy，或关闭对应 `MODEL_CONTROL_XPERT_ENABLED` / `MODEL_CONTROL_XPERT_APP_ENABLED` 后重启。
- 保留 v16 表、Binding、资格与脱敏 Receipt，不删除 Router SQLite、Provider 凭据或 Xpert 数据。