### PR TITLE
feature: 接入 Fusion Managed Provider 控制面

### DIFF
--- a/client/src/components/AgencyExpertTeamTypes.ts
+++ b/client/src/components/AgencyExpertTeamTypes.ts
@@ -163,7 +163,7 @@ export interface ProviderRouteCallReceipt {
 
 export interface ProviderRouteReceipt {
   contract_version: "modelmirror-provider-workload-routing-v1";
-  entry_id: "expert_team_planner" | "expert_team_dag";
+  entry_id: "expert_team_planner" | "expert_team_dag" | "fusion";
   routing_mode: "managed_required";
   run_reference: string;
   status: "running" | "passed" | "failed" | "uncertain" | "cancelled";

--- a/client/src/pages/ExpertTeamPage.test.ts
+++ b/client/src/pages/ExpertTeamPage.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { AgencyPlanTask } from "../components/AgencyExpertTeamTypes";
 import {
+  FUSION_ROUTING_BOUNDARY_COPY,
+  fusionReceiptFromEvent,
   recommendedChatModels,
+  searchableFusionModels,
   validateAgencyHitlPlan,
 } from "./ExpertTeamPage";
 
@@ -68,9 +71,41 @@ describe("ExpertTeamPage HITL plan validation", () => {
 });
 
 describe("ExpertTeamPage model selection", () => {
-  it("keeps eligible exact managed models selectable beyond the featured prefix", () => {
+  it("finds exact managed models beyond the featured prefix and preserves selections", () => {
+    const modelId = "qwen/qwen3-8b";
+    expect(recommendedChatModels().findIndex((model) => model.id === modelId)).toBeGreaterThanOrEqual(48);
+    expect(searchableFusionModels([], modelId).map((model) => model.id)).toContain(modelId);
+    expect(searchableFusionModels([modelId], "")[0]?.id).toBe(modelId);
+  });
+
+  it("accepts only a sanitized Fusion provider receipt event", () => {
+    const receipt = fusionReceiptFromEvent({
+      event: "fusion_end",
+      provider_route_receipts: {
+        contract_version: "modelmirror-provider-workload-routing-v1",
+        entry_id: "fusion",
+        routing_mode: "managed_required",
+        run_reference: "workrun-fusion",
+        status: "passed",
+        call_count: 1,
+        reason_codes: [],
+        calls: [],
+        prompt: "must be discarded",
+      },
+    });
+    expect(receipt?.entry_id).toBe("fusion");
+    expect(receipt && "prompt" in receipt).toBe(false);
     expect(
-      recommendedChatModels().some((model) => model.id === "openai/gpt-4o-mini"),
-    ).toBe(true);
+      fusionReceiptFromEvent({
+        event: "fusion_end",
+        provider_route_receipts: { entry_id: "fusion", prompt: "secret" },
+      }),
+    ).toBeNull();
+  });
+
+  it("does not promise an automatic Fusion fallback in shared page copy", () => {
+    expect(FUSION_ROUTING_BOUNDARY_COPY).toContain("控制面策略");
+    expect(FUSION_ROUTING_BOUNDARY_COPY).not.toContain("自动");
+    expect(FUSION_ROUTING_BOUNDARY_COPY).not.toContain("兜底");
   });
 });

--- a/client/src/pages/ExpertTeamPage.tsx
+++ b/client/src/pages/ExpertTeamPage.tsx
@@ -11,6 +11,8 @@ import {
   type AgencyPlannerCapabilities,
   type AgencyTeamAsset,
   type AgencyValidationIssue,
+  type ProviderRouteCallReceipt,
+  type ProviderRouteReceipt,
 } from "../components/AgencyExpertTeamTypes";
 import { useAgencyAssets } from "../components/useAgencyAssets";
 import { useAgencyDagRun } from "../components/useAgencyDagRun";
@@ -139,6 +141,97 @@ interface FusionModelResult {
   error?: string;
 }
 
+export const FUSION_ROUTING_BOUNDARY_COPY =
+  "原生 Fusion 为 Beta 通道；备用路径仅由当前控制面策略明确决定。";
+
+export function fusionReceiptFromEvent(
+  event: JsonStreamEvent,
+): ProviderRouteReceipt | null {
+  const receipt = event.provider_route_receipts;
+  if (
+    !receipt ||
+    typeof receipt !== "object" ||
+    !("contract_version" in receipt) ||
+    receipt.contract_version !== "modelmirror-provider-workload-routing-v1" ||
+    !("entry_id" in receipt) ||
+    receipt.entry_id !== "fusion" ||
+    !("routing_mode" in receipt) ||
+    receipt.routing_mode !== "managed_required" ||
+    !("run_reference" in receipt) ||
+    typeof receipt.run_reference !== "string" ||
+    !("status" in receipt) ||
+    !["running", "passed", "failed", "uncertain", "cancelled"].includes(
+      String(receipt.status),
+    ) ||
+    !("call_count" in receipt) ||
+    typeof receipt.call_count !== "number" ||
+    !("reason_codes" in receipt) ||
+    !Array.isArray(receipt.reason_codes) ||
+    !("calls" in receipt) ||
+    !Array.isArray(receipt.calls)
+  ) {
+    return null;
+  }
+  const calls: ProviderRouteCallReceipt[] = [];
+  for (const rawCall of receipt.calls) {
+    if (
+      !rawCall ||
+      typeof rawCall !== "object" ||
+      !("call_sequence" in rawCall) ||
+      typeof rawCall.call_sequence !== "number" ||
+      !("model_id" in rawCall) ||
+      typeof rawCall.model_id !== "string" ||
+      !("dispatched" in rawCall) ||
+      typeof rawCall.dispatched !== "boolean" ||
+      !("status" in rawCall) ||
+      !["running", "passed", "failed", "uncertain", "cancelled"].includes(
+        String(rawCall.status),
+      )
+    ) {
+      return null;
+    }
+    calls.push({
+      call_sequence: rawCall.call_sequence,
+      model_id: rawCall.model_id,
+      actual_model:
+        "actual_model" in rawCall && typeof rawCall.actual_model === "string"
+          ? rawCall.actual_model
+          : null,
+      dispatched: rawCall.dispatched,
+      status: rawCall.status as ProviderRouteCallReceipt["status"],
+      error_code:
+        "error_code" in rawCall && typeof rawCall.error_code === "string"
+          ? rawCall.error_code
+          : null,
+      prompt_tokens:
+        "prompt_tokens" in rawCall && typeof rawCall.prompt_tokens === "number"
+          ? rawCall.prompt_tokens
+          : null,
+      completion_tokens:
+        "completion_tokens" in rawCall &&
+        typeof rawCall.completion_tokens === "number"
+          ? rawCall.completion_tokens
+          : null,
+      total_tokens:
+        "total_tokens" in rawCall && typeof rawCall.total_tokens === "number"
+          ? rawCall.total_tokens
+          : null,
+    });
+  }
+  return {
+    contract_version: "modelmirror-provider-workload-routing-v1",
+    entry_id: "fusion",
+    routing_mode: "managed_required",
+    run_reference: receipt.run_reference,
+    status: receipt.status as ProviderRouteReceipt["status"],
+    call_count: receipt.call_count,
+    reason_codes: receipt.reason_codes.filter(
+      (item): item is string => typeof item === "string",
+    ),
+    calls,
+  };
+}
+
 interface TeamSavedConfig {
   id: string;
   name: string;
@@ -205,6 +298,25 @@ export function recommendedChatModels() {
   const remaining = models
     .filter((model) => isLikelyChatModel(model) && !seen.has(model.id));
   return [...preferred, ...remaining];
+}
+
+export function searchableFusionModels(
+  selectedModelIds: string[],
+  query: string,
+  limit = 48,
+) {
+  const allModels = recommendedChatModels();
+  const selected = new Set(selectedModelIds);
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const matches = normalizedQuery
+    ? allModels.filter((model) =>
+        `${model.name}\n${model.id}`.toLocaleLowerCase().includes(normalizedQuery),
+      )
+    : allModels;
+  return [
+    ...allModels.filter((model) => selected.has(model.id)),
+    ...matches.filter((model) => !selected.has(model.id)),
+  ].slice(0, Math.max(selected.size, limit));
 }
 
 function eventText(event: JsonStreamEvent, key: string) {
@@ -395,11 +507,6 @@ export default function ExpertTeamPage() {
         .slice(0, 3),
     [textModelIds],
   );
-  const modelPool = useMemo(
-    () => recommendedChatModels().slice(0, 48),
-    [],
-  );
-
   const [activeDesk, setActiveDesk] = useState<ExpertDesk>(() => {
     const desk = searchParams.get("desk");
     return desk === "route" || desk === "team" || desk === "fusion"
@@ -421,10 +528,17 @@ export default function ExpertTeamPage() {
       ? initialFusionIds
       : textModelIds.slice(0, 3),
   );
+  const [fusionModelSearch, setFusionModelSearch] = useState("");
+  const modelPool = useMemo(
+    () => searchableFusionModels(fusionModelIds, fusionModelSearch),
+    [fusionModelIds, fusionModelSearch],
+  );
   const [fusionResults, setFusionResults] = useState<FusionModelResult[]>([]);
   const [fusionFinal, setFusionFinal] = useState("");
   const [fusionStatus, setFusionStatus] = useState<RunStatus>("idle");
   const [fusionLog, setFusionLog] = useState<string[]>([]);
+  const [fusionProviderReceipt, setFusionProviderReceipt] =
+    useState<ProviderRouteReceipt | null>(null);
   const [useNativeFusion, setUseNativeFusion] = useState(true);
 
   const [routeMessage, setRouteMessage] = useState(
@@ -817,6 +931,7 @@ export default function ExpertTeamPage() {
     if (fusionModelIds.length < 2 || !fusionQuestion.trim()) return;
     setFusionStatus("running");
     setFusionFinal("");
+    setFusionProviderReceipt(null);
     setFusionLog(["正在咨询多位模型专家..."]);
     setFusionResults(
       fusionModelIds.map((modelId) => ({
@@ -838,6 +953,8 @@ export default function ExpertTeamPage() {
           max_tokens: 2048,
         },
         onEvent: (event) => {
+          const receipt = fusionReceiptFromEvent(event);
+          if (receipt) setFusionProviderReceipt(receipt);
           const eventName = event.event;
           if (eventName === "fusion_stage") {
             const message = eventText(event, "message");
@@ -875,6 +992,10 @@ export default function ExpertTeamPage() {
           }
           if (eventName === "fusion_delta") {
             setFusionFinal((current) => current + eventText(event, "output"));
+          }
+          if (eventName === "fusion_end") {
+            const warning = eventText(event, "warning");
+            if (warning) setFusionLog((current) => [...current, warning]);
           }
           if (eventName === "error") {
             throw new Error(eventText(event, "message"));
@@ -1338,7 +1459,7 @@ export default function ExpertTeamPage() {
             Fusion、自动派工和 AI Team 都在这里开会。当前专家库共 {agents.length} 位。
           </p>
           <div className="mt-4 rounded-lg border border-hire-300/20 bg-hire-300/10 p-3 text-xs leading-5 text-hire-50">
-            原生融合为 Beta 通道，系统会自动准备本地裁判兜底。
+            {FUSION_ROUTING_BOUNDARY_COPY}
           </div>
         </div>
       }
@@ -1398,7 +1519,7 @@ export default function ExpertTeamPage() {
                   onChange={(event) => setUseNativeFusion(event.target.checked)}
                   type="checkbox"
                 />
-                优先使用原生融合
+                使用原生 Fusion
               </label>
             </div>
 
@@ -1433,9 +1554,19 @@ export default function ExpertTeamPage() {
             </div>
 
             <div className="mt-5 max-h-64 overflow-y-auto rounded-lg border border-white/10 bg-white/[0.035] p-3">
-              <p className="mb-3 text-xs font-semibold text-slate-400">
-                候选模型池（最多 5 位）
-              </p>
+              <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-xs font-semibold text-slate-400">
+                  候选模型池（最多 5 位）
+                </p>
+                <input
+                  aria-label="搜索候选模型"
+                  className="h-9 w-full rounded-lg border border-white/10 bg-ink-950/76 px-3 text-xs text-white outline-none transition placeholder:text-slate-400 focus:border-hire-300/70 focus:ring-4 focus:ring-hire-300/10 sm:w-64"
+                  onChange={(event) => setFusionModelSearch(event.target.value)}
+                  placeholder="按名称或模型 ID 搜索"
+                  type="search"
+                  value={fusionModelSearch}
+                />
+              </div>
               <div className="grid gap-2 sm:grid-cols-2">
                 {modelPool.map((model) => {
                   const checked = fusionModelIds.includes(model.id);
@@ -1457,6 +1588,11 @@ export default function ExpertTeamPage() {
                     </button>
                   );
                 })}
+                {modelPool.length === 0 ? (
+                  <p className="py-4 text-sm text-slate-400">
+                    未找到匹配的文本模型。
+                  </p>
+                ) : null}
               </div>
             </div>
 
@@ -1520,6 +1656,10 @@ export default function ExpertTeamPage() {
               <p className="mt-3 whitespace-pre-wrap text-sm leading-7 text-slate-200">
                 {fusionFinal || "Fusion 完成后，综合意见会出现在这里。"}
               </p>
+              <ProviderRouteReceiptSummary
+                receipts={fusionProviderReceipt}
+                title="Fusion 控制面"
+              />
             </div>
           </div>
         </section>

--- a/client/src/utils/fetchJsonEventStream.test.ts
+++ b/client/src/utils/fetchJsonEventStream.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchJsonEventStream } from "./fetchJsonEventStream";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchJsonEventStream", () => {
+  it("propagates a business error thrown by the event handler", async () => {
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            'data: {"event":"error","message":"managed blocked"}\n\n',
+          ),
+        );
+        controller.close();
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      ),
+    );
+
+    await expect(
+      fetchJsonEventStream({
+        url: "/api/fusion/chat",
+        payload: {},
+        onEvent: (event) => {
+          if (event.event === "error") throw new Error("managed blocked");
+        },
+      }),
+    ).rejects.toThrow("managed blocked");
+  });
+});

--- a/client/src/utils/fetchJsonEventStream.ts
+++ b/client/src/utils/fetchJsonEventStream.ts
@@ -45,11 +45,14 @@ function parseEventBlock(block: string, onEvent: (event: JsonStreamEvent) => voi
 
   if (!data || data === "[DONE]") return;
 
+  let event: JsonStreamEvent;
   try {
-    onEvent(JSON.parse(data) as JsonStreamEvent);
+    event = JSON.parse(data) as JsonStreamEvent;
   } catch (error) {
     console.warn("ModelMirror JSON event parse failed", error, data);
+    return;
   }
+  onEvent(event);
 }
 
 export async function fetchJsonEventStream({

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -246,6 +246,13 @@ Provider Key、URL 与连接信息不进入 Worker 环境。DAG 初始执行、H
 legacy 或 managed 模式，管理员并发修改策略只会令 managed 请求失败关闭，不会静默回退。
 用户侧仅显示按片段聚合的模型、调用数与脱敏状态，完整连接证据仍只在管理面可见。
 
+Round 6H 将 `/api/fusion/chat` 的原生与应用层模式接入 `fusion` Policy。原生模式要求
+`openrouter/fusion + fusion_native` 的资格 Profile 与运行时有序候选、裁判完全一致，一个
+逻辑运行最多派发一次。应用层模式在任何 POST 前预检全部候选与裁判的精确 `chat_text`
+Binding，再并发执行已计划候选并单独执行裁判。单个候选失败不会触发备用 Provider；原生与
+应用层、裁判与 legacy 之间均不发生派发后回退。既有 SSE 事件仅加法携带脱敏 Receipt，模型
+正文仍只走原回答事件，不进入 v16 Receipt。
+
 接入入口只允许 Python 主进程解析凭据和调用 Provider，Worker 与
 工具执行器继续只处理模型消息、Tool Call 和脱敏结果。
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -257,13 +257,20 @@ legacy，不删除 v16 Receipt、Xpert 会话、App 部署或 Provider 配置。
 Expert Team Planner 与 DAG 必须分别配置并批准 `expert_team_planner`、
 `expert_team_dag` Policy，并分别开启
 `MODEL_CONTROL_EXPERT_TEAM_PLANNER_ENABLED`、
-`MODEL_CONTROL_EXPERT_TEAM_DAG_ENABLED`。Planner 要求精确模型的 `chat_json_object`
+`MODEL_CONTROL_EXPERT_TEAM_DAG_ENABLED`。Planner 要求精确模型的 `chat_text_unary`
 Binding；DAG 同时要求同一精确模型的 `chat_text_unary` 与 `chat_json_object` Binding，缺少
 任一资格都会在 Provider POST 前阻断。开关关闭或 Policy 为 `legacy` 时保留原静态网关；
 已纳管请求在执行期间遇到策略、Binding、凭据或资格漂移时保持失败关闭，不会转回 legacy。
 HITL 恢复会创建新的脱敏运行片段，但继续使用原任务冻结的控制模式；重启后的不确定调用不得
 自动恢复。回退只需显式停用对应 Policy 或关闭 Flag 并重启，不删除 Expert Team 运行数据、
 v16 Receipt 或 Provider 配置。
+
+Fusion 接管要求 `MODEL_CONTROL_FUSION_ENABLED=true`、`fusion` Policy 已批准，并按实际
+模式配置资格。原生模式需要精确 `openrouter/fusion` 的 `fusion_native` Binding，认证时的
+有序候选模型和裁判模型必须与运行请求一致；应用层模式需要为每个候选和裁判配置独立的
+`chat_text` Binding。Managed 原生失败不会自动转应用层，应用层候选或裁判失败也不会调用
+备用 Provider、第二 IP 或 legacy。关闭 Flag 并重启或显式停用 Policy 才恢复原 legacy
+行为；回退不得删除 v16 Receipt、Provider 资格或 Fusion 运行证据。
 
 同一清理命令从 v16 起同时报告 R5 Chat 与 R6 Workload 的过期记录；第一条仍是 dry-run，
 只有第二条显式 `--apply` 才删除已完成记录。不得对正在运行的父运行或逻辑调用执行清理。

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -247,13 +247,18 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
   Receipt，不改变回答正文或会话历史。受控子 Xpert/Handoff 显式继承 `xpert` 上下文，Managed
   失败不自动重放；Automation、Goal、评测、进化、记忆候选、后台增强与 Skill 流程保持排除。
   文件仅使用既有抽取文本，多模态继续专用 Adapter。
-- R6G 接入 Expert Team Planner 与 Agency DAG。Planner 使用 `chat_json_object`；DAG 的普通
+- R6G 接入 Expert Team Planner 与 Agency DAG。Planner 使用 `chat_text_unary`；DAG 的普通
   执行调用使用 `chat_text_unary`，JSON 验收/裁判使用独立 `chat_json_object`，两类 Binding
   都必须匹配精确模型与当前连接指纹。Worker request ID 直接成为逻辑调用键；初始、HITL
   恢复、续跑和返工以独立稳定片段记录 Receipt。请求开始时冻结控制模式，managed 请求派发前
   资格漂移或策略停用只会失败关闭，派发后失败不得换连接、模型、IP 或 legacy。Worker 环境、
   API、SQLite、日志和浏览器不保存 Key、Prompt 或模型正文。
-- 后续 R6H—R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
+- R6H 接入 Fusion。原生模式只使用精确 `openrouter/fusion` 的 `fusion_native` Binding，
+  运行时有序候选与裁判必须匹配当前资格 Profile；失败后不再自动转应用层。应用层模式在首个
+  POST 前一次性预检全部候选和裁判 `chat_text` Binding；候选与裁判分别记录计划调用，候选
+  部分失败可继续其余已计划调用，但不切换 Provider。裁判失败不会调用备用模型，也不会把候选
+  正文伪装为裁判结果。两种模式互斥，legacy 只在 Flag 关闭或管理员显式停用 Policy 后恢复。
+- 后续 R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
   只能存在于 Python 主进程内存，Worker、工具执行器和浏览器不得收到 Key、URL 或连接细节。
 - Receipt 清理命令现在同时检查 R5 Chat 与 R6 Workload 记录，仍默认 dry-run；`--apply`
   才删除超过保留期的已完成运行、尝试或调用。

--- a/docs/task-cards/provider-workload-r6h.md
+++ b/docs/task-cards/provider-workload-r6h.md
@@ -1,0 +1,91 @@
+# 任务卡：R6H Fusion Managed Provider
+
+## 1. 单一目标
+
+- 本次要完成：将 `/api/fusion/chat` 的原生 Fusion 与应用层候选/裁判调用接入现有 v16 Managed Provider Route Plan、精确 Binding 和脱敏 Receipt。
+- 本次明确不做：R6I Route Agent/Team Chat、普通 Chat、RAG、多模态、Coding、多租户、积分、充值、账本和 ModelMirror 计费。
+
+## 2. 基线与证据
+
+| 结论 | 等级 | 证据路径或命令 |
+| --- | --- | --- |
+| R6G 已合并，R6H 基线为 `origin/main@61d855c1` | 已证实事实 | `gh pr view 288`; `git rev-parse origin/main` |
+| v16 已预置 `fusion`、`chat_text`、`fusion_native`、Feature Flag 与原生资格，但数据面尚未标记接入 | 已证实事实 | `server/model_router/workload_control.py`; `server/model_router/schemas.py` |
+| 原生 Fusion 失败后当前会自动切换应用层 Fusion | 已证实事实 | `server/main.py::fusion_chat` |
+| 应用层候选与裁判当前直接使用 legacy gateway；裁判还会自动切换 `TEXT_FALLBACK_MODEL` | 已证实事实 | `server/main.py::collect_chat_completion_text`; `stream_text_with_model_fallback` |
+| 最新主线控制面与相关前端基线通过 | 已证实事实 | 后端 18 passed；前端 3 files / 11 tests passed |
+
+## 3. 影响范围
+
+- 允许修改：Fusion 专用 Provider adapter、必要的共享流式 Transport adapter、`server/main.py` Fusion 路由、Fusion/控制面测试、Expert Team Fusion UI、控制面文档。
+- 禁止修改：R6I、R5 Chat、RAG、多模态、Coding、Router SQLite Schema、Provider/newAPI 数据与凭据。
+- 公共接口：保持 `/api/fusion/chat` 请求和既有 SSE 事件名称；仅加法附带脱敏 `provider_route_receipts`。
+- 持久化：复用 v16 `provider_workload_runs/calls`，不新增迁移、不重写旧数据。
+- 依赖：不新增或升级生产依赖。
+- 风险：涉及真实 Provider 网络调用；Key 只允许存在于 Python Host 内存。
+
+超过五个文件的原因：Provider 执行、API/SSE、前端证据展示和文档属于同一端到端门禁，但拆为后端 adapter、API/UI、文档三批分别验证，每批最多五个文件。
+
+## 4. 执行契约
+
+### 原生 Fusion
+
+- `use_native_fusion=true` 只允许精确 `openrouter/fusion` 的 `fusion_native` Binding。
+- 运行时有序候选模型和裁判模型必须与当前资格 Profile 完全一致。
+- 一个逻辑运行最多一个 Provider POST；派发后失败不得转应用层 Fusion、第二连接、第二 IP、备用模型或 legacy。
+
+### 应用层 Fusion
+
+- `use_native_fusion=false` 时，在任何 POST 前一次性预检全部候选模型和裁判模型的精确 `chat_text` Binding。
+- 每个候选和裁判是独立计划调用，各自最多一个 POST并产生独立 Receipt。
+- 单个候选失败不触发备用 Provider，其余已预检候选可以继续。
+- 至少一个候选成功时才派发裁判；全部候选失败时裁判记录为未派发失败，不自动选择候选正文。
+- 裁判派发失败或返回空流时直接失败，不调用 `TEXT_FALLBACK_MODEL`，也不把候选正文伪装成裁判结果。
+
+## 5. 验收标准
+
+- Flag 关闭或 Policy 为 `legacy` 时，既有 Fusion 行为与 SSE 顺序保持不变。
+- Managed Policy 未就绪、Binding/资格/Profile 漂移时在首个 POST 前失败关闭。
+- 应用层预检失败时所有 Provider POST 数为零。
+- 原生模式最多一个 POST；应用层实际 POST 数等于成功派发的计划调用数。
+- 原生 POST 后失败不会启动应用层；应用层候选/裁判失败不会调用第二 Provider 或 legacy。
+- 候选并发、部分失败、裁判、取消、空流、非法 SSE、模型不一致和策略漂移均有稳定 Receipt。
+- API、SQLite、日志和浏览器状态不保存 Key、Prompt、用户消息、模型正文或完整上游错误。
+- 前端显示已纳管/已阻断、调用数、模型和状态，不显示连接、认证 ID或目标 URL。
+- R5、R6A-G、Catalog、模型数量和提示词选择器零回归。
+
+## 6. 验证矩阵
+
+1. Fusion Managed Gateway 单元与并发测试。
+2. Provider Workload、Transport、SSRF/DNS pinning 与 Receipt 回归。
+3. `/api/fusion/chat` legacy/managed SSE 专项测试。
+4. Expert Team Fusion 与 Settings 组件测试。
+5. 前端全量测试、typecheck、production build；后端全量 `server/tests/`。
+6. Core、新API、Overlay Compose 配置验证。
+7. 独立预览验证策略、Binding、阻断、原生/应用层 Receipt。
+8. 真实付费 Smoke 需用户逐次授权；授权前不得声称真实 Provider 已验收。
+9. `git diff --check`、敏感信息扫描、最终 Diff 与 Git 状态审查。
+
+## 7. 停止条件与回退
+
+- 出现重复 POST、派发后回退、Receipt/实际模型不一致、需要保存 Prompt/输出、需要迁移数据或扩大到 R6I 时立即停止。
+- 回退：显式停用 `fusion` Policy，再关闭 `MODEL_CONTROL_FUSION_ENABLED` 并重启，恢复 legacy；保留 v16 资格和脱敏 Receipt。
+- Commit、Push、PR、真实付费调用与生产启用继续分别等待授权。
+
+## 8. 实施与证伪记录
+
+- 已实现原生与应用层 Fusion 的精确 Managed Route Plan、单次派发边界、逐调用 Receipt 和前端脱敏展示。
+- 定向攻击发现并修复两个问题：共享页面仍承诺 legacy 自动兜底；Flag 关闭时仍会提前初始化 Router Service。前者改为中性控制面边界说明，后者在入口最前端按部署 Flag 短路，确保回滚不依赖控制面可用性。
+- 真实认证攻击发现 OpenRouter Fusion 的响应 `model` 是实际裁判模型，而不是虚拟请求模型 `openrouter/fusion`。认证、资格投影和运行时已统一按精确裁判模型验证；返回其他模型时仍失败关闭。修复后专项回归为 `23 passed`，受影响后端回归为 `54 passed`。
+- 候选模型池增加全量名称/ID 搜索并保留已选模型；前端最终全量为 `113 files / 650 tests passed`，`typecheck` 与 production build 均通过；build 仅保留现有大 chunk 告警。
+- Core、独立 newAPI 与 Core+Overlay Compose 均通过 `config --quiet`；Overlay 未提供显式 `LLM_GATEWAY_URL` 时按设计失败关闭。
+- 独立预览运行于 `127.0.0.1:15143` / `127.0.0.1:18143`，Server 健康；浏览器已验证原生/应用层切换、候选搜索与裁判、三页签设置和零 iframe，容器及浏览器日志未见异常或敏感信息。
+- 原生 Fusion 资格认证通过：请求模型 `openrouter/fusion`，实际模型 `openai/gpt-4.1-nano`，单次 POST，`241` tokens，无警告。
+- 原生 Fusion Smoke 通过：单次 POST，实际模型 `openai/gpt-4.1-nano`，`286` tokens，页面、Route Plan 与 Receipt 一致。
+- 应用层 Fusion Smoke 通过：候选 `qwen/qwen3-8b`、`openai/gpt-4.1-nano` 与 GPT-4.1 Nano 裁判严格产生三次计划 POST，三次均通过，共 `1158` tokens，无备用 Provider 或重复派发。
+- 一次候选替换顺序错误在首个 POST 前以 `provider_workload_binding_missing` 失败关闭，Receipt 为零调用；随后零付费诊断证明两个合格 Binding 均可进入准备阶段。该事件证明 fail-closed 边界，未计作真实 Smoke。
+- 最终代码全量后端运行结果为 `4539 passed, 29 skipped, 3 failed, 6 warnings`；仅有的三个失败均为 Skill 跨语言一致性用例在一次性后端镜像中找不到 `orchestration_worker` 的锁定 TypeScript 开发运行时。按 `server/orchestration_worker/package-lock.json` 补齐依赖后，三项隔离复测为 `3 passed`。因此最终 `4542` 项均有通过证据，但证据分为“全量主体 + 环境隔离补测”，不表述为单次全量绿测。
+- 在同一补齐依赖环境发起的统一全量复跑运行至约 69% 时测试会话句柄失效，未取得完整结果，因此不计入验收证据，也未用局部进度替代最终结论。
+- 提交前已将分支无冲突变基至 `origin/main@a8258ba6`。新增 MCP 与 Workflow/Handoff 变更不修改 R6H 的 Fusion、共享 Transport 或前端文件；唯一共同文件 `server/main.py` 的上游 hunk 与本轮 import、factory 和 Fusion endpoint hunk 不重叠。
+- 变基后 Fusion、Provider Workload 与 Workflow/Handoff 交叉回归为 `91 passed`；前端全量为 `114 files / 659 tests passed`，`typecheck`、production build 和 Core/newAPI/Overlay Compose 配置均通过。
+- Merge、生产启用与任何后续真实额度调用尚未完成，继续分别等待授权。

--- a/server/main.py
+++ b/server/main.py
@@ -1287,6 +1287,7 @@ try:
         ManagedExpertTeamGateway,
         ManagedExpertTeamRun,
     )
+    from server.model_router.fusion_gateway import ManagedFusionGateway
     from server.model_router.workflow_gateway import (
         ManagedWorkflowGateway,
         ManagedWorkflowAgentRun,
@@ -1298,6 +1299,7 @@ except ModuleNotFoundError:
         ManagedExpertTeamGateway,
         ManagedExpertTeamRun,
     )
+    from model_router.fusion_gateway import ManagedFusionGateway
     from model_router.workflow_gateway import (
         ManagedWorkflowGateway,
         ManagedWorkflowAgentRun,
@@ -4987,6 +4989,19 @@ agency_worker_client = AgencyWorkerClient(
 
 def expert_team_managed_gateway() -> ManagedExpertTeamGateway:
     return ManagedExpertTeamGateway.for_router(get_model_router_service())
+
+
+def fusion_managed_gateway() -> ManagedFusionGateway:
+    return ManagedFusionGateway.for_router(get_model_router_service())
+
+
+def fusion_control_enabled() -> bool:
+    return os.getenv("MODEL_CONTROL_FUSION_ENABLED", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 def expert_team_managed_run(
@@ -25191,7 +25206,9 @@ async def get_runtime_environment_summary():
 
 @app.post("/api/fusion/chat")
 async def fusion_chat(payload: FusionChatRequest, request: Request):
-    if not get_llm_gateway_config()[0]:
+    managed_gateway = fusion_managed_gateway() if fusion_control_enabled() else None
+    managed_mode = managed_gateway.routing_mode() if managed_gateway else "legacy"
+    if managed_mode == "legacy" and not get_llm_gateway_config()[0]:
         return JSONResponse(
             status_code=500,
             content={"error": LLM_GATEWAY_NOT_CONFIGURED_MESSAGE},
@@ -25203,6 +25220,22 @@ async def fusion_chat(payload: FusionChatRequest, request: Request):
     except HTTPException as exc:
         return JSONResponse(status_code=exc.status_code, content={"error": str(exc.detail)})
 
+    managed_run = None
+    managed_start_error: dict[str, Any] | None = None
+    if managed_mode != "legacy":
+        assert managed_gateway is not None
+        try:
+            managed_run = managed_gateway.start_run()
+        except ManagedWorkflowRoutingError as exc:
+            managed_start_error = {
+                "event": "error",
+                "message": exc.public_message,
+                "reason_code": exc.code,
+                "provider_route_receipts": (
+                    exc.receipt or managed_gateway.blocked_receipt(exc.code)
+                ),
+            }
+
     async def fusion_stream():
         yield sse_payload(
             {
@@ -25210,9 +25243,38 @@ async def fusion_chat(payload: FusionChatRequest, request: Request):
                 "native": payload.use_native_fusion,
                 "model_ids": payload.model_ids,
                 "judge_model_id": payload.judge_model_id,
-                "note": "OpenRouter Fusion Router 为 Beta 能力；如原生调用失败，将自动切换到应用层并行裁判融合。",
+                "note": (
+                    "Fusion 已启用 Managed Provider；原生与应用层路径互斥，失败不会自动切换。"
+                    if managed_mode != "legacy"
+                    else "OpenRouter Fusion Router 为 Beta 能力；如原生调用失败，将自动切换到应用层并行裁判融合。"
+                ),
             }
         )
+
+        if managed_start_error is not None:
+            yield sse_payload(managed_start_error)
+            return
+
+        if managed_run is not None:
+            last_user_question = next(
+                (
+                    message_text(message.content)
+                    for message in reversed(payload.messages)
+                    if message.role == "user"
+                ),
+                "",
+            )
+            async for event in managed_run.stream_events(
+                use_native_fusion=payload.use_native_fusion,
+                candidate_model_ids=payload.model_ids,
+                judge_model_id=payload.judge_model_id,
+                messages=chat_messages_json(payload.messages),
+                user_question=last_user_question,
+                temperature=payload.temperature,
+                max_tokens=payload.max_tokens,
+            ):
+                yield sse_payload(event)
+            return
 
         native_text = ""
         if payload.use_native_fusion:

--- a/server/model_router/fusion_gateway.py
+++ b/server/model_router/fusion_gateway.py
@@ -1,0 +1,548 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+import httpx
+
+from .service import ModelRouterService, RouterServiceError
+from .workload_control import (
+    PROVIDER_WORKLOAD_CONTRACT_VERSION,
+    ProviderWorkloadCallService,
+    ProviderWorkloadPreparedCall,
+)
+from .workflow_gateway import (
+    ManagedWorkflowGateway,
+    ManagedWorkflowNodeRun,
+    ManagedWorkflowRoutingError,
+    WorkflowEntryId,
+)
+
+
+FUSION_MODEL_ID = "openrouter/fusion"
+FusionRoutingMode = Literal["legacy", "managed_required", "degraded_required"]
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedApplicationFusionPlan:
+    candidates: tuple[ProviderWorkloadPreparedCall, ...]
+    judge: ProviderWorkloadPreparedCall
+
+
+class ManagedFusionGateway:
+    """Fail-closed Provider control-plane adapter for Fusion."""
+
+    def __init__(
+        self,
+        call_service: ProviderWorkloadCallService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self.call_service = call_service
+        self._workflow_gateway = ManagedWorkflowGateway(
+            call_service,
+            client_factory=client_factory,
+        )
+
+    @classmethod
+    def for_router(
+        cls,
+        router_service: ModelRouterService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> ManagedFusionGateway:
+        return cls(
+            ProviderWorkloadCallService(router_service),
+            client_factory=client_factory,
+        )
+
+    def routing_mode(self) -> FusionRoutingMode:
+        control = self.call_service.control
+        if not control.feature_enabled("fusion"):
+            return "legacy"
+        policy = control.get_policy("fusion")
+        if policy.configured_status == "legacy":
+            return "legacy"
+        if policy.effective_status == "managed_required":
+            return "managed_required"
+        return "degraded_required"
+
+    def start_run(self) -> ManagedFusionRun:
+        if self.routing_mode() != "managed_required":
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_policy_not_active",
+                "Fusion 的 Managed Provider 策略未就绪，当前调用失败关闭。",
+                status_code=409,
+                receipt=self.blocked_receipt("provider_workload_policy_not_active"),
+            )
+        try:
+            run_id = self.call_service.start_run("fusion")
+        except RouterServiceError as exc:
+            raise ManagedWorkflowRoutingError(
+                exc.code,
+                "Fusion 的 Provider 资格已失效，当前调用失败关闭。",
+                status_code=exc.status_code,
+                receipt=self.blocked_receipt(exc.code),
+            ) from exc
+        node_run = ManagedWorkflowNodeRun(
+            self._workflow_gateway,
+            cast(WorkflowEntryId, "fusion"),
+            run_id,
+        )
+        return ManagedFusionRun(node_run)
+
+    @staticmethod
+    def blocked_receipt(reason_code: str) -> dict[str, Any]:
+        return {
+            "contract_version": PROVIDER_WORKLOAD_CONTRACT_VERSION,
+            "entry_id": "fusion",
+            "routing_mode": "managed_required",
+            "run_reference": "blocked_before_dispatch",
+            "status": "failed",
+            "call_count": 0,
+            "reason_codes": [reason_code],
+            "calls": [],
+        }
+
+
+class ManagedFusionRun:
+    """One explicit native or application Fusion run with planned calls."""
+
+    def __init__(self, node_run: ManagedWorkflowNodeRun) -> None:
+        self._node_run = node_run
+
+    async def prepare_native(
+        self,
+        *,
+        candidate_model_ids: list[str],
+        judge_model_id: str,
+    ) -> ProviderWorkloadPreparedCall:
+        prepared = await self._node_run.prepare_stream_call(
+            logical_call_key="native:1",
+            call_sequence=1,
+            execution_shape="fusion_native",
+            model_id=FUSION_MODEL_ID,
+        )
+        profile = {
+            "execution_shape": "fusion_native",
+            "model_id": FUSION_MODEL_ID,
+            "candidate_model_ids": list(candidate_model_ids),
+            "judge_model_id": judge_model_id,
+        }
+        profile_fingerprint = hashlib.sha256(
+            json.dumps(profile, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()
+        try:
+            certification = self._node_run.gateway.call_service.repository.get_latest_workload_certification(
+                self._node_run.gateway.call_service.router_service.tenant_id,
+                prepared.connection_id,
+                FUSION_MODEL_ID,
+                "fusion_native",
+                profile_fingerprint=profile_fingerprint,
+            )
+        except Exception as exc:
+            code = "provider_workload_fusion_profile_unavailable"
+            self._node_run.fail_prepared_call(prepared, code=code)
+            self._node_run.finish("failed", reason_code=code)
+            raise ManagedWorkflowRoutingError(
+                code,
+                "原生 Fusion 的资格 Profile 当前不可用。",
+                status_code=503,
+                receipt=self.receipt_summary(),
+            ) from exc
+        if (
+            certification is None
+            or str(certification["id"]) != prepared.certification_id
+        ):
+            code = "provider_workload_fusion_profile_mismatch"
+            self._node_run.fail_prepared_call(prepared, code=code)
+            self._node_run.finish("failed", reason_code=code)
+            raise ManagedWorkflowRoutingError(
+                code,
+                "原生 Fusion 的候选与裁判配置未通过当前精确资格认证。",
+                status_code=409,
+                receipt=self.receipt_summary(),
+            )
+        return prepared
+
+    async def prepare_application(
+        self,
+        *,
+        candidate_model_ids: list[str],
+        judge_model_id: str,
+    ) -> ManagedApplicationFusionPlan:
+        prepared: list[ProviderWorkloadPreparedCall] = []
+        try:
+            for index, model_id in enumerate(candidate_model_ids, start=1):
+                prepared.append(
+                    await self._node_run.prepare_stream_call(
+                        logical_call_key=f"candidate:{index}:{model_id}",
+                        call_sequence=index,
+                        execution_shape="chat_text",
+                        model_id=model_id,
+                    )
+                )
+            judge = await self._node_run.prepare_stream_call(
+                logical_call_key=f"judge:{len(candidate_model_ids) + 1}:{judge_model_id}",
+                call_sequence=len(candidate_model_ids) + 1,
+                execution_shape="chat_text",
+                model_id=judge_model_id,
+            )
+        except asyncio.CancelledError:
+            self._abandon_prepared(
+                prepared,
+                code="provider_workload_call_cancelled",
+                status="cancelled",
+                result_class="client_cancelled",
+            )
+            self._node_run.finish("cancelled", reason_code="provider_workload_call_cancelled")
+            raise
+        except ManagedWorkflowRoutingError as exc:
+            self._abandon_prepared(
+                prepared,
+                code="provider_workload_fusion_preflight_aborted",
+            )
+            self._node_run.finish("failed", reason_code=exc.code)
+            exc.receipt = self.receipt_summary()
+            raise
+        return ManagedApplicationFusionPlan(tuple(prepared), judge)
+
+    async def collect_prepared_text(
+        self,
+        prepared: ProviderWorkloadPreparedCall,
+        *,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        cancel_event: asyncio.Event | None = None,
+    ) -> str:
+        parts: list[str] = []
+        async for delta in self._node_run.stream_prepared_text(
+            prepared,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            cancel_event=cancel_event,
+        ):
+            parts.append(delta)
+        return "".join(parts)
+
+    async def stream_native(
+        self,
+        prepared: ProviderWorkloadPreparedCall,
+        *,
+        candidate_model_ids: list[str],
+        judge_model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        cancel_event: asyncio.Event | None = None,
+    ) -> AsyncIterator[str]:
+        async for delta in self._node_run.stream_prepared_text(
+            prepared,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            extra_payload={
+                "plugins": [
+                    {
+                        "id": "fusion",
+                        "analysis_models": list(candidate_model_ids),
+                        "model": judge_model_id,
+                    }
+                ]
+            },
+            expected_actual_model=judge_model_id,
+            cancel_event=cancel_event,
+        ):
+            yield delta
+
+    def abandon_judge(
+        self,
+        prepared: ProviderWorkloadPreparedCall,
+        *,
+        code: str = "provider_workload_fusion_no_candidate_answers",
+        status: Literal["failed", "cancelled"] = "failed",
+    ) -> None:
+        self._node_run.fail_prepared_call(
+            prepared,
+            code=code,
+            status=status,
+            result_class="planned_call_not_dispatched",
+        )
+
+    async def stream_events(
+        self,
+        *,
+        use_native_fusion: bool,
+        candidate_model_ids: list[str],
+        judge_model_id: str,
+        messages: list[dict[str, Any]],
+        user_question: str,
+        temperature: float,
+        max_tokens: int,
+        cancel_event: asyncio.Event | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        if use_native_fusion:
+            yield {
+                "event": "fusion_stage",
+                "stage": "native_start",
+                "message": "正在启动原生 Fusion 会诊室...",
+            }
+            native_text = ""
+            try:
+                prepared = await self.prepare_native(
+                    candidate_model_ids=candidate_model_ids,
+                    judge_model_id=judge_model_id,
+                )
+                async for delta in self.stream_native(
+                    prepared,
+                    candidate_model_ids=candidate_model_ids,
+                    judge_model_id=judge_model_id,
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    cancel_event=cancel_event,
+                ):
+                    native_text += delta
+                    yield {"event": "fusion_delta", "output": delta}
+            except asyncio.CancelledError:
+                self.finish(
+                    "cancelled", reason_code="provider_workload_call_cancelled"
+                )
+                raise
+            except ManagedWorkflowRoutingError as exc:
+                status = self.failure_status()
+                receipt = self.finish(status, reason_code=exc.code)
+                if native_text.strip():
+                    yield {
+                        "event": "fusion_end",
+                        "mode": "native_partial",
+                        "final_output": native_text,
+                        "warning": "原生 Fusion 中途结束，系统未切换第二条 Fusion 路径。",
+                        "reason_code": exc.code,
+                        "provider_route_receipts": receipt,
+                    }
+                else:
+                    yield self._error_event(exc.code, receipt)
+                return
+            receipt = self.finish("passed")
+            yield {
+                "event": "fusion_end",
+                "mode": "native",
+                "final_output": native_text,
+                "provider_route_receipts": receipt,
+            }
+            return
+
+        try:
+            plan = await self.prepare_application(
+                candidate_model_ids=candidate_model_ids,
+                judge_model_id=judge_model_id,
+            )
+        except asyncio.CancelledError:
+            raise
+        except ManagedWorkflowRoutingError as exc:
+            yield self._error_event(exc.code, self.receipt_summary())
+            return
+
+        for model_id in candidate_model_ids:
+            yield {"event": "model_start", "model_id": model_id}
+
+        async def collect_candidate(
+            prepared: ProviderWorkloadPreparedCall,
+        ) -> dict[str, str]:
+            try:
+                answer = await self.collect_prepared_text(
+                    prepared,
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    cancel_event=cancel_event,
+                )
+                return {
+                    "model_id": prepared.model_id,
+                    "answer": answer,
+                    "error_code": "",
+                }
+            except ManagedWorkflowRoutingError as exc:
+                return {
+                    "model_id": prepared.model_id,
+                    "answer": "",
+                    "error_code": exc.code,
+                }
+
+        tasks = [
+            asyncio.create_task(collect_candidate(prepared))
+            for prepared in plan.candidates
+        ]
+        answers: list[dict[str, str]] = []
+        try:
+            for task in asyncio.as_completed(tasks):
+                result = await task
+                if result["error_code"]:
+                    yield {
+                        "event": "model_error",
+                        "model_id": result["model_id"],
+                        "message": "候选模型调用失败，系统未切换备用 Provider。",
+                        "reason_code": result["error_code"],
+                    }
+                else:
+                    answers.append(result)
+                    yield {
+                        "event": "model_end",
+                        "model_id": result["model_id"],
+                        "output": result["answer"],
+                    }
+        except asyncio.CancelledError:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            self.abandon_judge(
+                plan.judge,
+                code="provider_workload_call_cancelled",
+                status="cancelled",
+            )
+            self.finish("cancelled", reason_code="provider_workload_call_cancelled")
+            raise
+
+        if not answers:
+            self.abandon_judge(plan.judge)
+            status = self.failure_status()
+            receipt = self.finish(
+                status,
+                reason_code="provider_workload_fusion_no_candidate_answers",
+            )
+            yield self._error_event(
+                "provider_workload_fusion_no_candidate_answers", receipt
+            )
+            return
+
+        judge_messages = [
+            {
+                "role": "user",
+                "content": fusion_judge_prompt(user_question, answers),
+            }
+        ]
+        yield {
+            "event": "fusion_stage",
+            "stage": "judge_start",
+            "message": "候选答案已收齐，裁判模型正在合并共识...",
+        }
+        try:
+            final_output = ""
+            async for delta in self._node_run.stream_prepared_text(
+                plan.judge,
+                messages=judge_messages,
+                temperature=0.35,
+                max_tokens=max_tokens,
+                cancel_event=cancel_event,
+            ):
+                final_output += delta
+                yield {"event": "fusion_delta", "output": delta}
+        except asyncio.CancelledError:
+            self.finish("cancelled", reason_code="provider_workload_call_cancelled")
+            raise
+        except ManagedWorkflowRoutingError as exc:
+            status = self.failure_status()
+            receipt = self.finish(status, reason_code=exc.code)
+            yield self._error_event(exc.code, receipt)
+            return
+
+        final_status: Literal["passed", "failed", "uncertain"] = (
+            "passed"
+            if all(call.status == "passed" for call in self._node_run.calls)
+            else self.failure_status()
+        )
+        receipt = self.finish(
+            final_status,
+            reason_code=(
+                None
+                if final_status == "passed"
+                else "provider_workload_fusion_partial_candidate_failure"
+            ),
+        )
+        yield {
+            "event": "fusion_end",
+            "mode": "application",
+            "final_output": final_output,
+            "provider_route_receipts": receipt,
+        }
+
+    def finish(
+        self,
+        status: Literal["passed", "failed", "uncertain", "cancelled"],
+        *,
+        reason_code: str | None = None,
+    ) -> dict[str, Any]:
+        self._node_run.finish(status, reason_code=reason_code)
+        return self.receipt_summary()
+
+    def failure_status(self) -> Literal["failed", "uncertain"]:
+        return (
+            "uncertain"
+            if any(call.status == "uncertain" for call in self._node_run.calls)
+            else "failed"
+        )
+
+    def receipt_summary(self) -> dict[str, Any]:
+        summary = self._node_run.receipt_summary()
+        summary["entry_id"] = "fusion"
+        summary["calls"] = sorted(
+            summary["calls"], key=lambda item: int(item["call_sequence"])
+        )
+        return summary
+
+    def _abandon_prepared(
+        self,
+        prepared: list[ProviderWorkloadPreparedCall],
+        *,
+        code: str,
+        status: Literal["failed", "cancelled"] = "failed",
+        result_class: str = "preflight_error",
+    ) -> None:
+        for item in prepared:
+            self._node_run.fail_prepared_call(
+                item,
+                code=code,
+                status=status,
+                result_class=result_class,
+            )
+
+    @staticmethod
+    def _error_event(code: str, receipt: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "event": "error",
+            "message": "Fusion 的 Managed Provider 调用失败，系统未执行备用路径。",
+            "reason_code": code,
+            "provider_route_receipts": receipt,
+        }
+
+
+def fusion_judge_prompt(
+    user_question: str,
+    model_answers: list[dict[str, str]],
+) -> str:
+    answer_blocks = "\n\n".join(
+        f"### 候选模型：{item['model_id']}\n{item['answer']}"
+        for item in model_answers
+    )
+    return f"""你是模镜专家团的首席裁判。请阅读多个模型对同一问题的回答，做事实核验、去重、互补整合，输出一份更可靠、更清晰的综合意见。
+
+用户问题：
+{user_question}
+
+候选回答：
+{answer_blocks}
+
+输出要求：
+1. 先给出“专家团综合意见”。
+2. 标注不同模型观点中有价值的互补点。
+3. 对不确定或冲突的信息明确提示复核。
+4. 最后给出按优先级排序的行动清单。"""

--- a/server/model_router/workflow_gateway.py
+++ b/server/model_router/workflow_gateway.py
@@ -320,26 +320,141 @@ class ManagedWorkflowNodeRun:
         max_tokens: int,
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncIterator[str]:
-        prepared: ProviderWorkloadPreparedCall | None = None
-        dispatched = False
-        started = time.perf_counter()
-        evidence = _StreamEvidence()
+        prepared = await self.prepare_stream_call(
+            logical_call_key=logical_call_key,
+            call_sequence=call_sequence,
+            execution_shape="chat_text",
+            model_id=model_id,
+        )
+        async for delta in self.stream_prepared_text(
+            prepared,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            cancel_event=cancel_event,
+        ):
+            yield delta
+
+    async def prepare_stream_call(
+        self,
+        *,
+        logical_call_key: str,
+        call_sequence: int,
+        execution_shape: Literal["chat_text", "fusion_native"],
+        model_id: str,
+    ) -> ProviderWorkloadPreparedCall:
         try:
-            prepared = await self.gateway.call_service.prepare_call(
+            return await self.gateway.call_service.prepare_call(
                 run_id=self.run_id,
                 entry_id=self.entry_id,
-                execution_shape="chat_text",
+                execution_shape=execution_shape,
                 model_id=model_id,
                 logical_call_key=logical_call_key,
                 call_sequence=call_sequence,
             )
-            payload = {
-                "model": model_id,
+        except asyncio.CancelledError:
+            self._record_failure(
+                None,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=False,
+                status="cancelled",
+                result_class="client_cancelled",
+                code="provider_workload_call_cancelled",
+            )
+            raise
+        except ManagedWorkflowRoutingError as exc:
+            self._record_failure(
+                None,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=False,
+                status="failed",
+                result_class="preflight_error",
+                code=exc.code,
+            )
+            exc.receipt = self.receipt_summary()
+            raise
+        except RouterServiceError as exc:
+            self._record_failure(
+                None,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=False,
+                status="failed",
+                result_class="control_plane_error",
+                code=exc.code,
+            )
+            raise self._closed_error(exc.code, False) from exc
+        except (httpx.TimeoutException, TimeoutError) as exc:
+            self._record_failure(
+                None,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=False,
+                status="failed",
+                result_class="transport_error",
+                code="provider_workload_timeout",
+            )
+            raise self._closed_error("provider_workload_timeout", False) from exc
+        except httpx.HTTPError as exc:
+            self._record_failure(
+                None,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=False,
+                status="failed",
+                result_class="transport_error",
+                code="provider_workload_transport_error",
+            )
+            raise self._closed_error(
+                "provider_workload_transport_error", False
+            ) from exc
+        except Exception as exc:
+            self._record_failure(
+                None,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                dispatched=False,
+                status="failed",
+                result_class="unexpected_error",
+                code="provider_workload_preflight_failed",
+            )
+            raise self._closed_error(
+                "provider_workload_preflight_failed", False
+            ) from exc
+
+    async def stream_prepared_text(
+        self,
+        prepared: ProviderWorkloadPreparedCall,
+        *,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        extra_payload: Mapping[str, Any] | None = None,
+        expected_actual_model: str | None = None,
+        cancel_event: asyncio.Event | None = None,
+    ) -> AsyncIterator[str]:
+        dispatched = False
+        started = time.perf_counter()
+        evidence = _StreamEvidence()
+        try:
+            payload: dict[str, Any] = {
+                "model": prepared.model_id,
                 "messages": messages,
                 "stream": True,
                 "temperature": temperature,
                 "max_tokens": max_tokens,
             }
+            if extra_payload:
+                conflicting = sorted(set(payload).intersection(extra_payload))
+                if conflicting:
+                    raise ManagedWorkflowRoutingError(
+                        "provider_workload_payload_conflict",
+                        "Managed Provider 的扩展请求字段与稳定调用契约冲突。",
+                        status_code=409,
+                    )
+                payload.update(extra_payload)
             async with self._client() as client:
                 request = self.gateway.call_service.transport.build_authorized_stream_request(
                     client,
@@ -358,7 +473,9 @@ class ManagedWorkflowNodeRun:
                         for delta in self._consume_stream_event(
                             event,
                             evidence,
-                            requested_model=model_id,
+                            requested_model=(
+                                expected_actual_model or prepared.model_id
+                            ),
                             started=started,
                         ):
                             yield delta
@@ -388,8 +505,8 @@ class ManagedWorkflowNodeRun:
             )
             self.calls.append(
                 WorkflowProviderCallReceipt(
-                    call_sequence=call_sequence,
-                    model_id=model_id,
+                    call_sequence=prepared.call_sequence,
+                    model_id=prepared.model_id,
                     actual_model=evidence.actual_model,
                     dispatched=True,
                     status="passed",
@@ -401,8 +518,8 @@ class ManagedWorkflowNodeRun:
         except asyncio.CancelledError:
             self._record_failure(
                 prepared,
-                call_sequence=call_sequence,
-                model_id=model_id,
+                call_sequence=prepared.call_sequence,
+                model_id=prepared.model_id,
                 dispatched=dispatched,
                 status="cancelled",
                 result_class="client_cancelled",
@@ -412,8 +529,8 @@ class ManagedWorkflowNodeRun:
         except ManagedWorkflowRoutingError as exc:
             self._record_failure(
                 prepared,
-                call_sequence=call_sequence,
-                model_id=model_id,
+                call_sequence=prepared.call_sequence,
+                model_id=prepared.model_id,
                 dispatched=dispatched,
                 status="failed",
                 result_class="provider_error" if dispatched else "preflight_error",
@@ -425,8 +542,8 @@ class ManagedWorkflowNodeRun:
             status: WorkflowCallStatus = "uncertain" if dispatched else "failed"
             self._record_failure(
                 prepared,
-                call_sequence=call_sequence,
-                model_id=model_id,
+                call_sequence=prepared.call_sequence,
+                model_id=prepared.model_id,
                 dispatched=dispatched,
                 status=status,
                 result_class="control_plane_error",
@@ -437,8 +554,8 @@ class ManagedWorkflowNodeRun:
             status = "uncertain" if dispatched else "failed"
             self._record_failure(
                 prepared,
-                call_sequence=call_sequence,
-                model_id=model_id,
+                call_sequence=prepared.call_sequence,
+                model_id=prepared.model_id,
                 dispatched=dispatched,
                 status=status,
                 result_class="transport_error",
@@ -449,8 +566,8 @@ class ManagedWorkflowNodeRun:
             status = "uncertain" if dispatched else "failed"
             self._record_failure(
                 prepared,
-                call_sequence=call_sequence,
-                model_id=model_id,
+                call_sequence=prepared.call_sequence,
+                model_id=prepared.model_id,
                 dispatched=dispatched,
                 status=status,
                 result_class="transport_error",
@@ -468,14 +585,32 @@ class ManagedWorkflowNodeRun:
             )
             self._record_failure(
                 prepared,
-                call_sequence=call_sequence,
-                model_id=model_id,
+                call_sequence=prepared.call_sequence,
+                model_id=prepared.model_id,
                 dispatched=dispatched,
                 status=status,
                 result_class="unexpected_error",
                 code=code,
             )
             raise self._closed_error(code, dispatched) from exc
+
+    def fail_prepared_call(
+        self,
+        prepared: ProviderWorkloadPreparedCall,
+        *,
+        code: str,
+        status: WorkflowCallStatus = "failed",
+        result_class: str = "preflight_error",
+    ) -> None:
+        self._record_failure(
+            prepared,
+            call_sequence=prepared.call_sequence,
+            model_id=prepared.model_id,
+            dispatched=False,
+            status=status,
+            result_class=result_class,
+            code=code,
+        )
 
     async def complete_text_unary(
         self,

--- a/server/model_router/workload_control.py
+++ b/server/model_router/workload_control.py
@@ -114,6 +114,7 @@ DATA_PLANE_INTEGRATED_ENTRIES: frozenset[ProviderWorkloadEntryId] = frozenset(
         "xpert_app",
         "expert_team_planner",
         "expert_team_dag",
+        "fusion",
     }
 )
 
@@ -382,7 +383,9 @@ class ProviderWorkloadCertificationService:
                                 response,
                                 evidence,
                                 started,
-                                requested_model=payload.model_id,
+                                expected_model=(
+                                    payload.judge_model_id or payload.model_id
+                                ),
                             )
                         else:
                             await self._consume_unary_response(
@@ -567,7 +570,7 @@ class ProviderWorkloadCertificationService:
         evidence: _CertificationEvidence,
         started: float,
         *,
-        requested_model: str,
+        expected_model: str,
     ) -> None:
         buffer = b""
         total_bytes = 0
@@ -605,7 +608,7 @@ class ProviderWorkloadCertificationService:
                         ) from exc
                     terminal = (
                         ProviderWorkloadCertificationService._consume_sse_event(
-                            event, evidence, started, requested_model=requested_model
+                            event, evidence, started, expected_model=expected_model
                         )
                         or terminal
                     )
@@ -622,7 +625,7 @@ class ProviderWorkloadCertificationService:
                     ) from exc
                 terminal = (
                     ProviderWorkloadCertificationService._consume_sse_event(
-                        event, evidence, started, requested_model=requested_model
+                        event, evidence, started, expected_model=expected_model
                     )
                     or terminal
                 )
@@ -646,7 +649,7 @@ class ProviderWorkloadCertificationService:
         evidence: _CertificationEvidence,
         started: float,
         *,
-        requested_model: str,
+        expected_model: str,
     ) -> bool:
         data_lines = [
             line[5:].lstrip()
@@ -670,7 +673,7 @@ class ProviderWorkloadCertificationService:
         model = payload.get("model")
         if isinstance(model, str) and model:
             evidence.actual_model = model
-            if model != requested_model:
+            if model != expected_model:
                 raise _WorkloadCertificationFailure(
                     "provider_workload_model_mismatch"
                 )
@@ -1321,8 +1324,17 @@ class ProviderWorkloadControlService:
         )
         if time_reason is not None:
             return None, time_reason.replace("provider_chat_", "provider_workload_", 1)
+        expected_actual_model = model_id
+        if execution_shape == "fusion_native":
+            profile = _safe_json_object(
+                json.loads(str(certification.get("profile_json") or "{}"))
+            )
+            judge_model_id = profile.get("judge_model_id")
+            if not isinstance(judge_model_id, str) or not judge_model_id:
+                return None, "provider_workload_fusion_profile_mismatch"
+            expected_actual_model = judge_model_id
         actual_model = certification.get("actual_model")
-        if actual_model and str(actual_model) != model_id:
+        if actual_model and str(actual_model) != expected_actual_model:
             return None, "provider_workload_certification_model_mismatch"
         qualification = {
             "execution_shape": execution_shape,

--- a/server/tests/test_fusion_managed_api.py
+++ b/server/tests/test_fusion_managed_api.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server import main as main_module
+from server.main import app
+from server.model_router.workflow_gateway import ManagedWorkflowRoutingError
+
+
+RECEIPT = {
+    "contract_version": "modelmirror-provider-workload-routing-v1",
+    "entry_id": "fusion",
+    "routing_mode": "managed_required",
+    "run_reference": "workrun_fusion_api",
+    "status": "passed",
+    "call_count": 1,
+    "reason_codes": [],
+    "calls": [
+        {
+            "call_sequence": 1,
+            "model_id": "openrouter/fusion",
+            "actual_model": "openrouter/fusion",
+            "dispatched": True,
+            "status": "passed",
+            "error_code": None,
+            "prompt_tokens": 2,
+            "completion_tokens": 1,
+            "total_tokens": 3,
+        }
+    ],
+}
+
+
+@pytest_asyncio.fixture
+async def client():
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
+
+
+class FakeFusionRun:
+    def __init__(self) -> None:
+        self.arguments: dict | None = None
+
+    async def stream_events(self, **kwargs):
+        self.arguments = kwargs
+        yield {"event": "fusion_delta", "output": "managed answer"}
+        yield {
+            "event": "fusion_end",
+            "mode": "native",
+            "final_output": "managed answer",
+            "provider_route_receipts": RECEIPT,
+        }
+
+
+class FakeFusionGateway:
+    def __init__(self, mode: str, run: FakeFusionRun | None = None) -> None:
+        self.mode = mode
+        self.run = run or FakeFusionRun()
+
+    def routing_mode(self) -> str:
+        return self.mode
+
+    def start_run(self) -> FakeFusionRun:
+        if self.mode != "managed_required":
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_policy_not_active",
+                "Fusion Managed policy is not active.",
+                status_code=409,
+                receipt=self.blocked_receipt(
+                    "provider_workload_policy_not_active"
+                ),
+            )
+        return self.run
+
+    @staticmethod
+    def blocked_receipt(code: str) -> dict:
+        return {
+            **RECEIPT,
+            "run_reference": "blocked_before_dispatch",
+            "status": "failed",
+            "call_count": 0,
+            "reason_codes": [code],
+            "calls": [],
+        }
+
+
+def _request_payload(*, native: bool = True) -> dict:
+    return {
+        "model_ids": ["provider/a", "provider/b"],
+        "judge_model_id": "provider/judge",
+        "use_native_fusion": native,
+        "messages": [{"role": "user", "content": "Compare them."}],
+        "temperature": 0.2,
+        "max_tokens": 256,
+    }
+
+
+@pytest.mark.asyncio
+async def test_managed_fusion_does_not_require_legacy_gateway(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run = FakeFusionRun()
+    monkeypatch.setenv("MODEL_CONTROL_FUSION_ENABLED", "true")
+    monkeypatch.setattr(
+        main_module, "fusion_managed_gateway", lambda: FakeFusionGateway("managed_required", run)
+    )
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("", ""))
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+
+    response = await client.post("/api/fusion/chat", json=_request_payload())
+
+    assert response.status_code == 200
+    assert "managed answer" in response.text
+    assert "provider_route_receipts" in response.text
+    assert run.arguments is not None
+    assert run.arguments["use_native_fusion"] is True
+    assert run.arguments["candidate_model_ids"] == ["provider/a", "provider/b"]
+
+
+@pytest.mark.asyncio
+async def test_degraded_managed_fusion_fails_before_stream(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MODEL_CONTROL_FUSION_ENABLED", "true")
+    monkeypatch.setattr(
+        main_module, "fusion_managed_gateway", lambda: FakeFusionGateway("degraded_required")
+    )
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+
+    response = await client.post("/api/fusion/chat", json=_request_payload())
+
+    assert response.status_code == 200
+    assert '"reason_code": "provider_workload_policy_not_active"' in response.text
+    assert '"provider_route_receipts"' in response.text
+    assert '"call_count": 0' in response.text
+
+
+@pytest.mark.asyncio
+async def test_legacy_fusion_still_requires_legacy_gateway(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_if_control_plane_initializes() -> FakeFusionGateway:
+        raise AssertionError("disabled Fusion must not initialize control plane")
+
+    monkeypatch.setenv("MODEL_CONTROL_FUSION_ENABLED", "false")
+    monkeypatch.setattr(
+        main_module,
+        "fusion_managed_gateway",
+        fail_if_control_plane_initializes,
+    )
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("", ""))
+
+    response = await client.post("/api/fusion/chat", json=_request_payload())
+
+    assert response.status_code == 500
+    assert response.json()["error"] == main_module.LLM_GATEWAY_NOT_CONFIGURED_MESSAGE
+
+
+def test_receipt_fixture_contains_no_prompt_or_connection_details() -> None:
+    serialized = json.dumps(RECEIPT)
+    assert "Compare them" not in serialized
+    assert "connection_id" not in serialized
+    assert "base_url" not in serialized

--- a/server/tests/test_fusion_managed_gateway.py
+++ b/server/tests/test_fusion_managed_gateway.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from server.model_router.egress import ProviderEgressPolicy
+from server.model_router.fusion_gateway import ManagedFusionGateway
+from server.model_router.provider_chat import PROVIDER_CHAT_CONTRACT_VERSION
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import (
+    ProviderWorkloadActivationRequest,
+    ProviderWorkloadBindingUpdate,
+    ProviderWorkloadPolicyUpdate,
+    RouterConnectionCreate,
+)
+from server.model_router.service import ModelRouterService
+from server.model_router.workload_control import (
+    PROVIDER_WORKLOAD_CONTRACT_VERSION,
+    ProviderWorkloadControlService,
+)
+
+
+CANDIDATE_A = "provider/candidate-a"
+CANDIDATE_B = "provider/candidate-b"
+JUDGE = "provider/judge"
+FUSION = "openrouter/fusion"
+MESSAGES = [{"role": "user", "content": "Compare the candidates."}]
+
+
+def _fingerprint(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _sse(model_id: str, text: str) -> bytes:
+    chunks = [
+        {
+            "model": model_id,
+            "choices": [{"delta": {"content": text}, "finish_reason": None}],
+        },
+        {
+            "model": model_id,
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+        },
+    ]
+    return (
+        "".join(f"data: {json.dumps(item)}\n\n" for item in chunks)
+        + "data: [DONE]\n\n"
+    ).encode("utf-8")
+
+
+def _gateway(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    handler,
+    include_judge_binding: bool = True,
+) -> tuple[ManagedFusionGateway, SQLiteRouterRepository]:
+    repository = SQLiteRouterRepository(tmp_path / "router", master_key=b"x" * 32)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Fusion Provider",
+            kind="openrouter",
+            base_url="https://provider.example/v1",
+            api_key="test-fusion-key",
+            scopes=["chat"],
+        ),
+    )
+    repository.save_test_result(
+        "local",
+        connection.id,
+        health="online",
+        model_count=4,
+        checked_at="2026-08-24T00:00:00+00:00",
+    )
+    connection_fingerprint = repository.connection_config_fingerprint(
+        "local", connection.id
+    )
+    repository.claim_catalog_refresh(
+        "local",
+        refresh_id="refresh-r6h",
+        connection_id=connection.id,
+        connection_fingerprint=connection_fingerprint,
+    )
+    repository.complete_catalog_refresh(
+        "local",
+        "refresh-r6h",
+        connection_id=connection.id,
+        models=[
+            {
+                "model_id": model_id,
+                "normalized_model_id": model_id,
+                "capability_state": "declared",
+            }
+            for model_id in (CANDIDATE_A, CANDIDATE_B, JUDGE, FUSION)
+        ],
+        offerings=[],
+        model_count=4,
+        truncated=False,
+        catalog_fingerprint="catalog-r6h",
+        observed_at="2026-08-24T00:00:00+00:00",
+    )
+    for model_id in (CANDIDATE_A, CANDIDATE_B, JUDGE):
+        certification, created = repository.claim_chat_certification(
+            "local",
+            certification_id=f"chat-{model_id.rsplit('/', 1)[-1]}",
+            connection_id=connection.id,
+            connection_fingerprint=connection_fingerprint,
+            contract_version=PROVIDER_CHAT_CONTRACT_VERSION,
+            capability="chat_text",
+            requested_model=model_id,
+            idempotency_key_hash=_fingerprint({"chat": model_id}),
+        )
+        assert created is True
+        repository.complete_chat_certification(
+            "local",
+            str(certification["id"]),
+            status="passed",
+            checks={
+                "catalog_contains_model": True,
+                "http_2xx": True,
+                "content_observed": True,
+                "response_complete": True,
+                "terminal_observed": True,
+            },
+            warning_codes=[],
+            actual_model=model_id,
+        )
+
+    native_profile = {
+        "execution_shape": "fusion_native",
+        "model_id": FUSION,
+        "candidate_model_ids": [CANDIDATE_A, CANDIDATE_B],
+        "judge_model_id": JUDGE,
+    }
+    native_certification, created = repository.claim_workload_certification(
+        "local",
+        certification_id="native-fusion-cert",
+        connection_id=connection.id,
+        connection_fingerprint=connection_fingerprint,
+        contract_version=PROVIDER_WORKLOAD_CONTRACT_VERSION,
+        execution_shape="fusion_native",
+        requested_model=FUSION,
+        profile=native_profile,
+        profile_fingerprint=_fingerprint(native_profile),
+        idempotency_key_hash=_fingerprint({"native": "r6h"}),
+    )
+    assert created is True
+    repository.complete_workload_certification(
+        "local",
+        str(native_certification["id"]),
+        status="passed",
+        checks={
+            "content_observed": True,
+            "actual_model_verified": True,
+            "fusion_profile_verified": True,
+        },
+        warning_codes=[],
+        actual_model=JUDGE,
+    )
+
+    monkeypatch.setenv("MODEL_CONTROL_FUSION_ENABLED", "true")
+    service = ModelRouterService(
+        repository,
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+    bindings = [
+        ProviderWorkloadBindingUpdate(
+            connection_id=connection.id,
+            model_id=model_id,
+            execution_shape="chat_text",
+        )
+        for model_id in (
+            CANDIDATE_A,
+            CANDIDATE_B,
+            *([JUDGE] if include_judge_binding else []),
+        )
+    ]
+    bindings.append(
+        ProviderWorkloadBindingUpdate(
+            connection_id=connection.id,
+            model_id=FUSION,
+            execution_shape="fusion_native",
+        )
+    )
+    control = ProviderWorkloadControlService(service)
+    saved = control.update_policy(
+        "fusion",
+        ProviderWorkloadPolicyUpdate(expected_revision=0, bindings=bindings),
+    )
+    control.activate(
+        "fusion",
+        ProviderWorkloadActivationRequest(
+            expected_revision=saved.revision,
+            acknowledge_fail_closed=True,
+            no_open_p0_p1=True,
+        ),
+    )
+    return (
+        ManagedFusionGateway.for_router(
+            service,
+            client_factory=lambda: httpx.AsyncClient(
+                transport=httpx.MockTransport(handler), trust_env=False
+            ),
+        ),
+        repository,
+    )
+
+
+async def _events(run, *, native: bool) -> list[dict]:
+    return [
+        event
+        async for event in run.stream_events(
+            use_native_fusion=native,
+            candidate_model_ids=[CANDIDATE_A, CANDIDATE_B],
+            judge_model_id=JUDGE,
+            messages=MESSAGES,
+            user_question="Compare the candidates.",
+            temperature=0.2,
+            max_tokens=256,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_application_preflight_failure_sends_zero_provider_posts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(500)
+
+    gateway, _repository = _gateway(
+        tmp_path,
+        monkeypatch,
+        handler=handler,
+        include_judge_binding=False,
+    )
+    events = await _events(gateway.start_run(), native=False)
+
+    assert requests == []
+    assert events[-1]["event"] == "error"
+    assert events[-1]["reason_code"] == "provider_workload_binding_missing"
+    receipt = events[-1]["provider_route_receipts"]
+    assert receipt["call_count"] == 0
+    assert all(call["dispatched"] is False for call in receipt["calls"])
+
+
+@pytest.mark.asyncio
+async def test_application_partial_candidate_failure_keeps_planned_calls_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requested_models: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        model_id = json.loads(request.content)["model"]
+        requested_models.append(model_id)
+        if model_id == CANDIDATE_A:
+            return httpx.Response(500)
+        return httpx.Response(200, content=_sse(model_id, f"answer:{model_id}"))
+
+    gateway, _repository = _gateway(tmp_path, monkeypatch, handler=handler)
+    events = await _events(gateway.start_run(), native=False)
+
+    assert sorted(requested_models) == sorted([CANDIDATE_A, CANDIDATE_B, JUDGE])
+    assert len(requested_models) == 3
+    assert events[-1]["event"] == "fusion_end"
+    assert events[-1]["mode"] == "application"
+    receipt = events[-1]["provider_route_receipts"]
+    assert receipt["status"] == "failed"
+    assert receipt["reason_codes"] == [
+        "provider_workload_fusion_partial_candidate_failure"
+    ]
+    assert receipt["call_count"] == 3
+    calls = {call["model_id"]: call for call in receipt["calls"]}
+    assert calls[CANDIDATE_A]["status"] == "failed"
+    assert calls[CANDIDATE_B]["status"] == "passed"
+    assert calls[JUDGE]["status"] == "passed"
+
+
+@pytest.mark.asyncio
+async def test_native_fusion_uses_exact_profile_and_one_post(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payloads: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        payloads.append(payload)
+        return httpx.Response(200, content=_sse(JUDGE, "native answer"))
+
+    gateway, _repository = _gateway(tmp_path, monkeypatch, handler=handler)
+    events = await _events(gateway.start_run(), native=True)
+
+    assert len(payloads) == 1
+    assert payloads[0]["model"] == FUSION
+    assert payloads[0]["plugins"] == [
+        {
+            "id": "fusion",
+            "analysis_models": [CANDIDATE_A, CANDIDATE_B],
+            "model": JUDGE,
+        }
+    ]
+    assert events[-1]["event"] == "fusion_end"
+    assert events[-1]["mode"] == "native"
+    receipt = events[-1]["provider_route_receipts"]
+    assert receipt["call_count"] == 1
+    assert receipt["calls"][0]["actual_model"] == JUDGE
+
+
+@pytest.mark.asyncio
+async def test_native_fusion_rejects_actual_model_other_than_judge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requested_models: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_models.append(json.loads(request.content)["model"])
+        return httpx.Response(200, content=_sse(CANDIDATE_A, "wrong model"))
+
+    gateway, _repository = _gateway(tmp_path, monkeypatch, handler=handler)
+    events = await _events(gateway.start_run(), native=True)
+
+    assert requested_models == [FUSION]
+    assert events[-1]["event"] == "error"
+    assert events[-1]["reason_code"] == "provider_workload_actual_model_mismatch"
+    assert events[-1]["provider_route_receipts"]["call_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_native_profile_drift_blocks_before_post(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, content=_sse(FUSION, "must not run"))
+
+    gateway, _repository = _gateway(tmp_path, monkeypatch, handler=handler)
+    run = gateway.start_run()
+    events = [
+        event
+        async for event in run.stream_events(
+            use_native_fusion=True,
+            candidate_model_ids=[CANDIDATE_B, CANDIDATE_A],
+            judge_model_id=JUDGE,
+            messages=MESSAGES,
+            user_question="Compare the candidates.",
+            temperature=0.2,
+            max_tokens=256,
+        )
+    ]
+
+    assert requests == []
+    assert events[-1]["event"] == "error"
+    assert events[-1]["reason_code"] == "provider_workload_fusion_profile_mismatch"
+    assert events[-1]["provider_route_receipts"]["call_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_native_failure_never_starts_application_fusion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requested_models: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_models.append(json.loads(request.content)["model"])
+        return httpx.Response(503)
+
+    gateway, _repository = _gateway(tmp_path, monkeypatch, handler=handler)
+    events = await _events(gateway.start_run(), native=True)
+
+    assert requested_models == [FUSION]
+    assert events[-1]["event"] == "error"
+    assert events[-1]["reason_code"] == "provider_workload_http_5xx"
+    assert events[-1]["provider_route_receipts"]["call_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_application_all_candidates_fail_without_dispatching_judge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requested_models: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        model_id = json.loads(request.content)["model"]
+        requested_models.append(model_id)
+        return httpx.Response(503)
+
+    gateway, _repository = _gateway(tmp_path, monkeypatch, handler=handler)
+    events = await _events(gateway.start_run(), native=False)
+
+    assert sorted(requested_models) == sorted([CANDIDATE_A, CANDIDATE_B])
+    assert JUDGE not in requested_models
+    assert events[-1]["event"] == "error"
+    assert events[-1]["reason_code"] == (
+        "provider_workload_fusion_no_candidate_answers"
+    )
+    calls = events[-1]["provider_route_receipts"]["calls"]
+    judge_call = next(call for call in calls if call["model_id"] == JUDGE)
+    assert judge_call["dispatched"] is False
+
+
+@pytest.mark.asyncio
+async def test_application_judge_failure_has_no_fallback_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requested_models: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        model_id = json.loads(request.content)["model"]
+        requested_models.append(model_id)
+        if model_id == JUDGE:
+            return httpx.Response(429)
+        return httpx.Response(200, content=_sse(model_id, f"answer:{model_id}"))
+
+    gateway, _repository = _gateway(tmp_path, monkeypatch, handler=handler)
+    events = await _events(gateway.start_run(), native=False)
+
+    assert sorted(requested_models) == sorted([CANDIDATE_A, CANDIDATE_B, JUDGE])
+    assert len(requested_models) == 3
+    assert events[-1]["event"] == "error"
+    assert events[-1]["reason_code"] == "provider_workload_http_429"
+    assert events[-1]["provider_route_receipts"]["call_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_native_profile_storage_error_closes_claimed_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, content=_sse(FUSION, "must not run"))
+
+    gateway, repository = _gateway(tmp_path, monkeypatch, handler=handler)
+
+    original_profile_lookup = repository.get_latest_workload_certification
+
+    def fail_profile_lookup(*args, **kwargs):
+        if kwargs.get("profile_fingerprint"):
+            raise RuntimeError("storage unavailable")
+        return original_profile_lookup(*args, **kwargs)
+
+    run = gateway.start_run()
+    monkeypatch.setattr(
+        repository,
+        "get_latest_workload_certification",
+        fail_profile_lookup,
+    )
+    events = await _events(run, native=True)
+
+    assert requests == []
+    assert events[-1]["reason_code"] == (
+        "provider_workload_fusion_profile_unavailable"
+    )
+    receipts = repository.list_workload_receipts("local")
+    assert all(row["status"] != "running" for row in receipts["runs"])
+    assert all(row["status"] != "running" for row in receipts["calls"])

--- a/server/tests/test_provider_workload_control.py
+++ b/server/tests/test_provider_workload_control.py
@@ -924,7 +924,7 @@ async def test_native_fusion_certification_is_openrouter_only_and_one_post(
         return Response(
             200,
             content=(
-                b'data: {"model":"openrouter/fusion","choices":'
+                b'data: {"model":"provider/judge","choices":'
                 b'[{"delta":{"content":"OK"},"finish_reason":null}]}\n\n'
                 b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
                 b"data: [DONE]\n\n"
@@ -977,6 +977,7 @@ async def test_native_fusion_certification_is_openrouter_only_and_one_post(
         "provider/candidate-b",
     ]
     assert result.judge_model_id == "provider/judge"
+    assert result.actual_model == "provider/judge"
     assert [request.method for request in requests].count("POST") == 1
     assert "fusion-secret" not in result.model_dump_json()
 


### PR DESCRIPTION
## 改动摘要

- 将 `/api/fusion/chat` 的原生 Fusion 与应用层候选/裁判调用接入 v16 Managed Provider Route Plan、精确 Binding 和脱敏 Receipt。
- 原生路径严格绑定 `openrouter/fusion` 的精确候选/裁判 Profile；应用层在任何 POST 前一次性预检全部候选与裁判。
- POST 派发后禁止切换第二连接、第二 IP、备用模型、legacy 或第二条 Fusion 路径。
- 按 OpenRouter 实际语义校验裁判模型，并为专家团页面补充全量候选搜索、已选模型保留和控制面证据展示。
- Feature Flag 默认关闭，不改变 R5 Chat、Catalog、多模态、RAG、Coding 或 R6I Route Agent/Team Chat。

## 验证

- 变基后 Fusion、Provider Workload、Workflow/Handoff 交叉回归：`91 passed`。
- 前端全量串行：`114 files / 659 tests passed`。
- 前端 `typecheck`、production build：通过；build 仅有既有大 chunk 告警。
- Core、独立 newAPI、Core+Overlay Compose：`config --quiet` 通过。
- 最终代码后端主体：`4539 passed, 29 skipped`；3 个 Skill 跨语言用例因一次性后端镜像缺少锁定 TypeScript 开发运行时失败，补齐 `orchestration_worker` 锁定依赖后隔离复测 `3 passed`。未把丢失尾部的统一复跑表述为完整绿测。
- 原生 Fusion 真实认证：1 次 POST，通过，实际裁判模型 `openai/gpt-4.1-nano`。
- 原生 Fusion Smoke：1 次 POST，通过，Route Plan、实际模型与 Receipt 一致。
- 应用层 Fusion Smoke：2 个候选 + 1 个裁判，严格 3 次 POST，全部通过，无重复派发或备用 Provider。
- 发送前错误配置验证：`provider_workload_binding_missing`、0 次 Provider 调用，确认 fail closed。
- `git diff --check` 与敏感信息扫描：通过。

## 风险与回退

- PR 合并不等于生产启用；`MODEL_CONTROL_FUSION_ENABLED` 保持默认关闭。
- 回退时先显式停用 `fusion` Policy，再关闭 Feature Flag 并重启；保留 v16 资格与脱敏 Receipt。
- 不包含生产切换、R6I、多租户、计费、积分、充值、账本或后续真实额度调用。