### PR TITLE
feature: R6I 接入 Route Agent 与 Team Chat Managed Provider

### DIFF
--- a/client/src/components/AgencyExpertTeamTypes.ts
+++ b/client/src/components/AgencyExpertTeamTypes.ts
@@ -163,7 +163,12 @@ export interface ProviderRouteCallReceipt {
 
 export interface ProviderRouteReceipt {
   contract_version: "modelmirror-provider-workload-routing-v1";
-  entry_id: "expert_team_planner" | "expert_team_dag" | "fusion";
+  entry_id:
+    | "expert_team_planner"
+    | "expert_team_dag"
+    | "fusion"
+    | "route_agent"
+    | "team_chat";
   routing_mode: "managed_required";
   run_reference: string;
   status: "running" | "passed" | "failed" | "uncertain" | "cancelled";

--- a/client/src/pages/ExpertTeamPage.test.ts
+++ b/client/src/pages/ExpertTeamPage.test.ts
@@ -6,6 +6,7 @@ import {
   recommendedChatModels,
   searchableFusionModels,
   validateAgencyHitlPlan,
+  workloadReceiptFromEvent,
 } from "./ExpertTeamPage";
 
 function expert(
@@ -101,6 +102,38 @@ describe("ExpertTeamPage model selection", () => {
         provider_route_receipts: { entry_id: "fusion", prompt: "secret" },
       }),
     ).toBeNull();
+  });
+
+  it("accepts only the expected Route Agent or Team Chat receipt", () => {
+    const event = {
+      event: "team_end",
+      provider_route_receipts: {
+        contract_version: "modelmirror-provider-workload-routing-v1",
+        entry_id: "team_chat",
+        routing_mode: "managed_required",
+        run_reference: "workrun-team",
+        status: "passed",
+        call_count: 3,
+        reason_codes: [],
+        calls: [
+          {
+            call_sequence: 1,
+            model_id: "provider/model",
+            dispatched: true,
+            status: "passed",
+          },
+        ],
+        connection_id: "must-be-discarded",
+        prompt: "must-be-discarded",
+      },
+    };
+
+    const receipt = workloadReceiptFromEvent(event, "team_chat");
+    expect(receipt?.entry_id).toBe("team_chat");
+    expect(receipt?.call_count).toBe(3);
+    expect(receipt && "connection_id" in receipt).toBe(false);
+    expect(receipt && "prompt" in receipt).toBe(false);
+    expect(workloadReceiptFromEvent(event, "route_agent")).toBeNull();
   });
 
   it("does not promise an automatic Fusion fallback in shared page copy", () => {

--- a/client/src/pages/ExpertTeamPage.tsx
+++ b/client/src/pages/ExpertTeamPage.tsx
@@ -144,8 +144,9 @@ interface FusionModelResult {
 export const FUSION_ROUTING_BOUNDARY_COPY =
   "原生 Fusion 为 Beta 通道；备用路径仅由当前控制面策略明确决定。";
 
-export function fusionReceiptFromEvent(
+export function workloadReceiptFromEvent(
   event: JsonStreamEvent,
+  expectedEntryId: ProviderRouteReceipt["entry_id"],
 ): ProviderRouteReceipt | null {
   const receipt = event.provider_route_receipts;
   if (
@@ -154,7 +155,7 @@ export function fusionReceiptFromEvent(
     !("contract_version" in receipt) ||
     receipt.contract_version !== "modelmirror-provider-workload-routing-v1" ||
     !("entry_id" in receipt) ||
-    receipt.entry_id !== "fusion" ||
+    receipt.entry_id !== expectedEntryId ||
     !("routing_mode" in receipt) ||
     receipt.routing_mode !== "managed_required" ||
     !("run_reference" in receipt) ||
@@ -220,7 +221,7 @@ export function fusionReceiptFromEvent(
   }
   return {
     contract_version: "modelmirror-provider-workload-routing-v1",
-    entry_id: "fusion",
+    entry_id: expectedEntryId,
     routing_mode: "managed_required",
     run_reference: receipt.run_reference,
     status: receipt.status as ProviderRouteReceipt["status"],
@@ -230,6 +231,12 @@ export function fusionReceiptFromEvent(
     ),
     calls,
   };
+}
+
+export function fusionReceiptFromEvent(
+  event: JsonStreamEvent,
+): ProviderRouteReceipt | null {
+  return workloadReceiptFromEvent(event, "fusion");
 }
 
 interface TeamSavedConfig {
@@ -549,6 +556,8 @@ export default function ExpertTeamPage() {
   const [routeAnswer, setRouteAnswer] = useState("");
   const [routeStatus, setRouteStatus] = useState<RunStatus>("idle");
   const [routeError, setRouteError] = useState("");
+  const [routeProviderReceipt, setRouteProviderReceipt] =
+    useState<ProviderRouteReceipt | null>(null);
   const [routePlannerMode, setRoutePlannerMode] =
     useState<RoutePlannerMode>(initialAgencyDraft?.preview ? "agency" : "quick");
   const [agencyCapabilities, setAgencyCapabilities] =
@@ -620,6 +629,8 @@ export default function ExpertTeamPage() {
   const [teamOutputs, setTeamOutputs] = useState<TeamAgentOutput[]>([]);
   const [teamFinal, setTeamFinal] = useState("");
   const [teamStatus, setTeamStatus] = useState<RunStatus>("idle");
+  const [teamProviderReceipt, setTeamProviderReceipt] =
+    useState<ProviderRouteReceipt | null>(null);
   const [savedTeams] = useState<TeamSavedConfig[]>(readSavedTeams);
   const [teamName, setTeamName] = useState(
     initialAgencyDraft?.team_name ||
@@ -1018,6 +1029,7 @@ export default function ExpertTeamPage() {
     setRouteAnswer("");
     setRouteMatches([]);
     setRouteError("");
+    setRouteProviderReceipt(null);
 
     try {
       await fetchJsonEventStream({
@@ -1030,6 +1042,8 @@ export default function ExpertTeamPage() {
           max_tokens: 2048,
         },
         onEvent: (event) => {
+          const receipt = workloadReceiptFromEvent(event, "route_agent");
+          if (receipt) setRouteProviderReceipt(receipt);
           if (event.event === "route_result" && Array.isArray(event.matches)) {
             setRouteMatches(event.matches.filter(isAgentSummary));
           }
@@ -1386,6 +1400,7 @@ export default function ExpertTeamPage() {
     setTeamStatus("running");
     setTeamOutputs([]);
     setTeamFinal("");
+    setTeamProviderReceipt(null);
 
     try {
       await fetchJsonEventStream({
@@ -1402,6 +1417,8 @@ export default function ExpertTeamPage() {
           })),
         },
         onEvent: (event) => {
+          const receipt = workloadReceiptFromEvent(event, "team_chat");
+          if (receipt) setTeamProviderReceipt(receipt);
           const eventAgent = event.agent;
           if (event.event === "agent_start" && isAgentSummary(eventAgent)) {
             setTeamOutputs((current) => [
@@ -1773,6 +1790,10 @@ export default function ExpertTeamPage() {
                   <p className="mt-3 whitespace-pre-wrap text-sm leading-7 text-slate-200">
                     {routeAnswer || "自动路由完成后，专家会在这里回复。"}
                   </p>
+                  <ProviderRouteReceiptSummary
+                    receipts={routeProviderReceipt}
+                    title="自动路由控制面"
+                  />
                 </div>
               </div>
             </div>
@@ -2769,6 +2790,10 @@ export default function ExpertTeamPage() {
               <p className="mt-3 whitespace-pre-wrap text-sm leading-7 text-slate-200">
                 {teamFinal || "项目经理汇总会出现在这里。"}
               </p>
+              <ProviderRouteReceiptSummary
+                receipts={teamProviderReceipt}
+                title="AI Team 控制面"
+              />
             </div>
               </>
             )}

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -258,8 +258,13 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
   POST 前一次性预检全部候选和裁判 `chat_text` Binding；候选与裁判分别记录计划调用，候选
   部分失败可继续其余已计划调用，但不切换 Provider。裁判失败不会调用备用模型，也不会把候选
   正文伪装为裁判结果。两种模式互斥，legacy 只在 Flag 关闭或管理员显式停用 Policy 后恢复。
-- 后续 R6I 将逐入口接入同一 Call Service。每个逻辑调用只能派发一次；Provider Key
-  只能存在于 Python 主进程内存，Worker、工具执行器和浏览器不得收到 Key、URL 或连接细节。
+- R6I 接入 Route Agent 与 Team Chat。专家匹配继续使用本地索引，Route 最终作答使用一次精确
+  `chat_text` 调用；Team 在首个 POST 前一次性预检全部成员轮次和最终汇总，计划调用数固定为
+  成员数加一。任一 Managed 调用失败后不再切换 `TEXT_FALLBACK_MODEL`、第二连接、第二 IP 或
+  legacy；未派发的剩余 Team 调用写入失败证据。Flag 关闭或管理员显式停用 Policy 时，两个
+  入口继续保留原 legacy 行为。
+- 所有 R6 入口的每个逻辑调用只能派发一次；Provider Key 只能存在于 Python 主进程内存，
+  Worker、工具执行器和浏览器不得收到 Key、URL 或连接细节。
 - Receipt 清理命令现在同时检查 R5 Chat 与 R6 Workload 记录，仍默认 dry-run；`--apply`
   才删除超过保留期的已完成运行、尝试或调用。
 

--- a/docs/task-cards/provider-workload-r6i.md
+++ b/docs/task-cards/provider-workload-r6i.md
@@ -1,0 +1,94 @@
+# 任务卡：R6I Route Agent 与 Team Chat Managed Provider
+
+## 1. 单一目标
+
+- 本次要完成：将 `/api/route-agent` 与 `/api/team/chat` 接入现有 v16 Managed Provider Route Plan、精确 `chat_text` Binding 和脱敏 Receipt。
+- 本次明确不做：普通 Agent Workbench、RAG、多模态、Coding、普通 Chat、多租户、积分、充值、账本和 ModelMirror 计费。
+
+## 2. 基线与证据
+
+| 结论 | 等级 | 证据路径或命令 |
+| --- | --- | --- |
+| R6H 已合并，R6I 基线为 `origin/main@2409c032` | 已证实事实 | `gh pr view 292`; `git rev-parse origin/main` |
+| v16 已预置 `route_agent`、`team_chat`、`chat_text` 与默认关闭的 Feature Flag，但数据面尚未接入 | 已证实事实 | `server/model_router/workload_control.py`; `.env.example` |
+| Route Agent 当前失败后会自动切换 `TEXT_FALLBACK_MODEL` | 已证实事实 | `server/main.py::stream_text_with_model_fallback`; `route_agent` |
+| Team Chat 当前每位成员及最终汇总都使用同一 legacy fallback 路径 | 已证实事实 | `server/main.py::team_chat` |
+| 最新主线 Route/Team 与 Workload 控制面基线通过 | 已证实事实 | 后端 `15 passed` |
+
+## 3. 影响范围
+
+- 允许修改：Route/Team 专用 Managed adapter、两个 API 的分流与 Receipt、Expert Team 脱敏展示、控制面接入标记、专项测试和文档。
+- 禁止修改：R5 Chat、Fusion、RAG、多模态、Coding、Router SQLite Schema、Provider/newAPI 数据与凭据。
+- 公共接口：保持两个请求体和既有 SSE 事件名称；仅在阶段结束或错误事件中加法附带 `provider_route_receipts`。
+- 持久化：复用 v16 `provider_workload_runs/calls`，不新增迁移、不重写旧数据。
+- 依赖：不新增或升级生产依赖。
+
+超过五个文件的原因：Provider adapter、API/SSE、前端证据与文档属于同一端到端门禁，但按后端、前端和文档三批分别实施与验证，每批最多五个文件。
+
+## 4. 执行契约
+
+### Route Agent
+
+- 专家匹配仍由现有本地索引完成，只有最终模型作答进入 Managed Provider。
+- 每次运行只允许精确模型的一次 `chat_text` 计划调用。
+- 派发后失败不得切换模型、Provider、连接、第二 IP 或 legacy。
+
+### Team Chat
+
+- 在首个 POST 前一次性预检全部成员轮次和一次最终汇总；计划调用数固定为成员数加一。
+- 串行与辩论继续沿用现有 Prompt 和 SSE 顺序，每个成员及汇总分别记录调用序号。
+- 任一成员或汇总失败时停止本次团队运行；未派发的剩余计划调用写入失败证据，不调用备用模型。
+- 用户显式重新运行创建新的逻辑运行，不重放旧运行。
+
+## 5. 验收标准
+
+- Flag 关闭或 Policy 为 `legacy` 时，既有请求、SSE 与自动 fallback 行为保持不变。
+- Managed Policy 未就绪、Binding/资格/策略漂移时在对应 POST 前失败关闭。
+- Team 任一预检失败时 Provider POST 数为零。
+- Route 实际 POST 数最多为一；Team 实际 POST 数等于已派发的计划调用数。
+- POST 后错误、空流、非法 SSE、取消或模型不一致均不得产生备用调用。
+- SSE 只加法附带脱敏 Receipt，不改变回答正文、匹配结果或成员输出。
+- API、SQLite、日志和浏览器状态不保存 Key、Prompt、用户消息、模型正文、连接 ID或 URL。
+- R5、R6A-H、Catalog、模型数量、提示词选择器和多模态零回归。
+
+## 6. 验证矩阵
+
+1. Managed Route/Team 网关的全量预检、单次派发、失败与取消测试。
+2. 两个 API 的 legacy、managed、degraded 与 SSE 兼容测试。
+3. Provider Workload、Transport、SSRF/DNS pinning、Fusion 和 Expert Team 回归。
+4. Expert Team Receipt 解析、脱敏展示、前端全量测试、typecheck 和 production build。
+5. 后端全量 `server/tests/`，并区分基线、环境与新增失败。
+6. Core、新API、Overlay Compose 配置验证。
+7. 独立预览验证策略、Binding、阻断、Route 与 Team Receipt。
+8. Route 与 Team 真实付费 Smoke 分别需要用户授权；授权前不得声称真实 Provider 已验收。
+9. `git diff --check`、敏感信息扫描、最终 Diff 与 Git 状态审查。
+
+## 7. 停止条件与回退
+
+- 出现重复 POST、派发后 fallback、Receipt 与真实目标不一致、需要保存 Prompt/输出、需要迁移数据或扩大到 R7 时立即停止。
+- 回退：显式停用对应 Policy，再关闭 `MODEL_CONTROL_ROUTE_AGENT_ENABLED` 或 `MODEL_CONTROL_TEAM_CHAT_ENABLED` 并重启，恢复该入口 legacy；保留 v16 资格和脱敏 Receipt。
+- Commit、Push、PR、真实付费调用与生产启用继续分别等待授权。
+
+## 8. 当前实施记录
+
+- 已新增薄的 Route/Team Managed adapter，复用现有 SSRF、DNS pinning、单 IP、零重试、响应关闭和 Receipt 状态机。
+- 已将两个入口接入 `managed_required`，同时保证 Flag 关闭时不初始化控制面且继续要求 legacy gateway。
+- Team 在任何 POST 前创建全部成员及汇总 Prepared Call；成员失败会关闭剩余未派发调用，不再触发 `TEXT_FALLBACK_MODEL`。
+- Expert Team 页面仅在现有结果卡中显示脱敏调用总数、模型与分段状态，不持久化 Receipt，也不修改模型回答正文。
+- 定向出口与 R6I 回归为 `36 passed`；R6A-I 受影响后端矩阵为 `190 passed`；最终后端全量为
+  `4583 passed, 29 skipped`。新 worktree 初次缺少 Worker build 产物导致的三项环境失败，已按
+  `server/orchestration_worker/package-lock.json` 构建后原样复测为 `3 passed`，最终全量也在
+  Worker 已构建的同一源树上完整通过。
+- 前端全量为 `114 files / 660 tests passed`，typecheck 和 production build 通过；第一次全量
+  有一项无关 Skill Creator 用例在 5 秒门槛超时，隔离复测 `9 passed`，完整复跑随后 `660/660`
+  通过。build 仅保留既有大 chunk 告警。
+- Core、独立 newAPI 与 Overlay Compose 均通过 `config --quiet`；`git diff --check` 通过。
+- 用户已分别授权并完成隔离预览与真实付费 Smoke：R6I 预览运行于
+  `127.0.0.1:15144` / `127.0.0.1:18144`，Router 数据从 R6H 卷只读克隆到新卷且源/目标
+  SHA-256 一致；R6H 原卷、容器和端口保持不动。
+- Route Agent 使用 `openai/gpt-4.1-nano` 完成一次真实调用；UI 显示“已纳管 · 1 次
+  Provider 调用”，SQLite 只有一条已派发、通过且实际模型一致的 Call。
+- 两成员串行 Team Chat 完成两次成员调用和一次汇总调用；UI 显示“已纳管 · 3 次
+  Provider 调用”，SQLite 恰有三条已派发、通过且实际模型一致的 Call。
+- 后端日志合计恰有四次 Provider Chat POST 且全部为 HTTP 200，精确错误信号为 0；Receipt
+  表没有 Prompt、消息、模型正文、Base URL 或凭据列，验收文本标记未写入 Receipt 值。

--- a/server/main.py
+++ b/server/main.py
@@ -1288,6 +1288,10 @@ try:
         ManagedExpertTeamRun,
     )
     from server.model_router.fusion_gateway import ManagedFusionGateway
+    from server.model_router.route_team_gateway import (
+        ManagedRouteTeamGateway,
+        ManagedRouteTeamRun,
+    )
     from server.model_router.workflow_gateway import (
         ManagedWorkflowGateway,
         ManagedWorkflowAgentRun,
@@ -1300,6 +1304,10 @@ except ModuleNotFoundError:
         ManagedExpertTeamRun,
     )
     from model_router.fusion_gateway import ManagedFusionGateway
+    from model_router.route_team_gateway import (
+        ManagedRouteTeamGateway,
+        ManagedRouteTeamRun,
+    )
     from model_router.workflow_gateway import (
         ManagedWorkflowGateway,
         ManagedWorkflowAgentRun,
@@ -4995,8 +5003,30 @@ def fusion_managed_gateway() -> ManagedFusionGateway:
     return ManagedFusionGateway.for_router(get_model_router_service())
 
 
+def route_team_managed_gateway() -> ManagedRouteTeamGateway:
+    return ManagedRouteTeamGateway.for_router(get_model_router_service())
+
+
 def fusion_control_enabled() -> bool:
     return os.getenv("MODEL_CONTROL_FUSION_ENABLED", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def route_agent_control_enabled() -> bool:
+    return os.getenv("MODEL_CONTROL_ROUTE_AGENT_ENABLED", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def team_chat_control_enabled() -> bool:
+    return os.getenv("MODEL_CONTROL_TEAM_CHAT_ENABLED", "false").strip().lower() in {
         "1",
         "true",
         "yes",
@@ -25416,9 +25446,71 @@ async def fusion_chat(payload: FusionChatRequest, request: Request):
     )
 
 
+def team_member_chat_messages(
+    payload: TeamChatRequest,
+    agent: AgentRecord,
+    task: str,
+    prior_outputs: list[dict[str, str]],
+) -> list[ChatMessage]:
+    if payload.mode == "debate":
+        user_prompt = (
+            f"团队任务：{payload.message}\n\n"
+            f"你的独立发言任务：{task}\n"
+            "请先给出你的专业判断，不要假设你已看到其他专家的意见。"
+        )
+    else:
+        previous = "\n\n".join(
+            f"### {item['agent_name']} 的上一棒意见\n{item['output']}"
+            for item in prior_outputs
+        )
+        user_prompt = (
+            f"团队总任务：{payload.message}\n\n"
+            f"你的接力任务：{task}\n\n"
+            f"前序专家输出：\n{previous or '暂无，你是第一棒。'}\n\n"
+            "请基于自己的专业角色补充、纠偏并推进到下一步。"
+        )
+    return [
+        agent_system_message(agent, task),
+        ChatMessage(role="user", content=user_prompt),
+    ]
+
+
+def team_summary_chat_messages(
+    payload: TeamChatRequest,
+    prior_outputs: list[dict[str, str]],
+) -> list[ChatMessage]:
+    summary_prompt = "\n\n".join(
+        f"### {item['agent_name']}（{item['department']}）\n{item['output']}"
+        for item in prior_outputs
+    )
+    return [
+        ChatMessage(
+            role="system",
+            content=(
+                "你是模镜专家团的项目经理。请整合多个专家的意见，"
+                "输出一份可执行、去重、分优先级的最终方案。"
+            ),
+        ),
+        ChatMessage(
+            role="user",
+            content=(
+                f"用户任务：{payload.message}\n\n"
+                f"专家意见如下：\n{summary_prompt}\n\n"
+                "请给出团队综合意见、执行清单、风险提醒和下一步建议。"
+            ),
+        ),
+    ]
+
+
 @app.post("/api/route-agent")
 async def route_agent(payload: RouteAgentRequest, request: Request):
-    if not get_llm_gateway_config()[0]:
+    managed_gateway = (
+        route_team_managed_gateway() if route_agent_control_enabled() else None
+    )
+    managed_mode = (
+        managed_gateway.routing_mode("route_agent") if managed_gateway else "legacy"
+    )
+    if managed_mode == "legacy" and not get_llm_gateway_config()[0]:
         return JSONResponse(
             status_code=500,
             content={"error": LLM_GATEWAY_NOT_CONFIGURED_MESSAGE},
@@ -25438,6 +25530,22 @@ async def route_agent(payload: RouteAgentRequest, request: Request):
         agent_system_message(selected_agent),
         ChatMessage(role="user", content=payload.message),
     ]
+    managed_run: ManagedRouteTeamRun | None = None
+    managed_start_error: dict[str, Any] | None = None
+    if managed_mode != "legacy":
+        assert managed_gateway is not None
+        try:
+            managed_run = managed_gateway.start_run("route_agent")
+        except ManagedWorkflowRoutingError as exc:
+            managed_start_error = {
+                "event": "error",
+                "message": exc.public_message,
+                "reason_code": exc.code,
+                "provider_route_receipts": (
+                    exc.receipt
+                    or managed_gateway.blocked_receipt("route_agent", exc.code)
+                ),
+            }
 
     async def route_stream():
         yield sse_payload(
@@ -25450,7 +25558,60 @@ async def route_agent(payload: RouteAgentRequest, request: Request):
             }
         )
 
+        if managed_start_error is not None:
+            yield sse_payload(managed_start_error)
+            return
+
         output = ""
+        if managed_run is not None:
+            try:
+                plan = await managed_run.prepare_plan(
+                    model_id=payload.model_id,
+                    logical_call_keys=["route-answer:1"],
+                )
+                async for delta in managed_run.stream_text(
+                    plan[0],
+                    messages=chat_messages_json(agent_messages),
+                    temperature=payload.temperature,
+                    max_tokens=payload.max_tokens,
+                ):
+                    output += delta
+                    yield sse_payload(
+                        {
+                            "event": "answer_delta",
+                            "agent_id": selected_agent.id,
+                            "output": delta,
+                        }
+                    )
+            except asyncio.CancelledError:
+                managed_run.finish(
+                    "cancelled", reason_code="provider_workload_call_cancelled"
+                )
+                raise
+            except ManagedWorkflowRoutingError as exc:
+                receipt = managed_run.finish(
+                    managed_run.failure_status(), reason_code=exc.code
+                )
+                yield sse_payload(
+                    {
+                        "event": "error",
+                        "message": "自动路由的 Managed Provider 调用失败，系统未切换备用模型。",
+                        "reason_code": exc.code,
+                        "provider_route_receipts": receipt,
+                    }
+                )
+                return
+            receipt = managed_run.finish("passed")
+            yield sse_payload(
+                {
+                    "event": "answer_end",
+                    "agent": agent_public_payload(selected_agent),
+                    "final_output": output,
+                    "provider_route_receipts": receipt,
+                }
+            )
+            return
+
         try:
             async for delta in stream_text_with_model_fallback(
                 payload.model_id,
@@ -25498,7 +25659,13 @@ async def route_agent(payload: RouteAgentRequest, request: Request):
 
 @app.post("/api/team/chat")
 async def team_chat(payload: TeamChatRequest, request: Request):
-    if not get_llm_gateway_config()[0]:
+    managed_gateway = (
+        route_team_managed_gateway() if team_chat_control_enabled() else None
+    )
+    managed_mode = (
+        managed_gateway.routing_mode("team_chat") if managed_gateway else "legacy"
+    )
+    if managed_mode == "legacy" and not get_llm_gateway_config()[0]:
         return JSONResponse(
             status_code=500,
             content={"error": LLM_GATEWAY_NOT_CONFIGURED_MESSAGE},
@@ -25527,6 +25694,23 @@ async def team_chat(payload: TeamChatRequest, request: Request):
     if not members:
         return JSONResponse(status_code=400, content={"error": "请至少选择一位专家。"})
 
+    managed_run: ManagedRouteTeamRun | None = None
+    managed_start_error: dict[str, Any] | None = None
+    if managed_mode != "legacy":
+        assert managed_gateway is not None
+        try:
+            managed_run = managed_gateway.start_run("team_chat")
+        except ManagedWorkflowRoutingError as exc:
+            managed_start_error = {
+                "event": "error",
+                "message": exc.public_message,
+                "reason_code": exc.code,
+                "provider_route_receipts": (
+                    exc.receipt
+                    or managed_gateway.blocked_receipt("team_chat", exc.code)
+                ),
+            }
+
     async def team_stream():
         yield sse_payload(
             {
@@ -25535,6 +25719,154 @@ async def team_chat(payload: TeamChatRequest, request: Request):
                 "members": [agent_public_payload(agent) for agent, _ in members],
             }
         )
+
+        if managed_start_error is not None:
+            yield sse_payload(managed_start_error)
+            return
+
+        if managed_run is not None:
+            logical_call_keys = [
+                f"member:{index}"
+                for index in range(1, len(members) + 1)
+            ] + [f"summary:{len(members) + 1}"]
+            try:
+                plan = await managed_run.prepare_plan(
+                    model_id=payload.model_id,
+                    logical_call_keys=logical_call_keys,
+                )
+            except asyncio.CancelledError:
+                managed_run.finish(
+                    "cancelled", reason_code="provider_workload_call_cancelled"
+                )
+                raise
+            except ManagedWorkflowRoutingError as exc:
+                yield sse_payload(
+                    {
+                        "event": "error",
+                        "message": "AI Team 的 Managed Provider 计划未通过发送前预检。",
+                        "reason_code": exc.code,
+                        "provider_route_receipts": managed_run.receipt_summary(),
+                    }
+                )
+                return
+
+            prior_outputs: list[dict[str, str]] = []
+            for index, (agent, task) in enumerate(members, start=1):
+                yield sse_payload(
+                    {
+                        "event": "agent_start",
+                        "agent": agent_public_payload(agent),
+                        "step": index,
+                        "task": task,
+                    }
+                )
+                messages = team_member_chat_messages(
+                    payload, agent, task, prior_outputs
+                )
+                output = ""
+                try:
+                    async for delta in managed_run.stream_text(
+                        plan[index - 1],
+                        messages=chat_messages_json(messages),
+                        temperature=payload.temperature,
+                        max_tokens=payload.max_tokens,
+                    ):
+                        output += delta
+                        yield sse_payload(
+                            {
+                                "event": "agent_delta",
+                                "agent_id": agent.id,
+                                "output": delta,
+                            }
+                        )
+                except asyncio.CancelledError:
+                    managed_run.abandon(
+                        plan[index:],
+                        code="provider_workload_call_cancelled",
+                        status="cancelled",
+                    )
+                    managed_run.finish(
+                        "cancelled", reason_code="provider_workload_call_cancelled"
+                    )
+                    raise
+                except ManagedWorkflowRoutingError as exc:
+                    managed_run.abandon(
+                        plan[index:], code="provider_workload_team_plan_aborted"
+                    )
+                    receipt = managed_run.finish(
+                        managed_run.failure_status(), reason_code=exc.code
+                    )
+                    yield sse_payload(
+                        {
+                            "event": "error",
+                            "message": "AI Team 成员调用失败，系统未切换备用模型。",
+                            "reason_code": exc.code,
+                            "provider_route_receipts": receipt,
+                        }
+                    )
+                    return
+                prior_outputs.append(
+                    {
+                        "agent_id": agent.id,
+                        "agent_name": agent.name,
+                        "department": agent.department,
+                        "output": output,
+                    }
+                )
+                yield sse_payload(
+                    {
+                        "event": "agent_end",
+                        "agent": agent_public_payload(agent),
+                        "output": output,
+                        "provider_route_receipts": managed_run.receipt_summary(),
+                    }
+                )
+
+            summary_messages = team_summary_chat_messages(payload, prior_outputs)
+            final_output = ""
+            yield sse_payload(
+                {
+                    "event": "summary_start",
+                    "message": "专家接力完成，项目经理正在汇总最终方案...",
+                }
+            )
+            try:
+                async for delta in managed_run.stream_text(
+                    plan[-1],
+                    messages=chat_messages_json(summary_messages),
+                    temperature=0.45,
+                    max_tokens=payload.max_tokens,
+                ):
+                    final_output += delta
+                    yield sse_payload({"event": "summary_delta", "output": delta})
+            except asyncio.CancelledError:
+                managed_run.finish(
+                    "cancelled", reason_code="provider_workload_call_cancelled"
+                )
+                raise
+            except ManagedWorkflowRoutingError as exc:
+                receipt = managed_run.finish(
+                    managed_run.failure_status(), reason_code=exc.code
+                )
+                yield sse_payload(
+                    {
+                        "event": "error",
+                        "message": "AI Team 汇总调用失败，系统未切换备用模型。",
+                        "reason_code": exc.code,
+                        "provider_route_receipts": receipt,
+                    }
+                )
+                return
+            receipt = managed_run.finish("passed")
+            yield sse_payload(
+                {
+                    "event": "team_end",
+                    "final_output": final_output,
+                    "agent_outputs": prior_outputs,
+                    "provider_route_receipts": receipt,
+                }
+            )
+            return
 
         prior_outputs: list[dict[str, str]] = []
         try:
@@ -25547,28 +25879,9 @@ async def team_chat(payload: TeamChatRequest, request: Request):
                         "task": task,
                     }
                 )
-                if payload.mode == "debate":
-                    user_prompt = (
-                        f"团队任务：{payload.message}\n\n"
-                        f"你的独立发言任务：{task}\n"
-                        "请先给出你的专业判断，不要假设你已看到其他专家的意见。"
-                    )
-                else:
-                    previous = "\n\n".join(
-                        f"### {item['agent_name']} 的上一棒意见\n{item['output']}"
-                        for item in prior_outputs
-                    )
-                    user_prompt = (
-                        f"团队总任务：{payload.message}\n\n"
-                        f"你的接力任务：{task}\n\n"
-                        f"前序专家输出：\n{previous or '暂无，你是第一棒。'}\n\n"
-                        "请基于自己的专业角色补充、纠偏并推进到下一步。"
-                    )
-
-                messages = [
-                    agent_system_message(agent, task),
-                    ChatMessage(role="user", content=user_prompt),
-                ]
+                messages = team_member_chat_messages(
+                    payload, agent, task, prior_outputs
+                )
                 output = ""
                 async for delta in stream_text_with_model_fallback(
                     payload.model_id,
@@ -25609,27 +25922,7 @@ async def team_chat(payload: TeamChatRequest, request: Request):
                     }
                 )
 
-            summary_prompt = "\n\n".join(
-                f"### {item['agent_name']}（{item['department']}）\n{item['output']}"
-                for item in prior_outputs
-            )
-            summary_messages = [
-                ChatMessage(
-                    role="system",
-                    content=(
-                        "你是模镜专家团的项目经理。请整合多个专家的意见，"
-                        "输出一份可执行、去重、分优先级的最终方案。"
-                    ),
-                ),
-                ChatMessage(
-                    role="user",
-                    content=(
-                        f"用户任务：{payload.message}\n\n"
-                        f"专家意见如下：\n{summary_prompt}\n\n"
-                        "请给出团队综合意见、执行清单、风险提醒和下一步建议。"
-                    ),
-                ),
-            ]
+            summary_messages = team_summary_chat_messages(payload, prior_outputs)
             final_output = ""
             yield sse_payload(
                 {

--- a/server/model_router/route_team_gateway.py
+++ b/server/model_router/route_team_gateway.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable, Iterable
+from dataclasses import replace
+from typing import Any, Literal, cast
+
+import httpx
+
+from .service import ModelRouterService, RouterServiceError
+from .workflow_gateway import (
+    ManagedWorkflowGateway,
+    ManagedWorkflowNodeRun,
+    ManagedWorkflowRoutingError,
+    WorkflowEntryId,
+)
+from .workload_control import (
+    PROVIDER_WORKLOAD_CONTRACT_VERSION,
+    ProviderWorkloadCallService,
+    ProviderWorkloadPreparedCall,
+)
+
+
+RouteTeamEntryId = Literal["route_agent", "team_chat"]
+RouteTeamRoutingMode = Literal[
+    "legacy", "managed_required", "degraded_required"
+]
+
+
+class ManagedRouteTeamGateway:
+    """Fail-closed Provider control-plane adapter for Route Agent and Team Chat."""
+
+    def __init__(
+        self,
+        call_service: ProviderWorkloadCallService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self.call_service = call_service
+        self._workflow_gateway = ManagedWorkflowGateway(
+            call_service,
+            client_factory=client_factory,
+        )
+
+    @classmethod
+    def for_router(
+        cls,
+        router_service: ModelRouterService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> ManagedRouteTeamGateway:
+        return cls(
+            ProviderWorkloadCallService(router_service),
+            client_factory=client_factory,
+        )
+
+    def routing_mode(self, entry_id: RouteTeamEntryId) -> RouteTeamRoutingMode:
+        control = self.call_service.control
+        if not control.feature_enabled(entry_id):
+            return "legacy"
+        policy = control.get_policy(entry_id)
+        if policy.configured_status == "legacy":
+            return "legacy"
+        if policy.effective_status == "managed_required":
+            return "managed_required"
+        return "degraded_required"
+
+    def start_run(self, entry_id: RouteTeamEntryId) -> ManagedRouteTeamRun:
+        if self.routing_mode(entry_id) != "managed_required":
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_policy_not_active",
+                "该专家团入口的 Managed Provider 策略未就绪，当前调用失败关闭。",
+                status_code=409,
+                receipt=self.blocked_receipt(
+                    entry_id, "provider_workload_policy_not_active"
+                ),
+            )
+        try:
+            run_id = self.call_service.start_run(entry_id)
+        except RouterServiceError as exc:
+            raise ManagedWorkflowRoutingError(
+                exc.code,
+                "该专家团入口的 Provider 资格已失效，当前调用失败关闭。",
+                status_code=exc.status_code,
+                receipt=self.blocked_receipt(entry_id, exc.code),
+            ) from exc
+        return ManagedRouteTeamRun(
+            entry_id,
+            ManagedWorkflowNodeRun(
+                self._workflow_gateway,
+                cast(WorkflowEntryId, entry_id),
+                run_id,
+            ),
+        )
+
+    @staticmethod
+    def blocked_receipt(
+        entry_id: RouteTeamEntryId, reason_code: str
+    ) -> dict[str, Any]:
+        return {
+            "contract_version": PROVIDER_WORKLOAD_CONTRACT_VERSION,
+            "entry_id": entry_id,
+            "routing_mode": "managed_required",
+            "run_reference": "blocked_before_dispatch",
+            "status": "failed",
+            "call_count": 0,
+            "reason_codes": [reason_code],
+            "calls": [],
+        }
+
+
+class ManagedRouteTeamRun:
+    """One Route Agent or Team Chat run with a fully preflighted call plan."""
+
+    def __init__(
+        self,
+        entry_id: RouteTeamEntryId,
+        node_run: ManagedWorkflowNodeRun,
+    ) -> None:
+        self.entry_id = entry_id
+        self._node_run = node_run
+
+    async def prepare_plan(
+        self,
+        *,
+        model_id: str,
+        logical_call_keys: Iterable[str],
+    ) -> tuple[ProviderWorkloadPreparedCall, ...]:
+        prepared: list[ProviderWorkloadPreparedCall] = []
+        try:
+            for call_sequence, logical_call_key in enumerate(
+                logical_call_keys, start=1
+            ):
+                prepared.append(
+                    await self._node_run.prepare_stream_call(
+                        logical_call_key=logical_call_key,
+                        call_sequence=call_sequence,
+                        execution_shape="chat_text",
+                        model_id=model_id,
+                    )
+                )
+        except ManagedWorkflowRoutingError as exc:
+            self.abandon(
+                prepared,
+                code="provider_workload_plan_preflight_aborted",
+            )
+            self.finish("failed", reason_code=exc.code)
+            exc.receipt = self.receipt_summary()
+            raise
+        return tuple(prepared)
+
+    async def stream_text(
+        self,
+        prepared: ProviderWorkloadPreparedCall,
+        *,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+    ) -> AsyncIterator[str]:
+        try:
+            authorized_target = (
+                await self._node_run.gateway.call_service.transport.authorize_managed_target(
+                    prepared.target
+                )
+            )
+        except httpx.HTTPError as exc:
+            code = str(getattr(exc, "code", "provider_workload_egress_rejected"))
+            self._node_run.fail_prepared_call(prepared, code=code)
+            raise ManagedWorkflowRoutingError(
+                code,
+                "Managed Provider 在实际派发前未通过出口授权，系统未发送请求。",
+                status_code=409,
+                receipt=self.receipt_summary(),
+            ) from exc
+        prepared = replace(prepared, authorized_target=authorized_target)
+        async for delta in self._node_run.stream_prepared_text(
+            prepared,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        ):
+            yield delta
+
+    def abandon(
+        self,
+        prepared_calls: Iterable[ProviderWorkloadPreparedCall],
+        *,
+        code: str,
+        status: Literal["failed", "cancelled"] = "failed",
+    ) -> None:
+        for prepared in prepared_calls:
+            self._node_run.fail_prepared_call(
+                prepared,
+                code=code,
+                status=status,
+                result_class=(
+                    "client_cancelled" if status == "cancelled" else "plan_aborted"
+                ),
+            )
+
+    def finish(
+        self,
+        status: Literal["passed", "failed", "uncertain", "cancelled"],
+        *,
+        reason_code: str | None = None,
+    ) -> dict[str, Any]:
+        self._node_run.finish(status, reason_code=reason_code)
+        return self.receipt_summary()
+
+    def failure_status(self) -> Literal["failed", "uncertain"]:
+        return (
+            "uncertain"
+            if any(call.status == "uncertain" for call in self._node_run.calls)
+            else "failed"
+        )
+
+    def receipt_summary(self) -> dict[str, Any]:
+        summary = self._node_run.receipt_summary()
+        summary["entry_id"] = self.entry_id
+        summary["calls"] = sorted(
+            summary["calls"], key=lambda item: int(item["call_sequence"])
+        )
+        return summary

--- a/server/model_router/workload_control.py
+++ b/server/model_router/workload_control.py
@@ -115,6 +115,8 @@ DATA_PLANE_INTEGRATED_ENTRIES: frozenset[ProviderWorkloadEntryId] = frozenset(
         "expert_team_planner",
         "expert_team_dag",
         "fusion",
+        "route_agent",
+        "team_chat",
     }
 )
 

--- a/server/tests/test_route_team_managed_api.py
+++ b/server/tests/test_route_team_managed_api.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server import main as main_module
+from server.main import app
+from server.model_router.workflow_gateway import ManagedWorkflowRoutingError
+
+
+MODEL_ID = "provider/route-team-model"
+
+
+def _receipt(entry_id: str, call_count: int, status: str = "passed") -> dict:
+    return {
+        "contract_version": "modelmirror-provider-workload-routing-v1",
+        "entry_id": entry_id,
+        "routing_mode": "managed_required",
+        "run_reference": f"workrun_{entry_id}_api",
+        "status": status,
+        "call_count": call_count,
+        "reason_codes": [],
+        "calls": [
+            {
+                "call_sequence": index,
+                "model_id": MODEL_ID,
+                "actual_model": MODEL_ID,
+                "dispatched": True,
+                "status": "passed",
+                "error_code": None,
+                "prompt_tokens": 2,
+                "completion_tokens": 1,
+                "total_tokens": 3,
+            }
+            for index in range(1, call_count + 1)
+        ],
+    }
+
+
+@pytest_asyncio.fixture
+async def client():
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
+
+
+class FakeRouteTeamRun:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+        self.logical_call_keys: list[str] = []
+        self.streamed_calls: list[int] = []
+
+    async def prepare_plan(self, *, model_id: str, logical_call_keys):
+        assert model_id == MODEL_ID
+        self.logical_call_keys = list(logical_call_keys)
+        return tuple(range(1, len(self.logical_call_keys) + 1))
+
+    async def stream_text(self, prepared, **_kwargs):
+        self.streamed_calls.append(int(prepared))
+        yield f"managed-{prepared}"
+
+    def finish(self, status: str, *, reason_code: str | None = None) -> dict:
+        receipt = _receipt(self.entry_id, len(self.streamed_calls), status)
+        receipt["reason_codes"] = [reason_code] if reason_code else []
+        return receipt
+
+    def receipt_summary(self) -> dict:
+        return _receipt(self.entry_id, len(self.streamed_calls), "running")
+
+    @staticmethod
+    def failure_status() -> str:
+        return "failed"
+
+    @staticmethod
+    def abandon(*_args, **_kwargs) -> None:
+        return None
+
+
+class FakeRouteTeamGateway:
+    def __init__(self, mode: str) -> None:
+        self.mode = mode
+        self.runs: dict[str, FakeRouteTeamRun] = {}
+
+    def routing_mode(self, _entry_id: str) -> str:
+        return self.mode
+
+    def start_run(self, entry_id: str) -> FakeRouteTeamRun:
+        if self.mode != "managed_required":
+            raise ManagedWorkflowRoutingError(
+                "provider_workload_policy_not_active",
+                "Managed policy is not active.",
+                status_code=409,
+                receipt=self.blocked_receipt(
+                    entry_id, "provider_workload_policy_not_active"
+                ),
+            )
+        run = FakeRouteTeamRun(entry_id)
+        self.runs[entry_id] = run
+        return run
+
+    @staticmethod
+    def blocked_receipt(entry_id: str, reason_code: str) -> dict:
+        receipt = _receipt(entry_id, 0, "failed")
+        receipt["run_reference"] = "blocked_before_dispatch"
+        receipt["reason_codes"] = [reason_code]
+        return receipt
+
+
+@pytest.mark.asyncio
+async def test_managed_route_and_team_do_not_require_legacy_gateway(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    gateway = FakeRouteTeamGateway("managed_required")
+    experts = main_module.AGENT_RECORDS[:2]
+    monkeypatch.setenv("MODEL_CONTROL_ROUTE_AGENT_ENABLED", "true")
+    monkeypatch.setenv("MODEL_CONTROL_TEAM_CHAT_ENABLED", "true")
+    monkeypatch.setattr(main_module, "route_team_managed_gateway", lambda: gateway)
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("", ""))
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+
+    route = await client.post(
+        "/api/route-agent",
+        json={"message": "制定测试计划", "model_id": MODEL_ID},
+    )
+    team = await client.post(
+        "/api/team/chat",
+        json={
+            "message": "协作制定测试计划",
+            "model_id": MODEL_ID,
+            "mode": "serial",
+            "members": [
+                {"agent_id": experts[0].id, "task": "分析风险"},
+                {"agent_id": experts[1].id, "task": "整理验收"},
+            ],
+        },
+    )
+
+    assert route.status_code == 200
+    assert '"event": "answer_end"' in route.text
+    assert '"entry_id": "route_agent"' in route.text
+    assert gateway.runs["route_agent"].logical_call_keys == ["route-answer:1"]
+    assert gateway.runs["route_agent"].streamed_calls == [1]
+
+    assert team.status_code == 200
+    assert '"event": "team_end"' in team.text
+    assert '"entry_id": "team_chat"' in team.text
+    assert gateway.runs["team_chat"].logical_call_keys == [
+        "member:1",
+        "member:2",
+        "summary:3",
+    ]
+    assert gateway.runs["team_chat"].streamed_calls == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "flag", "entry_id", "payload"),
+    [
+        (
+            "/api/route-agent",
+            "MODEL_CONTROL_ROUTE_AGENT_ENABLED",
+            "route_agent",
+            {"message": "制定测试计划", "model_id": MODEL_ID},
+        ),
+        (
+            "/api/team/chat",
+            "MODEL_CONTROL_TEAM_CHAT_ENABLED",
+            "team_chat",
+            {
+                "message": "协作制定测试计划",
+                "model_id": MODEL_ID,
+                "members": [],
+            },
+        ),
+    ],
+)
+async def test_degraded_managed_entry_fails_closed_with_zero_call_receipt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    flag: str,
+    entry_id: str,
+    payload: dict,
+) -> None:
+    if entry_id == "team_chat":
+        expert = main_module.AGENT_RECORDS[0]
+        payload = {**payload, "members": [{"agent_id": expert.id}]}
+    monkeypatch.setenv(flag, "true")
+    monkeypatch.setattr(
+        main_module,
+        "route_team_managed_gateway",
+        lambda: FakeRouteTeamGateway("degraded_required"),
+    )
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+
+    response = await client.post(path, json=payload)
+
+    assert response.status_code == 200
+    assert '"reason_code": "provider_workload_policy_not_active"' in response.text
+    assert f'"entry_id": "{entry_id}"' in response.text
+    assert '"call_count": 0' in response.text
+
+
+@pytest.mark.asyncio
+async def test_disabled_route_and_team_never_initialize_control_plane(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MODEL_CONTROL_ROUTE_AGENT_ENABLED", "false")
+    monkeypatch.setenv("MODEL_CONTROL_TEAM_CHAT_ENABLED", "false")
+
+    def fail_if_initialized():
+        raise AssertionError("disabled entry must not initialize control plane")
+
+    monkeypatch.setattr(main_module, "route_team_managed_gateway", fail_if_initialized)
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("", ""))
+
+    route = await client.post(
+        "/api/route-agent", json={"message": "legacy", "model_id": MODEL_ID}
+    )
+    team = await client.post(
+        "/api/team/chat",
+        json={
+            "message": "legacy",
+            "model_id": MODEL_ID,
+            "members": [{"agent_id": main_module.AGENT_RECORDS[0].id}],
+        },
+    )
+
+    assert route.status_code == 500
+    assert team.status_code == 500
+    assert route.json()["error"] == main_module.LLM_GATEWAY_NOT_CONFIGURED_MESSAGE
+    assert team.json()["error"] == main_module.LLM_GATEWAY_NOT_CONFIGURED_MESSAGE
+
+
+def test_receipt_fixture_contains_no_prompt_or_connection_details() -> None:
+    serialized = json.dumps(_receipt("team_chat", 3))
+    assert "协作制定测试计划" not in serialized
+    assert "connection_id" not in serialized
+    assert "base_url" not in serialized

--- a/server/tests/test_route_team_managed_gateway.py
+++ b/server/tests/test_route_team_managed_gateway.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from server.model_router.egress import ProviderEgressPolicy
+from server.model_router.egress import ProviderEgressError
+from server.model_router.provider_chat import PROVIDER_CHAT_CONTRACT_VERSION
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.route_team_gateway import ManagedRouteTeamGateway
+from server.model_router.schemas import (
+    ProviderWorkloadActivationRequest,
+    ProviderWorkloadBindingUpdate,
+    ProviderWorkloadPolicyUpdate,
+    RouterConnectionCreate,
+    RouterConnectionUpdate,
+)
+from server.model_router.service import ModelRouterService, RouterServiceError
+from server.model_router.workflow_gateway import ManagedWorkflowRoutingError
+from server.model_router.workload_control import ProviderWorkloadControlService
+
+
+MODEL_ID = "provider/route-team-model"
+
+
+def _fingerprint(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _sse(
+    text: str = "managed answer", *, actual_model: str = MODEL_ID
+) -> bytes:
+    chunks = [
+        {
+            "model": actual_model,
+            "choices": [{"delta": {"content": text}, "finish_reason": None}],
+        },
+        {
+            "model": actual_model,
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 3,
+                "completion_tokens": 2,
+                "total_tokens": 5,
+            },
+        },
+    ]
+    return (
+        "".join(f"data: {json.dumps(item)}\n\n" for item in chunks)
+        + "data: [DONE]\n\n"
+    ).encode("utf-8")
+
+
+def _gateway(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    entry_id: str,
+    handler,
+) -> tuple[ManagedRouteTeamGateway, SQLiteRouterRepository]:
+    repository = SQLiteRouterRepository(tmp_path / "router", master_key=b"x" * 32)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Route Team Provider",
+            kind="openrouter",
+            base_url="https://provider.example/v1",
+            api_key="test-route-team-key",
+            scopes=["chat"],
+        ),
+    )
+    repository.save_test_result(
+        "local",
+        connection.id,
+        health="online",
+        model_count=1,
+        checked_at="2026-08-25T00:00:00+00:00",
+    )
+    connection_fingerprint = repository.connection_config_fingerprint(
+        "local", connection.id
+    )
+    repository.claim_catalog_refresh(
+        "local",
+        refresh_id="refresh-r6i",
+        connection_id=connection.id,
+        connection_fingerprint=connection_fingerprint,
+    )
+    repository.complete_catalog_refresh(
+        "local",
+        "refresh-r6i",
+        connection_id=connection.id,
+        models=[
+            {
+                "model_id": MODEL_ID,
+                "normalized_model_id": MODEL_ID,
+                "capability_state": "declared",
+            }
+        ],
+        offerings=[],
+        model_count=1,
+        truncated=False,
+        catalog_fingerprint="catalog-r6i",
+        observed_at="2026-08-25T00:00:00+00:00",
+    )
+    certification, created = repository.claim_chat_certification(
+        "local",
+        certification_id="route-team-chat-cert",
+        connection_id=connection.id,
+        connection_fingerprint=connection_fingerprint,
+        contract_version=PROVIDER_CHAT_CONTRACT_VERSION,
+        capability="chat_text",
+        requested_model=MODEL_ID,
+        idempotency_key_hash=_fingerprint({"route-team": MODEL_ID}),
+    )
+    assert created is True
+    repository.complete_chat_certification(
+        "local",
+        str(certification["id"]),
+        status="passed",
+        checks={
+            "catalog_contains_model": True,
+            "http_2xx": True,
+            "content_observed": True,
+            "response_complete": True,
+            "terminal_observed": True,
+        },
+        warning_codes=[],
+        actual_model=MODEL_ID,
+    )
+
+    flag = (
+        "MODEL_CONTROL_ROUTE_AGENT_ENABLED"
+        if entry_id == "route_agent"
+        else "MODEL_CONTROL_TEAM_CHAT_ENABLED"
+    )
+    monkeypatch.setenv(flag, "true")
+    service = ModelRouterService(
+        repository,
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+    control = ProviderWorkloadControlService(service)
+    saved = control.update_policy(
+        entry_id,
+        ProviderWorkloadPolicyUpdate(
+            expected_revision=0,
+            bindings=[
+                ProviderWorkloadBindingUpdate(
+                    connection_id=connection.id,
+                    model_id=MODEL_ID,
+                    execution_shape="chat_text",
+                )
+            ],
+        ),
+    )
+    control.activate(
+        entry_id,
+        ProviderWorkloadActivationRequest(
+            expected_revision=saved.revision,
+            acknowledge_fail_closed=True,
+            no_open_p0_p1=True,
+        ),
+    )
+    return (
+        ManagedRouteTeamGateway.for_router(
+            service,
+            client_factory=lambda: httpx.AsyncClient(
+                transport=httpx.MockTransport(handler), trust_env=False
+            ),
+        ),
+        repository,
+    )
+
+
+@pytest.mark.asyncio
+async def test_route_agent_uses_one_exact_managed_post_and_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payloads: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payloads.append(json.loads(request.content))
+        return httpx.Response(200, content=_sse())
+
+    gateway, _repository = _gateway(
+        tmp_path, monkeypatch, entry_id="route_agent", handler=handler
+    )
+    run = gateway.start_run("route_agent")
+    plan = await run.prepare_plan(
+        model_id=MODEL_ID, logical_call_keys=["route-answer:1"]
+    )
+    output = ""
+    async for delta in run.stream_text(
+        plan[0],
+        messages=[{"role": "user", "content": "route me"}],
+        temperature=0.2,
+        max_tokens=128,
+    ):
+        output += delta
+    receipt = run.finish("passed")
+
+    assert output == "managed answer"
+    assert len(payloads) == 1
+    assert payloads[0]["model"] == MODEL_ID
+    assert receipt["entry_id"] == "route_agent"
+    assert receipt["call_count"] == 1
+    assert receipt["calls"][0]["status"] == "passed"
+
+
+@pytest.mark.asyncio
+async def test_team_chat_preflights_all_members_and_summary_before_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payloads: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payloads.append(json.loads(request.content))
+        return httpx.Response(200, content=_sse(f"answer-{len(payloads)}"))
+
+    gateway, _repository = _gateway(
+        tmp_path, monkeypatch, entry_id="team_chat", handler=handler
+    )
+    run = gateway.start_run("team_chat")
+    plan = await run.prepare_plan(
+        model_id=MODEL_ID,
+        logical_call_keys=["member:1", "member:2", "summary:3"],
+    )
+    assert payloads == []
+
+    outputs: list[str] = []
+    for prepared in plan:
+        text = ""
+        async for delta in run.stream_text(
+            prepared,
+            messages=[{"role": "user", "content": "planned team call"}],
+            temperature=0.2,
+            max_tokens=128,
+        ):
+            text += delta
+        outputs.append(text)
+    receipt = run.finish("passed")
+
+    assert outputs == ["answer-1", "answer-2", "answer-3"]
+    assert len(payloads) == 3
+    assert receipt["entry_id"] == "team_chat"
+    assert receipt["call_count"] == 3
+    assert [call["call_sequence"] for call in receipt["calls"]] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_team_preflight_failure_sends_zero_provider_posts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, content=_sse())
+
+    gateway, repository = _gateway(
+        tmp_path, monkeypatch, entry_id="team_chat", handler=handler
+    )
+    original_prepare = gateway.call_service.prepare_call
+
+    async def fail_summary(**kwargs):
+        if kwargs["call_sequence"] == 3:
+            raise RouterServiceError(
+                "provider_workload_binding_missing",
+                "summary binding missing",
+                status_code=409,
+            )
+        return await original_prepare(**kwargs)
+
+    monkeypatch.setattr(gateway.call_service, "prepare_call", fail_summary)
+    run = gateway.start_run("team_chat")
+    with pytest.raises(ManagedWorkflowRoutingError) as caught:
+        await run.prepare_plan(
+            model_id=MODEL_ID,
+            logical_call_keys=["member:1", "member:2", "summary:3"],
+        )
+
+    assert caught.value.code == "provider_workload_binding_missing"
+    assert requests == []
+    receipt = caught.value.receipt
+    assert receipt["call_count"] == 0
+    assert all(call["dispatched"] is False for call in receipt["calls"])
+    stored = repository.list_workload_receipts("local")
+    assert all(row["status"] != "running" for row in stored["runs"])
+    assert all(row["status"] != "running" for row in stored["calls"])
+
+
+@pytest.mark.asyncio
+async def test_team_member_failure_never_dispatches_summary_or_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requested_models: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_models.append(json.loads(request.content)["model"])
+        return httpx.Response(503)
+
+    gateway, _repository = _gateway(
+        tmp_path, monkeypatch, entry_id="team_chat", handler=handler
+    )
+    run = gateway.start_run("team_chat")
+    plan = await run.prepare_plan(
+        model_id=MODEL_ID,
+        logical_call_keys=["member:1", "member:2", "summary:3"],
+    )
+    with pytest.raises(ManagedWorkflowRoutingError) as caught:
+        async for _delta in run.stream_text(
+            plan[0],
+            messages=[{"role": "user", "content": "first member"}],
+            temperature=0.2,
+            max_tokens=128,
+        ):
+            pass
+    run.abandon(plan[1:], code="provider_workload_team_plan_aborted")
+    receipt = run.finish(run.failure_status(), reason_code=caught.value.code)
+
+    assert requested_models == [MODEL_ID]
+    assert receipt["call_count"] == 1
+    assert [call["dispatched"] for call in receipt["calls"]] == [True, False, False]
+    assert all(call["model_id"] == MODEL_ID for call in receipt["calls"])
+
+
+def test_disabled_entry_keeps_legacy_without_control_plane_activation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("MODEL_CONTROL_ROUTE_AGENT_ENABLED", raising=False)
+    monkeypatch.delenv("MODEL_CONTROL_TEAM_CHAT_ENABLED", raising=False)
+    repository = SQLiteRouterRepository(tmp_path / "router", master_key=b"x" * 32)
+    gateway = ManagedRouteTeamGateway.for_router(ModelRouterService(repository))
+
+    assert gateway.routing_mode("route_agent") == "legacy"
+    assert gateway.routing_mode("team_chat") == "legacy"
+
+
+@pytest.mark.asyncio
+async def test_policy_drift_after_full_preflight_sends_zero_posts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, content=_sse())
+
+    gateway, repository = _gateway(
+        tmp_path, monkeypatch, entry_id="route_agent", handler=handler
+    )
+    run = gateway.start_run("route_agent")
+    plan = await run.prepare_plan(
+        model_id=MODEL_ID, logical_call_keys=["route-answer:1"]
+    )
+    connection_id = repository.list_connections("local")[0].id
+    repository.update_connection(
+        "local",
+        connection_id,
+        RouterConnectionUpdate(api_key="rotated-after-preflight"),
+    )
+
+    with pytest.raises(ManagedWorkflowRoutingError) as caught:
+        async for _delta in run.stream_text(
+            plan[0],
+            messages=[{"role": "user", "content": "must not dispatch"}],
+            temperature=0.2,
+            max_tokens=128,
+        ):
+            pass
+    receipt = run.finish(run.failure_status(), reason_code=caught.value.code)
+
+    assert caught.value.code in {
+        "provider_workload_policy_not_active",
+        "provider_workload_binding_changed",
+    }
+    assert requests == []
+    assert receipt["call_count"] == 0
+    assert receipt["calls"][0]["dispatched"] is False
+
+
+@pytest.mark.asyncio
+async def test_egress_is_reauthorized_immediately_before_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, content=_sse())
+
+    gateway, _repository = _gateway(
+        tmp_path, monkeypatch, entry_id="team_chat", handler=handler
+    )
+    run = gateway.start_run("team_chat")
+    plan = await run.prepare_plan(
+        model_id=MODEL_ID, logical_call_keys=["member:1", "summary:2"]
+    )
+
+    async def reject_reauthorization(_target):
+        raise ProviderEgressError(
+            "provider_egress_forbidden_address",
+            "target changed to a forbidden address",
+        )
+
+    monkeypatch.setattr(
+        gateway.call_service.transport,
+        "authorize_managed_target",
+        reject_reauthorization,
+    )
+    with pytest.raises(ManagedWorkflowRoutingError) as caught:
+        async for _delta in run.stream_text(
+            plan[0],
+            messages=[{"role": "user", "content": "must not dispatch"}],
+            temperature=0.2,
+            max_tokens=128,
+        ):
+            pass
+    run.abandon(plan[1:], code="provider_workload_team_plan_aborted")
+    receipt = run.finish("failed", reason_code=caught.value.code)
+
+    assert caught.value.code == "provider_egress_forbidden_address"
+    assert requests == []
+    assert receipt["call_count"] == 0
+    assert all(call["dispatched"] is False for call in receipt["calls"])
+
+
+@pytest.mark.asyncio
+async def test_actual_model_mismatch_is_one_failed_post_without_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requested_models: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_models.append(json.loads(request.content)["model"])
+        return httpx.Response(
+            200,
+            content=_sse(actual_model="provider/unexpected-model"),
+        )
+
+    gateway, _repository = _gateway(
+        tmp_path, monkeypatch, entry_id="route_agent", handler=handler
+    )
+    run = gateway.start_run("route_agent")
+    plan = await run.prepare_plan(
+        model_id=MODEL_ID, logical_call_keys=["route-answer:1"]
+    )
+    with pytest.raises(ManagedWorkflowRoutingError) as caught:
+        async for _delta in run.stream_text(
+            plan[0],
+            messages=[{"role": "user", "content": "exact model required"}],
+            temperature=0.2,
+            max_tokens=128,
+        ):
+            pass
+    receipt = run.finish(run.failure_status(), reason_code=caught.value.code)
+
+    assert caught.value.code == "provider_workload_actual_model_mismatch"
+    assert requested_models == [MODEL_ID]
+    assert receipt["call_count"] == 1
+    assert receipt["calls"][0]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_cancel_after_first_delta_closes_one_post_without_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requests: list[httpx.Request] = []
+    release = asyncio.Event()
+
+    class BlockingStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield (
+                b'data: {"model":"provider/route-team-model","choices":'
+                b'[{"delta":{"content":"first"},"finish_reason":null}]}\n\n'
+            )
+            await release.wait()
+            yield b"data: [DONE]\n\n"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, stream=BlockingStream())
+
+    gateway, _repository = _gateway(
+        tmp_path, monkeypatch, entry_id="route_agent", handler=handler
+    )
+    run = gateway.start_run("route_agent")
+    plan = await run.prepare_plan(
+        model_id=MODEL_ID, logical_call_keys=["route-answer:1"]
+    )
+    stream = run.stream_text(
+        plan[0],
+        messages=[{"role": "user", "content": "cancel me"}],
+        temperature=0.2,
+        max_tokens=128,
+    )
+    assert await anext(stream) == "first"
+    pending = asyncio.create_task(anext(stream))
+    await asyncio.sleep(0)
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    receipt = run.finish(
+        "cancelled", reason_code="provider_workload_call_cancelled"
+    )
+
+    assert len(requests) == 1
+    assert receipt["status"] == "cancelled"
+    assert receipt["call_count"] == 1
+    assert receipt["calls"][0]["status"] == "cancelled"


### PR DESCRIPTION
## 范围
- 将 Route Agent 与两种 Team Chat 模式接入现有 v16 Managed Provider Route Plan。
- 增加精确 chat_text Binding、单次派发约束和脱敏 provider_route_receipts。
- 保留 Feature Flag 关闭时的 legacy 行为；不修改 R5 Chat、Catalog、多模态、RAG、Coding 或计费边界。

## 验证
- R6I 定向与出口测试：36 passed。
- R6A-I 受影响后端矩阵：190 passed。
- 后端全量：4583 passed, 29 skipped。
- 前端全量：114 files / 660 tests passed；typecheck 与 production build 通过。
- Core、独立 newAPI、Overlay Compose config --quiet 通过；git diff --check 通过。
- 独立预览真实 Smoke：Route Agent 1 次 Provider POST；两成员 Team Chat 3 次 Provider POST；全部 HTTP 200，Receipt 与实际模型一致。

## 安全与回滚
- Receipt 不保存 Prompt、消息、模型正文、Base URL 或凭据。
- POST 派发后不切换第二模型、Provider、连接、IP 或 legacy。
- 对应 Feature Flag 默认关闭；停用 Policy 并关闭 Flag 可恢复 legacy，v16 Receipt 保留。

## 未包含
- 不启用生产策略，不进入 R7，不实现多租户、积分、充值、账本或 ModelMirror 计费。