### PR TITLE
R6G: Expert Team Planner 与 DAG 接入 Managed Provider

### DIFF
--- a/client/src/components/AgencyDagRunPanel.tsx
+++ b/client/src/components/AgencyDagRunPanel.tsx
@@ -8,6 +8,7 @@ import type {
   AgencyInteractionDecisionPayload,
   AgencyPlanPreview,
 } from "./AgencyExpertTeamTypes";
+import ProviderRouteReceiptSummary from "./ProviderRouteReceiptSummary";
 
 interface AgencyDagRunSummary {
   task_id: string;
@@ -691,6 +692,10 @@ export default function AgencyDagRunPanel({
             版本链累计：{run.lineage_model_calls} 次调用 · {(run.lineage_usage?.input_tokens || 0).toLocaleString()} 输入 / {(run.lineage_usage?.output_tokens || 0).toLocaleString()} 输出 token
           </p>
         ) : null}
+        <ProviderRouteReceiptSummary
+          receipts={run?.provider_route_receipts}
+          title="DAG 控制面"
+        />
         {run?.revisable && !capabilities?.revision?.enabled ? (
           <p className="mt-2 text-xs text-slate-500">对话式返工当前未启用；历史结果仍可查看和下载。</p>
         ) : null}

--- a/client/src/components/AgencyExpertTeamTypes.ts
+++ b/client/src/components/AgencyExpertTeamTypes.ts
@@ -149,6 +149,29 @@ export interface AgencyAgentSummary {
   score?: number;
 }
 
+export interface ProviderRouteCallReceipt {
+  call_sequence: number;
+  model_id: string;
+  actual_model?: string | null;
+  dispatched: boolean;
+  status: "running" | "passed" | "failed" | "uncertain" | "cancelled";
+  error_code?: string | null;
+  prompt_tokens?: number | null;
+  completion_tokens?: number | null;
+  total_tokens?: number | null;
+}
+
+export interface ProviderRouteReceipt {
+  contract_version: "modelmirror-provider-workload-routing-v1";
+  entry_id: "expert_team_planner" | "expert_team_dag";
+  routing_mode: "managed_required";
+  run_reference: string;
+  status: "running" | "passed" | "failed" | "uncertain" | "cancelled";
+  call_count: number;
+  reason_codes: string[];
+  calls: ProviderRouteCallReceipt[];
+}
+
 export interface AgencyPlanPreview {
   plan: {
     summary: string;
@@ -177,6 +200,7 @@ export interface AgencyPlanPreview {
   repair_used: boolean;
   model_calls: number;
   usage: AgencyDagUsage;
+  provider_route_receipts?: ProviderRouteReceipt | null;
   capability_snapshot_version: string;
   capability_snapshot_hash: string;
   upstream_project: string;
@@ -224,6 +248,7 @@ export interface AgencyDagEvent {
   model_calls?: number;
   quality_status?: string;
   final_output?: string;
+  provider_route_receipts?: ProviderRouteReceipt;
 }
 
 export interface AgencyDagRun {
@@ -254,6 +279,7 @@ export interface AgencyDagRun {
   warnings: string[];
   model_calls: number;
   usage: AgencyDagUsage;
+  provider_route_receipts?: ProviderRouteReceipt[];
   estimated_cost?: number | null;
   error?: string | null;
   error_code?: string | null;

--- a/client/src/components/ProviderRouteReceiptSummary.test.tsx
+++ b/client/src/components/ProviderRouteReceiptSummary.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ProviderRouteReceiptSummary from "./ProviderRouteReceiptSummary";
+
+describe("ProviderRouteReceiptSummary", () => {
+  it("shows redacted per-segment evidence without internal connection details", () => {
+    render(
+      <ProviderRouteReceiptSummary
+        title="DAG 控制面"
+        receipts={[
+          {
+            contract_version: "modelmirror-provider-workload-routing-v1",
+            entry_id: "expert_team_dag",
+            routing_mode: "managed_required",
+            run_reference: "run-1",
+            status: "passed",
+            call_count: 2,
+            reason_codes: [],
+            calls: [
+              {
+                call_sequence: 1,
+                model_id: "provider/model",
+                dispatched: true,
+                status: "passed",
+              },
+            ],
+            connection_id: "must-not-render",
+            base_url: "https://must-not-render.example",
+          } as never,
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("DAG 控制面：已纳管 · 2 次 Provider 调用")).toBeVisible();
+    expect(screen.getByText(/执行片段 1：通过 · 2 次 · provider\/model/)).toBeVisible();
+    expect(screen.queryByText(/must-not-render/)).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/ProviderRouteReceiptSummary.tsx
+++ b/client/src/components/ProviderRouteReceiptSummary.tsx
@@ -1,0 +1,45 @@
+import type { ProviderRouteReceipt } from "./AgencyExpertTeamTypes";
+
+const statusLabels: Record<ProviderRouteReceipt["status"], string> = {
+  running: "执行中",
+  passed: "通过",
+  failed: "失败",
+  uncertain: "结果不确定",
+  cancelled: "已取消",
+};
+
+interface ProviderRouteReceiptSummaryProps {
+  receipts?: ProviderRouteReceipt | ProviderRouteReceipt[] | null;
+  title: string;
+}
+
+export default function ProviderRouteReceiptSummary({
+  receipts,
+  title,
+}: ProviderRouteReceiptSummaryProps) {
+  const items = Array.isArray(receipts) ? receipts : receipts ? [receipts] : [];
+  if (!items.length) return null;
+  const callCount = items.reduce((total, item) => total + item.call_count, 0);
+
+  return (
+    <section
+      aria-label={`${title} Provider 控制面证据`}
+      className="mt-3 rounded-lg border border-cyan-300/20 bg-cyan-300/[0.06] p-3 text-xs text-cyan-50"
+    >
+      <p className="font-semibold">
+        {title}：已纳管 · {callCount} 次 Provider 调用
+      </p>
+      <ul className="mt-2 space-y-1 text-cyan-100/80">
+        {items.map((item, index) => {
+          const models = [...new Set(item.calls.map((call) => call.model_id).filter(Boolean))];
+          return (
+            <li key={item.run_reference || `${item.entry_id}-${index}`}>
+              执行片段 {index + 1}：{statusLabels[item.status]} · {item.call_count} 次
+              {models.length ? ` · ${models.join("、")}` : ""}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/client/src/components/settings/ProviderWorkloadControlSettings.test.tsx
+++ b/client/src/components/settings/ProviderWorkloadControlSettings.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import ProviderWorkloadControlSettings from "./ProviderWorkloadControlSettings";
+import ProviderWorkloadControlSettings, {
+  ENTRY_SHAPES,
+} from "./ProviderWorkloadControlSettings";
 
 const connection = {
   id: "connection-openrouter",
@@ -19,6 +21,16 @@ function jsonResponse(payload: unknown, ok = true, status = 200) {
 }
 
 describe("ProviderWorkloadControlSettings", () => {
+  it("binds Expert Team Planner to its unary YAML contract", () => {
+    expect(ENTRY_SHAPES.expert_team_planner).toEqual(["chat_text_unary"]);
+  });
+
+  it("requires both unary text and JSON qualifications for Expert Team DAG", () => {
+    expect(ENTRY_SHAPES.expert_team_dag).toEqual([
+      "chat_text_unary",
+      "chat_json_object",
+    ]);
+  });
   afterEach(() => vi.unstubAllGlobals());
 
   it("requires an explicit confirmation before one billed workload certification", async () => {
@@ -217,6 +229,51 @@ describe("ProviderWorkloadControlSettings", () => {
       acknowledge_fail_closed: true,
     });
     await screen.findByText("Managed 必经");
+  });
+
+  it("allows a degraded managed entry to be explicitly re-approved", async () => {
+    const policy = {
+      contract_version: "modelmirror-provider-workload-routing-v1",
+      entry_id: "expert_team_planner",
+      feature_enabled: true,
+      data_plane_integrated: true,
+      configured_status: "managed_required",
+      effective_status: "degraded_required",
+      revision: 3,
+      policy_fingerprint: "fingerprint",
+      bindings: [{
+        execution_shape: "chat_text_unary",
+        model_id: "openai/gpt-test",
+        connection_id: connection.id,
+        connection_name: connection.name,
+        provider_kind: connection.kind,
+        certification_id: "cert-unary",
+        valid: true,
+        reason_code: "qualified",
+      }],
+      approval_valid: false,
+      blocking_reason_codes: [],
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/router/workload-control/policies") {
+        return jsonResponse({ policies: [policy] });
+      }
+      if (url === "/api/router/connections") return jsonResponse([connection]);
+      if (url.startsWith("/api/router/workload-control/receipts")) {
+        return jsonResponse({ runs: [] });
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ProviderWorkloadControlSettings csrfToken="csrf-value" view="routing" />);
+    await screen.findByText("R6 入口、精确 Binding 与 Receipt");
+    fireEvent.change(screen.getByLabelText("入口"), {
+      target: { value: "expert_team_planner" },
+    });
+    expect(await screen.findByRole("button", { name: "重新批准 Managed 必经" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "显式恢复 Legacy" })).toBeEnabled();
   });
 
   it("keeps connection and call evidence in the authenticated settings view", async () => {

--- a/client/src/components/settings/ProviderWorkloadControlSettings.tsx
+++ b/client/src/components/settings/ProviderWorkloadControlSettings.tsx
@@ -146,7 +146,7 @@ const NEW_CERTIFICATION_SHAPES: ExecutionShape[] = [
   "fusion_native",
 ];
 
-const ENTRY_SHAPES: Record<EntryId, ExecutionShape[]> = {
+export const ENTRY_SHAPES: Record<EntryId, ExecutionShape[]> = {
   agent_shadow: ["chat_tools"],
   meta_agent: ["chat_json_object"],
   workflow_interactive_llm: ["chat_text", "chat_text_unary", "chat_json_object"],
@@ -155,8 +155,8 @@ const ENTRY_SHAPES: Record<EntryId, ExecutionShape[]> = {
   workflow_deployment_agent: ["chat_text", "chat_tools", "chat_json_object"],
   xpert: ["chat_text", "chat_tools", "chat_json_object"],
   xpert_app: ["chat_text", "chat_tools", "chat_json_object"],
-  expert_team_planner: ["chat_json_object"],
-  expert_team_dag: ["chat_text_unary"],
+  expert_team_planner: ["chat_text_unary"],
+  expert_team_dag: ["chat_text_unary", "chat_json_object"],
   fusion: ["chat_text", "fusion_native"],
   route_agent: ["chat_text"],
   team_chat: ["chat_text"],
@@ -584,7 +584,7 @@ export default function ProviderWorkloadControlSettings({
             <select aria-label={`Binding ${index + 1} 连接`} className="rounded-lg border border-white/10 bg-ink-950 px-2 py-2 text-sm text-white" value={binding.connection_id} onChange={(event) => setEditableBindings((current) => current.map((item, position) => position === index ? { ...item, connection_id: event.target.value } : item))}>{eligibleConnections.map((connection) => <option key={connection.id} value={connection.id}>{connection.name}</option>)}</select>
             <button className="rounded-full border border-rose-300/20 px-3 py-2 text-xs text-rose-100" onClick={() => setEditableBindings((current) => current.filter((_, position) => position !== index))} type="button">移除</button>
           </div>)}{!editableBindings.length ? <p className="rounded-lg border border-dashed border-white/10 p-4 text-sm text-slate-400">尚未配置；没有 Binding 时不能激活。</p> : null}</div>
-          <div className="mt-4 flex flex-wrap gap-2"><button className="rounded-full bg-sky-200 px-4 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={busy || !selectedPolicy || editableBindings.some((item) => !item.model_id.trim() || !item.connection_id)} onClick={() => void savePolicy()} type="button">保存 Binding</button>{selectedPolicy?.configured_status !== "legacy" ? <button className="rounded-full border border-white/15 px-4 py-2 text-sm text-slate-200" disabled={busy} onClick={() => void deactivate()} type="button">显式恢复 Legacy</button> : <button className="rounded-full border border-amber-300/30 px-4 py-2 text-sm text-amber-100 disabled:cursor-not-allowed disabled:opacity-40" disabled={busy || !selectedPolicy.data_plane_integrated || !selectedPolicy.feature_enabled || selectedPolicy.blocking_reason_codes.length > 0} onClick={() => setConfirmActivation(true)} type="button">激活 Managed 必经</button>}</div>
+          <div className="mt-4 flex flex-wrap gap-2"><button className="rounded-full bg-sky-200 px-4 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={busy || !selectedPolicy || editableBindings.some((item) => !item.model_id.trim() || !item.connection_id)} onClick={() => void savePolicy()} type="button">保存 Binding</button>{selectedPolicy?.configured_status !== "legacy" ? <button className="rounded-full border border-white/15 px-4 py-2 text-sm text-slate-200" disabled={busy} onClick={() => void deactivate()} type="button">显式恢复 Legacy</button> : null}{selectedPolicy && (selectedPolicy.configured_status === "legacy" || !selectedPolicy.approval_valid) ? <button className="rounded-full border border-amber-300/30 px-4 py-2 text-sm text-amber-100 disabled:cursor-not-allowed disabled:opacity-40" disabled={busy || !selectedPolicy.data_plane_integrated || !selectedPolicy.feature_enabled || selectedPolicy.blocking_reason_codes.length > 0} onClick={() => setConfirmActivation(true)} type="button">{selectedPolicy.configured_status === "legacy" ? "激活 Managed 必经" : "重新批准 Managed 必经"}</button> : null}</div>
         </div>
       </div>
       <div className="border-t border-white/10 p-5">

--- a/client/src/pages/ExpertTeamPage.test.ts
+++ b/client/src/pages/ExpertTeamPage.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { AgencyPlanTask } from "../components/AgencyExpertTeamTypes";
-import { validateAgencyHitlPlan } from "./ExpertTeamPage";
+import {
+  recommendedChatModels,
+  validateAgencyHitlPlan,
+} from "./ExpertTeamPage";
 
 function expert(
   taskId: string,
@@ -61,5 +64,13 @@ describe("ExpertTeamPage HITL plan validation", () => {
     expect(issues.map((issue) => issue.code)).toContain(
       "agency_hitl_sink_acceptance_required",
     );
+  });
+});
+
+describe("ExpertTeamPage model selection", () => {
+  it("keeps eligible exact managed models selectable beyond the featured prefix", () => {
+    expect(
+      recommendedChatModels().some((model) => model.id === "openai/gpt-4o-mini"),
+    ).toBe(true);
   });
 });

--- a/client/src/pages/ExpertTeamPage.tsx
+++ b/client/src/pages/ExpertTeamPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import PageContainer from "../components/PageContainer";
 import AgencyDagRunPanel from "../components/AgencyDagRunPanel";
+import ProviderRouteReceiptSummary from "../components/ProviderRouteReceiptSummary";
 import {
   type AgencyAgentSummary,
   type AgencyDagRevisionPayload,
@@ -196,14 +197,13 @@ function isLikelyChatModel(model: (typeof models)[number]) {
   );
 }
 
-function recommendedChatModels() {
+export function recommendedChatModels() {
   const preferred = defaultFusionIds
     .map((modelId) => models.find((model) => model.id === modelId))
     .filter((model): model is (typeof models)[number] => Boolean(model));
   const seen = new Set(preferred.map((model) => model.id));
   const remaining = models
-    .filter((model) => isLikelyChatModel(model) && !seen.has(model.id))
-    .slice(0, 180);
+    .filter((model) => isLikelyChatModel(model) && !seen.has(model.id));
   return [...preferred, ...remaining];
 }
 
@@ -2237,6 +2237,10 @@ export default function ExpertTeamPage() {
                         <p className="mt-2 text-slate-400">
                           本次规划：{agencyPreview.model_calls || 0} 次调用 · {(agencyPreview.usage.input_tokens || 0).toLocaleString()} 入 / {(agencyPreview.usage.output_tokens || 0).toLocaleString()} 出
                         </p>
+                        <ProviderRouteReceiptSummary
+                          receipts={agencyPreview.provider_route_receipts}
+                          title="Planner 控制面"
+                        />
                       </div>
                       <div className="mt-4 flex flex-wrap gap-2">
                         <button

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -236,6 +236,16 @@ Round 6F 复用同一执行服务，将直接 Published Xpert 与已部署 Xpert
 和 Skill 流程不携带该上下文，继续使用原路径。文件仅在既有抽取流程转成文本后进入 R6F；
 视觉、音频及其他专用操作仍由原 Adapter 执行。
 
+Round 6G 将 Expert Team 的智能组队 Planner 与 Agency DAG 分别接入
+`expert_team_planner` / `expert_team_dag` Policy。Planner 只接受 `chat_text_unary`，
+并由现有 Agency Runtime 解析 YAML 计划；DAG
+执行步骤使用 `chat_text_unary`，验收与裁判调用独立要求 `chat_json_object`，两种资格不能
+互相继承。Agency Worker 继续只通过 Host callback 发送带稳定 `request_id` 的模型请求，
+Provider Key、URL 与连接信息不进入 Worker 环境。DAG 初始执行、HITL 恢复、显式续跑和返工
+各自建立稳定运行片段；每个逻辑调用只派发一次，`uncertain` 不自动重放。请求开始时冻结
+legacy 或 managed 模式，管理员并发修改策略只会令 managed 请求失败关闭，不会静默回退。
+用户侧仅显示按片段聚合的模型、调用数与脱敏状态，完整连接证据仍只在管理面可见。
+
 接入入口只允许 Python 主进程解析凭据和调用 Provider，Worker 与
 工具执行器继续只处理模型消息、Tool Call 和脱敏结果。
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -254,6 +254,17 @@ Published Xpert 与 Xpert App 必须分别配置并批准 `xpert`、`xpert_app` 
 评测、进化、记忆候选、后台增强和 Skill 流程仍未纳管。关闭对应 Flag 并重启只恢复该入口
 legacy，不删除 v16 Receipt、Xpert 会话、App 部署或 Provider 配置。
 
+Expert Team Planner 与 DAG 必须分别配置并批准 `expert_team_planner`、
+`expert_team_dag` Policy，并分别开启
+`MODEL_CONTROL_EXPERT_TEAM_PLANNER_ENABLED`、
+`MODEL_CONTROL_EXPERT_TEAM_DAG_ENABLED`。Planner 要求精确模型的 `chat_json_object`
+Binding；DAG 同时要求同一精确模型的 `chat_text_unary` 与 `chat_json_object` Binding，缺少
+任一资格都会在 Provider POST 前阻断。开关关闭或 Policy 为 `legacy` 时保留原静态网关；
+已纳管请求在执行期间遇到策略、Binding、凭据或资格漂移时保持失败关闭，不会转回 legacy。
+HITL 恢复会创建新的脱敏运行片段，但继续使用原任务冻结的控制模式；重启后的不确定调用不得
+自动恢复。回退只需显式停用对应 Policy 或关闭 Flag 并重启，不删除 Expert Team 运行数据、
+v16 Receipt 或 Provider 配置。
+
 同一清理命令从 v16 起同时报告 R5 Chat 与 R6 Workload 的过期记录；第一条仍是 dry-run，
 只有第二条显式 `--apply` 才删除已完成记录。不得对正在运行的父运行或逻辑调用执行清理。
 

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -247,7 +247,13 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
   Receipt，不改变回答正文或会话历史。受控子 Xpert/Handoff 显式继承 `xpert` 上下文，Managed
   失败不自动重放；Automation、Goal、评测、进化、记忆候选、后台增强与 Skill 流程保持排除。
   文件仅使用既有抽取文本，多模态继续专用 Adapter。
-- 后续 R6G—R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
+- R6G 接入 Expert Team Planner 与 Agency DAG。Planner 使用 `chat_json_object`；DAG 的普通
+  执行调用使用 `chat_text_unary`，JSON 验收/裁判使用独立 `chat_json_object`，两类 Binding
+  都必须匹配精确模型与当前连接指纹。Worker request ID 直接成为逻辑调用键；初始、HITL
+  恢复、续跑和返工以独立稳定片段记录 Receipt。请求开始时冻结控制模式，managed 请求派发前
+  资格漂移或策略停用只会失败关闭，派发后失败不得换连接、模型、IP 或 legacy。Worker 环境、
+  API、SQLite、日志和浏览器不保存 Key、Prompt 或模型正文。
+- 后续 R6H—R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
   只能存在于 Python 主进程内存，Worker、工具执行器和浏览器不得收到 Key、URL 或连接细节。
 - Receipt 清理命令现在同时检查 R5 Chat 与 R6 Workload 记录，仍默认 dry-run；`--apply`
   才删除超过保留期的已完成运行、尝试或调用。

--- a/docs/task-cards/provider-workload-r6g.md
+++ b/docs/task-cards/provider-workload-r6g.md
@@ -1,0 +1,89 @@
+# 任务卡：R6G Expert Team Planner 与 DAG Managed Provider
+
+## 1. 单一目标
+
+- 本次要完成：将 Expert Team Planner 与 DAG 的模型调用接入现有 v16 Managed Provider Route Plan、精确 Binding 和脱敏 Receipt，同时保留 Worker 编排、HITL、返工与恢复语义。
+- 本次明确不做：R6H Fusion、R6I Route Agent/Team Chat、Agent Workbench、RAG、多模态、Coding、多租户和计费。
+
+## 2. 证据
+
+| 结论 | 等级 | 证据路径或命令 |
+| --- | --- | --- |
+| R6F 已合并；R6G 已在提交前变基至最新 `origin/main@af50340c` | 已证实事实 | `git merge-base HEAD origin/main`; `git rev-parse origin/main` |
+| Planner 与 DAG 当前都经 Python Host callback 调用 legacy gateway，Worker 不接收 Provider Key | 已证实事实 | `server/main.py::collect_agency_worker_model`; `server/orchestration_worker/client.py`; `execution_client.py` |
+| DAG 同时产生普通文本调用和 JSON 验收调用 | 已证实事实 | `server/orchestration_worker/src/execution_connector.ts`; `server/orchestration_worker/test/execution.test.ts` |
+| v16 已预留 `expert_team_planner` 与 `expert_team_dag`，但尚未标记数据面已接入 | 已证实事实 | `server/model_router/workload_control.py` |
+| 新 Worktree 缺少编译后的 Worker 产物；基线 73 passed，3 个 Worker 启动型失败；显式镜像 Worker 后其中 1 passed、2 仍使用默认缺失路径 | 已证实事实 | R6G 基线 pytest 输出 |
+
+## 3. 影响范围
+
+- 允许修改路径：`server/model_router/`、`server/main.py`、`server/expert_team_agency*.py`、`server/tests/test_expert_team_*`、Expert Team 前端组件与对应测试、控制面/部署文档。
+- 禁止修改路径：普通 Chat、RAG、多模态、Fusion、Route Agent、Team Chat、Coding、Provider/newAPI 持久数据与凭据。
+- 预计文件数：约 12 个，拆为多个不超过 5 个文件的独立实现批次。
+- 影响路由/API：现有 Expert Team 响应加法返回脱敏 `provider_route_receipts`；不删除或重命名字段。
+- 影响持久化数据：仅复用 v16 `provider_workload_runs/calls`；不新增迁移、不改写旧数据。
+- 新增或升级依赖：无。
+- 涉及密钥/网络/文件/子进程/公开访问：涉及 Managed Provider 网络调用和 Agency Worker 子进程；Key 仅留在 Python Host 内存。
+
+超过 5 个文件的原因：控制面 Adapter、两个运行入口、持久化事件投影和前端 Receipt 展示属于同一端到端目标，但按控制面、运行时、前端文档三批分别验收。
+
+## 4. 验收标准
+
+### Managed 正常路径
+
+- Given：入口 Feature Flag 与 Policy 激活，精确模型拥有所需执行形态 Binding。
+- When：执行 Planner 预览或 DAG 计划调用。
+- Then：每个 Worker request ID 最多派发一次 Managed Provider POST，Receipt 与实际调用数、模型和状态一致，响应不包含连接或凭据。
+
+### 失败场景
+
+- Given：策略 degraded、Binding 缺失、资格漂移、取消、超时、断流或重启中断。
+- When：Planner/DAG 尝试调用或恢复。
+- Then：在派发前失败关闭，或派发后标记 failed/uncertain；不调用第二 IP、连接、模型或 legacy；uncertain 不自动重放。
+
+## 5. 实施顺序
+
+1. 模型/契约：新增 Expert Team Managed Gateway；DAG 明确要求 unary 与 JSON 两种资格。
+2. 校验/安全：接入 feature/policy/degraded 门禁和稳定逻辑调用键。
+3. 执行：Planner 与 DAG/HITL/返工/续跑使用独立 Managed Run，终态写入脱敏 Receipt。
+4. 前端：显示 Planner 与 DAG 总调用数、阶段状态和原因码，不显示连接细节。
+5. 文档：更新架构、部署与控制面轮次状态。
+
+## 6. 验证矩阵
+
+| 检查 | 命令或步骤 | 预期 | 状态 |
+| --- | --- | --- | --- |
+| 语法/类型 | Python AST；Client `tsc -b`/Vite build | 通过 | 已通过 |
+| 目标测试 | Provider Workload、Expert Team Planner/DAG、Managed Gateway 与 Worker Bridge | 通过 | 最终 114 passed |
+| 回归测试 | Provider workload、R5/R6 与后端全量 | 通过或明确基线失败 | 最新主线复测：受影响矩阵 114 passed；后端全量 4529 passed、29 skipped |
+| 前端组件 | Settings、Planner、DAG 与脱敏 Receipt | 通过 | 最新主线复测：前端全量 112 files、647 tests passed |
+| 构建 | 前端生产构建、Server 镜像重建 | 通过 | 已通过；仅保留既有大 chunk 警告 |
+| Docker/人工验收 | 独立预览配对、资格、Planner 与 DAG Smoke | 经单独额度授权后通过 | 已通过：Planner 3/3 次、DAG 3/10 次真实调用；请求/实际模型均为 `openai/gpt-4o-mini`，Receipt 与日志 POST 数一致 |
+| 敏感信息扫描 | Diff/API/SQLite/日志/浏览器状态 | 无 Key、Prompt 或模型正文 | 静态扫描、真实调用日志与 v16 Receipt 字段已复核；仅保存脱敏模型、状态、指标和 usage |
+
+真实验收前的证伪发现并已回归：Agency Planner 实际使用非流式 YAML/文本合同，原实现错误要求 JSON Object；同时修复了长模型列表截断导致已认证模型无法选择，以及 `degraded_required` 只能回退 Legacy、无法重新批准的设置页缺口。两次失败尝试均在 Provider POST 前阻断，未产生额度调用。Planner 最终使用三次计划内调用（含一次格式修复）；模型生成的人工节点偏离用户目标，已在本地静态编辑并重新校验，未增加 Planner 调用。DAG 以两个专家任务完成三次计划内调用，其中两次 unary、一次 JSON 验收。
+
+## 7. 风险与停止条件
+
+- 主要风险：并发 DAG Call 序号冲突、HITL 恢复重放、派发后 legacy 回退、JSON 裁判错误复用 unary 资格。
+- 兼容风险：Expert Team 事件和响应只能加法扩展；既有 legacy flag-off 行为必须原样保留。
+- 安全风险：Provider Key 不得进入 Worker、事件、API、SQLite、日志或前端。
+- 触发停止的条件：重复 POST、Receipt 与实际目标不一致、需要保存 Prompt/输出、需要迁移数据或扩展到 R6H/I。
+- 需要用户确认的问题：真实 Planner 与 DAG 付费 Smoke 的调用次数和执行授权；实现与 Mock 测试不需要新增产品决策。
+
+## 8. 回退
+
+1. 停用 `expert_team_planner` / `expert_team_dag` Policy。
+2. 关闭 `MODEL_CONTROL_EXPERT_TEAM_PLANNER_ENABLED` / `MODEL_CONTROL_EXPERT_TEAM_DAG_ENABLED` 并重启，恢复 legacy。
+3. 保留 v16 资格与脱敏 Receipt，不删除 Router SQLite、Expert Team 运行数据或 Provider 配置。
+4. 回退后重跑 Expert Team Planner/DAG legacy 测试与独立预览健康检查。
+
+## 9. 完成定义
+
+- [x] 实现只覆盖声明范围。
+- [x] 正常与失败路径均有自动验证。
+- [x] 公共接口和数据影响已说明。
+- [x] Diff 已审查，无用户改动被覆盖。
+- [x] 无密钥、运行存储或构建产物进入提交。
+- [x] 文档与 Harness 已同步。
+- [x] 未知产品信息仍明确标为待确认。

--- a/server/expert_team_agency.py
+++ b/server/expert_team_agency.py
@@ -137,6 +137,7 @@ class ExpertTeamPlanPreviewResponse(BaseModel):
     repair_used: bool = False
     model_calls: int = Field(default=0, ge=0, le=3)
     usage: dict[str, int] = Field(default_factory=dict)
+    provider_route_receipts: dict[str, Any] | None = None
     capability_snapshot_version: str
     capability_snapshot_hash: str
     upstream_project: str = AGENCY_UPSTREAM_PROJECT

--- a/server/expert_team_agency_runtime.py
+++ b/server/expert_team_agency_runtime.py
@@ -6,7 +6,7 @@ import re
 import uuid
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -78,6 +78,22 @@ TEMPLATE_PATTERN = re.compile(r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}")
 AgencyModelRunner = Callable[
     [AgencyModelRequest], Awaitable[AgencyModelResponse | str]
 ]
+
+
+class AgencyManagedRun(Protocol):
+    async def complete(self, request: AgencyModelRequest) -> AgencyModelResponse: ...
+
+    def finish(
+        self,
+        status: Literal["passed", "failed", "uncertain", "cancelled"],
+        *,
+        reason_code: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    def receipt_summary(self) -> dict[str, Any]: ...
+
+
+AgencyManagedRunFactory = Callable[[str, str], AgencyManagedRun | None]
 
 
 class StrictModel(BaseModel):
@@ -669,6 +685,7 @@ class AgencyExecutionCoordinator:
         worker_entry: str | None = None,
         enabled: bool = False,
         client_factory: Callable[[], AgencyExecutionClient] | None = None,
+        managed_run_factory: AgencyManagedRunFactory | None = None,
     ) -> None:
         self.store = store
         self.run_registry = run_registry
@@ -677,6 +694,7 @@ class AgencyExecutionCoordinator:
         self.worker_entry = worker_entry
         self.enabled = enabled
         self.client_factory = client_factory
+        self.managed_run_factory = managed_run_factory
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._lock = asyncio.Lock()
 
@@ -697,6 +715,7 @@ class AgencyExecutionCoordinator:
         revision: Mapping[str, Any] | None = None,
         revision_metadata: Mapping[str, Any] | None = None,
         resumed_from_task_id: str | None = None,
+        managed_provider_required: bool = False,
     ) -> dict[str, Any]:
         if resume is not None and revision is not None:
             raise AgencyExecutionValidationError(
@@ -753,69 +772,95 @@ class AgencyExecutionCoordinator:
                     "revision_request_digest",
                 }
             }
-            run = await self.run_registry.create_run(
-                "expert_team",
-                f"Expert Team DAG: {goal[:80]}",
-                status="running",
-                source_id="expert_team",
-                metadata={
-                    "surface": "expert_team",
-                    "backend": "agency_orchestrator",
-                    "upstream_project": AGENCY_UPSTREAM_PROJECT,
-                    "upstream_revision": upstream_revision,
-                    "model_id": model_id,
-                    "capability_snapshot_hash": capability_snapshot_hash,
-                    "max_steps": MAX_EXECUTION_STEPS,
-                    "max_concurrency": MAX_EXECUTION_CONCURRENCY,
-                    "max_model_calls": MAX_EXECUTION_MODEL_CALLS,
-                    "resumed_from_task_id": resumed_from_task_id,
-                    **public_revision_metadata,
-                    "initial_model_calls": int(
-                        (resume or {}).get("prior_model_calls") or 0
-                    ),
-                    "initial_usage": dict(
-                        (resume or {}).get("prior_usage") or {}
-                    ),
-                },
-            )
             task_id = f"agency_dag_{uuid.uuid4().hex}"
-            item = self.store.create(
-                task_id=task_id,
-                run_id=run.run_id,
-                run_type="expert_team",
-                workflow=prepared.workflow,
-                inputs={"goal": goal},
-                source_kind="expert_team_agency",
-                runtime_metadata={
-                    "protocol": (
-                        AGENCY_HITL_PROTOCOL
-                        if any(
-                            str(step.get("type") or "normal")
-                            in {"human_input", "approval"}
-                            for step in prepared.workflow.get("steps", [])
-                            if isinstance(step, dict)
-                        )
-                        else AGENCY_EXECUTION_PROTOCOL
-                    ),
-                    "model_id": model_id,
-                    "upstream_revision": upstream_revision,
-                    "capability_snapshot_version": capability_snapshot_version,
-                    "capability_snapshot_hash": capability_snapshot_hash,
-                    "sink_task_id": prepared.sink_task_id,
-                    "selected_agent_ids": prepared.selected_agent_ids,
-                    "method_skill_digests": {
-                        skill.skill_id: skill.digest for skill in prepared.skills
-                    },
-                    "resumed_from_task_id": resumed_from_task_id,
-                    **revision_metadata,
-                    "initial_model_calls": int(
-                        (resume or {}).get("prior_model_calls") or 0
-                    ),
-                    "initial_usage": dict(
-                        (resume or {}).get("prior_usage") or {}
-                    ),
-                },
+            managed_run = self._managed_run(
+                task_id,
+                "initial",
+                required=managed_provider_required,
             )
+            try:
+                run = await self.run_registry.create_run(
+                    "expert_team",
+                    f"Expert Team DAG: {goal[:80]}",
+                    status="running",
+                    source_id="expert_team",
+                    metadata={
+                        "surface": "expert_team",
+                        "backend": "agency_orchestrator",
+                        "upstream_project": AGENCY_UPSTREAM_PROJECT,
+                        "upstream_revision": upstream_revision,
+                        "model_id": model_id,
+                        "capability_snapshot_hash": capability_snapshot_hash,
+                        "max_steps": MAX_EXECUTION_STEPS,
+                        "max_concurrency": MAX_EXECUTION_CONCURRENCY,
+                        "max_model_calls": MAX_EXECUTION_MODEL_CALLS,
+                        "resumed_from_task_id": resumed_from_task_id,
+                        **public_revision_metadata,
+                        "initial_model_calls": int(
+                            (resume or {}).get("prior_model_calls") or 0
+                        ),
+                        "initial_usage": dict(
+                            (resume or {}).get("prior_usage") or {}
+                        ),
+                        "provider_control_mode": (
+                            "managed_required"
+                            if managed_provider_required
+                            else "legacy"
+                        ),
+                    },
+                )
+                item = self.store.create(
+                    task_id=task_id,
+                    run_id=run.run_id,
+                    run_type="expert_team",
+                    workflow=prepared.workflow,
+                    inputs={"goal": goal},
+                    source_kind="expert_team_agency",
+                    runtime_metadata={
+                        "protocol": (
+                            AGENCY_HITL_PROTOCOL
+                            if any(
+                                str(step.get("type") or "normal")
+                                in {"human_input", "approval"}
+                                for step in prepared.workflow.get("steps", [])
+                                if isinstance(step, dict)
+                            )
+                            else AGENCY_EXECUTION_PROTOCOL
+                        ),
+                        "model_id": model_id,
+                        "upstream_revision": upstream_revision,
+                        "capability_snapshot_version": (
+                            capability_snapshot_version
+                        ),
+                        "capability_snapshot_hash": capability_snapshot_hash,
+                        "sink_task_id": prepared.sink_task_id,
+                        "selected_agent_ids": prepared.selected_agent_ids,
+                        "method_skill_digests": {
+                            skill.skill_id: skill.digest
+                            for skill in prepared.skills
+                        },
+                        "resumed_from_task_id": resumed_from_task_id,
+                        **revision_metadata,
+                        "initial_model_calls": int(
+                            (resume or {}).get("prior_model_calls") or 0
+                        ),
+                        "initial_usage": dict(
+                            (resume or {}).get("prior_usage") or {}
+                        ),
+                        "provider_control_mode": (
+                            "managed_required"
+                            if managed_provider_required
+                            else "legacy"
+                        ),
+                    },
+                )
+            except Exception:
+                if managed_run is not None:
+                    managed_run.finish(
+                        "failed",
+                        reason_code="agency_execution_bootstrap_failed",
+                    )
+                raise
             task = asyncio.create_task(
                 self._run(
                     task_id=task_id,
@@ -825,6 +870,7 @@ class AgencyExecutionCoordinator:
                     resume=resume,
                     revision=revision,
                     interaction_resume=None,
+                    managed_run=managed_run,
                 ),
                 name=f"expert-team-agency:{task_id}",
             )
@@ -899,6 +945,14 @@ class AgencyExecutionCoordinator:
                 raise AgencyExecutionCapacityError(
                     "当前已有两个 DAG 正在执行，HITL 任务将在有容量后继续。"
                 )
+            managed_run = self._managed_run(
+                execution.task_id,
+                f"interaction:{approval.approval_id}:{approval.revision}",
+                required=(
+                    execution.runtime_metadata.get("provider_control_mode")
+                    == "managed_required"
+                ),
+            )
             task = asyncio.create_task(
                 self._run(
                     task_id=execution.task_id,
@@ -908,6 +962,7 @@ class AgencyExecutionCoordinator:
                     resume=None,
                     revision=None,
                     interaction_resume=interaction_resume,
+                    managed_run=managed_run,
                 ),
                 name=f"expert-team-agency-hitl:{execution.task_id}",
             )
@@ -972,6 +1027,7 @@ class AgencyExecutionCoordinator:
         *,
         source_task_id: str,
         prepared: PreparedAgencyExecution,
+        managed_provider_required: bool = False,
     ) -> dict[str, Any]:
         source = self.store.require(source_task_id)
         if source.source_kind != "expert_team_agency" or source.status != "failed":
@@ -1052,6 +1108,7 @@ class AgencyExecutionCoordinator:
             upstream_revision=str(metadata.get("upstream_revision") or ""),
             resume=resume,
             resumed_from_task_id=source_task_id,
+            managed_provider_required=managed_provider_required,
         )
 
     async def revise(
@@ -1061,6 +1118,7 @@ class AgencyExecutionCoordinator:
         target_task_id: str,
         feedback: str,
         prepared: PreparedAgencyExecution,
+        managed_provider_required: bool = False,
     ) -> dict[str, Any]:
         source = self.store.require(source_task_id)
         if (
@@ -1240,6 +1298,7 @@ class AgencyExecutionCoordinator:
             upstream_revision=str(metadata.get("upstream_revision") or ""),
             revision=revision,
             revision_metadata=revision_metadata,
+            managed_provider_required=managed_provider_required,
         )
 
     async def cancel(self, task_id: str) -> dict[str, Any]:
@@ -1367,8 +1426,28 @@ class AgencyExecutionCoordinator:
         resume: Mapping[str, Any] | None = None,
         revision: Mapping[str, Any] | None = None,
         interaction_resume: Mapping[str, Any] | None = None,
+        managed_run: AgencyManagedRun | None = None,
     ) -> None:
         item = self.store.require(task_id)
+        managed_run_finished = False
+
+        def finish_managed_run(
+            status: Literal["passed", "failed", "uncertain", "cancelled"],
+            *,
+            reason_code: str | None = None,
+        ) -> None:
+            nonlocal managed_run_finished
+            if managed_run_finished:
+                return
+            try:
+                self._finish_managed_run(
+                    managed_run,
+                    task_id,
+                    status,
+                    reason_code=reason_code,
+                )
+            finally:
+                managed_run_finished = True
 
         async def on_event(event: dict[str, Any]) -> None:
             current = self.store.require(task_id)
@@ -1379,15 +1458,18 @@ class AgencyExecutionCoordinator:
                     and str(event.get("final_output") or "")
                 ):
                     # The completion event is the worker's durable commit point.
-                    # Mark it before yielding back to the event loop so a late
-                    # cancel cannot overwrite a finished, already-billed run.
+                    # Persist the Provider receipt before exposing completion so
+                    # a reader never observes a billed run without its audit.
+                    finish_managed_run("passed")
                     self.store.complete(
                         task_id,
                         result=str(event["final_output"]),
                     )
 
         try:
-            result = await self._client().execute(
+            result = await self._client(
+                model_runner=(managed_run.complete if managed_run is not None else None)
+            ).execute(
                 goal=goal,
                 model_id=model_id,
                 workflow=prepared.workflow,
@@ -1400,6 +1482,7 @@ class AgencyExecutionCoordinator:
             )
             payload = result.payload
             if payload.get("status") == "waiting":
+                finish_managed_run("passed")
                 await self._suspend_interaction(task_id, payload)
                 return
             final_output = str(payload.get("final_output") or "")
@@ -1413,6 +1496,7 @@ class AgencyExecutionCoordinator:
                 self.store.complete(task_id, result=final_output)
                 current = self.store.require(task_id)
             if current.status == "completed":
+                finish_managed_run("passed")
                 await self._safe_update_run(
                     item.run_id,
                     status="completed",
@@ -1423,6 +1507,10 @@ class AgencyExecutionCoordinator:
                     },
                 )
         except asyncio.CancelledError:
+            finish_managed_run(
+                "cancelled",
+                reason_code="agency_execution_cancelled",
+            )
             current = self.store.require(task_id)
             if current.status not in TERMINAL_STATUSES:
                 self._append_terminal_event(
@@ -1438,6 +1526,17 @@ class AgencyExecutionCoordinator:
             raise
         except Exception as exc:
             code = getattr(exc, "code", "agency_execution_failed")
+            managed_status: Literal["failed", "uncertain"] = "failed"
+            if managed_run is not None and any(
+                call.get("status") == "uncertain"
+                for call in managed_run.receipt_summary().get("calls", [])
+                if isinstance(call, dict)
+            ):
+                managed_status = "uncertain"
+            finish_managed_run(
+                managed_status,
+                reason_code=str(code),
+            )
             current = self.store.require(task_id)
             if current.status not in TERMINAL_STATUSES:
                 self._append_terminal_event(
@@ -1546,12 +1645,59 @@ class AgencyExecutionCoordinator:
             },
         )
 
-    def _client(self) -> AgencyExecutionClient:
+    def _client(
+        self, *, model_runner: AgencyModelRunner | None = None
+    ) -> AgencyExecutionClient:
         if self.client_factory is not None:
-            return self.client_factory()
+            client = self.client_factory()
+            if model_runner is not None:
+                client.model_runner = model_runner
+            return client
         return AgencyExecutionClient(
-            model_runner=self.model_runner,
+            model_runner=model_runner or self.model_runner,
             worker_entry=self.worker_entry,
+        )
+
+    def _managed_run(
+        self,
+        task_id: str,
+        segment_key: str,
+        *,
+        required: bool,
+    ) -> AgencyManagedRun | None:
+        if not required:
+            return None
+        if self.managed_run_factory is None:
+            raise AgencyExecutionValidationError(
+                "专家团 Managed Provider 执行器不可用，当前调用失败关闭。",
+                code="provider_workload_policy_not_active",
+            )
+        managed_run = self.managed_run_factory(task_id, segment_key)
+        if managed_run is None:
+            raise AgencyExecutionValidationError(
+                "专家团 Managed Provider 策略已变化，当前调用失败关闭。",
+                code="provider_workload_policy_not_active",
+            )
+        return managed_run
+
+    def _finish_managed_run(
+        self,
+        managed_run: AgencyManagedRun | None,
+        task_id: str,
+        status: Literal["passed", "failed", "uncertain", "cancelled"],
+        *,
+        reason_code: str | None = None,
+    ) -> None:
+        if managed_run is None:
+            return
+        receipt = managed_run.finish(status, reason_code=reason_code)
+        self.store.append_event(
+            task_id,
+            {
+                "event": "agency.provider.receipt",
+                "status": status,
+                "provider_route_receipts": receipt,
+            },
         )
 
     async def _safe_update_run(self, run_id: str, **kwargs: Any) -> None:
@@ -1577,6 +1723,7 @@ class AgencyExecutionCoordinator:
         public = WorkflowExecutionStore.serialize_public(item)
         latest_steps: dict[str, dict[str, Any]] = {}
         summary: dict[str, Any] = {}
+        provider_route_receipts: list[dict[str, Any]] = []
         for event in item.events:
             event_name = str(event.get("event") or "")
             step_id = str(event.get("task_id") or "")
@@ -1591,6 +1738,11 @@ class AgencyExecutionCoordinator:
             cumulative_usage = event.get("cumulative_usage")
             if isinstance(cumulative_usage, dict):
                 summary["usage"] = dict(cumulative_usage)
+            provider_receipt = event.get("provider_route_receipts")
+            if event_name == "agency.provider.receipt" and isinstance(
+                provider_receipt, dict
+            ):
+                provider_route_receipts.append(dict(provider_receipt))
             if event_name in {
                 "agency.run.completed",
                 "agency.run.failed",
@@ -1762,6 +1914,7 @@ class AgencyExecutionCoordinator:
             "lineage_model_calls": lineage_calls_before + current_model_calls,
             "lineage_usage": lineage_usage,
             "estimated_cost": None,
+            "provider_route_receipts": provider_route_receipts,
             "error_code": item.error,
             "error_message": str(
                 summary.get("message") or summary.get("error") or ""

--- a/server/main.py
+++ b/server/main.py
@@ -1281,6 +1281,10 @@ except ModuleNotFoundError:
     from model_router.api import get_catalog_coordinator
 
 try:
+    from server.model_router.expert_team_gateway import (
+        ManagedExpertTeamGateway,
+        ManagedExpertTeamRun,
+    )
     from server.model_router.workflow_gateway import (
         ManagedWorkflowGateway,
         ManagedWorkflowAgentRun,
@@ -1288,6 +1292,10 @@ try:
         ManagedWorkflowRoutingError,
     )
 except ModuleNotFoundError:
+    from model_router.expert_team_gateway import (
+        ManagedExpertTeamGateway,
+        ManagedExpertTeamRun,
+    )
     from model_router.workflow_gateway import (
         ManagedWorkflowGateway,
         ManagedWorkflowAgentRun,
@@ -4959,11 +4967,55 @@ agency_worker_client = AgencyWorkerClient(
     asset_root=expert_team_agency_asset_root(),
     timeout_seconds=expert_team_agency_planner_timeout_seconds(),
 )
+
+
+def expert_team_managed_gateway() -> ManagedExpertTeamGateway:
+    return ManagedExpertTeamGateway.for_router(get_model_router_service())
+
+
+def expert_team_managed_run(
+    task_id: str,
+    segment_key: str,
+) -> ManagedExpertTeamRun | None:
+    gateway = expert_team_managed_gateway()
+    mode = gateway.routing_mode("expert_team_dag")
+    if mode == "legacy":
+        return None
+    if mode != "managed_required":
+        raise ManagedWorkflowRoutingError(
+            "provider_workload_policy_not_active",
+            "专家团 DAG 的 Managed Provider 策略未就绪，当前执行失败关闭。",
+            status_code=409,
+            receipt=gateway.blocked_receipt(
+                "expert_team_dag", "provider_workload_policy_not_active"
+            ),
+        )
+    return gateway.start_run(
+        "expert_team_dag",
+        parent_run_reference=f"expert-team-dag:{task_id}:{segment_key}",
+    )
+
+
+def agency_worker_client_for_model_runner(
+    model_runner: Callable[
+        [AgencyModelRequest], Awaitable[AgencyModelResponse | str]
+    ],
+) -> AgencyWorkerClient:
+    return AgencyWorkerClient(
+        model_runner=model_runner,
+        node_binary=agency_worker_client.node_binary,
+        worker_entry=agency_worker_client.worker_entry,
+        asset_root=agency_worker_client.asset_root,
+        timeout_seconds=agency_worker_client.timeout_seconds,
+    )
+
+
 agency_execution_coordinator = AgencyExecutionCoordinator(
     store=workflow_execution_store,
     run_registry=run_registry,
     model_runner=collect_agency_worker_model,
     approval_store=runtime_approval_store,
+    managed_run_factory=expert_team_managed_run,
 )
 
 
@@ -7118,10 +7170,24 @@ async def preview_expert_team_plan(
                 "code": "expert_team_agency_planner_disabled",
             },
         )
-    if not get_llm_gateway_config()[0]:
+    provider_gateway = expert_team_managed_gateway()
+    provider_mode = provider_gateway.routing_mode("expert_team_planner")
+    if provider_mode == "legacy" and not get_llm_gateway_config()[0]:
         return JSONResponse(
             status_code=500,
             content={"error": LLM_GATEWAY_NOT_CONFIGURED_MESSAGE},
+        )
+    if provider_mode == "degraded_required":
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": "专家团 Planner 的 Managed Provider 策略未就绪，当前规划失败关闭。",
+                "code": "provider_workload_policy_not_active",
+                "provider_route_receipts": provider_gateway.blocked_receipt(
+                    "expert_team_planner",
+                    "provider_workload_policy_not_active",
+                ),
+            },
         )
     try:
         rate_limit_or_raise(client_ip(request))
@@ -7202,8 +7268,35 @@ async def preview_expert_team_plan(
         },
     )
 
+    managed_run: ManagedExpertTeamRun | None = None
+    provider_receipt: dict[str, Any] | None = None
+
+    def finish_provider_run(
+        status: Literal["passed", "failed", "uncertain", "cancelled"],
+        *,
+        reason_code: str | None = None,
+    ) -> dict[str, Any] | None:
+        nonlocal provider_receipt
+        if managed_run is None:
+            return None
+        if provider_receipt is None:
+            provider_receipt = managed_run.finish(
+                status,
+                reason_code=reason_code,
+            )
+        return provider_receipt
+
     try:
-        worker_result = await agency_worker_client.compose(
+        planner_client = agency_worker_client
+        if provider_mode == "managed_required":
+            managed_run = provider_gateway.start_run(
+                "expert_team_planner",
+                parent_run_reference=f"expert-team-planner:{run.run_id}",
+            )
+            planner_client = agency_worker_client_for_model_runner(
+                managed_run.complete
+            )
+        worker_result = await planner_client.compose(
             goal=planning_goal,
             model_id=payload.planner_model_id,
             agents=adapt_expert_catalog(AGENT_RECORDS),
@@ -7305,6 +7398,7 @@ async def preview_expert_team_plan(
             agent_public_payload(agent, score)
             for agent, score in match_agents(payload.goal, min(payload.max_agents, 5))
         ]
+        finish_provider_run("passed")
         await run_registry.record_checkpoint(
             run.run_id,
             event_type="meta_planner.completed",
@@ -7351,8 +7445,31 @@ async def preview_expert_team_plan(
             capability_snapshot_version=snapshot_version,
             capability_snapshot_hash=snapshot_hash,
             upstream_revision=AGENCY_UPSTREAM_REVISION,
+            provider_route_receipts=provider_receipt,
         )
+    except ManagedWorkflowRoutingError as exc:
+        provider_receipt = exc.receipt
+        await run_registry.update_run(
+            run.run_id,
+            status="failed",
+            error=f"{exc.code}: {exc.public_message}"[:500],
+        )
+        content: dict[str, Any] = {
+            "error": exc.public_message,
+            "code": exc.code,
+        }
+        if provider_receipt is not None:
+            content["provider_route_receipts"] = provider_receipt
+        return JSONResponse(status_code=exc.status_code, content=content)
     except AgencyWorkerError as exc:
+        failure_status: Literal["failed", "uncertain"] = "failed"
+        if managed_run is not None and any(
+            item.get("status") == "uncertain"
+            for item in managed_run.receipt_summary().get("calls", [])
+            if isinstance(item, dict)
+        ):
+            failure_status = "uncertain"
+        finish_provider_run(failure_status, reason_code=exc.code)
         await run_registry.update_run(
             run.run_id,
             status="failed",
@@ -7364,30 +7481,41 @@ async def preview_expert_team_plan(
                 "规划模型输出达到当前 token 上限，未生成可执行计划。"
                 "请精简目标、减少最大专家数或更换更适合结构化规划的模型后重试。"
             )
+        content = {"error": error_message, "code": exc.code}
+        if provider_receipt is not None:
+            content["provider_route_receipts"] = provider_receipt
         return JSONResponse(
             status_code=agency_worker_http_status(exc.code),
-            content={"error": error_message, "code": exc.code},
+            content=content,
         )
     except ValueError as exc:
+        finish_provider_run("failed", reason_code="agency_plan_invalid")
         await run_registry.update_run(
             run.run_id,
             status="failed",
             error=str(exc)[:500],
         )
+        content = {"error": str(exc), "code": "agency_plan_invalid"}
+        if provider_receipt is not None:
+            content["provider_route_receipts"] = provider_receipt
         return JSONResponse(
             status_code=422,
-            content={"error": str(exc), "code": "agency_plan_invalid"},
+            content=content,
         )
     except Exception as exc:
+        finish_provider_run("failed", reason_code="agency_preview_failed")
         logger.exception("Expert Team Agency preview failed")
         await run_registry.update_run(
             run.run_id,
             status="failed",
             error=str(exc)[:500],
         )
+        content = {"error": "专家团智能组队预览失败。", "code": "agency_preview_failed"}
+        if provider_receipt is not None:
+            content["provider_route_receipts"] = provider_receipt
         return JSONResponse(
             status_code=500,
-            content={"error": "专家团智能组队预览失败。", "code": "agency_preview_failed"},
+            content=content,
         )
 
 
@@ -7395,11 +7523,53 @@ def agency_execution_error(
     status_code: int,
     code: str,
     message: str,
+    *,
+    provider_route_receipts: dict[str, Any] | None = None,
 ) -> JSONResponse:
+    content: dict[str, Any] = {"error": message, "code": code}
+    if provider_route_receipts is not None:
+        content["provider_route_receipts"] = provider_route_receipts
     return JSONResponse(
         status_code=status_code,
-        content={"error": message, "code": code},
+        content=content,
     )
+
+
+def expert_team_dag_runtime_preflight() -> tuple[str, JSONResponse | None]:
+    gateway = expert_team_managed_gateway()
+    mode = gateway.routing_mode("expert_team_dag")
+    if not agency_execution_coordinator.worker_available():
+        return (
+            mode,
+            agency_execution_error(
+                503,
+                "agency_worker_unavailable",
+                "Agency Worker 当前不可用。",
+            ),
+        )
+    if mode == "legacy" and not get_llm_gateway_config()[0]:
+        return (
+            mode,
+            agency_execution_error(
+                503,
+                "agency_worker_unavailable",
+                "LLM 网关当前不可用。",
+            ),
+        )
+    if mode == "degraded_required":
+        return (
+            mode,
+            agency_execution_error(
+                409,
+                "provider_workload_policy_not_active",
+                "专家团 DAG 的 Managed Provider 策略未就绪，当前执行失败关闭。",
+                provider_route_receipts=gateway.blocked_receipt(
+                    "expert_team_dag",
+                    "provider_workload_policy_not_active",
+                ),
+            ),
+        )
+    return mode, None
 
 
 async def expert_team_execution_model_is_text(model_id: str) -> bool:
@@ -7435,12 +7605,9 @@ async def start_expert_team_dag_run(
             "agency_execution_disabled",
             "专家团 DAG Beta 当前未启用。",
         )
-    if not agency_execution_coordinator.worker_available() or not get_llm_gateway_config()[0]:
-        return agency_execution_error(
-            503,
-            "agency_worker_unavailable",
-            "Agency Worker 或 LLM 网关当前不可用。",
-        )
+    provider_mode, preflight_error = expert_team_dag_runtime_preflight()
+    if preflight_error is not None:
+        return preflight_error
     if payload.upstream_revision != AGENCY_UPSTREAM_REVISION:
         return agency_execution_error(
             409,
@@ -7501,6 +7668,7 @@ async def start_expert_team_dag_run(
             capability_snapshot_version=payload.capability_snapshot_version,
             capability_snapshot_hash=payload.capability_snapshot_hash,
             upstream_revision=payload.upstream_revision,
+            managed_provider_required=(provider_mode == "managed_required"),
         )
         await asyncio.to_thread(
             record_expert_team_method_skill_applications,
@@ -7511,9 +7679,22 @@ async def start_expert_team_dag_run(
         return agency_execution_error(
             429, "agency_execution_capacity_reached", str(exc)
         )
+    except ManagedWorkflowRoutingError as exc:
+        return agency_execution_error(
+            exc.status_code,
+            exc.code,
+            exc.public_message,
+            provider_route_receipts=exc.receipt,
+        )
     except AgencyExecutionValidationError as exc:
         return agency_execution_error(
-            409 if exc.code == "agency_method_skill_changed" else 422,
+            409
+            if exc.code
+            in {
+                "agency_method_skill_changed",
+                "provider_workload_policy_not_active",
+            }
+            else 422,
             exc.code,
             str(exc),
         )
@@ -7743,12 +7924,9 @@ async def retry_expert_team_dag_run(task_id: str, request: Request):
         return agency_execution_error(
             503, "agency_execution_disabled", "专家团 DAG Beta 当前未启用。"
         )
-    if not agency_execution_coordinator.worker_available() or not get_llm_gateway_config()[0]:
-        return agency_execution_error(
-            503,
-            "agency_worker_unavailable",
-            "Agency Worker 或 LLM 网关当前不可用。",
-        )
+    provider_mode, preflight_error = expert_team_dag_runtime_preflight()
+    if preflight_error is not None:
+        return preflight_error
     source = workflow_execution_store.get(task_id)
     if source is None or source.source_kind != "expert_team_agency":
         return agency_execution_error(
@@ -7829,6 +8007,7 @@ async def retry_expert_team_dag_run(task_id: str, request: Request):
         result = await agency_execution_coordinator.retry(
             source_task_id=task_id,
             prepared=prepared,
+            managed_provider_required=(provider_mode == "managed_required"),
         )
         await asyncio.to_thread(
             record_expert_team_method_skill_applications,
@@ -7839,11 +8018,19 @@ async def retry_expert_team_dag_run(task_id: str, request: Request):
         return agency_execution_error(
             429, "agency_execution_capacity_reached", str(exc)
         )
+    except ManagedWorkflowRoutingError as exc:
+        return agency_execution_error(
+            exc.status_code,
+            exc.code,
+            exc.public_message,
+            provider_route_receipts=exc.receipt,
+        )
     except AgencyExecutionValidationError as exc:
         status = 409 if exc.code in {
             "agency_execution_not_retryable",
             "agency_method_skill_changed",
             "capability_snapshot_changed",
+            "provider_workload_policy_not_active",
         } else 422
         return agency_execution_error(status, exc.code, str(exc))
     new_task_id = str(result["task_id"])
@@ -7872,12 +8059,9 @@ async def revise_expert_team_dag_run(
             "agency_revision_disabled",
             "专家团对话式返工当前未启用。",
         )
-    if not agency_execution_coordinator.worker_available() or not get_llm_gateway_config()[0]:
-        return agency_execution_error(
-            503,
-            "agency_worker_unavailable",
-            "Agency Worker 或 LLM 网关当前不可用。",
-        )
+    provider_mode, preflight_error = expert_team_dag_runtime_preflight()
+    if preflight_error is not None:
+        return preflight_error
     source = workflow_execution_store.get(task_id)
     if source is None or source.source_kind != "expert_team_agency":
         return agency_execution_error(
@@ -7910,6 +8094,7 @@ async def revise_expert_team_dag_run(
             target_task_id=revision_request.target_task_id,
             feedback=revision_request.feedback,
             prepared=prepared,
+            managed_provider_required=(provider_mode == "managed_required"),
         )
         await asyncio.to_thread(
             record_expert_team_method_skill_applications,
@@ -7920,6 +8105,13 @@ async def revise_expert_team_dag_run(
         return agency_execution_error(
             429, "agency_execution_capacity_reached", str(exc)
         )
+    except ManagedWorkflowRoutingError as exc:
+        return agency_execution_error(
+            exc.status_code,
+            exc.code,
+            exc.public_message,
+            provider_route_receipts=exc.receipt,
+        )
     except AgencyExecutionValidationError as exc:
         status = 409 if exc.code in {
             "agency_execution_not_revisable",
@@ -7927,6 +8119,7 @@ async def revise_expert_team_dag_run(
             "agency_method_skill_changed",
             "capability_snapshot_changed",
             "upstream_revision_changed",
+            "provider_workload_policy_not_active",
         } else 422
         return agency_execution_error(status, exc.code, str(exc))
     new_task_id = str(result["task_id"])

--- a/server/model_router/expert_team_gateway.py
+++ b/server/model_router/expert_team_gateway.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Literal, cast
+
+import httpx
+
+try:
+    from server.orchestration_worker import (
+        AgencyModelRequest,
+        AgencyModelResponse,
+        AgencyWorkerError,
+    )
+except ImportError:  # pragma: no cover - direct server package execution
+    from orchestration_worker import (
+        AgencyModelRequest,
+        AgencyModelResponse,
+        AgencyWorkerError,
+    )
+
+from .service import ModelRouterService, RouterServiceError
+from .workflow_gateway import (
+    ManagedWorkflowGateway,
+    ManagedWorkflowNodeRun,
+    ManagedWorkflowRoutingError,
+    WorkflowEntryId,
+)
+from .workload_control import (
+    PROVIDER_WORKLOAD_CONTRACT_VERSION,
+    ProviderWorkloadCallService,
+)
+
+
+ExpertTeamEntryId = Literal["expert_team_planner", "expert_team_dag"]
+ExpertTeamRoutingMode = Literal[
+    "legacy", "managed_required", "degraded_required"
+]
+
+
+class ManagedExpertTeamGateway:
+    """Provider control-plane adapter for Agency Worker host callbacks."""
+
+    def __init__(
+        self,
+        call_service: ProviderWorkloadCallService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self.call_service = call_service
+        self._workflow_gateway = ManagedWorkflowGateway(
+            call_service,
+            client_factory=client_factory,
+        )
+
+    @classmethod
+    def for_router(
+        cls,
+        router_service: ModelRouterService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> ManagedExpertTeamGateway:
+        return cls(
+            ProviderWorkloadCallService(router_service),
+            client_factory=client_factory,
+        )
+
+    def routing_mode(self, entry_id: ExpertTeamEntryId) -> ExpertTeamRoutingMode:
+        control = self.call_service.control
+        if not control.feature_enabled(entry_id):
+            return "legacy"
+        policy = control.get_policy(entry_id)
+        if policy.configured_status == "legacy":
+            return "legacy"
+        if policy.effective_status == "managed_required":
+            return "managed_required"
+        return "degraded_required"
+
+    def start_run(
+        self,
+        entry_id: ExpertTeamEntryId,
+        *,
+        parent_run_reference: str,
+    ) -> ManagedExpertTeamRun:
+        if self.routing_mode(entry_id) != "managed_required":
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_policy_not_active",
+                "Expert Team 的 Managed Provider 策略未就绪，当前调用失败关闭。",
+                status_code=409,
+                receipt=self.blocked_receipt(
+                    entry_id, "provider_workload_policy_not_active"
+                ),
+            )
+        try:
+            run_id = self.call_service.start_stable_run(
+                entry_id,
+                parent_run_reference=parent_run_reference,
+            )
+        except RouterServiceError as exc:
+            raise ManagedWorkflowRoutingError(
+                exc.code,
+                "Expert Team 已有执行证据或资格已失效，系统不会自动重放。",
+                status_code=exc.status_code,
+                receipt=self.blocked_receipt(entry_id, exc.code),
+            ) from exc
+        node_run = ManagedWorkflowNodeRun(
+            self._workflow_gateway,
+            cast(WorkflowEntryId, entry_id),
+            run_id,
+        )
+        return ManagedExpertTeamRun(entry_id, node_run)
+
+    @staticmethod
+    def blocked_receipt(
+        entry_id: ExpertTeamEntryId, reason_code: str
+    ) -> dict[str, Any]:
+        return {
+            "contract_version": PROVIDER_WORKLOAD_CONTRACT_VERSION,
+            "entry_id": entry_id,
+            "routing_mode": "managed_required",
+            "run_reference": "blocked_before_dispatch",
+            "status": "failed",
+            "call_count": 0,
+            "reason_codes": [reason_code],
+            "calls": [],
+        }
+
+
+class ManagedExpertTeamRun:
+    """One Planner or DAG segment with stable Worker request receipts."""
+
+    def __init__(
+        self,
+        entry_id: ExpertTeamEntryId,
+        node_run: ManagedWorkflowNodeRun,
+    ) -> None:
+        self.entry_id = entry_id
+        self._node_run = node_run
+        self._call_sequence = 0
+
+    async def complete(self, request: AgencyModelRequest) -> AgencyModelResponse:
+        self._call_sequence += 1
+        call_sequence = self._call_sequence
+        messages = [
+            {"role": message.role, "content": message.content}
+            for message in request.messages
+        ]
+        try:
+            if request.json_response:
+                content = await self._node_run.complete_json_object(
+                    logical_call_key=request.request_id,
+                    call_sequence=call_sequence,
+                    model_id=request.model_id,
+                    messages=messages,
+                    temperature=request.temperature,
+                    max_tokens=request.max_tokens,
+                )
+            else:
+                content = await self._node_run.complete_text_unary(
+                    logical_call_key=request.request_id,
+                    call_sequence=call_sequence,
+                    model_id=request.model_id,
+                    messages=messages,
+                    temperature=request.temperature,
+                    max_tokens=request.max_tokens,
+                )
+        except ManagedWorkflowRoutingError as exc:
+            raise AgencyWorkerError(
+                exc.public_message,
+                code=exc.code,
+            ) from exc
+
+        receipt = next(
+            (
+                item
+                for item in self._node_run.calls
+                if item.call_sequence == call_sequence
+            ),
+            None,
+        )
+        usage: dict[str, int] = {}
+        if receipt is not None:
+            if receipt.prompt_tokens is not None:
+                usage["input_tokens"] = receipt.prompt_tokens
+            if receipt.completion_tokens is not None:
+                usage["output_tokens"] = receipt.completion_tokens
+        return AgencyModelResponse(content=content, usage=usage)
+
+    def finish(
+        self,
+        status: Literal["passed", "failed", "uncertain", "cancelled"],
+        *,
+        reason_code: str | None = None,
+    ) -> dict[str, Any]:
+        self._node_run.finish(status, reason_code=reason_code)
+        return self.receipt_summary()
+
+    def receipt_summary(self) -> dict[str, Any]:
+        summary = self._node_run.receipt_summary()
+        summary["calls"] = sorted(
+            summary["calls"], key=lambda item: int(item["call_sequence"])
+        )
+        return summary

--- a/server/model_router/workload_control.py
+++ b/server/model_router/workload_control.py
@@ -90,8 +90,11 @@ ENTRY_ALLOWED_SHAPES: dict[
     ),
     "xpert": frozenset({"chat_text", "chat_tools", "chat_json_object"}),
     "xpert_app": frozenset({"chat_text", "chat_tools", "chat_json_object"}),
-    "expert_team_planner": frozenset({"chat_json_object"}),
-    "expert_team_dag": frozenset({"chat_text_unary"}),
+    # The Agency planner emits a YAML plan through a non-streaming text request.
+    "expert_team_planner": frozenset({"chat_text_unary"}),
+    # The Agency DAG executes expert text steps and JSON acceptance checks.
+    # These qualifications are independent and both must be explicit.
+    "expert_team_dag": frozenset({"chat_text_unary", "chat_json_object"}),
     "fusion": frozenset({"chat_text", "fusion_native"}),
     "route_agent": frozenset({"chat_text"}),
     "team_chat": frozenset({"chat_text"}),
@@ -109,6 +112,8 @@ DATA_PLANE_INTEGRATED_ENTRIES: frozenset[ProviderWorkloadEntryId] = frozenset(
         "workflow_deployment_agent",
         "xpert",
         "xpert_app",
+        "expert_team_planner",
+        "expert_team_dag",
     }
 )
 

--- a/server/tests/test_expert_team_agency_execution.py
+++ b/server/tests/test_expert_team_agency_execution.py
@@ -22,6 +22,7 @@ from server.orchestration_worker import (
     AgencySkillDefinition,
     AgencyWorkerError,
 )
+from server.orchestration_worker.contracts import AgencyModelMessage, AgencyModelRequest
 from server.workflow_native.schemas import NativeWorkflowDefinition
 from server.xpert_runtime import (
     RunRegistry,
@@ -610,6 +611,79 @@ class CompletingClient:
         )
 
 
+class ManagedCallingClient:
+    worker_entry = Path(__file__)
+
+    def __init__(self):
+        self.model_runner = None
+
+    async def execute(self, *, on_event, model_id, **_kwargs):
+        assert self.model_runner is not None
+        response = await self.model_runner(
+            AgencyModelRequest(
+                request_id="worker-request-delivery",
+                model_id=model_id,
+                messages=[AgencyModelMessage(role="user", content="execute")],
+                temperature=0.2,
+                max_tokens=128,
+                json_response=False,
+            )
+        )
+        await on_event(
+            {
+                "event": "agency.run.completed",
+                "status": "completed",
+                "final_output": response.content,
+                "model_calls": 1,
+                "usage": response.usage,
+            }
+        )
+        return SimpleNamespace(
+            payload={
+                "final_output": response.content,
+                "model_calls": 1,
+                "usage": response.usage,
+            }
+        )
+
+
+class FakeManagedRun:
+    def __init__(self):
+        self.requests = []
+        self.status = "running"
+
+    async def complete(self, request):
+        self.requests.append(request)
+        return AgencyModelResponse(
+            content="managed result",
+            usage={"input_tokens": 2, "output_tokens": 3},
+        )
+
+    def finish(self, status, *, reason_code=None):
+        self.status = status
+        return self.receipt_summary(reason_code=reason_code)
+
+    def receipt_summary(self, *, reason_code=None):
+        return {
+            "contract_version": "modelmirror-provider-workload-routing-v1",
+            "entry_id": "expert_team_dag",
+            "routing_mode": "managed_required",
+            "run_reference": "managed-test-run",
+            "status": self.status,
+            "call_count": len(self.requests),
+            "reason_codes": [reason_code] if reason_code else [],
+            "calls": [
+                {
+                    "call_sequence": index,
+                    "model_id": request.model_id,
+                    "status": "passed",
+                    "dispatched": True,
+                }
+                for index, request in enumerate(self.requests, start=1)
+            ],
+        }
+
+
 class CompletionCommitClient:
     worker_entry = Path(__file__)
 
@@ -860,6 +934,45 @@ def coordinator(tmp_path, client):
     )
 
 
+def test_managed_start_closes_control_run_when_local_bootstrap_fails(
+    tmp_path, monkeypatch
+):
+    async def scenario():
+        plan, workflow = valid_plan_and_workflow()
+        prepared = prepare_agency_execution(
+            plan=plan, workflow=workflow, expert_records=experts()
+        )
+        managed_run = FakeManagedRun()
+        run_registry = RunRegistry()
+
+        async def fail_create_run(*_args, **_kwargs):
+            raise RuntimeError("local registry unavailable")
+
+        monkeypatch.setattr(run_registry, "create_run", fail_create_run)
+        runtime = AgencyExecutionCoordinator(
+            store=WorkflowExecutionStore(tmp_path),
+            run_registry=run_registry,
+            model_runner=_noop_model,
+            client_factory=CompletingClient,
+            managed_run_factory=lambda _task_id, _segment_key: managed_run,
+        )
+
+        with pytest.raises(RuntimeError, match="local registry unavailable"):
+            await runtime.start(
+                goal="形成发布方案。",
+                model_id="managed-model",
+                prepared=prepared,
+                capability_snapshot_version="snapshot-v1",
+                capability_snapshot_hash="hash",
+                upstream_revision="revision",
+                managed_provider_required=True,
+            )
+
+        assert managed_run.status == "failed"
+
+    asyncio.run(scenario())
+
+
 def test_hitl_wait_persists_and_resumes_same_task(tmp_path):
     async def scenario():
         plan, workflow = valid_hitl_plan_and_workflow()
@@ -921,6 +1034,81 @@ def test_hitl_wait_persists_and_resumes_same_task(tmp_path):
         assert client.calls[1]["prior_model_calls"] == 1
         assert client.calls[1]["prior_active_duration_ms"] == 1200
         assert completed["interaction_history"][0]["input"] == "采购负责人"
+
+    asyncio.run(scenario())
+
+
+def test_managed_hitl_uses_distinct_initial_and_resume_segments(tmp_path):
+    async def scenario():
+        plan, workflow = valid_hitl_plan_and_workflow()
+        prepared = prepare_agency_execution(
+            plan=plan, workflow=workflow, expert_records=experts()
+        )
+        approvals = RuntimeApprovalStore(tmp_path)
+        created_runs = []
+
+        def managed_run_factory(task_id, segment_key):
+            managed_run = FakeManagedRun()
+            created_runs.append((task_id, segment_key, managed_run))
+            return managed_run
+
+        runtime = AgencyExecutionCoordinator(
+            store=WorkflowExecutionStore(tmp_path),
+            run_registry=RunRegistry(),
+            model_runner=_noop_model,
+            client_factory=HitlCheckpointClient,
+            approval_store=approvals,
+            managed_run_factory=managed_run_factory,
+        )
+        started = await runtime.start(
+            goal="为采购负责人形成发布方案。",
+            model_id="managed-model",
+            prepared=prepared,
+            capability_snapshot_version="snapshot-v1",
+            capability_snapshot_hash="hash",
+            upstream_revision="revision",
+            managed_provider_required=True,
+        )
+        for _ in range(50):
+            waiting = runtime.get(started["task_id"])
+            if waiting["status"] == "waiting":
+                break
+            await asyncio.sleep(0.01)
+        interaction = waiting["pending_interaction"]
+        approval = approvals.decide(
+            interaction["approval_id"],
+            revision=interaction["revision"],
+            decision="replace",
+            operator="tester",
+            replacement_text="采购负责人",
+        )
+        runtime.store.mark_ready(started["task_id"], approval_id=approval.approval_id)
+        claimed = runtime.store.claim(
+            started["task_id"], worker_id="test", lease_seconds=60
+        )
+        await runtime.resume_interaction(
+            execution=claimed,
+            approval=approval,
+            prepared=prepared,
+        )
+        for _ in range(50):
+            completed = runtime.get(started["task_id"])
+            if completed["status"] == "completed":
+                break
+            await asyncio.sleep(0.01)
+
+        assert completed["status"] == "completed"
+        assert [(task_id, segment) for task_id, segment, _run in created_runs] == [
+            (started["task_id"], "initial"),
+            (
+                started["task_id"],
+                f"interaction:{approval.approval_id}:{approval.revision}",
+            ),
+        ]
+        assert [item["status"] for item in completed["provider_route_receipts"]] == [
+            "passed",
+            "passed",
+        ]
 
     asyncio.run(scenario())
 
@@ -1033,6 +1221,123 @@ def test_coordinator_persists_events_and_completes(tmp_path):
         assert current["selected_agent_ids"] == ["agent-alpha", "agent-beta"]
 
     asyncio.run(scenario())
+
+
+def test_managed_dag_uses_worker_request_id_and_persists_redacted_receipt(tmp_path):
+    async def scenario():
+        plan, workflow = valid_plan_and_workflow()
+        prepared = prepare_agency_execution(
+            plan=plan, workflow=workflow, expert_records=experts()
+        )
+        created_runs = []
+
+        def managed_run_factory(task_id, segment_key):
+            managed_run = FakeManagedRun()
+            created_runs.append((task_id, segment_key, managed_run))
+            return managed_run
+
+        runtime = AgencyExecutionCoordinator(
+            store=WorkflowExecutionStore(tmp_path),
+            run_registry=RunRegistry(),
+            model_runner=_noop_model,
+            client_factory=ManagedCallingClient,
+            managed_run_factory=managed_run_factory,
+        )
+        started = await runtime.start(
+            goal="制定一个可执行的专家协作方案。",
+            model_id="managed-model",
+            prepared=prepared,
+            capability_snapshot_version="snapshot-v1",
+            capability_snapshot_hash="hash",
+            upstream_revision="revision",
+            managed_provider_required=True,
+        )
+        for _ in range(50):
+            current = runtime.get(started["task_id"])
+            if current["status"] == "completed":
+                break
+            await asyncio.sleep(0.01)
+
+        assert current["status"] == "completed"
+        assert len(created_runs) == 1
+        assert created_runs[0][0] == started["task_id"]
+        assert created_runs[0][1] == "initial"
+        managed_run = created_runs[0][2]
+        assert [request.request_id for request in managed_run.requests] == [
+            "worker-request-delivery"
+        ]
+        assert managed_run.status == "passed"
+        receipt = current["provider_route_receipts"][0]
+        assert receipt["entry_id"] == "expert_team_dag"
+        assert receipt["status"] == "passed"
+        assert receipt["call_count"] == 1
+        assert receipt["calls"][0]["call_sequence"] == 1
+        assert receipt["calls"][0]["model_id"] == "managed-model"
+        assert receipt["calls"][0]["dispatched"] is True
+        receipt_event = next(
+            event
+            for event in current["events"]
+            if event["event"] == "agency.provider.receipt"
+        )
+        serialized = json.dumps(receipt_event, ensure_ascii=False)
+        assert "execute" not in serialized
+        assert "managed result" not in serialized
+
+    asyncio.run(scenario())
+
+
+def test_managed_dag_policy_drift_fails_before_legacy_worker_start(tmp_path):
+    async def scenario():
+        plan, workflow = valid_plan_and_workflow()
+        prepared = prepare_agency_execution(
+            plan=plan, workflow=workflow, expert_records=experts()
+        )
+        client = CompletingClient()
+        runtime = AgencyExecutionCoordinator(
+            store=WorkflowExecutionStore(tmp_path),
+            run_registry=RunRegistry(),
+            model_runner=_noop_model,
+            client_factory=lambda: client,
+            managed_run_factory=lambda _task_id, _segment_key: None,
+        )
+
+        with pytest.raises(AgencyExecutionValidationError) as caught:
+            await runtime.start(
+                goal="制定一个可执行的专家协作方案。",
+                model_id="managed-model",
+                prepared=prepared,
+                capability_snapshot_version="snapshot-v1",
+                capability_snapshot_hash="hash",
+                upstream_revision="revision",
+                managed_provider_required=True,
+            )
+
+        assert caught.value.code == "provider_workload_policy_not_active"
+        assert runtime.store.list_items(limit=10) == []
+
+    asyncio.run(scenario())
+
+
+def test_expert_team_receipt_projection_preserves_ten_planned_calls() -> None:
+    receipt = WorkflowExecutionStore._safe_provider_route_receipt(
+        {
+            "entry_id": "expert_team_dag",
+            "status": "passed",
+            "calls": [
+                {
+                    "call_sequence": index,
+                    "model_id": "managed-model",
+                    "dispatched": True,
+                    "status": "passed",
+                }
+                for index in range(1, 13)
+            ],
+        }
+    )
+
+    assert receipt["call_count"] == 10
+    assert len(receipt["calls"]) == 10
+    assert receipt["calls"][-1]["call_sequence"] == 10
 
 
 def test_cancel_is_idempotent_and_stops_background_client(tmp_path):
@@ -2270,9 +2575,10 @@ def test_execution_retry_api_rebuilds_server_owned_contract(tmp_path, monkeypatc
 
     captured = {}
 
-    async def fake_retry(*, source_task_id, prepared):
+    async def fake_retry(*, source_task_id, prepared, managed_provider_required):
         captured["source_task_id"] = source_task_id
         captured["prepared"] = prepared
+        captured["managed_provider_required"] = managed_provider_required
         return {
             "task_id": "retry-new",
             "run_id": "retry-new-run",
@@ -2299,6 +2605,7 @@ def test_execution_retry_api_rebuilds_server_owned_contract(tmp_path, monkeypatc
     assert captured["source_task_id"] == source.task_id
     assert captured["prepared"].selected_agent_ids == [agent_id]
     assert captured["prepared"].workflow == source.workflow
+    assert captured["managed_provider_required"] is False
 
 
 def test_execution_revision_api_is_gated_and_rebuilds_frozen_contract(
@@ -2430,12 +2737,20 @@ def test_execution_revision_api_is_gated_and_rebuilds_frozen_contract(
 
     captured = {}
 
-    async def fake_revise(*, source_task_id, target_task_id, feedback, prepared):
+    async def fake_revise(
+        *,
+        source_task_id,
+        target_task_id,
+        feedback,
+        prepared,
+        managed_provider_required,
+    ):
         captured.update(
             source_task_id=source_task_id,
             target_task_id=target_task_id,
             feedback=feedback,
             prepared=prepared,
+            managed_provider_required=managed_provider_required,
         )
         return {
             "task_id": "revision-api-new",
@@ -2465,6 +2780,7 @@ def test_execution_revision_api_is_gated_and_rebuilds_frozen_contract(
     assert captured["source_task_id"] == source.task_id
     assert captured["target_task_id"] == "final"
     assert captured["prepared"].workflow == source.workflow
+    assert captured["managed_provider_required"] is False
     assert captured["prepared"].selected_agent_ids == [agent_id]
 
 

--- a/server/tests/test_expert_team_agency_planner.py
+++ b/server/tests/test_expert_team_agency_planner.py
@@ -411,6 +411,89 @@ def test_plan_preview_auto_compiles_without_authoring_proposal(
     assert expert_run.metadata["backend"] == "agency_orchestrator"
 
 
+def test_plan_preview_managed_mode_uses_bound_runner_and_returns_receipt(
+    monkeypatch,
+) -> None:
+    experts = main_module.AGENT_RECORDS[:2]
+    observed: dict = {}
+
+    class FakeManagedRun:
+        async def complete(self, request):
+            observed["request"] = request
+            raise AssertionError("the fake worker should not call the runner")
+
+        def finish(self, status, *, reason_code=None):
+            observed["finish"] = (status, reason_code)
+            return self.receipt_summary(status=status)
+
+        def receipt_summary(self, *, status="running"):
+            return {
+                "contract_version": "modelmirror-provider-workload-routing-v1",
+                "entry_id": "expert_team_planner",
+                "routing_mode": "managed_required",
+                "run_reference": "planner-managed-run",
+                "status": status,
+                "call_count": 1,
+                "reason_codes": [],
+                "calls": [],
+            }
+
+    managed_run = FakeManagedRun()
+
+    class FakeGateway:
+        def routing_mode(self, entry_id):
+            assert entry_id == "expert_team_planner"
+            return "managed_required"
+
+        def start_run(self, entry_id, *, parent_run_reference):
+            observed["entry_id"] = entry_id
+            observed["parent_run_reference"] = parent_run_reference
+            return managed_run
+
+    class FakePlannerClient:
+        async def compose(self, **kwargs):
+            observed["compose"] = kwargs
+            return agency_result(experts[0].id, experts[1].id)
+
+    def fake_client_for_runner(runner):
+        observed["runner"] = runner
+        return FakePlannerClient()
+
+    monkeypatch.setenv("EXPERT_TEAM_AGENCY_PLANNER_ENABLED", "1")
+    monkeypatch.setattr(main_module, "expert_team_managed_gateway", FakeGateway)
+    monkeypatch.setattr(
+        main_module,
+        "agency_worker_client_for_model_runner",
+        fake_client_for_runner,
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: (_ for _ in ()).throw(AssertionError("legacy gateway used")),
+    )
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+
+    response = client.post(
+        "/api/expert-team/plan-preview",
+        json={
+            "goal": "研究新产品并形成可执行的发布方案。",
+            "planner_model_id": "model/planner",
+            "default_agent_model_id": "model/agent",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert observed["runner"] == managed_run.complete
+    assert observed["finish"] == ("passed", None)
+    assert observed["entry_id"] == "expert_team_planner"
+    assert observed["parent_run_reference"].startswith("expert-team-planner:")
+    assert payload["provider_route_receipts"]["entry_id"] == (
+        "expert_team_planner"
+    )
+    assert payload["provider_route_receipts"]["status"] == "passed"
+
+
 def test_plan_preview_keeps_catalog_examples_out_of_workflow_variables(
     monkeypatch,
 ) -> None:

--- a/server/tests/test_expert_team_managed_gateway.py
+++ b/server/tests/test_expert_team_managed_gateway.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from server.model_router.expert_team_gateway import ManagedExpertTeamGateway
+from server.model_router.egress import ProviderEgressPolicy
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import (
+    ProviderWorkloadActivationRequest,
+    ProviderWorkloadBindingUpdate,
+    ProviderWorkloadPolicyUpdate,
+    RouterConnectionCreate,
+)
+from server.model_router.service import ModelRouterService
+from server.model_router.workload_control import PROVIDER_WORKLOAD_CONTRACT_VERSION
+from server.orchestration_worker import AgencyWorkerError
+from server.orchestration_worker.contracts import AgencyModelMessage, AgencyModelRequest
+
+
+MODEL_ID = "provider/expert-team-model"
+
+
+def _request(*, request_id: str, json_response: bool) -> AgencyModelRequest:
+    return AgencyModelRequest(
+        request_id=request_id,
+        model_id=MODEL_ID,
+        messages=[
+            AgencyModelMessage(role="system", content="Follow the contract."),
+            AgencyModelMessage(role="user", content="Produce the result."),
+        ],
+        temperature=0.0 if json_response else 0.3,
+        max_tokens=512,
+        json_response=json_response,
+    )
+
+
+def _gateway(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    entry_id: str,
+    shapes: list[str],
+    handler,
+) -> ManagedExpertTeamGateway:
+    repository = SQLiteRouterRepository(tmp_path / "router", master_key=b"x" * 32)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Expert Team Provider",
+            kind="openrouter",
+            base_url="https://provider.example/v1",
+            api_key="test-key",
+            scopes=["chat"],
+        ),
+    )
+    repository.save_test_result(
+        "local",
+        connection.id,
+        health="online",
+        model_count=1,
+        checked_at="2026-08-24T00:00:00+00:00",
+    )
+    connection_fingerprint = repository.connection_config_fingerprint(
+        "local", connection.id
+    )
+    repository.claim_catalog_refresh(
+        "local",
+        refresh_id="refresh-r6g",
+        connection_id=connection.id,
+        connection_fingerprint=connection_fingerprint,
+    )
+    repository.complete_catalog_refresh(
+        "local",
+        "refresh-r6g",
+        connection_id=connection.id,
+        models=[
+            {
+                "model_id": MODEL_ID,
+                "normalized_model_id": MODEL_ID,
+                "capability_state": "declared",
+            }
+        ],
+        offerings=[],
+        model_count=1,
+        truncated=False,
+        catalog_fingerprint="catalog-r6g",
+        observed_at="2026-08-24T00:00:00+00:00",
+    )
+    bindings = []
+    for index, shape in enumerate(shapes, start=1):
+        profile = {
+            "execution_shape": shape,
+            "model_id": MODEL_ID,
+            "candidate_model_ids": [],
+            "judge_model_id": None,
+        }
+        profile_fingerprint = hashlib.sha256(
+            json.dumps(profile, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        certification, created = repository.claim_workload_certification(
+            "local",
+            certification_id=f"cert-r6g-{index}",
+            connection_id=connection.id,
+            connection_fingerprint=connection_fingerprint,
+            contract_version=PROVIDER_WORKLOAD_CONTRACT_VERSION,
+            execution_shape=shape,
+            requested_model=MODEL_ID,
+            profile=profile,
+            profile_fingerprint=profile_fingerprint,
+            idempotency_key_hash=hashlib.sha256(
+                f"idem-r6g-{index}".encode()
+            ).hexdigest(),
+        )
+        assert created is True
+        repository.complete_workload_certification(
+            "local",
+            str(certification["id"]),
+            status="passed",
+            checks={
+                "content_observed": True,
+                "actual_model_verified": True,
+                "json_object_verified": shape == "chat_json_object",
+            },
+            warning_codes=[],
+            actual_model=MODEL_ID,
+        )
+        bindings.append(
+            ProviderWorkloadBindingUpdate(
+                connection_id=connection.id,
+                model_id=MODEL_ID,
+                execution_shape=shape,
+            )
+        )
+    monkeypatch.setenv(
+        "MODEL_CONTROL_EXPERT_TEAM_PLANNER_ENABLED" if entry_id == "expert_team_planner" else "MODEL_CONTROL_EXPERT_TEAM_DAG_ENABLED",
+        "true",
+    )
+    service = ModelRouterService(
+        repository,
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+    control = ManagedExpertTeamGateway.for_router(service).call_service.control
+    policy = control.get_policy(entry_id)
+    updated = control.update_policy(
+        entry_id,
+        ProviderWorkloadPolicyUpdate(
+            expected_revision=policy.revision,
+            bindings=bindings,
+        ),
+    )
+    control.activate(
+        entry_id,
+        ProviderWorkloadActivationRequest(
+            expected_revision=updated.revision,
+            acknowledge_fail_closed=True,
+            no_open_p0_p1=True,
+        ),
+    )
+    return ManagedExpertTeamGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), trust_env=False
+        ),
+    )
+
+
+def test_planner_uses_text_unary_qualification_and_records_one_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "model": MODEL_ID,
+                "choices": [{"message": {"content": "name: Smoke plan"}}],
+                "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+            },
+        )
+
+    gateway = _gateway(
+        tmp_path,
+        monkeypatch,
+        entry_id="expert_team_planner",
+        shapes=["chat_text_unary"],
+        handler=handler,
+    )
+    run = gateway.start_run(
+        "expert_team_planner", parent_run_reference="planner:run-1"
+    )
+    response = asyncio.run(
+        run.complete(_request(request_id="planner-request-1", json_response=False))
+    )
+    receipt = run.finish("passed")
+
+    assert response.content == "name: Smoke plan"
+    assert response.usage == {"input_tokens": 3, "output_tokens": 4}
+    assert len(requests) == 1
+    assert "response_format" not in json.loads(requests[0].content)
+    assert receipt["entry_id"] == "expert_team_planner"
+    assert receipt["call_count"] == 1
+    assert receipt["calls"][0]["status"] == "passed"
+
+
+def test_dag_uses_independent_text_and_json_qualifications(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payloads: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        payloads.append(payload)
+        content = '{"pass":true,"failed":[]}' if payload.get("response_format") else "delivery"
+        return httpx.Response(
+            200,
+            json={"model": MODEL_ID, "choices": [{"message": {"content": content}}]},
+        )
+
+    gateway = _gateway(
+        tmp_path,
+        monkeypatch,
+        entry_id="expert_team_dag",
+        shapes=["chat_text_unary", "chat_json_object"],
+        handler=handler,
+    )
+    run = gateway.start_run("expert_team_dag", parent_run_reference="dag:run-1")
+
+    async def scenario():
+        text = await run.complete(
+            _request(request_id="dag-text-request", json_response=False)
+        )
+        judge = await run.complete(
+            _request(request_id="dag-json-request", json_response=True)
+        )
+        return text, judge
+
+    text, judge = asyncio.run(scenario())
+    receipt = run.finish("passed")
+    assert text.content == "delivery"
+    assert json.loads(judge.content)["pass"] is True
+    assert len(payloads) == 2
+    assert "response_format" not in payloads[0]
+    assert payloads[1]["response_format"] == {"type": "json_object"}
+    assert receipt["call_count"] == 2
+    assert [call["call_sequence"] for call in receipt["calls"]] == [1, 2]
+
+
+def test_duplicate_worker_request_id_is_never_dispatched_twice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dispatches = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal dispatches
+        dispatches += 1
+        return httpx.Response(
+            200,
+            json={"model": MODEL_ID, "choices": [{"message": {"content": "ok"}}]},
+        )
+
+    gateway = _gateway(
+        tmp_path,
+        monkeypatch,
+        entry_id="expert_team_dag",
+        shapes=["chat_text_unary", "chat_json_object"],
+        handler=handler,
+    )
+    run = gateway.start_run("expert_team_dag", parent_run_reference="dag:run-replay")
+    request = _request(request_id="same-worker-request", json_response=False)
+
+    async def scenario():
+        await run.complete(request)
+        with pytest.raises(AgencyWorkerError) as caught:
+            await run.complete(request)
+        assert getattr(caught.value, "code", "") == "provider_workload_logical_call_replay_blocked"
+
+    asyncio.run(scenario())
+    assert dispatches == 1
+    receipt = run.finish("failed", reason_code="provider_workload_logical_call_replay_blocked")
+    assert receipt["call_count"] == 1
+
+
+def test_feature_off_keeps_legacy_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("MODEL_CONTROL_EXPERT_TEAM_PLANNER_ENABLED", raising=False)
+    repository = SQLiteRouterRepository(tmp_path / "router", master_key=b"x" * 32)
+    gateway = ManagedExpertTeamGateway.for_router(
+        ModelRouterService(repository)
+    )
+    assert gateway.routing_mode("expert_team_planner") == "legacy"

--- a/server/xpert_runtime/execution_store.py
+++ b/server/xpert_runtime/execution_store.py
@@ -695,6 +695,8 @@ class WorkflowExecutionStore:
             "workflow_deployment_agent",
             "xpert",
             "xpert_app",
+            "expert_team_planner",
+            "expert_team_dag",
         }
         allowed_statuses = {
             "running",
@@ -707,7 +709,7 @@ class WorkflowExecutionStore:
         status = str(raw.get("status") or "failed")
         calls: list[dict[str, Any]] = []
         raw_calls = raw.get("calls")
-        for item in raw_calls[:8] if isinstance(raw_calls, list) else []:
+        for item in raw_calls[:10] if isinstance(raw_calls, list) else []:
             if not isinstance(item, dict):
                 continue
             call_status = str(item.get("status") or "failed")
@@ -749,7 +751,7 @@ class WorkflowExecutionStore:
             "run_reference": str(raw.get("run_reference") or "")[:200],
             "status": status if status in allowed_statuses else "failed",
             "call_count": min(
-                8,
+                10,
                 sum(1 for item in calls if item["dispatched"]),
             ),
             "reason_codes": [


### PR DESCRIPTION
## 范围

- 将 Expert Team Planner 与 DAG 模型调用接入 v16 Managed Provider Route Plan、精确 Binding 和脱敏 Receipt。
- 保留 Worker 编排、HITL、返工、恢复与调用上限；Provider Key 仅留在 Python Host 内存。
- Planner 使用真实的非流式文本/YAML 合同；DAG 分离 unary 与 JSON 资格。
- Settings 支持 degraded_required 重新批准，Expert Team 页面展示脱敏调用摘要。
- 不包含 R6H/R6I、普通 Chat、RAG、多模态、Coding、多租户或计费；Feature Flag 默认关闭。

## 验证

- 受影响后端矩阵：114 passed。
- 后端全量：4529 passed，29 skipped。
- 前端全量：112 files / 647 tests passed。
- 前端 production build 与 Server 镜像构建通过。
- Core、独立 newAPI、Overlay 三套 Compose 均通过 config --quiet。
- 独立预览真实验收：Planner 3/3、DAG 3/10 计划调用；请求/实际模型均为 openai/gpt-4o-mini，Receipt、usage 与 Provider POST 数一致。
- Diff check、工作树范围与敏感字面量扫描通过。

## 风险与回退

- 合并不会启用入口，也不批准生产切换。
- 回退时先停用 expert_team_planner / expert_team_dag Policy，再关闭对应 Feature Flag；保留 v16 Receipt 与现有数据。
- 未执行 Merge 或 Deploy。