### PR TITLE
fix: 固定工作流审计历史快照

### DIFF
--- a/docs/audits/N8N_NODE_CAPABILITY_MATRIX.md
+++ b/docs/audits/N8N_NODE_CAPABILITY_MATRIX.md
@@ -13,8 +13,9 @@
 - R2.0 结果：不新增普通节点，将 `human_intervention`、`mcp_tool`、`variable_assign` 提升为完整 V2 合同，并退役旧知识引用新增入口；当前 50 Native、48 个可新增 Palette 项、41 个完整合同、9 个 compatibility 合同、7 个 Planner 节点
 - R2.1 PR1 结果：不新增 `NativeNodeKind`，将 `code` 提升为只执行预定义操作的“安全文本加工 V2”完整合同，并从 Palette 移除退役 `template_transform`；旧草稿和既有激活版本继续兼容，模板文本能力由 `variable_assign` V2 承接；当时 50 Native、47 个可新增 Palette 项、42 个完整合同、8 个 compatibility 合同、7 个 Planner 节点
 - R2.1 PR2 结果：新增完整合同 `data_merge`，并将经典运行器升级为带持久化边到达账本的 Scheduler V2；支持可靠 Fan-in、有界数组拼接和受限一对一 inner join；当时 51 Native、48 个可新增 Palette 项、43 个完整合同、8 个 compatibility 合同、7 个 Planner 节点
-- R2.2 PR1 结果：将 `variable_aggregator` 提升为“变量打包”V2 完整合同，修正元智能体新图的报告汇总，并为 563 行参考清单增加 exact/limited/composable/none 证据门禁；当前 51 Native、47 个可新增 Palette 项、47 个完整合同、4 个 compatibility 合同、7 个 Planner 节点
-- R2.2 PR2 结果：将 `agent_task`、`agent_handoff`、`handoff_router` 提升为类型化 V2 合同，新增 occurrence 幂等索引、原子 Router 与持久 Handoff 恢复，并退役旧 `agent` 新增入口；当前 51 Native、47 个可新增 Palette 项、47 个完整合同、4 个 compatibility 合同、7 个 Planner 节点
+- R2.2 PR1 结果：将 `variable_aggregator` 提升为“变量打包”V2 完整合同，修正元智能体新图的报告汇总，并为 563 行参考清单增加 exact/limited/composable/none 证据门禁；当时 51 Native、48 个可新增 Palette 项、44 个完整合同、7 个 compatibility 合同、7 个 Planner 节点
+- R2.2 PR2 结果：将 `agent_task`、`agent_handoff`、`handoff_router` 提升为类型化 V2 合同，新增 occurrence 幂等索引、原子 Router 与持久 Handoff 恢复，并退役旧 `agent` 新增入口；当时 51 Native、47 个可新增 Palette 项、47 个完整合同、4 个 compatibility 合同、7 个 Planner 节点
+- 当前 Registry 事实：51 Native、47 个可新增 Palette 项、47 个完整合同、4 个 compatibility 合同、7 个 Planner 节点
 - 参考清单：563 条节点名称/类型，其中 `.ee` 2 条仅保留名称审计
 
 ## 结论与许可证边界

--- a/scripts/generate_workflow_capability_audit.py
+++ b/scripts/generate_workflow_capability_audit.py
@@ -13,6 +13,23 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+HISTORICAL_REGISTRY_SNAPSHOTS = {
+    "r22_pr1": {
+        "native": 51,
+        "palette": 48,
+        "complete": 44,
+        "compatibility": 7,
+        "planner": 7,
+    },
+    "r22_pr2": {
+        "native": 51,
+        "palette": 47,
+        "complete": 47,
+        "compatibility": 4,
+        "planner": 7,
+    },
+}
+
 DIRECT_UPDATES = {
     "merge": {
         "模镜当前状态": "已实现",
@@ -619,6 +636,8 @@ def main() -> None:
     native_count, palette_count, complete_count, compatibility_count, planner_count = (
         current_registry_counts()
     )
+    r22_pr1 = HISTORICAL_REGISTRY_SNAPSHOTS["r22_pr1"]
+    r22_pr2 = HISTORICAL_REGISTRY_SNAPSHOTS["r22_pr2"]
 
     domain_lines = []
     for domain, counts in domains.items():
@@ -647,8 +666,9 @@ def main() -> None:
 - R2.0 结果：不新增普通节点，将 `human_intervention`、`mcp_tool`、`variable_assign` 提升为完整 V2 合同，并退役旧知识引用新增入口；当前 50 Native、48 个可新增 Palette 项、41 个完整合同、9 个 compatibility 合同、7 个 Planner 节点
 - R2.1 PR1 结果：不新增 `NativeNodeKind`，将 `code` 提升为只执行预定义操作的“安全文本加工 V2”完整合同，并从 Palette 移除退役 `template_transform`；旧草稿和既有激活版本继续兼容，模板文本能力由 `variable_assign` V2 承接；当时 50 Native、47 个可新增 Palette 项、42 个完整合同、8 个 compatibility 合同、7 个 Planner 节点
 - R2.1 PR2 结果：新增完整合同 `data_merge`，并将经典运行器升级为带持久化边到达账本的 Scheduler V2；支持可靠 Fan-in、有界数组拼接和受限一对一 inner join；当时 51 Native、48 个可新增 Palette 项、43 个完整合同、8 个 compatibility 合同、7 个 Planner 节点
-- R2.2 PR1 结果：将 `variable_aggregator` 提升为“变量打包”V2 完整合同，修正元智能体新图的报告汇总，并为 563 行参考清单增加 exact/limited/composable/none 证据门禁；当前 {native_count} Native、{palette_count} 个可新增 Palette 项、{complete_count} 个完整合同、{compatibility_count} 个 compatibility 合同、{planner_count} 个 Planner 节点
-- R2.2 PR2 结果：将 `agent_task`、`agent_handoff`、`handoff_router` 提升为类型化 V2 合同，新增 occurrence 幂等索引、原子 Router 与持久 Handoff 恢复，并退役旧 `agent` 新增入口；当前 {native_count} Native、{palette_count} 个可新增 Palette 项、{complete_count} 个完整合同、{compatibility_count} 个 compatibility 合同、{planner_count} 个 Planner 节点
+- R2.2 PR1 结果：将 `variable_aggregator` 提升为“变量打包”V2 完整合同，修正元智能体新图的报告汇总，并为 563 行参考清单增加 exact/limited/composable/none 证据门禁；当时 {r22_pr1['native']} Native、{r22_pr1['palette']} 个可新增 Palette 项、{r22_pr1['complete']} 个完整合同、{r22_pr1['compatibility']} 个 compatibility 合同、{r22_pr1['planner']} 个 Planner 节点
+- R2.2 PR2 结果：将 `agent_task`、`agent_handoff`、`handoff_router` 提升为类型化 V2 合同，新增 occurrence 幂等索引、原子 Router 与持久 Handoff 恢复，并退役旧 `agent` 新增入口；当时 {r22_pr2['native']} Native、{r22_pr2['palette']} 个可新增 Palette 项、{r22_pr2['complete']} 个完整合同、{r22_pr2['compatibility']} 个 compatibility 合同、{r22_pr2['planner']} 个 Planner 节点
+- 当前 Registry 事实：{native_count} Native、{palette_count} 个可新增 Palette 项、{complete_count} 个完整合同、{compatibility_count} 个 compatibility 合同、{planner_count} 个 Planner 节点
 - 参考清单：563 条节点名称/类型，其中 `.ee` {ee_count} 条仅保留名称审计
 
 ## 结论与许可证边界

--- a/server/tests/test_workflow_capability_audit.py
+++ b/server/tests/test_workflow_capability_audit.py
@@ -246,9 +246,12 @@ def test_capability_audit_tracks_baseline_and_r1_nodes() -> None:
     assert "44、画布目录项 42" in markdown
     assert "R1.6 结果" in markdown
     assert "自研节点总数 47、画布目录项 45、当前 18 个" in markdown
-    assert f"{compatibility_count} 个 compatibility 合同" in markdown
-    assert f"当前 {native_count} Native" in markdown
-    assert f"{palette_count} 个可新增 Palette 项" in markdown
+    current_registry_line = (
+        f"当前 Registry 事实：{native_count} Native、{palette_count} 个可新增 Palette 项、"
+        f"{complete_count} 个完整合同、{compatibility_count} 个 compatibility 合同、"
+        f"{planner_count} 个 Planner 节点"
+    )
+    assert current_registry_line in markdown
     assert f"Planner 可生成类型仍固定为 {planner_count} 类" in markdown
     assert "R1.8 结果" in markdown
     assert native_count == 51
@@ -279,9 +282,28 @@ def test_capability_audit_tracks_baseline_and_r1_nodes() -> None:
     assert (
         "- R2.2 PR1 结果：将 `variable_aggregator` 提升为“变量打包”V2 完整合同"
     ) in markdown
+    r22_pr1_snapshot = (
+        "当时 51 Native、48 个可新增 Palette 项、44 个完整合同、"
+        "7 个 compatibility 合同、7 个 Planner 节点"
+    )
+    assert r22_pr1_snapshot in markdown
     assert (
         "- R2.2 PR2 结果：将 `agent_task`、`agent_handoff`、`handoff_router` "
         "提升为类型化 V2 合同"
     ) in markdown
+    r22_pr2_snapshot = (
+        "当时 51 Native、47 个可新增 Palette 项、47 个完整合同、"
+        "4 个 compatibility 合同、7 个 Planner 节点"
+    )
+    assert r22_pr2_snapshot in markdown
+    assert r22_pr1_snapshot != r22_pr2_snapshot
+    assert (
+        "- R2.2 PR1 结果：将 `variable_aggregator` 提升为“变量打包”V2 完整合同，"
+        "修正元智能体新图的报告汇总，并为 563 行参考清单增加 "
+        "exact/limited/composable/none 证据门禁；" + r22_pr2_snapshot
+    ) not in markdown
     assert "覆盖等级用于表达证据强度" in markdown
-    assert "当前 51 Native、47 个可新增 Palette 项、47 个完整合同、4 个 compatibility 合同、7 个 Planner 节点" in markdown
+    assert current_registry_line == (
+        "当前 Registry 事实：51 Native、47 个可新增 Palette 项、47 个完整合同、"
+        "4 个 compatibility 合同、7 个 Planner 节点"
+    )


### PR DESCRIPTION
## 摘要
- 固定 R2.2 PR1 与 PR2 的 Registry 历史计数，避免未来 Registry 变化回写历史
- 将当前 Registry 事实单独从真实注册表派生
- 增加历史阶段精确断言和防覆盖负向门禁

## 验证
- 能力审计针对性测试：3 passed
- 审计、NodeContract、Registry 联合门禁：31 passed
- git diff --check：通过
- 563 行 CSV 未变化

## 边界
- 不修改 NodeContract、Registry、checksum 或工作流运行行为
- 本 PR 合并后，R2.3 iteration V2 将从最新主线另建分支实施