### PR TITLE
feature: 添加 AI Research AR1 科研控制台

### DIFF
--- a/.github/workflows/ai-research.yml
+++ b/.github/workflows/ai-research.yml
@@ -1,4 +1,4 @@
-name: AI Research AR0
+name: AI Research AR1
 
 on:
   pull_request:
@@ -45,14 +45,14 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12.13"
-      - name: Verify AR0
+      - name: Verify AR1
         working-directory: extensions/ai-research
         run: bash scripts/verify.sh origin/main full
       - name: Preserve module logs on failure
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ai-research-ar0-diagnostics
+          name: ai-research-ar1-diagnostics
           path: extensions/ai-research/runtime/diagnostics
           if-no-files-found: ignore
           retention-days: 7

--- a/extensions/ai-research/.dockerignore
+++ b/extensions/ai-research/.dockerignore
@@ -15,3 +15,7 @@ artifacts/**
 .env
 .env.*
 !*.env.example
+ui/node_modules
+ui/node_modules/**
+ui/dist
+ui/dist/**

--- a/extensions/ai-research/.gitignore
+++ b/extensions/ai-research/.gitignore
@@ -2,3 +2,5 @@ runtime/
 **/__pycache__/
 *.py[cod]
 .pytest_cache/
+ui/node_modules/
+ui/dist/

--- a/extensions/ai-research/AGENTS.md
+++ b/extensions/ai-research/AGENTS.md
@@ -1,10 +1,11 @@
-# ModelMirror AI Research AR0 collaboration rules
+# ModelMirror AI Research AR1 collaboration rules
 
 These rules apply to every file under `extensions/ai-research/`.
 
 ## Boundary
 
 - This directory is an optional, fixture-only engineering module. It is not a scientific benchmark, model integration, leaderboard, or production multi-tenant service.
+- The Research Console is module-local. Its source, lockfile, build, static output, and runtime must remain independent of the parent client.
 - Runtime code must not import, open, mount, or depend on parent `client/`, `server/`, configuration, credentials, databases, storage, or build outputs.
 - Parent changes are limited to `.dockerignore` and `.github/workflows/ai-research.yml`. Any other parent change requires a separate approved task.
 - Do not add this module to the root Compose file, root Python requirements, client dependencies, Plugin manifests, Studio routes, or default images.
@@ -16,6 +17,7 @@ These rules apply to every file under `extensions/ai-research/`.
 - MLflow is fixed to 3.15.1 and may only be used through its documented server and client interfaces.
 - Do not patch upstream scientific tasks or scorers. Test fixtures must stay clearly labelled `fixture_only` and `harness_only`.
 - Keep exact dependency locks, source hashes, image digests, licenses, notices, and an auditable upgrade boundary.
+- UI dependencies must use exact versions and registry integrity locks. `workspace:`, `file:`, symlinks, and parent source imports are forbidden.
 
 ## Security and evidence
 

--- a/extensions/ai-research/README.md
+++ b/extensions/ai-research/README.md
@@ -1,6 +1,6 @@
 # 模镜科研 / ModelMirror AI Research
 
-AR0 是一个可选、同仓但独立构建的 AI/Agent 评测工程框架。它只证明受控运行、Inspect 终态归一化、取消、MLflow 证据持久化和重启恢复，不代表模镜已接入模型或具备科研评测能力。
+AR1 是一个可选、同仓但独立构建的 AI/Agent 评测工程框架与操作控制台。它只证明受控运行、Inspect 终态归一化、取消、MLflow 证据持久化、网页复核和重启恢复，不代表模镜已接入模型或具备科研评测能力。
 
 ## 明确限制
 
@@ -8,13 +8,16 @@ AR0 是一个可选、同仓但独立构建的 AI/Agent 评测工程框架。它
 - 所有运行固定标记为 `fixture_only` 和 `harness_only`。
 - 不调用模型，不读取模镜配置或密钥，不安装 EvalPack，不产生科学分数。
 - 不修改或连接模镜主前后端；不会出现在 Studio、Plugin 或默认 Compose 中。
-- MLflow UI 与 Control API 只绑定本机回环地址，不是多用户服务。
+- Research Console、MLflow UI 与 Inspect View 只绑定本机回环地址，不是多用户服务。
+- 为兼容 Docker Desktop 的回环端口发布，Control、Tracking 与 Inspect View 使用普通模块私有 bridge，并非出站阻断网络；只有 Worker 固定 `network_mode: none`。这些服务不挂载平台凭据。
 
 ## 组件
 
 - `ai-research-control`：版本化 HTTP API、SQLite 控制账本、证据 outbox。
 - `ai-research-tracking`：MLflow 3.15.1、SQLite backend、本地 artifacts。
 - `ai-research-worker`：Inspect AI 0.3.260、无网 Linux worker、Unix socket 控制协议。
+- `ai-research-inspect-view`：复用 Worker 镜像、只读挂载 EvalLog 的 Inspect View。
+- `ui/`：独立 React/Vite/Tailwind 控制台；构建产物进入 Control 镜像，最终镜像不包含 Node 运行时。
 
 ## 显式启动
 
@@ -22,17 +25,21 @@ AR0 是一个可选、同仓但独立构建的 AI/Agent 评测工程框架。它
 docker compose -f extensions/ai-research/compose.yml --profile ai-research up -d --build
 ```
 
-Control 默认地址是 `http://127.0.0.1:8790`，MLflow 开发视图是 `http://127.0.0.1:8791`。停止时不要附加 `-v`，以保留证据卷。
+Research Console 默认地址是 `http://127.0.0.1:8790`，MLflow 是 `http://127.0.0.1:8791`，Inspect View 是 `http://127.0.0.1:8793`。停止时不要附加 `-v`，以保留证据卷。
 
 ## 冻结接口
 
 - `GET /healthz`
 - `GET /readyz`
 - `GET /api/v1/module`
+- `GET /api/v1/system`
 - `POST /api/v1/runs`
 - `GET /api/v1/runs`
+- `GET /api/v1/runs/summary`
 - `GET /api/v1/runs/{runId}`
 - `GET /api/v1/runs/{runId}/events?afterSeq=`
+- `GET /api/v1/runs/{runId}/evidence`
+- `GET /api/v1/runs/{runId}/artifacts/{artifactName}`
 - `POST /api/v1/runs/{runId}/cancel`
 
 请求只允许固定 fixture、case、`local` 租户兼容位和幂等键。不存在任意命令、路径、上传、模型、prompt 或凭据入口。
@@ -44,7 +51,7 @@ cd extensions/ai-research
 .\scripts\verify.ps1 -Base origin/main -Mode Full
 ```
 
-完整验证会主动攻击退出码误判、取消竞态、畸形日志、幂等冲突、MLflow 中断、路径逃逸、Worker 网络和证据篡改。
+完整验证会先运行独立 UI 的 `npm ci`、类型检查、Vitest 和生产构建，再主动攻击退出码误判、取消竞态、畸形日志、幂等冲突、MLflow 中断、路径逃逸、Worker 网络、SPA 回退和证据篡改。
 Windows 验证机需要 Python 3.12.13；若 `python`/`py -3.12` 不可用，请把
 `AI_RESEARCH_PYTHON` 指向精确的 Python 3.12.13 可执行文件。镜像内运行时仍由
 digest 与哈希锁固定，不读取宿主的模镜配置或密钥。

--- a/extensions/ai-research/THIRD_PARTY_NOTICES.md
+++ b/extensions/ai-research/THIRD_PARTY_NOTICES.md
@@ -12,6 +12,19 @@ ModelMirror AI Research is a ModelMirror optional module. The module name and pr
 | Uvicorn | resolved and hash-locked with the control image | BSD-3-Clause | https://github.com/encode/uvicorn |
 | Python | 3.12.13 | PSF-2.0 | https://www.python.org/ |
 
-The machine-readable source lock and hash-locked requirement files are the authoritative component inventory. The build must fail if a dependency has missing license metadata or falls outside the reviewed allowlist. Full license texts are copied into `/usr/share/doc/modelmirror-ai-research/licenses` in the optional images.
+## Research Console runtime components
+
+| Component | Fixed version | License | Upstream |
+| --- | --- | --- | --- |
+| React | 19.2.7 | MIT | https://github.com/facebook/react |
+| React Router DOM | 6.30.4 | MIT | https://github.com/remix-run/react-router |
+| Lucide React | 1.27.0 | ISC | https://github.com/lucide-icons/lucide |
+
+The console build toolchain is also locked in `ui/package-lock.json`. Its complete
+machine-readable license inventory is distributed as
+`/usr/share/doc/modelmirror-ai-research/ui-build-inventory.json`; build-only
+dependencies are not present in the final Python runtime image.
+
+The machine-readable source lock, npm lock, and hash-locked requirement files are the authoritative component inventory. The build must fail if a dependency has missing license metadata or falls outside the reviewed allowlist. Runtime license texts are copied into `/usr/share/doc/modelmirror-ai-research/licenses` in the optional images.
 
 No upstream project listed here is represented as a ModelMirror-authored scientific method, benchmark, scorer, or model integration.

--- a/extensions/ai-research/compose.yml
+++ b/extensions/ai-research/compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: control/Dockerfile
       target: runtime
-    image: modelmirror-ai-research-control:ar0
+    image: modelmirror-ai-research-control:ar1
     command: ["python", "-m", "ai_research_control.app"]
     depends_on:
       ai-research-tracking:
@@ -16,6 +16,7 @@ services:
         condition: service_healthy
     networks:
       - tracking_internal
+      - inspect_view_internal
     user: "65532:65532"
     read_only: true
     cap_drop: [ALL]
@@ -32,8 +33,12 @@ services:
       AI_RESEARCH_INSPECT_LOG_ROOT: /data/inspect-logs
       AI_RESEARCH_WORKER_SOCKET: /run/ai-research/worker.sock
       AI_RESEARCH_MLFLOW_URI: http://ai-research-tracking:5000
-      AI_RESEARCH_MLFLOW_EXPERIMENT: modelmirror-ai-research-ar0
+      AI_RESEARCH_MLFLOW_EXPERIMENT: modelmirror-ai-research-ar1
+      AI_RESEARCH_INSPECT_VIEW_URI: http://ai-research-inspect-view:7575
+      AI_RESEARCH_MLFLOW_PUBLIC_URL: http://127.0.0.1:${AI_RESEARCH_MLFLOW_PORT:-8791}
+      AI_RESEARCH_INSPECT_VIEW_PUBLIC_URL: http://127.0.0.1:${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}
       AI_RESEARCH_ENABLE_DOCS: "0"
+      MLFLOW_DISABLE_TELEMETRY: "true"
       PYTHONUTF8: "1"
     volumes:
       - control_data:/data/control
@@ -56,7 +61,7 @@ services:
       context: .
       dockerfile: control/Dockerfile
       target: runtime
-    image: modelmirror-ai-research-control:ar0
+    image: modelmirror-ai-research-control:ar1
     command:
       - mlflow
       - server
@@ -87,6 +92,7 @@ services:
       - "127.0.0.1:${AI_RESEARCH_MLFLOW_PORT:-8791}:5000"
     environment:
       PYTHONUTF8: "1"
+      MLFLOW_DISABLE_TELEMETRY: "true"
       MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD: "false"
       MLFLOW_SERVER_ENABLE_JOB_EXECUTION: "false"
       OPENBLAS_NUM_THREADS: "1"
@@ -110,7 +116,7 @@ services:
       context: .
       dockerfile: worker/Dockerfile
       target: runtime
-    image: modelmirror-ai-research-worker:ar0
+    image: modelmirror-ai-research-worker:ar1
     network_mode: none
     user: "65532:65532"
     read_only: true
@@ -148,11 +154,67 @@ services:
     restart: unless-stopped
     stop_grace_period: 20s
 
+  ai-research-inspect-view:
+    profiles: [ai-research]
+    build:
+      context: .
+      dockerfile: worker/Dockerfile
+      target: runtime
+    image: modelmirror-ai-research-worker:ar1
+    command:
+      - inspect
+      - view
+      - start
+      - --recursive
+      - --host
+      - 0.0.0.0
+      - --port
+      - "7575"
+      - --trusted-origin
+      - http://127.0.0.1:${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}
+      - --trusted-origin
+      - http://localhost:${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}
+      - --trusted-host
+      - ai-research-inspect-view:7575
+      - --trusted-host
+      - 127.0.0.1:7575
+      - --unsafe-allow-unauthenticated
+      - --log-dir
+      - /data/inspect-logs
+    networks:
+      - inspect_view_internal
+    user: "65532:65532"
+    read_only: true
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 128
+    mem_limit: 512m
+    cpus: 0.5
+    ports:
+      - "127.0.0.1:${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}:7575"
+    volumes:
+      - inspect_logs:/data/inspect-logs:ro
+    tmpfs:
+      - /tmp:rw,nosuid,nodev,noexec,size=128m,uid=65532,gid=65532,mode=0700
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; assert urllib.request.urlopen('http://127.0.0.1:7575/', timeout=3).status == 200"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    restart: unless-stopped
+    stop_grace_period: 20s
+
 networks:
   tracking_internal:
     ipam:
       config:
         - subnet: 10.254.76.0/28
+  inspect_view_internal:
+    ipam:
+      config:
+        - subnet: 10.254.76.16/28
 
 volumes:
   control_data:

--- a/extensions/ai-research/control/Dockerfile
+++ b/extensions/ai-research/control/Dockerfile
@@ -1,3 +1,19 @@
+FROM node@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS ui-test
+
+ENV npm_config_update_notifier=false \
+    npm_config_fund=false \
+    npm_config_audit=false
+
+WORKDIR /ui
+COPY ui/package.json ui/package-lock.json ./
+RUN npm ci --ignore-scripts --no-audit --no-fund
+COPY ui/ ./
+RUN npm run typecheck \
+    && npm run test:run
+
+FROM ui-test AS ui-build
+RUN npm run build
+
 FROM python@sha256:401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461 AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -20,8 +36,19 @@ RUN python /tmp/license-audit/audit_licenses.py \
         --policy /tmp/license-audit/license-policy.json \
         --output /usr/share/doc/modelmirror-ai-research/runtime-inventory.json \
         --licenses-dir /usr/share/doc/modelmirror-ai-research/licenses
+COPY ui/package-lock.json /tmp/ui-package-lock.json
+COPY scripts/audit_ui_licenses.py /tmp/license-audit/audit_ui_licenses.py
+RUN python /tmp/license-audit/audit_ui_licenses.py \
+        --lock /tmp/ui-package-lock.json \
+        --policy /tmp/license-audit/license-policy.json \
+        --output /usr/share/doc/modelmirror-ai-research/ui-build-inventory.json
 
 COPY --chown=65532:65532 control/ai_research_control ./ai_research_control
+COPY --from=ui-build --chown=65532:65532 /ui/dist ./ui-dist
+COPY --from=ui-build /ui/node_modules/react/LICENSE /usr/share/doc/modelmirror-ai-research/licenses/react-MIT.txt
+COPY --from=ui-build /ui/node_modules/react-dom/LICENSE /usr/share/doc/modelmirror-ai-research/licenses/react-dom-MIT.txt
+COPY --from=ui-build /ui/node_modules/react-router-dom/LICENSE.md /usr/share/doc/modelmirror-ai-research/licenses/react-router-dom-MIT.txt
+COPY --from=ui-build /ui/node_modules/lucide-react/LICENSE /usr/share/doc/modelmirror-ai-research/licenses/lucide-react-ISC.txt
 COPY --chown=65532:65532 module-boundary.json source-lock.json THIRD_PARTY_NOTICES.md ./
 
 RUN mkdir -p /data/control/evidence /data/tracking/artifacts /run/ai-research /usr/share/doc/modelmirror-ai-research \

--- a/extensions/ai-research/control/ai_research_control/app.py
+++ b/extensions/ai-research/control/ai_research_control/app.py
@@ -3,20 +3,38 @@ from __future__ import annotations
 import json
 import asyncio
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Annotated, Any
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, Query, Request, status
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
+from fastapi.staticfiles import StaticFiles
 
 from .config import Settings
-from .models import EventListResponse, EventView, ReadyView, RunCreateRequest, RunListResponse, RunView
+from .models import (
+    CaseId,
+    EventListResponse,
+    EventView,
+    EvidenceState,
+    EvidenceView,
+    Outcome,
+    Phase,
+    ReadyView,
+    RunCreateRequest,
+    RunListResponse,
+    RunSummaryResponse,
+    RunView,
+    SystemView,
+)
+from .evidence import EvidenceError
 from .service import NotReady, ResearchService
 from .store import IdempotencyConflict
 
 
 settings = Settings.from_env()
+ui_directory = Path(__file__).resolve().parents[1] / "ui-dist"
 
 
 @asynccontextmanager
@@ -31,8 +49,8 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
-    title="ModelMirror AI Research AR0",
-    version="0.1.0-ar0",
+    title="ModelMirror AI Research",
+    version="0.2.0-ar1",
     docs_url="/docs" if settings.docs_enabled else None,
     redoc_url=None,
     openapi_url="/openapi.json" if settings.docs_enabled else None,
@@ -42,6 +60,29 @@ app.add_middleware(
     TrustedHostMiddleware,
     allowed_hosts=["127.0.0.1", "localhost", "ai-research-control", "testserver"],
 )
+app.mount(
+    "/assets",
+    StaticFiles(directory=ui_directory / "assets", check_dir=True),
+    name="research-console-assets",
+)
+
+
+@app.middleware("http")
+async def security_headers(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["Content-Security-Policy"] = (
+        "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; "
+        "font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; "
+        "form-action 'self'; frame-ancestors 'none'"
+    )
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
+    if request.url.path.startswith("/assets/") and response.status_code < 400:
+        response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+    elif response.headers.get("content-type", "").startswith("text/html"):
+        response.headers["Cache-Control"] = "no-store"
+    return response
 
 
 def service(request: Request) -> ResearchService:
@@ -69,7 +110,10 @@ def to_view(run: dict[str, Any]) -> RunView:
             "mlflowRunId": run["mlflow_run_id"],
             "createdAt": run["created_at"],
             "startedAt": run["started_at"],
+            "cancelRequestedAt": run.get("cancel_requested_at"),
+            "cancelAppliedAt": run.get("cancel_applied_at"),
             "terminalAt": run["terminal_at"],
+            "evidenceSyncedAt": run.get("evidence_synced_at"),
             "updatedAt": run["updated_at"],
         }
     )
@@ -105,12 +149,30 @@ async def module_metadata() -> dict[str, Any]:
         "packStatus": "fixture_only",
         "fixtures": boundary["allowedFixtures"],
         "runtimes": source_lock["runtimes"],
+        "capabilities": {
+            "fixtureExecution": True,
+            "cancellation": True,
+            "evidenceVerification": True,
+            "inspectView": True,
+            "mlflow": True,
+            "modelEvaluation": False,
+            "multiTenant": False,
+        },
+        "links": {
+            "mlflow": settings.mlflow_public_url,
+            "inspectView": settings.inspect_view_public_url,
+        },
         "limitations": [
             "no model or provider connection",
             "no scientific EvalPack or score",
             "local single-tenant compatibility mode only",
         ],
     }
+
+
+@app.get("/api/v1/system", response_model=SystemView, response_model_by_alias=True)
+async def system_status(request: Request) -> SystemView:
+    return SystemView.model_validate(await service(request).system_status())
 
 
 @app.post("/api/v1/runs", response_model=RunView, response_model_by_alias=True)
@@ -134,10 +196,22 @@ async def list_runs(
     request: Request,
     cursor: str | None = None,
     limit: Annotated[int, Query(ge=1, le=100)] = 50,
+    q: Annotated[str | None, Query(max_length=100)] = None,
+    case_id: Annotated[CaseId | None, Query(alias="caseId")] = None,
+    phase: Phase | None = None,
+    outcome: Outcome | None = None,
+    evidence_state: Annotated[EvidenceState | None, Query(alias="evidenceState")] = None,
 ) -> RunListResponse:
     try:
         runs = await asyncio.to_thread(
-            service(request).store.list, after_run_id=cursor, limit=limit + 1
+            service(request).store.list,
+            after_run_id=cursor,
+            limit=limit + 1,
+            query=q,
+            case_id=case_id,
+            phase=phase,
+            outcome=outcome,
+            evidence_state=evidence_state,
         )
     except KeyError as exc:
         raise HTTPException(status_code=400, detail="invalid cursor") from exc
@@ -149,6 +223,24 @@ async def list_runs(
     )
 
 
+@app.get(
+    "/api/v1/runs/summary",
+    response_model=RunSummaryResponse,
+    response_model_by_alias=True,
+)
+async def run_summary(request: Request) -> RunSummaryResponse:
+    value = await asyncio.to_thread(service(request).store.summary)
+    return RunSummaryResponse.model_validate(
+        {
+            "total": value["total"],
+            "phases": value["phases"],
+            "outcomes": value["outcomes"],
+            "evidenceStates": value["evidence_states"],
+            "updatedAt": value["updated_at"],
+        }
+    )
+
+
 @app.get("/api/v1/runs/{run_id}", response_model=RunView, response_model_by_alias=True)
 async def get_run(run_id: str, request: Request) -> RunView:
     try:
@@ -156,6 +248,38 @@ async def get_run(run_id: str, request: Request) -> RunView:
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="run not found") from exc
     return to_view(run)
+
+
+@app.get(
+    "/api/v1/runs/{run_id}/evidence",
+    response_model=EvidenceView,
+    response_model_by_alias=True,
+)
+async def get_evidence(run_id: str, request: Request) -> EvidenceView:
+    try:
+        value = await service(request).evidence(run_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="run not found") from exc
+    return EvidenceView.model_validate(value)
+
+
+@app.get("/api/v1/runs/{run_id}/artifacts/{artifact_name}")
+async def download_artifact(run_id: str, artifact_name: str, request: Request) -> Response:
+    try:
+        content, digest = await service(request).artifact(run_id, artifact_name)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="artifact not found") from exc
+    except EvidenceError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return Response(
+        content=content,
+        media_type="application/octet-stream",
+        headers={
+            "Content-Disposition": f'attachment; filename="{artifact_name}"',
+            "Cache-Control": "no-store",
+            "X-Artifact-SHA256": digest,
+        },
+    )
 
 
 @app.get(
@@ -199,6 +323,21 @@ async def cancel_run(run_id: str, request: Request) -> RunView:
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="run not found") from exc
     return to_view(run)
+
+
+@app.api_route(
+    "/api/{unmatched_path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
+)
+async def unknown_api(unmatched_path: str) -> None:
+    raise HTTPException(status_code=404, detail="API route not found")
+
+
+app.frontend(
+    "/",
+    directory=ui_directory,
+    fallback="index.html",
+)
 
 
 def main() -> None:

--- a/extensions/ai-research/control/ai_research_control/config.py
+++ b/extensions/ai-research/control/ai_research_control/config.py
@@ -3,6 +3,27 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlsplit
+
+
+def _loopback_url(value: str, *, variable: str) -> str:
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"127.0.0.1", "localhost"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise ValueError(f"{variable} must be a plain loopback HTTP origin")
+    try:
+        if parsed.port is None:
+            raise ValueError
+    except ValueError as exc:
+        raise ValueError(f"{variable} must include a valid port") from exc
+    return f"http://{parsed.hostname}:{parsed.port}"
 
 
 @dataclass(frozen=True)
@@ -17,6 +38,9 @@ class Settings:
     module_boundary: Path
     poll_seconds: float
     docs_enabled: bool
+    inspect_view_uri: str = "http://ai-research-inspect-view:7575"
+    mlflow_public_url: str = "http://127.0.0.1:8791"
+    inspect_view_public_url: str = "http://127.0.0.1:8793"
 
     @classmethod
     def from_env(cls) -> "Settings":
@@ -46,6 +70,19 @@ class Settings:
                 0.1, min(float(os.environ.get("AI_RESEARCH_POLL_SECONDS", "0.5")), 5.0)
             ),
             docs_enabled=os.environ.get("AI_RESEARCH_ENABLE_DOCS", "0") == "1",
+            inspect_view_uri=os.environ.get(
+                "AI_RESEARCH_INSPECT_VIEW_URI", "http://ai-research-inspect-view:7575"
+            ).rstrip("/"),
+            mlflow_public_url=_loopback_url(
+                os.environ.get("AI_RESEARCH_MLFLOW_PUBLIC_URL", "http://127.0.0.1:8791"),
+                variable="AI_RESEARCH_MLFLOW_PUBLIC_URL",
+            ),
+            inspect_view_public_url=_loopback_url(
+                os.environ.get(
+                    "AI_RESEARCH_INSPECT_VIEW_PUBLIC_URL", "http://127.0.0.1:8793"
+                ),
+                variable="AI_RESEARCH_INSPECT_VIEW_PUBLIC_URL",
+            ),
         )
 
     def prepare(self) -> None:

--- a/extensions/ai-research/control/ai_research_control/evidence.py
+++ b/extensions/ai-research/control/ai_research_control/evidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shutil
 from pathlib import Path
 from typing import Any
@@ -11,6 +12,10 @@ from .config import Settings
 
 class EvidenceError(RuntimeError):
     pass
+
+
+MAX_ARTIFACT_BYTES = 1_048_576
+MAX_RECEIPT_BYTES = 1_048_576
 
 
 def canonical_json(value: Any) -> bytes:
@@ -140,15 +145,77 @@ def write_receipt(destination: Path, receipt: dict[str, Any]) -> dict[str, Any]:
 
 
 def verify_receipt(destination: Path, receipt: dict[str, Any]) -> None:
+    destination = destination.resolve()
     body = dict(receipt)
     expected_receipt_hash = body.pop("receiptSha256", None)
     if expected_receipt_hash != sha256_bytes(canonical_json(body)):
         raise EvidenceError("receipt body hash mismatch")
     artifacts = receipt.get("artifacts") or {}
+    if not isinstance(artifacts, dict):
+        raise EvidenceError("receipt artifact manifest is invalid")
     for name, descriptor in artifacts.items():
-        path = (destination / name).resolve()
-        path.relative_to(destination.resolve())
-        if path.is_symlink() or not path.is_file():
+        if not isinstance(name, str) or Path(name).name != name or name.startswith("."):
+            raise EvidenceError("receipt artifact name is unsafe")
+        if not isinstance(descriptor, dict):
+            raise EvidenceError(f"receipt artifact descriptor is invalid: {name}")
+        source = destination / name
+        if source.is_symlink():
             raise EvidenceError(f"receipt artifact is unavailable or unsafe: {name}")
+        path = source.resolve()
+        path.relative_to(destination)
+        if not path.is_file():
+            raise EvidenceError(f"receipt artifact is unavailable or unsafe: {name}")
+        actual_size = path.stat().st_size
+        if actual_size > MAX_ARTIFACT_BYTES:
+            raise EvidenceError(f"receipt artifact exceeds the size limit: {name}")
         if sha256_file(path) != descriptor.get("sha256"):
             raise EvidenceError(f"receipt artifact hash mismatch: {name}")
+        if actual_size != descriptor.get("sizeBytes"):
+            raise EvidenceError(f"receipt artifact size mismatch: {name}")
+
+
+def verify_persisted_receipt(destination: Path, receipt: dict[str, Any]) -> None:
+    root = destination.resolve()
+    receipt_path = root / "receipt.json"
+    if receipt_path.is_symlink() or not receipt_path.is_file():
+        raise EvidenceError("persisted receipt is unavailable or unsafe")
+    resolved = receipt_path.resolve()
+    resolved.relative_to(root)
+    if resolved.stat().st_size > MAX_RECEIPT_BYTES:
+        raise EvidenceError("persisted receipt exceeds the size limit")
+    try:
+        persisted = json.loads(resolved.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise EvidenceError("persisted receipt is malformed") from exc
+    if persisted != receipt:
+        raise EvidenceError("persisted receipt does not match the control ledger")
+    verify_receipt(root, receipt)
+
+
+def read_verified_artifact(
+    destination: Path, receipt: dict[str, Any], name: str
+) -> tuple[bytes, str]:
+    if Path(name).name != name or name.startswith("."):
+        raise EvidenceError("artifact name is unsafe")
+    artifacts = receipt.get("artifacts") or {}
+    if not isinstance(artifacts, dict) or name not in artifacts:
+        raise KeyError(name)
+    verify_persisted_receipt(destination, receipt)
+    source = destination.resolve() / name
+    if source.is_symlink():
+        raise EvidenceError("artifact path is a symbolic link")
+    resolved = source.resolve()
+    resolved.relative_to(destination.resolve())
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = artifacts[name]
+        with os.fdopen(os.open(source, flags), "rb") as handle:
+            data = handle.read(MAX_ARTIFACT_BYTES + 1)
+    except OSError as exc:
+        raise EvidenceError("artifact could not be read safely") from exc
+    if len(data) > MAX_ARTIFACT_BYTES:
+        raise EvidenceError("artifact exceeds the size limit")
+    actual_hash = sha256_bytes(data)
+    if len(data) != descriptor.get("sizeBytes") or actual_hash != descriptor.get("sha256"):
+        raise EvidenceError("artifact changed during download verification")
+    return data, actual_hash

--- a/extensions/ai-research/control/ai_research_control/mlflow_sink.py
+++ b/extensions/ai-research/control/ai_research_control/mlflow_sink.py
@@ -28,7 +28,51 @@ class MlflowSink:
         self.client = MlflowClient(tracking_uri=self.tracking_uri)
 
     def probe(self) -> str:
-        return self._experiment_id()
+        endpoint = f"{self.tracking_uri}/api/2.0/mlflow/experiments/get-by-name"
+        try:
+            response = requests.get(
+                endpoint,
+                params={"experiment_name": self.experiment_name},
+                timeout=2,
+            )
+            if response.status_code == 200:
+                return self._experiment_id_from_response(response)
+            if response.status_code != 404:
+                raise MlflowSinkError(
+                    f"MLflow experiment probe failed with status {response.status_code}"
+                )
+
+            created = requests.post(
+                f"{self.tracking_uri}/api/2.0/mlflow/experiments/create",
+                json={"name": self.experiment_name},
+                timeout=2,
+            )
+            if 200 <= created.status_code < 300:
+                experiment_id = str(created.json()["experiment_id"])
+                if not experiment_id:
+                    raise ValueError("empty experiment id")
+                return experiment_id
+
+            # Another control instance may have won the create race.
+            response = requests.get(
+                endpoint,
+                params={"experiment_name": self.experiment_name},
+                timeout=2,
+            )
+            if response.status_code == 200:
+                return self._experiment_id_from_response(response)
+            raise MlflowSinkError(
+                f"MLflow experiment creation failed with status {created.status_code}"
+            )
+        except (requests.RequestException, KeyError, TypeError, ValueError) as exc:
+            raise MlflowSinkError("MLflow experiment probe failed") from exc
+
+    @staticmethod
+    def _experiment_id_from_response(response: requests.Response) -> str:
+        experiment_id = str(response.json()["experiment"]["experiment_id"])
+        if not experiment_id:
+            raise ValueError("empty experiment id")
+        return experiment_id
 
     def sync(
         self,

--- a/extensions/ai-research/control/ai_research_control/models.py
+++ b/extensions/ai-research/control/ai_research_control/models.py
@@ -48,7 +48,10 @@ class RunView(BaseModel):
     mlflow_run_id: str | None = Field(alias="mlflowRunId")
     created_at: str = Field(alias="createdAt")
     started_at: str | None = Field(alias="startedAt")
+    cancel_requested_at: str | None = Field(alias="cancelRequestedAt")
+    cancel_applied_at: str | None = Field(alias="cancelAppliedAt")
     terminal_at: str | None = Field(alias="terminalAt")
+    evidence_synced_at: str | None = Field(alias="evidenceSyncedAt")
     updated_at: str = Field(alias="updatedAt")
 
     @model_validator(mode="after")
@@ -72,6 +75,14 @@ class RunListResponse(BaseModel):
     next_cursor: str | None = Field(alias="nextCursor")
 
 
+class RunSummaryResponse(BaseModel):
+    total: int
+    phases: dict[Phase, int]
+    outcomes: dict[Outcome, int]
+    evidence_states: dict[EvidenceState, int] = Field(alias="evidenceStates")
+    updated_at: str | None = Field(alias="updatedAt")
+
+
 class EventListResponse(BaseModel):
     items: list[EventView]
     next_sequence: int = Field(alias="nextSequence")
@@ -80,3 +91,36 @@ class EventListResponse(BaseModel):
 class ReadyView(BaseModel):
     status: Literal["ready", "not_ready"]
     checks: dict[str, str]
+
+
+class SystemCheckView(BaseModel):
+    id: str
+    status: Literal["ready", "not_ready"]
+    required: bool
+
+
+class SystemView(BaseModel):
+    status: Literal["ready", "degraded", "not_ready"]
+    checks: list[SystemCheckView]
+    checked_at: str = Field(alias="checkedAt")
+
+
+class ArtifactView(BaseModel):
+    name: str
+    size_bytes: int = Field(alias="sizeBytes")
+    sha256: str
+    download_url: str = Field(alias="downloadUrl")
+
+
+class EvidenceView(BaseModel):
+    run_id: str = Field(alias="runId")
+    evidence_state: EvidenceState = Field(alias="evidenceState")
+    integrity_status: Literal["pending", "verified", "failed"] = Field(
+        alias="integrityStatus"
+    )
+    integrity_error: str | None = Field(alias="integrityError")
+    verified_at: str = Field(alias="verifiedAt")
+    receipt: dict[str, object] | None
+    artifacts: list[ArtifactView]
+    mlflow: dict[str, str | None]
+    outbox: dict[str, object] | None

--- a/extensions/ai-research/control/ai_research_control/service.py
+++ b/extensions/ai-research/control/ai_research_control/service.py
@@ -2,11 +2,18 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from urllib.request import Request, urlopen
 
 from .config import Settings
-from .evidence import build_receipt
+from .evidence import (
+    EvidenceError,
+    build_receipt,
+    read_verified_artifact,
+    verify_persisted_receipt,
+)
 from .mlflow_sink import MlflowSink
 from .store import IdempotencyConflict, RunStore
 from .worker_client import WorkerBusy, WorkerClient, WorkerClientError
@@ -55,6 +62,91 @@ class ResearchService:
             checks["tracking"] = "not_ready"
         return checks
 
+    async def system_status(self) -> dict[str, Any]:
+        required = await self.readiness()
+        try:
+            await asyncio.to_thread(self._probe_inspect_view)
+            inspect_status = "ready"
+        except Exception:
+            inspect_status = "not_ready"
+        checks = [
+            {"id": check_id, "status": status, "required": True}
+            for check_id, status in required.items()
+        ]
+        checks.append(
+            {"id": "inspectView", "status": inspect_status, "required": False}
+        )
+        if any(item["required"] and item["status"] != "ready" for item in checks):
+            status = "not_ready"
+        elif inspect_status != "ready":
+            status = "degraded"
+        else:
+            status = "ready"
+        return {
+            "status": status,
+            "checks": checks,
+            "checkedAt": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        }
+
+    def _probe_inspect_view(self) -> None:
+        request = Request(self.settings.inspect_view_uri + "/", method="GET")
+        with urlopen(request, timeout=2.0) as response:
+            if response.status < 200 or response.status >= 400:
+                raise RuntimeError("Inspect View returned an unhealthy status")
+
+    async def evidence(self, run_id: str) -> dict[str, Any]:
+        record = await asyncio.to_thread(self.store.evidence, run_id)
+        receipt = record.get("receipt_json")
+        verified_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        integrity_status = "pending"
+        integrity_error: str | None = None
+        artifacts: list[dict[str, Any]] = []
+        if isinstance(receipt, dict):
+            destination = (self.settings.evidence_root / run_id).resolve()
+            try:
+                await asyncio.to_thread(verify_persisted_receipt, destination, receipt)
+                integrity_status = "verified"
+                artifacts = [
+                    {
+                        "name": name,
+                        "sizeBytes": descriptor["sizeBytes"],
+                        "sha256": descriptor["sha256"],
+                        "downloadUrl": f"/api/v1/runs/{run_id}/artifacts/{name}",
+                    }
+                    for name, descriptor in sorted((receipt.get("artifacts") or {}).items())
+                ]
+            except (EvidenceError, OSError, ValueError) as exc:
+                integrity_status = "failed"
+                integrity_error = f"{type(exc).__name__}: {str(exc)[:400]}"
+        return {
+            "runId": run_id,
+            "evidenceState": record["evidence_state"],
+            "integrityStatus": integrity_status,
+            "integrityError": integrity_error,
+            "verifiedAt": verified_at,
+            "receipt": receipt if isinstance(receipt, dict) else None,
+            "artifacts": artifacts,
+            "mlflow": (receipt or {}).get("mlflow", {}) if isinstance(receipt, dict) else {},
+            "outbox": (
+                {
+                    "state": record["outbox_state"],
+                    "attemptCount": record["attempt_count"],
+                    "nextAttemptAt": record["next_attempt_at"],
+                    "lastError": record["last_error"],
+                }
+                if record.get("outbox_state") is not None
+                else None
+            ),
+        }
+
+    async def artifact(self, run_id: str, name: str) -> tuple[bytes, str]:
+        record = await asyncio.to_thread(self.store.evidence, run_id)
+        receipt = record.get("receipt_json")
+        if not isinstance(receipt, dict):
+            raise EvidenceError("run receipt is not available")
+        destination = (self.settings.evidence_root / run_id).resolve()
+        return await asyncio.to_thread(read_verified_artifact, destination, receipt, name)
+
     async def create_run(self, request: dict[str, Any]) -> tuple[dict[str, Any], bool]:
         checks = await self.readiness()
         if any(value != "ready" for value in checks.values()):
@@ -66,6 +158,10 @@ class ResearchService:
         if run["phase"] == "terminal":
             return run
         run = await asyncio.to_thread(self.store.request_cancel, run_id)
+        # The run may have reached a terminal state between the first read and
+        # the atomic cancel transaction. Never send a stale cancel to Worker.
+        if run["phase"] == "terminal":
+            return run
         if run["phase"] == "queued":
             worker_result = {
                 "runId": run_id,

--- a/extensions/ai-research/control/ai_research_control/store.py
+++ b/extensions/ai-research/control/ai_research_control/store.py
@@ -170,8 +170,40 @@ class RunStore:
             raise KeyError(run_id)
         return self._row(row)
 
-    def list(self, *, after_run_id: str | None, limit: int) -> list[dict[str, Any]]:
-        limit = max(1, min(limit, 100))
+    def list(
+        self,
+        *,
+        after_run_id: str | None,
+        limit: int,
+        query: str | None = None,
+        case_id: str | None = None,
+        phase: str | None = None,
+        outcome: str | None = None,
+        evidence_state: str | None = None,
+    ) -> list[dict[str, Any]]:
+        # The HTTP API exposes at most 100 rows, but asks for one additional
+        # row to decide whether it should emit a continuation cursor.
+        limit = max(1, min(limit, 101))
+        conditions: list[str] = []
+        parameters: list[Any] = []
+        if query:
+            escaped = query.strip().lower().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            if escaped:
+                pattern = f"%{escaped}%"
+                conditions.append(
+                    "(LOWER(run_id) LIKE ? ESCAPE '\\' OR LOWER(fixture_id) LIKE ? ESCAPE '\\' "
+                    "OR LOWER(case_id) LIKE ? ESCAPE '\\' OR LOWER(COALESCE(error_type,'')) LIKE ? ESCAPE '\\')"
+                )
+                parameters.extend([pattern, pattern, pattern, pattern])
+        for column, value in (
+            ("case_id", case_id),
+            ("phase", phase),
+            ("outcome", outcome),
+            ("evidence_state", evidence_state),
+        ):
+            if value is not None:
+                conditions.append(f"{column} = ?")
+                parameters.append(value)
         with self.connection() as connection:
             if after_run_id:
                 anchor = connection.execute(
@@ -179,19 +211,45 @@ class RunStore:
                 ).fetchone()
                 if anchor is None:
                     raise KeyError(after_run_id)
-                rows = connection.execute(
-                    """
-                    SELECT * FROM runs
-                    WHERE (created_at, run_id) < (?, ?)
-                    ORDER BY created_at DESC, run_id DESC LIMIT ?
-                    """,
-                    (anchor["created_at"], anchor["run_id"], limit),
-                ).fetchall()
-            else:
-                rows = connection.execute(
-                    "SELECT * FROM runs ORDER BY created_at DESC, run_id DESC LIMIT ?", (limit,)
-                ).fetchall()
+                conditions.append("(created_at, run_id) < (?, ?)")
+                parameters.extend([anchor["created_at"], anchor["run_id"]])
+            where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+            rows = connection.execute(
+                f"SELECT * FROM runs {where} ORDER BY created_at DESC, run_id DESC LIMIT ?",
+                (*parameters, limit),
+            ).fetchall()
         return [self._row(row) for row in rows]
+
+    def summary(self) -> dict[str, Any]:
+        phases = {value: 0 for value in ("queued", "running", "terminal")}
+        outcomes = {
+            value: 0
+            for value in ("success", "task_error", "cancelled", "infrastructure_error")
+        }
+        evidence_states = {value: 0 for value in ("pending", "synced", "failed")}
+        with self.connection() as connection:
+            total_row = connection.execute(
+                "SELECT COUNT(*) AS total, MAX(updated_at) AS updated_at FROM runs"
+            ).fetchone()
+            for row in connection.execute(
+                "SELECT phase AS value, COUNT(*) AS count FROM runs GROUP BY phase"
+            ):
+                phases[row["value"]] = row["count"]
+            for row in connection.execute(
+                "SELECT outcome AS value, COUNT(*) AS count FROM runs WHERE outcome IS NOT NULL GROUP BY outcome"
+            ):
+                outcomes[row["value"]] = row["count"]
+            for row in connection.execute(
+                "SELECT evidence_state AS value, COUNT(*) AS count FROM runs GROUP BY evidence_state"
+            ):
+                evidence_states[row["value"]] = row["count"]
+        return {
+            "total": total_row["total"],
+            "phases": phases,
+            "outcomes": outcomes,
+            "evidence_states": evidence_states,
+            "updated_at": total_row["updated_at"],
+        }
 
     def queued(self) -> list[dict[str, Any]]:
         with self.connection() as connection:
@@ -223,16 +281,30 @@ class RunStore:
         )
 
     def request_cancel(self, run_id: str) -> dict[str, Any]:
-        current = self.get(run_id)
-        if current["cancel_requested"]:
-            return current
-        now = utc_now()
-        return self._update(
-            run_id,
-            {"cancel_requested": 1, "cancel_requested_at": now, "updated_at": now},
-            "run.cancel_requested",
-            {},
-        )
+        with self.connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            current = connection.execute(
+                "SELECT * FROM runs WHERE run_id = ?", (run_id,)
+            ).fetchone()
+            if current is None:
+                connection.rollback()
+                raise KeyError(run_id)
+            if current["cancel_requested"] or current["phase"] == "terminal":
+                connection.rollback()
+                return self._row(current)
+
+            now = utc_now()
+            connection.execute(
+                """
+                UPDATE runs
+                SET cancel_requested=1,cancel_requested_at=?,updated_at=?
+                WHERE run_id=?
+                """,
+                (now, now, run_id),
+            )
+            self._append_event_tx(connection, run_id, "run.cancel_requested", {})
+            connection.commit()
+        return self.get(run_id)
 
     def update_worker(self, run_id: str, worker: dict[str, Any]) -> dict[str, Any]:
         current = self.get(run_id)
@@ -301,6 +373,20 @@ class RunStore:
                 (now,),
             ).fetchall()
         return [self._row(row) for row in rows]
+
+    def evidence(self, run_id: str) -> dict[str, Any]:
+        with self.connection() as connection:
+            row = connection.execute(
+                """
+                SELECT r.*,o.state AS outbox_state,o.attempt_count,o.next_attempt_at,o.last_error
+                FROM runs r LEFT JOIN outbox o ON o.run_id=r.run_id
+                WHERE r.run_id=?
+                """,
+                (run_id,),
+            ).fetchone()
+        if row is None:
+            raise KeyError(run_id)
+        return self._row(row)
 
     def mark_evidence_synced(
         self, run_id: str, mlflow_run_id: str, receipt: dict[str, Any]

--- a/extensions/ai-research/license-policy.json
+++ b/extensions/ai-research/license-policy.json
@@ -5,6 +5,8 @@
     "0BSD",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "BlueOak-1.0.0",
+    "CC-BY-4.0",
     "CC0-1.0",
     "CNRI-Python",
     "ISC",

--- a/extensions/ai-research/module-boundary.json
+++ b/extensions/ai-research/module-boundary.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "moduleId": "modelmirror.ai-research",
-  "moduleVersion": "0.1.0-ar0",
-  "baseCommit": "296c38a58a8274d9a80ad35b187eabaddd06ae46",
+  "moduleVersion": "0.2.0-ar1",
+  "baseCommit": "174baf6a5289520b53578dc29cab82fd4c1d1e9e",
   "claimLevel": "harness_only",
   "packStatus": "fixture_only",
   "parentIntegration": "none",
@@ -27,11 +27,13 @@
   "services": [
     "ai-research-control",
     "ai-research-tracking",
-    "ai-research-worker"
+    "ai-research-worker",
+    "ai-research-inspect-view"
   ],
   "publicBindings": [
     "127.0.0.1:8790",
-    "127.0.0.1:8791"
+    "127.0.0.1:8791",
+    "127.0.0.1:8793"
   ],
   "workerProtocolVersion": 1,
   "apiVersion": "v1",

--- a/extensions/ai-research/scripts/acceptance.py
+++ b/extensions/ai-research/scripts/acceptance.py
@@ -14,6 +14,7 @@ from typing import Any
 
 CONTROL = "http://127.0.0.1:8790"
 TRACKING = "http://127.0.0.1:8791"
+INSPECT_VIEW = "http://127.0.0.1:8793"
 
 
 class AcceptanceFailure(RuntimeError):
@@ -37,7 +38,14 @@ def request(
     try:
         with urllib.request.urlopen(req, timeout=10) as response:
             content = response.read()
-            return response.status, json.loads(content) if content else None
+            content_type = response.headers.get_content_type()
+            if not content:
+                decoded: Any = None
+            elif content_type == "application/json":
+                decoded = json.loads(content)
+            else:
+                decoded = content
+            return response.status, decoded
     except urllib.error.HTTPError as exc:
         content = exc.read()
         try:
@@ -106,6 +114,34 @@ def verify_run(run: dict[str, Any], outcome: str, inspect_status: str) -> None:
         raise AcceptanceFailure("synced run is missing MLflow identity")
 
 
+def verify_console_evidence(run: dict[str, Any]) -> None:
+    status, evidence = request(
+        "GET", f"{CONTROL}/api/v1/runs/{run['runId']}/evidence"
+    )
+    if (
+        status != 200
+        or evidence.get("integrityStatus") != "verified"
+        or evidence.get("evidenceState") != "synced"
+        or evidence.get("receipt", {}).get("runId") != run["runId"]
+    ):
+        raise AcceptanceFailure(f"console evidence was not verified: {status} {evidence}")
+    artifacts = evidence.get("artifacts") or []
+    if not artifacts:
+        raise AcceptanceFailure("console evidence did not expose registered artifacts")
+    artifact = artifacts[0]
+    status, content = request("GET", f"{CONTROL}{artifact['downloadUrl']}")
+    if status != 200 or not isinstance(content, bytes) or len(content) != artifact["sizeBytes"]:
+        raise AcceptanceFailure("registered artifact download failed")
+    unknown_status, _ = request(
+        "GET", f"{CONTROL}/api/v1/runs/{run['runId']}/artifacts/not-registered.json"
+    )
+    traversal_status, _ = request(
+        "GET", f"{CONTROL}/api/v1/runs/{run['runId']}/artifacts/%2e%2e%2freceipt.json"
+    )
+    if unknown_status != 404 or traversal_status not in {404, 409}:
+        raise AcceptanceFailure("artifact allowlist or traversal protection failed")
+
+
 def verify_mlflow_run(run: dict[str, Any]) -> None:
     run_id = urllib.parse.quote(str(run["mlflowRunId"]), safe="")
     status, payload = request(
@@ -149,8 +185,36 @@ def write_state(path: Path, value: dict[str, Any]) -> None:
 def initial(state_path: Path) -> None:
     wait_ready()
     status, module = request("GET", f"{CONTROL}/api/v1/module")
-    if status != 200 or module.get("claimLevel") != "harness_only" or module.get("packStatus") != "fixture_only":
+    if (
+        status != 200
+        or module.get("moduleVersion") != "0.2.0-ar1"
+        or module.get("claimLevel") != "harness_only"
+        or module.get("packStatus") != "fixture_only"
+        or module.get("capabilities", {}).get("modelEvaluation") is not False
+    ):
         raise AcceptanceFailure(f"module claims are invalid: {status} {module}")
+    system_status, system = request("GET", f"{CONTROL}/api/v1/system")
+    if system_status != 200 or system.get("status") not in {"ready", "degraded"}:
+        raise AcceptanceFailure(f"system status is invalid: {system_status} {system}")
+    deep_status, deep_body = request(
+        "GET", f"{CONTROL}/runs/example/evidence", headers={"Accept": "text/html"}
+    )
+    missing_api, missing_api_body = request(
+        "GET", f"{CONTROL}/api/v1/does-not-exist", headers={"Accept": "text/html"}
+    )
+    missing_asset, missing_asset_body = request(
+        "GET", f"{CONTROL}/assets/does-not-exist.js", headers={"Accept": "text/html"}
+    )
+    if (
+        deep_status != 200
+        or not isinstance(deep_body, bytes)
+        or "模镜科研控制台" not in deep_body.decode("utf-8")
+        or missing_api != 404
+        or not isinstance(missing_api_body, dict)
+        or missing_asset != 404
+        or "<title>" in str(missing_asset_body)
+    ):
+        raise AcceptanceFailure("SPA deep-link or API/asset fallback contract failed")
     suffix = uuid.uuid4().hex
 
     success_key = f"ar0:{suffix}:success"
@@ -158,6 +222,7 @@ def initial(state_path: Path) -> None:
     success = wait_run(created["runId"])
     verify_run(success, "success", "success")
     verify_mlflow_run(success)
+    verify_console_evidence(success)
     if success.get("replayVerified") is not True:
         raise AcceptanceFailure("success fixture did not verify config replay")
     repeated_status, repeated = create("success", success_key)
@@ -179,6 +244,7 @@ def initial(state_path: Path) -> None:
     task_error = wait_run(error_created["runId"])
     verify_run(task_error, "task_error", "error")
     verify_mlflow_run(task_error)
+    verify_console_evidence(task_error)
 
     _, cancel_created = create("long_running_cancel", f"ar0:{suffix}:cancel")
     wait_running(cancel_created["runId"])
@@ -196,6 +262,7 @@ def initial(state_path: Path) -> None:
     cancelled = wait_run(cancel_created["runId"])
     verify_run(cancelled, "cancelled", "error")
     verify_mlflow_run(cancelled)
+    verify_console_evidence(cancelled)
     if cancelled.get("cancelRequested") is not True or cancelled.get("cancelApplied") is not True:
         raise AcceptanceFailure("cancel request/applied facts were not preserved")
     terminal_facts = {
@@ -226,6 +293,17 @@ def initial(state_path: Path) -> None:
     sequences = [item["sequence"] for item in events.get("items", [])]
     if event_status != 200 or sequences != sorted(set(sequences)):
         raise AcceptanceFailure("event sequence is not ordered and unique")
+    summary_status, summary = request("GET", f"{CONTROL}/api/v1/runs/summary")
+    filtered_status, filtered = request(
+        "GET", f"{CONTROL}/api/v1/runs?caseId=task_error&phase=terminal&outcome=task_error"
+    )
+    if (
+        summary_status != 200
+        or summary.get("total", 0) < 3
+        or filtered_status != 200
+        or not all(item["caseId"] == "task_error" for item in filtered.get("items", []))
+    ):
+        raise AcceptanceFailure("summary or AND-filter query failed")
 
     bad_tenant, _ = request(
         "POST",
@@ -283,6 +361,51 @@ def initial(state_path: Path) -> None:
         },
     )
     print("initial fixture acceptance passed")
+
+
+def inspect_view_logs(_: Path) -> None:
+    status, payload = request(
+        "GET",
+        f"{INSPECT_VIEW}/api/log-files",
+        headers={"Origin": INSPECT_VIEW},
+    )
+    files = (payload or {}).get("files", []) if isinstance(payload, dict) else []
+    if status != 200 or len(files) < 3 or not all(str(item.get("name", "")).endswith(".eval") for item in files):
+        raise AcceptanceFailure(f"Inspect View did not expose recursive EvalLog files: {status} {payload}")
+    print("Inspect View recursive EvalLog acceptance passed")
+
+
+def view_degraded(state_path: Path) -> None:
+    status, system = request("GET", f"{CONTROL}/api/v1/system")
+    ready_status, ready = request("GET", f"{CONTROL}/readyz")
+    created_status, created = create("success", f"ar1:{uuid.uuid4().hex}:view-degraded")
+    if status != 200 or system.get("status") != "degraded" or ready_status != 200 or created_status != 201:
+        raise AcceptanceFailure(f"optional View incorrectly changed readiness: {system} {ready}")
+    write_state(state_path, {"runId": created["runId"]})
+    print("optional Inspect View degraded acceptance passed")
+
+
+def required_not_ready(_: Path) -> None:
+    status, system = request("GET", f"{CONTROL}/api/v1/system")
+    list_status, runs = request("GET", f"{CONTROL}/api/v1/runs?limit=1")
+    create_status, _ = request(
+        "POST",
+        f"{CONTROL}/api/v1/runs",
+        {
+            "fixtureId": "inspect-smoke-v1",
+            "caseId": "success",
+            "idempotencyKey": f"ar1:{uuid.uuid4().hex}:required-offline",
+        },
+    )
+    if (
+        status != 200
+        or system.get("status") != "not_ready"
+        or list_status != 200
+        or not isinstance(runs.get("items"), list)
+        or create_status != 503
+    ):
+        raise AcceptanceFailure("required dependency gate or history browsing failed")
+    print("required dependency not-ready acceptance passed")
 
 
 def recovery(state_path: Path) -> None:
@@ -361,6 +484,9 @@ def main() -> int:
             "outbox-recovery",
             "worker-restart-create",
             "worker-restart-recovery",
+            "inspect-view-logs",
+            "view-degraded",
+            "required-not-ready",
         ],
     )
     parser.add_argument("--state", type=Path, required=True)
@@ -373,6 +499,9 @@ def main() -> int:
         "outbox-recovery": outbox_recovery,
         "worker-restart-create": worker_restart_create,
         "worker-restart-recovery": worker_restart_recovery,
+        "inspect-view-logs": inspect_view_logs,
+        "view-degraded": view_degraded,
+        "required-not-ready": required_not_ready,
     }
     actions[args.mode](args.state)
     return 0

--- a/extensions/ai-research/scripts/audit_ui_licenses.py
+++ b/extensions/ai-research/scripts/audit_ui_licenses.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+class UiLicenseFailure(RuntimeError):
+    pass
+
+
+def package_name(path: str) -> str:
+    return path.rsplit("node_modules/", 1)[-1]
+
+
+def canonical(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--lock", type=Path, required=True)
+    parser.add_argument("--policy", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    lock = json.loads(args.lock.read_text(encoding="utf-8"))
+    policy = json.loads(args.policy.read_text(encoding="utf-8"))
+    if lock.get("lockfileVersion") != 3:
+        raise UiLicenseFailure("UI lockfileVersion must be 3")
+    allowed = set(policy["allowedExpressions"])
+    inventory: list[dict[str, Any]] = []
+    for path, descriptor in sorted(lock.get("packages", {}).items()):
+        if not path:
+            continue
+        if descriptor.get("link"):
+            raise UiLicenseFailure(f"linked UI dependency is forbidden: {path}")
+        resolved = descriptor.get("resolved")
+        integrity = descriptor.get("integrity")
+        license_expression = descriptor.get("license")
+        if not isinstance(resolved, str) or not resolved.startswith("https://"):
+            raise UiLicenseFailure(f"UI dependency is not HTTPS registry locked: {path}")
+        if not isinstance(integrity, str) or not integrity.startswith("sha512-"):
+            raise UiLicenseFailure(f"UI dependency is missing sha512 integrity: {path}")
+        if license_expression not in allowed:
+            raise UiLicenseFailure(
+                f"UI dependency license is missing or denied: {path}: {license_expression!r}"
+            )
+        inventory.append(
+            {
+                "name": package_name(path),
+                "version": descriptor.get("version"),
+                "license": license_expression,
+                "developmentOnly": bool(descriptor.get("dev")),
+                "integrity": integrity,
+                "resolved": resolved,
+            }
+        )
+
+    document = {
+        "schemaVersion": 1,
+        "lockSha256": hashlib.sha256(args.lock.read_bytes()).hexdigest(),
+        "packageCount": len(inventory),
+        "packages": inventory,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(canonical(document) + b"\n")
+    print(f"UI license audit passed: {len(inventory)} locked packages")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (UiLicenseFailure, json.JSONDecodeError) as exc:
+        print(f"UI license audit failed: {exc}")
+        raise SystemExit(1)

--- a/extensions/ai-research/scripts/validate_boundary.py
+++ b/extensions/ai-research/scripts/validate_boundary.py
@@ -20,6 +20,14 @@ class BoundaryFailure(RuntimeError):
     pass
 
 
+def is_ui_generated(path: Path) -> bool:
+    relative = path.relative_to(MODULE_ROOT).parts
+    return len(relative) >= 2 and relative[:2] in {
+        ("ui", "node_modules"),
+        ("ui", "dist"),
+    }
+
+
 def git(*args: str) -> list[str]:
     result = subprocess.run(
         ["git", *args],
@@ -72,6 +80,8 @@ def validate_paths(base: str, boundary: dict) -> None:
     if illegal:
         raise BoundaryFailure(f"files outside the approved boundary changed: {illegal}")
     for path in MODULE_ROOT.rglob("*"):
+        if is_ui_generated(path):
+            continue
         mode = path.lstat().st_mode
         if stat.S_ISLNK(mode):
             raise BoundaryFailure(f"symlink is forbidden: {path.relative_to(MODULE_ROOT)}")
@@ -93,13 +103,35 @@ def validate_locked_files(source_lock: dict) -> None:
     license_audit = source_lock["licenseAudit"]
     if sha256(MODULE_ROOT / "license-policy.json") != license_audit["policySha256"]:
         raise BoundaryFailure("license policy drifted from the source lock")
+    ui_package = (MODULE_ROOT / "ui" / "package.json").read_text(encoding="utf-8")
+    ui_lock = (MODULE_ROOT / "ui" / "package-lock.json").read_text(encoding="utf-8")
+    if "workspace:" in ui_package + ui_lock or "file:" in ui_package + ui_lock:
+        raise BoundaryFailure("UI dependencies must not use workspace: or file: references")
+    subprocess.run(
+        [
+            sys.executable,
+            str(MODULE_ROOT / "scripts" / "audit_ui_licenses.py"),
+            "--lock",
+            str(MODULE_ROOT / "ui" / "package-lock.json"),
+            "--policy",
+            str(MODULE_ROOT / "license-policy.json"),
+            "--output",
+            str(MODULE_ROOT / "runtime" / "sbom" / "ui-build-inventory.json"),
+        ],
+        check=True,
+    )
 
 
 def validate_runtime_references(boundary: dict) -> None:
-    runtime_suffixes = {".py", ".sh", ".ps1"}
+    runtime_suffixes = {".py", ".sh", ".ps1", ".ts", ".tsx", ".js", ".cjs", ".html"}
     runtime_names = {"Dockerfile", "compose.yml"}
     for path in MODULE_ROOT.rglob("*"):
-        if not path.is_file() or "tests" in path.parts or "scripts" in path.parts:
+        if (
+            not path.is_file()
+            or "tests" in path.parts
+            or "scripts" in path.parts
+            or is_ui_generated(path)
+        ):
             continue
         if path.suffix not in runtime_suffixes and path.name not in runtime_names:
             continue
@@ -136,6 +168,14 @@ def validate_parent_controls() -> None:
         raise BoundaryFailure("path-filtered module workflow is missing")
 
 
+def validate_runtime_privacy_defaults() -> None:
+    compose = (MODULE_ROOT / "compose.yml").read_text(encoding="utf-8")
+    if compose.count('MLFLOW_DISABLE_TELEMETRY: "true"') != 2:
+        raise BoundaryFailure(
+            "MLflow telemetry must be disabled in both control and tracking services"
+        )
+
+
 def validate_no_secrets(boundary: dict) -> None:
     patterns = [
         re.compile(r"-----BEGIN " + r"(?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
@@ -143,7 +183,9 @@ def validate_no_secrets(boundary: dict) -> None:
         re.compile(r"gh" + r"[pousr]_[A-Za-z0-9]{30,}"),
         re.compile(r"AIza" + r"[A-Za-z0-9_-]{30,}"),
     ]
-    candidates = [path for path in MODULE_ROOT.rglob("*") if path.is_file()]
+    candidates = [
+        path for path in MODULE_ROOT.rglob("*") if path.is_file() and not is_ui_generated(path)
+    ]
     candidates.extend(REPO_ROOT / relative for relative in boundary["allowedParentFiles"])
     for path in candidates:
         if path.suffix in {".pyc", ".png", ".webp", ".zip", ".gz", ".tar"}:
@@ -169,6 +211,7 @@ def main() -> int:
     validate_runtime_references(boundary)
     validate_metric_names()
     validate_parent_controls()
+    validate_runtime_privacy_defaults()
     validate_no_secrets(boundary)
     if source_lock["licenseAudit"]["status"] != "passed" and not args.allow_pending_license:
         raise BoundaryFailure("runtime license audit is not passed")

--- a/extensions/ai-research/scripts/verify.ps1
+++ b/extensions/ai-research/scripts/verify.ps1
@@ -90,41 +90,56 @@ try {
     Invoke-Python @("scripts/validate_boundary.py", "--base", $Base)
     Invoke-Checked "docker" ($compose + @("config", "--quiet"))
 
-    Invoke-Checked "docker" @("build", "--target", "test", "-f", "control/Dockerfile", "-t", "modelmirror-ai-research-control-test:ar0", ".")
-    Invoke-Checked "docker" @("run", "--rm", "modelmirror-ai-research-control-test:ar0")
-    Invoke-Checked "docker" @("build", "--target", "test", "-f", "worker/Dockerfile", "-t", "modelmirror-ai-research-worker-test:ar0", ".")
-    Invoke-Checked "docker" @("run", "--rm", "modelmirror-ai-research-worker-test:ar0")
+    Invoke-Checked "docker" @("build", "--target", "test", "-f", "control/Dockerfile", "-t", "modelmirror-ai-research-control-test:ar1", ".")
+    Invoke-Checked "docker" @("run", "--rm", "modelmirror-ai-research-control-test:ar1")
+    Invoke-Checked "docker" @("build", "--target", "test", "-f", "worker/Dockerfile", "-t", "modelmirror-ai-research-worker-test:ar1", ".")
+    Invoke-Checked "docker" @("run", "--rm", "modelmirror-ai-research-worker-test:ar1")
 
     if ($Mode -eq "Quick") { return }
 
-    Invoke-Checked "docker" @("build", "--sbom=true", "--provenance=true", "--target", "runtime", "-f", "control/Dockerfile", "-t", "modelmirror-ai-research-control:ar0", ".")
-    Invoke-Checked "docker" @("build", "--sbom=true", "--provenance=true", "--target", "runtime", "-f", "worker/Dockerfile", "-t", "modelmirror-ai-research-worker:ar0", ".")
+    Invoke-Checked "docker" @("build", "--sbom=true", "--provenance=true", "--target", "runtime", "-f", "control/Dockerfile", "-t", "modelmirror-ai-research-control:ar1", ".")
+    Invoke-Checked "docker" @("build", "--sbom=true", "--provenance=true", "--target", "runtime", "-f", "worker/Dockerfile", "-t", "modelmirror-ai-research-worker:ar1", ".")
     $controlInventoryPath = Join-Path $sbom "control-runtime-inventory.json"
     $workerInventoryPath = Join-Path $sbom "worker-runtime-inventory.json"
-    Extract-ImageFile "modelmirror-ai-research-control:ar0" "/usr/share/doc/modelmirror-ai-research/runtime-inventory.json" $controlInventoryPath
-    Extract-ImageFile "modelmirror-ai-research-worker:ar0" "/usr/share/doc/modelmirror-ai-research/runtime-inventory.json" $workerInventoryPath
+    $uiInventoryPath = Join-Path $sbom "ui-build-inventory.json"
+    Extract-ImageFile "modelmirror-ai-research-control:ar1" "/usr/share/doc/modelmirror-ai-research/runtime-inventory.json" $controlInventoryPath
+    Extract-ImageFile "modelmirror-ai-research-control:ar1" "/usr/share/doc/modelmirror-ai-research/ui-build-inventory.json" $uiInventoryPath
+    Extract-ImageFile "modelmirror-ai-research-worker:ar1" "/usr/share/doc/modelmirror-ai-research/runtime-inventory.json" $workerInventoryPath
     $sourceLock = Get-Content -Raw -Encoding utf8 source-lock.json | ConvertFrom-Json
     $controlInventoryHash = (Get-FileHash -Algorithm SHA256 $controlInventoryPath).Hash.ToLowerInvariant()
     $workerInventoryHash = (Get-FileHash -Algorithm SHA256 $workerInventoryPath).Hash.ToLowerInvariant()
+    $uiInventoryHash = (Get-FileHash -Algorithm SHA256 $uiInventoryPath).Hash.ToLowerInvariant()
     if ($controlInventoryHash -ne $sourceLock.licenseAudit.control.inventorySha256) {
         throw "control runtime inventory hash disagrees with source-lock"
     }
     if ($workerInventoryHash -ne $sourceLock.licenseAudit.worker.inventorySha256) {
         throw "worker runtime inventory hash disagrees with source-lock"
     }
+    if ($uiInventoryHash -ne $sourceLock.licenseAudit.ui.inventorySha256) {
+        throw "UI build inventory hash disagrees with source-lock"
+    }
     $imageEvidence = @(
-        (Measure-Image "modelmirror-ai-research-control:ar0" "control"),
-        (Measure-Image "modelmirror-ai-research-worker:ar0" "worker")
+        (Measure-Image "modelmirror-ai-research-control:ar1" "control"),
+        (Measure-Image "modelmirror-ai-research-worker:ar1" "worker")
     )
     Set-Content -LiteralPath (Join-Path $diagnostics "image-identities.txt") -Value $imageEvidence -Encoding utf8
 
     Invoke-Checked "docker" ($compose + @("up", "-d"))
     $state = Join-Path $runtime "acceptance-state.json"
     Invoke-Python @("scripts/acceptance.py", "initial", "--state", $state)
+    Invoke-Python @("scripts/acceptance.py", "inspect-view-logs", "--state", $state)
+    $viewState = Join-Path $runtime "view-degraded-state.json"
+    try {
+        Invoke-Checked "docker" ($compose + @("stop", "ai-research-inspect-view"))
+        Invoke-Python @("scripts/acceptance.py", "view-degraded", "--state", $viewState)
+    } finally {
+        Invoke-Checked "docker" ($compose + @("start", "ai-research-inspect-view"))
+    }
     $outboxState = Join-Path $runtime "outbox-state.json"
     Invoke-Python @("scripts/acceptance.py", "outbox-create", "--state", $outboxState)
     try {
         Invoke-Checked "docker" ($compose + @("stop", "ai-research-tracking"))
+        Invoke-Python @("scripts/acceptance.py", "required-not-ready", "--state", $outboxState)
         Invoke-Python @("scripts/acceptance.py", "outbox-terminal", "--state", $outboxState)
     } finally {
         Invoke-Checked "docker" ($compose + @("start", "ai-research-tracking"))
@@ -175,7 +190,8 @@ if unexpected:
     $containerEnv = @(
         (& docker inspect modelmirror-ai-research-ai-research-control-1 --format "{{json .Config.Env}}"),
         (& docker inspect modelmirror-ai-research-ai-research-tracking-1 --format "{{json .Config.Env}}"),
-        (& docker inspect modelmirror-ai-research-ai-research-worker-1 --format "{{json .Config.Env}}")
+        (& docker inspect modelmirror-ai-research-ai-research-worker-1 --format "{{json .Config.Env}}"),
+        (& docker inspect modelmirror-ai-research-ai-research-inspect-view-1 --format "{{json .Config.Env}}")
     ) -join "`n"
     if ($containerEnv -match "OPENROUTER_API_KEY|LLM_GATEWAY_KEY|DIFY_API_KEY|PROVIDER.*(KEY|TOKEN|SECRET)|sk-(or-v1-)?[A-Za-z0-9_-]{32,}|gh[pousr]_[A-Za-z0-9]{30,}|BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY") {
         throw "provider credential names were exposed to module containers"
@@ -197,17 +213,17 @@ if unexpected:
         Build-ClientProof `
             $sourceLock.modelMirrorBaseCommit `
             $clientBaselineContext `
-            "modelmirror-ai-research-client-proof:ar0-baseline"
+            "modelmirror-ai-research-client-proof:ar1-baseline"
         Build-ClientProof `
             "HEAD" `
             $clientCurrentContext `
-            "modelmirror-ai-research-client-proof:ar0"
+            "modelmirror-ai-research-client-proof:ar1"
         Extract-ImageFile `
-            "modelmirror-ai-research-client-proof:ar0-baseline" `
+            "modelmirror-ai-research-client-proof:ar1-baseline" `
             "/proof/dist/." `
             $clientBaselineProof
         Extract-ImageFile `
-            "modelmirror-ai-research-client-proof:ar0" `
+            "modelmirror-ai-research-client-proof:ar1" `
             "/proof/dist/." `
             $clientCurrentProof
         Invoke-Python @(

--- a/extensions/ai-research/scripts/verify.sh
+++ b/extensions/ai-research/scripts/verify.sh
@@ -36,29 +36,34 @@ trap cleanup EXIT
 
 python scripts/validate_boundary.py --base "$BASE"
 "${COMPOSE[@]}" config --quiet
-docker build --target test -f control/Dockerfile -t modelmirror-ai-research-control-test:ar0 .
-docker run --rm modelmirror-ai-research-control-test:ar0
-docker build --target test -f worker/Dockerfile -t modelmirror-ai-research-worker-test:ar0 .
-docker run --rm modelmirror-ai-research-worker-test:ar0
+docker build --target test -f control/Dockerfile -t modelmirror-ai-research-control-test:ar1 .
+docker run --rm modelmirror-ai-research-control-test:ar1
+docker build --target test -f worker/Dockerfile -t modelmirror-ai-research-worker-test:ar1 .
+docker run --rm modelmirror-ai-research-worker-test:ar1
 
 if [[ "$MODE" == "quick" ]]; then
   exit 0
 fi
 
 docker build --sbom=true --provenance=true --target runtime -f control/Dockerfile \
-  -t modelmirror-ai-research-control:ar0 .
+  -t modelmirror-ai-research-control:ar1 .
 docker build --sbom=true --provenance=true --target runtime -f worker/Dockerfile \
-  -t modelmirror-ai-research-worker:ar0 .
-docker run --rm modelmirror-ai-research-control:ar0 \
+  -t modelmirror-ai-research-worker:ar1 .
+docker run --rm modelmirror-ai-research-control:ar1 \
   cat //usr/share/doc/modelmirror-ai-research/runtime-inventory.json \
   > runtime/sbom/control-runtime-inventory.json
-docker run --rm modelmirror-ai-research-worker:ar0 \
+docker run --rm modelmirror-ai-research-control:ar1 \
+  cat //usr/share/doc/modelmirror-ai-research/ui-build-inventory.json \
+  > runtime/sbom/ui-build-inventory.json
+docker run --rm modelmirror-ai-research-worker:ar1 \
   cat //usr/share/doc/modelmirror-ai-research/runtime-inventory.json \
   > runtime/sbom/worker-runtime-inventory.json
 CONTROL_EXPECTED=$(python -c "import json; print(json.load(open('source-lock.json'))['licenseAudit']['control']['inventorySha256'])")
 WORKER_EXPECTED=$(python -c "import json; print(json.load(open('source-lock.json'))['licenseAudit']['worker']['inventorySha256'])")
+UI_EXPECTED=$(python -c "import json; print(json.load(open('source-lock.json'))['licenseAudit']['ui']['inventorySha256'])")
 [[ "$(sha256sum runtime/sbom/control-runtime-inventory.json | cut -d' ' -f1)" == "$CONTROL_EXPECTED" ]]
 [[ "$(sha256sum runtime/sbom/worker-runtime-inventory.json | cut -d' ' -f1)" == "$WORKER_EXPECTED" ]]
+[[ "$(sha256sum runtime/sbom/ui-build-inventory.json | cut -d' ' -f1)" == "$UI_EXPECTED" ]]
 measure_image() {
   local image="$1" slug="$2" tar_path="runtime/diagnostics/${2}-image.tar"
   docker save -o "$tar_path" "$image"
@@ -68,14 +73,22 @@ measure_image() {
   rm -f "$tar_path" "${tar_path}.gz"
 }
 {
-  measure_image modelmirror-ai-research-control:ar0 control
-  measure_image modelmirror-ai-research-worker:ar0 worker
+  measure_image modelmirror-ai-research-control:ar1 control
+  measure_image modelmirror-ai-research-worker:ar1 worker
 } > runtime/diagnostics/image-identities.txt
 
 "${COMPOSE[@]}" up -d
 python scripts/acceptance.py initial --state runtime/acceptance-state.json
+python scripts/acceptance.py inspect-view-logs --state runtime/acceptance-state.json
+"${COMPOSE[@]}" stop ai-research-inspect-view
+if ! python scripts/acceptance.py view-degraded --state runtime/view-degraded-state.json; then
+  "${COMPOSE[@]}" start ai-research-inspect-view
+  exit 1
+fi
+"${COMPOSE[@]}" start ai-research-inspect-view
 python scripts/acceptance.py outbox-create --state runtime/outbox-state.json
 "${COMPOSE[@]}" stop ai-research-tracking
+python scripts/acceptance.py required-not-ready --state runtime/outbox-state.json
 if ! python scripts/acceptance.py outbox-terminal --state runtime/outbox-state.json; then
   "${COMPOSE[@]}" start ai-research-tracking
   exit 1
@@ -124,6 +137,8 @@ CONTAINER_ENV=$(docker inspect \
   modelmirror-ai-research-ai-research-control-1 \
   modelmirror-ai-research-ai-research-tracking-1 \
   modelmirror-ai-research-ai-research-worker-1 --format '{{json .Config.Env}}')
+CONTAINER_ENV+=$(docker inspect \
+  modelmirror-ai-research-ai-research-inspect-view-1 --format '{{json .Config.Env}}')
 if grep -E 'OPENROUTER_API_KEY|LLM_GATEWAY_KEY|DIFY_API_KEY|PROVIDER.*(KEY|TOKEN|SECRET)|sk-(or-v1-)?[A-Za-z0-9_-]{32,}|gh[pousr]_[A-Za-z0-9]{30,}|BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY' <<<"$CONTAINER_ENV"; then
   echo "provider credential names were exposed to module containers" >&2
   exit 1
@@ -164,16 +179,16 @@ esac
 build_client_proof \
   "$LOCKED_BASE" \
   "$CLIENT_BASELINE_CONTEXT" \
-  modelmirror-ai-research-client-proof:ar0-baseline
+  modelmirror-ai-research-client-proof:ar1-baseline
 build_client_proof \
   HEAD \
   "$CLIENT_CURRENT_CONTEXT" \
-  modelmirror-ai-research-client-proof:ar0
+  modelmirror-ai-research-client-proof:ar1
 extract_client_proof \
-  modelmirror-ai-research-client-proof:ar0-baseline \
+  modelmirror-ai-research-client-proof:ar1-baseline \
   "$CLIENT_BASELINE_PROOF_DIR"
 extract_client_proof \
-  modelmirror-ai-research-client-proof:ar0 \
+  modelmirror-ai-research-client-proof:ar1 \
   "$CLIENT_CURRENT_PROOF_DIR"
 python scripts/zero_footprint.py \
   --baseline-client-dist "$CLIENT_BASELINE_PROOF_DIR" \

--- a/extensions/ai-research/source-lock.json
+++ b/extensions/ai-research/source-lock.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-23",
-  "modelMirrorBaseCommit": "296c38a58a8274d9a80ad35b187eabaddd06ae46",
+  "generatedAt": "2026-08-24",
+  "modelMirrorBaseCommit": "174baf6a5289520b53578dc29cab82fd4c1d1e9e",
   "claimLevel": "harness_only",
   "packStatus": "fixture_only",
   "runtimes": {
@@ -9,7 +9,11 @@
     "inspectAi": "0.3.260",
     "mlflow": "3.15.1",
     "fastapi": "0.141.1",
-    "uvicorn": "0.52.4"
+    "uvicorn": "0.52.4",
+    "node": "22.23.2",
+    "npm": "10.9.8",
+    "react": "19.2.7",
+    "vite": "7.3.5"
   },
   "baseImage": {
     "reference": "python@sha256:401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461",
@@ -22,15 +26,15 @@
   "coreBaseline": {
     "clientDistGate": {
       "mode": "same_runner_base_vs_head",
-      "baseCommit": "296c38a58a8274d9a80ad35b187eabaddd06ae46"
+      "baseCommit": "174baf6a5289520b53578dc29cab82fd4c1d1e9e"
     },
     "clientDistReference": {
       "fileCount": 26,
-      "totalBytes": 17596261,
-      "aggregateSha256": "46937edea789dbdec5100e970845ae67661a857789ee09b107f29928daa48f5f"
+      "totalBytes": 17611866,
+      "aggregateSha256": "f7eec2e2477f00b62d7ea80050ed75298c8623b5b941c901696104fa8549670e"
     },
     "trackedFiles": {
-      "docker-compose.yml": "594d734aea7ba39b33543266ffa63a46eb1599f894ce44489181be72bf11b338",
+      "docker-compose.yml": "c41af89b65dde80b6925d63c7b44f435fdf9984f8460d7b3d1351ab2a62019d1",
       "server/requirements.txt": "2bdcee334343bfbeed372d9173ae684d0df839c209d293b780987cfc687a92a4",
       "server/Dockerfile": "d192d823e21cd51c3a67bc35285130ab77ed22a64a0a8a0cd0083c2875927e63",
       "client/package.json": "21ea8333343d09df2bb081e9caa05fe9e080d9c8509e71bea7fd12ae33c23ced",
@@ -113,8 +117,8 @@
       "sha256": "c6095d8c3647eafc5287ed73cf976540c5d0de9b1da8810f12198bd779ed47ae"
     },
     "control/Dockerfile": {
-      "sizeBytes": 1858,
-      "sha256": "372bf9e02ea9a73f521026776bb12704f43e7ffeba938ed540806891c1db6bf5"
+      "sizeBytes": 3181,
+      "sha256": "06f307490ad2c24e0621ef943e4df756eb414da2e5fe3f2100bc348911c7b866"
     },
     "worker/Dockerfile": {
       "sizeBytes": 1736,
@@ -123,12 +127,20 @@
     "scripts/client-proof.Dockerfile": {
       "sizeBytes": 362,
       "sha256": "ca8ad9be55ddc67a3ef2a563e38abf354fc40b930c28d08824ee6868c6f4c34d"
+    },
+    "ui/package.json": {
+      "sizeBytes": 848,
+      "sha256": "96c426a30006a7bb3bfe1fe933a847277ff701373de86fbc2d36f216139a5424"
+    },
+    "ui/package-lock.json": {
+      "sizeBytes": 136849,
+      "sha256": "32ef64bd8937c5aa8b975aabb94853596b1afe33599c09f1fb61002ff31c01f5"
     }
   },
   "licenseAudit": {
     "status": "passed",
     "policy": "no unknown or denied runtime licenses",
-    "policySha256": "eb5e2caf6007d5c2a5fb03f3f1f17b7b672bd4b025f4abc81c1cf81ccf66b8ae",
+    "policySha256": "b5842c43da0a044133de3eaadde94de73e8363c57c9e51f98f8a67d444df48d8",
     "inventory": "runtime/sbom",
     "control": {
       "packageCount": 91,
@@ -137,6 +149,10 @@
     "worker": {
       "packageCount": 83,
       "inventorySha256": "7272d758ce92230ed35bf9a4030a9458a8e84cee061ce5507dae5e3fe452b08e"
+    },
+    "ui": {
+      "packageCount": 275,
+      "inventorySha256": "4eb07c393d3ae648abe6ca1175b11995cbf357b84a4f2c30b2b3bdd49dfe69fb"
     }
   }
 }

--- a/extensions/ai-research/tests/control/test_api.py
+++ b/extensions/ai-research/tests/control/test_api.py
@@ -27,7 +27,10 @@ def record() -> dict[str, Any]:
         "mlflow_run_id": None,
         "created_at": "2026-08-23T00:00:00Z",
         "started_at": None,
+        "cancel_requested_at": None,
+        "cancel_applied_at": None,
         "terminal_at": None,
+        "evidence_synced_at": None,
         "updated_at": "2026-08-23T00:00:00Z",
     }
 
@@ -38,8 +41,22 @@ class FakeStore:
             raise KeyError(run_id)
         return record()
 
-    def list(self, *, after_run_id: str | None, limit: int) -> list[dict[str, Any]]:
+    def list(self, *, after_run_id: str | None, limit: int, **_: object) -> list[dict[str, Any]]:
         return [record()]
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "total": 1,
+            "phases": {"queued": 1, "running": 0, "terminal": 0},
+            "outcomes": {
+                "success": 0,
+                "task_error": 0,
+                "cancelled": 0,
+                "infrastructure_error": 0,
+            },
+            "evidence_states": {"pending": 1, "synced": 0, "failed": 0},
+            "updated_at": "2026-08-23T00:00:00Z",
+        }
 
     def events(self, run_id: str, after_sequence: int) -> list[dict[str, Any]]:
         self.get(run_id)
@@ -66,6 +83,45 @@ class FakeService:
     async def readiness(self) -> dict[str, str]:
         return {"controlLedger": "ready", "worker": "ready", "tracking": "ready"}
 
+    async def system_status(self) -> dict[str, object]:
+        return {
+            "status": "degraded",
+            "checks": [
+                {"id": "controlLedger", "status": "ready", "required": True},
+                {"id": "worker", "status": "ready", "required": True},
+                {"id": "tracking", "status": "ready", "required": True},
+                {"id": "inspectView", "status": "not_ready", "required": False},
+            ],
+            "checkedAt": "2026-08-23T00:00:00Z",
+        }
+
+    async def evidence(self, run_id: str) -> dict[str, object]:
+        self.store.get(run_id)
+        return {
+            "runId": run_id,
+            "evidenceState": "synced",
+            "integrityStatus": "verified",
+            "integrityError": None,
+            "verifiedAt": "2026-08-23T00:00:00Z",
+            "receipt": {"runId": run_id},
+            "artifacts": [
+                {
+                    "name": "eval-log.json",
+                    "sizeBytes": 2,
+                    "sha256": "a" * 64,
+                    "downloadUrl": f"/api/v1/runs/{run_id}/artifacts/eval-log.json",
+                }
+            ],
+            "mlflow": {"runId": "mlflow-run", "experimentId": "1", "traceId": "trace"},
+            "outbox": {"state": "synced", "attemptCount": 0},
+        }
+
+    async def artifact(self, run_id: str, name: str) -> tuple[bytes, str]:
+        self.store.get(run_id)
+        if name != "eval-log.json":
+            raise KeyError(name)
+        return b"{}", "a" * 64
+
     async def create_run(self, request: dict[str, Any]) -> tuple[dict[str, Any], bool]:
         return record(), True
 
@@ -87,11 +143,29 @@ def test_frozen_http_contract(monkeypatch) -> None:
         assert created.status_code == 201
         assert created.json()["runId"] == "ar0_test"
         assert client.get("/api/v1/runs").json()["items"][0]["runId"] == "ar0_test"
+        assert client.get("/api/v1/runs/summary").json()["total"] == 1
+        assert client.get("/api/v1/runs?caseId=success&phase=queued").status_code == 200
+        assert client.get("/api/v1/system").json()["status"] == "degraded"
+        assert client.get("/api/v1/runs/ar0_test/evidence").json()["integrityStatus"] == "verified"
+        artifact = client.get("/api/v1/runs/ar0_test/artifacts/eval-log.json")
+        assert artifact.content == b"{}"
+        assert artifact.headers["x-artifact-sha256"] == "a" * 64
+        assert artifact.headers["x-content-type-options"] == "nosniff"
         assert client.get("/api/v1/runs/ar0_test/events?afterSeq=0").json()[
             "nextSequence"
         ] == 1
         assert client.post("/api/v1/runs/ar0_test/cancel").status_code == 200
         assert client.get("/docs").status_code == 404
+        deep_link = client.get("/runs/ar0_test/evidence", headers={"Accept": "text/html"})
+        assert deep_link.status_code == 200
+        assert "<title>模镜科研控制台</title>" in deep_link.text
+        assert deep_link.headers["cache-control"] == "no-store"
+        missing_api = client.get("/api/v1/does-not-exist", headers={"Accept": "text/html"})
+        assert missing_api.status_code == 404
+        assert missing_api.headers["content-type"].startswith("application/json")
+        missing_asset = client.get("/assets/does-not-exist.js", headers={"Accept": "text/html"})
+        assert missing_asset.status_code == 404
+        assert "<title>模镜科研控制台</title>" not in missing_asset.text
 
 
 def test_request_surface_fails_closed(monkeypatch) -> None:
@@ -104,4 +178,25 @@ def test_request_surface_fails_closed(monkeypatch) -> None:
         }
         assert client.post("/api/v1/runs", json={**base, "tenantId": "other"}).status_code == 422
         assert client.post("/api/v1/runs", json={**base, "command": "id"}).status_code == 422
+        assert client.get("/api/v1/runs?phase=unknown").status_code == 422
+        assert client.get("/api/v1/runs?evidenceState=unknown").status_code == 422
         assert client.get("/healthz", headers={"Host": "evil.example"}).status_code == 400
+
+
+def test_maximum_page_uses_one_row_lookahead_and_emits_cursor(monkeypatch) -> None:
+    monkeypatch.setattr(app_module, "ResearchService", FakeService)
+    requested_limits: list[int] = []
+    with TestClient(app_module.app) as client:
+        store = app_module.app.state.research.store
+
+        def page(*, after_run_id: str | None, limit: int, **_: object) -> list[dict[str, Any]]:
+            requested_limits.append(limit)
+            return [{**record(), "run_id": f"ar0_{index:03d}"} for index in range(limit)]
+
+        monkeypatch.setattr(store, "list", page)
+        response = client.get("/api/v1/runs?limit=100")
+
+    assert response.status_code == 200
+    assert requested_limits == [101]
+    assert len(response.json()["items"]) == 100
+    assert response.json()["nextCursor"] == "ar0_099"

--- a/extensions/ai-research/tests/control/test_evidence.py
+++ b/extensions/ai-research/tests/control/test_evidence.py
@@ -7,7 +7,13 @@ from pathlib import Path
 import pytest
 
 from ai_research_control.config import Settings
-from ai_research_control.evidence import EvidenceError, build_receipt, verify_receipt
+from ai_research_control.evidence import (
+    EvidenceError,
+    build_receipt,
+    read_verified_artifact,
+    verify_persisted_receipt,
+    verify_receipt,
+)
 
 
 def write_json(path: Path, value: object) -> None:
@@ -107,6 +113,76 @@ def test_receipt_detects_artifact_tampering(tmp_path: Path) -> None:
     (destination / "eval-log.json").write_text("tampered", encoding="utf-8")
     with pytest.raises(EvidenceError, match="hash mismatch"):
         verify_receipt(destination, receipt)
+
+
+def test_download_revalidates_manifest_and_rejects_unregistered_file(tmp_path: Path) -> None:
+    config = settings(tmp_path)
+    run_id = "ar0_download"
+    source = config.inspect_log_root / run_id
+    source.mkdir(parents=True)
+    artifact = source / "eval-log.json"
+    artifact.write_text("{}", encoding="utf-8")
+    data = artifact.read_bytes()
+    receipt, destination = build_receipt(
+        config,
+        run_record(run_id),
+        {
+            "artifacts": {
+                artifact.name: {
+                    "sha256": hashlib.sha256(data).hexdigest(),
+                    "sizeBytes": len(data),
+                }
+            }
+        },
+    )
+
+    verify_persisted_receipt(destination, receipt)
+    downloaded, digest = read_verified_artifact(destination, receipt, artifact.name)
+    assert downloaded == data
+    assert digest == hashlib.sha256(data).hexdigest()
+    with pytest.raises(KeyError):
+        read_verified_artifact(destination, receipt, "not-listed.json")
+    with pytest.raises(EvidenceError, match="unsafe"):
+        read_verified_artifact(destination, receipt, "../receipt.json")
+
+    (destination / artifact.name).unlink()
+    with pytest.raises(EvidenceError, match="unavailable"):
+        read_verified_artifact(destination, receipt, artifact.name)
+
+
+def test_download_rejects_symlink_and_persisted_receipt_tampering(tmp_path: Path) -> None:
+    config = settings(tmp_path)
+    run_id = "ar0_symlink"
+    source = config.inspect_log_root / run_id
+    source.mkdir(parents=True)
+    artifact = source / "eval-log.json"
+    artifact.write_text("{}", encoding="utf-8")
+    data = artifact.read_bytes()
+    receipt, destination = build_receipt(
+        config,
+        run_record(run_id),
+        {
+            "artifacts": {
+                artifact.name: {
+                    "sha256": hashlib.sha256(data).hexdigest(),
+                    "sizeBytes": len(data),
+                }
+            }
+        },
+    )
+
+    copied = destination / artifact.name
+    copied.unlink()
+    copied.symlink_to(destination / "receipt.json")
+    with pytest.raises(EvidenceError, match="symbolic link|unsafe"):
+        read_verified_artifact(destination, receipt, artifact.name)
+
+    copied.unlink()
+    copied.write_bytes(data)
+    receipt_path = destination / "receipt.json"
+    receipt_path.write_bytes(receipt_path.read_bytes().replace(b'"runId"', b'"runID"', 1))
+    with pytest.raises(EvidenceError, match="does not match|body hash"):
+        verify_persisted_receipt(destination, receipt)
 
 
 def test_receipt_rejects_path_traversal(tmp_path: Path) -> None:

--- a/extensions/ai-research/tests/control/test_mlflow_sink.py
+++ b/extensions/ai-research/tests/control/test_mlflow_sink.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import hashlib
 
-from ai_research_control.mlflow_sink import MlflowSink
+import pytest
+import requests
+
+from ai_research_control.mlflow_sink import MlflowSink, MlflowSinkError
 
 
 def test_otlp_export_returns_mlflow_readable_trace_id(monkeypatch) -> None:
@@ -23,3 +26,65 @@ def test_otlp_export_returns_mlflow_readable_trace_id(monkeypatch) -> None:
     assert trace_id == f"tr-{expected}"
     assert observed["headers"]["x-mlflow-experiment-id"] == "17"
     assert observed["data"]
+
+
+def test_probe_uses_bounded_rest_request(monkeypatch) -> None:
+    observed: dict[str, object] = {}
+
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict[str, object]:
+            return {"experiment": {"experiment_id": "17"}}
+
+    def fake_get(url, *, params, timeout):
+        observed.update(url=url, params=params, timeout=timeout)
+        return Response()
+
+    monkeypatch.setattr("ai_research_control.mlflow_sink.requests.get", fake_get)
+    sink = MlflowSink("http://ai-research-tracking:5000", "fixture")
+
+    assert sink.probe() == "17"
+    assert observed["timeout"] == 2
+    assert observed["params"] == {"experiment_name": "fixture"}
+
+
+def test_probe_fails_closed_when_tracking_times_out(monkeypatch) -> None:
+    def fake_get(*_args, **_kwargs):
+        raise requests.Timeout("offline")
+
+    monkeypatch.setattr("ai_research_control.mlflow_sink.requests.get", fake_get)
+    sink = MlflowSink("http://ai-research-tracking:5000", "fixture")
+
+    with pytest.raises(MlflowSinkError, match="probe failed"):
+        sink.probe()
+
+
+def test_probe_creates_missing_experiment_with_bounded_request(monkeypatch) -> None:
+    class MissingResponse:
+        status_code = 404
+
+    class CreatedResponse:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict[str, str]:
+            return {"experiment_id": "23"}
+
+    observed: dict[str, object] = {}
+    monkeypatch.setattr(
+        "ai_research_control.mlflow_sink.requests.get",
+        lambda *_args, **_kwargs: MissingResponse(),
+    )
+
+    def fake_post(url, *, json, timeout):
+        observed.update(url=url, json=json, timeout=timeout)
+        return CreatedResponse()
+
+    monkeypatch.setattr("ai_research_control.mlflow_sink.requests.post", fake_post)
+    sink = MlflowSink("http://ai-research-tracking:5000", "fixture")
+
+    assert sink.probe() == "23"
+    assert observed["json"] == {"name": "fixture"}
+    assert observed["timeout"] == 2

--- a/extensions/ai-research/tests/control/test_service.py
+++ b/extensions/ai-research/tests/control/test_service.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+
+from ai_research_control.service import ResearchService
+
+
+class TerminalRaceStore:
+    def get(self, run_id: str) -> dict[str, object]:
+        return {"run_id": run_id, "phase": "running", "case_id": "success"}
+
+    def request_cancel(self, run_id: str) -> dict[str, object]:
+        return {
+            "run_id": run_id,
+            "phase": "terminal",
+            "outcome": "success",
+            "case_id": "success",
+            "cancel_requested": False,
+        }
+
+
+class UnexpectedWorker:
+    async def cancel(self, run_id: str) -> dict[str, object]:
+        raise AssertionError(f"terminal run was sent to Worker: {run_id}")
+
+
+def test_cancel_race_does_not_send_terminal_run_to_worker() -> None:
+    service = object.__new__(ResearchService)
+    service.store = TerminalRaceStore()
+    service.worker = UnexpectedWorker()
+
+    result = asyncio.run(service.cancel("ar0_terminal_race"))
+
+    assert result["phase"] == "terminal"
+    assert result["outcome"] == "success"
+    assert result["cancel_requested"] is False

--- a/extensions/ai-research/tests/control/test_store.py
+++ b/extensions/ai-research/tests/control/test_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -100,3 +101,96 @@ def test_receipt_outbox_survives_store_reopen(tmp_path: Path) -> None:
     assert pending[0]["run_id"] == run["run_id"]
     assert pending[0]["receipt_json"] == receipt
     assert terminal["phase"] == "terminal"
+
+
+def test_filtered_list_and_summary(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "control.db")
+    success, _ = store.create_or_get(request(key="fixture:key-success"))
+    error, _ = store.create_or_get(
+        request(key="fixture:key-error", case_id="task_error")
+    )
+    store.mark_running(error["run_id"], {"phase": "running"})
+    store.update_worker(
+        error["run_id"],
+        {
+            "phase": "terminal",
+            "outcome": "task_error",
+            "inspectStatus": "error",
+            "cancelRequested": False,
+            "cancelApplied": False,
+            "errorType": "FixtureTaskError",
+            "errorMessage": "fixture failed",
+            "replayVerified": False,
+            "artifacts": {},
+        },
+    )
+
+    assert [item["run_id"] for item in store.list(
+        after_run_id=None, limit=10, case_id="success"
+    )] == [success["run_id"]]
+    assert [item["run_id"] for item in store.list(
+        after_run_id=None, limit=10, query="fixturetask"
+    )] == [error["run_id"]]
+    assert store.list(after_run_id=None, limit=10, query="100%") == []
+
+    summary = store.summary()
+    assert summary["total"] == 2
+    assert summary["phases"] == {"queued": 1, "running": 0, "terminal": 1}
+    assert summary["outcomes"]["task_error"] == 1
+    assert summary["evidence_states"]["pending"] == 2
+    assert summary["updated_at"] is not None
+
+
+def test_list_preserves_one_row_for_max_page_lookahead(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "control.db")
+    for index in range(101):
+        store.create_or_get(request(key=f"fixture:key-{index:03d}"))
+
+    page_with_lookahead = store.list(after_run_id=None, limit=101)
+
+    assert len(page_with_lookahead) == 101
+
+
+def test_cancel_request_is_atomic_under_concurrency(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "control.db")
+    run, _ = store.create_or_get(request(case_id="long_running_cancel"))
+    store.mark_running(run["run_id"], {"phase": "running"})
+
+    with ThreadPoolExecutor(max_workers=12) as executor:
+        results = list(
+            executor.map(lambda _: store.request_cancel(run["run_id"]), range(12))
+        )
+
+    assert all(item["cancel_requested"] for item in results)
+    cancel_events = [
+        event
+        for event in store.events(run["run_id"], 0)
+        if event["event_type"] == "run.cancel_requested"
+    ]
+    assert len(cancel_events) == 1
+
+
+def test_cancel_after_terminal_does_not_rewrite_run_facts(tmp_path: Path) -> None:
+    store = RunStore(tmp_path / "control.db")
+    run, _ = store.create_or_get(request())
+    store.mark_running(run["run_id"], {"phase": "running"})
+    terminal = store.update_worker(
+        run["run_id"],
+        {
+            "phase": "terminal",
+            "outcome": "success",
+            "inspectStatus": "success",
+            "cancelRequested": False,
+            "cancelApplied": False,
+            "replayVerified": True,
+            "artifacts": {},
+        },
+    )
+    events_before = store.events(run["run_id"], 0)
+
+    unchanged = store.request_cancel(run["run_id"])
+
+    assert unchanged["cancel_requested"] is False
+    assert unchanged["cancel_requested_at"] is None
+    assert unchanged["terminal_at"] == terminal["terminal_at"]
+    assert store.events(run["run_id"], 0) == events_before

--- a/extensions/ai-research/tests/worker/test_runner.py
+++ b/extensions/ai-research/tests/worker/test_runner.py
@@ -130,6 +130,29 @@ def test_health_caches_the_pinned_inspect_version(tmp_path: Path) -> None:
     assert manager.version_calls == 1
 
 
+def test_concurrent_health_checks_share_one_inspect_version_probe(tmp_path: Path) -> None:
+    class ConcurrentHealthManager(FakeInspectManager):
+        version_calls = 0
+
+        async def _command(self, *argv: str, timeout: float):
+            if list(argv)[1:2] == ["--version"]:
+                self.version_calls += 1
+                await asyncio.sleep(0.05)
+            return await super()._command(*argv, timeout=timeout)
+
+    async def scenario() -> None:
+        fixture = tmp_path / "fixture.py"
+        fixture.write_text("# fixture", encoding="utf-8")
+        manager = ConcurrentHealthManager(tmp_path / "logs", fixture, "success")
+
+        results = await asyncio.gather(*(manager.health() for _ in range(20)))
+
+        assert all(result["status"] == "ready" for result in results)
+        assert manager.version_calls == 1
+
+    asyncio.run(scenario())
+
+
 def test_interrupted_marker_recovers_as_infrastructure_error(tmp_path: Path) -> None:
     log_root = tmp_path / "logs"
     run_dir = log_root / "ar0_interrupted"

--- a/extensions/ai-research/ui/index.html
+++ b/extensions/ai-research/ui/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#090b0e" />
+    <title>模镜科研控制台</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/extensions/ai-research/ui/package-lock.json
+++ b/extensions/ai-research/ui/package-lock.json
@@ -1,0 +1,4051 @@
+{
+  "name": "@modelmirror/ai-research-console",
+  "version": "0.2.0-ar1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@modelmirror/ai-research-console",
+      "version": "0.2.0-ar1",
+      "dependencies": {
+        "lucide-react": "1.27.0",
+        "react": "19.2.7",
+        "react-dom": "19.2.7",
+        "react-router-dom": "6.30.4"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "7.0.0",
+        "@testing-library/react": "16.3.2",
+        "@testing-library/user-event": "14.6.3",
+        "@types/react": "19.2.17",
+        "@types/react-dom": "19.2.3",
+        "@vitejs/plugin-react": "5.2.0",
+        "autoprefixer": "10.5.0",
+        "jsdom": "30.0.1",
+        "postcss": "8.5.15",
+        "tailwindcss": "3.4.19",
+        "typescript": "5.8.3",
+        "vite": "7.3.5",
+        "vitest": "4.1.6"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.5.tgz",
+      "integrity": "sha512-jfkGfTwhQpsiSckPF8r9bU3pn3vyd72NlWaO+TgEO6WPSDnUhXzrNYCHBMOYj0ACaUgjm6eERLF+XV9a6RstoA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.5.tgz",
+      "integrity": "sha512-oGVqyQlxnrz9/ty89oHpU857VUHEl5/Xu4R2lS+aivCTrNnSsbiENzTnNaBsjxH0CNWGPhzHArOLFwo+oKXveA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.5.tgz",
+      "integrity": "sha512-bW7B8xMEq8n99Q3ieEcPRGuphurdZAaFzQc9Efyyw3FL6DZO6pMy9xhdN+kBoD7Sy05xNXSr4OyPPnpkYriS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.5.tgz",
+      "integrity": "sha512-YSwBS86QeHOGlrxJ1PSOIZSkzRL/JmKeunhc+lV6M1a6En8QuVCD/T/qIA0J4Gd2Y86RIOBYrLcOUtqGh9+/1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.5.tgz",
+      "integrity": "sha512-2fST8lILgl7cKbme/1KDdPCmbXbG+gqoV3bHp19L0ypX/3akYMBVdOunPleRCwonoLnXOZ/0F+Mt/v8POFmfcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.5.tgz",
+      "integrity": "sha512-cpIxQCP9J+EVad0a6LO1kY3ZGODlk80VlI+2I96B8xMcdHZ4pLVhfQ49JFpYqjPF91FFkQWftf57YlDcTiw9yQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.5.tgz",
+      "integrity": "sha512-r9fGh3eFs3e/udWh5ZjXQtxiYK/xoFxQaYR/cELxac/Udkl5Th+IsFm0CX3Kl9hmUH/we7EoMpjJgeQNnE0+IA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.5.tgz",
+      "integrity": "sha512-xdvFdp7OM6KLJviJT2g/YuRSUjnZgGHk4RNgwIbN7X6cPugOucV60DdHXWzsBVCUdrGb6qSXnJQrrAKMmQuj3Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.5.tgz",
+      "integrity": "sha512-rRqILAndyzHzP7T9NFQrq+4HFWNhqkqkKur7eiBpfLmz01PO0JKx5Vchu3YllE4YXI/Ftgq/szrDWg5GJ0mI8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.5.tgz",
+      "integrity": "sha512-Gf4X3qVMucayUvux6aXXPgXovocSFUC0rrffDuPI/S2nHhNMhjcZxsrAFYCOF350PRreW1XwzFj3CT/3bKsWCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.5.tgz",
+      "integrity": "sha512-+s5qA0TNM0qm8PK/a5gt/1Hpx+NV08uSuCncvhziIlQzT6AEV2fnUQo7eBtFTFO0nA9scauvoR2HusfXmQnO4w==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.5.tgz",
+      "integrity": "sha512-ybb6QvWwWJCbBWqERpc8K3pYVGIrXlG8MEQ8IIuJY6Y9KdHQxoFoNyfkAOtKn1VHu3KuLidXvwrvGR1mEjeWCw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.5.tgz",
+      "integrity": "sha512-nZb1DtnOyhCmYvsC8A2CwOkopVg+IS1+fPUa7rMOAXtNw5+lLCLLPqd6XAiNrGtoQKsbvIBOwsHnBH/3wnb4HQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.5.tgz",
+      "integrity": "sha512-yMbj63Sp89ryrXLWyz+sy+fYD2HpOnMCLGbe4Oa1smclFSUukdtD/BgdiHaAetJNb74URD8U4hM+qG5KVzMEkg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.5.tgz",
+      "integrity": "sha512-mhoan3OJw2kYV/e1jtIdmvUZgyBFeA6zGWsOswmR0Tg19TQbowZuR+JMLID6spbbBN7Zee2ejrgmy3+FxGrIdA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.5.tgz",
+      "integrity": "sha512-5ZTLmjWbb1VZdjuyhe83K/8QO0/h11midQCBP+X5OYn32ra7eOBoM0ZqtaY4nkgNsYgmdVhMYPoyVPTjUpHf3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.5.tgz",
+      "integrity": "sha512-m53kG+br6PGxOTmgBEM2DHSDs9RVjsyEbUwjJPJGTFm1grWOG8EKJggDCTb60unD4Tjby8fi7/m9XfkEWasVWg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.5.tgz",
+      "integrity": "sha512-6RHPJR1g/uvdYU8uXBnfq3nlqyZCP82Fr6NHgfGoaIeSh0YEqnX/x6uA9MmJJbnSH7swqX4F+CkGdUF+6doiQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.5.tgz",
+      "integrity": "sha512-xs+OXQtEXgpXT0DmA5+U3qnRZHdCST/5HRQxS8wSPZTUZN/EMWeHuSIod32LQklTBZBV9DyfncKBQ8n5V3eFdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.5.tgz",
+      "integrity": "sha512-e7hD+sl3s+mcLQDZ8pbudBVsdG6r5yN4w3LqG2TJ8sQHDpblWj5lrJs/3m01Cvlxbt4x13zu5thLjgypgtkYzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.5.tgz",
+      "integrity": "sha512-GiyJaCf+WpMub/17aPcKk27QMl5W6f+KhdPTjlFOn5akH5Wa/DCM9Stdx5cDfmasyKB08MqpVQ1uJE2RkkpbXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.5.tgz",
+      "integrity": "sha512-+OQ8U2DdoEfXl8T4Fb18AjmEwbXMerKDKCL8yCPAYhKCEEKoul7rkbeGCBFCbAlaGaa7pmtRTpkAJM2LE/i5FA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.5.tgz",
+      "integrity": "sha512-KanvAZrPKbDBFwrgiU9yEVpQoox9QPV1WZOXX7HudJQY+eSlu82CtWxDU8WtuRRvtN5EGkLczkd6Y6DTcvm9wA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.5.tgz",
+      "integrity": "sha512-1aC3UEWTtRl3RK3VpDJ/Tqk1XI4SLTmXIthAq6wRWo8XiSXJNd+VprJM4/1P4+i6HIaFEFlVi9sTTziniD2tOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.5.tgz",
+      "integrity": "sha512-/gDJaRs4gl0NPIwqCz+6PkpmhhjRAD2j6P4rSNHBzUkO3naEx2mIU0pRle1vUNRQ7mE/+8OOeXLTv/J56FKiQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.3.tgz",
+      "integrity": "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.18.tgz",
+      "integrity": "sha512-1iEmLEYSiE1SeBoAfPo/Mnx3PzfzHUkDK61ASkCpuk3YXugYLH5DYK1SzqV55F8FMI6s0F+/tCP7Polz1QRjxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.413",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.413.tgz",
+      "integrity": "sha512-F1XPKvt7HVfly5WND90ec16nFsdr4g5x/cVUP3EqjeyXynupabGDqpMa84wwvuYGDnldXLBz6DLXyZXWO9TPvw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.27.0.tgz",
+      "integrity": "sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.2.tgz",
+      "integrity": "sha512-/peqiBB/n07gQGLsWaHho3WfvUyRscw0gYTsEFMhrIe/nWLkYaf5SbKYjGYqtRV3aPwykJgF2VEMo1ac4bnsGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.5.tgz",
+      "integrity": "sha512-/tqMfgP7GPA3PHhCmuiS4vIjrSVhHLgY++i+dhbG462euyAj7FpM4D9uq1X3BgjlqRdpcOrYhcQtfiQLNc8tqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.5",
+        "@rollup/rollup-android-arm64": "4.62.5",
+        "@rollup/rollup-darwin-arm64": "4.62.5",
+        "@rollup/rollup-darwin-x64": "4.62.5",
+        "@rollup/rollup-freebsd-arm64": "4.62.5",
+        "@rollup/rollup-freebsd-x64": "4.62.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.5",
+        "@rollup/rollup-linux-arm64-musl": "4.62.5",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.5",
+        "@rollup/rollup-linux-loong64-musl": "4.62.5",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.5",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.5",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.5",
+        "@rollup/rollup-linux-x64-gnu": "4.62.5",
+        "@rollup/rollup-linux-x64-musl": "4.62.5",
+        "@rollup/rollup-openbsd-x64": "4.62.5",
+        "@rollup/rollup-openharmony-arm64": "4.62.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.5",
+        "@rollup/rollup-win32-x64-gnu": "4.62.5",
+        "@rollup/rollup-win32-x64-msvc": "4.62.5",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/extensions/ai-research/ui/package.json
+++ b/extensions/ai-research/ui/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@modelmirror/ai-research-console",
+  "version": "0.2.0-ar1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit && vite build",
+    "typecheck": "tsc --noEmit --pretty false",
+    "test:run": "vitest run --configLoader runner"
+  },
+  "dependencies": {
+    "lucide-react": "1.27.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "react-router-dom": "6.30.4"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "7.0.0",
+    "@testing-library/react": "16.3.2",
+    "@testing-library/user-event": "14.6.3",
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "5.2.0",
+    "autoprefixer": "10.5.0",
+    "jsdom": "30.0.1",
+    "postcss": "8.5.15",
+    "tailwindcss": "3.4.19",
+    "typescript": "5.8.3",
+    "vite": "7.3.5",
+    "vitest": "4.1.6"
+  }
+}

--- a/extensions/ai-research/ui/postcss.config.cjs
+++ b/extensions/ai-research/ui/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/extensions/ai-research/ui/src/App.test.tsx
+++ b/extensions/ai-research/ui/src/App.test.tsx
@@ -1,0 +1,157 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter, MemoryRouter, RouterProvider } from "react-router-dom";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import { App } from "./App";
+
+const system = {
+  status: "ready",
+  checks: [
+    { id: "controlLedger", status: "ready", required: true },
+    { id: "worker", status: "ready", required: true },
+    { id: "tracking", status: "ready", required: true },
+    { id: "inspectView", status: "ready", required: false },
+  ],
+  checkedAt: "2026-08-24T00:00:00Z",
+};
+const createBodies: string[] = [];
+
+beforeEach(() => {
+  createBodies.length = 0;
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const path = String(input);
+    if (init?.method === "POST" && path.endsWith("/api/v1/runs")) {
+      createBodies.push(String(init.body));
+      return new Response(JSON.stringify({ detail: "模拟响应丢失" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    const body = path.includes("/system")
+      ? system
+      : path.includes("/summary")
+        ? { total: 0, phases: { queued: 0, running: 0, terminal: 0 }, outcomes: { success: 0, task_error: 0, cancelled: 0, infrastructure_error: 0 }, evidenceStates: { pending: 0, synced: 0, failed: 0 }, updatedAt: null }
+        : { items: [], nextCursor: null };
+    return new Response(JSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } });
+  }));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+test("overview states the fixture-only product boundary", async () => {
+  render(<MemoryRouter initialEntries={["/"]}><App /></MemoryRouter>);
+  expect(screen.getByRole("heading", { name: "科研执行控制台" })).toBeInTheDocument();
+  expect(screen.getByText(/不调用模型，不产生科研结论/)).toBeInTheDocument();
+  await waitFor(() => expect(screen.getByText("创建工程夹具")).toBeInTheDocument());
+});
+
+test("illegal run filter is presented as all", async () => {
+  render(<MemoryRouter initialEntries={["/runs?phase=illegal"]}><App /></MemoryRouter>);
+  expect(screen.getByLabelText("阶段")).toHaveValue("");
+  await waitFor(() => expect(screen.getByText("没有匹配当前条件的运行")).toBeInTheDocument());
+});
+
+test("search input follows browser history URL changes", async () => {
+  const router = createMemoryRouter([{ path: "*", element: <App /> }], {
+    initialEntries: ["/runs?q=first", "/runs?q=second"],
+    initialIndex: 1,
+  });
+  render(<RouterProvider router={router} />);
+  expect(screen.getByLabelText("搜索")).toHaveValue("second");
+  await router.navigate(-1);
+  await waitFor(() => expect(screen.getByLabelText("搜索")).toHaveValue("first"));
+});
+
+test("run search has an explicit submit action and updates the URL", async () => {
+  const user = userEvent.setup();
+  const router = createMemoryRouter([{ path: "*", element: <App /> }], {
+    initialEntries: ["/runs?phase=running"],
+  });
+  render(<RouterProvider router={router} />);
+
+  await user.type(screen.getByLabelText("搜索"), "FixtureTaskError");
+  await user.click(screen.getByRole("button", { name: "搜索" }));
+
+  await waitFor(() => {
+    expect(router.state.location.search).toContain("q=FixtureTaskError");
+    expect(router.state.location.search).toContain("phase=running");
+  });
+});
+
+test("cancel confirmation receives focus and Escape returns it", async () => {
+  vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+    const path = String(input);
+    const body = path.endsWith("/api/v1/runs/ar0_active")
+      ? {
+          runId: "ar0_active",
+          fixtureId: "inspect-smoke-v1",
+          caseId: "long_running_cancel",
+          tenantId: "local",
+          projectId: "local",
+          actorId: "local",
+          phase: "running",
+          outcome: null,
+          inspectStatus: "started",
+          cancelRequested: false,
+          cancelApplied: false,
+          evidenceState: "pending",
+          errorType: null,
+          errorMessage: null,
+          replayVerified: false,
+          mlflowRunId: null,
+          createdAt: "2026-08-24T00:00:00Z",
+          startedAt: "2026-08-24T00:00:01Z",
+          cancelRequestedAt: null,
+          cancelAppliedAt: null,
+          terminalAt: null,
+          evidenceSyncedAt: null,
+          updatedAt: "2026-08-24T00:00:01Z",
+        }
+      : system;
+    return new Response(JSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } });
+  });
+  const user = userEvent.setup();
+  render(<MemoryRouter initialEntries={["/runs/ar0_active"]}><App /></MemoryRouter>);
+  const trigger = await screen.findByRole("button", { name: "请求取消" });
+
+  await user.click(trigger);
+
+  const confirm = screen.getByRole("button", { name: "确认取消" });
+  expect(confirm).toHaveFocus();
+  await user.keyboard("{Escape}");
+  await waitFor(() => expect(trigger).toHaveFocus());
+  expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+});
+
+test("mobile navigation closes on Escape and returns focus to its toggle", async () => {
+  const user = userEvent.setup();
+  render(<MemoryRouter initialEntries={["/runs"]}><App /></MemoryRouter>);
+  const open = screen.getByRole("button", { name: "打开导航" });
+
+  await user.click(open);
+  const runLink = screen.getByRole("link", { name: "运行" });
+  runLink.focus();
+  await user.keyboard("{Escape}");
+
+  const closed = screen.getByRole("button", { name: "打开导航" });
+  await waitFor(() => expect(closed).toHaveFocus());
+  expect(closed).toHaveAttribute("aria-expanded", "false");
+});
+
+test("a failed create retry reuses the same idempotency key", async () => {
+  const user = userEvent.setup();
+  render(<MemoryRouter initialEntries={["/"]}><App /></MemoryRouter>);
+  const create = screen.getByRole("button", { name: "创建并查看" });
+  await waitFor(() => expect(create).toBeEnabled());
+  await user.click(create);
+  await screen.findByText("模拟响应丢失");
+  await user.click(screen.getByRole("button", { name: "创建并查看" }));
+  await waitFor(() => expect(createBodies).toHaveLength(2));
+  expect(JSON.parse(createBodies[0]).idempotencyKey).toBe(
+    JSON.parse(createBodies[1]).idempotencyKey,
+  );
+});

--- a/extensions/ai-research/ui/src/App.tsx
+++ b/extensions/ai-research/ui/src/App.tsx
@@ -1,0 +1,30 @@
+import { Route, Routes } from "react-router-dom";
+
+import { PageHeader } from "./components/Page";
+import { Shell } from "./components/Shell";
+import { OverviewPage } from "./pages/OverviewPage";
+import { RunDetailPage } from "./pages/RunDetailPage";
+import { RunEventsPage } from "./pages/RunEventsPage";
+import { RunEvidencePage } from "./pages/RunEvidencePage";
+import { RunsPage } from "./pages/RunsPage";
+import { SystemPage } from "./pages/SystemPage";
+
+function NotFoundPage() {
+  return <div className="page"><PageHeader eyebrow="404" title="页面不存在" description="该地址不属于模镜科研控制台。" /><a className="button mt-6" href="/">返回总览</a></div>;
+}
+
+export function App() {
+  return (
+    <Routes>
+      <Route element={<Shell />}>
+        <Route index element={<OverviewPage />} />
+        <Route path="runs" element={<RunsPage />} />
+        <Route path="runs/:runId" element={<RunDetailPage />} />
+        <Route path="runs/:runId/events" element={<RunEventsPage />} />
+        <Route path="runs/:runId/evidence" element={<RunEvidencePage />} />
+        <Route path="system" element={<SystemPage />} />
+        <Route path="*" element={<NotFoundPage />} />
+      </Route>
+    </Routes>
+  );
+}

--- a/extensions/ai-research/ui/src/api.ts
+++ b/extensions/ai-research/ui/src/api.ts
@@ -1,0 +1,75 @@
+import type {
+  CaseId,
+  EventList,
+  Evidence,
+  ModuleInfo,
+  Run,
+  RunList,
+  RunSummary,
+  SystemStatus,
+} from "./types";
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(path, {
+    ...init,
+    headers: { "Content-Type": "application/json", ...init?.headers },
+  });
+  if (!response.ok) {
+    let message = `请求失败（HTTP ${response.status}）`;
+    try {
+      const body = (await response.json()) as { detail?: string };
+      if (body.detail) message = body.detail;
+    } catch {
+      // The status remains the authoritative error when no JSON body exists.
+    }
+    throw new ApiError(message, response.status);
+  }
+  return (await response.json()) as T;
+}
+
+export const api = {
+  module: (signal?: AbortSignal) => request<ModuleInfo>("/api/v1/module", { signal }),
+  system: (signal?: AbortSignal) => request<SystemStatus>("/api/v1/system", { signal }),
+  summary: (signal?: AbortSignal) => request<RunSummary>("/api/v1/runs/summary", { signal }),
+  runs: (params: URLSearchParams, signal?: AbortSignal) => {
+    const query = params.toString();
+    return request<RunList>(`/api/v1/runs${query ? `?${query}` : ""}`, { signal });
+  },
+  run: (runId: string, signal?: AbortSignal) =>
+    request<Run>(`/api/v1/runs/${encodeURIComponent(runId)}`, { signal }),
+  createRun: (caseId: CaseId, idempotencyKey: string, signal?: AbortSignal) =>
+    request<Run>("/api/v1/runs", {
+      method: "POST",
+      signal,
+      body: JSON.stringify({
+        fixtureId: "inspect-smoke-v1",
+        caseId,
+        idempotencyKey,
+        tenantId: "local",
+        projectId: "local",
+        actorId: "local",
+      }),
+    }),
+  cancel: (runId: string, signal?: AbortSignal) =>
+    request<Run>(`/api/v1/runs/${encodeURIComponent(runId)}/cancel`, {
+      method: "POST",
+      signal,
+    }),
+  events: (runId: string, afterSeq: number, signal?: AbortSignal) =>
+    request<EventList>(
+      `/api/v1/runs/${encodeURIComponent(runId)}/events?afterSeq=${afterSeq}`,
+      { signal },
+    ),
+  evidence: (runId: string, signal?: AbortSignal) =>
+    request<Evidence>(`/api/v1/runs/${encodeURIComponent(runId)}/evidence`, { signal }),
+};

--- a/extensions/ai-research/ui/src/components/Page.tsx
+++ b/extensions/ai-research/ui/src/components/Page.tsx
@@ -1,0 +1,56 @@
+import { AlertCircle, Beaker } from "lucide-react";
+import type { ReactNode } from "react";
+
+export function PageHeader({
+  eyebrow,
+  title,
+  description,
+  actions,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+  actions?: ReactNode;
+}) {
+  return (
+    <header className="flex flex-wrap items-start justify-between gap-4">
+      <div>
+        <p className="eyebrow">{eyebrow}</p>
+        <h1 className="page-title">{title}</h1>
+        <p className="page-description">{description}</p>
+      </div>
+      {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+    </header>
+  );
+}
+
+export function FixtureNotice() {
+  return (
+    <div className="notice" role="note">
+      <Beaker aria-hidden="true" className="mt-1 shrink-0 text-[var(--cyan)]" size={16} />
+      <span>当前仅运行工程夹具，用于验证执行、取消与证据链；不调用模型，不产生科研结论。</span>
+    </div>
+  );
+}
+
+export function ErrorNotice({ message, onRetry }: { message: string; onRetry?: () => void }) {
+  return (
+    <div className="mt-4 flex items-start justify-between gap-4 border-l-2 border-[var(--red)] bg-[#291719] px-4 py-3 text-sm text-[#ffc2c2]" role="alert">
+      <span className="flex items-start gap-2">
+        <AlertCircle aria-hidden="true" className="mt-0.5 shrink-0" size={16} />
+        {message}
+      </span>
+      {onRetry ? (
+        <button type="button" className="shrink-0 font-semibold underline" onClick={onRetry}>重试</button>
+      ) : null}
+    </div>
+  );
+}
+
+export function LoadingRows({ count = 3 }: { count?: number }) {
+  return (
+    <div className="mt-4 grid gap-2" aria-label="正在加载" aria-busy="true">
+      {Array.from({ length: count }, (_, index) => <div className="skeleton" key={index} />)}
+    </div>
+  );
+}

--- a/extensions/ai-research/ui/src/components/RunTable.tsx
+++ b/extensions/ai-research/ui/src/components/RunTable.tsx
@@ -1,0 +1,75 @@
+import { ArrowUpRight } from "lucide-react";
+import { Link } from "react-router-dom";
+
+import type { Run } from "../types";
+import { Status, statusLabel } from "./Status";
+
+export function formatTime(value: string | null) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("zh-CN", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(new Date(value));
+}
+
+export function RunTable({ runs, empty = "暂无运行记录" }: { runs: Run[]; empty?: string }) {
+  if (runs.length === 0) {
+    return <p className="my-8 text-center text-sm text-[var(--muted)]">{empty}</p>;
+  }
+
+  return (
+    <>
+      <div className="desktop-table overflow-x-auto">
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th scope="col">运行</th>
+              <th scope="col">夹具</th>
+              <th scope="col">阶段</th>
+              <th scope="col">结果</th>
+              <th scope="col">证据</th>
+              <th scope="col">创建时间</th>
+              <th scope="col"><span className="sr-only">操作</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            {runs.map((run) => (
+              <tr key={run.runId}>
+                <td className="font-mono text-xs text-[#d5dde1]">{run.runId}</td>
+                <td>{run.caseId}</td>
+                <td><Status value={run.phase} /></td>
+                <td><Status value={run.outcome} /></td>
+                <td><Status value={run.evidenceState} /></td>
+                <td className="whitespace-nowrap text-[var(--muted)]">{formatTime(run.createdAt)}</td>
+                <td>
+                  <Link className="inline-flex items-center gap-1 text-xs font-semibold text-[var(--cyan)] hover:underline" to={`/runs/${run.runId}`}>
+                    查看 <ArrowUpRight aria-hidden="true" size={13} />
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <ol className="record-list" aria-label="运行记录">
+        {runs.map((run) => (
+          <li className="record-item" key={run.runId}>
+            <div className="flex items-start justify-between gap-3">
+              <span className="break-all font-mono text-xs text-[#dce3e7]">{run.runId}</span>
+              <Link className="shrink-0 text-xs font-semibold text-[var(--cyan)]" to={`/runs/${run.runId}`}>
+                查看
+              </Link>
+            </div>
+            <div className="flex flex-wrap gap-2"><Status value={run.phase} /><Status value={run.outcome} /></div>
+            <span className="text-xs text-[var(--muted)]">
+              {run.caseId} · {statusLabel(run.evidenceState)} · {formatTime(run.createdAt)}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </>
+  );
+}

--- a/extensions/ai-research/ui/src/components/Shell.tsx
+++ b/extensions/ai-research/ui/src/components/Shell.tsx
@@ -1,0 +1,79 @@
+import { Activity, Beaker, ListTree, Menu, ServerCog, X } from "lucide-react";
+import { useRef, useState } from "react";
+import { NavLink, Outlet } from "react-router-dom";
+
+const links = [
+  { to: "/", label: "总览", icon: Activity, end: true },
+  { to: "/runs", label: "运行", icon: ListTree, end: false },
+  { to: "/system", label: "系统", icon: ServerCog, end: false },
+];
+
+export function Shell() {
+  const [open, setOpen] = useState(false);
+  const navigationToggle = useRef<HTMLButtonElement>(null);
+
+  const closeWithFocusReturn = () => {
+    setOpen(false);
+    requestAnimationFrame(() => navigationToggle.current?.focus());
+  };
+
+  return (
+    <div className="app-shell">
+      <aside className="sidebar" onKeyDown={(event) => { if (event.key === "Escape" && open) closeWithFocusReturn(); }}>
+        <div className="flex min-h-[66px] items-center justify-between border-b border-[var(--border)] px-4">
+          <NavLink to="/" className="flex min-w-0 items-center gap-3" onClick={() => setOpen(false)}>
+            <span className="grid h-8 w-8 shrink-0 place-items-center border border-[#3e7777] bg-[#102829] text-[var(--cyan)]">
+              <Beaker aria-hidden="true" size={17} />
+            </span>
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-semibold text-white">模镜科研</span>
+              <span className="block text-[10px] uppercase tracking-[0.12em] text-[var(--muted)]">
+                Research Console
+              </span>
+            </span>
+          </NavLink>
+          <button
+            ref={navigationToggle}
+            type="button"
+            className="button !min-h-9 !border-0 !p-2 md:hidden"
+            aria-label={open ? "关闭导航" : "打开导航"}
+            aria-expanded={open}
+            aria-controls="research-console-navigation"
+            onClick={() => setOpen((value) => !value)}
+          >
+            {open ? <X size={18} /> : <Menu size={18} />}
+          </button>
+        </div>
+
+        <nav id="research-console-navigation" className={`${open ? "flex" : "hidden"} flex-col gap-1 p-3 md:flex`} aria-label="科研控制台">
+          {links.map(({ to, label, icon: Icon, end }) => (
+            <NavLink
+              key={to}
+              to={to}
+              end={end}
+              onClick={() => setOpen(false)}
+              className={({ isActive }) =>
+                `flex min-h-10 items-center gap-3 rounded-[5px] px-3 text-sm font-medium transition-colors ${
+                  isActive
+                    ? "bg-[var(--cyan-soft)] text-[#b8efec]"
+                    : "text-[#aab3ba] hover:bg-white/[0.035] hover:text-white"
+                }`
+              }
+            >
+              <Icon aria-hidden="true" size={16} />
+              {label}
+            </NavLink>
+          ))}
+        </nav>
+
+        <div className={`${open ? "block" : "hidden"} mt-auto border-t border-[var(--border)] p-4 text-xs leading-5 text-[var(--muted)] md:block`}>
+          <span className="block font-semibold text-[#bdc7cd]">0.2.0-ar1</span>
+          fixture_only · harness_only
+        </div>
+      </aside>
+      <main className="main-column" id="main-content">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/extensions/ai-research/ui/src/components/Status.tsx
+++ b/extensions/ai-research/ui/src/components/Status.tsx
@@ -1,0 +1,51 @@
+import { AlertTriangle, CheckCircle2, CircleDashed, Clock3, XCircle } from "lucide-react";
+
+const labels: Record<string, string> = {
+  ready: "就绪",
+  degraded: "降级",
+  not_ready: "未就绪",
+  queued: "排队中",
+  running: "运行中",
+  terminal: "已终止",
+  success: "成功",
+  task_error: "任务错误",
+  cancelled: "已取消",
+  infrastructure_error: "基础设施错误",
+  pending: "待同步",
+  synced: "已同步",
+  failed: "失败",
+  verified: "完整性已验证",
+  started: "已启动",
+  error: "错误",
+};
+
+function tone(value: string) {
+  if (["ready", "success", "synced", "verified"].includes(value)) {
+    return { className: "border-[#275c43] bg-[#10291d] text-[#91e0af]", Icon: CheckCircle2 };
+  }
+  if (["degraded", "queued", "pending", "started"].includes(value)) {
+    return { className: "border-[#6b572a] bg-[#2b2414] text-[#f2cf83]", Icon: Clock3 };
+  }
+  if (["running"].includes(value)) {
+    return { className: "border-[#286264] bg-[#102c2e] text-[#83ddda]", Icon: CircleDashed };
+  }
+  if (["not_ready", "task_error", "infrastructure_error", "failed", "error"].includes(value)) {
+    return { className: "border-[#704044] bg-[#2b1719] text-[#f2a2a2]", Icon: XCircle };
+  }
+  return { className: "border-[var(--border-strong)] bg-[#171b20] text-[#c1c9ce]", Icon: AlertTriangle };
+}
+
+export function Status({ value, label }: { value: string | null; label?: string }) {
+  if (!value) return <span className="text-[var(--muted)]">—</span>;
+  const { className, Icon } = tone(value);
+  return (
+    <span className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-1 text-xs font-semibold ${className}`}>
+      <Icon aria-hidden="true" size={13} />
+      {label ?? labels[value] ?? value}
+    </span>
+  );
+}
+
+export function statusLabel(value: string | null) {
+  return value ? labels[value] ?? value : "—";
+}

--- a/extensions/ai-research/ui/src/hooks/usePolling.test.tsx
+++ b/extensions/ai-research/ui/src/hooks/usePolling.test.tsx
@@ -1,0 +1,63 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+
+import { usePolling } from "./usePolling";
+
+function Probe({ loader }: { loader: (signal: AbortSignal) => Promise<number> }) {
+  const state = usePolling(loader, 1_000);
+  return <output>{state.data ?? "empty"}</output>;
+}
+
+function TerminalProbe({ loader }: { loader: (signal: AbortSignal) => Promise<number> }) {
+  const state = usePolling(loader, 1_000, true, () => false);
+  return <output>{state.data ?? "empty"}</output>;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+});
+
+test("polling pauses while hidden and resumes immediately when visible", async () => {
+  vi.useFakeTimers();
+  const loader = vi.fn(async () => loader.mock.calls.length);
+  render(<Probe loader={loader} />);
+  await act(() => vi.advanceTimersByTimeAsync(0));
+  expect(loader).toHaveBeenCalledTimes(1);
+  expect(screen.getByText("1")).toBeInTheDocument();
+
+  Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+  document.dispatchEvent(new Event("visibilitychange"));
+  await act(() => vi.advanceTimersByTimeAsync(5_000));
+  expect(loader).toHaveBeenCalledTimes(1);
+
+  Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+  document.dispatchEvent(new Event("visibilitychange"));
+  await act(() => vi.advanceTimersByTimeAsync(0));
+  expect(loader).toHaveBeenCalledTimes(2);
+});
+
+test("polling aborts an in-flight request during cleanup", async () => {
+  vi.useFakeTimers();
+  let observedSignal: AbortSignal | undefined;
+  const loader = vi.fn((signal: AbortSignal) => {
+    observedSignal = signal;
+    return new Promise<number>(() => undefined);
+  });
+  const view = render(<Probe loader={loader} />);
+  await act(() => vi.advanceTimersByTimeAsync(0));
+  expect(observedSignal?.aborted).toBe(false);
+  view.unmount();
+  expect(observedSignal?.aborted).toBe(true);
+});
+
+test("polling stops scheduling after a terminal value", async () => {
+  vi.useFakeTimers();
+  const loader = vi.fn(async () => 1);
+  render(<TerminalProbe loader={loader} />);
+  await act(() => vi.advanceTimersByTimeAsync(0));
+  expect(screen.getByText("1")).toBeInTheDocument();
+  await act(() => vi.advanceTimersByTimeAsync(5_000));
+  expect(loader).toHaveBeenCalledTimes(1);
+});

--- a/extensions/ai-research/ui/src/hooks/usePolling.ts
+++ b/extensions/ai-research/ui/src/hooks/usePolling.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface PollingState<T> {
+  data: T | null;
+  error: Error | null;
+  loading: boolean;
+  refreshing: boolean;
+  refresh: () => void;
+}
+
+export function usePolling<T>(
+  loader: (signal: AbortSignal) => Promise<T>,
+  intervalMs: number,
+  enabled = true,
+  shouldContinue: (value: T) => boolean = () => true,
+): PollingState<T> {
+  const loaderRef = useRef(loader);
+  const shouldContinueRef = useRef(shouldContinue);
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(enabled);
+  const [refreshing, setRefreshing] = useState(false);
+  const [revision, setRevision] = useState(0);
+
+  useEffect(() => {
+    loaderRef.current = loader;
+    shouldContinueRef.current = shouldContinue;
+  }, [loader, shouldContinue]);
+
+  const refresh = useCallback(() => setRevision((value) => value + 1), []);
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      setRefreshing(false);
+      return;
+    }
+
+    let disposed = false;
+    let timer: number | undefined;
+    let failureCount = 0;
+    let controller: AbortController | null = null;
+
+    const schedule = (delay: number) => {
+      window.clearTimeout(timer);
+      timer = window.setTimeout(run, delay);
+    };
+
+    const run = async () => {
+      if (disposed || document.visibilityState === "hidden") return;
+      controller?.abort();
+      controller = new AbortController();
+      setRefreshing(true);
+      try {
+        const value = await loaderRef.current(controller.signal);
+        if (disposed) return;
+        failureCount = 0;
+        setData(value);
+        setError(null);
+        setLoading(false);
+        setRefreshing(false);
+        if (shouldContinueRef.current(value)) schedule(intervalMs);
+      } catch (caught) {
+        if (disposed || controller.signal.aborted) return;
+        failureCount += 1;
+        setError(caught instanceof Error ? caught : new Error("未知请求错误"));
+        setLoading(false);
+        setRefreshing(false);
+        schedule(Math.min(intervalMs * 2 ** failureCount, 30_000));
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        window.clearTimeout(timer);
+        controller?.abort();
+      } else {
+        schedule(0);
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    schedule(0);
+    return () => {
+      disposed = true;
+      window.clearTimeout(timer);
+      controller?.abort();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [enabled, intervalMs, revision]);
+
+  return { data, error, loading, refreshing, refresh };
+}

--- a/extensions/ai-research/ui/src/main.tsx
+++ b/extensions/ai-research/ui/src/main.tsx
@@ -1,0 +1,20 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+
+import { App } from "./App";
+import "./styles.css";
+
+const root = document.getElementById("root");
+
+if (!root) {
+  throw new Error("Research Console root element is missing");
+}
+
+createRoot(root).render(
+  <StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </StrictMode>,
+);

--- a/extensions/ai-research/ui/src/pages/OverviewPage.tsx
+++ b/extensions/ai-research/ui/src/pages/OverviewPage.tsx
@@ -1,0 +1,115 @@
+import { ArrowRight, Play, RefreshCw } from "lucide-react";
+import { FormEvent, useCallback, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+import { ApiError, api } from "../api";
+import { ErrorNotice, FixtureNotice, LoadingRows, PageHeader } from "../components/Page";
+import { RunTable } from "../components/RunTable";
+import { Status } from "../components/Status";
+import { usePolling } from "../hooks/usePolling";
+import type { CaseId } from "../types";
+
+const cases: { id: CaseId; label: string; description: string }[] = [
+  { id: "success", label: "成功夹具", description: "验证正常执行、日志与证据同步。" },
+  { id: "task_error", label: "任务错误夹具", description: "验证退出码与 Inspect 原始终态分离。" },
+  { id: "long_running_cancel", label: "长运行取消夹具", description: "验证取消意图、受理事实与终态保留。" },
+];
+
+export function OverviewPage() {
+  const navigate = useNavigate();
+  const [caseId, setCaseId] = useState<CaseId>("success");
+  const [submitting, setSubmitting] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const idempotencyKey = useRef<string | null>(null);
+  const system = usePolling(useCallback((signal: AbortSignal) => api.system(signal), []), 10_000);
+  const summary = usePolling(useCallback((signal: AbortSignal) => api.summary(signal), []), 5_000);
+  const recent = usePolling(
+    useCallback((signal: AbortSignal) => api.runs(new URLSearchParams({ limit: "5" }), signal), []),
+    5_000,
+  );
+  const creationBlocked = !system.data || system.data.status === "not_ready";
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (submitting || creationBlocked) return;
+    setSubmitting(true);
+    setCreateError(null);
+    idempotencyKey.current ??= `console:${crypto.randomUUID()}`;
+    try {
+      const run = await api.createRun(caseId, idempotencyKey.current);
+      idempotencyKey.current = null;
+      navigate(`/runs/${run.runId}`);
+    } catch (caught) {
+      setCreateError(caught instanceof ApiError ? caught.message : "创建请求未完成，请使用同一请求重试。 ");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="page">
+      <PageHeader eyebrow="AI Research / AR1" title="科研执行控制台" description="从受控夹具创建到 Inspect 原始终态、证据完整性与 MLflow 记录，集中查看工程闭环。" />
+      <FixtureNotice />
+
+      <section className="section" aria-labelledby="dependency-title">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="section-title" id="dependency-title">依赖状态</h2>
+          <Status value={system.data?.status ?? "not_ready"} />
+        </div>
+        {system.loading ? <LoadingRows count={1} /> : null}
+        {system.error ? <ErrorNotice message={system.error.message} onRetry={system.refresh} /> : null}
+        {system.data ? (
+          <ul className="mt-4 grid gap-px bg-[var(--border)] sm:grid-cols-2 lg:grid-cols-4">
+            {system.data.checks.map((check) => (
+              <li className="flex items-center justify-between gap-3 bg-[var(--surface)] px-3 py-3" key={check.id}>
+                <span className="text-sm text-[#c8d0d5]">{check.id}</span>
+                <Status value={check.status} label={check.required ? undefined : `${check.status === "ready" ? "就绪" : "离线"} · 可选`} />
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </section>
+
+      <section className="section" aria-labelledby="summary-title">
+        <h2 className="section-title" id="summary-title">运行摘要</h2>
+        {summary.data ? (
+          <dl className="mt-4 grid gap-px bg-[var(--border)] sm:grid-cols-4">
+            <div className="bg-[var(--surface)] p-4"><dt className="text-xs text-[var(--muted)]">全部</dt><dd className="mt-1 text-xl font-semibold">{summary.data.total}</dd></div>
+            <div className="bg-[var(--surface)] p-4"><dt className="text-xs text-[var(--muted)]">运行中</dt><dd className="mt-1 text-xl font-semibold">{summary.data.phases.running}</dd></div>
+            <div className="bg-[var(--surface)] p-4"><dt className="text-xs text-[var(--muted)]">成功</dt><dd className="mt-1 text-xl font-semibold">{summary.data.outcomes.success}</dd></div>
+            <div className="bg-[var(--surface)] p-4"><dt className="text-xs text-[var(--muted)]">证据待处理</dt><dd className="mt-1 text-xl font-semibold">{summary.data.evidenceStates.pending + summary.data.evidenceStates.failed}</dd></div>
+          </dl>
+        ) : summary.error ? <ErrorNotice message={summary.error.message} onRetry={summary.refresh} /> : <LoadingRows count={1} />}
+      </section>
+
+      <section className="section" aria-labelledby="create-title">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className="section-title" id="create-title">创建工程夹具</h2>
+          {creationBlocked ? <span className="text-xs text-[var(--amber)]">必需依赖未就绪，当前禁止创建</span> : null}
+        </div>
+        <form className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end" onSubmit={submit}>
+          <label className="field-label">
+            夹具场景
+            <select className="field" value={caseId} onChange={(event) => { setCaseId(event.target.value as CaseId); idempotencyKey.current = null; }}>
+              {cases.map((item) => <option key={item.id} value={item.id}>{item.label} — {item.description}</option>)}
+            </select>
+          </label>
+          <button className="button button-primary" type="submit" disabled={submitting || creationBlocked}>
+            {submitting ? <RefreshCw aria-hidden="true" className="animate-spin" size={16} /> : <Play aria-hidden="true" size={16} />}
+            {submitting ? "正在创建" : "创建并查看"}
+          </button>
+        </form>
+        {createError ? <ErrorNotice message={createError} /> : null}
+      </section>
+
+      <section className="section" aria-labelledby="recent-title">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="section-title" id="recent-title">最近运行</h2>
+          <Link className="inline-flex items-center gap-1 text-xs font-semibold text-[var(--cyan)] hover:underline" to="/runs">全部运行 <ArrowRight aria-hidden="true" size={14} /></Link>
+        </div>
+        {recent.data ? <RunTable runs={recent.data.items} /> : recent.error ? <ErrorNotice message={recent.error.message} onRetry={recent.refresh} /> : <LoadingRows />}
+      </section>
+      <p className="sr-only" aria-live="polite">{system.refreshing || recent.refreshing ? "状态正在更新" : "状态已更新"}</p>
+    </div>
+  );
+}

--- a/extensions/ai-research/ui/src/pages/RunDetailPage.tsx
+++ b/extensions/ai-research/ui/src/pages/RunDetailPage.tsx
@@ -1,0 +1,96 @@
+import { Ban, ExternalLink } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, NavLink, useParams } from "react-router-dom";
+
+import { api } from "../api";
+import { ErrorNotice, LoadingRows, PageHeader } from "../components/Page";
+import { formatTime } from "../components/RunTable";
+import { Status } from "../components/Status";
+import { usePolling } from "../hooks/usePolling";
+
+export function RunDetailPage() {
+  const { runId = "" } = useParams();
+  const [confirming, setConfirming] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+  const cancelButton = useRef<HTMLButtonElement>(null);
+  const confirmCancelButton = useRef<HTMLButtonElement>(null);
+  const run = usePolling(
+    useCallback((signal: AbortSignal) => api.run(runId, signal), [runId]),
+    2_000,
+    true,
+    (value) => value.phase !== "terminal",
+  );
+
+  useEffect(() => {
+    if (confirming) confirmCancelButton.current?.focus();
+  }, [confirming]);
+
+  const dismissConfirmation = () => {
+    setConfirming(false);
+    requestAnimationFrame(() => cancelButton.current?.focus());
+  };
+
+  const cancel = async () => {
+    setCancelling(true);
+    setCancelError(null);
+    try {
+      await api.cancel(runId);
+      setConfirming(false);
+      run.refresh();
+      requestAnimationFrame(() => cancelButton.current?.focus());
+    } catch (caught) {
+      setCancelError(caught instanceof Error ? caught.message : "取消请求失败");
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  return (
+    <div className="page">
+      <PageHeader
+        eyebrow="Run detail"
+        title="运行详情"
+        description={runId}
+        actions={run.data?.phase !== "terminal" ? (
+          <button ref={cancelButton} className="button button-danger" type="button" onClick={() => setConfirming(true)}><Ban aria-hidden="true" size={15} />请求取消</button>
+        ) : undefined}
+      />
+      <nav className="mt-5 flex flex-wrap gap-1 border-b border-[var(--border)]" aria-label="运行详情页面">
+        {[
+          ["", "概览"], ["events", "事件"], ["evidence", "证据"],
+        ].map(([path, label]) => (
+          <NavLink end={path === ""} key={path} to={path || "."} className={({ isActive }) => `border-b-2 px-3 py-2 text-sm font-semibold ${isActive ? "border-[var(--cyan)] text-white" : "border-transparent text-[var(--muted)] hover:text-white"}`}>{label}</NavLink>
+        ))}
+      </nav>
+
+      {confirming ? (
+        <div className="mt-5 flex flex-wrap items-center justify-between gap-4 border border-[#6c4a32] bg-[#241c13] px-4 py-3" role="alertdialog" aria-labelledby="cancel-title" aria-describedby="cancel-description" onKeyDown={(event) => { if (event.key === "Escape" && !cancelling) dismissConfirmation(); }}>
+          <div><h2 className="text-sm font-semibold text-[#ffd79a]" id="cancel-title">确认请求取消？</h2><p className="mt-1 text-xs text-[#c7b89f]" id="cancel-description">控制面会记录取消意图；Inspect 是否受理将作为独立事实保留。</p></div>
+          <div className="flex gap-2"><button className="button" type="button" onClick={dismissConfirmation}>返回</button><button ref={confirmCancelButton} className="button button-danger" disabled={cancelling} type="button" onClick={cancel}>{cancelling ? "正在请求" : "确认取消"}</button></div>
+        </div>
+      ) : null}
+      {cancelError ? <ErrorNotice message={cancelError} /> : null}
+
+      {run.data ? (
+        <>
+          <section className="section" aria-labelledby="lifecycle-title">
+            <div className="flex flex-wrap items-center justify-between gap-3"><h2 className="section-title" id="lifecycle-title">生命周期</h2><div className="flex flex-wrap gap-2"><Status value={run.data.phase} /><Status value={run.data.outcome} /></div></div>
+            <dl className="definition-grid mt-3">
+              <div className="definition-row"><dt>夹具</dt><dd>{run.data.caseId}</dd></div>
+              <div className="definition-row"><dt>Inspect 原始状态</dt><dd><Status value={run.data.inspectStatus} /></dd></div>
+              <div className="definition-row"><dt>创建</dt><dd>{formatTime(run.data.createdAt)}</dd></div>
+              <div className="definition-row"><dt>开始</dt><dd>{formatTime(run.data.startedAt)}</dd></div>
+              <div className="definition-row"><dt>终止</dt><dd>{formatTime(run.data.terminalAt)}</dd></div>
+              <div className="definition-row"><dt>证据同步</dt><dd>{formatTime(run.data.evidenceSyncedAt)}</dd></div>
+            </dl>
+          </section>
+          <section className="section" aria-labelledby="cancel-facts-title"><h2 className="section-title" id="cancel-facts-title">取消事实</h2><dl className="definition-grid mt-3"><div className="definition-row"><dt>已请求</dt><dd>{run.data.cancelRequested ? `是 · ${formatTime(run.data.cancelRequestedAt)}` : "否"}</dd></div><div className="definition-row"><dt>Inspect 已受理</dt><dd>{run.data.cancelApplied ? `是 · ${formatTime(run.data.cancelAppliedAt)}` : "否"}</dd></div></dl></section>
+          <section className="section" aria-labelledby="error-title"><h2 className="section-title" id="error-title">错误与标识</h2><dl className="definition-grid mt-3"><div className="definition-row"><dt>错误类型</dt><dd>{run.data.errorType ?? "—"}</dd></div><div className="definition-row"><dt>错误信息</dt><dd>{run.data.errorMessage ?? "—"}</dd></div><div className="definition-row"><dt>MLflow Run</dt><dd>{run.data.mlflowRunId ?? "—"}</dd></div><div className="definition-row"><dt>配置重放</dt><dd>{run.data.replayVerified ? "已验证" : "未验证"}</dd></div></dl></section>
+          <div className="mt-6 flex flex-wrap gap-2"><Link className="button" to="events">查看事件</Link><Link className="button" to="evidence">检查证据 <ExternalLink aria-hidden="true" size={14} /></Link></div>
+        </>
+      ) : run.error ? <ErrorNotice message={run.error.message} onRetry={run.refresh} /> : <LoadingRows count={5} />}
+      <p className="sr-only" aria-live="polite">{run.refreshing ? "运行状态正在更新" : "运行状态已更新"}</p>
+    </div>
+  );
+}

--- a/extensions/ai-research/ui/src/pages/RunEventsPage.test.ts
+++ b/extensions/ai-research/ui/src/pages/RunEventsPage.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest";
+
+import { groupTimelineEvents } from "./RunEventsPage";
+import type { RunEvent } from "../types";
+
+function event(sequence: number, eventType: string): RunEvent {
+  return { sequence, eventType, payload: { sequence }, createdAt: `2026-08-24T00:00:0${sequence}Z` };
+}
+
+test("only consecutive worker updates are grouped and remain individually available", () => {
+  const grouped = groupTimelineEvents([
+    event(1, "run.queued"),
+    event(2, "run.worker_update"),
+    event(3, "run.worker_update"),
+    event(4, "run.cancel_requested"),
+    event(5, "run.worker_update"),
+  ]);
+
+  expect(grouped.map((items) => items.map((item) => item.sequence))).toEqual([
+    [1],
+    [2, 3],
+    [4],
+    [5],
+  ]);
+});

--- a/extensions/ai-research/ui/src/pages/RunEventsPage.tsx
+++ b/extensions/ai-research/ui/src/pages/RunEventsPage.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { api } from "../api";
+import { ErrorNotice, LoadingRows, PageHeader } from "../components/Page";
+import { formatTime } from "../components/RunTable";
+import { usePolling } from "../hooks/usePolling";
+import type { RunEvent } from "../types";
+
+export function groupTimelineEvents(events: RunEvent[]): RunEvent[][] {
+  return events.reduce<RunEvent[][]>((groups, event) => {
+    const current = groups.at(-1);
+    if (event.eventType === "run.worker_update" && current?.at(-1)?.eventType === event.eventType) {
+      current.push(event);
+    } else {
+      groups.push([event]);
+    }
+    return groups;
+  }, []);
+}
+
+export function RunEventsPage() {
+  const { runId = "" } = useParams();
+  const [events, setEvents] = useState<RunEvent[]>([]);
+  const nextSequence = useRef(0);
+  const batch = usePolling(
+    useCallback((signal: AbortSignal) => api.events(runId, nextSequence.current, signal), [runId]),
+    2_000,
+  );
+
+  useEffect(() => {
+    setEvents([]);
+    nextSequence.current = 0;
+  }, [runId]);
+
+  useEffect(() => {
+    if (!batch.data) return;
+    nextSequence.current = Math.max(nextSequence.current, batch.data.nextSequence);
+    setEvents((current) => {
+      const bySequence = new Map(current.map((event) => [event.sequence, event]));
+      batch.data?.items.forEach((event) => bySequence.set(event.sequence, event));
+      return [...bySequence.values()].sort((left, right) => left.sequence - right.sequence);
+    });
+  }, [batch.data]);
+  const timeline = useMemo(() => groupTimelineEvents(events), [events]);
+
+  return (
+    <div className="page">
+      <PageHeader eyebrow="Run events" title="持久事件时间线" description={`${runId} · 按序增量轮询，不使用临时流连接。`} actions={<Link className="button" to={`/runs/${runId}`}>返回详情</Link>} />
+      <section className="section" aria-labelledby="timeline-title">
+        <div className="flex items-center justify-between gap-3"><h2 className="section-title" id="timeline-title">事件</h2><span className="text-xs text-[var(--muted)]">afterSeq {nextSequence.current}</span></div>
+        {events.length ? (
+          <ol className="relative mt-5 border-l border-[var(--border-strong)] pl-5">
+            {timeline.map((group) => {
+              const event = group[0];
+              const last = group.at(-1) ?? event;
+              const grouped = group.length > 1;
+              return (
+              <li className="relative pb-7" key={event.sequence}>
+                <span className="absolute -left-[25px] top-1 h-2 w-2 rounded-full bg-[var(--cyan)] ring-4 ring-[#10282a]" aria-hidden="true" />
+                <div className="flex flex-wrap items-baseline justify-between gap-2"><h3 className="font-mono text-sm font-semibold text-[#dce6e9]">{grouped ? `${event.sequence}–${last.sequence}. ${event.eventType} · ${group.length} 次` : `${event.sequence}. ${event.eventType}`}</h3><time className="text-xs text-[var(--muted)]">{formatTime(last.createdAt)}</time></div>
+                {grouped ? (
+                  <details className="mt-3 border-l border-[var(--border)] pl-3">
+                    <summary className="cursor-pointer text-xs font-semibold text-[var(--cyan)]">展开 {group.length} 条原始事件</summary>
+                    <ol className="mt-3 space-y-3">
+                      {group.map((item) => <li key={item.sequence}><p className="font-mono text-xs text-[var(--muted)]">#{item.sequence} · {formatTime(item.createdAt)}</p>{Object.keys(item.payload).length ? <pre className="code-block mt-2">{JSON.stringify(item.payload, null, 2)}</pre> : <p className="mt-2 text-xs text-[var(--muted)]">无附加载荷</p>}</li>)}
+                    </ol>
+                  </details>
+                ) : Object.keys(event.payload).length ? <pre className="code-block mt-3">{JSON.stringify(event.payload, null, 2)}</pre> : <p className="mt-2 text-xs text-[var(--muted)]">无附加载荷</p>}
+              </li>
+              );
+            })}
+          </ol>
+        ) : batch.loading ? <LoadingRows count={4} /> : batch.error ? <ErrorNotice message={batch.error.message} onRetry={batch.refresh} /> : <p className="my-8 text-center text-sm text-[var(--muted)]">尚无持久事件</p>}
+        <p className="sr-only" aria-live="polite">已加载 {events.length} 个事件</p>
+      </section>
+    </div>
+  );
+}

--- a/extensions/ai-research/ui/src/pages/RunEvidencePage.tsx
+++ b/extensions/ai-research/ui/src/pages/RunEvidencePage.tsx
@@ -1,0 +1,70 @@
+import { Download, ExternalLink, ShieldCheck } from "lucide-react";
+import { useCallback } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { api } from "../api";
+import { ErrorNotice, LoadingRows, PageHeader } from "../components/Page";
+import { formatTime } from "../components/RunTable";
+import { Status } from "../components/Status";
+import { usePolling } from "../hooks/usePolling";
+
+export function RunEvidencePage() {
+  const { runId = "" } = useParams();
+  const evidence = usePolling(
+    useCallback((signal: AbortSignal) => api.evidence(runId, signal), [runId]),
+    2_000,
+  );
+  const module = usePolling(useCallback((signal: AbortSignal) => api.module(signal), []), 60_000);
+  const receipt = evidence.data?.receipt;
+
+  return (
+    <div className="page">
+      <PageHeader eyebrow="Evidence" title="证据与完整性" description={`${runId} · 每次读取和下载都重新验证账本 receipt 与本地制品。`} actions={<Link className="button" to={`/runs/${runId}`}>返回详情</Link>} />
+      {evidence.data ? (
+        <>
+          <section className="section" aria-labelledby="integrity-title">
+            <div className="flex flex-wrap items-center justify-between gap-3"><h2 className="section-title" id="integrity-title">实时完整性</h2><Status value={evidence.data.integrityStatus} /></div>
+            <dl className="definition-grid mt-3">
+              <div className="definition-row"><dt>账本证据状态</dt><dd><Status value={evidence.data.evidenceState} /></dd></div>
+              <div className="definition-row"><dt>本次验证时间</dt><dd>{formatTime(evidence.data.verifiedAt)}</dd></div>
+              <div className="definition-row"><dt>Outbox</dt><dd>{String(evidence.data.outbox?.state ?? "尚未创建")}</dd></div>
+              <div className="definition-row"><dt>重试次数</dt><dd>{String(evidence.data.outbox?.attemptCount ?? 0)}</dd></div>
+            </dl>
+            {evidence.data.integrityError ? <ErrorNotice message={evidence.data.integrityError} /> : null}
+          </section>
+
+          <section className="section" aria-labelledby="artifact-title">
+            <h2 className="section-title" id="artifact-title">Artifact 清单</h2>
+            {evidence.data.artifacts.length ? (
+              <ul className="mt-4 divide-y divide-[var(--border)] border-y border-[var(--border)]">
+                {evidence.data.artifacts.map((artifact) => (
+                  <li className="flex flex-wrap items-center justify-between gap-3 py-3" key={artifact.name}>
+                    <div className="min-w-0"><p className="font-mono text-sm text-[#dfe7ea]">{artifact.name}</p><p className="mt-1 break-all font-mono text-[10px] text-[var(--muted)]">SHA-256 {artifact.sha256} · {artifact.sizeBytes} bytes</p></div>
+                    <a className="button" download href={artifact.downloadUrl}><Download aria-hidden="true" size={14} />下载并复验</a>
+                  </li>
+                ))}
+              </ul>
+            ) : <p className="my-7 text-sm text-[var(--muted)]">receipt 尚未登记可下载制品。</p>}
+          </section>
+
+          <section className="section" aria-labelledby="external-title">
+            <h2 className="section-title" id="external-title">复核入口</h2>
+            <p className="mt-2 text-sm leading-6 text-[var(--muted)]">入口仅绑定本机回环地址。Inspect View 为只读可选服务；MLflow 展示同步后的工程记录。</p>
+            <p className="mt-3 border-l-2 border-[#826b36] pl-3 text-xs leading-5 text-[#c8b98f]">MLflow 是本机上游开发界面，可修改其自身记录；生命周期与证据判定以 Control Ledger 和 canonical receipt 为准。</p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {module.data ? <a className="button" href={module.data.links.inspectView} target="_blank" rel="noopener noreferrer">Inspect View <ExternalLink aria-hidden="true" size={14} /></a> : null}
+              {module.data ? <a className="button" href={module.data.links.mlflow} target="_blank" rel="noopener noreferrer">打开 MLflow 开发界面 <ExternalLink aria-hidden="true" size={14} /></a> : null}
+            </div>
+            <dl className="definition-grid mt-3"><div className="definition-row"><dt>Experiment</dt><dd>{evidence.data.mlflow.experimentId ?? "—"}</dd></div><div className="definition-row"><dt>Run</dt><dd>{evidence.data.mlflow.runId ?? "—"}</dd></div><div className="definition-row"><dt>Trace</dt><dd>{evidence.data.mlflow.traceId ?? "—"}</dd></div></dl>
+          </section>
+
+          <section className="section" aria-labelledby="receipt-title">
+            <div className="flex items-center gap-2"><ShieldCheck aria-hidden="true" className="text-[var(--cyan)]" size={17} /><h2 className="section-title" id="receipt-title">Canonical receipt</h2></div>
+            {receipt ? <pre className="code-block mt-4">{JSON.stringify(receipt, null, 2)}</pre> : <p className="my-7 text-sm text-[var(--muted)]">运行尚未生成 receipt。</p>}
+          </section>
+        </>
+      ) : evidence.error ? <ErrorNotice message={evidence.error.message} onRetry={evidence.refresh} /> : <LoadingRows count={6} />}
+      <p className="sr-only" aria-live="polite">{evidence.refreshing ? "正在重新验证证据" : "证据验证已更新"}</p>
+    </div>
+  );
+}

--- a/extensions/ai-research/ui/src/pages/RunsPage.tsx
+++ b/extensions/ai-research/ui/src/pages/RunsPage.tsx
@@ -1,0 +1,99 @@
+import { RotateCcw, Search } from "lucide-react";
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+import { api } from "../api";
+import { ErrorNotice, LoadingRows, PageHeader } from "../components/Page";
+import { RunTable } from "../components/RunTable";
+import { usePolling } from "../hooks/usePolling";
+import type { CaseId, EvidenceState, Outcome, Phase } from "../types";
+
+const known = ["q", "caseId", "phase", "outcome", "evidenceState", "cursor"] as const;
+const cases = new Set<CaseId>(["success", "task_error", "long_running_cancel"]);
+const phases = new Set<Phase>(["queued", "running", "terminal"]);
+const outcomes = new Set<Outcome>(["success", "task_error", "cancelled", "infrastructure_error"]);
+const evidence = new Set<EvidenceState>(["pending", "synced", "failed"]);
+
+function legal<T extends string>(value: string | null, values: Set<T>): T | "" {
+  return value && values.has(value as T) ? (value as T) : "";
+}
+
+export function RunsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const q = (searchParams.get("q") ?? "").slice(0, 100);
+  const [draft, setDraft] = useState(q);
+  useEffect(() => setDraft(q), [q]);
+  const filters = {
+    caseId: legal(searchParams.get("caseId"), cases),
+    phase: legal(searchParams.get("phase"), phases),
+    outcome: legal(searchParams.get("outcome"), outcomes),
+    evidenceState: legal(searchParams.get("evidenceState"), evidence),
+  };
+  const apiParams = useMemo(() => {
+    const next = new URLSearchParams();
+    if (q) next.set("q", q);
+    for (const [key, value] of Object.entries(filters)) if (value) next.set(key, value);
+    const cursor = searchParams.get("cursor");
+    if (cursor) next.set("cursor", cursor);
+    next.set("limit", "25");
+    return next;
+  }, [q, filters.caseId, filters.phase, filters.outcome, filters.evidenceState, searchParams]);
+  const runs = usePolling(
+    useCallback((signal: AbortSignal) => api.runs(apiParams, signal), [apiParams]),
+    5_000,
+  );
+
+  const setFilter = (key: string, value: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (value) next.set(key, value); else next.delete(key);
+    if (key !== "cursor") next.delete("cursor");
+    setSearchParams(next);
+  };
+
+  const submitSearch = (event: FormEvent) => {
+    event.preventDefault();
+    setFilter("q", draft.trim().slice(0, 100));
+  };
+
+  const clear = () => {
+    const next = new URLSearchParams(searchParams);
+    known.forEach((key) => next.delete(key));
+    setDraft("");
+    setSearchParams(next);
+  };
+
+  return (
+    <div className="page">
+      <PageHeader eyebrow="Runs" title="运行记录" description="按夹具、生命周期、结果和证据状态组合筛选；所有筛选轴按 AND 生效。" />
+      <section className="section" aria-label="运行筛选">
+        <form className="grid gap-3 lg:grid-cols-[minmax(180px,1.5fr)_repeat(4,minmax(130px,1fr))_auto] lg:items-end" onSubmit={submitSearch}>
+          <label className="field-label">搜索
+            <span className="relative"><Search aria-hidden="true" className="absolute left-3 top-3 text-[var(--muted)]" size={15} /><input className="field pl-9" maxLength={100} value={draft} onChange={(event) => setDraft(event.target.value)} placeholder="运行 ID、夹具或错误类型" /></span>
+          </label>
+          <label className="field-label">夹具<select className="field" value={filters.caseId} onChange={(event) => setFilter("caseId", event.target.value)}><option value="">全部</option><option value="success">success</option><option value="task_error">task_error</option><option value="long_running_cancel">long_running_cancel</option></select></label>
+          <label className="field-label">阶段<select className="field" value={filters.phase} onChange={(event) => setFilter("phase", event.target.value)}><option value="">全部</option><option value="queued">queued</option><option value="running">running</option><option value="terminal">terminal</option></select></label>
+          <label className="field-label">结果<select className="field" value={filters.outcome} onChange={(event) => setFilter("outcome", event.target.value)}><option value="">全部</option><option value="success">success</option><option value="task_error">task_error</option><option value="cancelled">cancelled</option><option value="infrastructure_error">infrastructure_error</option></select></label>
+          <label className="field-label">证据<select className="field" value={filters.evidenceState} onChange={(event) => setFilter("evidenceState", event.target.value)}><option value="">全部</option><option value="pending">pending</option><option value="synced">synced</option><option value="failed">failed</option></select></label>
+          <div className="flex flex-wrap gap-2 lg:justify-end">
+            <button className="button button-primary" type="submit"><Search aria-hidden="true" size={15} />搜索</button>
+            <button className="button" type="button" onClick={clear}><RotateCcw aria-hidden="true" size={15} />清空</button>
+          </div>
+        </form>
+      </section>
+
+      <section className="section" aria-labelledby="results-title">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="section-title" id="results-title">筛选结果</h2>
+          {runs.refreshing ? <span className="text-xs text-[var(--muted)]">正在更新…</span> : null}
+        </div>
+        {runs.data ? <RunTable runs={runs.data.items} empty="没有匹配当前条件的运行" /> : runs.error ? <ErrorNotice message={runs.error.message} onRetry={runs.refresh} /> : <LoadingRows count={5} />}
+        <div className="mt-5 flex items-center justify-end gap-2">
+          {searchParams.has("cursor") ? <button className="button" type="button" onClick={() => navigate(-1)}>上一页</button> : null}
+          {runs.data?.nextCursor ? <button className="button" type="button" onClick={() => setFilter("cursor", runs.data?.nextCursor ?? "")}>下一页</button> : null}
+        </div>
+        <p className="sr-only" aria-live="polite">{runs.data ? `当前显示 ${runs.data.items.length} 条运行` : runs.loading ? "正在加载运行" : "运行加载失败"}</p>
+      </section>
+    </div>
+  );
+}

--- a/extensions/ai-research/ui/src/pages/SystemPage.tsx
+++ b/extensions/ai-research/ui/src/pages/SystemPage.tsx
@@ -1,0 +1,45 @@
+import { ExternalLink, RefreshCw } from "lucide-react";
+import { useCallback } from "react";
+
+import { api } from "../api";
+import { ErrorNotice, FixtureNotice, LoadingRows, PageHeader } from "../components/Page";
+import { formatTime } from "../components/RunTable";
+import { Status } from "../components/Status";
+import { usePolling } from "../hooks/usePolling";
+
+const names: Record<string, string> = {
+  controlLedger: "Control Ledger",
+  worker: "Inspect Worker",
+  tracking: "MLflow Tracking",
+  inspectView: "Inspect View",
+};
+
+export function SystemPage() {
+  const system = usePolling(useCallback((signal: AbortSignal) => api.system(signal), []), 10_000);
+  const module = usePolling(useCallback((signal: AbortSignal) => api.module(signal), []), 60_000);
+  return (
+    <div className="page">
+      <PageHeader eyebrow="System" title="系统与运行时" description="区分必需依赖和可选只读视图；可选服务离线只会降级，不阻止创建夹具。" actions={<button className="button" type="button" onClick={() => { system.refresh(); module.refresh(); }}><RefreshCw aria-hidden="true" size={14} />刷新</button>} />
+      <FixtureNotice />
+      <section className="section" aria-labelledby="health-title">
+        <div className="flex items-center justify-between gap-3"><h2 className="section-title" id="health-title">依赖检查</h2><Status value={system.data?.status ?? "not_ready"} /></div>
+        {system.data ? (
+          <ul className="mt-4 divide-y divide-[var(--border)] border-y border-[var(--border)]">
+            {system.data.checks.map((check) => <li className="flex items-center justify-between gap-3 py-3" key={check.id}><div><p className="text-sm font-semibold text-[#dde4e8]">{names[check.id] ?? check.id}</p><p className="mt-1 text-xs text-[var(--muted)]">{check.required ? "必需 · 影响创建门禁" : "可选 · 离线仅降级"}</p></div><Status value={check.status} /></li>)}
+          </ul>
+        ) : system.error ? <ErrorNotice message={system.error.message} onRetry={system.refresh} /> : <LoadingRows count={4} />}
+        {system.data ? <p className="mt-3 text-xs text-[var(--muted)]">检查时间 {formatTime(system.data.checkedAt)}</p> : null}
+      </section>
+
+      <section className="section" aria-labelledby="runtime-title">
+        <h2 className="section-title" id="runtime-title">精确运行时</h2>
+        {module.data ? <dl className="definition-grid mt-3">{Object.entries(module.data.runtimes).map(([name, version]) => <div className="definition-row" key={name}><dt>{name}</dt><dd className="font-mono">{version}</dd></div>)}</dl> : module.error ? <ErrorNotice message={module.error.message} onRetry={module.refresh} /> : <LoadingRows count={3} />}
+      </section>
+
+      <section className="section" aria-labelledby="boundary-title">
+        <h2 className="section-title" id="boundary-title">模块边界</h2>
+        {module.data ? <><dl className="definition-grid mt-3"><div className="definition-row"><dt>模块版本</dt><dd>{module.data.moduleVersion}</dd></div><div className="definition-row"><dt>控制协议</dt><dd>{module.data.apiVersion}</dd></div><div className="definition-row"><dt>Worker 协议</dt><dd>{module.data.workerProtocolVersion}</dd></div><div className="definition-row"><dt>声明级别</dt><dd>{module.data.claimLevel} · {module.data.packStatus}</dd></div></dl><ul className="mt-4 list-inside list-disc space-y-2 text-sm text-[var(--muted)]">{module.data.limitations.map((item) => <li key={item}>{item}</li>)}</ul><p className="mt-4 border-l-2 border-[#826b36] pl-3 text-xs leading-5 text-[#c8b98f]">MLflow 是本机上游开发界面，可修改其自身记录；Control Ledger 与 canonical receipt 才是本模块的权威事实。</p><div className="mt-4 flex flex-wrap gap-2"><a className="button" href={module.data.links.inspectView} target="_blank" rel="noopener noreferrer">Inspect View <ExternalLink aria-hidden="true" size={14} /></a><a className="button" href={module.data.links.mlflow} target="_blank" rel="noopener noreferrer">打开 MLflow 开发界面 <ExternalLink aria-hidden="true" size={14} /></a></div></> : null}
+      </section>
+    </div>
+  );
+}

--- a/extensions/ai-research/ui/src/styles.css
+++ b/extensions/ai-research/ui/src/styles.css
@@ -1,0 +1,343 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color: #e7ebee;
+  background: #090b0e;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "Microsoft YaHei", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  --surface: #0e1115;
+  --surface-raised: #13171c;
+  --border: #252b32;
+  --border-strong: #39424c;
+  --muted: #96a0aa;
+  --cyan: #51d6d2;
+  --cyan-soft: #143435;
+  --green: #72d39b;
+  --amber: #f1c46d;
+  --red: #f08a8a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  background: #090b0e;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at 80% -20%, rgb(34 89 91 / 18%), transparent 34rem),
+    #090b0e;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button,
+a,
+input,
+select {
+  outline: none;
+}
+
+:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 3px;
+}
+
+a {
+  color: inherit;
+}
+
+.app-shell {
+  min-height: 100vh;
+}
+
+.sidebar {
+  position: fixed;
+  inset: 0 auto 0 0;
+  z-index: 30;
+  display: flex;
+  width: 230px;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+  background: rgb(9 11 14 / 94%);
+  backdrop-filter: blur(16px);
+}
+
+.main-column {
+  min-width: 0;
+  padding-left: 230px;
+}
+
+.page {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+  padding: 32px clamp(20px, 4vw, 56px) 64px;
+}
+
+.eyebrow {
+  color: var(--cyan);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.page-title {
+  margin: 7px 0 8px;
+  color: #f7f9fa;
+  font-size: clamp(1.55rem, 3vw, 2.15rem);
+  font-weight: 650;
+  letter-spacing: -0.035em;
+}
+
+.page-description {
+  max-width: 760px;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.section {
+  margin-top: 28px;
+  border-top: 1px solid var(--border);
+  padding-top: 20px;
+}
+
+.section-title {
+  margin: 0;
+  color: #f1f4f6;
+  font-size: 0.98rem;
+  font-weight: 650;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.button {
+  display: inline-flex;
+  min-height: 38px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  padding: 8px 13px;
+  color: #e8edef;
+  background: #161b20;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 160ms ease, background 160ms ease, color 160ms ease;
+}
+
+.button:hover:not(:disabled) {
+  border-color: #52606c;
+  background: #1c2228;
+}
+
+.button-primary {
+  border-color: #49bbb9;
+  color: #061313;
+  background: var(--cyan);
+}
+
+.button-primary:hover:not(:disabled) {
+  border-color: #73e2de;
+  background: #73e2de;
+}
+
+.button-danger {
+  border-color: #7a4145;
+  color: #ffc2c2;
+  background: #291719;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.field {
+  width: 100%;
+  min-height: 40px;
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  padding: 8px 10px;
+  color: #f1f4f6;
+  background: #0b0e12;
+}
+
+.field:hover {
+  border-color: #52606c;
+}
+
+.field-label {
+  display: grid;
+  gap: 7px;
+  color: #cbd2d8;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-top: 20px;
+  border-left: 2px solid var(--cyan);
+  padding: 11px 14px;
+  color: #c7d1d6;
+  background: rgb(20 52 53 / 38%);
+  line-height: 1.6;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.86rem;
+}
+
+.data-table th,
+.data-table td {
+  border-bottom: 1px solid var(--border);
+  padding: 12px 10px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.data-table th {
+  color: #8e99a3;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.data-table tbody tr:hover {
+  background: rgb(255 255 255 / 2.5%);
+}
+
+.record-list {
+  display: none;
+}
+
+.definition-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 28px;
+}
+
+.definition-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.42fr) 1fr;
+  gap: 14px;
+  border-bottom: 1px solid var(--border);
+  padding: 12px 0;
+}
+
+.definition-row dt {
+  color: var(--muted);
+}
+
+.definition-row dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: #e5e9ec;
+}
+
+.code-block {
+  max-height: 420px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 14px;
+  color: #cdd8dc;
+  background: #07090b;
+  font-family: "Cascadia Code", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.65;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.skeleton {
+  height: 42px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #11161a 25%, #1a2025 50%, #11161a 75%);
+  background-size: 200% 100%;
+  animation: loading 1.4s infinite linear;
+}
+
+@keyframes loading {
+  to {
+    background-position-x: -200%;
+  }
+}
+
+@media (max-width: 760px) {
+  .sidebar {
+    position: sticky;
+    top: 0;
+    width: 100%;
+    height: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .main-column {
+    padding-left: 0;
+  }
+
+  .page {
+    padding: 24px 16px 48px;
+  }
+
+  .desktop-table {
+    display: none;
+  }
+
+  .record-list {
+    display: grid;
+    gap: 1px;
+    margin-top: 12px;
+    background: var(--border);
+  }
+
+  .record-item {
+    display: grid;
+    gap: 8px;
+    padding: 14px;
+    background: var(--surface);
+  }
+
+  .definition-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/extensions/ai-research/ui/src/test/setup.ts
+++ b/extensions/ai-research/ui/src/test/setup.ts
@@ -1,0 +1,6 @@
+import "@testing-library/jest-dom/vitest";
+
+Object.defineProperty(document, "visibilityState", {
+  configurable: true,
+  value: "visible",
+});

--- a/extensions/ai-research/ui/src/types.ts
+++ b/extensions/ai-research/ui/src/types.ts
@@ -1,0 +1,101 @@
+export type CaseId = "success" | "task_error" | "long_running_cancel";
+export type Phase = "queued" | "running" | "terminal";
+export type Outcome = "success" | "task_error" | "cancelled" | "infrastructure_error";
+export type EvidenceState = "pending" | "synced" | "failed";
+export type Readiness = "ready" | "not_ready";
+
+export interface Run {
+  runId: string;
+  fixtureId: string;
+  caseId: CaseId;
+  tenantId: "local";
+  projectId: "local";
+  actorId: "local";
+  phase: Phase;
+  outcome: Outcome | null;
+  inspectStatus: "started" | "success" | "error" | "cancelled" | null;
+  cancelRequested: boolean;
+  cancelApplied: boolean;
+  evidenceState: EvidenceState;
+  errorType: string | null;
+  errorMessage: string | null;
+  replayVerified: boolean;
+  mlflowRunId: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  cancelRequestedAt: string | null;
+  cancelAppliedAt: string | null;
+  terminalAt: string | null;
+  evidenceSyncedAt: string | null;
+  updatedAt: string;
+}
+
+export interface RunList {
+  items: Run[];
+  nextCursor: string | null;
+}
+
+export interface RunSummary {
+  total: number;
+  phases: Record<Phase, number>;
+  outcomes: Record<Outcome, number>;
+  evidenceStates: Record<EvidenceState, number>;
+  updatedAt: string | null;
+}
+
+export interface RunEvent {
+  sequence: number;
+  eventType: string;
+  payload: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface EventList {
+  items: RunEvent[];
+  nextSequence: number;
+}
+
+export interface SystemCheck {
+  id: "controlLedger" | "worker" | "tracking" | "inspectView";
+  status: Readiness;
+  required: boolean;
+}
+
+export interface SystemStatus {
+  status: "ready" | "degraded" | "not_ready";
+  checks: SystemCheck[];
+  checkedAt: string;
+}
+
+export interface ModuleInfo {
+  moduleId: string;
+  moduleVersion: string;
+  apiVersion: string;
+  workerProtocolVersion: number;
+  claimLevel: "harness_only";
+  packStatus: "fixture_only";
+  fixtures: CaseId[];
+  runtimes: Record<string, string>;
+  capabilities: Record<string, boolean>;
+  links: { mlflow: string; inspectView: string };
+  limitations: string[];
+}
+
+export interface EvidenceArtifact {
+  name: string;
+  sizeBytes: number;
+  sha256: string;
+  downloadUrl: string;
+}
+
+export interface Evidence {
+  runId: string;
+  evidenceState: EvidenceState;
+  integrityStatus: "pending" | "verified" | "failed";
+  integrityError: string | null;
+  verifiedAt: string;
+  receipt: Record<string, unknown> | null;
+  artifacts: EvidenceArtifact[];
+  mlflow: Record<string, string | null>;
+  outbox: Record<string, unknown> | null;
+}

--- a/extensions/ai-research/ui/tailwind.config.ts
+++ b/extensions/ai-research/ui/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;

--- a/extensions/ai-research/ui/tsconfig.json
+++ b/extensions/ai-research/ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "vite.config.ts", "tailwind.config.ts"]
+}

--- a/extensions/ai-research/ui/vite.config.ts
+++ b/extensions/ai-research/ui/vite.config.ts
@@ -1,0 +1,17 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+    sourcemap: false,
+  },
+  test: {
+    environment: "jsdom",
+    setupFiles: "./src/test/setup.ts",
+    css: true,
+    restoreMocks: true,
+  },
+});

--- a/extensions/ai-research/worker/ai_research_worker/runner.py
+++ b/extensions/ai-research/worker/ai_research_worker/runner.py
@@ -46,6 +46,7 @@ class WorkerRunManager:
         self._active: ActiveRun | None = None
         self._task: asyncio.Task[None] | None = None
         self._lock = asyncio.Lock()
+        self._health_lock = asyncio.Lock()
         self._health_cache: dict[str, str] | None = None
         self._recover_interrupted()
 
@@ -80,12 +81,13 @@ class WorkerRunManager:
                 continue
 
     async def health(self) -> dict[str, Any]:
-        if self._health_cache is None:
-            code, stdout, _ = await self._command("inspect", "--version", timeout=20)
-            self._health_cache = {
-                "status": "ready" if code == 0 and "0.3.260" in stdout else "not_ready",
-                "inspectVersion": stdout.strip(),
-            }
+        async with self._health_lock:
+            if self._health_cache is None:
+                code, stdout, _ = await self._command("inspect", "--version", timeout=20)
+                self._health_cache = {
+                    "status": "ready" if code == 0 and "0.3.260" in stdout else "not_ready",
+                    "inspectVersion": stdout.strip(),
+                }
         return {
             **self._health_cache,
             "busy": self._active is not None,


### PR DESCRIPTION
## 概要

将 AR0 的 fixture-only 执行与证据框架提升为独立的 AR1 Research Console，实现网页创建夹具、查看排队/运行、取消、复核 Inspect 原始终态、验证证据，并打开 Inspect View 与 MLflow。

## 主要变化

- 在 extensions/ai-research/ui 建立独立 React/Vite/Tailwind 控制台，并由 Control 同源托管。
- 增加运行筛选、summary、系统状态、证据实时校验和安全 artifact 下载接口。
- 增加只读 Inspect View 服务，以及必需/可选依赖的 ready、degraded、not_ready 状态模型。
- 加固取消原子性、终态竞态、Worker 健康探测单飞、轮询清理、键盘焦点和移动导航。
- 扩展许可证、SBOM、来源锁、零默认增量与完整验收门禁。

## 验证

- .\scripts\verify.ps1 -Base origin/main -Mode Full：通过。
- Control/API：20 passed。
- Worker：14 passed。
- UI：11 passed；typecheck 与 production build 通过。
- success、task_error、cancel、Inspect View 递归读取、Tracking 断连 outbox 恢复、Worker 重启 fail-closed、Control/Tracking 两轮重启、MLflow/trace/artifact 复核均通过。
- 最新主线客户端产物逐文件指纹一致；默认 Compose 16 个服务、22 个卷保持不变。

## 边界与限制

- 仍只运行 success、task_error、long_running_cancel 三个 fixture_only 工程夹具，不连接模型，不产生科研结论。
- 不修改主站 client、server、根 Compose、Plugin schema 或 Studio 路由。
- MLflow 是仅绑定本机的上游开发 UI，当前仍可写且无认证；Control Ledger 与 Evidence Receipt 才是权威记录。
- 本 PR 不包含部署、发布或真实 EvalPack。