### PR TITLE
feature: 添加 R7 Provider Operation 控制面基础

### DIFF
--- a/client/src/components/settings/ModelServiceConnections.test.tsx
+++ b/client/src/components/settings/ModelServiceConnections.test.tsx
@@ -30,6 +30,7 @@ describe("ModelServiceConnections editing", () => {
     render(<ModelServiceConnections csrfToken="csrf-test" />);
     fireEvent.click(await screen.findByRole("button", { name: "编辑" }));
     fireEvent.change(screen.getByLabelText("连接名称"), { target: { value: "更新后的 newAPI" } });
+    fireEvent.click(screen.getByLabelText("Embedding"));
     fireEvent.click(screen.getByRole("button", { name: "保存修改并测试" }));
 
     await waitFor(() => expect(fetchMock.mock.calls.some(([input, init]) => String(input) === "/api/router/connections/connection-1/test" && init?.method === "POST")).toBe(true));
@@ -37,7 +38,7 @@ describe("ModelServiceConnections editing", () => {
     expect(JSON.parse(String(patchCall?.[1]?.body))).toEqual({
       name: "更新后的 newAPI",
       base_url: "https://provider.example/v1",
-      scopes: ["chat"],
+      scopes: ["chat", "embedding"],
     });
   });
 

--- a/client/src/components/settings/ModelServiceConnections.tsx
+++ b/client/src/components/settings/ModelServiceConnections.tsx
@@ -14,7 +14,13 @@ type ConnectionKind =
   | "newapi"
   | "openai_compatible"
   | "openai";
-type ConnectionScope = "chat" | "audio" | "realtime";
+type ConnectionScope =
+  | "chat"
+  | "audio"
+  | "realtime"
+  | "embedding"
+  | "rerank"
+  | "batch";
 type ConnectionHealth = "untested" | "online" | "offline" | "disabled";
 
 interface RouterConnection {
@@ -92,7 +98,12 @@ const SCOPE_LABELS: Record<ConnectionScope, string> = {
   chat: "普通模型调用",
   audio: "音频能力",
   realtime: "实时语音",
+  embedding: "Embedding",
+  rerank: "Rerank",
+  batch: "异步 Batch",
 };
+
+const ALL_SCOPES = Object.keys(SCOPE_LABELS) as ConnectionScope[];
 
 const INITIAL_FORM: ConnectionForm = {
   kind: "openrouter",
@@ -201,6 +212,19 @@ export default function ModelServiceConnections({
     },
     [updateForm],
   );
+
+  const toggleScope = useCallback((scope: ConnectionScope) => {
+    setForm((current) => {
+      const selected = current.scopes.includes(scope);
+      if (selected && current.scopes.length === 1) return current;
+      return {
+        ...current,
+        scopes: selected
+          ? current.scopes.filter((item) => item !== scope)
+          : ALL_SCOPES.filter((item) => [...current.scopes, scope].includes(item)),
+      };
+    });
+  }, []);
 
   const payload = useMemo(
     () => ({
@@ -445,16 +469,31 @@ export default function ModelServiceConnections({
             <span className="mt-2 block text-xs leading-5 text-slate-400">
               {provider.hint}
             </span>
-            <span className="mt-2 flex flex-wrap gap-2">
-              {form.scopes.map((scope) => (
-                <span
-                  className="rounded-full bg-white/[0.055] px-2.5 py-1 text-xs text-slate-300"
-                  key={scope}
-                >
-                  {SCOPE_LABELS[scope]}
-                </span>
-              ))}
-            </span>
+            <fieldset className="mt-3">
+              <legend className="text-xs font-medium text-slate-300">
+                授权用途（旧连接不会自动扩大）
+              </legend>
+              <span className="mt-2 flex flex-wrap gap-2">
+                {ALL_SCOPES.map((scope) => {
+                  const checked = form.scopes.includes(scope);
+                  return (
+                    <label
+                      className={`cursor-pointer rounded-full border px-2.5 py-1 text-xs transition ${checked ? "border-cyan-300/35 bg-cyan-300/10 text-cyan-100" : "border-white/10 text-slate-400"}`}
+                      key={scope}
+                    >
+                      <input
+                        checked={checked}
+                        className="sr-only"
+                        disabled={checked && form.scopes.length === 1}
+                        onChange={() => toggleScope(scope)}
+                        type="checkbox"
+                      />
+                      {SCOPE_LABELS[scope]}
+                    </label>
+                  );
+                })}
+              </span>
+            </fieldset>
           </label>
 
           <div className="grid gap-4 sm:grid-cols-2">

--- a/client/src/components/settings/ProviderWorkloadControlSettings.test.tsx
+++ b/client/src/components/settings/ProviderWorkloadControlSettings.test.tsx
@@ -31,6 +31,16 @@ describe("ProviderWorkloadControlSettings", () => {
       "chat_json_object",
     ]);
   });
+
+  it("keeps R7 retrieval and batch operations explicit and uncombined", () => {
+    expect(ENTRY_SHAPES.rag_embedding).toEqual(["embedding_vectors"]);
+    expect(ENTRY_SHAPES.rag_rerank).toEqual(["rerank_documents"]);
+    expect(ENTRY_SHAPES.skill_rerank).toEqual(["rerank_documents"]);
+    expect(ENTRY_SHAPES.openrouter_batch).toEqual([
+      "openrouter_batch_chat",
+      "openrouter_batch_embeddings",
+    ]);
+  });
   afterEach(() => vi.unstubAllGlobals());
 
   it("requires an explicit confirmation before one billed workload certification", async () => {
@@ -59,7 +69,7 @@ describe("ProviderWorkloadControlSettings", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<ProviderWorkloadControlSettings csrfToken="csrf-value" view="certifications" />);
-    await screen.findByText("R6 非流式、JSON 与原生 Fusion 合同");
+    await screen.findByText("R6 / R7 精确 Operation 合同");
     fireEvent.change(screen.getByLabelText("执行形态"), {
       target: { value: "chat_json_object" },
     });
@@ -124,7 +134,7 @@ describe("ProviderWorkloadControlSettings", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<ProviderWorkloadControlSettings csrfToken="csrf-value" view="routing" />);
-    await screen.findByText("R6 入口、精确 Binding 与 Receipt");
+    await screen.findByText("R6 / R7 入口、精确 Binding 与 Receipt");
     expect(screen.getByRole("button", { name: /激活 Managed/ })).toBeDisabled();
     fireEvent.click(screen.getByRole("button", { name: "添加 Binding" }));
     fireEvent.change(screen.getByLabelText("Binding 1 模型 ID"), {
@@ -141,12 +151,139 @@ describe("ProviderWorkloadControlSettings", () => {
     );
     expect(JSON.parse(String(call?.[1]?.body))).toEqual({
       expected_revision: 3,
+      local_fallback_mode: "none",
       bindings: [{
         execution_shape: "chat_tools",
         model_id: "openai/gpt-test",
         connection_id: connection.id,
       }],
     });
+  });
+
+  it("persists the explicitly selected Rerank access mode in a binding", async () => {
+    const rerankConnection = {
+      ...connection,
+      id: "connection-rerank",
+      name: "Rerank managed",
+      scopes: ["rerank"],
+    };
+    const policy = {
+      contract_version: "modelmirror-provider-workload-routing-v1",
+      entry_id: "rag_rerank",
+      feature_enabled: false,
+      data_plane_integrated: false,
+      configured_status: "legacy",
+      effective_status: "legacy",
+      revision: 2,
+      policy_fingerprint: "rerank-fingerprint",
+      local_fallback_mode: "none",
+      bindings: [],
+      approval_valid: false,
+      blocking_reason_codes: ["provider_workload_data_plane_not_integrated"],
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/router/workload-control/policies" && !init) {
+        return jsonResponse({ policies: [policy] });
+      }
+      if (url === "/api/router/connections") return jsonResponse([rerankConnection]);
+      if (url.startsWith("/api/router/workload-control/receipts")) {
+        return jsonResponse({ runs: [] });
+      }
+      if (url === "/api/router/workload-control/policies/rag_rerank" && init?.method === "PUT") {
+        return jsonResponse({ ...policy, revision: 3 });
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ProviderWorkloadControlSettings csrfToken="csrf-value" view="routing" />);
+    await screen.findByText("R6 / R7 入口、精确 Binding 与 Receipt");
+    fireEvent.change(screen.getByLabelText("入口"), {
+      target: { value: "rag_rerank" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "添加 Binding" }));
+    fireEvent.change(screen.getByLabelText("Binding 1 Rerank 访问方式"), {
+      target: { value: "llm_json" },
+    });
+    fireEvent.change(screen.getByLabelText("Binding 1 模型 ID"), {
+      target: { value: "provider/rerank" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "保存 Binding" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      "/api/router/workload-control/policies/rag_rerank",
+      expect.objectContaining({ method: "PUT" }),
+    ));
+    const call = fetchMock.mock.calls.find(([url, options]) =>
+      url === "/api/router/workload-control/policies/rag_rerank"
+      && options?.method === "PUT"
+    );
+    expect(JSON.parse(String(call?.[1]?.body))).toMatchObject({
+      expected_revision: 2,
+      bindings: [{
+        execution_shape: "rerank_documents",
+        model_id: "provider/rerank",
+        connection_id: rerankConnection.id,
+        rerank_access_mode: "llm_json",
+      }],
+    });
+  });
+
+  it("never initializes an OpenRouter Batch binding with another provider kind", async () => {
+    const newApiBatchConnection = {
+      ...connection,
+      id: "connection-newapi-batch",
+      name: "newAPI Batch",
+      kind: "newapi",
+      scopes: ["batch"],
+    };
+    const openRouterBatchConnection = {
+      ...connection,
+      id: "connection-openrouter-batch",
+      name: "OpenRouter Batch",
+      scopes: ["batch"],
+    };
+    const policy = {
+      contract_version: "modelmirror-provider-workload-routing-v1",
+      entry_id: "openrouter_batch",
+      feature_enabled: false,
+      data_plane_integrated: false,
+      configured_status: "legacy",
+      effective_status: "legacy",
+      revision: 0,
+      policy_fingerprint: "batch-fingerprint",
+      local_fallback_mode: "none",
+      bindings: [],
+      approval_valid: false,
+      blocking_reason_codes: ["provider_workload_data_plane_not_integrated"],
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/router/workload-control/policies") {
+        return jsonResponse({ policies: [policy] });
+      }
+      if (url === "/api/router/connections") {
+        return jsonResponse([newApiBatchConnection, openRouterBatchConnection]);
+      }
+      if (url.startsWith("/api/router/workload-control/receipts")) {
+        return jsonResponse({ runs: [] });
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ProviderWorkloadControlSettings csrfToken="csrf-value" view="routing" />);
+    await screen.findByText("R6 / R7 入口、精确 Binding 与 Receipt");
+    fireEvent.change(screen.getByLabelText("入口"), {
+      target: { value: "openrouter_batch" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "添加 Binding" }));
+
+    expect(screen.getByLabelText("Binding 1 连接")).toHaveValue(
+      openRouterBatchConnection.id,
+    );
+    expect(screen.queryByRole("option", { name: newApiBatchConnection.name })).not.toBeInTheDocument();
   });
 
   it("requires both operator acknowledgements before activating an integrated entry", async () => {
@@ -202,7 +339,7 @@ describe("ProviderWorkloadControlSettings", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<ProviderWorkloadControlSettings csrfToken="csrf-value" view="routing" />);
-    await screen.findByText("R6 入口、精确 Binding 与 Receipt");
+    await screen.findByText("R6 / R7 入口、精确 Binding 与 Receipt");
     const activateButton = screen.getByRole("button", { name: "激活 Managed 必经" });
     expect(activateButton).toBeEnabled();
     fireEvent.click(activateButton);
@@ -268,7 +405,7 @@ describe("ProviderWorkloadControlSettings", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<ProviderWorkloadControlSettings csrfToken="csrf-value" view="routing" />);
-    await screen.findByText("R6 入口、精确 Binding 与 Receipt");
+    await screen.findByText("R6 / R7 入口、精确 Binding 与 Receipt");
     fireEvent.change(screen.getByLabelText("入口"), {
       target: { value: "expert_team_planner" },
     });
@@ -326,7 +463,7 @@ describe("ProviderWorkloadControlSettings", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<ProviderWorkloadControlSettings csrfToken="csrf-value" view="routing" />);
-    await screen.findByText("R6 入口、精确 Binding 与 Receipt");
+    await screen.findByText("R6 / R7 入口、精确 Binding 与 Receipt");
     fireEvent.click(screen.getByText("Workflow 交互 LLM · passed"));
 
     expect(screen.getByText("请求模型：openai/gpt-test")).toBeInTheDocument();

--- a/client/src/components/settings/ProviderWorkloadControlSettings.tsx
+++ b/client/src/components/settings/ProviderWorkloadControlSettings.tsx
@@ -21,14 +21,26 @@ type EntryId =
   | "expert_team_dag"
   | "fusion"
   | "route_agent"
-  | "team_chat";
+  | "team_chat"
+  | "rag_query_generate"
+  | "rag_processor_generate"
+  | "rag_embedding"
+  | "rag_rerank"
+  | "skill_rerank"
+  | "openrouter_batch";
 type ExecutionShape =
   | "chat_text"
   | "chat_tools"
   | "chat_text_unary"
   | "chat_json_object"
-  | "fusion_native";
+  | "fusion_native"
+  | "embedding_vectors"
+  | "rerank_documents"
+  | "openrouter_batch_chat"
+  | "openrouter_batch_embeddings";
 type PolicyStatus = "legacy" | "managed_required" | "degraded_required";
+type LocalFallbackMode = "none" | "extractive" | "lexical";
+type RerankAccessMode = "dedicated" | "llm_json";
 
 interface ConnectionSummary {
   id: string;
@@ -55,6 +67,10 @@ interface CertificationSummary {
   e2e_ms?: number | null;
   total_tokens?: number | null;
   completed_at?: string | null;
+  rerank_access_mode?: RerankAccessMode | null;
+  vector_dimension?: number | null;
+  batch_job_id?: string | null;
+  batch_status?: string | null;
 }
 
 interface BindingSummary {
@@ -64,6 +80,7 @@ interface BindingSummary {
   connection_name: string;
   provider_kind: string;
   certification_id: string;
+  rerank_access_mode?: RerankAccessMode | null;
   valid: boolean;
   reason_code: string;
 }
@@ -76,6 +93,7 @@ interface PolicySummary {
   effective_status: PolicyStatus;
   revision: number;
   policy_fingerprint: string;
+  local_fallback_mode: LocalFallbackMode;
   bindings: BindingSummary[];
   approval_valid: boolean;
   blocking_reason_codes: string[];
@@ -114,6 +132,7 @@ interface EditableBinding {
   execution_shape: ExecutionShape;
   model_id: string;
   connection_id: string;
+  rerank_access_mode?: RerankAccessMode | null;
 }
 
 const ENTRY_LABELS: Record<EntryId, string> = {
@@ -130,6 +149,12 @@ const ENTRY_LABELS: Record<EntryId, string> = {
   fusion: "Fusion",
   route_agent: "Route Agent",
   team_chat: "Team Chat",
+  rag_query_generate: "RAG 问答生成",
+  rag_processor_generate: "RAG AI Processor",
+  rag_embedding: "RAG Embedding",
+  rag_rerank: "RAG Rerank",
+  skill_rerank: "Skill Rerank",
+  openrouter_batch: "OpenRouter Batch",
 };
 
 const SHAPE_LABELS: Record<ExecutionShape, string> = {
@@ -138,12 +163,20 @@ const SHAPE_LABELS: Record<ExecutionShape, string> = {
   chat_text_unary: "非流式文本",
   chat_json_object: "JSON Object",
   fusion_native: "OpenRouter 原生 Fusion",
+  embedding_vectors: "Embedding 向量",
+  rerank_documents: "Rerank 文档",
+  openrouter_batch_chat: "OpenRouter Chat Batch",
+  openrouter_batch_embeddings: "OpenRouter Embedding Batch",
 };
 
 const NEW_CERTIFICATION_SHAPES: ExecutionShape[] = [
   "chat_text_unary",
   "chat_json_object",
   "fusion_native",
+  "embedding_vectors",
+  "rerank_documents",
+  "openrouter_batch_chat",
+  "openrouter_batch_embeddings",
 ];
 
 export const ENTRY_SHAPES: Record<EntryId, ExecutionShape[]> = {
@@ -160,7 +193,33 @@ export const ENTRY_SHAPES: Record<EntryId, ExecutionShape[]> = {
   fusion: ["chat_text", "fusion_native"],
   route_agent: ["chat_text"],
   team_chat: ["chat_text"],
+  rag_query_generate: ["chat_text_unary"],
+  rag_processor_generate: ["chat_json_object"],
+  rag_embedding: ["embedding_vectors"],
+  rag_rerank: ["rerank_documents"],
+  skill_rerank: ["rerank_documents"],
+  openrouter_batch: ["openrouter_batch_chat", "openrouter_batch_embeddings"],
 };
+
+const FALLBACK_OPTIONS: Record<EntryId, LocalFallbackMode[]> = Object.fromEntries(
+  (Object.keys(ENTRY_LABELS) as EntryId[]).map((entry) => [entry, ["none"]]),
+) as Record<EntryId, LocalFallbackMode[]>;
+FALLBACK_OPTIONS.rag_query_generate = ["none", "extractive"];
+FALLBACK_OPTIONS.rag_rerank = ["none", "lexical"];
+FALLBACK_OPTIONS.skill_rerank = ["none", "lexical"];
+
+const FALLBACK_LABELS: Record<LocalFallbackMode, string> = {
+  none: "不使用本地降级",
+  extractive: "本地抽取式答案（非模型）",
+  lexical: "保留词法顺序（非模型）",
+};
+
+function requiredScope(shape: ExecutionShape) {
+  if (shape === "embedding_vectors") return "embedding";
+  if (shape === "rerank_documents") return "rerank";
+  if (shape.startsWith("openrouter_batch_")) return "batch";
+  return "chat";
+}
 
 const REASON_LABELS: Record<string, string> = {
   provider_workload_bindings_required: "尚未配置精确模型 Binding",
@@ -224,10 +283,15 @@ export default function ProviderWorkloadControlSettings({
   const [certificationModel, setCertificationModel] = useState("");
   const [candidateModels, setCandidateModels] = useState("");
   const [judgeModel, setJudgeModel] = useState("");
+  const [rerankAccessMode, setRerankAccessMode] = useState<RerankAccessMode>(
+    "dedicated",
+  );
   const [confirmCertification, setConfirmCertification] = useState(false);
 
   const [entryId, setEntryId] = useState<EntryId>("agent_shadow");
   const [editableBindings, setEditableBindings] = useState<EditableBinding[]>([]);
+  const [localFallbackMode, setLocalFallbackMode] =
+    useState<LocalFallbackMode>("none");
   const [confirmActivation, setConfirmActivation] = useState(false);
   const [confirmNoOpenP0P1, setConfirmNoOpenP0P1] = useState(false);
   const [acknowledgeFailClosed, setAcknowledgeFailClosed] = useState(false);
@@ -295,23 +359,35 @@ export default function ProviderWorkloadControlSettings({
     setConfirmActivation(false);
     setConfirmNoOpenP0P1(false);
     setAcknowledgeFailClosed(false);
+    setLocalFallbackMode(selectedPolicy.local_fallback_mode ?? "none");
     setEditableBindings(
       selectedPolicy.bindings.map((binding) => ({
         execution_shape: binding.execution_shape,
         model_id: binding.model_id,
         connection_id: binding.connection_id,
+        rerank_access_mode: binding.rerank_access_mode ?? null,
       })),
     );
   }, [selectedPolicy]);
 
   const eligibleConnections = useMemo(
-    () =>
-      connections.filter(
-        (connection) =>
-          connection.enabled && (connection.scopes ?? []).includes("chat"),
-      ),
+    () => connections.filter((connection) => connection.enabled),
     [connections],
   );
+  const certificationEligibleConnections = useMemo(
+    () => eligibleConnections.filter((connection) =>
+      (connection.scopes ?? []).includes(requiredScope(certificationShape))
+      && (!certificationShape.startsWith("openrouter_batch_") || connection.kind === "openrouter"),
+    ),
+    [certificationShape, eligibleConnections],
+  );
+
+  useEffect(() => {
+    if (certificationEligibleConnections.some((item) => item.id === connectionId)) {
+      return;
+    }
+    setConnectionId(certificationEligibleConnections[0]?.id ?? "");
+  }, [certificationEligibleConnections, connectionId]);
 
   const runCertification = useCallback(async () => {
     if (!connectionId || !certificationModel.trim()) return;
@@ -338,6 +414,8 @@ export default function ProviderWorkloadControlSettings({
                 : [],
             judge_model_id:
               certificationShape === "fusion_native" ? judgeModel.trim() : null,
+            rerank_access_mode:
+              certificationShape === "rerank_documents" ? rerankAccessMode : null,
           }),
         },
       );
@@ -363,15 +441,24 @@ export default function ProviderWorkloadControlSettings({
     csrfToken,
     judgeModel,
     load,
+    rerankAccessMode,
   ]);
 
   const addBinding = () => {
-    const firstConnection = eligibleConnections[0]?.id ?? "";
     const shape = ENTRY_SHAPES[entryId][0];
+    const firstConnection = eligibleConnections.find((connection) =>
+      (connection.scopes ?? []).includes(requiredScope(shape))
+      && (!shape.startsWith("openrouter_batch_") || connection.kind === "openrouter"),
+    )?.id ?? "";
     if (!firstConnection || !shape) return;
     setEditableBindings((current) => [
       ...current,
-      { execution_shape: shape, model_id: "", connection_id: firstConnection },
+      {
+        execution_shape: shape,
+        model_id: "",
+        connection_id: firstConnection,
+        rerank_access_mode: shape === "rerank_documents" ? "dedicated" : null,
+      },
     ]);
   };
 
@@ -391,9 +478,14 @@ export default function ProviderWorkloadControlSettings({
           },
           body: JSON.stringify({
             expected_revision: selectedPolicy.revision,
+            local_fallback_mode: localFallbackMode,
             bindings: editableBindings.map((binding) => ({
-              ...binding,
+              execution_shape: binding.execution_shape,
               model_id: binding.model_id.trim(),
+              connection_id: binding.connection_id,
+              ...(binding.execution_shape === "rerank_documents"
+                ? { rerank_access_mode: binding.rerank_access_mode ?? "dedicated" }
+                : {}),
             })),
           }),
         },
@@ -408,7 +500,7 @@ export default function ProviderWorkloadControlSettings({
     } finally {
       setBusy(false);
     }
-  }, [csrfToken, editableBindings, entryId, load, selectedPolicy]);
+  }, [csrfToken, editableBindings, entryId, load, localFallbackMode, selectedPolicy]);
 
   const activate = useCallback(async () => {
     if (!selectedPolicy || !confirmNoOpenP0P1 || !acknowledgeFailClosed) return;
@@ -498,10 +590,10 @@ export default function ProviderWorkloadControlSettings({
       <section className="mb-6 overflow-hidden rounded-lg border border-violet-300/15 bg-ink-950/82 shadow-prism">
         <div className="flex flex-wrap items-start justify-between gap-3 border-b border-white/10 bg-violet-300/[0.04] px-5 py-5">
           <div>
-            <p className="text-sm font-semibold text-violet-100">Agent / Workflow 资格</p>
-            <h2 className="mt-2 text-xl font-semibold text-white">R6 非流式、JSON 与原生 Fusion 合同</h2>
+            <p className="text-sm font-semibold text-violet-100">Managed Workload 资格</p>
+            <h2 className="mt-2 text-xl font-semibold text-white">R6 / R7 精确 Operation 合同</h2>
             <p className="mt-2 max-w-[78ch] text-sm leading-6 text-slate-300">
-              仅发送固定合成输入，自动刷新完整目录，并对精确连接、模型和执行形态留存脱敏资格。流式文本与工具调用继续复用 R5 认证。
+              仅发送固定合成输入，自动刷新完整目录，并对精确连接、模型和执行形态留存脱敏资格。Embedding、Rerank 与 Batch 不会因此自动接管数据面。
             </p>
           </div>
           <button className="inline-flex items-center gap-2 rounded-full border border-white/15 px-3 py-2 text-xs font-semibold text-slate-200" onClick={() => void load()} type="button">
@@ -514,7 +606,7 @@ export default function ProviderWorkloadControlSettings({
               Managed 连接
               <select className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-white" value={connectionId} onChange={(event) => setConnectionId(event.target.value)}>
                 <option value="">选择连接</option>
-                {eligibleConnections.map((connection) => <option key={connection.id} value={connection.id}>{connection.name} · {connection.kind}</option>)}
+                {certificationEligibleConnections.map((connection) => <option key={connection.id} value={connection.id}>{connection.name} · {connection.kind}</option>)}
               </select>
             </label>
             <label className="block text-sm text-slate-300">
@@ -531,6 +623,13 @@ export default function ProviderWorkloadControlSettings({
               <label className="block text-sm text-slate-300">有序候选模型（每行一个）<textarea className="mt-2 min-h-24 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 font-mono text-xs text-white" onChange={(event) => setCandidateModels(event.target.value)} value={candidateModels} /></label>
               <label className="block text-sm text-slate-300">裁判模型 ID<input className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-white" onChange={(event) => setJudgeModel(event.target.value)} value={judgeModel} /></label>
             </> : null}
+            {certificationShape === "rerank_documents" ? <label className="block text-sm text-slate-300">
+              Rerank 访问方式
+              <select aria-label="Rerank 访问方式" className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-white" onChange={(event) => setRerankAccessMode(event.target.value as RerankAccessMode)} value={rerankAccessMode}>
+                <option value="dedicated">Dedicated Rerank API</option>
+                <option value="llm_json">LLM JSON Adapter</option>
+              </select>
+            </label> : null}
             <button className="inline-flex items-center gap-2 rounded-full bg-violet-200 px-4 py-2 text-sm font-semibold text-ink-950 disabled:cursor-not-allowed disabled:opacity-40" disabled={!canConfirm || busy} onClick={() => setConfirmCertification(true)} type="button">
               <ShieldCheck className="h-4 w-4" />运行资格认证
             </button>
@@ -542,13 +641,16 @@ export default function ProviderWorkloadControlSettings({
                 <div className="flex flex-wrap items-center justify-between gap-2"><p className="text-sm font-semibold text-white">{item.connection_name} · {SHAPE_LABELS[item.execution_shape]}</p><span className={`rounded-full border px-2.5 py-1 text-xs ${item.status === "passed" ? "border-emerald-300/25 text-emerald-200" : "border-amber-300/25 text-amber-100"}`}>{item.status}</span></div>
                 <p className="mt-2 break-all font-mono text-xs text-slate-300">{item.requested_model ?? "尚未运行"}</p>
                 <p className="mt-1 text-xs text-slate-400">{item.error_code ?? (item.total_tokens != null ? `${item.total_tokens} tokens` : "不保存合成输入或模型正文")}</p>
-              </div>) : <p className="rounded-lg border border-dashed border-white/10 p-4 text-sm text-slate-400">尚无 R6 Workload 资格记录。</p>}
+                {item.rerank_access_mode ? <p className="mt-1 text-xs text-slate-500">访问方式：{item.rerank_access_mode}</p> : null}
+                {item.vector_dimension != null ? <p className="mt-1 text-xs text-slate-500">向量维度：{item.vector_dimension}</p> : null}
+                {item.batch_status ? <p className="mt-1 text-xs text-slate-500">Batch：{item.batch_status} · {item.batch_job_id}</p> : null}
+              </div>) : <p className="rounded-lg border border-dashed border-white/10 p-4 text-sm text-slate-400">尚无 Workload 资格记录。</p>}
             </div>
           </div>
         </div>
         {confirmCertification ? <div aria-modal="true" className="border-t border-amber-300/20 bg-amber-300/[0.05] p-5" role="dialog">
           <p className="text-sm font-semibold text-amber-100">确认一次真实付费资格调用</p>
-          <p className="mt-2 text-sm leading-6 text-slate-300">将发送固定合成文本；不发送用户会话、文件或工具参数。最多一个 Provider POST、零自动重试，可能产生少量费用。</p>
+          <p className="mt-2 text-sm leading-6 text-slate-300">将发送固定合成输入；不发送用户会话、文件或工具参数。{certificationShape.startsWith("openrouter_batch_") ? "最多提交一个异步 Batch；后续只读轮询不会重放提交" : "最多一个 Provider POST、零自动重试"}，可能产生少量费用。</p>
           <div className="mt-3 flex gap-2"><button className="rounded-full bg-amber-200 px-4 py-2 text-sm font-semibold text-ink-950" disabled={busy} onClick={() => void runCertification()} type="button">确认并运行</button><button className="rounded-full border border-white/15 px-4 py-2 text-sm text-slate-200" onClick={() => setConfirmCertification(false)} type="button">取消</button></div>
         </div> : null}
         {error ? <p className="m-5 flex items-center gap-2 rounded-lg border border-rose-300/20 bg-rose-300/10 p-3 text-sm text-rose-100"><CircleAlert className="h-4 w-4" />{error}</p> : null}
@@ -562,7 +664,7 @@ export default function ProviderWorkloadControlSettings({
       <div className="flex flex-wrap items-start justify-between gap-3 border-b border-white/10 bg-sky-300/[0.04] px-5 py-5">
         <div>
           <p className="text-sm font-semibold text-sky-100">Managed Workload 控制策略</p>
-          <h2 className="mt-2 text-xl font-semibold text-white">R6 入口、精确 Binding 与 Receipt</h2>
+          <h2 className="mt-2 text-xl font-semibold text-white">R6 / R7 入口、精确 Binding 与 Receipt</h2>
           <p className="mt-2 max-w-[80ch] text-sm leading-6 text-slate-300">仅已完成对应数据面子轮次、资格有效且通过人工 fail-closed 确认的入口可以激活；其他入口继续保持 Legacy。</p>
         </div>
         <button className="inline-flex items-center gap-2 rounded-full border border-white/15 px-3 py-2 text-xs font-semibold text-slate-200" onClick={() => void load()} type="button"><RefreshCw className="h-3.5 w-3.5" />刷新</button>
@@ -573,15 +675,31 @@ export default function ProviderWorkloadControlSettings({
           {selectedPolicy ? <div className="mt-4 rounded-lg border border-white/10 bg-white/[0.025] p-4">
             <div className="flex items-center justify-between gap-3"><span className="text-sm font-semibold text-white">{statusLabel(selectedPolicy.effective_status)}</span><span className="text-xs text-slate-400">revision {selectedPolicy.revision}</span></div>
             <dl className="mt-3 grid gap-2 text-xs text-slate-300"><div className="flex justify-between"><dt>部署开关</dt><dd>{selectedPolicy.feature_enabled ? "开启" : "关闭"}</dd></div><div className="flex justify-between"><dt>数据面接入</dt><dd>{selectedPolicy.data_plane_integrated ? "已接入" : "当前子轮次未接入"}</dd></div><div className="flex justify-between"><dt>人工批准</dt><dd>{selectedPolicy.approval_valid ? "有效" : "未生效"}</dd></div></dl>
+            <label className="mt-3 block text-xs text-slate-300">本地降级模式<select aria-label="本地降级模式" className="mt-1.5 w-full rounded-lg border border-white/10 bg-ink-950 px-2 py-2 text-sm text-white" onChange={(event) => setLocalFallbackMode(event.target.value as LocalFallbackMode)} value={localFallbackMode}>{FALLBACK_OPTIONS[entryId].map((mode) => <option key={mode} value={mode}>{FALLBACK_LABELS[mode]}</option>)}</select></label>
+            {localFallbackMode !== "none" ? <p className="mt-2 text-xs text-amber-100">本地降级必须在用户结果中标记为非模型结果，不会调用第二个远程 Provider。</p> : null}
             <div className="mt-3 space-y-1">{selectedPolicy.blocking_reason_codes.map((reason) => <p className="text-xs text-amber-100" key={reason}>· {REASON_LABELS[reason] ?? reason}</p>)}</div>
           </div> : null}
         </div>
         <div>
           <div className="flex items-center justify-between"><h3 className="flex items-center gap-2 text-sm font-semibold text-white"><Route className="h-4 w-4" />精确模型 Binding</h3><button className="rounded-full border border-white/15 px-3 py-1.5 text-xs text-slate-200 disabled:opacity-40" disabled={!eligibleConnections.length} onClick={addBinding} type="button">添加 Binding</button></div>
-          <div className="mt-3 space-y-3">{editableBindings.map((binding, index) => <div className="grid gap-2 rounded-lg border border-white/10 bg-white/[0.025] p-3 md:grid-cols-[0.8fr_1.2fr_1fr_auto]" key={`${index}-${binding.execution_shape}`}>
-            <select aria-label={`Binding ${index + 1} 执行形态`} className="rounded-lg border border-white/10 bg-ink-950 px-2 py-2 text-sm text-white" value={binding.execution_shape} onChange={(event) => setEditableBindings((current) => current.map((item, position) => position === index ? { ...item, execution_shape: event.target.value as ExecutionShape } : item))}>{ENTRY_SHAPES[entryId].map((shape) => <option key={shape} value={shape}>{SHAPE_LABELS[shape]}</option>)}</select>
+          <div className="mt-3 space-y-3">{editableBindings.map((binding, index) => <div className="grid gap-2 rounded-lg border border-white/10 bg-white/[0.025] p-3 md:grid-cols-[0.8fr_0.85fr_1.2fr_1fr_auto]" key={`${index}-${binding.execution_shape}`}>
+            <select aria-label={`Binding ${index + 1} 执行形态`} className="rounded-lg border border-white/10 bg-ink-950 px-2 py-2 text-sm text-white" value={binding.execution_shape} onChange={(event) => setEditableBindings((current) => current.map((item, position) => {
+              if (position !== index) return item;
+              const executionShape = event.target.value as ExecutionShape;
+              const nextConnection = eligibleConnections.find((connection) =>
+                (connection.scopes ?? []).includes(requiredScope(executionShape))
+                && (!executionShape.startsWith("openrouter_batch_") || connection.kind === "openrouter")
+              )?.id ?? "";
+              return {
+                ...item,
+                execution_shape: executionShape,
+                connection_id: nextConnection,
+                rerank_access_mode: executionShape === "rerank_documents" ? "dedicated" : null,
+              };
+            }))}>{ENTRY_SHAPES[entryId].map((shape) => <option key={shape} value={shape}>{SHAPE_LABELS[shape]}</option>)}</select>
+            {binding.execution_shape === "rerank_documents" ? <select aria-label={`Binding ${index + 1} Rerank 访问方式`} className="rounded-lg border border-white/10 bg-ink-950 px-2 py-2 text-sm text-white" onChange={(event) => setEditableBindings((current) => current.map((item, position) => position === index ? { ...item, rerank_access_mode: event.target.value as RerankAccessMode } : item))} value={binding.rerank_access_mode ?? "dedicated"}><option value="dedicated">Dedicated API</option><option value="llm_json">LLM JSON Adapter</option></select> : <span className="flex items-center rounded-lg border border-white/5 px-2 text-xs text-slate-500">固定契约</span>}
             <input aria-label={`Binding ${index + 1} 模型 ID`} className="rounded-lg border border-white/10 bg-ink-950 px-2 py-2 font-mono text-xs text-white" onChange={(event) => setEditableBindings((current) => current.map((item, position) => position === index ? { ...item, model_id: event.target.value } : item))} placeholder="精确模型 ID" value={binding.model_id} />
-            <select aria-label={`Binding ${index + 1} 连接`} className="rounded-lg border border-white/10 bg-ink-950 px-2 py-2 text-sm text-white" value={binding.connection_id} onChange={(event) => setEditableBindings((current) => current.map((item, position) => position === index ? { ...item, connection_id: event.target.value } : item))}>{eligibleConnections.map((connection) => <option key={connection.id} value={connection.id}>{connection.name}</option>)}</select>
+            <select aria-label={`Binding ${index + 1} 连接`} className="rounded-lg border border-white/10 bg-ink-950 px-2 py-2 text-sm text-white" value={binding.connection_id} onChange={(event) => setEditableBindings((current) => current.map((item, position) => position === index ? { ...item, connection_id: event.target.value } : item))}>{eligibleConnections.filter((connection) => (connection.scopes ?? []).includes(requiredScope(binding.execution_shape)) && (!binding.execution_shape.startsWith("openrouter_batch_") || connection.kind === "openrouter")).map((connection) => <option key={connection.id} value={connection.id}>{connection.name}</option>)}</select>
             <button className="rounded-full border border-rose-300/20 px-3 py-2 text-xs text-rose-100" onClick={() => setEditableBindings((current) => current.filter((_, position) => position !== index))} type="button">移除</button>
           </div>)}{!editableBindings.length ? <p className="rounded-lg border border-dashed border-white/10 p-4 text-sm text-slate-400">尚未配置；没有 Binding 时不能激活。</p> : null}</div>
           <div className="mt-4 flex flex-wrap gap-2"><button className="rounded-full bg-sky-200 px-4 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={busy || !selectedPolicy || editableBindings.some((item) => !item.model_id.trim() || !item.connection_id)} onClick={() => void savePolicy()} type="button">保存 Binding</button>{selectedPolicy?.configured_status !== "legacy" ? <button className="rounded-full border border-white/15 px-4 py-2 text-sm text-slate-200" disabled={busy} onClick={() => void deactivate()} type="button">显式恢复 Legacy</button> : null}{selectedPolicy && (selectedPolicy.configured_status === "legacy" || !selectedPolicy.approval_valid) ? <button className="rounded-full border border-amber-300/30 px-4 py-2 text-sm text-amber-100 disabled:cursor-not-allowed disabled:opacity-40" disabled={busy || !selectedPolicy.data_plane_integrated || !selectedPolicy.feature_enabled || selectedPolicy.blocking_reason_codes.length > 0} onClick={() => setConfirmActivation(true)} type="button">{selectedPolicy.configured_status === "legacy" ? "激活 Managed 必经" : "重新批准 Managed 必经"}</button> : null}</div>

--- a/server/main.py
+++ b/server/main.py
@@ -1302,9 +1302,17 @@ except ModuleNotFoundError:
     )
 
 try:
-    from server.model_router.api import get_catalog_coordinator
+    from server.model_router.api import (
+        get_catalog_coordinator,
+        start_provider_batch_recovery,
+        stop_provider_batch_recovery,
+    )
 except ModuleNotFoundError:
-    from model_router.api import get_catalog_coordinator
+    from model_router.api import (
+        get_catalog_coordinator,
+        start_provider_batch_recovery,
+        stop_provider_batch_recovery,
+    )
 
 try:
     from server.model_router.expert_team_gateway import (
@@ -26836,6 +26844,7 @@ async def start_mcp_ttl_cleanup() -> None:
     get_xpert_evaluation_executor().start()
     start_skill_creator_evaluation_runtime()
     get_benchmark_job_executor().start()
+    start_provider_batch_recovery()
     if skill_creator_resource_build_service.enabled:
         try:
             await asyncio.to_thread(skill_creator_resource_build_store.recover_interrupted)
@@ -26854,6 +26863,7 @@ async def start_mcp_ttl_cleanup() -> None:
 
 @app.on_event("shutdown")
 async def shutdown_mcp_sessions() -> None:
+    await stop_provider_batch_recovery()
     await close_shared_llm_client()
     await get_pipeline_executor().stop()
     await get_evaluation_executor().stop()

--- a/server/model_router/api.py
+++ b/server/model_router/api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
 import threading
 from typing import Literal
@@ -88,6 +90,8 @@ _service: ModelRouterService | None = None
 _service_lock = threading.Lock()
 _catalog_coordinator: object | None = None
 _native_engine: object | None = None
+_batch_recovery_task: asyncio.Task[int] | None = None
+logger = logging.getLogger(__name__)
 
 
 def configure_model_router(service: ModelRouterService) -> None:
@@ -105,6 +109,45 @@ def get_model_router_service() -> ModelRouterService:
             if _service is None:
                 _service = ModelRouterService()
     return _service
+
+
+def start_provider_batch_recovery() -> None:
+    """Start one background GET-only recovery pass for persisted Batch jobs."""
+
+    global _batch_recovery_task
+    if _batch_recovery_task is not None and not _batch_recovery_task.done():
+        return
+
+    async def recover() -> int:
+        try:
+            return await ProviderWorkloadCertificationService(
+                get_model_router_service()
+            ).resume_pending_batch_certifications()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "Provider Batch certification recovery stopped: %s",
+                type(exc).__name__,
+            )
+            return 0
+
+    _batch_recovery_task = asyncio.create_task(
+        recover(), name="provider-batch-certification-recovery"
+    )
+
+
+async def stop_provider_batch_recovery() -> None:
+    global _batch_recovery_task
+    task = _batch_recovery_task
+    _batch_recovery_task = None
+    if task is None or task.done():
+        return
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
 
 
 def get_catalog_coordinator():
@@ -527,13 +570,20 @@ async def run_workload_certification(
     _principal: ProviderControlPrincipal = Depends(require_provider_admin_csrf),
 ) -> ProviderWorkloadCertificationSummary:
     try:
-        return await ProviderWorkloadCertificationService(
+        result = await ProviderWorkloadCertificationService(
             get_model_router_service()
         ).run(
             connection_id,
             payload,
             idempotency_key=idempotency_key,
         )
+        if (
+            result.status == "uncertain"
+            and payload.execution_shape
+            in {"openrouter_batch_chat", "openrouter_batch_embeddings"}
+        ):
+            start_provider_batch_recovery()
+        return result
     except (
         ProviderEgressError,
         RouterServiceError,

--- a/server/model_router/provider_operations.py
+++ b/server/model_router/provider_operations.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Mapping
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+
+from .egress import AuthorizedProviderTarget, ProviderEgressPolicy
+from .provider_chat import ProviderChatEndpointResolver
+
+
+PROVIDER_OPERATION_CONTRACT_VERSION = "modelmirror-provider-operation-v1"
+OPENROUTER_BATCHES_URL = "https://openrouter.ai/api/beta/batches"
+ProviderOperation = Literal[
+    "embedding_vectors",
+    "rerank_documents",
+    "openrouter_batch_chat",
+    "openrouter_batch_embeddings",
+]
+ProviderRerankAccessMode = Literal["dedicated", "llm_json"]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderOperationEndpoints:
+    base_url: str
+    embeddings_url: str
+    rerank_url: str
+    chat_completions_url: str
+    batches_url: str | None
+
+
+class ProviderOperationEndpointResolver:
+    """Resolve retrieval and OpenRouter Batch endpoints without guessing models."""
+
+    @staticmethod
+    def resolve(*, provider_kind: str, base_url: str) -> ProviderOperationEndpoints:
+        chat = ProviderChatEndpointResolver.resolve(base_url)
+        parsed = urlsplit(chat.base_url)
+        api_path = parsed.path.rstrip("/") or "/v1"
+        base = urlunsplit((parsed.scheme, parsed.netloc, api_path, "", ""))
+        return ProviderOperationEndpoints(
+            base_url=base,
+            embeddings_url=f"{base}/embeddings",
+            rerank_url=f"{base}/rerank",
+            chat_completions_url=chat.chat_completions_url,
+            batches_url=(
+                OPENROUTER_BATCHES_URL
+                if str(provider_kind).casefold() == "openrouter"
+                else None
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderOperationTarget:
+    provider_kind: str
+    connection_id: str
+    endpoints: ProviderOperationEndpoints
+    _api_key: str = field(default="", repr=False, compare=False)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        provider_kind: str,
+        connection_id: str,
+        base_url: str,
+        api_key: str,
+    ) -> "ProviderOperationTarget":
+        clean_connection = str(connection_id or "").strip()
+        if not clean_connection:
+            raise ValueError("provider_operation_connection_id_required")
+        return cls(
+            provider_kind=str(provider_kind or "openai_compatible"),
+            connection_id=clean_connection,
+            endpoints=ProviderOperationEndpointResolver.resolve(
+                provider_kind=provider_kind,
+                base_url=base_url,
+            ),
+            _api_key=str(api_key or ""),
+        )
+
+    def endpoint_for(
+        self,
+        operation: ProviderOperation,
+        *,
+        rerank_access_mode: ProviderRerankAccessMode | None = None,
+        upstream_batch_id: str | None = None,
+    ) -> str:
+        if operation == "embedding_vectors":
+            return self.endpoints.embeddings_url
+        if operation == "rerank_documents":
+            if rerank_access_mode == "llm_json":
+                return self.endpoints.chat_completions_url
+            if rerank_access_mode != "dedicated":
+                raise ValueError("provider_rerank_access_mode_required")
+            return self.endpoints.rerank_url
+        if self.provider_kind.casefold() != "openrouter" or not self.endpoints.batches_url:
+            raise ValueError("provider_batch_requires_openrouter")
+        if upstream_batch_id is None:
+            return self.endpoints.batches_url
+        clean_batch_id = str(upstream_batch_id).strip()
+        if not clean_batch_id or any(
+            character not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:-"
+            for character in clean_batch_id
+        ):
+            raise ValueError("provider_batch_invalid_upstream_id")
+        return f"{self.endpoints.batches_url}/{clean_batch_id}"
+
+    def authorization_headers(
+        self, extra: Mapping[str, str] | None = None
+    ) -> dict[str, str]:
+        headers = dict(extra or {})
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+
+class ProviderOperationTransport:
+    """Build one pinned request; callers record dispatch before sending it."""
+
+    def __init__(self, egress_policy: ProviderEgressPolicy) -> None:
+        self.egress_policy = egress_policy
+
+    @staticmethod
+    def client_kwargs() -> dict[str, object]:
+        return {
+            "timeout": httpx.Timeout(connect=5, read=45, write=45, pool=5),
+            "follow_redirects": False,
+            "trust_env": False,
+            "transport": httpx.AsyncHTTPTransport(retries=0),
+        }
+
+    async def authorize(
+        self,
+        target: ProviderOperationTarget,
+        operation: ProviderOperation,
+        *,
+        rerank_access_mode: ProviderRerankAccessMode | None = None,
+        upstream_batch_id: str | None = None,
+    ) -> AuthorizedProviderTarget:
+        return await self.egress_policy.authorize(
+            target.endpoint_for(
+                operation,
+                rerank_access_mode=rerank_access_mode,
+                upstream_batch_id=upstream_batch_id,
+            )
+        )
+
+    @staticmethod
+    def build_authorized_request(
+        client: httpx.AsyncClient,
+        target: ProviderOperationTarget,
+        authorized: AuthorizedProviderTarget,
+        *,
+        method: Literal["GET", "POST"],
+        payload: Mapping[str, object] | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> httpx.Request:
+        return client.build_request(
+            method,
+            authorized.pinned_urls[0],
+            headers=authorized.request_headers(target.authorization_headers(headers)),
+            extensions=authorized.extensions,
+            json=dict(payload) if payload is not None else None,
+        )
+
+    @staticmethod
+    async def send_authorized(
+        client: httpx.AsyncClient, request: httpx.Request
+    ) -> httpx.Response:
+        return await client.send(request, stream=True, follow_redirects=False)

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -33,7 +33,7 @@ from .schemas import (
 )
 
 
-SCHEMA_VERSION = 16
+SCHEMA_VERSION = 17
 DEFAULT_TENANT_ID = "local"
 CANONICAL_MASTER_KEY_ENV = "MODEL_MIRROR_CREDENTIAL_MASTER_KEY"
 LEGACY_MASTER_KEY_ENV = "MODEL_ROUTER_CREDENTIAL_MASTER_KEY"
@@ -559,6 +559,7 @@ class SQLiteRouterRepository:
             prompt_tokens INTEGER,
             completion_tokens INTEGER,
             total_tokens INTEGER,
+            vector_dimension INTEGER,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             completed_at TEXT,
@@ -571,6 +572,7 @@ class SQLiteRouterRepository:
             status TEXT NOT NULL DEFAULT 'legacy',
             revision INTEGER NOT NULL DEFAULT 0,
             policy_fingerprint TEXT NOT NULL,
+            local_fallback_mode TEXT NOT NULL DEFAULT 'none',
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             PRIMARY KEY (tenant_id, entry_id)
@@ -585,6 +587,7 @@ class SQLiteRouterRepository:
             certification_source TEXT NOT NULL,
             connection_fingerprint TEXT NOT NULL,
             qualification_fingerprint TEXT NOT NULL,
+            rerank_access_mode TEXT,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             PRIMARY KEY (tenant_id, entry_id, execution_shape, model_id)
@@ -641,6 +644,34 @@ class SQLiteRouterRepository:
             approved_at TEXT NOT NULL,
             revoked_at TEXT,
             PRIMARY KEY (tenant_id, entry_id, policy_fingerprint)
+        );
+        CREATE TABLE IF NOT EXISTS provider_batch_jobs (
+            id TEXT NOT NULL,
+            tenant_id TEXT NOT NULL,
+            connection_id TEXT NOT NULL,
+            connection_fingerprint TEXT NOT NULL,
+            endpoint TEXT NOT NULL,
+            model_id TEXT NOT NULL,
+            certification_id TEXT,
+            workload_run_id TEXT,
+            idempotency_key_hash TEXT NOT NULL,
+            request_fingerprint TEXT NOT NULL,
+            upstream_batch_id TEXT,
+            status TEXT NOT NULL,
+            request_count INTEGER NOT NULL DEFAULT 0,
+            completed_count INTEGER NOT NULL DEFAULT 0,
+            failed_count INTEGER NOT NULL DEFAULT 0,
+            usage_json TEXT NOT NULL DEFAULT '{}',
+            cost_value TEXT,
+            cost_currency TEXT,
+            billing_authoritative INTEGER NOT NULL DEFAULT 0,
+            purpose TEXT NOT NULL,
+            error_code TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            completed_at TEXT,
+            PRIMARY KEY (tenant_id, id),
+            UNIQUE (tenant_id, idempotency_key_hash)
         );
         CREATE INDEX IF NOT EXISTS idx_router_connections_tenant_enabled
             ON router_connections (tenant_id, enabled);
@@ -731,6 +762,8 @@ class SQLiteRouterRepository:
             ON provider_workload_runs (tenant_id, created_at DESC);
         CREATE INDEX IF NOT EXISTS idx_provider_workload_calls_run
             ON provider_workload_calls (tenant_id, run_id, call_sequence);
+        CREATE INDEX IF NOT EXISTS idx_provider_batch_jobs_status
+            ON provider_batch_jobs (tenant_id, status, updated_at DESC);
         """
         with self._lock, self._connect() as connection:
             previous_schema_version = int(
@@ -748,6 +781,39 @@ class SQLiteRouterRepository:
                     "ALTER TABLE router_connections "
                     "ADD COLUMN scopes_json "
                     """TEXT NOT NULL DEFAULT '["chat"]'"""
+                )
+            workload_policy_columns = {
+                row["name"]
+                for row in connection.execute(
+                    "PRAGMA table_info(provider_workload_policies)"
+                ).fetchall()
+            }
+            if "local_fallback_mode" not in workload_policy_columns:
+                connection.execute(
+                    "ALTER TABLE provider_workload_policies "
+                    "ADD COLUMN local_fallback_mode TEXT NOT NULL DEFAULT 'none'"
+                )
+            workload_binding_columns = {
+                row["name"]
+                for row in connection.execute(
+                    "PRAGMA table_info(provider_workload_bindings)"
+                ).fetchall()
+            }
+            if "rerank_access_mode" not in workload_binding_columns:
+                connection.execute(
+                    "ALTER TABLE provider_workload_bindings "
+                    "ADD COLUMN rerank_access_mode TEXT"
+                )
+            workload_certification_columns = {
+                row["name"]
+                for row in connection.execute(
+                    "PRAGMA table_info(provider_workload_certifications)"
+                ).fetchall()
+            }
+            if "vector_dimension" not in workload_certification_columns:
+                connection.execute(
+                    "ALTER TABLE provider_workload_certifications "
+                    "ADD COLUMN vector_dimension INTEGER"
                 )
             if previous_schema_version < 8:
                 connection.execute(
@@ -1002,6 +1068,15 @@ class SQLiteRouterRepository:
                     reason_codes_json = '["server_restarted"]',
                     updated_at = ?, completed_at = ?
                 WHERE status = 'running'
+                """,
+                (now, now),
+            )
+            connection.execute(
+                """
+                UPDATE provider_batch_jobs
+                SET status = 'uncertain', error_code = 'server_restarted',
+                    updated_at = ?, completed_at = ?
+                WHERE status = 'submitting' AND upstream_batch_id IS NULL
                 """,
                 (now, now),
             )
@@ -1590,6 +1665,75 @@ class SQLiteRouterRepository:
                 tuple(values),
             ).fetchall()
         return [dict(row) for row in rows]
+
+    def upsert_certified_catalog_offering(
+        self,
+        tenant_id: str,
+        *,
+        connection_id: str,
+        model_id: str,
+        operation: str,
+        access_mode: str,
+    ) -> dict[str, object]:
+        clean_tenant = self._tenant_id(tenant_id)
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            inventory = connection.execute(
+                """
+                SELECT last_refresh_id FROM provider_catalog_models
+                WHERE tenant_id = ? AND connection_id = ? AND model_id = ?
+                    AND status = 'active'
+                """,
+                (clean_tenant, connection_id, model_id),
+            ).fetchone()
+            if inventory is None:
+                raise RouterRepositoryError(
+                    "provider_workload_model_inventory_missing"
+                )
+            connection.execute(
+                """
+                INSERT INTO provider_catalog_offerings (
+                    tenant_id, connection_id, model_id, operation,
+                    access_mode, capability_source, pricing_json,
+                    pricing_source, pricing_status, pricing_observed_at,
+                    billing_authoritative, stale, observed_at,
+                    last_refresh_id
+                ) VALUES (?, ?, ?, ?, ?, 'certification', NULL, NULL,
+                    'unknown', NULL, 0, 0, ?, ?)
+                ON CONFLICT(
+                    tenant_id, connection_id, model_id, operation, access_mode
+                ) DO UPDATE SET
+                    capability_source = 'certification',
+                    billing_authoritative = 0,
+                    stale = 0,
+                    observed_at = excluded.observed_at,
+                    last_refresh_id = excluded.last_refresh_id
+                """,
+                (
+                    clean_tenant,
+                    connection_id,
+                    model_id,
+                    operation,
+                    access_mode,
+                    now,
+                    str(inventory["last_refresh_id"]),
+                ),
+            )
+            row = connection.execute(
+                """
+                SELECT * FROM provider_catalog_offerings
+                WHERE tenant_id = ? AND connection_id = ? AND model_id = ?
+                    AND operation = ? AND access_mode = ?
+                """,
+                (
+                    clean_tenant,
+                    connection_id,
+                    model_id,
+                    operation,
+                    access_mode,
+                ),
+            ).fetchone()
+        return dict(row)
 
     def claim_chat_certification(
         self,
@@ -2710,6 +2854,274 @@ class SQLiteRouterRepository:
             "attempts": attempt_count,
         }
 
+    def claim_provider_batch_job(
+        self,
+        tenant_id: str,
+        *,
+        job_id: str,
+        connection_id: str,
+        connection_fingerprint: str,
+        endpoint: str,
+        model_id: str,
+        idempotency_key_hash: str,
+        request_fingerprint: str,
+        purpose: str,
+        request_count: int,
+        certification_id: str | None = None,
+        workload_run_id: str | None = None,
+    ) -> tuple[dict[str, object], bool]:
+        clean_tenant = self._tenant_id(tenant_id)
+        self.get_connection(clean_tenant, connection_id)
+        if purpose not in {"certification", "runtime"}:
+            raise RouterRepositoryError("provider_batch_invalid_purpose")
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            existing = connection.execute(
+                """
+                SELECT * FROM provider_batch_jobs
+                WHERE tenant_id = ? AND idempotency_key_hash = ?
+                """,
+                (clean_tenant, idempotency_key_hash),
+            ).fetchone()
+            if existing is not None:
+                if str(existing["request_fingerprint"]) != request_fingerprint:
+                    raise RouterRepositoryError(
+                        "provider_batch_idempotency_conflict"
+                    )
+                return dict(existing), False
+            connection.execute(
+                """
+                INSERT INTO provider_batch_jobs (
+                    id, tenant_id, connection_id, connection_fingerprint,
+                    endpoint, model_id, certification_id, workload_run_id,
+                    idempotency_key_hash, request_fingerprint, status,
+                    request_count, purpose, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'submitting', ?, ?, ?, ?)
+                """,
+                (
+                    job_id,
+                    clean_tenant,
+                    connection_id,
+                    connection_fingerprint,
+                    endpoint,
+                    model_id,
+                    certification_id,
+                    workload_run_id,
+                    idempotency_key_hash,
+                    request_fingerprint,
+                    max(0, int(request_count)),
+                    purpose,
+                    now,
+                    now,
+                ),
+            )
+            row = connection.execute(
+                "SELECT * FROM provider_batch_jobs WHERE tenant_id = ? AND id = ?",
+                (clean_tenant, job_id),
+            ).fetchone()
+        return dict(row), True
+
+    def mark_provider_batch_submitted(
+        self,
+        tenant_id: str,
+        job_id: str,
+        *,
+        upstream_batch_id: str,
+        status: str,
+    ) -> dict[str, object]:
+        if status not in {"validating", "in_progress", "finalizing"}:
+            raise RouterRepositoryError("provider_batch_invalid_submitted_status")
+        clean_tenant = self._tenant_id(tenant_id)
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE provider_batch_jobs
+                SET upstream_batch_id = ?, status = ?, error_code = NULL,
+                    updated_at = ?
+                WHERE tenant_id = ? AND id = ? AND status = 'submitting'
+                    AND upstream_batch_id IS NULL
+                """,
+                (upstream_batch_id, status, now, clean_tenant, job_id),
+            )
+            if cursor.rowcount != 1:
+                raise RouterRepositoryError(
+                    "provider_batch_submission_already_recorded"
+                )
+            row = connection.execute(
+                "SELECT * FROM provider_batch_jobs WHERE tenant_id = ? AND id = ?",
+                (clean_tenant, job_id),
+            ).fetchone()
+        return dict(row)
+
+    def mark_provider_batch_uncertain(
+        self,
+        tenant_id: str,
+        job_id: str,
+        *,
+        error_code: str,
+    ) -> dict[str, object]:
+        clean_tenant = self._tenant_id(tenant_id)
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE provider_batch_jobs
+                SET status = 'uncertain', error_code = ?, updated_at = ?,
+                    completed_at = ?
+                WHERE tenant_id = ? AND id = ? AND status = 'submitting'
+                    AND upstream_batch_id IS NULL
+                """,
+                (error_code, now, now, clean_tenant, job_id),
+            )
+            if cursor.rowcount != 1:
+                raise RouterRepositoryError("provider_batch_job_not_submitting")
+            row = connection.execute(
+                "SELECT * FROM provider_batch_jobs WHERE tenant_id = ? AND id = ?",
+                (clean_tenant, job_id),
+            ).fetchone()
+        return dict(row)
+
+    def fail_provider_batch_submission(
+        self,
+        tenant_id: str,
+        job_id: str,
+        *,
+        error_code: str,
+    ) -> dict[str, object]:
+        clean_tenant = self._tenant_id(tenant_id)
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE provider_batch_jobs
+                SET status = 'failed', error_code = ?, updated_at = ?,
+                    completed_at = ?
+                WHERE tenant_id = ? AND id = ? AND status = 'submitting'
+                    AND upstream_batch_id IS NULL
+                """,
+                (error_code, now, now, clean_tenant, job_id),
+            )
+            if cursor.rowcount != 1:
+                raise RouterRepositoryError("provider_batch_job_not_submitting")
+            row = connection.execute(
+                "SELECT * FROM provider_batch_jobs WHERE tenant_id = ? AND id = ?",
+                (clean_tenant, job_id),
+            ).fetchone()
+        return dict(row)
+
+    def update_provider_batch_job(
+        self,
+        tenant_id: str,
+        job_id: str,
+        *,
+        status: str,
+        completed_count: int = 0,
+        failed_count: int = 0,
+        usage: dict[str, object] | None = None,
+        cost_value: str | None = None,
+        cost_currency: str | None = None,
+        error_code: str | None = None,
+    ) -> dict[str, object]:
+        allowed = {
+            "validating",
+            "in_progress",
+            "finalizing",
+            "completed",
+            "failed",
+            "cancelled",
+            "expired",
+            "uncertain",
+        }
+        if status not in allowed:
+            raise RouterRepositoryError("provider_batch_invalid_status")
+        clean_tenant = self._tenant_id(tenant_id)
+        now = utc_now()
+        terminal = status in {"completed", "failed", "cancelled", "expired", "uncertain"}
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE provider_batch_jobs
+                SET status = ?, completed_count = ?, failed_count = ?,
+                    usage_json = ?, cost_value = ?, cost_currency = ?,
+                    billing_authoritative = 0, error_code = ?, updated_at = ?,
+                    completed_at = ?
+                WHERE tenant_id = ? AND id = ? AND upstream_batch_id IS NOT NULL
+                    AND status NOT IN ('completed', 'failed', 'cancelled', 'expired', 'uncertain')
+                """,
+                (
+                    status,
+                    max(0, int(completed_count)),
+                    max(0, int(failed_count)),
+                    json.dumps(usage or {}, sort_keys=True, separators=(",", ":")),
+                    cost_value,
+                    cost_currency,
+                    error_code,
+                    now,
+                    now if terminal else None,
+                    clean_tenant,
+                    job_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise RouterRepositoryError("provider_batch_job_not_pollable")
+            row = connection.execute(
+                "SELECT * FROM provider_batch_jobs WHERE tenant_id = ? AND id = ?",
+                (clean_tenant, job_id),
+            ).fetchone()
+        return dict(row)
+
+    def get_provider_batch_job(
+        self, tenant_id: str, job_id: str
+    ) -> dict[str, object] | None:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM provider_batch_jobs WHERE tenant_id = ? AND id = ?",
+                (clean_tenant, job_id),
+            ).fetchone()
+        return dict(row) if row is not None else None
+
+    def get_provider_batch_job_by_certification(
+        self, tenant_id: str, certification_id: str
+    ) -> dict[str, object] | None:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM provider_batch_jobs
+                WHERE tenant_id = ? AND certification_id = ?
+                ORDER BY created_at DESC, id DESC LIMIT 1
+                """,
+                (clean_tenant, certification_id),
+            ).fetchone()
+        return dict(row) if row is not None else None
+
+    def list_provider_batch_jobs(
+        self,
+        tenant_id: str,
+        *,
+        connection_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, object]]:
+        clean_tenant = self._tenant_id(tenant_id)
+        clause = ""
+        values: list[object] = [clean_tenant]
+        if connection_id is not None:
+            clause = " AND connection_id = ?"
+            values.append(connection_id)
+        values.append(max(1, min(int(limit), 500)))
+        with self._lock, self._connect() as connection:
+            rows = connection.execute(
+                f"""
+                SELECT * FROM provider_batch_jobs
+                WHERE tenant_id = ?{clause}
+                ORDER BY created_at DESC, id DESC LIMIT ?
+                """,
+                tuple(values),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
     def claim_workload_certification(
         self,
         tenant_id: str,
@@ -2803,6 +3215,53 @@ class SQLiteRouterRepository:
             ).fetchone()
         return dict(row) if row is not None else None
 
+    def get_workload_certification(
+        self, tenant_id: str, certification_id: str
+    ) -> dict[str, object] | None:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM provider_workload_certifications
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (clean_tenant, certification_id),
+            ).fetchone()
+        return dict(row) if row is not None else None
+
+    def resume_workload_certification(
+        self, tenant_id: str, certification_id: str
+    ) -> dict[str, object]:
+        clean_tenant = self._tenant_id(tenant_id)
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            try:
+                cursor = connection.execute(
+                    """
+                    UPDATE provider_workload_certifications
+                    SET status = 'running', error_code = NULL,
+                        updated_at = ?, completed_at = NULL
+                    WHERE tenant_id = ? AND id = ? AND status = 'uncertain'
+                    """,
+                    (now, clean_tenant, certification_id),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise RouterRepositoryError(
+                    "provider_workload_certification_already_running"
+                ) from exc
+            if cursor.rowcount != 1:
+                raise RouterRepositoryError(
+                    "provider_workload_certification_not_resumable"
+                )
+            row = connection.execute(
+                """
+                SELECT * FROM provider_workload_certifications
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (clean_tenant, certification_id),
+            ).fetchone()
+        return dict(row)
+
     def complete_workload_certification(
         self,
         tenant_id: str,
@@ -2818,6 +3277,7 @@ class SQLiteRouterRepository:
         prompt_tokens: int | None = None,
         completion_tokens: int | None = None,
         total_tokens: int | None = None,
+        vector_dimension: int | None = None,
     ) -> dict[str, object]:
         if status not in {"passed", "failed", "uncertain"}:
             raise RouterRepositoryError(
@@ -2832,7 +3292,7 @@ class SQLiteRouterRepository:
                 SET status = ?, checks_json = ?, warnings_json = ?,
                     error_code = ?, actual_model = ?, ttft_ms = ?, e2e_ms = ?,
                     prompt_tokens = ?, completion_tokens = ?, total_tokens = ?,
-                    updated_at = ?, completed_at = ?
+                    vector_dimension = ?, updated_at = ?, completed_at = ?
                 WHERE tenant_id = ? AND id = ? AND status = 'running'
                 """,
                 (
@@ -2846,6 +3306,7 @@ class SQLiteRouterRepository:
                     prompt_tokens,
                     completion_tokens,
                     total_tokens,
+                    vector_dimension,
                     now,
                     now,
                     clean_tenant,
@@ -2907,6 +3368,7 @@ class SQLiteRouterRepository:
         execution_shape: str,
         *,
         profile_fingerprint: str | None = None,
+        rerank_access_mode: str | None = None,
     ) -> dict[str, object] | None:
         clean_tenant = self._tenant_id(tenant_id)
         profile_clause = ""
@@ -2920,18 +3382,28 @@ class SQLiteRouterRepository:
             profile_clause = " AND profile_fingerprint = ?"
             values.append(profile_fingerprint)
         with self._lock, self._connect() as connection:
-            row = connection.execute(
+            rows = connection.execute(
                 f"""
                 SELECT * FROM provider_workload_certifications
                 WHERE tenant_id = ? AND connection_id = ?
                     AND requested_model = ? AND execution_shape = ?
                     {profile_clause}
                 ORDER BY created_at DESC, id DESC
-                LIMIT 1
                 """,
                 tuple(values),
-            ).fetchone()
-        return dict(row) if row is not None else None
+            ).fetchall()
+        for row in rows:
+            if rerank_access_mode is not None:
+                try:
+                    profile = json.loads(str(row["profile_json"] or "{}"))
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(profile, dict) or str(
+                    profile.get("rerank_access_mode") or ""
+                ) != rerank_access_mode:
+                    continue
+            return dict(row)
+        return None
 
     def get_workload_policy_bundle(
         self, tenant_id: str, *, entry_id: str | None = None
@@ -2980,6 +3452,7 @@ class SQLiteRouterRepository:
         entry_id: str,
         expected_revision: int,
         policy_fingerprint: str,
+        local_fallback_mode: str,
         bindings: list[dict[str, object]],
     ) -> dict[str, object]:
         clean_tenant = self._tenant_id(tenant_id)
@@ -3013,12 +3486,13 @@ class SQLiteRouterRepository:
                 """
                 INSERT INTO provider_workload_policies (
                     tenant_id, entry_id, status, revision,
-                    policy_fingerprint, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    policy_fingerprint, local_fallback_mode, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(tenant_id, entry_id) DO UPDATE SET
                     status = excluded.status,
                     revision = excluded.revision,
                     policy_fingerprint = excluded.policy_fingerprint,
+                    local_fallback_mode = excluded.local_fallback_mode,
                     updated_at = excluded.updated_at
                 """,
                 (
@@ -3027,6 +3501,7 @@ class SQLiteRouterRepository:
                     status,
                     revision,
                     policy_fingerprint,
+                    local_fallback_mode,
                     created_at,
                     now,
                 ),
@@ -3043,8 +3518,8 @@ class SQLiteRouterRepository:
                         tenant_id, entry_id, execution_shape, model_id,
                         connection_id, certification_id, certification_source,
                         connection_fingerprint, qualification_fingerprint,
-                        created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        rerank_access_mode, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         clean_tenant,
@@ -3056,6 +3531,7 @@ class SQLiteRouterRepository:
                         binding["certification_source"],
                         binding["connection_fingerprint"],
                         binding["qualification_fingerprint"],
+                        binding.get("rerank_access_mode"),
                         now,
                         now,
                     ),
@@ -5374,7 +5850,14 @@ class SQLiteRouterRepository:
             [
                 scope
                 for scope in decoded_scopes
-                if scope in {"chat", "audio", "realtime"}
+                if scope in {
+                    "chat",
+                    "audio",
+                    "realtime",
+                    "embedding",
+                    "rerank",
+                    "batch",
+                }
             ],
             kind=kind,
         )

--- a/server/model_router/schemas.py
+++ b/server/model_router/schemas.py
@@ -15,7 +15,14 @@ ConnectionKind = Literal[
     "openai_compatible",
     "openai",
 ]
-ConnectionScope = Literal["chat", "audio", "realtime"]
+ConnectionScope = Literal[
+    "chat",
+    "audio",
+    "realtime",
+    "embedding",
+    "rerank",
+    "batch",
+]
 ConnectionHealth = Literal["untested", "online", "offline", "disabled"]
 ProviderChatCertificationStatus = Literal[
     "not_run",
@@ -57,6 +64,12 @@ ProviderWorkloadEntryId = Literal[
     "fusion",
     "route_agent",
     "team_chat",
+    "rag_query_generate",
+    "rag_processor_generate",
+    "rag_embedding",
+    "rag_rerank",
+    "skill_rerank",
+    "openrouter_batch",
 ]
 ProviderWorkloadExecutionShape = Literal[
     "chat_text",
@@ -64,7 +77,13 @@ ProviderWorkloadExecutionShape = Literal[
     "chat_text_unary",
     "chat_json_object",
     "fusion_native",
+    "embedding_vectors",
+    "rerank_documents",
+    "openrouter_batch_chat",
+    "openrouter_batch_embeddings",
 ]
+ProviderWorkloadLocalFallbackMode = Literal["none", "extractive", "lexical"]
+ProviderWorkloadRerankAccessMode = Literal["dedicated", "llm_json"]
 ProviderWorkloadPolicyStatus = Literal[
     "legacy",
     "managed_required",
@@ -120,6 +139,9 @@ CONNECTION_SCOPE_ORDER: tuple[ConnectionScope, ...] = (
     "chat",
     "audio",
     "realtime",
+    "embedding",
+    "rerank",
+    "batch",
 )
 
 
@@ -161,7 +183,7 @@ class RouterConnectionCreate(BaseModel):
     kind: ConnectionKind
     base_url: str = Field(min_length=1, max_length=2048)
     api_key: SecretStr
-    scopes: list[ConnectionScope] = Field(default_factory=list, max_length=3)
+    scopes: list[ConnectionScope] = Field(default_factory=list, max_length=6)
     enabled: bool = True
 
     @field_validator("name")
@@ -198,7 +220,7 @@ class RouterConnectionUpdate(BaseModel):
     api_key: SecretStr | None = None
     scopes: list[ConnectionScope] | None = Field(
         default=None,
-        max_length=3,
+        max_length=6,
     )
     enabled: bool | None = None
 
@@ -718,6 +740,7 @@ class ProviderWorkloadCertificationRequest(BaseModel):
     acknowledge_billed_call: bool
     candidate_model_ids: list[str] = Field(default_factory=list, max_length=5)
     judge_model_id: str | None = Field(default=None, max_length=512)
+    rerank_access_mode: ProviderWorkloadRerankAccessMode | None = None
 
     @field_validator("model_id")
     @classmethod
@@ -753,6 +776,11 @@ class ProviderWorkloadCertificationRequest(BaseModel):
                 )
         elif self.candidate_model_ids or self.judge_model_id is not None:
             raise ValueError("fusion profile is only valid for fusion_native")
+        if self.execution_shape == "rerank_documents":
+            if self.rerank_access_mode is None:
+                raise ValueError("rerank_documents requires rerank_access_mode")
+        elif self.rerank_access_mode is not None:
+            raise ValueError("rerank_access_mode is only valid for rerank_documents")
         if self.execution_shape in {"chat_text", "chat_tools"}:
             raise ValueError("chat_text and chat_tools reuse Provider Chat certification")
         return self
@@ -767,6 +795,9 @@ class ProviderWorkloadCertificationChecks(BaseModel):
     json_object_verified: bool = False
     fusion_profile_verified: bool = False
     actual_model_verified: bool = False
+    embedding_vectors_verified: bool = False
+    rerank_results_verified: bool = False
+    batch_terminal_verified: bool = False
 
 
 class ProviderWorkloadCertificationSummary(BaseModel):
@@ -788,6 +819,10 @@ class ProviderWorkloadCertificationSummary(BaseModel):
     candidate_model_ids: list[str] = Field(default_factory=list)
     judge_model_id: str | None = None
     profile_fingerprint: str | None = None
+    rerank_access_mode: ProviderWorkloadRerankAccessMode | None = None
+    vector_dimension: int | None = None
+    batch_job_id: str | None = None
+    batch_status: str | None = None
     ttft_ms: float | None = None
     e2e_ms: float | None = None
     prompt_tokens: int | None = None
@@ -809,15 +844,28 @@ class ProviderWorkloadBindingUpdate(BaseModel):
     execution_shape: ProviderWorkloadExecutionShape
     model_id: str = Field(min_length=1, max_length=512)
     connection_id: str = Field(min_length=1, max_length=128)
+    rerank_access_mode: ProviderWorkloadRerankAccessMode | None = None
 
     @field_validator("model_id", "connection_id")
     @classmethod
     def validate_required_text(cls, value: str, info) -> str:
         return _required_text(value, field_name=info.field_name, limit=512)
 
+    @model_validator(mode="after")
+    def validate_rerank_access_mode(self) -> "ProviderWorkloadBindingUpdate":
+        if self.execution_shape == "rerank_documents":
+            if self.rerank_access_mode is None:
+                raise ValueError("rerank_documents binding requires rerank_access_mode")
+        elif self.rerank_access_mode is not None:
+            raise ValueError(
+                "rerank_access_mode is only valid for rerank_documents binding"
+            )
+        return self
+
 
 class ProviderWorkloadPolicyUpdate(BaseModel):
     expected_revision: int = Field(ge=0)
+    local_fallback_mode: ProviderWorkloadLocalFallbackMode = "none"
     bindings: list[ProviderWorkloadBindingUpdate] = Field(
         default_factory=list,
         max_length=500,
@@ -844,6 +892,7 @@ class ProviderWorkloadBindingSummary(BaseModel):
     certification_source: Literal["provider_chat", "provider_workload"]
     connection_fingerprint: str
     qualification_fingerprint: str
+    rerank_access_mode: ProviderWorkloadRerankAccessMode | None = None
     valid: bool
     reason_code: str
 
@@ -857,6 +906,7 @@ class ProviderWorkloadPolicyResponse(BaseModel):
     effective_status: ProviderWorkloadPolicyStatus
     revision: int
     policy_fingerprint: str
+    local_fallback_mode: ProviderWorkloadLocalFallbackMode = "none"
     bindings: list[ProviderWorkloadBindingSummary] = Field(default_factory=list)
     approval_valid: bool = False
     blocking_reason_codes: list[str] = Field(default_factory=list)

--- a/server/model_router/workload_control.py
+++ b/server/model_router/workload_control.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import math
 import os
 import time
 import uuid
@@ -15,6 +16,10 @@ from .chat_control import ProviderChatControlService
 from .egress import AuthorizedProviderTarget, ProviderEgressError
 from .provider_catalog import ProviderCatalogService
 from .provider_chat import ProviderChatTarget, ProviderChatTransport
+from .provider_operations import (
+    ProviderOperationTarget,
+    ProviderOperationTransport,
+)
 from .repository import RouterCredentialUnavailable, RouterRepositoryError
 from .schemas import (
     ProviderWorkloadActivationRequest,
@@ -45,6 +50,16 @@ PROVIDER_WORKLOAD_CERTIFICATION_ENABLED_ENV = (
 )
 SYNTHETIC_UNARY_PROMPT = "Reply with OK."
 SYNTHETIC_JSON_PROMPT = 'Return exactly one JSON object: {"ok":true}'
+SYNTHETIC_EMBEDDING_INPUTS = (
+    "ModelMirror embedding certification one.",
+    "ModelMirror embedding certification two.",
+)
+SYNTHETIC_RERANK_QUERY = "ModelMirror provider routing certification"
+SYNTHETIC_RERANK_DOCUMENTS = (
+    "ModelMirror routes requests through an explicit provider control plane.",
+    "This document is unrelated to provider routing.",
+    "Managed bindings select one exact provider model.",
+)
 MAX_WORKLOAD_UNARY_RESPONSE_BYTES = 1024 * 1024
 MAX_WORKLOAD_SSE_EVENT_BYTES = 256 * 1024
 MAX_WORKLOAD_STREAM_BYTES = 4 * 1024 * 1024
@@ -69,6 +84,12 @@ ENTRY_FEATURE_FLAGS: dict[ProviderWorkloadEntryId, tuple[str, ...]] = {
     "fusion": ("MODEL_CONTROL_FUSION_ENABLED",),
     "route_agent": ("MODEL_CONTROL_ROUTE_AGENT_ENABLED",),
     "team_chat": ("MODEL_CONTROL_TEAM_CHAT_ENABLED",),
+    "rag_query_generate": ("MODEL_CONTROL_RAG_QUERY_ENABLED",),
+    "rag_processor_generate": ("MODEL_CONTROL_RAG_PROCESSOR_ENABLED",),
+    "rag_embedding": ("MODEL_CONTROL_RAG_EMBEDDING_ENABLED",),
+    "rag_rerank": ("MODEL_CONTROL_RAG_RERANK_ENABLED",),
+    "skill_rerank": ("MODEL_CONTROL_SKILL_RERANK_ENABLED",),
+    "openrouter_batch": ("MODEL_CONTROL_OPENROUTER_BATCH_ENABLED",),
 }
 
 ENTRY_ALLOWED_SHAPES: dict[
@@ -98,7 +119,26 @@ ENTRY_ALLOWED_SHAPES: dict[
     "fusion": frozenset({"chat_text", "fusion_native"}),
     "route_agent": frozenset({"chat_text"}),
     "team_chat": frozenset({"chat_text"}),
+    "rag_query_generate": frozenset({"chat_text_unary"}),
+    "rag_processor_generate": frozenset({"chat_json_object"}),
+    "rag_embedding": frozenset({"embedding_vectors"}),
+    "rag_rerank": frozenset({"rerank_documents"}),
+    "skill_rerank": frozenset({"rerank_documents"}),
+    "openrouter_batch": frozenset(
+        {"openrouter_batch_chat", "openrouter_batch_embeddings"}
+    ),
 }
+
+ENTRY_ALLOWED_LOCAL_FALLBACKS: dict[ProviderWorkloadEntryId, frozenset[str]] = {
+    entry_id: frozenset({"none"}) for entry_id in ENTRY_FEATURE_FLAGS
+}
+ENTRY_ALLOWED_LOCAL_FALLBACKS.update(
+    {
+        "rag_query_generate": frozenset({"none", "extractive"}),
+        "rag_rerank": frozenset({"none", "lexical"}),
+        "skill_rerank": frozenset({"none", "lexical"}),
+    }
+)
 
 # R6A deliberately provides only the control-plane foundation. Each later data-plane
 # PR adds its entry here after its dedicated tests and real smoke are complete.
@@ -144,6 +184,12 @@ class _WorkloadCertificationFailure(Exception):
         self.code = code
 
 
+class _WorkloadCertificationUncertain(Exception):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
 @dataclass(slots=True)
 class _CertificationEvidence:
     checks: dict[str, bool]
@@ -153,6 +199,7 @@ class _CertificationEvidence:
     prompt_tokens: int | None = None
     completion_tokens: int | None = None
     total_tokens: int | None = None
+    vector_dimension: int | None = None
 
     @classmethod
     def create(cls) -> "_CertificationEvidence":
@@ -166,6 +213,9 @@ class _CertificationEvidence:
                 "json_object_verified": False,
                 "fusion_profile_verified": False,
                 "actual_model_verified": False,
+                "embedding_vectors_verified": False,
+                "rerank_results_verified": False,
+                "batch_terminal_verified": False,
             },
             warning_codes=[],
         )
@@ -179,14 +229,21 @@ class ProviderWorkloadCertificationService:
         router_service: ModelRouterService,
         *,
         client_factory: Callable[[], httpx.AsyncClient] | None = None,
+        batch_poll_interval_seconds: float = 1.0,
     ) -> None:
         self.router_service = router_service
         self.repository = router_service.repository
         self.transport = ProviderChatTransport(router_service.egress_policy)
+        self.operation_transport = ProviderOperationTransport(
+            router_service.egress_policy
+        )
         self._client_factory = client_factory or (
             lambda: httpx.AsyncClient(
                 **ProviderChatTransport.client_kwargs(certification=True)
             )
+        )
+        self._batch_poll_interval_seconds = max(
+            0.0, float(batch_poll_interval_seconds)
         )
 
     @staticmethod
@@ -276,6 +333,18 @@ class ProviderWorkloadCertificationService:
                     "该 Idempotency-Key 已用于另一份 Workload 资格配置。",
                     status_code=409,
                 )
+            if (
+                payload.execution_shape
+                in {"openrouter_batch_chat", "openrouter_batch_embeddings"}
+                and str(existing["status"]) == "uncertain"
+            ):
+                resumed = await self._resume_batch_certification(
+                    connection,
+                    existing,
+                    payload,
+                )
+                if resumed is not None:
+                    return resumed
             return self._summary(connection, existing)
 
         refreshed = await ProviderCatalogService(
@@ -359,49 +428,76 @@ class ProviderWorkloadCertificationService:
             api_key = self.repository.resolve_api_key(
                 self.router_service.tenant_id, connection_id
             )
-            target = ProviderChatTarget.create(
-                source="managed",
-                provider_kind=connection.kind,
-                base_url=connection.base_url,
-                api_key=api_key,
-                connection_id=connection.id,
-            )
-            request_payload = self._request_payload(payload)
             async with asyncio.timeout(60):
                 async with self._client_factory() as client:
-                    authorized = await self.transport.authorize_managed_target(target)
-                    request = self.transport.build_authorized_stream_request(
-                        client,
-                        target,
-                        authorized,
-                        request_payload,
-                    )
-                    response = await self.transport.send_authorized_stream(client, request)
-                    try:
-                        self._validate_status(response.status_code)
-                        evidence.checks["http_ok"] = True
-                        if payload.execution_shape == "fusion_native":
-                            await self._consume_fusion_stream(
-                                response,
-                                evidence,
-                                started,
-                                expected_model=(
-                                    payload.judge_model_id or payload.model_id
-                                ),
-                            )
-                        else:
-                            await self._consume_unary_response(
-                                response,
-                                evidence,
-                                started,
-                                requested_model=payload.model_id,
-                                execution_shape=payload.execution_shape,
-                            )
-                    finally:
-                        await response.aclose()
+                    if payload.execution_shape in {
+                        "embedding_vectors",
+                        "rerank_documents",
+                        "openrouter_batch_chat",
+                        "openrouter_batch_embeddings",
+                    }:
+                        terminal = await self._run_operation_certification(
+                            client,
+                            connection,
+                            api_key,
+                            payload,
+                            evidence,
+                            started,
+                            certification_id=str(row["id"]),
+                            idempotency_key_hash=idempotency_hash,
+                            connection_fingerprint=connection_fingerprint,
+                        )
+                        if not terminal:
+                            status = "uncertain"
+                            error_code = "provider_batch_certification_pending"
+                    else:
+                        target = ProviderChatTarget.create(
+                            source="managed",
+                            provider_kind=connection.kind,
+                            base_url=connection.base_url,
+                            api_key=api_key,
+                            connection_id=connection.id,
+                        )
+                        request_payload = self._request_payload(payload)
+                        authorized = await self.transport.authorize_managed_target(target)
+                        request = self.transport.build_authorized_stream_request(
+                            client,
+                            target,
+                            authorized,
+                            request_payload,
+                        )
+                        response = await self.transport.send_authorized_stream(
+                            client, request
+                        )
+                        try:
+                            self._validate_status(response.status_code)
+                            evidence.checks["http_ok"] = True
+                            if payload.execution_shape == "fusion_native":
+                                await self._consume_fusion_stream(
+                                    response,
+                                    evidence,
+                                    started,
+                                    expected_model=(
+                                        payload.judge_model_id or payload.model_id
+                                    ),
+                                )
+                            else:
+                                await self._consume_unary_response(
+                                    response,
+                                    evidence,
+                                    started,
+                                    requested_model=payload.model_id,
+                                    execution_shape=payload.execution_shape,
+                                )
+                        finally:
+                            await response.aclose()
             if payload.execution_shape == "fusion_native":
                 evidence.checks["fusion_profile_verified"] = True
-            status = "passed"
+            if status != "uncertain":
+                status = "passed"
+        except _WorkloadCertificationUncertain as exc:
+            status = "uncertain"
+            error_code = exc.code
         except _WorkloadCertificationFailure as exc:
             error_code = exc.code
         except httpx.ConnectTimeout:
@@ -411,7 +507,14 @@ class ProviderWorkloadCertificationService:
         except httpx.TimeoutException:
             error_code = "provider_workload_timeout"
         except TimeoutError:
-            error_code = "provider_workload_total_timeout"
+            if payload.execution_shape in {
+                "openrouter_batch_chat",
+                "openrouter_batch_embeddings",
+            }:
+                status = "uncertain"
+                error_code = "provider_batch_certification_pending"
+            else:
+                error_code = "provider_workload_total_timeout"
         except httpx.ConnectError:
             error_code = "provider_workload_connect_error"
         except ProviderEgressError as exc:
@@ -442,8 +545,199 @@ class ProviderWorkloadCertificationService:
                 prompt_tokens=evidence.prompt_tokens,
                 completion_tokens=evidence.completion_tokens,
                 total_tokens=evidence.total_tokens,
+                vector_dimension=evidence.vector_dimension,
             )
+        if status == "passed":
+            self._record_certified_offering(connection, completed)
         return self._summary(connection, completed)
+
+    async def resume_pending_batch_certifications(self) -> int:
+        """Resume only GET polling for persisted Batch certifications."""
+
+        resumed = 0
+        jobs = self._repository_method("list_provider_batch_jobs")(
+            self.router_service.tenant_id,
+            limit=500,
+        )
+        for job in jobs:
+            if (
+                str(job.get("status") or "")
+                not in {"validating", "in_progress", "finalizing"}
+                or not job.get("upstream_batch_id")
+                or not job.get("certification_id")
+            ):
+                continue
+            certification = self._repository_method(
+                "get_workload_certification"
+            )(
+                self.router_service.tenant_id,
+                str(job["certification_id"]),
+            )
+            if certification is None or str(certification["status"]) != "uncertain":
+                continue
+            try:
+                connection = self.repository.get_connection(
+                    self.router_service.tenant_id,
+                    str(certification["connection_id"]),
+                )
+                payload = ProviderWorkloadCertificationRequest(
+                    execution_shape=str(certification["execution_shape"]),  # type: ignore[arg-type]
+                    model_id=str(certification["requested_model"]),
+                    acknowledge_billed_call=True,
+                )
+                result = await self._resume_batch_certification(
+                    connection,
+                    certification,
+                    payload,
+                )
+                if result is not None:
+                    resumed += 1
+            except (RouterRepositoryError, RouterServiceError, ValueError):
+                continue
+        return resumed
+
+    async def _resume_batch_certification(
+        self,
+        connection: RouterConnection,
+        certification: dict[str, object],
+        payload: ProviderWorkloadCertificationRequest,
+    ) -> ProviderWorkloadCertificationSummary | None:
+        job = self._repository_method("get_provider_batch_job_by_certification")(
+            self.router_service.tenant_id,
+            str(certification["id"]),
+        )
+        if (
+            job is None
+            or str(job.get("status") or "")
+            not in {"validating", "in_progress", "finalizing"}
+            or not job.get("upstream_batch_id")
+        ):
+            return None
+        current_fingerprint = self.repository.connection_config_fingerprint(
+            self.router_service.tenant_id,
+            connection.id,
+        )
+        if (
+            str(certification["connection_fingerprint"]) != current_fingerprint
+            or str(job["connection_fingerprint"]) != current_fingerprint
+        ):
+            return None
+        try:
+            running = self._repository_method("resume_workload_certification")(
+                self.router_service.tenant_id,
+                str(certification["id"]),
+            )
+        except RouterRepositoryError as exc:
+            if str(exc) in {
+                "provider_workload_certification_not_resumable",
+                "provider_workload_certification_already_running",
+            }:
+                latest = self._repository_method("get_workload_certification")(
+                    self.router_service.tenant_id,
+                    str(certification["id"]),
+                )
+                return self._summary(connection, latest) if latest else None
+            raise
+
+        evidence = _CertificationEvidence.create()
+        status = "failed"
+        error_code: str | None = None
+        started = time.perf_counter()
+        try:
+            api_key = self.repository.resolve_api_key(
+                self.router_service.tenant_id,
+                connection.id,
+            )
+            target = ProviderOperationTarget.create(
+                provider_kind=connection.kind,
+                connection_id=connection.id,
+                base_url=connection.base_url,
+                api_key=api_key,
+            )
+            async with asyncio.timeout(60):
+                async with self._client_factory() as client:
+                    await self._poll_batch_until_terminal(
+                        client,
+                        target,
+                        payload,
+                        evidence,
+                        job_id=str(job["id"]),
+                        upstream_batch_id=str(job["upstream_batch_id"]),
+                    )
+            status = "passed"
+        except _WorkloadCertificationUncertain as exc:
+            status = "uncertain"
+            error_code = exc.code
+        except _WorkloadCertificationFailure as exc:
+            error_code = exc.code
+        except (httpx.TimeoutException, TimeoutError):
+            status = "uncertain"
+            error_code = "provider_batch_certification_pending"
+        except ProviderEgressError as exc:
+            status = "uncertain"
+            error_code = exc.code
+        except (RouterCredentialUnavailable, httpx.HTTPError):
+            status = "uncertain"
+            error_code = "provider_batch_poll_unavailable"
+        except asyncio.CancelledError:
+            status = "uncertain"
+            error_code = "provider_workload_cancelled"
+            raise
+        except Exception:
+            status = "uncertain"
+            error_code = "provider_workload_unexpected_error"
+        finally:
+            completed = self._repository_method(
+                "complete_workload_certification"
+            )(
+                self.router_service.tenant_id,
+                str(running["id"]),
+                status=status,
+                checks=evidence.checks,
+                warning_codes=evidence.warning_codes,
+                error_code=error_code,
+                actual_model=evidence.actual_model,
+                ttft_ms=evidence.ttft_ms,
+                e2e_ms=(time.perf_counter() - started) * 1000,
+                prompt_tokens=evidence.prompt_tokens,
+                completion_tokens=evidence.completion_tokens,
+                total_tokens=evidence.total_tokens,
+                vector_dimension=evidence.vector_dimension,
+            )
+        if status == "passed":
+            self._record_certified_offering(connection, completed)
+        return self._summary(connection, completed)
+
+    def _record_certified_offering(
+        self,
+        connection: RouterConnection,
+        certification: dict[str, object],
+    ) -> None:
+        execution_shape = str(certification["execution_shape"])
+        profile = _safe_json_object(
+            json.loads(str(certification.get("profile_json") or "{}"))
+        )
+        mapping: dict[str, tuple[str, str]] = {
+            "embedding_vectors": ("embed", "managed_embedding"),
+            "openrouter_batch_chat": ("chat", "openrouter_batch"),
+            "openrouter_batch_embeddings": ("embed", "openrouter_batch"),
+        }
+        if execution_shape == "rerank_documents":
+            access = str(profile.get("rerank_access_mode") or "")
+            if access not in {"dedicated", "llm_json"}:
+                return
+            operation, access_mode = "rerank", f"managed_rerank_{access}"
+        elif execution_shape in mapping:
+            operation, access_mode = mapping[execution_shape]
+        else:
+            return
+        self._repository_method("upsert_certified_catalog_offering")(
+            self.router_service.tenant_id,
+            connection_id=connection.id,
+            model_id=str(certification["requested_model"]),
+            operation=operation,
+            access_mode=access_mode,
+        )
 
     @staticmethod
     def _profile(
@@ -454,6 +748,7 @@ class ProviderWorkloadCertificationService:
             "model_id": payload.model_id,
             "candidate_model_ids": list(payload.candidate_model_ids),
             "judge_model_id": payload.judge_model_id,
+            "rerank_access_mode": payload.rerank_access_mode,
         }
 
     @staticmethod
@@ -495,6 +790,575 @@ class ProviderWorkloadCertificationService:
                 }
             )
         return request
+
+    async def _run_operation_certification(
+        self,
+        client: httpx.AsyncClient,
+        connection: RouterConnection,
+        api_key: str,
+        payload: ProviderWorkloadCertificationRequest,
+        evidence: _CertificationEvidence,
+        started: float,
+        *,
+        certification_id: str,
+        idempotency_key_hash: str,
+        connection_fingerprint: str,
+    ) -> bool:
+        target = ProviderOperationTarget.create(
+            provider_kind=connection.kind,
+            connection_id=connection.id,
+            base_url=connection.base_url,
+            api_key=api_key,
+        )
+        if payload.execution_shape in {
+            "openrouter_batch_chat",
+            "openrouter_batch_embeddings",
+        }:
+            return await self._run_batch_certification(
+                client,
+                target,
+                payload,
+                evidence,
+                certification_id=certification_id,
+                idempotency_key_hash=idempotency_key_hash,
+                connection_fingerprint=connection_fingerprint,
+            )
+
+        operation = payload.execution_shape
+        authorized = await self.operation_transport.authorize(
+            target,
+            operation,  # type: ignore[arg-type]
+            rerank_access_mode=payload.rerank_access_mode,
+        )
+        request = self.operation_transport.build_authorized_request(
+            client,
+            target,
+            authorized,
+            method="POST",
+            payload=self._operation_request_payload(payload),
+        )
+        response = await self.operation_transport.send_authorized(client, request)
+        try:
+            self._validate_status(response.status_code)
+            evidence.checks["http_ok"] = True
+            response_payload = await self._read_json_response(response)
+            if operation == "embedding_vectors":
+                self._validate_embedding_response(
+                    response_payload,
+                    evidence,
+                    requested_model=payload.model_id,
+                )
+            else:
+                self._validate_rerank_response(
+                    response_payload,
+                    evidence,
+                    requested_model=payload.model_id,
+                    access_mode=payload.rerank_access_mode,
+                )
+            evidence.ttft_ms = (time.perf_counter() - started) * 1000
+            return True
+        finally:
+            await response.aclose()
+
+    @staticmethod
+    def _operation_request_payload(
+        payload: ProviderWorkloadCertificationRequest,
+    ) -> dict[str, object]:
+        if payload.execution_shape == "embedding_vectors":
+            return {
+                "model": payload.model_id,
+                "input": list(SYNTHETIC_EMBEDDING_INPUTS),
+                "encoding_format": "float",
+            }
+        if payload.rerank_access_mode == "dedicated":
+            return {
+                "model": payload.model_id,
+                "query": SYNTHETIC_RERANK_QUERY,
+                "documents": list(SYNTHETIC_RERANK_DOCUMENTS),
+                "top_n": len(SYNTHETIC_RERANK_DOCUMENTS),
+            }
+        return {
+            "model": payload.model_id,
+            "temperature": 0,
+            "max_tokens": 128,
+            "stream": False,
+            "response_format": {"type": "json_object"},
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "Return JSON with results containing every document index 0, 1, 2 "
+                        "exactly once and a score from 0 to 1. Query: "
+                        f"{SYNTHETIC_RERANK_QUERY} Documents: "
+                        + " | ".join(SYNTHETIC_RERANK_DOCUMENTS)
+                    ),
+                }
+            ],
+        }
+
+    @staticmethod
+    async def _read_json_response(response: httpx.Response) -> dict[str, object]:
+        chunks: list[bytes] = []
+        total_bytes = 0
+        async for chunk in response.aiter_bytes(
+            chunk_size=WORKLOAD_RESPONSE_CHUNK_BYTES
+        ):
+            total_bytes += len(chunk)
+            if total_bytes > MAX_WORKLOAD_UNARY_RESPONSE_BYTES:
+                raise _WorkloadCertificationFailure(
+                    "provider_workload_response_too_large"
+                )
+            chunks.append(chunk)
+        try:
+            parsed = json.loads(b"".join(chunks))
+        except (json.JSONDecodeError, UnicodeDecodeError, TypeError) as exc:
+            raise _WorkloadCertificationFailure(
+                "provider_workload_invalid_json_response"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise _WorkloadCertificationFailure(
+                "provider_workload_invalid_json_response"
+            )
+        return parsed
+
+    @staticmethod
+    def _validate_actual_model(
+        response_payload: Mapping[str, object],
+        evidence: _CertificationEvidence,
+        *,
+        requested_model: str,
+    ) -> None:
+        model = response_payload.get("model")
+        if isinstance(model, str) and model:
+            evidence.actual_model = model
+            if model != requested_model:
+                raise _WorkloadCertificationFailure(
+                    "provider_workload_model_mismatch"
+                )
+            evidence.checks["actual_model_verified"] = True
+        else:
+            evidence.warning_codes.append("actual_model_missing")
+
+    @classmethod
+    def _validate_embedding_response(
+        cls,
+        response_payload: dict[str, object],
+        evidence: _CertificationEvidence,
+        *,
+        requested_model: str,
+    ) -> None:
+        cls._validate_actual_model(
+            response_payload, evidence, requested_model=requested_model
+        )
+        if not evidence.checks["actual_model_verified"]:
+            raise _WorkloadCertificationFailure(
+                "provider_embedding_actual_model_missing"
+            )
+        data = response_payload.get("data")
+        if not isinstance(data, list) or len(data) != len(SYNTHETIC_EMBEDDING_INPUTS):
+            raise _WorkloadCertificationFailure(
+                "provider_embedding_vector_count_mismatch"
+            )
+        dimensions: set[int] = set()
+        indexes: set[int] = set()
+        for item in data:
+            if not isinstance(item, dict):
+                raise _WorkloadCertificationFailure(
+                    "provider_embedding_invalid_vector"
+                )
+            index = item.get("index")
+            vector = item.get("embedding")
+            if not isinstance(index, int) or isinstance(index, bool):
+                raise _WorkloadCertificationFailure(
+                    "provider_embedding_invalid_index"
+                )
+            if not isinstance(vector, list) or not vector:
+                raise _WorkloadCertificationFailure(
+                    "provider_embedding_invalid_vector"
+                )
+            if any(
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(float(value))
+                for value in vector
+            ):
+                raise _WorkloadCertificationFailure(
+                    "provider_embedding_non_finite_vector"
+                )
+            indexes.add(index)
+            dimensions.add(len(vector))
+        if indexes != set(range(len(SYNTHETIC_EMBEDDING_INPUTS))):
+            raise _WorkloadCertificationFailure(
+                "provider_embedding_invalid_index"
+            )
+        if len(dimensions) != 1:
+            raise _WorkloadCertificationFailure(
+                "provider_embedding_dimension_mismatch"
+            )
+        evidence.vector_dimension = next(iter(dimensions))
+        cls._read_usage(response_payload, evidence)
+        evidence.checks["response_complete"] = True
+        evidence.checks["content_observed"] = True
+        evidence.checks["embedding_vectors_verified"] = True
+
+    @classmethod
+    def _validate_rerank_response(
+        cls,
+        response_payload: dict[str, object],
+        evidence: _CertificationEvidence,
+        *,
+        requested_model: str,
+        access_mode: str | None,
+    ) -> None:
+        cls._validate_actual_model(
+            response_payload, evidence, requested_model=requested_model
+        )
+        cls._read_usage(response_payload, evidence)
+        result_payload: object = response_payload
+        if access_mode == "llm_json":
+            choices = response_payload.get("choices")
+            first = choices[0] if isinstance(choices, list) and choices else None
+            message = first.get("message") if isinstance(first, dict) else None
+            content = message.get("content") if isinstance(message, dict) else None
+            if not isinstance(content, str) or not content.strip():
+                raise _WorkloadCertificationFailure(
+                    "provider_rerank_empty_response"
+                )
+            try:
+                result_payload = json.loads(content)
+            except json.JSONDecodeError as exc:
+                raise _WorkloadCertificationFailure(
+                    "provider_rerank_invalid_json"
+                ) from exc
+        if not isinstance(result_payload, dict):
+            raise _WorkloadCertificationFailure("provider_rerank_invalid_results")
+        results = result_payload.get("results")
+        if not isinstance(results, list) or len(results) != len(
+            SYNTHETIC_RERANK_DOCUMENTS
+        ):
+            raise _WorkloadCertificationFailure(
+                "provider_rerank_incomplete_results"
+            )
+        indexes: set[int] = set()
+        for result in results:
+            if not isinstance(result, dict):
+                raise _WorkloadCertificationFailure(
+                    "provider_rerank_invalid_results"
+                )
+            index = result.get("index")
+            score = result.get("relevance_score", result.get("score"))
+            if (
+                not isinstance(index, int)
+                or isinstance(index, bool)
+                or isinstance(score, bool)
+                or not isinstance(score, (int, float))
+                or not math.isfinite(float(score))
+                or not 0 <= float(score) <= 1
+            ):
+                raise _WorkloadCertificationFailure(
+                    "provider_rerank_invalid_results"
+                )
+            indexes.add(index)
+        if indexes != set(range(len(SYNTHETIC_RERANK_DOCUMENTS))):
+            raise _WorkloadCertificationFailure(
+                "provider_rerank_duplicate_or_missing_index"
+            )
+        evidence.checks["response_complete"] = True
+        evidence.checks["content_observed"] = True
+        evidence.checks["rerank_results_verified"] = True
+
+    async def _run_batch_certification(
+        self,
+        client: httpx.AsyncClient,
+        target: ProviderOperationTarget,
+        payload: ProviderWorkloadCertificationRequest,
+        evidence: _CertificationEvidence,
+        *,
+        certification_id: str,
+        idempotency_key_hash: str,
+        connection_fingerprint: str,
+    ) -> bool:
+        operation = payload.execution_shape
+        endpoint = (
+            "/v1/chat/completions"
+            if operation == "openrouter_batch_chat"
+            else "/v1/embeddings"
+        )
+        body: dict[str, object]
+        if operation == "openrouter_batch_chat":
+            body = {
+                "model": payload.model_id,
+                "messages": [{"role": "user", "content": SYNTHETIC_UNARY_PROMPT}],
+                "max_tokens": 16,
+                "temperature": 0,
+            }
+        else:
+            body = {
+                "model": payload.model_id,
+                "input": SYNTHETIC_EMBEDDING_INPUTS[0],
+                "encoding_format": "float",
+            }
+        request_payload = {
+            "endpoint": endpoint,
+            "model": payload.model_id,
+            "requests": [{"custom_id": "modelmirror-certification", "body": body}],
+        }
+        request_fingerprint = _fingerprint(request_payload)
+        authorized = await self.operation_transport.authorize(
+            target, operation  # type: ignore[arg-type]
+        )
+        job_id = f"mmbatch_{uuid.uuid4().hex}"
+        job, created = self._repository_method("claim_provider_batch_job")(
+            self.router_service.tenant_id,
+            job_id=job_id,
+            connection_id=target.connection_id,
+            connection_fingerprint=connection_fingerprint,
+            endpoint=endpoint,
+            model_id=payload.model_id,
+            certification_id=certification_id,
+            idempotency_key_hash=idempotency_key_hash,
+            request_fingerprint=request_fingerprint,
+            purpose="certification",
+            request_count=1,
+        )
+        if not created:
+            if str(job["request_fingerprint"]) != request_fingerprint:
+                raise _WorkloadCertificationFailure(
+                    "provider_batch_idempotency_conflict"
+                )
+            return str(job["status"]) == "completed"
+        request = self.operation_transport.build_authorized_request(
+            client,
+            target,
+            authorized,
+            method="POST",
+            payload=request_payload,
+        )
+        try:
+            response = await self.operation_transport.send_authorized(client, request)
+        except (httpx.HTTPError, TimeoutError) as exc:
+            self._repository_method("mark_provider_batch_uncertain")(
+                self.router_service.tenant_id,
+                job_id,
+                error_code="provider_batch_submission_uncertain",
+            )
+            raise _WorkloadCertificationUncertain(
+                "provider_batch_submission_uncertain"
+            ) from exc
+        try:
+            try:
+                self._validate_status(response.status_code)
+                submitted_payload = await self._read_json_response(response)
+            except _WorkloadCertificationFailure as exc:
+                self._repository_method("fail_provider_batch_submission")(
+                    self.router_service.tenant_id,
+                    job_id,
+                    error_code=exc.code,
+                )
+                raise
+        finally:
+            await response.aclose()
+        upstream_id = submitted_payload.get("id")
+        upstream_status = str(submitted_payload.get("status") or "validating")
+        if not isinstance(upstream_id, str) or not upstream_id:
+            self._repository_method("fail_provider_batch_submission")(
+                self.router_service.tenant_id,
+                job_id,
+                error_code="provider_batch_missing_upstream_id",
+            )
+            raise _WorkloadCertificationFailure(
+                "provider_batch_missing_upstream_id"
+            )
+        initial_status = (
+            upstream_status
+            if upstream_status in {"validating", "in_progress", "finalizing"}
+            else "validating"
+        )
+        self._repository_method("mark_provider_batch_submitted")(
+            self.router_service.tenant_id,
+            job_id,
+            upstream_batch_id=upstream_id,
+            status=initial_status,
+        )
+        return await self._poll_batch_until_terminal(
+            client,
+            target,
+            payload,
+            evidence,
+            job_id=job_id,
+            upstream_batch_id=upstream_id,
+            initial_payload=submitted_payload,
+        )
+
+    async def _poll_batch_until_terminal(
+        self,
+        client: httpx.AsyncClient,
+        target: ProviderOperationTarget,
+        payload: ProviderWorkloadCertificationRequest,
+        evidence: _CertificationEvidence,
+        *,
+        job_id: str,
+        upstream_batch_id: str,
+        initial_payload: dict[str, object] | None = None,
+    ) -> bool:
+        operation = payload.execution_shape
+        polled_payload = initial_payload
+        current_status = "validating"
+        poll_count = 0
+        while True:
+            if polled_payload is None:
+                if poll_count and self._batch_poll_interval_seconds:
+                    await asyncio.sleep(self._batch_poll_interval_seconds)
+                authorized_poll = await self.operation_transport.authorize(
+                    target,
+                    operation,  # type: ignore[arg-type]
+                    upstream_batch_id=upstream_batch_id,
+                )
+                poll_request = self.operation_transport.build_authorized_request(
+                    client,
+                    target,
+                    authorized_poll,
+                    method="GET",
+                )
+                try:
+                    poll_response = await self.operation_transport.send_authorized(
+                        client, poll_request
+                    )
+                    try:
+                        self._validate_status(poll_response.status_code)
+                        polled_payload = await self._read_json_response(poll_response)
+                    finally:
+                        await poll_response.aclose()
+                except _WorkloadCertificationFailure as exc:
+                    self._repository_method("update_provider_batch_job")(
+                        self.router_service.tenant_id,
+                        job_id,
+                        status="failed",
+                        error_code=exc.code,
+                    )
+                    raise
+                except (httpx.HTTPError, TimeoutError) as exc:
+                    self._repository_method("update_provider_batch_job")(
+                        self.router_service.tenant_id,
+                        job_id,
+                        status=current_status,
+                        error_code="provider_batch_poll_uncertain",
+                    )
+                    raise _WorkloadCertificationUncertain(
+                        "provider_batch_poll_uncertain"
+                    ) from exc
+                poll_count += 1
+
+            status = str(polled_payload.get("status") or "in_progress")
+            normalized_status = (
+                status
+                if status
+                in {
+                    "validating",
+                    "in_progress",
+                    "finalizing",
+                    "completed",
+                    "failed",
+                    "cancelled",
+                    "expired",
+                }
+                else "in_progress"
+            )
+            current_status = normalized_status
+            terminal = normalized_status in {
+                "completed",
+                "failed",
+                "cancelled",
+                "expired",
+            }
+            counts = polled_payload.get("request_counts")
+            count_map = counts if isinstance(counts, dict) else {}
+            completed_count = self._integer(count_map.get("completed")) or 0
+            failed_count = self._integer(count_map.get("failed")) or 0
+            usage = polled_payload.get("usage")
+            usage_map = {
+                key: value
+                for key, value in (
+                    usage.items() if isinstance(usage, dict) else []
+                )
+                if key in {"prompt_tokens", "completion_tokens", "total_tokens"}
+                and isinstance(value, (int, float))
+                and not isinstance(value, bool)
+                and math.isfinite(float(value))
+            }
+            self._repository_method("update_provider_batch_job")(
+                self.router_service.tenant_id,
+                job_id,
+                status=normalized_status,
+                completed_count=completed_count,
+                failed_count=failed_count,
+                usage=usage_map,
+                error_code=(
+                    None
+                    if normalized_status in {"validating", "in_progress", "finalizing", "completed"}
+                    else f"provider_batch_{normalized_status}"
+                ),
+            )
+            if not terminal:
+                polled_payload = None
+                continue
+            if (
+                normalized_status != "completed"
+                or completed_count != 1
+                or failed_count != 0
+            ):
+                raise _WorkloadCertificationFailure(
+                    f"provider_batch_{normalized_status if normalized_status != 'completed' else 'result_failed'}"
+                )
+            results = polled_payload.get("results")
+            first_result = (
+                results[0]
+                if isinstance(results, list) and len(results) == 1
+                else None
+            )
+            if (
+                not isinstance(first_result, dict)
+                or first_result.get("custom_id") != "modelmirror-certification"
+            ):
+                raise _WorkloadCertificationFailure(
+                    "provider_batch_result_mismatch"
+                )
+            result_response = first_result.get("response")
+            result_status = (
+                result_response.get("status_code")
+                if isinstance(result_response, dict)
+                else None
+            )
+            result_body = (
+                result_response.get("body")
+                if isinstance(result_response, dict)
+                else None
+            )
+            actual_model = (
+                result_body.get("model") if isinstance(result_body, dict) else None
+            )
+            if not isinstance(result_status, int) or not 200 <= result_status < 300:
+                raise _WorkloadCertificationFailure("provider_batch_result_failed")
+            if not isinstance(actual_model, str) or not actual_model:
+                raise _WorkloadCertificationFailure(
+                    "provider_batch_actual_model_missing"
+                )
+            if actual_model != payload.model_id:
+                raise _WorkloadCertificationFailure(
+                    "provider_workload_model_mismatch"
+                )
+            evidence.actual_model = actual_model
+            evidence.checks["actual_model_verified"] = True
+            evidence.checks["http_ok"] = True
+            evidence.checks["response_complete"] = True
+            evidence.checks["content_observed"] = True
+            evidence.checks["batch_terminal_verified"] = True
+            evidence.prompt_tokens = self._integer(usage_map.get("prompt_tokens"))
+            evidence.completion_tokens = self._integer(
+                usage_map.get("completion_tokens")
+            )
+            evidence.total_tokens = self._integer(usage_map.get("total_tokens"))
+            return True
 
     @staticmethod
     async def _consume_unary_response(
@@ -740,10 +1604,11 @@ class ProviderWorkloadCertificationService:
             raise RouterServiceError(
                 "connection_disabled", "该模型服务已停用。", status_code=409
             )
-        if "chat" not in connection.scopes:
+        required_scope = self._required_scope(execution_shape)
+        if required_scope not in connection.scopes:
             raise RouterServiceError(
-                "connection_chat_scope_required",
-                "Workload 资格要求连接启用 Chat scope。",
+                f"connection_{required_scope}_scope_required",
+                f"Workload 资格要求连接启用 {required_scope} scope。",
                 status_code=409,
             )
         if execution_shape == "fusion_native" and connection.kind != "openrouter":
@@ -752,6 +1617,28 @@ class ProviderWorkloadCertificationService:
                 "原生 Fusion 资格只允许 OpenRouter 类型连接。",
                 status_code=409,
             )
+        if execution_shape in {
+            "openrouter_batch_chat",
+            "openrouter_batch_embeddings",
+        } and connection.kind != "openrouter":
+            raise RouterServiceError(
+                "provider_workload_batch_requires_openrouter",
+                "Batch 资格只允许 OpenRouter 类型连接。",
+                status_code=409,
+            )
+
+    @staticmethod
+    def _required_scope(execution_shape: ProviderWorkloadExecutionShape) -> str:
+        if execution_shape == "embedding_vectors":
+            return "embedding"
+        if execution_shape == "rerank_documents":
+            return "rerank"
+        if execution_shape in {
+            "openrouter_batch_chat",
+            "openrouter_batch_embeddings",
+        }:
+            return "batch"
+        return "chat"
 
     def _summary(
         self,
@@ -778,10 +1665,14 @@ class ProviderWorkloadCertificationService:
                 blocked_reason = time_reason.replace(
                     "provider_chat_", "provider_workload_", 1
                 )
+        profile = _safe_json_object(json.loads(str(row["profile_json"] or "{}")))
+        required_scope = self._required_scope(
+            str(row["execution_shape"])  # type: ignore[arg-type]
+        )
         if blocked_reason is None and not connection.enabled:
             blocked_reason = "connection_disabled"
-        elif blocked_reason is None and "chat" not in connection.scopes:
-            blocked_reason = "connection_chat_scope_required"
+        elif blocked_reason is None and required_scope not in connection.scopes:
+            blocked_reason = f"connection_{required_scope}_scope_required"
         elif blocked_reason is None and connection.health != "online":
             blocked_reason = "provider_connection_not_online"
         elif blocked_reason is None:
@@ -791,9 +1682,22 @@ class ProviderWorkloadCertificationService:
                 )
             except RouterCredentialUnavailable:
                 blocked_reason = "provider_workload_credential_unavailable"
-        profile = _safe_json_object(json.loads(str(row["profile_json"] or "{}")))
         checks = _safe_json_object(json.loads(str(row["checks_json"] or "{}")))
         warnings = json.loads(str(row["warnings_json"] or "[]"))
+        batch_job = None
+        if str(row["execution_shape"]).startswith("openrouter_batch_"):
+            batch_job = next(
+                (
+                    item
+                    for item in self._repository_method("list_provider_batch_jobs")(
+                        self.router_service.tenant_id,
+                        connection_id=connection.id,
+                        limit=100,
+                    )
+                    if str(item.get("certification_id") or "") == str(row["id"])
+                ),
+                None,
+            )
         return ProviderWorkloadCertificationSummary(
             certification_id=str(row["id"]),
             connection_id=connection.id,
@@ -821,11 +1725,19 @@ class ProviderWorkloadCertificationService:
                 else None
             ),
             profile_fingerprint=str(row["profile_fingerprint"]),
+            rerank_access_mode=(
+                str(profile["rerank_access_mode"])  # type: ignore[arg-type]
+                if profile.get("rerank_access_mode")
+                else None
+            ),
+            batch_job_id=(str(batch_job["id"]) if batch_job else None),
+            batch_status=(str(batch_job["status"]) if batch_job else None),
             ttft_ms=self._float(row["ttft_ms"]),
             e2e_ms=self._float(row["e2e_ms"]),
             prompt_tokens=self._integer(row["prompt_tokens"]),
             completion_tokens=self._integer(row["completion_tokens"]),
             total_tokens=self._integer(row["total_tokens"]),
+            vector_dimension=self._integer(row.get("vector_dimension")),
             created_at=str(row["created_at"]),
             completed_at=str(row["completed_at"]) if row["completed_at"] else None,
         )
@@ -894,6 +1806,12 @@ class ProviderWorkloadControlService:
         payload: ProviderWorkloadPolicyUpdate,
     ) -> ProviderWorkloadPolicyResponse:
         allowed_shapes = ENTRY_ALLOWED_SHAPES[entry_id]
+        if payload.local_fallback_mode not in ENTRY_ALLOWED_LOCAL_FALLBACKS[entry_id]:
+            raise RouterServiceError(
+                "provider_workload_local_fallback_not_allowed",
+                "该入口不允许所选本地降级模式。",
+                status_code=422,
+            )
         qualified: list[dict[str, object]] = []
         for binding in payload.bindings:
             if binding.execution_shape not in allowed_shapes:
@@ -906,6 +1824,7 @@ class ProviderWorkloadControlService:
                 connection_id=binding.connection_id,
                 model_id=binding.model_id,
                 execution_shape=binding.execution_shape,
+                rerank_access_mode=binding.rerank_access_mode,
             )
             if qualification is None:
                 raise RouterServiceError(
@@ -914,13 +1833,18 @@ class ProviderWorkloadControlService:
                     status_code=409,
                 )
             qualified.append(qualification)
-        policy_fingerprint = self._policy_fingerprint(entry_id, qualified)
+        policy_fingerprint = self._policy_fingerprint(
+            entry_id,
+            qualified,
+            local_fallback_mode=payload.local_fallback_mode,
+        )
         try:
             bundle = self._repository_method("replace_workload_policy")(
                 self.router_service.tenant_id,
                 entry_id=entry_id,
                 expected_revision=payload.expected_revision,
                 policy_fingerprint=policy_fingerprint,
+                local_fallback_mode=payload.local_fallback_mode,
                 bindings=qualified,
             )
         except RouterRepositoryError as exc:
@@ -1155,7 +2079,9 @@ class ProviderWorkloadControlService:
         fingerprint = (
             str(policy["policy_fingerprint"])
             if isinstance(policy, dict)
-            else self._policy_fingerprint(entry_id, [])
+            else self._policy_fingerprint(
+                entry_id, [], local_fallback_mode="none"
+            )
         )
         configured_status = (
             str(policy["status"]) if isinstance(policy, dict) else "legacy"
@@ -1180,6 +2106,11 @@ class ProviderWorkloadControlService:
                     certification_source=str(row["certification_source"]),  # type: ignore[arg-type]
                     connection_fingerprint=str(row["connection_fingerprint"]),
                     qualification_fingerprint=str(row["qualification_fingerprint"]),
+                    rerank_access_mode=(
+                        str(row["rerank_access_mode"])  # type: ignore[arg-type]
+                        if row.get("rerank_access_mode")
+                        else None
+                    ),
                     valid=valid,
                     reason_code=reason,
                 )
@@ -1221,6 +2152,11 @@ class ProviderWorkloadControlService:
             effective_status=effective_status,  # type: ignore[arg-type]
             revision=int(policy["revision"]) if isinstance(policy, dict) else 0,
             policy_fingerprint=fingerprint,
+            local_fallback_mode=(
+                str(policy.get("local_fallback_mode") or "none")  # type: ignore[arg-type]
+                if isinstance(policy, dict)
+                else "none"
+            ),
             bindings=binding_summaries,
             approval_valid=approval_valid,
             blocking_reason_codes=list(dict.fromkeys(blockers)),
@@ -1235,7 +2171,13 @@ class ProviderWorkloadControlService:
         connection_id: str,
         model_id: str,
         execution_shape: ProviderWorkloadExecutionShape,
+        rerank_access_mode: str | None = None,
     ) -> tuple[dict[str, object] | None, str]:
+        if execution_shape == "rerank_documents":
+            if rerank_access_mode not in {"dedicated", "llm_json"}:
+                return None, "provider_workload_rerank_access_mode_required"
+        elif rerank_access_mode is not None:
+            return None, "provider_workload_rerank_access_mode_not_allowed"
         if execution_shape in {"chat_text", "chat_tools"}:
             qualification, reason = ProviderChatControlService(
                 self.router_service
@@ -1263,8 +2205,11 @@ class ProviderWorkloadControlService:
             return None, "provider_workload_connection_missing"
         if not connection.enabled:
             return None, "connection_disabled"
-        if "chat" not in connection.scopes:
-            return None, "connection_chat_scope_required"
+        required_scope = ProviderWorkloadCertificationService._required_scope(
+            execution_shape
+        )
+        if required_scope not in connection.scopes:
+            return None, f"connection_{required_scope}_scope_required"
         if connection.health != "online":
             return None, "provider_connection_not_online"
         try:
@@ -1275,6 +2220,11 @@ class ProviderWorkloadControlService:
             return None, "provider_workload_credential_unavailable"
         if execution_shape == "fusion_native" and connection.kind != "openrouter":
             return None, "provider_workload_fusion_requires_openrouter"
+        if execution_shape in {
+            "openrouter_batch_chat",
+            "openrouter_batch_embeddings",
+        } and connection.kind != "openrouter":
+            return None, "provider_workload_batch_requires_openrouter"
         fingerprint = self.repository.connection_config_fingerprint(
             self.router_service.tenant_id, connection_id
         )
@@ -1312,6 +2262,7 @@ class ProviderWorkloadControlService:
             connection_id,
             model_id,
             execution_shape,
+            rerank_access_mode=rerank_access_mode,
         )
         if certification is None:
             return None, "provider_workload_certification_required"
@@ -1347,6 +2298,7 @@ class ProviderWorkloadControlService:
             "connection_fingerprint": fingerprint,
             "contract_version": PROVIDER_WORKLOAD_CONTRACT_VERSION,
             "profile_fingerprint": str(certification["profile_fingerprint"]),
+            "rerank_access_mode": rerank_access_mode,
         }
         qualification["qualification_fingerprint"] = _fingerprint(qualification)
         return qualification, "qualified"
@@ -1364,6 +2316,11 @@ class ProviderWorkloadControlService:
             connection_id=str(row["connection_id"]),
             model_id=str(row["model_id"]),
             execution_shape=str(row["execution_shape"]),  # type: ignore[arg-type]
+            rerank_access_mode=(
+                str(row["rerank_access_mode"])
+                if row.get("rerank_access_mode")
+                else None
+            ),
         )
         if current is None:
             return False, reason, connection
@@ -1387,12 +2344,15 @@ class ProviderWorkloadControlService:
     def _policy_fingerprint(
         entry_id: ProviderWorkloadEntryId,
         bindings: list[dict[str, object]],
+        *,
+        local_fallback_mode: str,
     ) -> str:
         material = [
             {
                 "execution_shape": item["execution_shape"],
                 "model_id": item["model_id"],
                 "connection_id": item["connection_id"],
+                "rerank_access_mode": item.get("rerank_access_mode"),
                 "qualification_fingerprint": item["qualification_fingerprint"],
             }
             for item in sorted(
@@ -1408,6 +2368,7 @@ class ProviderWorkloadControlService:
             {
                 "contract_version": PROVIDER_WORKLOAD_CONTRACT_VERSION,
                 "entry_id": entry_id,
+                "local_fallback_mode": local_fallback_mode,
                 "bindings": material,
             }
         )

--- a/server/tests/test_provider_workload_control.py
+++ b/server/tests/test_provider_workload_control.py
@@ -17,6 +17,12 @@ from server.model_router.repository import (
     RouterRepositoryError,
     SQLiteRouterRepository,
 )
+from server.model_router.provider_operations import (
+    OPENROUTER_BATCHES_URL,
+    ProviderOperationEndpointResolver,
+    ProviderOperationTarget,
+    ProviderOperationTransport,
+)
 from server.model_router.schemas import (
     ProviderWorkloadActivationRequest,
     ProviderWorkloadCertificationRequest,
@@ -40,13 +46,14 @@ from server.model_router.cleanup_chat_receipts import cleanup_receipts
 
 
 PAIRING_SECRET = "provider-admin-test-secret-at-least-32-chars"
-V16_TABLES = {
+V17_TABLES = {
     "provider_workload_certifications",
     "provider_workload_policies",
     "provider_workload_bindings",
     "provider_workload_runs",
     "provider_workload_calls",
     "provider_workload_approvals",
+    "provider_batch_jobs",
 }
 
 
@@ -57,30 +64,229 @@ def _reset_admin_auth() -> None:
     reset_provider_admin_auth()
 
 
-def test_v15_to_v16_is_additive_and_tenant_scoped(tmp_path: Path) -> None:
+def test_v16_to_v17_is_additive_and_tenant_scoped(tmp_path: Path) -> None:
     database_path = tmp_path / "router.sqlite3"
     with sqlite3.connect(database_path) as connection:
         connection.execute("CREATE TABLE preserved_v15_data (value TEXT NOT NULL)")
         connection.execute("INSERT INTO preserved_v15_data VALUES ('keep-me')")
-        connection.execute("PRAGMA user_version = 15")
+        connection.execute(
+            """
+            CREATE TABLE provider_workload_policies (
+                tenant_id TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'legacy',
+                revision INTEGER NOT NULL DEFAULT 0,
+                policy_fingerprint TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, entry_id)
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO provider_workload_policies VALUES (
+                'local', 'meta_agent', 'legacy', 1, 'preserved-policy',
+                '2026-08-25T00:00:00Z', '2026-08-25T00:00:00Z'
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE provider_workload_bindings (
+                tenant_id TEXT NOT NULL,
+                entry_id TEXT NOT NULL,
+                execution_shape TEXT NOT NULL,
+                model_id TEXT NOT NULL,
+                connection_id TEXT NOT NULL,
+                certification_id TEXT NOT NULL,
+                certification_source TEXT NOT NULL,
+                connection_fingerprint TEXT NOT NULL,
+                qualification_fingerprint TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, entry_id, execution_shape, model_id)
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO provider_workload_bindings VALUES (
+                'local', 'meta_agent', 'chat_json_object', 'provider/model',
+                'conn-old', 'cert-old', 'provider_workload', 'conn-fp',
+                'qualification-fp', '2026-08-25T00:00:00Z',
+                '2026-08-25T00:00:00Z'
+            )
+            """
+        )
+        connection.execute("PRAGMA user_version = 16")
 
     repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
 
     with sqlite3.connect(database_path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 16
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 17
         tables = {
             row[0]
             for row in connection.execute(
                 "SELECT name FROM sqlite_master WHERE type = 'table'"
             )
         }
-        assert V16_TABLES <= tables
+        assert V17_TABLES <= tables
         assert connection.execute("SELECT value FROM preserved_v15_data").fetchone()[0] == (
             "keep-me"
         )
-    assert SCHEMA_VERSION == 16
-    assert repository.get_workload_policy_bundle("local")["policies"] == []
+        policy = connection.execute(
+            "SELECT policy_fingerprint, local_fallback_mode "
+            "FROM provider_workload_policies WHERE tenant_id = 'local'"
+        ).fetchone()
+        assert policy == ("preserved-policy", "none")
+        binding = connection.execute(
+            "SELECT certification_id, rerank_access_mode "
+            "FROM provider_workload_bindings WHERE tenant_id = 'local'"
+        ).fetchone()
+        assert binding == ("cert-old", None)
+        assert "vector_dimension" in {
+            row[1]
+            for row in connection.execute(
+                "PRAGMA table_info(provider_workload_certifications)"
+            )
+        }
+    assert SCHEMA_VERSION == 17
+    assert len(repository.get_workload_policy_bundle("local")["policies"]) == 1
     assert repository.get_workload_policy_bundle("other")["policies"] == []
+
+
+@pytest.mark.asyncio
+async def test_operation_endpoints_are_explicit_and_transport_is_single_ip() -> None:
+    endpoints = ProviderOperationEndpointResolver.resolve(
+        provider_kind="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert endpoints.embeddings_url == "https://openrouter.ai/api/v1/embeddings"
+    assert endpoints.rerank_url == "https://openrouter.ai/api/v1/rerank"
+    assert endpoints.batches_url == OPENROUTER_BATCHES_URL
+
+    target = ProviderOperationTarget.create(
+        provider_kind="openrouter",
+        connection_id="conn-openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="operation-secret",
+    )
+    assert target.endpoint_for("rerank_documents", rerank_access_mode="llm_json") == (
+        "https://openrouter.ai/api/v1/chat/completions"
+    )
+    assert target.endpoint_for("openrouter_batch_chat") == OPENROUTER_BATCHES_URL
+    assert target.endpoint_for(
+        "openrouter_batch_chat", upstream_batch_id="batch_123"
+    ) == f"{OPENROUTER_BATCHES_URL}/batch_123"
+
+    egress = ProviderEgressPolicy(
+        resolver=lambda _host, _port: ["93.184.216.34"]
+    )
+    transport = ProviderOperationTransport(egress)
+    authorized = await transport.authorize(target, "embedding_vectors")
+    observed: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        observed.append(request)
+        assert request.url == "https://93.184.216.34/api/v1/embeddings"
+        assert request.headers["host"] == "openrouter.ai"
+        assert request.headers["authorization"] == "Bearer operation-secret"
+        assert request.extensions["sni_hostname"] == "openrouter.ai"
+        return httpx.Response(200, json={"data": []})
+
+    async with httpx.AsyncClient(
+        transport=MockTransport(handler),
+        follow_redirects=False,
+        trust_env=False,
+    ) as client:
+        request = transport.build_authorized_request(
+            client,
+            target,
+            authorized,
+            method="POST",
+            payload={"model": "provider/embed", "input": ["one", "two"]},
+        )
+        response = await transport.send_authorized(client, request)
+        await response.aclose()
+    assert len(observed) == 1
+    assert ProviderOperationTransport.client_kwargs()["follow_redirects"] is False
+    assert ProviderOperationTransport.client_kwargs()["trust_env"] is False
+
+
+def test_provider_batch_job_is_tenant_scoped_idempotent_and_restart_safe(
+    tmp_path: Path,
+) -> None:
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="OpenRouter batch",
+            kind="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="test-secret",
+            scopes=["batch"],
+        ),
+    )
+    base = {
+        "connection_id": connection.id,
+        "connection_fingerprint": "connection-fingerprint",
+        "endpoint": "/v1/chat/completions",
+        "model_id": "provider/model",
+        "idempotency_key_hash": "idem-one",
+        "request_fingerprint": "request-one",
+        "purpose": "certification",
+        "request_count": 1,
+    }
+    claimed, created = repository.claim_provider_batch_job(
+        "local", job_id="mmbatch_one", **base
+    )
+    replay, replay_created = repository.claim_provider_batch_job(
+        "local", job_id="must-not-be-used", **base
+    )
+    assert created is True
+    assert replay_created is False
+    assert replay["id"] == claimed["id"] == "mmbatch_one"
+    with pytest.raises(RouterRepositoryError) as conflict:
+        repository.claim_provider_batch_job(
+            "local",
+            job_id="mmbatch_conflict",
+            **{**base, "request_fingerprint": "different"},
+        )
+    assert str(conflict.value) == "provider_batch_idempotency_conflict"
+    assert repository.list_provider_batch_jobs("other") == []
+
+    submitted = repository.mark_provider_batch_submitted(
+        "local",
+        "mmbatch_one",
+        upstream_batch_id="batch_upstream_1",
+        status="validating",
+    )
+    assert submitted["upstream_batch_id"] == "batch_upstream_1"
+    repository.update_provider_batch_job(
+        "local",
+        "mmbatch_one",
+        status="in_progress",
+        completed_count=0,
+        failed_count=0,
+        usage={"total_tokens": 0},
+    )
+
+    repository.claim_provider_batch_job(
+        "local",
+        job_id="mmbatch_uncertain",
+        **{**base, "idempotency_key_hash": "idem-two"},
+    )
+    restarted = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    assert restarted.get_provider_batch_job("local", "mmbatch_one")["status"] == (
+        "in_progress"
+    )
+    uncertain = restarted.get_provider_batch_job("local", "mmbatch_uncertain")
+    assert uncertain["status"] == "uncertain"
+    assert uncertain["error_code"] == "server_restarted"
+    serialized = json.dumps(restarted.list_provider_batch_jobs("local"))
+    assert "test-secret" not in serialized
+    assert "prompt" not in serialized.casefold()
 
 
 def test_policy_revision_drift_and_receipt_replay_guards(tmp_path: Path) -> None:
@@ -90,6 +296,7 @@ def test_policy_revision_drift_and_receipt_replay_guards(tmp_path: Path) -> None
         entry_id="meta_agent",
         expected_revision=0,
         policy_fingerprint="policy-one",
+        local_fallback_mode="none",
         bindings=[
             {
                 "execution_shape": "chat_json_object",
@@ -110,6 +317,7 @@ def test_policy_revision_drift_and_receipt_replay_guards(tmp_path: Path) -> None
             entry_id="meta_agent",
             expected_revision=0,
             policy_fingerprint="stale",
+            local_fallback_mode="none",
             bindings=[],
         )
     assert str(exc_info.value) == "provider_workload_policy_revision_conflict"
@@ -119,6 +327,7 @@ def test_policy_revision_drift_and_receipt_replay_guards(tmp_path: Path) -> None
         entry_id="meta_agent",
         expected_revision=0,
         policy_fingerprint="other-policy",
+        local_fallback_mode="none",
         bindings=[],
     )
     assert other_saved["policies"][0]["revision"] == 1
@@ -660,6 +869,595 @@ async def test_workload_certification_rejects_oversized_unary_response(
 
 
 @pytest.mark.asyncio
+async def test_embedding_certification_validates_exact_finite_vector_space(
+    tmp_path: Path,
+) -> None:
+    requests: list[Request] = []
+
+    def handler(request: Request) -> Response:
+        requests.append(request)
+        if request.method == "GET":
+            return Response(200, json={"data": [{"id": "provider/embed"}]})
+        assert request.url.path.endswith("/v1/embeddings")
+        assert json.loads(request.content) == {
+            "model": "provider/embed",
+            "input": [
+                "ModelMirror embedding certification one.",
+                "ModelMirror embedding certification two.",
+            ],
+            "encoding_format": "float",
+        }
+        return Response(
+            200,
+            json={
+                "model": "provider/embed",
+                "data": [
+                    {"index": 0, "embedding": [0.1, 0.2, 0.3]},
+                    {"index": 1, "embedding": [0.4, 0.5, 0.6]},
+                ],
+                "usage": {"prompt_tokens": 4, "total_tokens": 4},
+            },
+        )
+
+    transport = MockTransport(handler)
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Embedding Provider",
+            kind="openai_compatible",
+            base_url="https://provider.example/v1",
+            api_key="embedding-cert-secret",
+            scopes=["embedding"],
+        ),
+    )
+    router_service = ModelRouterService(
+        repository,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+    result = await ProviderWorkloadCertificationService(
+        router_service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    ).run(
+        connection.id,
+        ProviderWorkloadCertificationRequest(
+            execution_shape="embedding_vectors",
+            model_id="provider/embed",
+            acknowledge_billed_call=True,
+        ),
+        idempotency_key="embedding-certification",
+    )
+
+    assert result.status == "passed"
+    assert result.checks.embedding_vectors_verified is True
+    assert result.checks.actual_model_verified is True
+    assert result.vector_dimension == 3
+    offering = repository.list_catalog_offerings(
+        "local",
+        connection_id=connection.id,
+        model_id="provider/embed",
+        operation="embed",
+        include_stale=False,
+    )
+    assert any(
+        item["capability_source"] == "certification"
+        and item["access_mode"] == "managed_embedding"
+        for item in offering
+    )
+    assert sum(request.method == "POST" for request in requests) == 1
+    serialized = repository.database_path.read_bytes()
+    assert b"0.1" not in serialized
+    assert b"embedding-cert-secret" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_rerank_certification_keeps_dedicated_and_llm_json_modes_explicit(
+    tmp_path: Path,
+) -> None:
+    post_paths: list[str] = []
+
+    def handler(request: Request) -> Response:
+        if request.method == "GET":
+            return Response(200, json={"data": [{"id": "provider/rerank"}]})
+        post_paths.append(request.url.path)
+        results = [
+            {"index": 0, "relevance_score": 0.9},
+            {"index": 2, "relevance_score": 0.7},
+            {"index": 1, "relevance_score": 0.1},
+        ]
+        if request.url.path.endswith("/rerank"):
+            return Response(
+                200,
+                json={"model": "provider/rerank", "results": results},
+            )
+        return Response(
+            200,
+            json={
+                "model": "provider/rerank",
+                "choices": [
+                    {"message": {"content": json.dumps({"results": results})}}
+                ],
+            },
+        )
+
+    transport = MockTransport(handler)
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Rerank Provider",
+            kind="openai_compatible",
+            base_url="https://provider.example/v1",
+            api_key="rerank-cert-secret",
+            scopes=["rerank"],
+        ),
+    )
+    router_service = ModelRouterService(
+        repository,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+    service = ProviderWorkloadCertificationService(
+        router_service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    )
+    dedicated = await service.run(
+        connection.id,
+        ProviderWorkloadCertificationRequest(
+            execution_shape="rerank_documents",
+            model_id="provider/rerank",
+            rerank_access_mode="dedicated",
+            acknowledge_billed_call=True,
+        ),
+        idempotency_key="rerank-dedicated",
+    )
+    llm_json = await service.run(
+        connection.id,
+        ProviderWorkloadCertificationRequest(
+            execution_shape="rerank_documents",
+            model_id="provider/rerank",
+            rerank_access_mode="llm_json",
+            acknowledge_billed_call=True,
+        ),
+        idempotency_key="rerank-llm-json",
+    )
+
+    assert dedicated.status == llm_json.status == "passed"
+    assert dedicated.rerank_access_mode == "dedicated"
+    assert llm_json.rerank_access_mode == "llm_json"
+    assert dedicated.profile_fingerprint != llm_json.profile_fingerprint
+    assert post_paths == ["/v1/rerank", "/v1/chat/completions"]
+    control = ProviderWorkloadControlService(router_service)
+    dedicated_policy = control.update_policy(
+        "rag_rerank",
+        ProviderWorkloadPolicyUpdate(
+            expected_revision=0,
+            bindings=[
+                ProviderWorkloadBindingUpdate(
+                    execution_shape="rerank_documents",
+                    model_id="provider/rerank",
+                    connection_id=connection.id,
+                    rerank_access_mode="dedicated",
+                )
+            ],
+        ),
+    )
+    assert dedicated_policy.bindings[0].certification_id == dedicated.certification_id
+    assert dedicated_policy.bindings[0].rerank_access_mode == "dedicated"
+    llm_policy = control.update_policy(
+        "rag_rerank",
+        ProviderWorkloadPolicyUpdate(
+            expected_revision=dedicated_policy.revision,
+            bindings=[
+                ProviderWorkloadBindingUpdate(
+                    execution_shape="rerank_documents",
+                    model_id="provider/rerank",
+                    connection_id=connection.id,
+                    rerank_access_mode="llm_json",
+                )
+            ],
+        ),
+    )
+    assert llm_policy.bindings[0].certification_id == llm_json.certification_id
+    assert llm_policy.bindings[0].rerank_access_mode == "llm_json"
+    assert llm_policy.policy_fingerprint != dedicated_policy.policy_fingerprint
+    with pytest.raises(ValueError, match="rerank_access_mode"):
+        ProviderWorkloadCertificationRequest(
+            execution_shape="rerank_documents",
+            model_id="provider/rerank",
+            acknowledge_billed_call=True,
+        )
+    with pytest.raises(ValueError, match="rerank_access_mode"):
+        ProviderWorkloadBindingUpdate(
+            execution_shape="rerank_documents",
+            model_id="provider/rerank",
+            connection_id=connection.id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_embedding_and_rerank_reject_invalid_contract_evidence(
+    tmp_path: Path,
+) -> None:
+    def handler(request: Request) -> Response:
+        if request.method == "GET":
+            return Response(
+                200,
+                json={
+                    "data": [
+                        {"id": "provider/embed"},
+                        {"id": "provider/rerank"},
+                    ]
+                },
+            )
+        if request.url.path.endswith("/embeddings"):
+            return Response(
+                200,
+                content=(
+                    b'{"model":"provider/embed","data":['
+                    b'{"index":0,"embedding":[0.1,NaN]},'
+                    b'{"index":1,"embedding":[0.2,0.3]}]}'
+                ),
+                headers={"content-type": "application/json"},
+            )
+        return Response(
+            200,
+            json={
+                "model": "provider/rerank",
+                "results": [
+                    {"index": 0, "relevance_score": 0.9},
+                    {"index": 0, "relevance_score": 0.8},
+                    {"index": 2, "relevance_score": 0.1},
+                ],
+            },
+        )
+
+    transport = MockTransport(handler)
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    embedding_connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Invalid Embedding",
+            kind="openai_compatible",
+            base_url="https://provider.example/v1",
+            api_key="invalid-evidence-secret",
+            scopes=["embedding"],
+        ),
+    )
+    rerank_connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Invalid Rerank",
+            kind="openai_compatible",
+            base_url="https://provider.example/v1",
+            api_key="invalid-evidence-secret",
+            scopes=["rerank"],
+        ),
+    )
+    router_service = ModelRouterService(
+        repository,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+    service = ProviderWorkloadCertificationService(
+        router_service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    )
+    embedding = await service.run(
+        embedding_connection.id,
+        ProviderWorkloadCertificationRequest(
+            execution_shape="embedding_vectors",
+            model_id="provider/embed",
+            acknowledge_billed_call=True,
+        ),
+        idempotency_key="invalid-embedding",
+    )
+    rerank = await service.run(
+        rerank_connection.id,
+        ProviderWorkloadCertificationRequest(
+            execution_shape="rerank_documents",
+            model_id="provider/rerank",
+            rerank_access_mode="dedicated",
+            acknowledge_billed_call=True,
+        ),
+        idempotency_key="invalid-rerank",
+    )
+    assert embedding.status == rerank.status == "failed"
+    assert embedding.error_code == "provider_embedding_non_finite_vector"
+    assert rerank.error_code == "provider_rerank_duplicate_or_missing_index"
+    database_bytes = repository.database_path.read_bytes()
+    assert b"invalid-evidence-secret" not in database_bytes
+    assert b"relevance_score" not in database_bytes
+
+
+@pytest.mark.asyncio
+async def test_batch_certification_posts_once_then_polls_without_storing_results(
+    tmp_path: Path,
+) -> None:
+    requests: list[Request] = []
+
+    def handler(request: Request) -> Response:
+        requests.append(request)
+        if request.url.path.endswith("/api/v1/models"):
+            return Response(200, json={"data": [{"id": "provider/model"}]})
+        if request.method == "POST":
+            assert request.url.path == "/api/beta/batches"
+            return Response(202, json={"id": "batch_cert_1", "status": "validating"})
+        assert request.url.path == "/api/beta/batches/batch_cert_1"
+        return Response(
+            200,
+            json={
+                "id": "batch_cert_1",
+                "status": "completed",
+                "request_counts": {"total": 1, "completed": 1, "failed": 0},
+                "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+                "results": [
+                    {
+                        "custom_id": "modelmirror-certification",
+                        "response": {
+                            "status_code": 200,
+                            "body": {
+                                "model": "provider/model",
+                                "choices": [{"message": {"content": "OK"}}],
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+
+    transport = MockTransport(handler)
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="OpenRouter Batch",
+            kind="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="batch-cert-secret",
+            scopes=["batch"],
+        ),
+    )
+    router_service = ModelRouterService(
+        repository,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+    result = await ProviderWorkloadCertificationService(
+        router_service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    ).run(
+        connection.id,
+        ProviderWorkloadCertificationRequest(
+            execution_shape="openrouter_batch_chat",
+            model_id="provider/model",
+            acknowledge_billed_call=True,
+        ),
+        idempotency_key="batch-certification",
+    )
+
+    assert result.status == "passed"
+    assert result.batch_status == "completed"
+    assert result.checks.batch_terminal_verified is True
+    assert sum(request.method == "POST" for request in requests) == 1
+    assert sum(request.method == "GET" for request in requests) == 2
+    database_bytes = repository.database_path.read_bytes()
+    assert b"modelmirror-certification" not in database_bytes
+    assert b'"content":"OK"' not in database_bytes
+    assert b"batch-cert-secret" not in database_bytes
+
+
+@pytest.mark.asyncio
+async def test_batch_poll_recovers_after_restart_without_second_post(
+    tmp_path: Path,
+) -> None:
+    requests: list[Request] = []
+    poll_attempts = 0
+
+    def handler(request: Request) -> Response:
+        nonlocal poll_attempts
+        requests.append(request)
+        if request.url.path.endswith("/api/v1/models"):
+            return Response(200, json={"data": [{"id": "provider/model"}]})
+        if request.method == "POST":
+            return Response(202, json={"id": "batch_restart_1", "status": "validating"})
+        poll_attempts += 1
+        if poll_attempts == 1:
+            raise httpx.ReadTimeout("poll interrupted", request=request)
+        return Response(
+            200,
+            json={
+                "id": "batch_restart_1",
+                "status": "completed",
+                "request_counts": {"total": 1, "completed": 1, "failed": 0},
+                "results": [
+                    {
+                        "custom_id": "modelmirror-certification",
+                        "response": {
+                            "status_code": 200,
+                            "body": {"model": "provider/model"},
+                        },
+                    }
+                ],
+            },
+        )
+
+    transport = MockTransport(handler)
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Restart-safe Batch",
+            kind="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="batch-restart-secret",
+            scopes=["batch"],
+        ),
+    )
+
+    def service_for(repository: SQLiteRouterRepository) -> ProviderWorkloadCertificationService:
+        router_service = ModelRouterService(
+            repository,
+            client_factory=lambda: httpx.AsyncClient(
+                transport=transport, follow_redirects=False, trust_env=False
+            ),
+            egress_policy=ProviderEgressPolicy(
+                resolver=lambda _host, _port: ["8.8.8.8"]
+            ),
+        )
+        return ProviderWorkloadCertificationService(
+            router_service,
+            client_factory=lambda: httpx.AsyncClient(
+                transport=transport, follow_redirects=False, trust_env=False
+            ),
+            batch_poll_interval_seconds=0,
+        )
+
+    payload = ProviderWorkloadCertificationRequest(
+        execution_shape="openrouter_batch_chat",
+        model_id="provider/model",
+        acknowledge_billed_call=True,
+    )
+    first = await service_for(repository).run(
+        connection.id,
+        payload,
+        idempotency_key="restart-safe-batch",
+    )
+    assert first.status == "uncertain"
+    assert first.error_code == "provider_batch_poll_uncertain"
+
+    restarted = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    restarted_service = service_for(restarted)
+    assert await restarted_service.resume_pending_batch_certifications() == 1
+    resumed = next(
+        item
+        for item in restarted_service.list().certifications
+        if item.certification_id == first.certification_id
+    )
+    assert resumed.status == "passed"
+    assert resumed.checks.batch_terminal_verified is True
+    assert sum(request.method == "POST" for request in requests) == 1
+    assert poll_attempts == 2
+    assert restarted.list_provider_batch_jobs("local")[0]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_batch_submission_uncertainty_never_reposts_same_idempotency_key(
+    tmp_path: Path,
+) -> None:
+    requests: list[Request] = []
+
+    def handler(request: Request) -> Response:
+        requests.append(request)
+        if request.url.path.endswith("/api/v1/models"):
+            return Response(200, json={"data": [{"id": "provider/model"}]})
+        raise httpx.ReadTimeout("submission outcome unknown", request=request)
+
+    transport = MockTransport(handler)
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Uncertain OpenRouter Batch",
+            kind="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="batch-uncertain-secret",
+            scopes=["batch"],
+        ),
+    )
+    router_service = ModelRouterService(
+        repository,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+    service = ProviderWorkloadCertificationService(
+        router_service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    )
+    payload = ProviderWorkloadCertificationRequest(
+        execution_shape="openrouter_batch_chat",
+        model_id="provider/model",
+        acknowledge_billed_call=True,
+    )
+    first = await service.run(
+        connection.id,
+        payload,
+        idempotency_key="uncertain-batch-certification",
+    )
+    replay = await service.run(
+        connection.id,
+        payload,
+        idempotency_key="uncertain-batch-certification",
+    )
+    assert first.status == replay.status == "uncertain"
+    assert first.error_code == "provider_batch_submission_uncertain"
+    assert sum(request.method == "POST" for request in requests) == 1
+    jobs = repository.list_provider_batch_jobs("local")
+    assert len(jobs) == 1
+    assert jobs[0]["status"] == "uncertain"
+    assert b"batch-uncertain-secret" not in repository.database_path.read_bytes()
+
+
+def test_r7_local_fallback_policy_is_explicit_and_entry_scoped(
+    tmp_path: Path,
+) -> None:
+    control = ProviderWorkloadControlService(
+        ModelRouterService(SQLiteRouterRepository(tmp_path, master_key=b"x" * 32))
+    )
+    policy = control.update_policy(
+        "rag_query_generate",
+        ProviderWorkloadPolicyUpdate(
+            expected_revision=0,
+            local_fallback_mode="extractive",
+            bindings=[],
+        ),
+    )
+    assert policy.local_fallback_mode == "extractive"
+    assert policy.data_plane_integrated is False
+    with pytest.raises(RouterServiceError) as invalid:
+        control.update_policy(
+            "rag_embedding",
+            ProviderWorkloadPolicyUpdate(
+                expected_revision=0,
+                local_fallback_mode="lexical",
+                bindings=[],
+            ),
+        )
+    assert invalid.value.code == "provider_workload_local_fallback_not_allowed"
+
+
+@pytest.mark.asyncio
 async def test_json_certification_qualifies_exact_binding_and_new_evidence_stales_it(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1078,7 +1876,16 @@ async def test_workload_admin_api_is_session_and_csrf_protected_and_public_redac
         csrf = paired.json()["csrf_token"]
         policies = await client.get("/api/router/workload-control/policies")
         assert policies.status_code == 200
-        assert len(policies.json()["policies"]) == 13
+        assert len(policies.json()["policies"]) == 19
+        r7_policies = {
+            item["entry_id"]: item for item in policies.json()["policies"]
+            if item["entry_id"].startswith("rag_")
+            or item["entry_id"] in {"skill_rerank", "openrouter_batch"}
+        }
+        assert len(r7_policies) == 6
+        assert all(item["data_plane_integrated"] is False for item in r7_policies.values())
+        assert all(item["feature_enabled"] is False for item in r7_policies.values())
+        assert all(item["local_fallback_mode"] == "none" for item in r7_policies.values())
         assert policies.json()["contract_version"] == PROVIDER_WORKLOAD_CONTRACT_VERSION
 
         update = {


### PR DESCRIPTION
## 范围

- 将 Router SQLite 纯加法升级到 v17，加入 Batch 任务、显式本地降级和 Rerank 访问模式。
- 新增 Embedding、Rerank 与 OpenRouter Batch 的安全 Endpoint Resolver、DNS/SSRF 授权、单 IP、无重定向、无代理环境和零重试 Transport。
- 新增 Embedding/Rerank 资格认证及 OpenRouter Batch 幂等提交、GET-only 轮询和重启恢复基础。
- 扩展 Provider scope、Workload Policy/Binding/Receipt 与 Settings 管理入口。
- R7 数据面入口仍未接管，全部 R7 Feature Flag 默认关闭。

## 关键边界

- 不修改 RAG、Skill 或 Batch 现有运行数据面。
- 不改变 `/api/chat`、Catalog 数量、提示词选择器或多模态协议。
- 不保存问题、文档、向量、模型输出、完整上游错误或凭据。
- 不新增生产依赖，不执行真实付费调用。

## 验证

- 后端全量：`4592 passed, 29 skipped`。
- 最新 `origin/main` rebase 后交叉回归：`88 passed`。
- 前端全量：`114 files / 663 tests passed`。
- rebase 后 Settings 专项：`2 files / 12 tests passed`。
- `npm.cmd run typecheck`：通过。
- `npm.cmd run build`：通过，仅保留既有大 chunk 告警。
- Core、独立 newAPI、Overlay Compose `config --quiet`：通过。
- `py_compile`、`git diff --check` 与敏感信息扫描：通过。

## 回滚

- R7 Feature Flag 保持关闭即可继续使用 legacy 路径。
- v17 迁移为加法变更；回退代码时保留新增表、资格和 Batch 状态，旧代码可忽略。
