### PR TITLE
fix: 收口 V20 Harness 协议与恢复边界

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "typecheck": "tsc -b --pretty false",
     "preview": "vite preview --host 0.0.0.0",
     "test": "vitest --configLoader runner",
-    "test:run": "vitest run --configLoader runner",
+    "test:run": "vitest run --configLoader runner --maxWorkers=1 --fileParallelism=false",
     "test:streaming-audio": "node scripts/verify-streaming-audio.mjs"
   },
   "dependencies": {

--- a/docker-compose.coding-worker-v15-claude.yml
+++ b/docker-compose.coding-worker-v15-claude.yml
@@ -2,6 +2,7 @@ services:
   server:
     environment:
       CODING_WORKER_CLAUDE_ENABLED: ${CODING_WORKER_CLAUDE_ENABLED:-false}
+      CODING_WORKER_CLAUDE_SLOT_IDS: slot-b
       CODING_WORKER_MODEL_ROUTES: coding/default,coding/quality
       CODING_WORKER_ROUTE_SLOTS_JSON: '{"coding/default":["slot-a"],"coding/quality":["slot-b"]}'
 
@@ -20,6 +21,7 @@ services:
       CODING_WORKER_ROUTE_ID: coding/quality
       CODING_WORKER_MODEL_ID: ${CODING_WORKER_CLAUDE_MODEL_ID:?set the controlled Claude model id}
       CODING_WORKER_CLAUDE_SECRET_PATH: /run/secrets/modelmirror_claude_api_key
+      CODING_WORKER_CLAUDE_GATEWAY_BASE_URL: ${CODING_WORKER_CLAUDE_GATEWAY_BASE_URL:-}
       CODING_WORKER_PROVIDER_PROXY_URL: http://provider:${CODING_WORKER_CLAUDE_PROXY_TOKEN:?set a random URL-safe Claude proxy token}@coding-worker-claude-egress:8081
     volumes: !override
       - coding_worker_provider_b:/run/modelmirror-coding
@@ -54,7 +56,7 @@ services:
       - /tmp:rw,nosuid,noexec,size=8m,uid=65532,gid=65532,mode=0700
     environment:
       CODING_WORKER_PROVIDER_EGRESS_TOKEN: ${CODING_WORKER_CLAUDE_PROXY_TOKEN:?set a random URL-safe Claude proxy token}
-      CODING_WORKER_PROVIDER_NETWORK_DOMAINS: api.anthropic.com
+      CODING_WORKER_PROVIDER_NETWORK_DOMAINS: ${CODING_WORKER_CLAUDE_EGRESS_DOMAINS:-api.anthropic.com}
       CODING_WORKER_PROVIDER_ALLOW_DOCKER_DESKTOP_DNS_PROXY: ${CODING_WORKER_PROVIDER_ALLOW_DOCKER_DESKTOP_DNS_PROXY:-false}
     restart: unless-stopped
 

--- a/docker-compose.coding-worker-v18-harness.yml
+++ b/docker-compose.coding-worker-v18-harness.yml
@@ -12,6 +12,18 @@ services:
         source: ${CODING_WORKER_HARNESS_V3_FIXTURE_FILE:?set the absolute V18 fixture bundle path}
         target: /harness-v3/fixture-bundle.json
         read_only: true
+      - type: bind
+        source: ${CODING_IMPLEMENTATION_WORKTREE:?set the implementation worktree}/benchmarks/coding-worker-v18/tasks/session-clarify-before-edit/scenario.json
+        target: /harness-v3/tasks/session-clarify-before-edit/scenario.json
+        read_only: true
+      - type: bind
+        source: ${CODING_IMPLEMENTATION_WORKTREE:?set the implementation worktree}/benchmarks/coding-worker-v18/tasks/session-restart-command-reconcile/scenario.json
+        target: /harness-v3/tasks/session-restart-command-reconcile/scenario.json
+        read_only: true
+      - type: bind
+        source: ${CODING_IMPLEMENTATION_WORKTREE:?set the implementation worktree}/benchmarks/coding-worker-v18/tasks/session-steering-compaction/scenario.json
+        target: /harness-v3/tasks/session-steering-compaction/scenario.json
+        read_only: true
 
   coding-worker-provider-a:
     environment:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -915,14 +915,14 @@ CLI 的 `validate`、Fake `smoke`、`report` 和 `certify` 可以在自动门禁
 
 Harbor `0.21.0` 是评测工具，不是 Server 依赖，也不得加入共享产品栈。任务包位于 `benchmarks/coding-worker-v18/`，原生对照固定 OpenCode `1.18.9`。公开任务包不得保存隐藏 checker 正文；发布窗口另行提供仓库外只读绝对目录，并通过 `--sealed-checker-root` 交给 `validate`、`task-gate` 与 `run-round`。CLI 在临时任务副本中注入正文并绑定实际 bundle digest。先用专用 Python 环境安装固定 Harbor，再运行 `compile --write`、`validate` 和确定性任务门禁；不得修改 Server 的生产 requirements。
 
-评测 Server 只有在独立校准环境中才加载 `docker-compose.coding-worker-v18-harness.yml`；默认保持关闭，并且不能与 parity v2 同时启用。宿主变量只提供公开 fixture bundle 的绝对路径，overlay 把它只读挂到固定容器路径：
+评测 Server 只有在独立校准环境中才加载 `docker-compose.coding-worker-v18-harness.yml`；默认保持关闭，并且不能与 parity v2 同时启用。宿主变量提供公开 fixture bundle 的绝对路径，overlay 把它只读挂到固定容器路径：
 
 ```dotenv
 CODING_WORKER_HARNESS_V3_FIXTURE_FILE=C:\absolute\evaluation\fixture-bundle.json
 CODING_WORKER_HARNESS_CONTROLLER_TOKEN=<random-at-least-32-bytes>
 ```
 
-overlay 内固定 `CODING_WORKER_HARNESS_V3_ENABLED=true`、`CODING_WORKER_PARITY_ENABLED=false` 与容器路径 `/harness-v3/fixture-bundle.json`，并清空 V14 overlay 的单一 builtin source root/revision，让 Server 只注册公开的 12 项 fixture。Controller token 只进入评测 Server 与本次 Harbor Worker Agent 环境，不进入 route binding、日志或 Artifact。受控故障接口只在该 profile 可见，只能绑定唯一待批准的 mutate shell operation。overlay 不挂载 solution、公开 verifier 或密封 checker，不能加入共享产品栈。
+overlay 内固定 `CODING_WORKER_HARNESS_V3_ENABLED=true`、`CODING_WORKER_PARITY_ENABLED=false` 与容器路径 `/harness-v3/fixture-bundle.json`。它从 `CODING_IMPLEMENTATION_WORKTREE` 只读挂载三个固定的公开 `scenario.json`，供 Server 按 bundle 中的 `scenario_sha256` 校验冻结审批；不会挂载整个任务目录、`solution/`、`tests/`、公开 verifier 或密封 checker。overlay 同时清空 V14 overlay 的单一 builtin source root/revision，让 Server 只注册公开的 12 项 fixture。Controller token 只进入评测 Server 与本次 Harbor Worker Agent 环境，不进入 route binding、日志或 Artifact。受控故障接口只在该 profile 可见，只能绑定唯一待批准的 mutate shell operation，且不能加入共享产品栈。
 
 Docker Desktop 无法满足 Harbor 标准动态出站控制时，确定性 Oracle/Nop/near-miss 仍只能使用仓库提供的 `StaticNoNetworkDockerEnvironment`；该环境对所有阶段强制 `network_mode:none`。评测专用 `DockerDesktopAllowlistProbeEnvironment` 可让少量明确选择的场景经 exact-host sidecar 做真实模型探测，但 `run-round` 会硬拒绝该适配器，因此结果不是校准证据。探测 overlay 使用显式可路由子网；将其标成 `internal:true` 会在到达 sidecar 前阻断 DNS/egress，真正的边界是任务网络中只允许访问 exact-host sidecar，直连仍拒绝。真实 `run-round` 必须迁移到 Linux、使用 Harbor 标准 Docker environment，并先验证动态 egress preflight。容器化 controller 的仓库和 jobs 参数必须使用 Docker host 看到的真实绝对路径；把 controller 内 `/jobs` 直接交给 Docker API 会导致 verifier 产物对宿主不可见，必须传入 Docker host 可解析的同一绝对路径。
 

--- a/docs/tasks/CODING_WORKER_V20.md
+++ b/docs/tasks/CODING_WORKER_V20.md
@@ -221,3 +221,25 @@ R3 不新增公共 API、数据库或运行协议，不调用额外模型。回�
 离线证据：真实失败形状的回放测试修正前稳定复现 Provider cwd 下 `FileNotFoundError`；修正后 replace 成功/歧义失败两项通过，Broker/Tool Broker/Shell/Session Controls 为 `81 passed`，OpenCode/Claude/Provider RPC/Service 为 `153 passed`，最终精确展开的完整 Coding Worker 套件为 `616 passed, 5 skipped`。兼容 `write_file` 的原始无效参数未被持久化，现有证据不能独立重建该次供应商输入；因此本修复只关闭已证明的 replace 结构性缺口，不将其外推为完整四项烟测通过。
 
 该候选仍为 Experimental，未追加真实模型额度。进入下一次付费验证前仍需迁移到最新主线、重建候选镜像并重跑完整自动门禁；不得通过放宽冻结命令掩盖 Agent 偏离。
+
+### 12.6 R11/R12 定向收口与提交前门禁
+
+本次只收口已证明的 Project Source 并发阻塞、Claude 审批重启和既有生命周期/副作用边界，不恢复四项矩阵。原候选基于 `d4bd6b8d`；实现 Diff 以二进制 patch 固化，SHA-256 为 `3e78fd2341e51e9608894e22a0d01351215498764a9fc63cfbd3ce658596c06b`。该实现被拆为 11 个、每个不超过 5 个文件的逻辑提交后，迁移到最新主线 `cc49136c`；range-diff 全部为 `=`。另以 2 文件测试提交加入脱敏 Claude 审批重启回放，未改变产品行为。
+
+Project Source 的隔离资格探针连续为 `5.129s / 4.960s / 3.231s`；7 个来源均 `available`，四个 exact source 均正确绑定，未复现 `BrokenPipe`。实现仅将独立来源检查放入有界 4-worker executor，并保持清单顺序、精确 revision 和安全错误语义。
+
+经明确授权只执行了一次付费 Claude 任务。任务在审批等待点重启 Provider 后唯一恢复并完成：Evidence `1/1`、operation `10`、未结算 operation `0`、重复副作用 `0`、孤立交互 `0`、公共泄漏 `0`。原始 journal 曾因控制器错误要求 `turn_resumed` 晚于 `capability_changed` 而给出 `post_restart_turn_resume_missing` 假阴性；脱敏回放现在以重启边界为权威，固定验证 `turn_resumed` 与 `capability_changed` 均发生在边界之后，并允许二者的合法投影顺序。该证据只关闭审批重启的已知判断缺口，不代表四项真实矩阵通过。
+
+R12 最终自动门禁：
+
+- Coding Worker 与 Project Source：`625 passed, 5 skipped`。
+- Agent Workspace、Coding Runtime 与 Project Host：`439 passed, 9 skipped`。
+- 后端首次全量因 RAG PDF safety 子进程在 10 秒阈值内未返回而为 `1 failed, 4798 passed, 29 skipped`；该用例在全新无网络容器中精确复跑通过，未修改 RAG 代码或阈值。随后从零再次执行完整后端套件，结果为 `4799 passed, 29 skipped`。
+- 前端：`116 files / 678 tests`，production build 通过；保留既有大 chunk 警告。
+- 主 Worker 与 V20 evaluation Compose 静态展开通过；V18 compile 与 Fake smoke 通过，Fake smoke 仍为 8 条、四类别齐全，摘要 `472b88ae9de93f3816de84bc40d07e7c192ec82c4eca6cb67ef2f56dc60a1df3`。
+- OpenCode、Claude、Project Source、ACP evaluation、Codex evaluation 五个镜像均以 UID/GID `65532:65532` 运行；无网络探针分别确认 OpenCode `1.18.9`、Claude Code `2.1.89`、ACP SDK `0.12.0` 与 Codex CLI `0.149.0`。
+- `git diff --check`、秘密候选和禁止产物扫描通过；所有逻辑提交仍不超过 5 个文件。
+
+生产 Server Dockerfile 仍显式使用 root，这是既有部署偏差，不在本次最小修复边界内；不得以 sidecar 非 root 结论掩盖。客户端锁文件未变化，`npm ci` 仍报告 5 个既有 audit 项，本次不升级依赖或运行 `audit fix`。
+
+交付状态继续为 **Experimental**：完整 OpenCode/Claude 四项真实矩阵仍为零，没有运行 calibration、parity、certification 或 48/288 对照，不使用“现有 OpenCode/Claude 已通过该内核运行”、能力提升、接近或等效表述，也不据此进入 V21。回退仍为关闭 V20/evaluation 开关并恢复上一镜像；已有任务、Workspace、Evidence、operation 与 checkpoint 保留，不降级、不自动重放。

--- a/docs/tasks/CODING_WORKER_V20.md
+++ b/docs/tasks/CODING_WORKER_V20.md
@@ -118,3 +118,106 @@ R2 不启用 ACP/Codex transport，也不调用真实模型。范围只覆盖生
 - Adapter 与 `ProviderSidecarClientPool` 均以 `task_id + private session_id` 绑定会话，防止两个隔离槽使用相同私有 ID 时发生覆盖或串路由。
 
 R2 的结论只允许表述为“中立 HarnessDriver 边界完成收口”。真实 OpenCode/Claude 任务、ACP/Codex 实时 transport、校准、认证和任何等效表述仍不属于本轮。
+
+## 12. R3 真实烟测复盘与收口决定
+
+R3 在自动门禁通过后尝试四项真实任务，但按停止条件未形成一次完整矩阵。后续不再通过增加付费重试或针对单次模型行为继续追加补丁。
+
+### 12.1 冻结事实
+
+| 指标 | 结果 |
+| --- | ---: |
+| Smoke Journal | 14 |
+| 已创建任务 | 41 |
+| 完成 | 2 |
+| 失败 | 11 |
+| budget_limited | 1 |
+| fail-closed 后取消 | 27 |
+| 计划但未创建 | 15 |
+| 完整四项矩阵 | 0 |
+| Task 4 实际创建 | 0 |
+
+Controller 先并行创建 Task 1/3，再创建排队的 Task 2；只有前三项全部完成后才创建 Task 4。因此该矩阵适合作为最终门禁，不适合作为故障定位工具。任一前置失败都会取消其余任务并遮蔽 Task 4 覆盖。
+
+### 12.2 十四次运行台账
+
+planned 表示未创建，不消耗该任务额度。Schema v1 的 cleanup_success 只证明清理成功；它覆盖了主失败，不能作为运行成功或精确归因证据。
+
+| Journal | Schema | Task 1 / 2 / 3 / 4 | 可证明主结论 |
+| --- | --- | --- | --- |
+| final-01 | v1 | cancelled / cancelled / failed / planned | 主失败不可恢复归因 |
+| final-02 | v1 | failed / cancelled / cancelled / planned | 主失败不可恢复归因 |
+| openrouter-01 | v1 | failed / planned / failed / planned | 主失败不可恢复归因 |
+| openrouter-02 | v1 | failed / cancelled / failed / planned | 主失败不可恢复归因 |
+| openrouter-03 | v1 | cancelled / cancelled / cancelled / planned | 主失败不可恢复归因 |
+| openrouter-04 | v1 | cancelled / cancelled / cancelled / planned | 主失败不可恢复归因 |
+| openrouter-05 | v1 | completed / failed / cancelled / planned | 仅 Task 1 单项完成 |
+| openrouter-06 | v1 | cancelled / failed / failed / planned | 主失败不可恢复归因 |
+| r3-01 | v2 | budget_limited / cancelled / completed / planned | OpenCode 流停滞；仅 Claude Python 完成 |
+| streamfix-01 | v2 | cancelled / cancelled / cancelled / planned | unexpected_approval_intent |
+| cleanupfix-01 | v2 | cancelled / cancelled / cancelled / planned | unexpected_approval_intent |
+| racefix-01 | v2 | failed / cancelled / cancelled / planned | Driver transport failure 与越界审批并存 |
+| cancelracefix-01 | v2 | failed / cancelled / cancelled / planned | 隔离栈短占位 Key，运行无效 |
+| cancelracefix-02 | v2 | cancelled / cancelled / cancelled / planned | 无必要的依赖安装 Shell 意图 |
+
+最后一次 Task 1 的冻结 python -m pytest -q 已实际运行并得到 1 failed, 2 passed，证明 pytest 与异步插件可用；随后请求 pip install pytest-asyncio 属于 Agent 策略偏离，不是夹具缺依赖。
+
+### 12.3 归因与保留范围
+
+保留的产品不变量修复：
+
+- Provider stream 由精确 session/turn 所有，interrupt/close 后确定回收；迟到清理不能 fence 新 turn。
+- stall、认证、协议、Broker 与 Executor 错误使用稳定中立分类，不再全部折叠为通用失败。
+- 公共事件使用供应商中立调用 ID，不暴露供应商原始工具 ID。
+- 取消先持久化终态，再中止 Provider；未决审批与剩余租约原子结算。
+- 外层取消必须回收同 tick 完成的 Driver 异常，禁止 cancelled -> failed 和未观察异常。
+- mutate 副作用结果无法证明时保持 operation_result_unknown，只允许精确 reconcile。
+
+对应离线回归包括：
+
+- test_v20_driver_replaces_supplier_tool_ids_before_public_events
+- test_stale_stream_cleanup_cannot_interrupt_the_next_harness_turn
+- test_harness_interrupt_deterministically_closes_nested_provider_stream
+- test_v20_stalled_harness_stream_is_transport_failure_not_budget
+- test_user_cancel_wins_over_concurrent_provider_abort_frame
+- test_cancel_atomically_settles_pending_approval_and_revokes_lease
+- test_outer_cancellation_retrieves_driver_exception_that_finished_same_tick
+- test_mcp_rejects_empty_shell_arguments_before_rpc
+- test_closing_session_quiesces_sidecar_stream_before_reusing_slot
+
+不作为根因修复保留的内容：
+
+- 不依靠提示词禁止 Shell 浏览、搜索或安装依赖。
+- 不依靠包管理器字符串正则证明 Shell 策略完备。
+- 不为某次采样中的新命令继续追加命令特例。
+
+现有相对路径、宿主/private runtime 路径拒绝仍属于 Broker 安全边界。评测场景的冻结命令白名单必须在审批创建前由 EvaluationAdapter/Broker 共同执行；在该能力完成前，外置 Controller 的事后 fail-closed 只能算评测保护，不能算生产策略证明。
+
+### 12.4 交付状态与重新进入条件
+
+V20 当前保持 Experimental，不得使用本任务卡第 6 节的最终结论，不得据此进入 V21。当前只允许表述：
+
+> Harness Protocol Kernel 的若干真实生命周期与副作用不变量已修复；标准 Driver 的完整生产闭环尚未通过。
+
+零额度收口中，空参数 fail-closed、冻结命令匹配、Provider RPC/Runtime 专项和一次完整 Coding Worker 套件通过；完整套件此前仍曾在压力下复现取消后槽位复用失败。单次 `611 passed / 5 skipped` 不能覆盖该历史失败，因此不作为稳定性封板证据。
+
+sidecar 现会在 session close 前精确回收该 session 的服务端 message handler；这修复了“Provider 要求流先静默”时的可证问题，但不宣称已解释或消除全部压力竞态。
+
+重新进入真实验证前必须同时满足：
+
+1. 用已捕获的真实失败帧完成无模型离线 replay，覆盖空工具参数、断流、迟到事件、取消竞态和越界命令。
+2. 每个 Driver 先独立、顺序完成资格探针；最终四项矩阵只用于封板，不再承担调试。
+3. 冻结命令策略在审批创建前生效，而不是只存在于提示词和外置 Controller。
+4. 候选迁移到最新主线并重新执行受影响自动门禁。
+
+R3 不新增公共 API、数据库或运行协议，不调用额外模型。回退方式仍为关闭 V20 开关并恢复上一镜像；已有任务、Workspace、Evidence、operation 和 checkpoint 不删除、不降级、不自动重放。
+
+### 12.5 R7 脱敏回放与 replace 边界修正
+
+授权冒烟在 Task 3 请求非冻结 Shell 时由外置 Controller 以 `unexpected_approval_intent` 停止；Task 4 未创建，完整矩阵仍为零。保留 Store 的无网络只读回放证明：冻结 pytest 与只读文件工具均形成持久 operation，但两次 `apply_changeset` 和一次兼容 `write_file` 失败均发生在权威 operation 创建之前。
+
+可证根因位于 `replace` 适配边界：Claude Provider 明确不挂载 Workspace，MCP adapter 却按 Provider 私有 state cwd 读取目标文件并把 replace 展开为完整 write。因此任何 replace 都可能在到达 Tool Broker 前以文件不存在失败。修正后，MCP 只转发已绑定 preimage 的 replace 意图，由 `ChangesetEngine` 在权威 Workspace 内校验路径、文件摘要、UTF-8 与唯一片段，再以既有原子 changeset 事务发布；歧义片段保持全旧并持久化 `tool_input_invalid`。未扩大 Shell 白名单、未新增工具、公共 API、数据库或运行协议。
+
+离线证据：真实失败形状的回放测试修正前稳定复现 Provider cwd 下 `FileNotFoundError`；修正后 replace 成功/歧义失败两项通过，Broker/Tool Broker/Shell/Session Controls 为 `81 passed`，OpenCode/Claude/Provider RPC/Service 为 `153 passed`，最终精确展开的完整 Coding Worker 套件为 `616 passed, 5 skipped`。兼容 `write_file` 的原始无效参数未被持久化，现有证据不能独立重建该次供应商输入；因此本修复只关闭已证明的 replace 结构性缺口，不将其外推为完整四项烟测通过。
+
+该候选仍为 Experimental，未追加真实模型额度。进入下一次付费验证前仍需迁移到最新主线、重建候选镜像并重跑完整自动门禁；不得通过放宽冻结命令掩盖 Agent 偏离。

--- a/docs/tasks/CODING_WORKER_V20.md
+++ b/docs/tasks/CODING_WORKER_V20.md
@@ -224,7 +224,7 @@ R3 不新增公共 API、数据库或运行协议，不调用额外模型。回�
 
 ### 12.6 R11/R12 定向收口与提交前门禁
 
-本次只收口已证明的 Project Source 并发阻塞、Claude 审批重启和既有生命周期/副作用边界，不恢复四项矩阵。原候选基于 `d4bd6b8d`；实现 Diff 以二进制 patch 固化，SHA-256 为 `3e78fd2341e51e9608894e22a0d01351215498764a9fc63cfbd3ce658596c06b`。该实现被拆为 11 个、每个不超过 5 个文件的逻辑提交后，迁移到最新主线 `cc49136c`；range-diff 全部为 `=`。另以 2 文件测试提交加入脱敏 Claude 审批重启回放，未改变产品行为。
+本次只收口已证明的 Project Source 并发阻塞、Claude 审批重启和既有生命周期/副作用边界，不恢复四项矩阵。原候选基于 `d4bd6b8d`；实现 Diff 以二进制 patch 固化，SHA-256 为 `3e78fd2341e51e9608894e22a0d01351215498764a9fc63cfbd3ce658596c06b`。该实现被拆为 11 个、每个不超过 5 个文件的逻辑提交后，先迁移到主线 `cc49136c`；提交前因主线继续前进，再重放到 `8c066b79`，重放时 14 个候选提交的 range-diff 全部为 `=`。最终提交随后只补入该基线上的验证计数与竞态收口说明。另以 2 文件测试提交加入脱敏 Claude 审批重启回放，未改变产品行为。
 
 Project Source 的隔离资格探针连续为 `5.129s / 4.960s / 3.231s`；7 个来源均 `available`，四个 exact source 均正确绑定，未复现 `BrokenPipe`。实现仅将独立来源检查放入有界 4-worker executor，并保持清单顺序、精确 revision 和安全错误语义。
 
@@ -232,10 +232,11 @@ Project Source 的隔离资格探针连续为 `5.129s / 4.960s / 3.231s`；7 个
 
 R12 最终自动门禁：
 
-- Coding Worker 与 Project Source：`625 passed, 5 skipped`。
+- PR 首轮 CI 在 `test_disabled_slot_never_runs_mixed_route_and_parks_bound_history` 暴露真实竞态：取消返回时 Driver 与 RPC client 已清除 session，但 Provider sidecar 尚未完成 close，调度器提前复用槽位，下一任务可能以 `harness_protocol_invalid` 失败。修复后普通取消会在 exact Harness close 结算后才释放 runner/槽位；Server shutdown 仍保留原有宽限与再次取消路径。修复前定向循环在第 6 次复现，修复后连续 `30/30` 通过，并新增 sidecar active task/session/message 全部清空的回归断言。
+- Runtime/Service/Provider RPC 受影响套件：`131 passed`；Coding Worker 与 Project Source：`625 passed, 5 skipped`。
 - Agent Workspace、Coding Runtime 与 Project Host：`439 passed, 9 skipped`。
-- 后端首次全量因 RAG PDF safety 子进程在 10 秒阈值内未返回而为 `1 failed, 4798 passed, 29 skipped`；该用例在全新无网络容器中精确复跑通过，未修改 RAG 代码或阈值。随后从零再次执行完整后端套件，结果为 `4799 passed, 29 skipped`。
-- 前端：`116 files / 678 tests`，production build 通过；保留既有大 chunk 警告。
+- 后端首次全量因 RAG PDF safety 子进程在 10 秒阈值内未返回而为 `1 failed, 4798 passed, 29 skipped`；该用例在全新无网络容器中精确复跑通过，未修改 RAG 代码或阈值。槽位修复后的完整后端套件曾出现一次输出丢失、无法归因的 52% 单点失败，因此不记为绿；随后以 fail-fast 从零完整执行为 `4799 passed, 29 skipped`。52% 收集区间位于模型路由/多模态测试，两个时间阈值用例另做 10 轮定向复跑，共 `20/20` 通过，未修改该模块代码或阈值。重放到最终主线后再从零执行完整后端套件，结果为 `4806 passed, 29 skipped`。
+- 最终主线前端：`119 files / 703 tests`，production build 通过；保留既有大 chunk 警告。
 - 主 Worker 与 V20 evaluation Compose 静态展开通过；V18 compile 与 Fake smoke 通过，Fake smoke 仍为 8 条、四类别齐全，摘要 `472b88ae9de93f3816de84bc40d07e7c192ec82c4eca6cb67ef2f56dc60a1df3`。
 - OpenCode、Claude、Project Source、ACP evaluation、Codex evaluation 五个镜像均以 UID/GID `65532:65532` 运行；无网络探针分别确认 OpenCode `1.18.9`、Claude Code `2.1.89`、ACP SDK `0.12.0` 与 Codex CLI `0.149.0`。
 - `git diff --check`、秘密候选和禁止产物扫描通过；所有逻辑提交仍不超过 5 个文件。

--- a/scripts/coding_worker_harbor_agent.py
+++ b/scripts/coding_worker_harbor_agent.py
@@ -1149,6 +1149,28 @@ class ModelMirrorWorkerAgent(BaseAgent):  # type: ignore[misc]
         }
         if reason in expected_states or reason.startswith("turn_parked_"):
             return None
+        if reason.startswith("harness_transport_"):
+            return "provider_transport"
+        if reason.startswith(
+            (
+                "harness_protocol_",
+                "harness_authentication_",
+                "harness_rate_",
+            )
+        ):
+            return "provider_protocol"
+        if reason.startswith("harness_policy_"):
+            return "policy"
+        if reason.startswith("harness_budget_"):
+            return "budget"
+        if reason in {
+            "harness_interrupted",
+            "harness_driver_internal",
+            "control_plane_internal_error",
+            "tool_broker_internal_error",
+            "operation_result_unknown",
+        }:
+            return "harness"
         mapping = (
             (("source",), "source_admission"),
             (("slot", "scheduler", "route_unavailable", "model_route"), "scheduler"),
@@ -1163,7 +1185,7 @@ class ModelMirrorWorkerAgent(BaseAgent):  # type: ignore[misc]
             (("acceptance", "evidence"), "visible_acceptance"),
             (("policy", "forbidden"), "policy"),
             (("budget",), "budget"),
-            (("operation_result_unknown", "tool_"), "tool_validation"),
+            (("tool_",), "tool_validation"),
             (("service_shutdown", "runner_cancelled"), "harness"),
         )
         for markers, stage in mapping:

--- a/server/coding_project_source/server.py
+++ b/server/coding_project_source/server.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Sequence
@@ -42,6 +43,7 @@ from server.coding_runtime.host_snapshot import (
 
 MAX_SOURCE_FRAME_BYTES = 64 * 1024
 SNAPSHOT_BUILD_TIMEOUT_SECONDS = 60.0
+PROJECT_LIST_MAX_WORKERS = 4
 SOURCE_SOCKET_PATH = Path(
     os.getenv(
         "CODING_PROJECT_SOURCE_SOCKET_PATH",
@@ -143,10 +145,17 @@ class ProjectSnapshotBroker:
             entries = load_project_manifest(self._projects_root)
         except ProjectCatalogError:
             entries = ()
-        return tuple(
-            inspect_project(self._projects_root, entry).to_public_dict()
-            for entry in entries
-        )
+        if not entries:
+            return ()
+
+        def inspect(entry: ProjectManifestEntry) -> dict[str, Any]:
+            return inspect_project(self._projects_root, entry).to_public_dict()
+
+        with ThreadPoolExecutor(
+            max_workers=min(PROJECT_LIST_MAX_WORKERS, len(entries)),
+            thread_name_prefix="project-catalog",
+        ) as executor:
+            return tuple(executor.map(inspect, entries))
 
     def import_uploaded(
         self,

--- a/server/coding_worker/adapters.py
+++ b/server/coding_worker/adapters.py
@@ -41,12 +41,14 @@ from .harness_contracts import (
     HarnessOpenRequest,
     HarnessSession,
 )
-from .harness_driver import ProviderV4HarnessTranslator
+from .harness_driver import HarnessDriverProtocolError, ProviderV4HarnessTranslator
 from .harness_protocol import HarnessBinding, HarnessDescriptorObservation
 from .provider import (
     CodingAgentProvider,
     ProviderCapabilities,
     ProviderCheckpoint,
+    ProviderEvent,
+    ProviderEventKind,
     ProviderOpenRequest,
     ProviderSession,
 )
@@ -121,10 +123,42 @@ class LegacyHarnessDriver:
             tuple[str, str], ProviderV4HarnessTranslator
         ] = {}
         self._active_turns: dict[tuple[str, str], str] = {}
+        self._provider_streams: dict[
+            tuple[str, str, str], AsyncIterator[ProviderEvent]
+        ] = {}
 
     @staticmethod
     def _session_key(session: HarnessSession | ProviderSession) -> tuple[str, str]:
         return session.task_id, session.session_id
+
+    @staticmethod
+    def _public_v20_event(
+        event: ProviderEvent,
+        *,
+        binding: HarnessBinding,
+        turn_id: str,
+    ) -> ProviderEvent:
+        """Replace supplier-local tool ids before an event reaches persistence.
+
+        Provider-v4 needs the original id inside its private stream to match a
+        tool result to its start frame.  The public ledger only needs a stable
+        correlation id, so derive one from the frozen task binding and turn.
+        """
+
+        if event.kind not in {
+            ProviderEventKind.TOOL_STARTED,
+            ProviderEventKind.TOOL_COMPLETED,
+        }:
+            return event
+        data = dict(event.data)
+        raw_operation_id = str(data["operation_id"])
+        digest = hashlib.sha256(
+            "\0".join(
+                (binding.binding_sha256, turn_id, raw_operation_id)
+            ).encode("utf-8")
+        ).hexdigest()
+        data["operation_id"] = f"harness_call_{digest[:32]}"
+        return event.model_copy(update={"data": data})
 
     @staticmethod
     def _provider_request(request: HarnessOpenRequest) -> ProviderOpenRequest:
@@ -154,6 +188,74 @@ class LegacyHarnessDriver:
             )
         return provider_session
 
+    @staticmethod
+    def _v20_boundary_error(exc: Exception) -> CodingSubstrateError:
+        code = getattr(exc, "code", None)
+        if code in {
+            "harness_transport_unavailable",
+            "harness_protocol_invalid",
+            "harness_driver_internal",
+            "harness_authentication_failed",
+            "harness_rate_limited",
+            "harness_policy_rejected",
+            "harness_budget_exhausted",
+            "harness_interrupted",
+        }:
+            return CodingSubstrateError(
+                "Harness request failed.", code=str(code), status=503
+            )
+        if isinstance(exc, (OSError, TimeoutError)) or code in {
+            "provider_unavailable",
+            "provider_offline",
+            "provider_stream_ended",
+            "provider_transport_unavailable",
+        }:
+            return CodingSubstrateError(
+                "Harness transport is unavailable.",
+                code="harness_transport_unavailable",
+                status=503,
+            )
+        if code in {
+            "provider_unauthorized",
+            "provider_credential_unavailable",
+        }:
+            return CodingSubstrateError(
+                "Harness authentication failed.",
+                code="harness_authentication_failed",
+                status=503,
+            )
+        if isinstance(exc, (HarnessDriverProtocolError, ValueError)) or code in {
+            "provider_invalid_response",
+            "provider_response_too_large",
+            "provider_request_too_large",
+            "provider_request_invalid",
+            "provider_endpoint_invalid",
+            "provider_capability_mismatch",
+            "provider_controller_stale",
+            "provider_session_busy",
+            "provider_slot_busy",
+            "provider_version_mismatch",
+            "session_not_found",
+            "checkpoint_invalid",
+            "harness_session_unavailable",
+        }:
+            return CodingSubstrateError(
+                "Harness protocol response is invalid.",
+                code="harness_protocol_invalid",
+                status=502,
+            )
+        return CodingSubstrateError(
+            "Harness driver failed internally.",
+            code="harness_driver_internal",
+            status=502,
+        )
+
+    @classmethod
+    def _raise_boundary(cls, exc: Exception, *, v20: bool) -> None:
+        if v20:
+            raise cls._v20_boundary_error(exc) from exc
+        raise exc
+
     def _bind(
         self,
         session: ProviderSession,
@@ -172,9 +274,13 @@ class LegacyHarnessDriver:
         *,
         binding: HarnessBinding | None = None,
     ) -> HarnessSession:
-        session = await self._provider.open(self._provider_request(request))
-        self._bind(session, binding)
-        return self._harness_session(session)
+        try:
+            session = await self._provider.open(self._provider_request(request))
+            self._bind(session, binding)
+            return self._harness_session(session)
+        except Exception as exc:
+            self._raise_boundary(exc, v20=binding is not None)
+            raise AssertionError("unreachable")
 
     def message(
         self,
@@ -188,20 +294,87 @@ class LegacyHarnessDriver:
         translator = self._translators.get(key)
 
         async def stream() -> AsyncIterator[HarnessEvent]:
-            if translator is not None:
-                translator.start_turn(turn_id)
-                self._active_turns[key] = turn_id
+            failed = False
+            finished = False
+            provider_stream = self._provider.message(provider_session, text).__aiter__()
+            stream_key = (*key, turn_id)
+            self._provider_streams[stream_key] = provider_stream
             try:
-                async for event in self._provider.message(provider_session, text):
+                if translator is not None:
+                    translator.start_turn(turn_id)
+                    self._active_turns[key] = turn_id
+                async for event in provider_stream:
                     if translator is not None:
                         translator.accept(event, turn_id=turn_id)
+                        event = self._public_v20_event(
+                            event,
+                            binding=translator.session.binding,
+                            turn_id=turn_id,
+                        )
+                    if event.kind in {
+                        ProviderEventKind.TURN_COMPLETED,
+                        ProviderEventKind.CANCELLED,
+                        ProviderEventKind.FAILED,
+                    }:
+                        finished = True
                     yield HarnessEvent.model_validate(event.model_dump(mode="json"))
+                finished = True
+            except Exception as exc:
+                failed = True
+                finished = True
+                self._raise_boundary(exc, v20=translator is not None)
             finally:
-                active_turn = self._active_turns.pop(key, None)
-                if translator is not None and active_turn is not None:
-                    translator.interrupt_turn(turn_id=active_turn)
+                owned_stream = self._provider_streams.get(stream_key)
+                if (
+                    (finished or translator is None)
+                    and owned_stream is provider_stream
+                ):
+                    try:
+                        await self._close_provider_stream(key, turn_id=turn_id)
+                    except Exception as exc:
+                        if not failed:
+                            self._raise_boundary(exc, v20=translator is not None)
+                # A completed stream can be finalized after its successor has
+                # already started.  Only the stream that still owns this exact
+                # turn may clear or interrupt it; otherwise stale cleanup would
+                # fence the newer turn as a protocol violation.
+                if (
+                    finished
+                    and translator is not None
+                    and self._active_turns.get(key) == turn_id
+                ):
+                    self._active_turns.pop(key, None)
+                    try:
+                        translator.interrupt_turn(turn_id=turn_id)
+                    except Exception as exc:
+                        if not failed:
+                            self._raise_boundary(exc, v20=True)
 
         return stream()
+
+    async def _close_provider_stream(
+        self, key: tuple[str, str], *, turn_id: str | None = None
+    ) -> None:
+        stream_keys = (
+            [(*key, turn_id)]
+            if turn_id is not None
+            else [item for item in tuple(self._provider_streams) if item[:2] == key]
+        )
+        failure: Exception | None = None
+        for stream_key in stream_keys:
+            current = self._provider_streams.pop(stream_key, None)
+            if current is None:
+                continue
+            close = getattr(current, "aclose", None)
+            if close is None:
+                continue
+            try:
+                await close()
+            except Exception as exc:
+                if failure is None:
+                    failure = exc
+        if failure is not None:
+            raise failure
 
     async def steer(self, session: HarnessSession, text: str) -> bool:
         # Provider v4 queues steering through the control plane at a durable
@@ -209,23 +382,60 @@ class LegacyHarnessDriver:
         return False
 
     async def cancel(self, session: HarnessSession) -> bool:
-        return await self._provider.cancel(self._require_provider_session(session))
+        provider_session = self._require_provider_session(session)
+        key = self._session_key(session)
+        v20 = key in self._translators
+        try:
+            # ``cancel`` fences the whole session but does not own the task
+            # currently awaiting the nested provider iterator.  The control
+            # plane cancels that reader next and ``close`` performs the final
+            # deterministic stream cleanup.  Calling ``aclose`` here races
+            # with the in-flight ``anext`` and can raise ``async generator is
+            # already running`` before the task is fenced.
+            return await self._provider.cancel(provider_session)
+        except Exception as exc:
+            self._raise_boundary(exc, v20=v20)
+            raise AssertionError("unreachable")
 
     async def interrupt_turn(self, session: HarnessSession) -> bool:
         provider_session = self._require_provider_session(session)
-        interrupted = await self._provider.interrupt_turn(provider_session)
         key = self._session_key(session)
-        active_turn = self._active_turns.pop(key, None)
         translator = self._translators.get(key)
+        failure: Exception | None = None
+        interrupted = False
+        try:
+            interrupted = await self._provider.interrupt_turn(provider_session)
+        except Exception as exc:
+            failure = exc
+        try:
+            await self._close_provider_stream(key)
+        except Exception as exc:
+            if failure is None:
+                failure = exc
+        active_turn = self._active_turns.pop(key, None)
         if translator is not None and active_turn is not None:
-            translator.interrupt_turn(turn_id=active_turn)
+            try:
+                translator.interrupt_turn(turn_id=active_turn)
+            except Exception as exc:
+                if failure is None:
+                    failure = exc
+        if failure is not None:
+            self._raise_boundary(failure, v20=translator is not None)
+            raise AssertionError("unreachable")
         return interrupted
 
     async def checkpoint(self, session: HarnessSession) -> HarnessCheckpoint:
-        checkpoint = await self._provider.checkpoint(
-            self._require_provider_session(session)
-        )
-        return HarnessCheckpoint.model_validate(checkpoint.model_dump(mode="json"))
+        key = self._session_key(session)
+        try:
+            checkpoint = await self._provider.checkpoint(
+                self._require_provider_session(session)
+            )
+            return HarnessCheckpoint.model_validate(
+                checkpoint.model_dump(mode="json")
+            )
+        except Exception as exc:
+            self._raise_boundary(exc, v20=key in self._translators)
+            raise AssertionError("unreachable")
 
     async def restore(
         self,
@@ -234,23 +444,45 @@ class LegacyHarnessDriver:
         *,
         binding: HarnessBinding | None = None,
     ) -> HarnessSession:
-        session = await self._provider.restore(
-            self._provider_request(request), self._provider_checkpoint(checkpoint)
-        )
-        self._bind(session, binding)
-        return self._harness_session(session)
+        try:
+            session = await self._provider.restore(
+                self._provider_request(request), self._provider_checkpoint(checkpoint)
+            )
+            self._bind(session, binding)
+            return self._harness_session(session)
+        except Exception as exc:
+            self._raise_boundary(exc, v20=binding is not None)
+            raise AssertionError("unreachable")
 
     async def close(self, session: HarnessSession) -> None:
         provider_session = self._require_provider_session(session)
+        key = self._session_key(session)
+        translator = self._translators.get(key)
+        failure: Exception | None = None
+        try:
+            await self._close_provider_stream(key)
+        except Exception as exc:
+            failure = exc
         try:
             await self._provider.close(provider_session)
+        except Exception as exc:
+            if failure is None:
+                failure = exc
         finally:
-            key = self._session_key(session)
             self._active_turns.pop(key, None)
-            translator = self._translators.pop(key, None)
+            for stream_key in tuple(self._provider_streams):
+                if stream_key[:2] == key:
+                    self._provider_streams.pop(stream_key, None)
+            self._translators.pop(key, None)
             if translator is not None:
-                translator.close()
+                try:
+                    translator.close()
+                except Exception as exc:
+                    if failure is None:
+                        failure = exc
             self._sessions.pop(key, None)
+        if failure is not None:
+            self._raise_boundary(failure, v20=translator is not None)
 
 
 class LegacyExecutionBackend:

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -53,6 +53,8 @@ from .ports import (
 from .runtime import (
     CodingWorkerRuntime,
     build_runtime_from_environment,
+    configured_model_route_catalog_from_environment,
+    configured_model_routes_from_environment,
     record_coding_substrate_unavailability,
 )
 
@@ -1283,15 +1285,11 @@ async def _fetch_preview(url: str) -> httpx.Response:
 
 
 def _configured_model_routes() -> list[str]:
-    return sorted({
-        value.strip()
-        for value in os.getenv("CODING_WORKER_MODEL_ROUTES", "coding/default").split(",")
-        if value.strip()
-    })
+    return list(configured_model_routes_from_environment())
 
 
 def _validate_model_route(model_route: str) -> None:
-    configured = set(_configured_model_routes())
+    configured = set(configured_model_route_catalog_from_environment())
     if model_route not in configured:
         raise HTTPException(
             status_code=400,

--- a/server/coding_worker/broker_mcp.py
+++ b/server/coding_worker/broker_mcp.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import hashlib
 import os
 from pathlib import Path
-from pathlib import PurePosixPath
 import re
-import stat
 import uuid
 from typing import Annotated, Any, Literal
 
@@ -77,62 +75,6 @@ BrokerChange = Annotated[
     | BrokerReplaceChange,
     Field(discriminator="kind"),
 ]
-
-
-def _replace_change_as_write(
-    change: BrokerReplaceChange, *, workspace: Path | None = None
-) -> dict[str, Any]:
-    """Resolve a unique replace inside the trusted adapter.
-
-    The model supplies the exact tree and file preimage bindings. This adapter
-    reads only the current task workspace and converts the focused replacement
-    into the private write contract; the Broker still performs the authoritative
-    tree/preimage CAS before publishing the batch.
-    """
-    relative = PurePosixPath(change.path)
-    if (
-        relative.is_absolute()
-        or relative.as_posix() != change.path
-        or any(part in {"", ".", ".."} for part in relative.parts)
-        or relative.parts[0] == ".git"
-        or "\\" in change.path
-        or "\x00" in change.path
-    ):
-        raise ValueError("replace path must be a canonical workspace-relative path")
-    root = (workspace or Path.cwd()).resolve(strict=True)
-    lexical = root.joinpath(*relative.parts)
-    current = root
-    for part in relative.parts:
-        current = current / part
-        metadata = current.lstat()
-        if stat.S_ISLNK(metadata.st_mode):
-            raise ValueError("replace path cannot traverse a symbolic link")
-    candidate = lexical.resolve(strict=True)
-    try:
-        candidate.relative_to(root)
-    except ValueError as exc:
-        raise ValueError("replace path escapes the task workspace") from exc
-    metadata = candidate.stat()
-    if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > 32 * 1024 * 1024:
-        raise ValueError("replace target must be a bounded regular file")
-    raw = candidate.read_bytes()
-    if hashlib.sha256(raw).hexdigest() != change.expected_sha256:
-        raise ValueError("replace target no longer matches expected_sha256")
-    try:
-        text = raw.decode("utf-8")
-    except UnicodeDecodeError as exc:
-        raise ValueError("replace target must be UTF-8 text") from exc
-    if text.count(change.old_text) != 1:
-        raise ValueError("old_text must occur exactly once")
-    updated = text.replace(change.old_text, change.new_text, 1)
-    return {
-        "kind": "write",
-        "path": change.path,
-        "expected_sha256": change.expected_sha256,
-        "expected_absent": False,
-        "content": updated,
-        "content_sha256": hashlib.sha256(updated.encode("utf-8")).hexdigest(),
-    }
 
 
 def _workspace_relative_shell_script(
@@ -315,9 +257,6 @@ def build_server(client: BrokerRPCClient) -> FastMCP:
         """Atomically publish a preimage-bound write, replace, patch, move, or delete batch."""
         encoded_changes: list[dict[str, Any]] = []
         for change in changes:
-            if isinstance(change, BrokerReplaceChange):
-                encoded_changes.append(_replace_change_as_write(change))
-                continue
             encoded = change.model_dump(mode="json", exclude_none=True)
             if isinstance(change, BrokerWriteChange):
                 encoded["content_sha256"] = hashlib.sha256(

--- a/server/coding_worker/changeset.py
+++ b/server/coding_worker/changeset.py
@@ -73,8 +73,16 @@ class _PatchChange(StrictModel):
     patch_sha256: str = Field(pattern=_DIGEST)
 
 
+class _ReplaceChange(StrictModel):
+    kind: Literal["replace"]
+    path: str = Field(min_length=1, max_length=1024)
+    expected_sha256: str = Field(pattern=_DIGEST)
+    old_text: str = Field(min_length=1, max_length=MAX_CHANGESET_BYTES)
+    new_text: str = Field(max_length=MAX_CHANGESET_BYTES)
+
+
 _Change = Annotated[
-    _WriteChange | _DeleteChange | _MoveChange | _PatchChange,
+    _WriteChange | _DeleteChange | _MoveChange | _PatchChange | _ReplaceChange,
     Field(discriminator="kind"),
 ]
 _CHANGE_ADAPTER = TypeAdapter(tuple[_Change, ...])
@@ -528,7 +536,7 @@ class ChangesetEngine:
                         destination=destination,
                     )
                 )
-            else:
+            elif isinstance(change, _PatchChange):
                 existing = self._read_regular(target, required=True)
                 assert existing is not None
                 self._require_digest(existing[0], change.expected_sha256)
@@ -538,6 +546,37 @@ class ChangesetEngine:
                     content = apply_unified_patch(path, existing[0], change.patch)
                 except UnifiedPatchError as exc:
                     raise ChangesetError(str(exc), code=exc.code) from exc
+                digest = hashlib.sha256(content).hexdigest()
+                desired_content[path] = (content, existing[1])
+                entries.append(
+                    self._entry(
+                        workspace_id,
+                        operation_id,
+                        path,
+                        ChangeKind.MODIFY,
+                        change.expected_sha256,
+                        digest,
+                    )
+                )
+            else:
+                existing = self._read_regular(target, required=True)
+                assert existing is not None
+                self._require_digest(existing[0], change.expected_sha256)
+                try:
+                    text = existing[0].decode("utf-8")
+                except UnicodeDecodeError as exc:
+                    raise ChangesetError(
+                        "Replace target must be UTF-8 text.",
+                        code="tool_input_invalid",
+                    ) from exc
+                if text.count(change.old_text) != 1:
+                    raise ChangesetError(
+                        "Replace preimage must occur exactly once.",
+                        code="tool_input_invalid",
+                    )
+                content = text.replace(change.old_text, change.new_text, 1).encode(
+                    "utf-8"
+                )
                 digest = hashlib.sha256(content).hexdigest()
                 desired_content[path] = (content, existing[1])
                 entries.append(

--- a/server/coding_worker/claude_provider.py
+++ b/server/coding_worker/claude_provider.py
@@ -13,8 +13,9 @@ from collections.abc import AsyncIterator, Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from .contracts import StrictModel
 from .harness_protocol import (
@@ -94,6 +95,26 @@ class ClaudeCodeRoute(StrictModel):
     route_id: str
     model_id: str = Field(min_length=1, max_length=128)
     max_budget_usd: float = Field(default=20.0, gt=0, le=1_000)
+    gateway_base_url: str | None = None
+
+    @field_validator("gateway_base_url")
+    @classmethod
+    def validate_gateway_base_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        parsed = urlparse(value)
+        path = parsed.path.rstrip("/").lower()
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+            or path.endswith(("/messages", "/chat/completions", "/responses"))
+        ):
+            raise ValueError("Claude gateway must use an HTTPS API root URL")
+        return value.rstrip("/")
 
 
 @dataclass(slots=True)
@@ -109,6 +130,7 @@ class ClaudeSessionHandle:
     resumed_once: bool = False
     active_process: asyncio.subprocess.Process | None = None
     public_context: list[str] = field(default_factory=list)
+    active_tool_names: dict[str, str] = field(default_factory=dict)
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
@@ -185,6 +207,7 @@ class ClaudeCodeProvider(CodingAgentProvider):
         )
 
     async def capabilities(self) -> ProviderCapabilities:
+        self._validate_secret_file()
         return ProviderCapabilities(
             supports_streaming=True,
             supports_cancel=True,
@@ -302,7 +325,11 @@ class ClaudeCodeProvider(CodingAgentProvider):
                             await _stop_process(process)
                             yield self._failure_event(ProviderFailureKind.BUDGET)
                             return
-                        events = self.map_stream_frame(line, session.session_id)
+                        events = self.map_stream_frame(
+                            line,
+                            session.session_id,
+                            tool_names=handle.active_tool_names,
+                        )
                         for event in events:
                             if event.kind is ProviderEventKind.MESSAGE:
                                 value = event.data.get("text")
@@ -352,7 +379,12 @@ class ClaudeCodeProvider(CodingAgentProvider):
         return True
 
     async def interrupt_turn(self, session: ProviderSession) -> bool:
-        return await self.cancel(session)
+        handle = self._require_session(session)
+        process = handle.active_process
+        if process is None or process.returncode is not None:
+            return True
+        await _stop_process(process)
+        return True
 
     async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
         handle = self._require_session(session)
@@ -480,7 +512,6 @@ class ClaudeCodeProvider(CodingAgentProvider):
             "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
             "HOME": str(handle.home),
             "TMPDIR": str(handle.state_root),
-            "ANTHROPIC_API_KEY": api_key,
             "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
             "CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL": "1",
             "CLAUDE_CODE_DONT_INHERIT_ENV": "1",
@@ -489,6 +520,12 @@ class ClaudeCodeProvider(CodingAgentProvider):
             "DISABLE_PLUGIN_AUTOLOAD": "1",
             "DISABLE_TELEMETRY": "1",
         }
+        if handle.route.gateway_base_url is None:
+            environment["ANTHROPIC_API_KEY"] = api_key
+        else:
+            environment["ANTHROPIC_BASE_URL"] = handle.route.gateway_base_url
+            environment["ANTHROPIC_AUTH_TOKEN"] = api_key
+            environment["ANTHROPIC_API_KEY"] = ""
         if self._provider_proxy_url is not None:
             environment["HTTPS_PROXY"] = self._provider_proxy_url
             environment["HTTP_PROXY"] = self._provider_proxy_url
@@ -508,7 +545,10 @@ class ClaudeCodeProvider(CodingAgentProvider):
 
     @staticmethod
     def map_stream_frame(
-        encoded: bytes, session_id: str
+        encoded: bytes,
+        session_id: str,
+        *,
+        tool_names: dict[str, str] | None = None,
     ) -> tuple[ProviderEvent, ...]:
         if len(encoded) > 1_048_576:
             return ()
@@ -546,6 +586,8 @@ class ClaudeCodeProvider(CodingAgentProvider):
                     ):
                         normalized_name = tool_name.rsplit("__", 1)[-1]
                         if normalized_name in PROVIDER_TOOL_NAMES:
+                            if tool_names is not None:
+                                tool_names[operation_id] = normalized_name
                             events.append(
                                 ProviderEvent(
                                     kind=ProviderEventKind.TOOL_STARTED,
@@ -580,12 +622,19 @@ class ClaudeCodeProvider(CodingAgentProvider):
                         continue
                     operation_id = item.get("tool_use_id")
                     if isinstance(operation_id, str):
+                        normalized_name = (
+                            tool_names.pop(operation_id, None)
+                            if tool_names is not None
+                            else "run_command"
+                        )
+                        if normalized_name not in PROVIDER_TOOL_NAMES:
+                            continue
                         events.append(
                             ProviderEvent(
                                 kind=ProviderEventKind.TOOL_COMPLETED,
                                 data={
                                     "operation_id": operation_id,
-                                    "tool_name": "run_command",
+                                    "tool_name": normalized_name,
                                     "summary": "Tool execution completed.",
                                     "success": item.get("is_error") is not True,
                                     "artifact_id": None,
@@ -603,7 +652,7 @@ class ClaudeCodeProvider(CodingAgentProvider):
                 failure = (
                     ProviderFailureKind.BUDGET
                     if subtype in {"error_max_budget_usd", "error_max_turns"}
-                    else ProviderFailureKind.UNAVAILABLE
+                    else _failure_kind_from_result(value)
                 )
                 events.append(ClaudeCodeProvider._failure_event(failure))
             else:
@@ -661,6 +710,10 @@ class ClaudeCodeProvider(CodingAgentProvider):
             )
         return metadata
 
+    def validate_environment(self) -> None:
+        """Fail closed before the sidecar publishes route capabilities."""
+        self._validate_secret_file()
+
     def _read_secret(self) -> str:
         expected = self._validate_secret_file()
         descriptor = os.open(self._secret_path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
@@ -706,6 +759,35 @@ class ClaudeCodeProvider(CodingAgentProvider):
             os.fsync(descriptor)
         finally:
             os.close(descriptor)
+
+
+def _failure_kind_from_result(value: dict[str, Any]) -> ProviderFailureKind:
+    fragments: list[str] = []
+    stack: list[Any] = [value.get("error"), value.get("errors")]
+    while stack and len(fragments) < 64:
+        item = stack.pop()
+        if isinstance(item, dict):
+            stack.extend(item.values())
+        elif isinstance(item, (list, tuple)):
+            stack.extend(item[:64])
+        elif isinstance(item, str):
+            fragments.append(item[:2_048].lower())
+    combined = " ".join(fragments)
+    if any(
+        marker in combined
+        for marker in ("authentication", "unauthorized", "invalid api key")
+    ):
+        return ProviderFailureKind.AUTHENTICATION
+    if any(
+        marker in combined for marker in ("rate limit", "rate_limit", "overloaded")
+    ):
+        return ProviderFailureKind.RATE_LIMITED
+    if any(
+        marker in combined
+        for marker in ("credit balance", "insufficient credit", "billing")
+    ):
+        return ProviderFailureKind.BUDGET
+    return ProviderFailureKind.UNAVAILABLE
 
 
 def _usage_from_mapping(value: Any, *, cost: Any) -> ProviderUsage | None:

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -15,7 +15,7 @@ from typing import Any
 from urllib.parse import quote, urlparse
 
 import httpx
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from .broker_rpc import BrokerRPCServer
 from .contracts import PolicyProfile, StrictModel
@@ -97,6 +97,23 @@ class OpenCodeRoute(StrictModel):
     # task-level output budget remains independent and spans all turns.
     output_tokens: int = Field(default=8_192, ge=1_024, le=262_144)
 
+    @field_validator("base_url")
+    @classmethod
+    def validate_api_root(cls, value: str) -> str:
+        parsed = urlparse(value)
+        path = parsed.path.rstrip("/").lower()
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+            or path.endswith(("/chat/completions", "/completions", "/responses"))
+        ):
+            raise ValueError("OpenCode route must use an API root URL")
+        return value.rstrip("/")
+
 
 @dataclass(slots=True)
 class OpenCodeServerHandle:
@@ -128,6 +145,7 @@ class OpenCodeProvider(CodingAgentProvider):
         tool_broker_command: tuple[str, ...] | None = None,
         broker_rpc: BrokerRPCServer | None = None,
         server_factory: ServerFactory | None = None,
+        provider_proxy_url: str | None = None,
     ) -> None:
         self._workspace_resolver = workspace_resolver
         self._runtime_root = Path(runtime_root)
@@ -140,6 +158,7 @@ class OpenCodeProvider(CodingAgentProvider):
             else None
         )
         self._server_factory = server_factory or self._launch_server
+        self._provider_proxy_url = provider_proxy_url
         self._handles: dict[str, OpenCodeServerHandle] = {}
         self._requests: dict[str, ProviderOpenRequest] = {}
         self._public_context: dict[str, list[str]] = {}
@@ -475,35 +494,13 @@ class OpenCodeProvider(CodingAgentProvider):
         password = secrets.token_urlsafe(32)
         port = _unused_loopback_port()
         broker_environment, revoke_broker = self._broker_environment(request.task_id)
-        provider_host = urlparse(route.base_url).hostname
-        no_proxy = ",".join(
-            ["localhost", "127.0.0.1", *([provider_host] if provider_host else [])]
+        environment = self._build_server_environment(
+            home=home,
+            route=route,
+            password=password,
+            broker_environment=broker_environment,
+            tool_allowlist=request.tool_allowlist,
         )
-        environment = {
-            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
-            "HOME": str(home),
-            "XDG_CONFIG_HOME": str(home / ".config"),
-            "XDG_DATA_HOME": str(home / ".local/share"),
-            "XDG_STATE_HOME": str(home / ".local/state"),
-            "XDG_CACHE_HOME": str(home / ".cache"),
-            "OPENCODE_CONFIG_CONTENT": json.dumps(
-                self.build_config(route, request.tool_allowlist),
-                ensure_ascii=False,
-                separators=(",", ":"),
-            ),
-            "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
-            "OPENCODE_PURE": "1",
-            "OPENCODE_DISABLE_AUTOUPDATE": "1",
-            "OPENCODE_DISABLE_AUTOCOMPACT": "1",
-            "OPENCODE_DISABLE_MODELS_FETCH": "1",
-            "OPENCODE_AUTH_CONTENT": "{}",
-            "OPENCODE_SERVER_PASSWORD": password,
-            "CODING_WORKER_ROUTE_KEY": route.api_key,
-            "NO_PROXY": no_proxy,
-            "no_proxy": no_proxy,
-            **OPENCODE_SECURITY_ENVIRONMENT,
-            **broker_environment,
-        }
         try:
             process = await asyncio.create_subprocess_exec(
                 self._executable,
@@ -555,6 +552,50 @@ class OpenCodeProvider(CodingAgentProvider):
             client=client,
             close_callback=close,
         )
+
+    def _build_server_environment(
+        self,
+        *,
+        home: Path,
+        route: OpenCodeRoute,
+        password: str,
+        broker_environment: Mapping[str, str],
+        tool_allowlist: tuple[str, ...],
+    ) -> dict[str, str]:
+        provider_host = urlparse(route.base_url).hostname
+        bypass_hosts = ["localhost", "127.0.0.1"]
+        if self._provider_proxy_url is None and provider_host:
+            bypass_hosts.append(provider_host)
+        no_proxy = ",".join(bypass_hosts)
+        environment = {
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(home / ".config"),
+            "XDG_DATA_HOME": str(home / ".local/share"),
+            "XDG_STATE_HOME": str(home / ".local/state"),
+            "XDG_CACHE_HOME": str(home / ".cache"),
+            "OPENCODE_CONFIG_CONTENT": json.dumps(
+                self.build_config(route, tool_allowlist),
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+            "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
+            "OPENCODE_PURE": "1",
+            "OPENCODE_DISABLE_AUTOUPDATE": "1",
+            "OPENCODE_DISABLE_AUTOCOMPACT": "1",
+            "OPENCODE_DISABLE_MODELS_FETCH": "1",
+            "OPENCODE_AUTH_CONTENT": "{}",
+            "OPENCODE_SERVER_PASSWORD": password,
+            "CODING_WORKER_ROUTE_KEY": route.api_key,
+            "NO_PROXY": no_proxy,
+            "no_proxy": no_proxy,
+            **OPENCODE_SECURITY_ENVIRONMENT,
+            **broker_environment,
+        }
+        if self._provider_proxy_url is not None:
+            environment["HTTPS_PROXY"] = self._provider_proxy_url
+            environment["HTTP_PROXY"] = self._provider_proxy_url
+        return environment
 
     def _broker_environment(self, task_id: str) -> tuple[dict[str, str], Callable[[], None]]:
         if self._broker_rpc is not None:
@@ -730,9 +771,16 @@ class OpenCodeProvider(CodingAgentProvider):
         if event_type in {"session.aborted", "session.cancelled"}:
             return ProviderEvent(kind=ProviderEventKind.CANCELLED)
         if event_type in {"session.error", "message.error"}:
+            failure_kind = _failure_kind_from_value(properties.get("error"))
+            # OpenCode reports an explicit session abort as an error frame
+            # instead of the session.cancelled frame used by some versions.
+            # Treat that supplier quirk as cancellation so a controller-led
+            # cleanup cannot be misreported as a Harness transport outage.
+            if failure_kind is ProviderFailureKind.INTERRUPTED:
+                return ProviderEvent(kind=ProviderEventKind.CANCELLED)
             return ProviderEvent(
                 kind=ProviderEventKind.FAILED,
-                data={"failure_kind": ProviderFailureKind.UNAVAILABLE.value},
+                data={"failure_kind": failure_kind.value},
             )
         return None
 
@@ -743,6 +791,51 @@ def _nonnegative_int(value: Any) -> int:
         if isinstance(value, int) and not isinstance(value, bool) and value >= 0
         else 0
     )
+
+
+def _failure_kind_from_value(value: Any) -> ProviderFailureKind:
+    statuses: set[int] = set()
+    fragments: list[str] = []
+    stack = [value]
+    while stack and len(fragments) < 64:
+        item = stack.pop()
+        if isinstance(item, dict):
+            for key, child in item.items():
+                normalized_key = str(key).lower()
+                if (
+                    normalized_key in {"status", "statuscode", "status_code"}
+                    and isinstance(child, int)
+                    and not isinstance(child, bool)
+                ):
+                    statuses.add(child)
+                stack.append(child)
+        elif isinstance(item, (list, tuple)):
+            stack.extend(item[:64])
+        elif isinstance(item, str):
+            fragments.append(item[:2_048].lower())
+    combined = " ".join(fragments)
+    if any(
+        marker in combined
+        for marker in ("aborted", "aborterror", "cancelled", "canceled")
+    ):
+        return ProviderFailureKind.INTERRUPTED
+    if statuses.intersection({401, 403}) or any(
+        marker in combined
+        for marker in ("authentication", "unauthorized", "invalid api key")
+    ):
+        return ProviderFailureKind.AUTHENTICATION
+    if 429 in statuses or any(
+        marker in combined for marker in ("rate limit", "rate_limit", "overloaded")
+    ):
+        return ProviderFailureKind.RATE_LIMITED
+    if 402 in statuses or any(
+        marker in combined
+        for marker in ("credit balance", "insufficient credit", "billing")
+    ):
+        return ProviderFailureKind.BUDGET
+    if statuses.intersection({400, 404, 405, 415, 422}):
+        return ProviderFailureKind.INVALID_RESPONSE
+    return ProviderFailureKind.UNAVAILABLE
 
 
 async def _iter_sse_json(response: httpx.Response) -> AsyncIterator[dict[str, Any]]:

--- a/server/coding_worker/provider.py
+++ b/server/coding_worker/provider.py
@@ -260,6 +260,26 @@ class ProviderOpenRequest(StrictModel):
 def provider_message_with_repository_instructions(
     request: ProviderOpenRequest, text: str
 ) -> str:
+    acceptance_guidance = (
+        "- Frozen acceptance is platform-owned. Use run_check for checks returned by "
+        "list_acceptance_checks, or end the turn so the platform runs the immutable "
+        "required checks. After using an explicitly authorized reproduction command "
+        "and editing the workspace, do not repeat that acceptance command through "
+        "run_command or run_shell for verification. A one-time reproduction approval "
+        "does not authorize a later verification call.\n"
+    )
+    command_guidance = (
+        "- Prefer run_command for an exact argv command that is not a frozen "
+        "acceptance check. run_shell mode is exactly inspect or mutate; use mutate "
+        "only when the requested product change is intentionally produced by that "
+        "command. Never add ad-hoc debug, output, or test-runner files to inspect "
+        "command output.\n"
+        if "run_command" in request.tool_allowlist
+        else "- Use run_shell only for a task-authorized exact script. run_shell mode "
+        "is exactly inspect or mutate; use mutate only when the requested product "
+        "change is intentionally produced by that command. Never add ad-hoc debug, "
+        "output, or test-runner files to inspect command output.\n"
+    )
     broker_contract = (
         "ModelMirror Tool Broker contract:\n"
         "- Call only the exact tool names shown in the current provider tool list. "
@@ -277,10 +297,8 @@ def provider_message_with_repository_instructions(
         "unique text fragment can express the edit.\n"
         "- Refresh the workspace tree hash and affected file SHA after every "
         "successful write or mutate operation before submitting another changeset.\n"
-        "- Prefer run_command for an exact argv command. run_shell mode is exactly "
-        "inspect or mutate; use mutate only when the requested product change is "
-        "intentionally produced by that command. Never add ad-hoc debug, output, or "
-        "test-runner files to inspect command output.\n"
+        f"{acceptance_guidance}"
+        f"{command_guidance}"
         "- Shell output artifacts are not workspace paths. Read streamed shell "
         "output with read_operation_output using the original operation_id instead "
         "of rerunning a command or creating a helper file.\n"

--- a/server/coding_worker/provider_rpc.py
+++ b/server/coding_worker/provider_rpc.py
@@ -21,6 +21,7 @@ from .provider import (
     ProviderCapabilities,
     ProviderCheckpoint,
     ProviderEvent,
+    ProviderEventKind,
     ProviderOpenRequest,
     ProviderSession,
 )
@@ -86,6 +87,7 @@ class ProviderRPCServer:
         self._controller_generation = 0
         self._lock = asyncio.Lock()
         self._connections: dict[asyncio.Task[None], asyncio.StreamWriter] = {}
+        self._message_tasks: dict[tuple[str, str], asyncio.Task[None]] = {}
 
     async def start_unix(self, socket_path: Path) -> str:
         if self._server is not None:
@@ -130,6 +132,7 @@ class ProviderRPCServer:
         current = asyncio.current_task()
         if current is not None:
             self._connections[current] = writer
+        message_key: tuple[str, str] | None = None
         try:
             request = await self._read_request(reader)
             if request.action == "message":
@@ -145,6 +148,15 @@ class ProviderRPCServer:
                 self._require_active_session(
                     session, controller_id, controller_generation
                 )
+                message_key = (session.task_id, session.session_id)
+                existing = self._message_tasks.get(message_key)
+                if existing is not None and existing is not current:
+                    raise ProviderRPCError(
+                        "Provider session already has an active stream.",
+                        code="provider_session_busy",
+                    )
+                if current is not None:
+                    self._message_tasks[message_key] = current
                 async for event in self.provider.message(session, text):
                     self._require_active_session(
                         session, controller_id, controller_generation
@@ -181,6 +193,11 @@ class ProviderRPCServer:
                 *_CLIENT_DISCONNECTED,
             ):
                 await asyncio.wait_for(writer.wait_closed(), timeout=1)
+            if (
+                message_key is not None
+                and self._message_tasks.get(message_key) is current
+            ):
+                self._message_tasks.pop(message_key, None)
             if current is not None:
                 self._connections.pop(current, None)
 
@@ -371,6 +388,7 @@ class ProviderRPCServer:
         if request.action == "checkpoint":
             return (await self.provider.checkpoint(session)).model_dump(mode="json")
         if request.action == "close":
+            await self._stop_message_stream(session)
             await self.provider.close(session)
             if self._executor is not None:
                 await self._executor.stop_task(session.task_id)
@@ -416,10 +434,23 @@ class ProviderRPCServer:
                 "Provider session was not found.", code="session_not_found"
             )
 
+    async def _stop_message_stream(self, session: ProviderSession) -> None:
+        stream = self._message_tasks.pop(
+            (session.task_id, session.session_id), None
+        )
+        current = asyncio.current_task()
+        if stream is None or stream is current:
+            return
+        stream.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await stream
+
     async def _release_active(self) -> None:
         session = self._active_session
         task_id = self._active_task_id
         if session is not None:
+            with contextlib.suppress(Exception):
+                await self._stop_message_stream(session)
             with contextlib.suppress(Exception):
                 await self.provider.cancel(session)
             with contextlib.suppress(Exception):
@@ -502,6 +533,7 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         self._controller_id = controller_id
         self._controller_generation = controller_generation
         self._sessions: dict[tuple[str, str], tuple[str, str, str]] = {}
+        self._fenced_streams: set[tuple[str, str]] = set()
 
     async def capabilities(self) -> ProviderCapabilities:
         values = [
@@ -522,12 +554,20 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         return self._controller_generation
 
     async def slot_capabilities(
-        self,
+        self, slot_ids: Sequence[str] | None = None
     ) -> dict[str, ProviderCapabilities | None]:
         """Return one fail-closed observation per configured provider slot."""
 
         observations: dict[str, ProviderCapabilities | None] = {}
-        for slot_id in self._endpoints:
+        targets = (
+            tuple(self._endpoints)
+            if slot_ids is None
+            else tuple(dict.fromkeys(slot_ids))
+        )
+        for slot_id in targets:
+            if slot_id not in self._endpoints:
+                observations[slot_id] = None
+                continue
             try:
                 observations[slot_id] = ProviderCapabilities.model_validate(
                     await self._call(slot_id, "capabilities", {})
@@ -539,7 +579,7 @@ class ProviderSidecarClientPool(CodingAgentProvider):
     async def capabilities_for_slots(
         self, slot_ids: Sequence[str]
     ) -> dict[str, ProviderCapabilities | None]:
-        observations = await self.slot_capabilities()
+        observations = await self.slot_capabilities(slot_ids)
         return {slot_id: observations.get(slot_id) for slot_id in slot_ids}
 
     async def harness_attestations(self) -> dict[str, dict[str, Any]]:
@@ -627,15 +667,17 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         self, session: ProviderSession, text: str
     ) -> AsyncIterator[ProviderEvent]:
         slot_id = self._require_session(session)
+        session_key = self._session_key(session)
+        self._fenced_streams.discard(session_key)
         reader, writer = await self._connect(slot_id)
-        await self._send(
-            writer,
-            "message",
-            {"session": session.model_dump(mode="json"), "text": text},
-            slot_id,
-        )
         completed = False
         try:
+            await self._send(
+                writer,
+                "message",
+                {"session": session.model_dump(mode="json"), "text": text},
+                slot_id,
+            )
             while True:
                 value = await self._read(reader)
                 if value.get("done") is True:
@@ -646,20 +688,36 @@ class ProviderSidecarClientPool(CodingAgentProvider):
                     raise ProviderRPCError(
                         "Provider stream is invalid.", code="provider_invalid_response"
                     )
-                yield ProviderEvent.model_validate(event)
+                parsed = ProviderEvent.model_validate(event)
+                if parsed.kind in {
+                    ProviderEventKind.TURN_COMPLETED,
+                    ProviderEventKind.CANCELLED,
+                    ProviderEventKind.FAILED,
+                }:
+                    # The normalized terminal event is the durable stream
+                    # boundary consumed by the control plane.  A caller may
+                    # stop here without reading the sidecar's trailing ``done``
+                    # frame; that must not emit a late abort into the next turn.
+                    completed = True
+                yield parsed
         finally:
             writer.close()
-            await writer.wait_closed()
-            if not completed:
+            with contextlib.suppress(OSError, TimeoutError):
+                await asyncio.wait_for(writer.wait_closed(), timeout=1)
+            if not completed and session_key not in self._fenced_streams:
                 with contextlib.suppress(Exception):
                     await self.interrupt_turn(session)
+            self._fenced_streams.discard(session_key)
 
     async def cancel(self, session: ProviderSession) -> bool:
         slot_id = self._require_session(session)
         result = await self._call(
             slot_id, "cancel", {"session": session.model_dump(mode="json")}
         )
-        return result.get("cancelled") is True
+        cancelled = result.get("cancelled") is True
+        if cancelled:
+            self._fenced_streams.add(self._session_key(session))
+        return cancelled
 
     async def interrupt_turn(self, session: ProviderSession) -> bool:
         slot_id = self._require_session(session)
@@ -668,7 +726,10 @@ class ProviderSidecarClientPool(CodingAgentProvider):
             "interrupt_turn",
             {"session": session.model_dump(mode="json")},
         )
-        return result.get("interrupted") is True
+        interrupted = result.get("interrupted") is True
+        if interrupted:
+            self._fenced_streams.add(self._session_key(session))
+        return interrupted
 
     async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
         slot_id = self._require_session(session)
@@ -679,7 +740,8 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         )
 
     async def close(self, session: ProviderSession) -> None:
-        binding = self._sessions.pop(self._session_key(session), None)
+        session_key = self._session_key(session)
+        binding = self._sessions.pop(session_key, None)
         if binding is None or binding[1] != session.task_id:
             return
         slot_id = binding[0]
@@ -688,6 +750,7 @@ class ProviderSidecarClientPool(CodingAgentProvider):
                 slot_id, "close", {"session": session.model_dump(mode="json")}
             )
         finally:
+            self._fenced_streams.discard(session_key)
             if self._executor_pool is not None:
                 with contextlib.suppress(Exception):
                     await self._executor_pool.close_task(session.task_id, binding[2])
@@ -791,8 +854,8 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         self, slot_id: str, action: str, payload: dict[str, Any]
     ) -> dict[str, Any]:
         reader, writer = await self._connect(slot_id)
-        await self._send(writer, action, payload, slot_id)
         try:
+            await self._send(writer, action, payload, slot_id)
             value = await self._read(reader)
             result = value.get("result")
             if not isinstance(result, dict):
@@ -802,7 +865,8 @@ class ProviderSidecarClientPool(CodingAgentProvider):
             return result
         finally:
             writer.close()
-            await writer.wait_closed()
+            with contextlib.suppress(OSError, TimeoutError):
+                await asyncio.wait_for(writer.wait_closed(), timeout=1)
 
     async def _send(
         self,
@@ -824,32 +888,68 @@ class ProviderSidecarClientPool(CodingAgentProvider):
                 "Provider request is too large.", code="provider_request_too_large"
             )
         writer.write(encoded)
-        await writer.drain()
+        try:
+            await writer.drain()
+        except (OSError, TimeoutError) as exc:
+            raise ProviderRPCError(
+                "Provider transport is unavailable.",
+                code="provider_transport_unavailable",
+            ) from exc
 
     async def _connect(
         self, slot_id: str
     ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
         endpoint = self._endpoints[slot_id]
-        if endpoint.startswith("unix:"):
-            return await asyncio.open_unix_connection(
-                endpoint.removeprefix("unix:"), limit=MAX_PROVIDER_RPC_BYTES
-            )
-        if endpoint.startswith("tcp:127.0.0.1:"):
-            return await asyncio.open_connection(
-                "127.0.0.1", int(endpoint.rsplit(":", 1)[1]), limit=MAX_PROVIDER_RPC_BYTES
-            )
+        try:
+            if endpoint.startswith("unix:"):
+                return await asyncio.open_unix_connection(
+                    endpoint.removeprefix("unix:"), limit=MAX_PROVIDER_RPC_BYTES
+                )
+            if endpoint.startswith("tcp:127.0.0.1:"):
+                return await asyncio.open_connection(
+                    "127.0.0.1",
+                    int(endpoint.rsplit(":", 1)[1]),
+                    limit=MAX_PROVIDER_RPC_BYTES,
+                )
+        except (OSError, TimeoutError) as exc:
+            raise ProviderRPCError(
+                "Provider transport is unavailable.",
+                code="provider_transport_unavailable",
+            ) from exc
         raise ProviderRPCError(
             "Provider endpoint is invalid.", code="provider_endpoint_invalid"
         )
 
     @staticmethod
     async def _read(reader: asyncio.StreamReader) -> dict[str, Any]:
-        raw = await reader.readline()
-        if not raw or len(raw) > MAX_PROVIDER_RPC_BYTES:
+        try:
+            raw = await reader.readline()
+        except (OSError, TimeoutError) as exc:
+            raise ProviderRPCError(
+                "Provider transport is unavailable.",
+                code="provider_transport_unavailable",
+            ) from exc
+        except ValueError as exc:
+            raise ProviderRPCError(
+                "Provider response is too large.",
+                code="provider_response_too_large",
+            ) from exc
+        if not raw or not raw.endswith(b"\n"):
+            raise ProviderRPCError(
+                "Provider transport ended before a complete response.",
+                code="provider_transport_unavailable",
+            )
+        if len(raw) > MAX_PROVIDER_RPC_BYTES:
+            raise ProviderRPCError(
+                "Provider response is too large.",
+                code="provider_response_too_large",
+            )
+        try:
+            value = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise ProviderRPCError(
                 "Provider response is invalid.", code="provider_invalid_response"
-            )
-        value = json.loads(raw)
+            ) from exc
         if not isinstance(value, dict) or value.get("ok") is not True:
             error = value.get("error") if isinstance(value, dict) else None
             code = error.get("code") if isinstance(error, dict) else "provider_failed"

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import shlex
 import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -21,7 +23,12 @@ from .provider_rpc import ProviderSidecarClientPool
 from .ports import CodingSubstrateHandle
 from .service import CodingWorkerService
 from .store import CodingWorkerStore, DEFAULT_RETENTION_SECONDS
-from .tool_broker import FrozenCheck, ToolBroker
+from .tool_broker import (
+    FrozenApprovalRule,
+    FrozenCheck,
+    ToolBroker,
+    frozen_approval_request_sha256,
+)
 from .workspace import (
     InMemoryWorkspaceSourceAdapter,
     WorkspaceBroker,
@@ -30,6 +37,7 @@ from .workspace import (
 from .source_adapters import (
     BuiltinGitWorkspaceSourceAdapter,
     HostSnapshotWorkspaceSourceAdapter,
+    ProjectSnapshotLeaseGate,
     ProjectSnapshotWorkspaceSourceAdapter,
 )
 
@@ -42,6 +50,69 @@ class CodingWorkerRuntimeError(RuntimeError):
 
 _ACTIVE_SUBSTRATE: CodingSubstrateHandle | None = None
 _SUBSTRATE_UNAVAILABLE_REASON: str | None = None
+
+
+def _environment_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _configured_model_route_catalog() -> set[str]:
+    return {
+        value.strip()
+        for value in os.getenv(
+            "CODING_WORKER_MODEL_ROUTES", "coding/default"
+        ).split(",")
+        if value.strip()
+    }
+
+
+def configured_model_route_catalog_from_environment() -> tuple[str, ...]:
+    """Return the complete provider-neutral route catalog, including disabled routes."""
+
+    return tuple(sorted(_configured_model_route_catalog()))
+
+
+def _schedulable_route_slots(
+    route_slots: Mapping[str, Sequence[str]], disabled_slot_ids: frozenset[str]
+) -> dict[str, tuple[str, ...]]:
+    """Remove disabled slots without disabling a route that still has capacity."""
+
+    return {
+        route_id: enabled_slots
+        for route_id, slot_ids in route_slots.items()
+        if (
+            enabled_slots := tuple(
+                slot_id for slot_id in dict.fromkeys(slot_ids) if slot_id not in disabled_slot_ids
+            )
+        )
+    }
+
+
+def configured_model_routes_from_environment() -> tuple[str, ...]:
+    """Return routes admitted for new tasks by the deployment composition."""
+
+    routes = set(configured_model_route_catalog_from_environment())
+    if _environment_flag_enabled("CODING_WORKER_CLAUDE_ENABLED"):
+        return tuple(sorted(routes))
+    claude_slots = {
+        value.strip()
+        for value in os.getenv("CODING_WORKER_CLAUDE_SLOT_IDS", "").split(",")
+        if value.strip()
+    }
+    if not claude_slots:
+        return tuple(sorted(routes))
+    route_slots = _route_slot_catalog_from_environment()
+    if route_slots is None:
+        return ()
+    routes.intersection_update(
+        _schedulable_route_slots(route_slots, frozenset(claude_slots))
+    )
+    return tuple(sorted(routes))
 
 
 def is_coding_substrate_enabled() -> bool:
@@ -105,10 +176,19 @@ class CodingWorkerRuntime:
         sidecar_uid: int = 65532,
         sidecar_gid: int = 65532,
         route_slots: Mapping[str, Sequence[str]] | None = None,
+        schedulable_route_slots: Mapping[str, Sequence[str]] | None = None,
+        new_task_model_routes: Sequence[str] | None = None,
+        disabled_model_routes: Sequence[str] = (),
+        disabled_slot_ids: Sequence[str] = (),
+        capability_route_slots: Mapping[str, Sequence[str]] | None = None,
         route_context_tokens: Mapping[str, int] | None = None,
         documentation_resources: Mapping[str, str] | None = None,
         harness_faults_enabled: bool = False,
         evaluation_profile: str | None = None,
+        frozen_approval_rules: Mapping[
+            tuple[str, str, str], Sequence[FrozenApprovalRule]
+        ]
+        | None = None,
     ) -> None:
         if (
             set(slot_roots) != set(provider_endpoints)
@@ -141,6 +221,7 @@ class CodingWorkerRuntime:
             egress_proxy_url=egress_proxy_url,
             documentation_resources=documentation_resources,
             harness_faults_enabled=harness_faults_enabled,
+            frozen_approval_rules=frozen_approval_rules,
         )
         self.broker_rpc = BrokerRPCServer(self.tool_broker)
         controller_id = f"controller_{uuid.uuid4().hex}"
@@ -193,6 +274,11 @@ class CodingWorkerRuntime:
             max_active_tasks=max_active_tasks,
             tool_broker=self.tool_broker,
             route_slots=route_slots,
+            schedulable_route_slots=schedulable_route_slots,
+            new_task_model_routes=new_task_model_routes,
+            disabled_model_routes=disabled_model_routes,
+            disabled_slot_ids=disabled_slot_ids,
+            capability_route_slots=capability_route_slots,
             route_context_tokens=route_context_tokens,
         )
         self.tool_broker.subtask_handler = self.service.create_subtask
@@ -354,6 +440,30 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         "slot-b": os.getenv("CODING_WORKER_SLOT_B_TOKEN", ""),
     }
     route_slots = _route_slots_from_environment(tuple(slot_roots))
+    claude_slots = {
+        value.strip()
+        for value in os.getenv("CODING_WORKER_CLAUDE_SLOT_IDS", "").split(",")
+        if value.strip()
+    }
+    if not claude_slots.issubset(slot_roots):
+        raise CodingWorkerRuntimeError(
+            "Claude slot declaration is invalid.", code="coding_worker_config_invalid"
+        )
+    claude_enabled = _environment_flag_enabled("CODING_WORKER_CLAUDE_ENABLED")
+    disabled_slot_ids = frozenset() if claude_enabled else frozenset(claude_slots)
+    new_task_model_routes = configured_model_routes_from_environment()
+    disabled_model_routes = tuple(
+        sorted(_configured_model_route_catalog().difference(new_task_model_routes))
+    )
+    if route_slots is None:
+        schedulable_route_slots = {} if disabled_slot_ids else None
+    elif disabled_slot_ids:
+        schedulable_route_slots = _schedulable_route_slots(
+            route_slots, disabled_slot_ids
+        )
+    else:
+        schedulable_route_slots = route_slots
+    capability_route_slots = schedulable_route_slots
     executor_endpoints = {
         "slot-a": os.getenv(
             "CODING_WORKER_EXECUTOR_A_ENDPOINT",
@@ -383,6 +493,9 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
     )
     source_adapters = dict(_SOURCE_ADAPTERS)
     frozen_checks = {**_DEFAULT_FROZEN_CHECKS, **_FROZEN_CHECKS}
+    frozen_approval_rules: dict[
+        tuple[str, str, str], tuple[FrozenApprovalRule, ...]
+    ] | None = None
     builtin_root = os.getenv("CODING_WORKER_BUILTIN_SOURCE_ROOT")
     builtin_revision = os.getenv("CODING_WORKER_BUILTIN_REVISION")
     if bool(builtin_root) != bool(builtin_revision):
@@ -435,9 +548,11 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
                 )
             frozen_checks[check_id] = check
     elif harness_v3_enabled and harness_v3_assets:
-        harness_adapter, harness_checks = _load_harness_v3_fixtures(
-            Path(harness_v3_assets)
-        )
+        (
+            harness_adapter,
+            harness_checks,
+            frozen_approval_rules,
+        ) = _load_harness_v3_fixtures(Path(harness_v3_assets))
         if "builtin" in source_adapters:
             raise CodingWorkerRuntimeError(
                 "Harness v3 fixtures conflict with a registered builtin source.",
@@ -470,9 +585,11 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         except ModuleNotFoundError:
             from coding_runtime.project_source_client import CodingProjectSourceClient
         project_source_client = CodingProjectSourceClient(project_source_socket)
+        project_snapshot_gate = ProjectSnapshotLeaseGate()
         project_adapter = ProjectSnapshotWorkspaceSourceAdapter(
             project_source_client,
             Path(os.getenv("CODING_WORKER_PROJECT_SNAPSHOT_ROOT", "/project-snapshots")),
+            lease_gate=project_snapshot_gate,
         )
         source_adapters.setdefault("manifest", project_adapter)
         try:
@@ -492,6 +609,7 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
                             "/project-snapshots",
                         )
                     ),
+                    lease_gate=project_snapshot_gate,
                 ),
             )
     return CodingWorkerRuntime(
@@ -520,9 +638,15 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         egress_proxy_url=os.getenv("CODING_WORKER_EGRESS_PROXY_URL") or None,
         network_grant_key=os.getenv("CODING_WORKER_EGRESS_GRANT_KEY") or None,
         route_slots=route_slots,
+        schedulable_route_slots=schedulable_route_slots,
+        new_task_model_routes=new_task_model_routes,
+        disabled_model_routes=disabled_model_routes,
+        disabled_slot_ids=tuple(sorted(disabled_slot_ids)),
+        capability_route_slots=capability_route_slots,
         route_context_tokens=_route_context_tokens_from_environment(),
         documentation_resources=_documentation_resources_from_environment(),
         harness_faults_enabled=harness_v3_enabled,
+        frozen_approval_rules=frozen_approval_rules,
         evaluation_profile=(
             "harness_v3"
             if harness_v3_enabled
@@ -570,7 +694,11 @@ def _load_parity_public_fixtures(
 
 def _load_harness_v3_fixtures(
     path: Path,
-) -> tuple[InMemoryWorkspaceSourceAdapter, dict[str, FrozenCheck]]:
+) -> tuple[
+    InMemoryWorkspaceSourceAdapter,
+    dict[str, FrozenCheck],
+    dict[tuple[str, str, str], tuple[FrozenApprovalRule, ...]],
+]:
     try:
         from .harness_v3 import load_harness_fixture_bundle
 
@@ -581,7 +709,11 @@ def _load_harness_v3_fixtures(
             code="coding_worker_config_invalid",
         ) from exc
     checks: dict[str, FrozenCheck] = {}
+    approval_rules: dict[
+        tuple[str, str, str], tuple[FrozenApprovalRule, ...]
+    ] = {}
     for fixture in bundle.fixtures:
+        rules: dict[tuple[str, str | None], FrozenApprovalRule] = {}
         for visible in fixture.visible_checks:
             check = FrozenCheck(
                 check_id=visible.check_id,
@@ -595,7 +727,78 @@ def _load_harness_v3_fixtures(
                     code="coding_worker_config_invalid",
                 )
             checks[check.check_id] = check
-    return InMemoryWorkspaceSourceAdapter(bundle.source_snapshots()), checks
+            command_rule = FrozenApprovalRule(
+                request_sha256=frozen_approval_request_sha256(
+                    "run_command",
+                    {
+                        "argv": list(visible.argv),
+                        "timeout_seconds": visible.timeout_seconds,
+                    },
+                ),
+                acceptance_check_id=visible.check_id,
+            )
+            rules[(command_rule.request_sha256, visible.check_id)] = command_rule
+            for rendered in (shlex.join(visible.argv), " ".join(visible.argv)):
+                shell_rule = FrozenApprovalRule(
+                    request_sha256=frozen_approval_request_sha256(
+                        "run_shell",
+                        {
+                            "script": rendered,
+                            "cwd": ".",
+                            "mode": "inspect",
+                            "timeout_seconds": visible.timeout_seconds,
+                        },
+                    ),
+                    acceptance_check_id=visible.check_id,
+                )
+                rules[(shell_rule.request_sha256, visible.check_id)] = shell_rule
+        scenario_path = path.parent / "tasks" / fixture.task_id / "scenario.json"
+        if fixture.scenario_sha256 is not None:
+            try:
+                encoded_scenario = scenario_path.read_bytes()
+                scenario = json.loads(encoded_scenario)
+            except (OSError, json.JSONDecodeError) as exc:
+                raise CodingWorkerRuntimeError(
+                    "Harness v3 scenario is unavailable.",
+                    code="coding_worker_config_invalid",
+                ) from exc
+            allowed = scenario.get("allowed_approvals") if isinstance(scenario, dict) else None
+            if (
+                hashlib.sha256(encoded_scenario).hexdigest()
+                != fixture.scenario_sha256
+                or not isinstance(allowed, list)
+            ):
+                raise CodingWorkerRuntimeError(
+                    "Harness v3 scenario binding is invalid.",
+                    code="coding_worker_config_invalid",
+                )
+            for approval in allowed:
+                if not isinstance(approval, dict):
+                    raise CodingWorkerRuntimeError(
+                        "Harness v3 approval is invalid.",
+                        code="coding_worker_config_invalid",
+                    )
+                tool_name = "run_command" if "argv" in approval else "run_shell"
+                try:
+                    approval_rule = FrozenApprovalRule(
+                        request_sha256=frozen_approval_request_sha256(
+                            tool_name, approval
+                        )
+                    )
+                except ValueError as exc:
+                    raise CodingWorkerRuntimeError(
+                        "Harness v3 approval is invalid.",
+                        code="coding_worker_config_invalid",
+                    ) from exc
+                rules[(approval_rule.request_sha256, None)] = approval_rule
+        approval_rules[("builtin", fixture.source_id, fixture.revision)] = tuple(
+            rules.values()
+        )
+    return (
+        InMemoryWorkspaceSourceAdapter(bundle.source_snapshots()),
+        checks,
+        approval_rules,
+    )
 
 
 def _documentation_resources_from_environment() -> dict[str, str]:
@@ -646,9 +849,7 @@ def _route_context_tokens_from_environment() -> dict[str, int]:
     return dict(value)
 
 
-def _route_slots_from_environment(
-    slot_ids: tuple[str, ...]
-) -> dict[str, tuple[str, ...]] | None:
+def _route_slot_catalog_from_environment() -> dict[str, tuple[str, ...]] | None:
     encoded = os.getenv("CODING_WORKER_ROUTE_SLOTS_JSON", "").strip()
     if not encoded:
         return None
@@ -662,7 +863,6 @@ def _route_slots_from_environment(
         raise CodingWorkerRuntimeError(
             "Worker route catalog is invalid.", code="coding_worker_config_invalid"
         )
-    allowed_slots = set(slot_ids)
     result: dict[str, tuple[str, ...]] = {}
     for route_id, raw_slots in value.items():
         if (
@@ -677,10 +877,19 @@ def _route_slots_from_environment(
                 code="coding_worker_config_invalid",
             )
         slots = tuple(dict.fromkeys(raw_slots))
-        if not set(slots).issubset(allowed_slots):
-            raise CodingWorkerRuntimeError(
-                "Worker route catalog is invalid.",
-                code="coding_worker_config_invalid",
-            )
         result[route_id] = slots
+    return result
+
+
+def _route_slots_from_environment(
+    slot_ids: tuple[str, ...]
+) -> dict[str, tuple[str, ...]] | None:
+    result = _route_slot_catalog_from_environment()
+    if result is None:
+        return None
+    allowed_slots = set(slot_ids)
+    if any(not set(slots).issubset(allowed_slots) for slots in result.values()):
+        raise CodingWorkerRuntimeError(
+            "Worker route catalog is invalid.", code="coding_worker_config_invalid"
+        )
     return result

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -2226,6 +2226,25 @@ class CodingWorkerService:
                 self._resume_parent_after_subtasks(task_id)
             self._wake.set()
 
+    async def _close_harness_before_slot_release(
+        self, session: HarnessSession
+    ) -> None:
+        if self._closing:
+            with contextlib.suppress(Exception):
+                await self.provider.close(session)
+            return
+        close_task = asyncio.create_task(self.provider.close(session))
+        while not close_task.done():
+            try:
+                await asyncio.shield(close_task)
+            except asyncio.CancelledError:
+                # The runner owns the slot until the exact Harness close has
+                # settled.  A second cancellation must not detach cleanup and
+                # let the scheduler race a new session against the sidecar.
+                continue
+        with contextlib.suppress(Exception):
+            close_task.result()
+
     async def _run_task(self, task_id: str, *, slot_id: str | None = None) -> None:
         session: HarnessSession | None = None
         try:
@@ -2494,8 +2513,7 @@ class CodingWorkerService:
             with contextlib.suppress(Exception):
                 self._settle_terminal_subtask(task_id)
             if session is not None:
-                with contextlib.suppress(Exception):
-                    await self.provider.close(session)
+                await self._close_harness_before_slot_release(session)
 
     def _uncheckpointed_completed_turns(self, task_id: str) -> int:
         cursor = 0

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -9,7 +9,7 @@ import os
 import re
 import time
 import uuid
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from dataclasses import dataclass
 
 from .contracts import (
@@ -49,24 +49,44 @@ from .harness_contracts import (
     HarnessCheckpoint,
     HarnessEvent,
     HarnessEventKind,
+    HarnessFailureKind,
     HarnessOpenRequest,
     HarnessSession,
     harness_tools_for_policy,
 )
-from .ports import HarnessDriver, HarnessSupervisor
+from .ports import CodingSubstrateError, HarnessDriver, HarnessSupervisor
 from .harness_protocol import (
     HarnessBinding,
     HarnessDescriptorObservation,
     HarnessPersistenceLevel,
     HarnessToolOwnership,
 )
-from .store import CodingWorkerStore, WorkerConflictError
+from .store import CodingWorkerStore, WorkerConflictError, WorkerNotFoundError
 from .changeset import ChangesetError
 from .tool_broker import ToolBroker, ToolBrokerError
 from .workspace import WorkspaceBroker, WorkspaceError, WorkspaceSnapshot
 
 
 PROVIDER_CAPABILITY_TTL_SECONDS = 30.0
+TURN_PARKING_SHUTDOWN_GRACE_SECONDS = 5.0
+V20_HARNESS_EVENT_STALL_SECONDS = 300.0
+
+_HARNESS_FAILURE_REASONS = {
+    HarnessFailureKind.UNAVAILABLE: "harness_transport_unavailable",
+    HarnessFailureKind.AUTHENTICATION: "harness_authentication_failed",
+    HarnessFailureKind.RATE_LIMITED: "harness_rate_limited",
+    HarnessFailureKind.INVALID_RESPONSE: "harness_protocol_invalid",
+    HarnessFailureKind.POLICY: "harness_policy_rejected",
+    HarnessFailureKind.BUDGET: "harness_budget_exhausted",
+    HarnessFailureKind.INTERRUPTED: "harness_interrupted",
+}
+_NORMALIZED_HARNESS_FAILURE_REASONS = frozenset(
+    (*_HARNESS_FAILURE_REASONS.values(), "harness_driver_internal")
+)
+
+
+class _HarnessTurnFenceUnconfirmed(WorkerConflictError):
+    pass
 
 
 @dataclass(frozen=True)
@@ -95,6 +115,11 @@ class CodingWorkerService:
         max_active_tasks: int = 2,
         tool_broker: ToolBroker | None = None,
         route_slots: Mapping[str, Sequence[str]] | None = None,
+        schedulable_route_slots: Mapping[str, Sequence[str]] | None = None,
+        new_task_model_routes: Sequence[str] | None = None,
+        disabled_model_routes: Sequence[str] = (),
+        disabled_slot_ids: Sequence[str] = (),
+        capability_route_slots: Mapping[str, Sequence[str]] | None = None,
         route_context_tokens: Mapping[str, int] | None = None,
     ) -> None:
         if not 1 <= max_active_tasks <= 16:
@@ -123,6 +148,62 @@ class CodingWorkerService:
                 for route_id, slot_ids in self._route_slots.items()
             ):
                 raise ValueError("provider route slot configuration is invalid")
+        self._schedulable_route_slots = (
+            {
+                route_id: tuple(dict.fromkeys(slot_ids))
+                for route_id, slot_ids in schedulable_route_slots.items()
+            }
+            if schedulable_route_slots is not None
+            else self._route_slots
+        )
+        if self._schedulable_route_slots is not None and any(
+            not route_id
+            or not slot_ids
+            or self._route_slots is not None
+            and (
+                route_id not in self._route_slots
+                or not set(slot_ids).issubset(self._route_slots[route_id])
+            )
+            for route_id, slot_ids in self._schedulable_route_slots.items()
+        ):
+            raise ValueError("schedulable route slot configuration is invalid")
+        self._new_task_model_routes = (
+            frozenset(new_task_model_routes)
+            if new_task_model_routes is not None
+            else None
+        )
+        self._disabled_model_routes = frozenset(disabled_model_routes)
+        self._disabled_slot_ids = frozenset(disabled_slot_ids)
+        if not self._disabled_slot_ids.issubset(self.workspace_broker.slot_ids):
+            raise ValueError("disabled slot configuration is invalid")
+        if self._new_task_model_routes is not None and not (
+            self._disabled_model_routes.isdisjoint(self._new_task_model_routes)
+        ):
+            raise ValueError("disabled model route configuration is invalid")
+        self._capability_route_slots = (
+            {
+                route_id: tuple(dict.fromkeys(slot_ids))
+                for route_id, slot_ids in capability_route_slots.items()
+            }
+            if capability_route_slots is not None
+            else self._schedulable_route_slots
+        )
+        if self._capability_route_slots is not None:
+            known_slots = set(self.workspace_broker.slot_ids)
+            if any(
+                not route_id
+                or not slot_ids
+                or not set(slot_ids).issubset(known_slots)
+                or (
+                    self._route_slots is not None
+                    and (
+                        route_id not in self._route_slots
+                        or not set(slot_ids).issubset(self._route_slots[route_id])
+                    )
+                )
+                for route_id, slot_ids in self._capability_route_slots.items()
+            ):
+                raise ValueError("capability route slot configuration is invalid")
         self._route_context_tokens = dict(route_context_tokens or {})
         if any(
             not route_id
@@ -216,6 +297,9 @@ class CodingWorkerService:
         self._started = True
         self._closing = False
         await self._interrupt_v20_tasks_if_disabled()
+        for record in self.store.list_tasks():
+            if record.state is TaskState.WAITING_SUBTASKS:
+                self._resume_parent_after_subtasks(record.task_id)
         self._scheduler = asyncio.create_task(
             self._scheduler_loop(), name="coding-worker-scheduler"
         )
@@ -229,25 +313,140 @@ class CodingWorkerService:
         if not self._started:
             return
         self._closing = True
-        for task_id, session in tuple(self._sessions.items()):
-            with contextlib.suppress(Exception):
-                await self.provider.cancel(session)
-            current = self.store.get_task(task_id)
-            if current.state not in TERMINAL_STATES:
-                with contextlib.suppress(WorkerConflictError):
-                    self.store.transition(task_id, TaskState.INTERRUPTED, reason="service_shutdown")
-        for task in tuple(self._active.values()):
-            task.cancel()
-        if self._active:
-            await asyncio.gather(*tuple(self._active.values()), return_exceptions=True)
+        shutdown_failures: list[str] = []
         if self._scheduler is not None:
             self._scheduler.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._scheduler
+            _done, pending = await asyncio.wait(
+                {self._scheduler},
+                timeout=TURN_PARKING_SHUTDOWN_GRACE_SECONDS,
+            )
+            if pending:
+                self._scheduler.cancel()
+                _done, pending = await asyncio.wait(
+                    pending,
+                    timeout=TURN_PARKING_SHUTDOWN_GRACE_SECONDS,
+                )
+            if pending:
+                shutdown_failures.append("scheduler")
+            else:
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    self._scheduler.result()
         if self._capability_refresher is not None:
             self._capability_refresher.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._capability_refresher
+            _done, pending = await asyncio.wait(
+                {self._capability_refresher},
+                timeout=TURN_PARKING_SHUTDOWN_GRACE_SECONDS,
+            )
+            if pending:
+                self._capability_refresher.cancel()
+                _done, pending = await asyncio.wait(
+                    pending,
+                    timeout=TURN_PARKING_SHUTDOWN_GRACE_SECONDS,
+                )
+            if pending:
+                shutdown_failures.append("capability_refresher")
+            else:
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    self._capability_refresher.result()
+        active = tuple(self._active.items())
+        sessions = dict(self._sessions)
+        parking_runners = tuple(
+            runner
+            for task_id, runner in active
+            if (
+                (turn := self.store.current_turn_transaction(task_id)) is not None
+                and turn.state is TurnTransactionState.PARKING
+            )
+        )
+        if parking_runners:
+            await asyncio.wait(
+                parking_runners,
+                timeout=TURN_PARKING_SHUTDOWN_GRACE_SECONDS,
+            )
+        unfinished = tuple(runner for _task_id, runner in active if not runner.done())
+        for runner in unfinished:
+            runner.cancel()
+        still_running: set[asyncio.Task[None]] = set()
+        if unfinished:
+            _done, still_running = await asyncio.wait(
+                unfinished,
+                timeout=TURN_PARKING_SHUTDOWN_GRACE_SECONDS,
+            )
+        cancel_requests = tuple(
+            asyncio.create_task(self.provider.cancel(session))
+            for task_id, session in sessions.items()
+            if any(
+                candidate_task_id == task_id and runner in still_running
+                for candidate_task_id, runner in active
+            )
+        )
+        if cancel_requests:
+            done, pending = await asyncio.wait(
+                cancel_requests,
+                timeout=TURN_PARKING_SHUTDOWN_GRACE_SECONDS,
+            )
+            for request in pending:
+                request.cancel()
+            if pending:
+                cancelled, pending = await asyncio.wait(
+                    pending,
+                    timeout=TURN_PARKING_SHUTDOWN_GRACE_SECONDS,
+                )
+                done |= cancelled
+            if pending:
+                shutdown_failures.append("harness_cancel")
+            for request in done:
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    request.result()
+        remaining: set[asyncio.Task[None]] = set()
+        if active:
+            remaining = {
+                runner for _task_id, runner in active if not runner.done()
+            }
+            for runner in remaining:
+                runner.cancel()
+            if remaining:
+                _done, remaining = await asyncio.wait(
+                    remaining,
+                    timeout=TURN_PARKING_SHUTDOWN_GRACE_SECONDS,
+                )
+            if remaining:
+                shutdown_failures.append("runner")
+        for task_id, runner in active:
+            if runner in remaining:
+                continue
+            turn = self.store.current_turn_transaction(task_id)
+            if turn is not None and turn.state is TurnTransactionState.OPEN:
+                with contextlib.suppress(WorkerConflictError):
+                    self.store.finish_turn_transaction(
+                        task_id=task_id,
+                        turn_id=turn.turn_id,
+                        state=TurnTransactionState.INTERRUPTED,
+                    )
+            current = self.store.get_task(task_id)
+            if current.state not in TERMINAL_STATES and current.state not in {
+                TaskState.PAUSED,
+                TaskState.INTERRUPTED,
+                TaskState.WAITING_APPROVAL,
+                TaskState.WAITING_INPUT,
+                TaskState.WAITING_SUBTASKS,
+            }:
+                with contextlib.suppress(WorkerConflictError):
+                    self.store.transition(
+                        task_id,
+                        TaskState.INTERRUPTED,
+                        reason=(
+                            "turn_checkpoint_failed"
+                            if turn is not None
+                            and turn.state is TurnTransactionState.PARKING
+                            else "service_shutdown"
+                        ),
+                    )
+        if shutdown_failures:
+            raise RuntimeError(
+                "Coding Worker shutdown did not quiesce: "
+                + ", ".join(sorted(set(shutdown_failures)))
+            )
         self._active.clear()
         self._task_slots.clear()
         self._sessions.clear()
@@ -260,9 +459,23 @@ class CodingWorkerService:
         existing = self._idempotent_task(origin, request.client_task_id, spec)
         if existing is not None:
             return existing
+        if (
+            self._new_task_model_routes is not None
+            and request.model_route not in self._new_task_model_routes
+        ):
+            raise WorkerConflictError(
+                "Model route is unavailable.", code="model_route_unavailable"
+            )
         if self._route_slots is not None and request.model_route not in self._route_slots:
             raise WorkerConflictError(
                 "Model route is unavailable.", code="model_route_unavailable"
+            )
+        v20_enabled = self._v20_enabled()
+        runtime_protocol = self._runtime_protocol()
+        if v20_enabled and runtime_protocol is not RuntimeProtocol.V17:
+            raise WorkerConflictError(
+                "V20 Harness prerequisites are disabled.",
+                code="harness_v20_prerequisites_disabled",
             )
         frozen_checks = getattr(self.tool_broker, "frozen_checks", None)
         if isinstance(frozen_checks, Mapping):
@@ -285,13 +498,11 @@ class CodingWorkerService:
             observation = await self.provider_capability_observation(
                 request.model_route, force=True
             )
-            v20_enabled = self._v20_enabled()
             if v20_enabled and not self._v20_route_ready(observation):
                 raise WorkerConflictError(
                     "Model route does not satisfy the V20 Harness contract.",
                     code="harness_v20_route_unavailable",
                 )
-            runtime_protocol = self._runtime_protocol()
             if runtime_protocol is RuntimeProtocol.V17 and not self._v17_route_ready(
                 observation.capabilities
             ):
@@ -476,11 +687,11 @@ class CodingWorkerService:
             ):
                 return
             observations: dict[str, ProviderCapabilityObservation] = {}
-            if self._route_slots is not None:
+            if self._capability_route_slots is not None:
                 all_slots = tuple(
                     dict.fromkeys(
                         slot_id
-                        for slot_ids in self._route_slots.values()
+                        for slot_ids in self._capability_route_slots.values()
                         for slot_id in slot_ids
                     )
                 )
@@ -488,7 +699,7 @@ class CodingWorkerService:
                     self.harness_supervisor.capabilities_for_slots(all_slots),
                     self.harness_supervisor.harness_descriptors_for_slots(all_slots),
                 )
-                for route_id, slot_ids in self._route_slots.items():
+                for route_id, slot_ids in self._capability_route_slots.items():
                     values = [slot_values.get(slot_id) for slot_id in slot_ids]
                     descriptors = [
                         descriptor_values.get(slot_id) for slot_id in slot_ids
@@ -599,6 +810,14 @@ class CodingWorkerService:
             raise WorkerConflictError(
                 "V20 Harness tasks are disabled.", code="harness_v20_disabled"
             )
+        if (
+            self._task_uses_v20(task_id)
+            and task.runtime_protocol is not RuntimeProtocol.V17
+        ):
+            raise WorkerConflictError(
+                "V20 Harness task prerequisites are invalid.",
+                code="harness_v20_prerequisites_disabled",
+            )
         if task.state not in {
             TaskState.INTERRUPTED,
             TaskState.PAUSED,
@@ -612,9 +831,40 @@ class CodingWorkerService:
         turn = self.store.current_turn_transaction(task_id)
         if task.runtime_protocol is RuntimeProtocol.V17 and turn is not None:
             if turn.state is TurnTransactionState.PARKING:
-                raise WorkerConflictError(
-                    "Turn checkpoint is not durable yet.", code="turn_not_parked"
+                if (
+                    task.state is not TaskState.INTERRUPTED
+                    or turn.checkpoint_id is None
+                ):
+                    raise WorkerConflictError(
+                        "Turn checkpoint is not durable yet.", code="turn_not_parked"
+                    )
+                try:
+                    checkpoint = self.store.get_checkpoint(
+                        task_id, turn.checkpoint_id
+                    )
+                except WorkerNotFoundError as exc:
+                    raise WorkerConflictError(
+                        "Turn checkpoint is invalid.",
+                        code="turn_checkpoint_invalid",
+                    ) from exc
+                current_tree_hash = self.workspace_broker.current_tree_hash(
+                    task.workspace_id or ""
                 )
+                if (
+                    checkpoint.workspace_tree_hash != current_tree_hash
+                    or turn.workspace_tree_hash != current_tree_hash
+                ):
+                    raise WorkerConflictError(
+                        "Turn checkpoint Workspace changed.",
+                        code="checkpoint_workspace_changed",
+                    )
+                resumed = self.store.resume_interrupted_parking_turn(
+                    task_id=task_id,
+                    turn_id=turn.turn_id,
+                    checkpoint_id=turn.checkpoint_id,
+                )
+                self._wake.set()
+                return resumed
             if turn.state is TurnTransactionState.PARKED:
                 if turn.checkpoint_id is None:
                     raise WorkerConflictError(
@@ -669,17 +919,30 @@ class CodingWorkerService:
         task = self.store.get_task(task_id)
         if task.state in TERMINAL_STATES:
             return task
+        # Persist the user's terminal intent before asking the Harness to
+        # abort. OpenCode can synchronously publish ``session.error: Aborted``
+        # from the abort request; if the provider is called first, that frame
+        # can win the race and incorrectly turn an explicit cancellation into
+        # a failed task.
+        cancelled = self.store.transition(
+            task_id, TaskState.CANCELLED, reason="user_cancelled"
+        )
         session = self._sessions.get(task_id)
-        if session is not None:
-            await self.provider.cancel(session)
         active = self._active.get(task_id)
-        if active is not None:
-            active.cancel()
-        cancelled = self.store.transition(task_id, TaskState.CANCELLED, reason="user_cancelled")
-        if active is not None:
-            with contextlib.suppress(asyncio.CancelledError):
-                await active
+        cancel_failure: Exception | None = None
+        try:
+            if session is not None:
+                await self.provider.cancel(session)
+        except Exception as exc:
+            cancel_failure = exc
+        finally:
+            if active is not None:
+                active.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await active
         self._wake.set()
+        if cancel_failure is not None:
+            raise cancel_failure
         return cancelled
 
     async def append_message(self, task_id: str, text: str) -> TaskRecord:
@@ -1498,6 +1761,27 @@ class CodingWorkerService:
         if not available:
             return None
         for record in queued:
+            if (
+                self._task_uses_v20(record.task_id)
+                and record.runtime_protocol is not RuntimeProtocol.V17
+            ):
+                with contextlib.suppress(WorkerConflictError):
+                    self.store.transition(
+                        record.task_id,
+                        TaskState.INTERRUPTED,
+                        reason="harness_v20_prerequisites_disabled",
+                        expected_state=TaskState.QUEUED,
+                    )
+                continue
+            if record.spec.model_route in self._disabled_model_routes:
+                with contextlib.suppress(WorkerConflictError):
+                    self.store.transition(
+                        record.task_id,
+                        TaskState.INTERRUPTED,
+                        reason="model_route_disabled",
+                        expected_state=TaskState.QUEUED,
+                    )
+                continue
             if self._task_uses_v20(record.task_id) and not self._v20_enabled():
                 with contextlib.suppress(WorkerConflictError):
                     self.store.transition(
@@ -1530,6 +1814,15 @@ class CodingWorkerService:
                     )
                 if required_slot is None:
                     continue
+                if required_slot in self._disabled_slot_ids:
+                    with contextlib.suppress(WorkerConflictError):
+                        self.store.transition(
+                            record.task_id,
+                            TaskState.INTERRUPTED,
+                            reason="model_route_disabled",
+                            expected_state=TaskState.QUEUED,
+                        )
+                    continue
                 if required_slot not in route_slots:
                     with contextlib.suppress(WorkerConflictError):
                         self.store.transition(
@@ -1556,6 +1849,80 @@ class CodingWorkerService:
             snapshot is not None
             and snapshot.snapshot.get("harness_protocol") == "v20"
         )
+
+    @staticmethod
+    def _normalize_failure_reason(
+        raw_code: object, *, fallback: str, v20: bool
+    ) -> str:
+        code = (
+            raw_code
+            if isinstance(raw_code, str) and SAFE_ID.fullmatch(raw_code) is not None
+            else fallback
+        )
+        if not v20:
+            return code
+        exact = {
+            "provider_failed": "harness_transport_unavailable",
+            "provider_unavailable": "harness_transport_unavailable",
+            "provider_offline": "harness_transport_unavailable",
+            "provider_unauthorized": "harness_authentication_failed",
+            "provider_invalid_response": "harness_protocol_invalid",
+            "tool_failed": "tool_broker_internal_error",
+            "executor_failed": "executor_runtime_failed",
+            "worker_failed": "control_plane_internal_error",
+        }
+        if code in exact:
+            return exact[code]
+        if code.startswith("provider_"):
+            if any(marker in code for marker in ("auth", "unauthorized")):
+                return "harness_authentication_failed"
+            if "rate" in code:
+                return "harness_rate_limited"
+            if any(
+                marker in code
+                for marker in (
+                    "invalid",
+                    "protocol",
+                    "request",
+                    "session",
+                    "binding",
+                    "checkpoint",
+                    "controller",
+                )
+            ):
+                return "harness_protocol_invalid"
+            return "harness_transport_unavailable"
+        return code
+
+    def _task_failure_reason(
+        self, task_id: str, raw_code: object, *, fallback: str
+    ) -> str:
+        return self._normalize_failure_reason(
+            raw_code,
+            fallback=fallback,
+            v20=self._task_uses_v20(task_id),
+        )
+
+    @staticmethod
+    def _checkpoint_failure_reason(
+        exc: Exception, *, fallback: str, v20: bool
+    ) -> str:
+        code = getattr(exc, "code", None)
+        if v20 and code in _NORMALIZED_HARNESS_FAILURE_REASONS:
+            return str(code)
+        return fallback
+
+    def _task_checkpoint_failure_reason(
+        self, task_id: str, exc: Exception, *, fallback: str
+    ) -> str:
+        return self._checkpoint_failure_reason(
+            exc, fallback=fallback, v20=self._task_uses_v20(task_id)
+        )
+
+    @staticmethod
+    def _harness_failure_reason(event: HarnessEvent) -> str:
+        failure_kind = HarnessFailureKind(str(event.data["failure_kind"]))
+        return _HARNESS_FAILURE_REASONS[failure_kind]
 
     async def _v20_binding_for_task(
         self, task: TaskRecord, *, slot_id: str | None
@@ -1593,54 +1960,21 @@ class CodingWorkerService:
                 "V20 Harness descriptor snapshot is invalid.",
                 code="harness_binding_changed",
             ) from exc
-        expected_slots = (
-            self._allowed_slots(task.spec.model_route)
-            if self._route_slots is not None
-            else ("*",)
-        )
-        if expected_slots is None or tuple(item[0] for item in descriptors) != tuple(
-            expected_slots
-        ):
+        frozen_slots = tuple(item[0] for item in descriptors)
+        if len(set(frozen_slots)) != len(frozen_slots):
             raise WorkerConflictError(
                 "V20 Harness route binding changed.",
                 code="harness_binding_changed",
             )
         selected_slot = slot_id if slot_id is not None else "*"
-        current_descriptors = (
-            await self.harness_supervisor.harness_descriptors_for_slots(
-                tuple(expected_slots)
-            )
-        )
-        if any(
-            current_descriptors.get(frozen_slot) != frozen
-            for frozen_slot, frozen in descriptors
-        ):
-            raise WorkerConflictError(
-                "V20 Harness sidecar binding changed.",
-                code="harness_binding_changed",
-            )
-        current_capability_values = (
-            await self.harness_supervisor.capabilities_for_slots(
-                tuple(expected_slots)
-            )
-        )
-        current_capabilities = tuple(
-            current_capability_values.get(expected_slot)
-            for expected_slot in expected_slots
-        )
-        frozen_capabilities = stored.snapshot.get("capabilities")
+        allowed_slots = self._allowed_slots(task.spec.model_route)
         if (
-            not current_capabilities
-            or any(item is None for item in current_capabilities)
-            or not isinstance(frozen_capabilities, dict)
-            or _intersect_provider_capabilities(
-                tuple(item for item in current_capabilities if item is not None)
-            )
-            != HarnessCapabilities.model_validate(frozen_capabilities)
+            selected_slot != "*"
+            and (allowed_slots is None or selected_slot not in allowed_slots)
         ):
             raise WorkerConflictError(
-                "V20 Harness capability health changed.",
-                code="harness_binding_changed",
+                "V20 Harness route is unavailable.",
+                code="harness_v20_route_unavailable",
             )
         frozen = next(
             (item for frozen_slot, item in descriptors if frozen_slot == selected_slot),
@@ -1651,9 +1985,32 @@ class CodingWorkerService:
                 "V20 Harness sidecar binding changed.",
                 code="harness_binding_changed",
             )
+        current_descriptors, current_capability_values = await asyncio.gather(
+            self.harness_supervisor.harness_descriptors_for_slots((selected_slot,)),
+            self.harness_supervisor.capabilities_for_slots((selected_slot,)),
+        )
+        if current_descriptors.get(selected_slot) != frozen:
+            raise WorkerConflictError(
+                "V20 Harness sidecar binding changed.",
+                code="harness_binding_changed",
+            )
+        current_capabilities = current_capability_values.get(selected_slot)
+        frozen_capabilities = stored.snapshot.get("capabilities")
+        if (
+            current_capabilities is None
+            or not isinstance(frozen_capabilities, dict)
+            or not _provider_capabilities_cover(
+                current_capabilities,
+                HarnessCapabilities.model_validate(frozen_capabilities),
+            )
+        ):
+            raise WorkerConflictError(
+                "V20 Harness capability health changed.",
+                code="harness_binding_changed",
+            )
         recalculated = self._capability_binding(
             task.spec.model_route,
-            tuple(expected_slots),
+            frozen_slots,
             tuple(descriptors),
         )
         if recalculated != stored.binding_sha256:
@@ -1674,14 +2031,6 @@ class CodingWorkerService:
         stored = self.store.get_task_capability_snapshot(task.task_id)
         if stored is None or stored.snapshot.get("harness_protocol") != "v20":
             return
-        observation = await self.provider_capability_observation(
-            task.spec.model_route, force=True
-        )
-        if not self._v20_route_ready(observation):
-            raise WorkerConflictError(
-                "V20 Harness route is unavailable.",
-                code="harness_v20_route_unavailable",
-            )
         raw_frozen = stored.snapshot.get("harness_descriptors")
         if not isinstance(raw_frozen, list):
             raise WorkerConflictError(
@@ -1703,21 +2052,118 @@ class CodingWorkerService:
                 "V20 Harness descriptor snapshot is invalid.",
                 code="harness_binding_changed",
             ) from exc
-        if len(frozen) != len(raw_frozen) or tuple(
-            slot_id for slot_id, _item in frozen
-        ) != tuple(slot_id for slot_id, _item in observation.harness_descriptors):
+        frozen_slots = tuple(slot_id for slot_id, _item in frozen)
+        if len(frozen) != len(raw_frozen) or len(set(frozen_slots)) != len(frozen):
             raise WorkerConflictError(
                 "V20 Harness route binding changed.",
                 code="harness_binding_changed",
             )
-        if any(
-            previous.descriptor != current.descriptor
-            for (_slot_id, previous), (_current_slot, current) in zip(
-                frozen, observation.harness_descriptors, strict=True
+        allowed_slots = self._allowed_slots(task.spec.model_route)
+        if task.workspace_id is None:
+            current_route_slots = (
+                tuple(allowed_slots)
+                if self._schedulable_route_slots is not None
+                and allowed_slots is not None
+                else ("*",)
             )
+            if current_route_slots != frozen_slots:
+                raise WorkerConflictError(
+                    "V20 Harness route binding changed.",
+                    code="harness_binding_changed",
+                )
+            target_slots = frozen_slots
+        else:
+            if self.workspace_broker.dedicated_slots:
+                try:
+                    required_slot = self.workspace_broker.workspace_slot(
+                        task.workspace_id
+                    )
+                except WorkspaceError as exc:
+                    raise WorkerConflictError(
+                        "V20 Harness Workspace binding is unavailable.",
+                        code="harness_binding_changed",
+                    ) from exc
+            else:
+                required_slot = "*"
+            if (
+                (required_slot != "*" and required_slot in self._disabled_slot_ids)
+                or allowed_slots is None
+                or (required_slot != "*" and required_slot not in allowed_slots)
+            ):
+                raise WorkerConflictError(
+                    "V20 Harness route is unavailable.",
+                    code="harness_v20_route_unavailable",
+                )
+            if required_slot not in frozen_slots:
+                raise WorkerConflictError(
+                    "V20 Harness route binding changed.",
+                    code="harness_binding_changed",
+                )
+            target_slots = (required_slot,)
+        descriptor_values, capability_values = await asyncio.gather(
+            self.harness_supervisor.harness_descriptors_for_slots(target_slots),
+            self.harness_supervisor.capabilities_for_slots(target_slots),
+        )
+        current_descriptors = tuple(
+            (slot_id, descriptor_values.get(slot_id)) for slot_id in target_slots
+        )
+        current_capability_values = tuple(
+            capability_values.get(slot_id) for slot_id in target_slots
+        )
+        if any(item is None for _slot_id, item in current_descriptors) or any(
+            item is None for item in current_capability_values
+        ):
+            raise WorkerConflictError(
+                "V20 Harness route is unavailable.",
+                code="harness_v20_route_unavailable",
+            )
+        capabilities = _intersect_provider_capabilities(
+            tuple(item for item in current_capability_values if item is not None)
+        )
+        concrete_descriptors = tuple(
+            (slot_id, item)
+            for slot_id, item in current_descriptors
+            if item is not None
+        )
+        if capabilities is None:
+            raise WorkerConflictError(
+                "V20 Harness route is unavailable.",
+                code="harness_v20_route_unavailable",
+            )
+        now = time.time()
+        observation = ProviderCapabilityObservation(
+            capabilities=capabilities,
+            binding_sha256=self._capability_binding(
+                task.spec.model_route,
+                target_slots,
+                concrete_descriptors,
+            ),
+            observed_at=now,
+            expires_at=now + PROVIDER_CAPABILITY_TTL_SECONDS,
+            reason=None,
+            harness_descriptors=concrete_descriptors,
+        )
+        if not self._v20_route_ready(observation):
+            raise WorkerConflictError(
+                "V20 Harness route is unavailable.",
+                code="harness_v20_route_unavailable",
+            )
+        frozen_by_slot = dict(frozen)
+        if any(
+            frozen_by_slot[slot_id].descriptor != current.descriptor
+            for slot_id, current in concrete_descriptors
         ):
             raise WorkerConflictError(
                 "V20 Harness implementation changed.",
+                code="harness_binding_changed",
+            )
+        raw_frozen_capabilities = stored.snapshot.get("capabilities")
+        if not isinstance(raw_frozen_capabilities, dict) or not _provider_capabilities_cover(
+            capabilities,
+            HarnessCapabilities.model_validate(raw_frozen_capabilities),
+        ):
+            raise WorkerConflictError(
+                "V20 Harness capability health changed.",
                 code="harness_binding_changed",
             )
         refreshed_snapshot = dict(stored.snapshot)
@@ -1765,9 +2211,9 @@ class CodingWorkerService:
                 runner.cancel()
 
     def _allowed_slots(self, model_route: str) -> tuple[str, ...] | None:
-        if self._route_slots is None:
+        if self._schedulable_route_slots is None:
             return self.workspace_broker.slot_ids
-        return self._route_slots.get(model_route)
+        return self._schedulable_route_slots.get(model_route)
 
     def _task_finished(self, task_id: str, _task: asyncio.Task[None]) -> None:
         owned_runner = self._active.get(task_id) is _task
@@ -1784,6 +2230,17 @@ class CodingWorkerService:
         session: HarnessSession | None = None
         try:
             task = self.store.get_task(task_id)
+            if (
+                self._task_uses_v20(task_id)
+                and task.runtime_protocol is not RuntimeProtocol.V17
+            ):
+                self.store.transition(
+                    task_id,
+                    TaskState.INTERRUPTED,
+                    reason="harness_v20_prerequisites_disabled",
+                    expected_state=TaskState.PREPARING,
+                )
+                return
             if self._task_uses_v20(task_id) and not self._v20_enabled():
                 self.store.transition(
                     task_id,
@@ -1824,6 +2281,13 @@ class CodingWorkerService:
                 raise WorkspaceError(
                     "Workspace slot binding changed.", code="workspace_slot_changed"
                 )
+            tool_allowlist = harness_tools_for_policy(task.spec.policy_profile)
+            if self._task_uses_v20(task_id):
+                tool_allowlist = tuple(
+                    tool_name
+                    for tool_name in tool_allowlist
+                    if tool_name != "run_command"
+                )
             request = HarnessOpenRequest(
                 task_id=task_id,
                 workspace_id=workspace.workspace_id,
@@ -1837,7 +2301,7 @@ class CodingWorkerService:
                 repository_instructions=self.workspace_broker.repository_instructions(
                     workspace.workspace_id
                 ),
-                tool_allowlist=harness_tools_for_policy(task.spec.policy_profile),
+                tool_allowlist=tool_allowlist,
             )
             resume_phase: str | None = None
             resume_context: dict[str, object] | None = None
@@ -1846,7 +2310,19 @@ class CodingWorkerService:
             resume_turn_public_before: dict[str, object] | None = None
             completed_turns = 0
             message_cursor = 0
-            checkpoint = self.store.latest_checkpoint(task_id)
+            recovery_turn = (
+                self.store.current_turn_transaction(task_id)
+                if task.runtime_protocol is RuntimeProtocol.V17
+                else None
+            )
+            checkpoint = (
+                self.store.get_checkpoint(task_id, recovery_turn.checkpoint_id)
+                if recovery_turn is not None
+                and recovery_turn.state is TurnTransactionState.RESUMING
+                and recovery_turn.barrier is not None
+                and recovery_turn.checkpoint_id is not None
+                else self.store.latest_checkpoint(task_id)
+            )
             uncheckpointed_turns = self._uncheckpointed_completed_turns(task_id)
             if uncheckpointed_turns:
                 current_tree_hash = self.workspace_broker.current_tree_hash(
@@ -1984,8 +2460,21 @@ class CodingWorkerService:
                 TaskState.PAUSED,
                 TaskState.INTERRUPTED,
             }:
+                turn = self.store.current_turn_transaction(task_id)
                 with contextlib.suppress(WorkerConflictError):
-                    self.store.transition(task_id, TaskState.INTERRUPTED, reason="runner_cancelled")
+                    self.store.transition(
+                        task_id,
+                        TaskState.INTERRUPTED,
+                        reason=(
+                            "turn_checkpoint_failed"
+                            if self._closing
+                            and turn is not None
+                            and turn.state is TurnTransactionState.PARKING
+                            else "service_shutdown"
+                            if self._closing
+                            else "runner_cancelled"
+                        ),
+                    )
             raise
         except WorkspaceError as exc:
             current = self.store.get_task(task_id)
@@ -1994,11 +2483,10 @@ class CodingWorkerService:
         except Exception as exc:
             current = self.store.get_task(task_id)
             if current.state not in TERMINAL_STATES:
-                code = getattr(exc, "code", "worker_failed")
-                reason = (
-                    code
-                    if isinstance(code, str) and SAFE_ID.fullmatch(code) is not None
-                    else "worker_failed"
+                reason = self._task_failure_reason(
+                    task_id,
+                    getattr(exc, "code", None),
+                    fallback="worker_failed",
                 )
                 with contextlib.suppress(WorkerConflictError):
                     self.store.transition(task_id, TaskState.FAILED, reason=reason)
@@ -2080,8 +2568,12 @@ class CodingWorkerService:
         finally:
             if not driver.done():
                 driver.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await driver
+            # The outer runner can be cancelled in the same loop turn in
+            # which the inner driver finishes with an exception.  Always
+            # retrieve the inner result so that cancellation cannot leave an
+            # unobserved task exception behind or replace the outer outcome.
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await driver
 
     async def _drive_session_steps(
         self,
@@ -2166,6 +2658,44 @@ class CodingWorkerService:
                 + "\nMerge only approved implement changes by exact child task id "
                 "and CAS, then rerun the immutable parent acceptance checks.",
             )
+        recovery_turn = (
+            self.store.current_turn_transaction(task_id)
+            if task.runtime_protocol is RuntimeProtocol.V17
+            else None
+        )
+        if (
+            resume_phase == "turn_open"
+            and recovery_turn is not None
+            and recovery_turn.state is TurnTransactionState.RESUMING
+            and recovery_turn.barrier is not None
+        ):
+            self.store.begin_turn_parking(
+                task_id=task_id,
+                turn_id=recovery_turn.turn_id,
+                barrier=recovery_turn.barrier,
+            )
+            try:
+                await self._park_v17_turn(
+                    task,
+                    session,
+                    turn_id=recovery_turn.turn_id,
+                    turns=turns,
+                    message_cursor=message_cursor,
+                    turn_before=resume_turn_before,
+                    turn_public_before=resume_turn_public_before or {},
+                    interrupt_provider=False,
+                )
+            except Exception:
+                current = self.store.get_task(task_id)
+                if current.state is TaskState.RUNNING:
+                    with contextlib.suppress(WorkerConflictError):
+                        self.store.transition(
+                            task_id,
+                            TaskState.INTERRUPTED,
+                            reason="turn_checkpoint_failed",
+                            expected_state=TaskState.RUNNING,
+                        )
+            return
         while True:
             durable_usage = self.store.budget_usage(task_id)
             turns = max(turns, durable_usage.turns_started)
@@ -2228,7 +2758,7 @@ class CodingWorkerService:
                                 turn_before=turn_before,
                                 turn_public_before=turn_public_before,
                             )
-                        except Exception:
+                        except Exception as exc:
                             with contextlib.suppress(WorkerConflictError):
                                 self.store.finish_turn_transaction(
                                     task_id=task_id,
@@ -2238,7 +2768,9 @@ class CodingWorkerService:
                             self.store.transition(
                                 task_id,
                                 TaskState.BLOCKED,
-                                reason="turn_checkpoint_failed",
+                                reason=self._task_checkpoint_failure_reason(
+                                    task_id, exc, fallback="turn_checkpoint_failed"
+                                ),
                                 expected_state=TaskState.RUNNING,
                             )
                         return
@@ -2250,7 +2782,9 @@ class CodingWorkerService:
                     self.store.transition(
                         task_id,
                         TaskState.BLOCKED,
-                        reason=exc.code,
+                        reason=self._task_failure_reason(
+                            task_id, exc.code, fallback="tool_failed"
+                        ),
                         expected_state=TaskState.RUNNING,
                     )
                     return
@@ -2311,7 +2845,7 @@ class CodingWorkerService:
                             turn_id=turn_id,
                             checkpoint_id=checkpoint.checkpoint_id,
                         )
-                    except Exception:
+                    except Exception as exc:
                         self.store.finish_session_turn(
                             task_id, turn_id=turn_id, result_state="interrupted"
                         )
@@ -2323,13 +2857,17 @@ class CodingWorkerService:
                         self.store.transition(
                             task_id,
                             TaskState.BLOCKED,
-                            reason="turn_entry_checkpoint_failed",
+                            reason=self._task_checkpoint_failure_reason(
+                                task_id, exc, fallback="turn_entry_checkpoint_failed"
+                            ),
                             expected_state=TaskState.RUNNING,
                         )
                         return
             outcome = "interrupted"
             question_data: dict[str, object] | None = None
-            compaction_failed = False
+            compaction_failure_reason: str | None = None
+            harness_failure_reason: str | None = None
+            stream: AsyncIterator[HarnessEvent] | None = None
             try:
                 stream = self.provider.message(
                     session, message, turn_id=turn_id
@@ -2400,9 +2938,15 @@ class CodingWorkerService:
                                 message_cursor=message_cursor,
                                 provider_note=str(event.data["summary"]),
                             )
-                        except Exception:
+                        except Exception as exc:
                             outcome = "interrupted"
-                            compaction_failed = True
+                            compaction_failure_reason = (
+                                self._task_checkpoint_failure_reason(
+                                    task_id,
+                                    exc,
+                                    fallback="context_compaction_failed",
+                                )
+                            )
                             break
                     if event.kind is HarnessEventKind.TURN_COMPLETED:
                         outcome = "completed"
@@ -2411,6 +2955,11 @@ class CodingWorkerService:
                         outcome = "cancelled"
                         break
                     if event.kind is HarnessEventKind.FAILED:
+                        harness_failure_reason = (
+                            self._harness_failure_reason(event)
+                            if self._task_uses_v20(task_id)
+                            else "provider_failed"
+                        )
                         outcome = "failed"
                         break
             except BaseException:
@@ -2418,6 +2967,9 @@ class CodingWorkerService:
                     task_id, turn_id=turn_id, result_state="interrupted"
                 )
                 raise
+            finally:
+                if stream is not None:
+                    await self._close_provider_stream(stream)
             if outcome == "turn_parking":
                 try:
                     await self._park_v17_turn(
@@ -2429,19 +2981,31 @@ class CodingWorkerService:
                         turn_before=turn_before,
                         turn_public_before=turn_public_before,
                     )
-                except Exception:
-                    with contextlib.suppress(WorkerConflictError):
-                        self.store.finish_turn_transaction(
-                            task_id=task_id,
-                            turn_id=turn_id,
-                            state=TurnTransactionState.INTERRUPTED,
-                        )
+                except Exception as exc:
                     current = self.store.get_task(task_id)
-                    if current.state is TaskState.RUNNING:
+                    if self._closing:
+                        if current.state is TaskState.RUNNING:
+                            with contextlib.suppress(WorkerConflictError):
+                                self.store.transition(
+                                    task_id,
+                                    TaskState.INTERRUPTED,
+                                    reason="turn_checkpoint_failed",
+                                    expected_state=TaskState.RUNNING,
+                                )
+                    else:
+                        if not isinstance(exc, _HarnessTurnFenceUnconfirmed):
+                            with contextlib.suppress(WorkerConflictError):
+                                self.store.finish_turn_transaction(
+                                    task_id=task_id,
+                                    turn_id=turn_id,
+                                    state=TurnTransactionState.INTERRUPTED,
+                                )
                         self.store.transition(
                             task_id,
                             TaskState.BLOCKED,
-                            reason="turn_checkpoint_failed",
+                            reason=self._task_checkpoint_failure_reason(
+                                task_id, exc, fallback="turn_checkpoint_failed"
+                            ),
                             expected_state=TaskState.RUNNING,
                         )
                 return
@@ -2520,11 +3084,13 @@ class CodingWorkerService:
                             ),
                         },
                     )
-                except Exception:
+                except Exception as exc:
                     self.store.transition(
                         task_id,
                         TaskState.BLOCKED,
-                        reason="question_checkpoint_failed",
+                        reason=self._task_checkpoint_failure_reason(
+                            task_id, exc, fallback="question_checkpoint_failed"
+                        ),
                         expected_state=TaskState.RUNNING,
                     )
                     return
@@ -2535,21 +3101,37 @@ class CodingWorkerService:
                     expected_state=TaskState.RUNNING,
                 )
                 return
-            if compaction_failed:
+            if compaction_failure_reason is not None:
                 self.store.transition(
                     task_id,
                     TaskState.BLOCKED,
-                    reason="context_compaction_failed",
+                    reason=compaction_failure_reason,
                     expected_state=TaskState.RUNNING,
                 )
                 return
             if outcome == "cancelled":
-                self.store.transition(
-                    task_id, TaskState.CANCELLED, reason="provider_cancelled"
-                )
+                try:
+                    self.store.transition(
+                        task_id,
+                        TaskState.CANCELLED,
+                        reason="provider_cancelled",
+                        expected_state=TaskState.RUNNING,
+                    )
+                except WorkerConflictError:
+                    if self.store.get_task(task_id).state not in TERMINAL_STATES:
+                        raise
                 return
             if outcome == "failed":
-                self.store.transition(task_id, TaskState.FAILED, reason="provider_failed")
+                try:
+                    self.store.transition(
+                        task_id,
+                        TaskState.FAILED,
+                        reason=harness_failure_reason or "harness_protocol_invalid",
+                        expected_state=TaskState.RUNNING,
+                    )
+                except WorkerConflictError:
+                    if self.store.get_task(task_id).state not in TERMINAL_STATES:
+                        raise
                 return
             if outcome == "state_changed":
                 return
@@ -2588,11 +3170,13 @@ class CodingWorkerService:
                             ),
                         },
                     )
-                except Exception:
+                except Exception as exc:
                     self.store.transition(
                         task_id,
                         TaskState.BLOCKED,
-                        reason="subtask_checkpoint_failed",
+                        reason=self._task_checkpoint_failure_reason(
+                            task_id, exc, fallback="subtask_checkpoint_failed"
+                        ),
                         expected_state=TaskState.WAITING_SUBTASKS,
                     )
                 return
@@ -2632,11 +3216,13 @@ class CodingWorkerService:
                             ),
                         },
                     )
-                except Exception:
+                except Exception as exc:
                     self.store.transition(
                         task_id,
                         TaskState.BLOCKED,
-                        reason="subtask_checkpoint_failed",
+                        reason=self._task_checkpoint_failure_reason(
+                            task_id, exc, fallback="subtask_checkpoint_failed"
+                        ),
                         expected_state=TaskState.WAITING_SUBTASKS,
                     )
                 return
@@ -2665,11 +3251,13 @@ class CodingWorkerService:
                         ),
                     },
                 )
-            except Exception:
+            except Exception as exc:
                 self.store.transition(
                     task_id,
                     TaskState.BLOCKED,
-                    reason="checkpoint_failed",
+                    reason=self._task_checkpoint_failure_reason(
+                        task_id, exc, fallback="checkpoint_failed"
+                    ),
                     expected_state=TaskState.RUNNING,
                 )
                 return
@@ -2722,6 +3310,11 @@ class CodingWorkerService:
             break
 
         pending = asyncio.create_task(anext(stream))
+        stall_deadline = (
+            time.monotonic() + V20_HARNESS_EVENT_STALL_SECONDS
+            if self._task_uses_v20(task_id)
+            else None
+        )
         try:
             while True:
                 current = self.store.get_task(task_id)
@@ -2768,7 +3361,18 @@ class CodingWorkerService:
                         await self._close_provider_stream(stream)
                         return None, None
                     return event, None
-                await asyncio.wait({pending}, timeout=0.05)
+                wait_seconds = 0.05
+                if stall_deadline is not None:
+                    stall_remaining = stall_deadline - time.monotonic()
+                    if stall_remaining <= 0:
+                        await self._close_provider_stream(stream, pending=pending)
+                        raise CodingSubstrateError(
+                            "Harness turn stopped making observable progress.",
+                            code="harness_transport_unavailable",
+                            status=503,
+                        )
+                    wait_seconds = min(wait_seconds, stall_remaining)
+                await asyncio.wait({pending}, timeout=wait_seconds)
         except BaseException:
             if not pending.done():
                 pending.cancel()
@@ -2928,15 +3532,25 @@ class CodingWorkerService:
             lease_id=approval.lease.lease_id,
             network_lease_id=network_lease_id,
         )
-        self.store.append_event(
-            task_id,
-            "operation_reconciled",
-            {
-                "operation_id": operation.operation_id,
-                "state": result.state.value,
-                "source": "approved_resume",
-            },
-        )
+        if operation.state is not OperationState.UNKNOWN or not self._task_uses_v20(
+            task_id
+        ):
+            self.store.append_event(
+                task_id,
+                "operation_reconciled",
+                {
+                    "operation_id": operation.operation_id,
+                    "state": result.state.value,
+                    "source": "approved_resume",
+                },
+            )
+        if result.state is OperationState.FAILED and self._task_uses_v20(task_id):
+            return (
+                f"Exact approved operation {operation.operation_id} is durably "
+                "settled as failed and must not be replayed under that operation_id. "
+                "Reinspect the current Workspace state; if the work is still required, "
+                "use a new operation_id with current input and obtain re-approval."
+            )
         output = str(result.data.get("output", ""))[:4096]
         exit_code = result.data.get("exit_code")
         summary = (
@@ -2958,6 +3572,7 @@ class CodingWorkerService:
         message_cursor: int,
         turn_before: WorkspaceSnapshot | None,
         turn_public_before: dict[str, object],
+        interrupt_provider: bool = True,
     ) -> None:
         transaction = self.store.get_turn_transaction(task.task_id, turn_id)
         if (
@@ -2969,7 +3584,14 @@ class CodingWorkerService:
             )
         workspace_id = self.store.get_task(task.task_id).workspace_id or ""
         tree_hash = self.workspace_broker.current_tree_hash(workspace_id)
-        await self.provider.interrupt_turn(session)
+        if interrupt_provider:
+            await self._interrupt_turn_for_parking(
+                task_id=task.task_id,
+                turn_id=turn_id,
+                session=session,
+            )
+        else:
+            self.store.interrupt_open_session_tools(task.task_id, turn_id)
         provider_checkpoint = await self.provider.checkpoint(session)
         provider_checkpoint = self._bind_provider_checkpoint_tree(
             provider_checkpoint, task_id=task.task_id, tree_hash=tree_hash
@@ -3235,6 +3857,41 @@ class CodingWorkerService:
             },
         )
 
+    async def _interrupt_turn_for_parking(
+        self,
+        *,
+        task_id: str,
+        turn_id: str,
+        session: HarnessSession,
+    ) -> None:
+        try:
+            interrupted = await self.provider.interrupt_turn(session)
+            if interrupted is not True:
+                raise WorkerConflictError(
+                    "Harness turn interruption was not confirmed.",
+                    code="harness_interrupted",
+                )
+        except Exception as interrupt_error:
+            cancel_confirmed = False
+            close_confirmed = False
+            try:
+                cancel_confirmed = await self.provider.cancel(session)
+            except Exception:
+                pass
+            try:
+                await self.provider.close(session)
+                close_confirmed = True
+            except Exception:
+                pass
+            if cancel_confirmed or close_confirmed:
+                self.store.interrupt_open_session_tools(task_id, turn_id)
+                raise
+            raise _HarnessTurnFenceUnconfirmed(
+                "Harness turn interruption could not be fenced.",
+                code="harness_interrupted",
+            ) from interrupt_error
+        self.store.interrupt_open_session_tools(task_id, turn_id)
+
     @staticmethod
     def _bind_provider_checkpoint_tree(
         checkpoint: HarnessCheckpoint, *, task_id: str, tree_hash: str
@@ -3484,7 +4141,9 @@ class CodingWorkerService:
             self.store.transition(
                 task_id,
                 TaskState.BLOCKED,
-                reason=exc.code,
+                reason=self._task_failure_reason(
+                    task_id, exc.code, fallback="tool_failed"
+                ),
                 expected_state=TaskState.TESTING,
             )
             return None, message_cursor
@@ -3660,11 +4319,16 @@ class CodingWorkerService:
         runner = self._active.get(parent_task_id)
         if runner is not None and not runner.done():
             return
-        self.store.append_message(
-            parent_task_id,
-            role="system",
-            content=self._subtask_results_message(parent_task_id),
-        )
+        summary = self._subtask_results_message(parent_task_id)
+        if not any(
+            item.role == "system" and item.content == summary
+            for item in self.store.list_messages(parent_task_id)
+        ):
+            self.store.append_message(
+                parent_task_id,
+                role="system",
+                content=summary,
+            )
         if parent.runtime_protocol is RuntimeProtocol.V17:
             self.store.settle_parked_turn(
                 task_id=parent_task_id,
@@ -3761,3 +4425,27 @@ def _intersect_provider_capabilities(
             tool_name for tool_name in values[0].tool_names if tool_name in tool_names
         ),
     )
+
+
+def _provider_capabilities_cover(
+    current: HarnessCapabilities, frozen: HarnessCapabilities
+) -> bool:
+    if current.contract_version != frozen.contract_version:
+        return False
+    fields = (
+        "supports_streaming",
+        "supports_cancel",
+        "supports_checkpoint",
+        "supports_restore",
+        "supports_steering",
+        "supports_usage",
+        "supports_structured_plan",
+        "supports_todo",
+        "supports_questions",
+        "supports_compaction",
+        "supports_tool_boundaries",
+        "supports_turn_interrupt",
+    )
+    return all(not getattr(frozen, name) or getattr(current, name) for name in fields) and set(
+        frozen.tool_names
+    ).issubset(current.tool_names)

--- a/server/coding_worker/sidecar.py
+++ b/server/coding_worker/sidecar.py
@@ -103,14 +103,22 @@ def _provider_from_environment(
     model_id = _required_environment("CODING_WORKER_MODEL_ID")
     command = ("python", "-m", "coding_worker.broker_mcp")
     if provider_kind == "claude-code":
-        route = ClaudeCodeRoute(route_id=route_id, model_id=model_id)
-        return ClaudeCodeProvider(
+        route = ClaudeCodeRoute(
+            route_id=route_id,
+            model_id=model_id,
+            gateway_base_url=(
+                os.getenv("CODING_WORKER_CLAUDE_GATEWAY_BASE_URL") or None
+            ),
+        )
+        provider = ClaudeCodeProvider(
             runtime_root=runtime_root,
             routes={route_id: route},
             secret_path=Path(_required_environment("CODING_WORKER_CLAUDE_SECRET_PATH")),
             tool_broker_command=command,
             provider_proxy_url=os.getenv("CODING_WORKER_PROVIDER_PROXY_URL") or None,
         )
+        provider.validate_environment()
+        return provider
     if provider_kind != "opencode":
         raise RuntimeError("CODING_WORKER_PROVIDER_KIND is invalid")
     route = OpenCodeRoute(
@@ -130,6 +138,7 @@ def _provider_from_environment(
         runtime_root=runtime_root,
         routes={route_id: route},
         tool_broker_command=command,
+        provider_proxy_url=os.getenv("CODING_WORKER_PROVIDER_PROXY_URL") or None,
     )
 
 

--- a/server/coding_worker/source_adapters.py
+++ b/server/coding_worker/source_adapters.py
@@ -61,6 +61,19 @@ class ProjectHostSnapshotClient(Protocol):
     def finish_transfer(self, transfer_id: str) -> None: ...
 
 
+class ProjectSnapshotLeaseGate:
+    """Serialize one Project Source lease through copy and release."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+
+    async def __aenter__(self) -> None:
+        await self._lock.acquire()
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        self._lock.release()
+
+
 _DANGEROUS_CONFIG = re.compile(
     r"^(?:include(?:if)?\.|filter\.|credential\.|url\.|diff\..*\.textconv$|"
     r"core\.worktree$|core\.excludesfile$|extensions\.(?:worktreeconfig|partialclone|refstorage)$|"
@@ -333,9 +346,16 @@ class ProjectSnapshotWorkspaceSourceAdapter:
 
     _KINDS = {"manifest": "local_clone"}
 
-    def __init__(self, client: ProjectSnapshotClient, snapshot_root: Path) -> None:
+    def __init__(
+        self,
+        client: ProjectSnapshotClient,
+        snapshot_root: Path,
+        *,
+        lease_gate: ProjectSnapshotLeaseGate | None = None,
+    ) -> None:
         self._client = client
         self._snapshot_root = Path(snapshot_root)
+        self._lease_gate = lease_gate or ProjectSnapshotLeaseGate()
 
     async def admit(self, source: WorkspaceSource) -> SourceAdmissionReceipt:
         expected_kind = self._KINDS.get(source.kind)
@@ -374,10 +394,64 @@ class ProjectSnapshotWorkspaceSourceAdapter:
             raise WorkspaceError(
                 "Workspace source kind is unsupported.", code="source_not_found"
             )
-        lease = await self._client.acquire(
-            source.source_id, expected_head=source.revision
-        )
-        return await self.consume_lease(source, lease, expected_kind=expected_kind)
+        async with self._lease_gate:
+            try:
+                lease = await self._client.acquire(
+                    source.source_id, expected_head=source.revision
+                )
+            except BaseException as exc:
+                if not self._acquire_result_is_unknown(exc):
+                    raise
+                await self._reconcile_unknown_acquire(source, expected_kind)
+                raise
+            return await self.consume_lease(
+                source, lease, expected_kind=expected_kind
+            )
+
+    @staticmethod
+    def _acquire_result_is_unknown(exc: BaseException) -> bool:
+        return isinstance(exc, (asyncio.CancelledError, TimeoutError)) or getattr(
+            exc, "code", None
+        ) in {
+            "project_source_timeout",
+            "project_source_unavailable",
+            "invalid_project_source_response",
+        }
+
+    async def _reconcile_unknown_acquire(
+        self, source: WorkspaceSource, expected_kind: str
+    ) -> None:
+        async def reconcile() -> None:
+            lease = await self._client.acquire(
+                source.source_id, expected_head=source.revision
+            )
+            lease_id = lease.get("lease_id")
+            if (
+                lease.get("kind") != expected_kind
+                or lease.get("project_id") != source.source_id
+                or lease.get("head") != source.revision
+                or not isinstance(lease_id, str)
+            ):
+                raise WorkspaceError(
+                    "Project source acquire could not be reconciled.",
+                    code="source_release_failed",
+                )
+            if not await self._release_reliably(source.source_id, lease_id):
+                raise WorkspaceError(
+                    "Project source lease could not be released.",
+                    code="source_release_failed",
+                )
+
+        task = asyncio.create_task(reconcile())
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            await task
+        except Exception as cleanup_error:
+            raise WorkspaceError(
+                "Project source acquire result is unknown.",
+                code="source_release_failed",
+            ) from cleanup_error
 
     async def consume_lease(
         self,
@@ -393,7 +467,7 @@ class ProjectSnapshotWorkspaceSourceAdapter:
             or lease.get("head") != source.revision
             or not isinstance(lease_id, str)
         ):
-            await self._release(source.source_id, lease_id)
+            await self._release_reliably(source.source_id, lease_id)
             raise WorkspaceError(
                 "Project source lease is inconsistent.",
                 code="source_revision_changed",
@@ -405,7 +479,7 @@ class ProjectSnapshotWorkspaceSourceAdapter:
             snapshot = await asyncio.to_thread(self._read_snapshot, source, lease)
         except BaseException as exc:
             failure = exc
-        released = await self._release(source.source_id, lease_id)
+        released = await self._release_reliably(source.source_id, lease_id)
         if not released:
             raise WorkspaceError(
                 "Project source lease could not be released.",
@@ -426,6 +500,13 @@ class ProjectSnapshotWorkspaceSourceAdapter:
                 "Project source lease could not be released.",
                 code="source_release_failed",
             ) from exc
+
+    async def _release_reliably(self, project_id: str, lease_id: object) -> bool:
+        task = asyncio.create_task(self._release(project_id, lease_id))
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            return await task
 
     def _read_snapshot(
         self, source: WorkspaceSource, lease: dict[str, Any]
@@ -558,11 +639,14 @@ class HostSnapshotWorkspaceSourceAdapter:
         host: ProjectHostSnapshotClient,
         project_source: ProjectSnapshotClient,
         snapshot_root: Path,
+        *,
+        lease_gate: ProjectSnapshotLeaseGate | None = None,
     ) -> None:
         self._host = host
         self._project_source = project_source
+        self._lease_gate = lease_gate or ProjectSnapshotLeaseGate()
         self._reader = ProjectSnapshotWorkspaceSourceAdapter(
-            project_source, snapshot_root
+            project_source, snapshot_root, lease_gate=self._lease_gate
         )
 
     async def admit(self, source: WorkspaceSource) -> SourceAdmissionReceipt:
@@ -604,39 +688,40 @@ class HostSnapshotWorkspaceSourceAdapter:
             )
         transfer_id: str | None = None
         try:
-            transfer = await self._host.request_snapshot(
-                source.source_id,
-                expected_head=source.revision,
-            )
-            project = transfer.get("project")
-            transfer_id = transfer.get("upload_id")
-            archive_sha256 = transfer.get("archive_sha256")
-            if (
-                not isinstance(project, dict)
-                or project.get("project_id") != source.source_id
-                or project.get("head") != source.revision
-                or not isinstance(project.get("name"), str)
-                or not isinstance(project.get("branch"), str)
-                or not isinstance(transfer_id, str)
-                or re.fullmatch(r"[a-f0-9]{32}", transfer_id) is None
-                or not isinstance(archive_sha256, str)
-                or re.fullmatch(r"[a-f0-9]{64}", archive_sha256) is None
-            ):
-                raise WorkspaceError(
-                    "Host snapshot response is inconsistent.",
-                    code="source_revision_changed",
+            async with self._lease_gate:
+                transfer = await self._host.request_snapshot(
+                    source.source_id,
+                    expected_head=source.revision,
                 )
-            lease = await self._project_source.import_uploaded(
-                upload_id=transfer_id,
-                archive_sha256=archive_sha256,
-                project_id=source.source_id,
-                name=project["name"],
-                branch=project["branch"],
-                head=source.revision,
-            )
-            return await self._reader.consume_lease(
-                source, lease, expected_kind="host_git"
-            )
+                project = transfer.get("project")
+                transfer_id = transfer.get("upload_id")
+                archive_sha256 = transfer.get("archive_sha256")
+                if (
+                    not isinstance(project, dict)
+                    or project.get("project_id") != source.source_id
+                    or project.get("head") != source.revision
+                    or not isinstance(project.get("name"), str)
+                    or not isinstance(project.get("branch"), str)
+                    or not isinstance(transfer_id, str)
+                    or re.fullmatch(r"[a-f0-9]{32}", transfer_id) is None
+                    or not isinstance(archive_sha256, str)
+                    or re.fullmatch(r"[a-f0-9]{64}", archive_sha256) is None
+                ):
+                    raise WorkspaceError(
+                        "Host snapshot response is inconsistent.",
+                        code="source_revision_changed",
+                    )
+                lease = await self._project_source.import_uploaded(
+                    upload_id=transfer_id,
+                    archive_sha256=archive_sha256,
+                    project_id=source.source_id,
+                    name=project["name"],
+                    branch=project["branch"],
+                    head=source.revision,
+                )
+                return await self._reader.consume_lease(
+                    source, lease, expected_kind="host_git"
+                )
         except WorkspaceError:
             raise
         except Exception as exc:

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -958,6 +958,46 @@ class CodingWorkerStore:
                 require_transition(current, target)
             except ValueError as exc:
                 raise WorkerConflictError(str(exc), code="task_state_conflict") from exc
+            if target is TaskState.CANCELLED:
+                pending_approval_rows = connection.execute(
+                    """
+                    SELECT approval_id FROM worker_approvals
+                    WHERE task_id = ? AND status = ?
+                    ORDER BY created_at, approval_id
+                    """,
+                    (task_id, ApprovalStatus.PENDING.value),
+                ).fetchall()
+                connection.execute(
+                    """
+                    UPDATE worker_approvals
+                    SET status = ?, lease_ciphertext = NULL, decided_at = ?
+                    WHERE task_id = ? AND status = ?
+                    """,
+                    (
+                        ApprovalStatus.CANCELLED.value,
+                        now,
+                        task_id,
+                        ApprovalStatus.PENDING.value,
+                    ),
+                )
+                connection.execute(
+                    """
+                    UPDATE worker_leases SET remaining_operations = 0
+                    WHERE task_id = ? AND remaining_operations > 0
+                    """,
+                    (task_id,),
+                )
+                for approval_row in pending_approval_rows:
+                    self._append_event_locked(
+                        connection,
+                        task_id=task_id,
+                        event_type="approval_decided",
+                        payload={
+                            "approval_id": str(approval_row["approval_id"]),
+                            "status": ApprovalStatus.CANCELLED.value,
+                        },
+                        created_at=now,
+                    )
             encrypted_reason = self._codec.encrypt(reason) if reason is not None else None
             encrypted_provider = (
                 self._codec.encrypt(provider_session_id)
@@ -1372,6 +1412,55 @@ class CodingWorkerStore:
                     (task_id,),
                 ).fetchone()[0]
             )
+
+    def interrupt_open_session_tools(
+        self, task_id: str, turn_id: str
+    ) -> list[WorkerSessionLedgerEntry]:
+        """Close unreceipted provider observations without inferring tool failure."""
+        now = self._now()
+        appended: list[WorkerSessionLedgerEntry] = []
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_task_row(connection, task_id)
+            self._require_open_turn(connection, task_id, turn_id)
+            rows = connection.execute(
+                """
+                SELECT started.operation_id, started.payload_ciphertext
+                FROM worker_session_ledger AS started
+                LEFT JOIN worker_session_ledger AS finished
+                  ON finished.task_id = started.task_id
+                 AND finished.operation_id = started.operation_id
+                 AND finished.kind = ?
+                WHERE started.task_id = ? AND started.turn_id = ?
+                  AND started.kind = ? AND finished.ledger_id IS NULL
+                ORDER BY started.sequence
+                """,
+                (
+                    SessionLedgerKind.TOOL_FINISHED.value,
+                    task_id,
+                    turn_id,
+                    SessionLedgerKind.TOOL_STARTED.value,
+                ),
+            ).fetchall()
+            for row in rows:
+                started = self._decrypt_dict(row["payload_ciphertext"])
+                appended.append(
+                    self._append_session_ledger_locked(
+                        connection,
+                        task_id=task_id,
+                        kind=SessionLedgerKind.TOOL_FINISHED,
+                        turn_id=turn_id,
+                        operation_id=str(row["operation_id"]),
+                        payload={
+                            "tool_name": started["tool_name"],
+                            "summary": "Provider turn was interrupted before a completion receipt.",
+                            "result_state": "unknown",
+                            "artifact_id": None,
+                        },
+                        created_at=now,
+                    )
+                )
+        return appended
 
     def latest_plan(self, task_id: str) -> WorkerPlan | None:
         with self._connect() as connection:
@@ -2303,6 +2392,86 @@ class CodingWorkerStore:
             )
         return self.get_turn_transaction(task_id, turn_id)
 
+    def resume_interrupted_parking_turn(
+        self, *, task_id: str, turn_id: str, checkpoint_id: str
+    ) -> TaskRecord:
+        """Retry one interrupted parking handshake from its exact entry checkpoint."""
+
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            task_row = self._require_task_row(connection, task_id)
+            task = self._task(task_row, connection)
+            if (
+                task.runtime_protocol is not RuntimeProtocol.V17
+                or task.state is not TaskState.INTERRUPTED
+                or task.reason != "turn_checkpoint_failed"
+            ):
+                raise WorkerConflictError(
+                    "Task cannot retry an interrupted parking turn.",
+                    code="turn_state_conflict",
+                )
+            turn_row = self._require_turn_row(connection, task_id, turn_id)
+            turn = self._turn_transaction(turn_row)
+            if (
+                turn.state is not TurnTransactionState.PARKING
+                or turn.barrier is None
+                or turn.checkpoint_id != checkpoint_id
+            ):
+                raise WorkerConflictError(
+                    "Interrupted parking checkpoint changed.",
+                    code="turn_checkpoint_conflict",
+                )
+            checkpoint = connection.execute(
+                "SELECT task_id, workspace_tree_hash FROM worker_checkpoints "
+                "WHERE checkpoint_id = ?",
+                (checkpoint_id,),
+            ).fetchone()
+            if (
+                checkpoint is None
+                or str(checkpoint["task_id"]) != task_id
+                or str(checkpoint["workspace_tree_hash"])
+                != turn.workspace_tree_hash
+            ):
+                raise WorkerConflictError(
+                    "Interrupted parking checkpoint is invalid.",
+                    code="turn_checkpoint_invalid",
+                )
+            connection.execute(
+                "UPDATE worker_turn_transactions SET state = ?, updated_at = ? "
+                "WHERE task_id = ? AND turn_id = ?",
+                (
+                    TurnTransactionState.RESUMING.value,
+                    now,
+                    task_id,
+                    turn_id,
+                ),
+            )
+            connection.execute(
+                "UPDATE worker_tasks SET state = ?, reason_ciphertext = NULL, "
+                "updated_at = ? WHERE task_id = ?",
+                (TaskState.QUEUED.value, now, task_id),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="turn_resumed",
+                payload={"turn_id": turn_id, "checkpoint_id": checkpoint_id},
+                created_at=now,
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="task_state",
+                payload={
+                    "from": TaskState.INTERRUPTED.value,
+                    "to": TaskState.QUEUED.value,
+                    "reason": None,
+                },
+                created_at=now,
+            )
+        return self.get_task(task_id)
+
     def settle_parked_turn(
         self,
         *,
@@ -2797,6 +2966,22 @@ class CodingWorkerStore:
                 (task_id,),
             ).fetchone()
         return self._checkpoint(row) if row is not None else None
+
+    def get_checkpoint(self, task_id: str, checkpoint_id: str) -> WorkerCheckpoint:
+        if SAFE_ID.fullmatch(checkpoint_id) is None:
+            raise ValueError("checkpoint identifier is invalid")
+        with self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            row = connection.execute(
+                "SELECT * FROM worker_checkpoints "
+                "WHERE task_id = ? AND checkpoint_id = ?",
+                (task_id, checkpoint_id),
+            ).fetchone()
+        if row is None:
+            raise WorkerNotFoundError(
+                "Checkpoint was not found.", code="checkpoint_not_found"
+            )
+        return self._checkpoint(row)
 
     def create_turn_checkpoint(
         self,
@@ -3314,6 +3499,85 @@ class CodingWorkerStore:
                 ).fetchone()
                 if (
                     str(row["runtime_protocol"]) == RuntimeProtocol.V17.value
+                    and str(row["state"]) == TaskState.RUNNING.value
+                    and turn_row is not None
+                    and str(turn_row["state"])
+                    == TurnTransactionState.PARKED.value
+                    and turn_row["barrier"] is not None
+                    and turn_row["checkpoint_id"] is not None
+                ):
+                    barrier = TurnBarrier(str(turn_row["barrier"]))
+                    waiting_state = {
+                        TurnBarrier.APPROVAL: TaskState.WAITING_APPROVAL,
+                        TurnBarrier.INPUT: TaskState.WAITING_INPUT,
+                        TurnBarrier.SUBTASKS: TaskState.WAITING_SUBTASKS,
+                    }.get(barrier)
+                    if waiting_state is not None:
+                        reason = f"turn_parked_{barrier.value}"
+                        connection.execute(
+                            "UPDATE worker_tasks SET state = ?, reason_ciphertext = ?, "
+                            "updated_at = ? WHERE task_id = ?",
+                            (
+                                waiting_state.value,
+                                self._codec.encrypt(reason),
+                                now,
+                                task_id,
+                            ),
+                        )
+                        self._append_event_locked(
+                            connection,
+                            task_id=task_id,
+                            event_type="task_state",
+                            payload={
+                                "from": TaskState.RUNNING.value,
+                                "to": waiting_state.value,
+                                "reason": reason,
+                            },
+                            created_at=now,
+                        )
+                        count += 1
+                        continue
+                    if barrier is TurnBarrier.COMPACTION:
+                        connection.execute(
+                            "UPDATE worker_turn_transactions SET state = ?, "
+                            "updated_at = ? WHERE task_id = ? AND turn_id = ?",
+                            (
+                                TurnTransactionState.RESUMING.value,
+                                now,
+                                task_id,
+                                str(turn_row["turn_id"]),
+                            ),
+                        )
+                        connection.execute(
+                            "UPDATE worker_tasks SET state = ?, reason_ciphertext = NULL, "
+                            "updated_at = ? WHERE task_id = ?",
+                            (TaskState.QUEUED.value, now, task_id),
+                        )
+                        self._append_event_locked(
+                            connection,
+                            task_id=task_id,
+                            event_type="turn_resumed",
+                            payload={
+                                "turn_id": str(turn_row["turn_id"]),
+                                "checkpoint_id": str(turn_row["checkpoint_id"]),
+                            },
+                            created_at=now,
+                        )
+                        self._append_event_locked(
+                            connection,
+                            task_id=task_id,
+                            event_type="task_state",
+                            payload={
+                                "from": TaskState.RUNNING.value,
+                                "to": TaskState.QUEUED.value,
+                                "reason": None,
+                            },
+                            created_at=now,
+                        )
+                        count += 1
+                        continue
+                if (
+                    str(row["runtime_protocol"]) == RuntimeProtocol.V17.value
                     and str(row["state"]) == TaskState.WAITING_APPROVAL.value
                     and turn_row is not None
                     and str(turn_row["state"]) == TurnTransactionState.PARKED.value
@@ -3338,6 +3602,15 @@ class CodingWorkerStore:
                         and turn_row is not None
                     )
                     else None
+                )
+                preserve_incomplete_parking = bool(
+                    str(row["runtime_protocol"]) == RuntimeProtocol.V17.value
+                    and turn_row is not None
+                    and str(turn_row["state"])
+                    == TurnTransactionState.PARKING.value
+                    and turn_row["barrier"] is not None
+                    and turn_row["checkpoint_id"] is not None
+                    and unknown_operation is None
                 )
                 if unknown_operation is not None and turn_row["checkpoint_id"] is not None:
                     connection.execute(
@@ -3367,12 +3640,14 @@ class CodingWorkerStore:
                         created_at=now,
                     )
                     reason = "operation_result_unknown"
+                elif preserve_incomplete_parking:
+                    reason = "turn_checkpoint_failed"
                 else:
                     reason = "server_restart"
                 if turn_row is not None and str(turn_row["state"]) in {
                     TurnTransactionState.OPEN.value,
                     TurnTransactionState.PARKING.value,
-                } and unknown_operation is None:
+                } and unknown_operation is None and not preserve_incomplete_parking:
                     connection.execute(
                         """
                         UPDATE worker_turn_transactions

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -56,6 +56,15 @@ from .workspace import WorkspaceBroker, WorkspaceError
 MAX_TOOL_OUTPUT_BYTES = 2 * 1024 * 1024
 MAX_WRITE_BYTES = 8 * 1024 * 1024
 SAFE_TOOL_NAME = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+SHELL_HOST_PATH = re.compile(
+    r"(?:^|[\s\"'=<>;&(])(?:[A-Za-z]:[\\/]|\\\\|~(?:[\\/]|$)|file://)",
+    re.IGNORECASE,
+)
+SHELL_PRIVATE_RUNTIME_PATH = re.compile(
+    r"/(?:worker-data/workspaces|project-snapshots|project-uploads)(?:/|$)"
+    r"|/run/modelmirror-[A-Za-z0-9_.-]+",
+    re.IGNORECASE,
+)
 ALWAYS_DENIED_EXECUTABLES = frozenset(
     {
         "bash",
@@ -84,6 +93,15 @@ CODE_INTELLIGENCE_TO_OPERATION = {
     "code_hover": "hover",
     "code_diagnostics": "diagnostics",
 }
+V20_SHELL_NO_SIDE_EFFECT_ERROR_CODES = frozenset(
+    {
+        "executor_binding_invalid",
+        "executor_request_invalid",
+        "executor_slot_busy",
+        "executor_unauthorized",
+        "executor_unavailable",
+    }
+)
 
 
 class ToolBrokerError(RuntimeError):
@@ -96,6 +114,67 @@ class FrozenCheck(StrictModel):
     check_id: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
     argv: tuple[str, ...] = Field(min_length=1, max_length=64)
     timeout_seconds: int = Field(default=300, ge=1, le=1800)
+
+
+class FrozenApprovalRule(StrictModel):
+    request_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    acceptance_check_id: str | None = Field(
+        default=None, pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$"
+    )
+
+
+def frozen_approval_request_sha256(
+    tool_name: str, arguments: Mapping[str, Any]
+) -> str:
+    if tool_name == "run_command":
+        if set(arguments) != {"argv", "timeout_seconds"}:
+            raise ValueError("frozen command request is invalid")
+        argv = arguments.get("argv")
+        timeout_seconds = arguments.get("timeout_seconds")
+        if (
+            not isinstance(argv, list)
+            or not argv
+            or not all(isinstance(value, str) and value for value in argv)
+            or isinstance(timeout_seconds, bool)
+            or not isinstance(timeout_seconds, int)
+            or not 1 <= timeout_seconds <= 1800
+        ):
+            raise ValueError("frozen command request is invalid")
+        normalized: dict[str, Any] = {
+            "tool_name": tool_name,
+            "argv": argv,
+            "timeout_seconds": timeout_seconds,
+        }
+    elif tool_name == "run_shell":
+        if set(arguments) != {"script", "cwd", "mode", "timeout_seconds"}:
+            raise ValueError("frozen shell request is invalid")
+        script = arguments.get("script")
+        cwd = arguments.get("cwd")
+        mode = arguments.get("mode")
+        timeout_seconds = arguments.get("timeout_seconds")
+        if (
+            not isinstance(script, str)
+            or not script
+            or not isinstance(cwd, str)
+            or not cwd
+            or mode not in {ShellMode.INSPECT.value, ShellMode.MUTATE.value}
+            or isinstance(timeout_seconds, bool)
+            or not isinstance(timeout_seconds, int)
+            or not 1 <= timeout_seconds <= 1800
+        ):
+            raise ValueError("frozen shell request is invalid")
+        normalized = {
+            "tool_name": tool_name,
+            "script_sha256": hashlib.sha256(script.encode("utf-8")).hexdigest(),
+            "cwd": cwd,
+            "mode": mode,
+            "timeout_seconds": timeout_seconds,
+        }
+    else:
+        raise ValueError("tool has no frozen approval contract")
+    return hashlib.sha256(
+        json.dumps(normalized, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
 
 
 class ToolResult(StrictModel):
@@ -134,6 +213,10 @@ class ToolBroker:
         ]
         | None = None,
         harness_faults_enabled: bool = False,
+        frozen_approval_rules: Mapping[
+            tuple[str, str, str], Sequence[FrozenApprovalRule]
+        ]
+        | None = None,
     ) -> None:
         if not 1024 <= max_output_bytes <= 16 * 1024 * 1024:
             raise ValueError("tool output limit is invalid")
@@ -153,6 +236,93 @@ class ToolBroker:
         self.changesets = ChangesetEngine(workspace_broker)
         self._harness_faults_enabled = harness_faults_enabled
         self._harness_faults: set[tuple[str, str, str, str]] = set()
+        self._frozen_approval_rules = (
+            None
+            if frozen_approval_rules is None
+            else {
+                key: tuple(value) for key, value in frozen_approval_rules.items()
+            }
+        )
+
+    def _enforce_frozen_approval(
+        self,
+        *,
+        task_id: str,
+        tool_name: str,
+        arguments: Mapping[str, Any],
+    ) -> None:
+        if self._frozen_approval_rules is None or tool_name not in {
+            "run_command",
+            "run_shell",
+        }:
+            return
+        task = self.store.get_task(task_id)
+        source = task.spec.workspace_source
+        rules = self._frozen_approval_rules.get(
+            (source.kind, source.source_id, source.revision), ()
+        )
+        required_checks = {
+            check.check_id for check in task.spec.acceptance.required_checks
+        }
+        try:
+            request_sha256 = frozen_approval_request_sha256(tool_name, arguments)
+        except ValueError as exc:
+            raise ToolBrokerError(
+                "Evaluation command is not frozen for this task.",
+                code="evaluation_command_not_allowed",
+            ) from exc
+        if not any(
+            rule.request_sha256 == request_sha256
+            and (
+                rule.acceptance_check_id is None
+                or rule.acceptance_check_id in required_checks
+            )
+            for rule in rules
+        ):
+            raise ToolBrokerError(
+                "Evaluation command is not frozen for this task.",
+                code="evaluation_command_not_allowed",
+            )
+
+    def _task_uses_v20(self, task_id: str) -> bool:
+        snapshot = self.store.get_task_capability_snapshot(task_id)
+        return (
+            snapshot is not None
+            and snapshot.snapshot.get("harness_protocol") == "v20"
+        )
+
+    def _failure_code(self, task_id: str, raw_code: object) -> str:
+        code = raw_code if isinstance(raw_code, str) else "tool_failed"
+        if not self._task_uses_v20(task_id):
+            return code
+        return {
+            "tool_failed": "tool_broker_internal_error",
+            "executor_failed": "executor_runtime_failed",
+        }.get(code, code)
+
+    def _v20_changeset_result_requires_reconcile(
+        self,
+        *,
+        task_id: str,
+        workspace_id: str,
+        operation_id: str,
+        tool_name: str,
+        request: Mapping[str, Any],
+        operation_state: OperationState,
+    ) -> bool:
+        if (
+            operation_state is not OperationState.RUNNING
+            or not self._task_uses_v20(task_id)
+            or not self._tool_can_publish_changeset(tool_name)
+            or not self.operation_side_effecting(tool_name, request)
+        ):
+            return False
+        try:
+            return self.changesets.has_transaction(
+                workspace_id=workspace_id, operation_id=operation_id
+            )
+        except Exception:
+            return True
 
     @staticmethod
     def operation_side_effecting(
@@ -465,15 +635,28 @@ class ToolBroker:
             OSError,
             asyncio.TimeoutError,
         ) as exc:
+            failure_code = self._failure_code(
+                task_id, getattr(exc, "code", "tool_failed")
+            )
             current = self.store.get_operation(operation_id)
             awaiting_approval = (
                 isinstance(exc, ToolBrokerError)
                 and exc.code == "approval_required"
                 and current.state is OperationState.PREPARED
             )
-            unknown_result = (
+            explicit_unknown_result = (
                 isinstance(exc, ToolBrokerError)
                 and exc.code == "operation_result_unknown"
+            )
+            unknown_result = explicit_unknown_result or (
+                self._v20_changeset_result_requires_reconcile(
+                    task_id=task_id,
+                    workspace_id=task.workspace_id,
+                    operation_id=operation_id,
+                    tool_name=tool_name,
+                    request=current.request,
+                    operation_state=current.state,
+                )
             )
             if unknown_result and current.state in {
                 OperationState.PREPARED,
@@ -498,27 +681,64 @@ class ToolBroker:
                 self.store.transition_operation(
                     operation_id,
                     OperationState.FAILED,
-                    result={"code": getattr(exc, "code", "tool_failed")},
+                    result={"code": failure_code},
                     expected_state=current.state,
                 )
+            if unknown_result and not explicit_unknown_result:
+                raise ToolBrokerError(
+                    "Durable tool result must be reconciled.",
+                    code="operation_result_unknown",
+                ) from exc
             if isinstance(exc, (ToolBrokerError, ChangesetError)):
                 if isinstance(exc, ChangesetError):
                     raise ToolBrokerError(
                         "Changeset operation failed.", code=exc.code
                     ) from exc
+                if failure_code != exc.code:
+                    raise ToolBrokerError(
+                        "Tool operation failed.", code=failure_code
+                    ) from exc
                 raise
-            raise ToolBrokerError("Tool operation failed.", code=getattr(exc, "code", "tool_failed")) from exc
+            raise ToolBrokerError("Tool operation failed.", code=failure_code) from exc
         except Exception as exc:
+            failure_code = self._failure_code(
+                task_id, getattr(exc, "code", "tool_failed")
+            )
             current = self.store.get_operation(operation_id)
+            unknown_result = self._v20_changeset_result_requires_reconcile(
+                task_id=task_id,
+                workspace_id=task.workspace_id,
+                operation_id=operation_id,
+                tool_name=tool_name,
+                request=current.request,
+                operation_state=current.state,
+            )
+            if unknown_result:
+                self.store.transition_operation(
+                    operation_id,
+                    OperationState.UNKNOWN,
+                    result={"code": "operation_result_unknown"},
+                    expected_state=current.state,
+                )
+                if task.runtime_protocol is RuntimeProtocol.V17 and current_turn is not None:
+                    self.store.begin_turn_parking(
+                        task_id=task_id,
+                        turn_id=current_turn.turn_id,
+                        barrier=TurnBarrier.OPERATION_UNKNOWN,
+                    )
+                raise ToolBrokerError(
+                    "Durable tool result must be reconciled.",
+                    code="operation_result_unknown",
+                ) from exc
             if current.state in {OperationState.PREPARED, OperationState.RUNNING}:
                 self.store.transition_operation(
                     operation_id,
                     OperationState.FAILED,
-                    result={"code": getattr(exc, "code", "tool_failed")},
+                    result={"code": failure_code},
                     expected_state=current.state,
                 )
             raise ToolBrokerError(
-                "Tool operation failed.", code=getattr(exc, "code", "tool_failed")
+                "Tool operation failed.", code=failure_code
             ) from exc
 
     def reconcile(self, operation_id: str) -> ToolResult:
@@ -788,6 +1008,11 @@ class ToolBroker:
             return None
         capability: CapabilityName
         approval_scope = request["arguments"]
+        self._enforce_frozen_approval(
+            task_id=task_id,
+            tool_name=tool_name,
+            arguments=request["arguments"],
+        )
         if tool_name == "run_shell":
             shell_scope = self._shell_approval_scope(
                 operation_id, request["arguments"]
@@ -1892,6 +2117,14 @@ class ToolBroker:
             or len(script.encode("utf-8")) > 64 * 1024
         ):
             raise ToolBrokerError("Shell input is invalid.", code="tool_input_invalid")
+        if (
+            SHELL_HOST_PATH.search(script) is not None
+            or SHELL_PRIVATE_RUNTIME_PATH.search(script) is not None
+        ):
+            raise ToolBrokerError(
+                "Shell scripts cannot reference host or private runtime paths.",
+                code="workspace_path_invalid",
+            )
         try:
             return ShellApprovalScope(
                 operation_id=operation_id,
@@ -1905,6 +2138,17 @@ class ToolBroker:
             raise ToolBrokerError(
                 "Shell input is invalid.", code="tool_input_invalid"
             ) from exc
+
+    @staticmethod
+    def _shell_executor_result_uncertain(exc: Exception) -> bool:
+        return (
+            isinstance(exc, (OSError, asyncio.TimeoutError, json.JSONDecodeError))
+            or getattr(exc, "code", None) == "executor_invalid_response"
+        )
+
+    @staticmethod
+    def _shell_executor_rejection_proves_no_effect(exc: Exception) -> bool:
+        return getattr(exc, "code", None) in V20_SHELL_NO_SIDE_EFFECT_ERROR_CODES
 
     async def _run_shell(
         self,
@@ -1954,12 +2198,36 @@ class ToolBroker:
                 timeout_seconds=scope.timeout_seconds,
                 output_callback=persist_output,
             )
-        except Exception:
+        except Exception as exc:
             if output:
                 self._archive_shell_output(
                     task_id, operation_id, bytes(output), state="interrupted"
                 )
-            raise
+            if not self._task_uses_v20(task_id):
+                raise
+            uncertain = self._shell_executor_result_uncertain(exc)
+            if (
+                scope.mode is ShellMode.MUTATE
+                and not self._shell_executor_rejection_proves_no_effect(exc)
+            ):
+                raise ToolBrokerError(
+                    "Mutating shell executor result is unknown.",
+                    code="operation_result_unknown",
+                ) from exc
+            if isinstance(exc, ToolBrokerError):
+                raise
+            raw_code = getattr(exc, "code", None)
+            failure_code = (
+                str(raw_code)
+                if isinstance(raw_code, str)
+                else "executor_transport_failed"
+                if uncertain
+                else self._failure_code(task_id, "executor_failed")
+            )
+            failure_code = self._failure_code(task_id, failure_code)
+            raise ToolBrokerError(
+                "Shell executor request failed.", code=failure_code
+            ) from exc
         result = self._validate_shell_result(
             raw_result,
             expected_mode=scope.mode,
@@ -2180,6 +2448,21 @@ class ToolBroker:
             and item.metadata.get("operation_id") == operation_id
         ]
         if not artifacts:
+            workspace_id = str(operation.request["workspace_id"])
+            try:
+                changeset_pending = self.changesets.has_transaction(
+                    workspace_id=workspace_id, operation_id=operation_id
+                )
+            except ChangesetError as exc:
+                raise ToolBrokerError(
+                    "Shell changeset state is unavailable.",
+                    code="operation_result_unknown",
+                ) from exc
+            if changeset_pending:
+                raise ToolBrokerError(
+                    "Shell receipt is unavailable while its changeset remains pending.",
+                    code="operation_result_unknown",
+                )
             failed = self.store.transition_operation(
                 operation_id,
                 OperationState.FAILED,

--- a/server/tests/fixtures/coding_worker_v20_replays/r11_claude_approval_restart.json
+++ b/server/tests/fixtures/coding_worker_v20_replays/r11_claude_approval_restart.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "candidate_base_sha": "d4bd6b8dc151b79001efc0bbe3f06e22716dae0a",
+  "candidate_diff_sha256": "3e78fd2341e51e9608894e22a0d01351215498764a9fc63cfbd3ce658596c06b",
+  "compose_config_sha256": "6bdfd9d9e8aef81fa1696f65677ba8de43062068b5ee99161c72ea8efaa2219b",
+  "restart_boundary_sequence": 13,
+  "events": [
+    {"sequence": 12, "type": "turn_parked"},
+    {"sequence": 15, "type": "turn_resumed"},
+    {"sequence": 18, "type": "task_state", "reason": "harness_binding_changed"},
+    {"sequence": 19, "type": "capability_changed"},
+    {"sequence": 31, "type": "operation_reconciled"},
+    {"sequence": 87, "type": "evidence_recorded"},
+    {"sequence": 90, "type": "task_state", "state": "completed"}
+  ],
+  "metrics": {
+    "events": 90,
+    "usage_events": 14,
+    "evidence_passed": 1,
+    "operations": 10,
+    "unsettled_operations": 0,
+    "duplicate_side_effects": 0,
+    "orphaned_interactions": 0,
+    "generic_failures": 0,
+    "public_leaks": 0,
+    "diff_bytes": 487
+  }
+}

--- a/server/tests/test_coding_project_source.py
+++ b/server/tests/test_coding_project_source.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import subprocess
+import threading
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -61,6 +63,37 @@ def _manifest(root: Path, projects: list[tuple[str, str]]) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def test_project_catalog_inspection_is_bounded_parallel_and_ordered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "projects"
+    root.mkdir()
+    projects = [(f"Project {index}", f"team/project-{index}") for index in range(8)]
+    _manifest(root, projects)
+    expected_ids = [entry.project_id for entry in load_project_manifest(root)]
+    barrier = threading.Barrier(4)
+    counter_lock = threading.Lock()
+    active = 0
+    maximum_active = 0
+
+    def inspect(_root: Path, entry: object) -> SimpleNamespace:
+        nonlocal active, maximum_active
+        with counter_lock:
+            active += 1
+            maximum_active = max(maximum_active, active)
+        barrier.wait(timeout=5)
+        with counter_lock:
+            active -= 1
+        return SimpleNamespace(to_public_dict=lambda: {"id": entry.project_id})
+
+    monkeypatch.setattr("server.coding_project_source.server.inspect_project", inspect)
+
+    projects = ProjectSnapshotBroker(root, tmp_path / "slot").list_projects()
+
+    assert maximum_active == 4
+    assert [project["id"] for project in projects] == expected_ids
 
 
 def test_snapshot_uses_head_blob_bytes_and_never_changes_source_repository(tmp_path: Path) -> None:

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -69,6 +69,7 @@ def _client(
     blocked: bool = False,
     provider: FakeCodingAgentProvider | None = None,
     master_key: bytes | None = None,
+    new_task_model_routes: tuple[str, ...] | None = None,
 ) -> tuple[TestClient, CodingWorkerService]:
     store = CodingWorkerStore(
         tmp_path / "worker", master_key=master_key or Fernet.generate_key()
@@ -91,6 +92,7 @@ def _client(
         workspace_broker=broker,
         provider=LegacyHarnessDriver(selected_provider),
         harness_supervisor=supervisor,
+        new_task_model_routes=new_task_model_routes,
     )
     evaluation = LegacyEvaluationAdapter(
         service,
@@ -551,6 +553,33 @@ def test_model_route_is_catalog_controlled(tmp_path: Path) -> None:
     response = client.post("/api/coding-worker/v1/tasks", json=payload)
     assert response.status_code == 400
     assert response.json()["detail"]["code"] == "model_route_not_allowed"
+
+
+def test_configured_but_disabled_route_uses_control_plane_conflict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(
+        "CODING_WORKER_MODEL_ROUTES", "coding/default,coding/quality"
+    )
+    monkeypatch.setenv(
+        "CODING_WORKER_ROUTE_SLOTS_JSON",
+        '{"coding/default":["slot-a"],"coding/quality":["slot-b"]}',
+    )
+    monkeypatch.setenv("CODING_WORKER_CLAUDE_SLOT_IDS", "slot-b")
+    monkeypatch.setenv("CODING_WORKER_CLAUDE_ENABLED", "false")
+    client, _service = _client(
+        tmp_path, new_task_model_routes=("coding/default",)
+    )
+    payload = _payload("disabled-quality")
+    payload["model_route"] = "coding/quality"
+
+    with client:
+        status = client.get("/api/coding-worker/v1").json()
+        response = client.post("/api/coding-worker/v1/tasks", json=payload)
+
+    assert status["model_routes"] == ["coding/default"]
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "model_route_unavailable"
 
 
 def test_workspace_endpoints_use_task_and_opaque_entry_ids(tmp_path: Path) -> None:

--- a/server/tests/test_coding_worker_broker_rpc.py
+++ b/server/tests/test_coding_worker_broker_rpc.py
@@ -6,11 +6,10 @@ from pathlib import Path
 
 import pytest
 from cryptography.fernet import Fernet
+from mcp.server.fastmcp.exceptions import ToolError
 
 from server.coding_worker.broker_rpc import BrokerRPCClient, BrokerRPCError, BrokerRPCServer
 from server.coding_worker.broker_mcp import (
-    BrokerReplaceChange,
-    _replace_change_as_write,
     _workspace_relative_cwd,
     _workspace_relative_shell_script,
     build_server,
@@ -243,6 +242,24 @@ async def test_mcp_exposes_only_modelmirror_broker_tools() -> None:
 
 
 @pytest.mark.asyncio
+async def test_mcp_rejects_empty_shell_arguments_before_rpc() -> None:
+    calls: list[dict[str, object]] = []
+
+    class RecordingClient:
+        async def call(self, **kwargs: object) -> dict[str, object]:
+            calls.append(kwargs)
+            return {"ok": True}
+
+    with pytest.raises(
+        ToolError,
+        match=r"(?s)operation_id.*Field required.*script.*Field required",
+    ):
+        await build_server(RecordingClient()).call_tool("run_shell", {})
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_mcp_defaults_omitted_plan_status_before_rpc() -> None:
     calls: list[dict[str, object]] = []
 
@@ -343,50 +360,93 @@ async def test_mcp_changeset_schema_computes_content_and_patch_digests() -> None
     ]
 
 
-def test_replace_change_preserves_unrelated_bytes_and_final_newline(
+@pytest.mark.asyncio
+async def test_mcp_replace_is_resolved_by_authoritative_workspace(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    source = "before\nold value\nafter\n"
-    target = tmp_path / "app.py"
-    target.write_text(source, encoding="utf-8", newline="")
-    expected_sha256 = hashlib.sha256(source.encode()).hexdigest()
+    monkeypatch.setenv("CODING_WORKER_V15_ENABLED", "true")
+    server, task_id, endpoint, _ = await _rpc(tmp_path)
+    token = server.register_task(task_id)
+    client = BrokerRPCClient(endpoint, token=token, task_id=task_id)
+    task = server.broker.store.get_task(task_id)
+    assert task.workspace_id is not None
+    workspace = server.broker.workspace_broker
+    repository = workspace.repository_path(task.workspace_id)
+    source = b"before\nold value\nafter\n"
+    (repository / "app.py").write_bytes(source)
+    base_tree_hash = workspace.current_tree_hash(task.workspace_id)
 
-    encoded = _replace_change_as_write(
-        BrokerReplaceChange(
-            kind="replace",
-            path="app.py",
-            expected_sha256=expected_sha256,
-            old_text="old value",
-            new_text="new value",
-        ),
-        workspace=tmp_path,
-    )
+    try:
+        await build_server(client).call_tool(
+            "apply_changeset",
+            {
+                "operation_id": "replace-authoritative-workspace",
+                "base_tree_hash": base_tree_hash,
+                "changes": [
+                        {
+                            "kind": "replace",
+                            "path": "app.py",
+                            "expected_sha256": hashlib.sha256(source).hexdigest(),
+                            "old_text": "old value",
+                            "new_text": "new value",
+                        }
+                    ],
+                },
+            )
+        assert (repository / "app.py").read_bytes() == b"before\nnew value\nafter\n"
+        assert (
+            server.broker.store.get_operation("replace-authoritative-workspace").state
+            is OperationState.COMPLETED
+        )
+    finally:
+        await server.close()
 
-    assert encoded == {
-        "kind": "write",
-        "path": "app.py",
-        "expected_sha256": expected_sha256,
-        "expected_absent": False,
-        "content": "before\nnew value\nafter\n",
-        "content_sha256": hashlib.sha256(
-            b"before\nnew value\nafter\n"
-        ).hexdigest(),
-    }
-    assert target.read_bytes() == source.encode()
 
+@pytest.mark.asyncio
+async def test_mcp_replace_rejects_ambiguous_preimage_without_modifying_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CODING_WORKER_V15_ENABLED", "true")
+    server, task_id, endpoint, _ = await _rpc(tmp_path)
+    token = server.register_task(task_id)
+    client = BrokerRPCClient(endpoint, token=token, task_id=task_id)
+    task = server.broker.store.get_task(task_id)
+    assert task.workspace_id is not None
+    workspace = server.broker.workspace_broker
+    repository = workspace.repository_path(task.workspace_id)
+    source = b"same\nsame\n"
+    (repository / "app.py").write_bytes(source)
 
-def test_replace_change_requires_one_exact_preimage_match(tmp_path: Path) -> None:
-    content = "same\nsame\n"
-    (tmp_path / "app.py").write_text(content, encoding="utf-8", newline="")
-    change = BrokerReplaceChange(
-        kind="replace",
-        path="app.py",
-        expected_sha256=hashlib.sha256(content.encode()).hexdigest(),
-        old_text="same",
-        new_text="different",
-    )
-    with pytest.raises(ValueError, match="exactly once"):
-        _replace_change_as_write(change, workspace=tmp_path)
+    try:
+        with pytest.raises(ToolError, match="Changeset operation failed"):
+            await build_server(client).call_tool(
+                "apply_changeset",
+                {
+                    "operation_id": "replace-ambiguous-preimage",
+                    "base_tree_hash": workspace.current_tree_hash(task.workspace_id),
+                    "changes": [
+                        {
+                            "kind": "replace",
+                            "path": "app.py",
+                            "expected_sha256": hashlib.sha256(source).hexdigest(),
+                            "old_text": "same",
+                            "new_text": "different",
+                        }
+                    ],
+                },
+            )
+        assert (repository / "app.py").read_bytes() == source
+        assert (
+            server.broker.store.get_operation("replace-ambiguous-preimage").state
+            is OperationState.FAILED
+        )
+        assert server.broker.store.get_operation(
+            "replace-ambiguous-preimage"
+        ).result == {"code": "tool_input_invalid"}
+    finally:
+        await server.close()
 
 
 def test_shell_adapter_canonicalizes_only_current_workspace_references(

--- a/server/tests/test_coding_worker_claude.py
+++ b/server/tests/test_coding_worker_claude.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from server.coding_worker.claude_provider import (
     CLAUDE_BUILTIN_TOOLS,
@@ -13,6 +14,7 @@ from server.coding_worker.claude_provider import (
     ClaudeCodeProvider,
     ClaudeCodeProviderError,
     ClaudeCodeRoute,
+    ClaudeSessionHandle,
 )
 from server.coding_worker.contracts import (
     PolicyProfile,
@@ -22,6 +24,7 @@ from server.coding_worker.contracts import (
 from server.coding_worker.provider import (
     ProviderCheckpointCompatibility,
     ProviderEventKind,
+    ProviderFailureKind,
     ProviderOpenRequest,
 )
 from server.coding_worker.sidecar import _provider_from_environment
@@ -106,6 +109,91 @@ def test_sidecar_selects_claude_without_gateway_key_or_workspace_resolver(
     )
     assert isinstance(provider, ClaudeCodeProvider)
     assert "secret" not in repr(provider)
+
+
+def test_sidecar_rejects_missing_claude_secret_before_advertising_capabilities(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CODING_WORKER_PROVIDER_KIND", "claude-code")
+    monkeypatch.setenv("CODING_WORKER_ROUTE_ID", "coding/quality")
+    monkeypatch.setenv("CODING_WORKER_MODEL_ID", "claude-test-model")
+    monkeypatch.setenv(
+        "CODING_WORKER_CLAUDE_SECRET_PATH", str(tmp_path / "missing-secret")
+    )
+
+    with pytest.raises(ClaudeCodeProviderError) as unavailable:
+        _provider_from_environment(tmp_path / "workspace", tmp_path / "runtime")
+    assert unavailable.value.code == "provider_credential_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_claude_capabilities_fail_closed_after_secret_disappears(
+    tmp_path: Path,
+) -> None:
+    provider = _provider(tmp_path, command_prefix=("claude",))
+    provider._secret_path.unlink()
+
+    with pytest.raises(ClaudeCodeProviderError) as unavailable:
+        await provider.capabilities()
+    assert unavailable.value.code == "provider_credential_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_interrupt_turn_confirms_an_already_quiescent_session(
+    tmp_path: Path,
+) -> None:
+    provider = _provider(tmp_path, command_prefix=("claude",))
+    session = await provider.open(_request())
+
+    assert await provider.cancel(session) is False
+    assert await provider.interrupt_turn(session) is True
+
+    await provider.close(session)
+
+
+def test_claude_gateway_route_requires_https_api_root() -> None:
+    for value in (
+        "http://openrouter.ai/api",
+        "https://user:secret@openrouter.ai/api",
+        "https://openrouter.ai/api?debug=true",
+        "https://openrouter.ai/api/v1/messages",
+    ):
+        with pytest.raises(ValidationError):
+            ClaudeCodeRoute(
+                route_id="coding/quality",
+                model_id="claude-test-model",
+                gateway_base_url=value,
+            )
+
+
+def test_claude_gateway_uses_auth_token_without_api_key(tmp_path: Path) -> None:
+    route = ClaudeCodeRoute(
+        route_id="coding/quality",
+        model_id="~anthropic/claude-sonnet-latest",
+        gateway_base_url="https://openrouter.ai/api/",
+    )
+    provider = ClaudeCodeProvider(
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/quality": route},
+        secret_path=tmp_path / "secret",
+        command_prefix=("claude",),
+    )
+    handle = ClaudeSessionHandle(
+        request=_request(),
+        route=route,
+        state_root=tmp_path,
+        home=tmp_path / "home",
+        settings_path=tmp_path / "settings.json",
+        mcp_path=tmp_path / "mcp.json",
+        session_id="session",
+        revoke_broker=lambda: None,
+    )
+
+    environment = provider.build_environment(handle, api_key="secret-token")
+
+    assert environment["ANTHROPIC_BASE_URL"] == "https://openrouter.ai/api"
+    assert environment["ANTHROPIC_AUTH_TOKEN"] == "secret-token"
+    assert environment["ANTHROPIC_API_KEY"] == ""
 
 
 @pytest.mark.asyncio
@@ -195,6 +283,86 @@ print(json.dumps({
     provider.bind_broker("task-claude", "unix:/run/broker.sock", "b" * 48)
     restored = await provider.restore(bound_request, checkpoint)
     await provider.close(restored)
+
+
+@pytest.mark.parametrize(
+    ("errors", "failure"),
+    [
+        (["Credit balance is too low; visit billing"], ProviderFailureKind.BUDGET),
+        ([{"message": "Rate limit exceeded"}], ProviderFailureKind.RATE_LIMITED),
+        (["Invalid API key"], ProviderFailureKind.AUTHENTICATION),
+    ],
+)
+def test_error_result_uses_a_sanitized_failure_classification(
+    errors: list[object], failure: ProviderFailureKind
+) -> None:
+    events = ClaudeCodeProvider.map_stream_frame(
+        json.dumps(
+            {
+                "type": "result",
+                "session_id": "claude_1",
+                "is_error": True,
+                "subtype": "error_during_execution",
+                "errors": errors,
+                "supplier_frame": "must-not-leak",
+            }
+        ).encode(),
+        "claude_1",
+    )
+
+    assert events == (
+        ClaudeCodeProvider._failure_event(failure),
+    )
+
+
+def test_tool_result_preserves_started_tool_name_and_rejects_duplicate() -> None:
+    tool_names: dict[str, str] = {}
+    started = ClaudeCodeProvider.map_stream_frame(
+        json.dumps(
+            {
+                "type": "assistant",
+                "session_id": "claude_1",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "mcp__modelmirror-tool-broker__read_operation_output",
+                        }
+                    ]
+                },
+            }
+        ).encode(),
+        "claude_1",
+        tool_names=tool_names,
+    )
+    result_frame = json.dumps(
+        {
+            "type": "user",
+            "session_id": "claude_1",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "is_error": False,
+                    }
+                ]
+            },
+        }
+    ).encode()
+
+    completed = ClaudeCodeProvider.map_stream_frame(
+        result_frame, "claude_1", tool_names=tool_names
+    )
+    duplicate = ClaudeCodeProvider.map_stream_frame(
+        result_frame, "claude_1", tool_names=tool_names
+    )
+
+    assert started[0].data["tool_name"] == "read_operation_output"
+    assert completed[0].data["tool_name"] == "read_operation_output"
+    assert tool_names == {}
+    assert duplicate == ()
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -92,7 +92,10 @@ def test_v15_claude_provider_has_a_pinned_private_image_and_secret_only_mount() 
     assert "internal: true" in compose
     assert "CODING_WORKER_ROUTE_SLOTS_JSON" in compose
     assert "coding-worker-claude-egress:" in compose
-    assert "CODING_WORKER_PROVIDER_NETWORK_DOMAINS: api.anthropic.com" in compose
+    assert (
+        "CODING_WORKER_PROVIDER_NETWORK_DOMAINS: "
+        "${CODING_WORKER_CLAUDE_EGRESS_DOMAINS:-api.anthropic.com}"
+    ) in compose
     assert "CODING_WORKER_PROVIDER_EGRESS_TOKEN" in compose
     assert (
         "CODING_WORKER_PROVIDER_ALLOW_DOCKER_DESKTOP_DNS_PROXY: "
@@ -106,7 +109,7 @@ def test_v15_claude_provider_has_a_pinned_private_image_and_secret_only_mount() 
     assert "coding_worker_provider_b" not in proxy
 
 
-def test_v18_harness_overlay_mounts_only_the_public_fixture_bundle() -> None:
+def test_v18_harness_overlay_mounts_only_public_evaluation_inputs() -> None:
     root = Path(__file__).parents[2]
     compose = (root / "docker-compose.coding-worker-v18-harness.yml").read_text()
 
@@ -118,7 +121,17 @@ def test_v18_harness_overlay_mounts_only_the_public_fixture_bundle() -> None:
     assert 'CODING_WORKER_BUILTIN_REVISION: ""' in compose
     assert "CODING_WORKER_HARNESS_V3_FIXTURE_FILE" in compose
     assert "target: /harness-v3/fixture-bundle.json" in compose
+    assert "CODING_WORKER_HARNESS_V3_TASKS_DIR" not in compose
+    assert compose.count("/scenario.json") == 6
+    assert "target: /harness-v3/tasks/session-clarify-before-edit/scenario.json" in compose
+    assert (
+        "target: /harness-v3/tasks/session-restart-command-reconcile/scenario.json"
+        in compose
+    )
+    assert "target: /harness-v3/tasks/session-steering-compaction/scenario.json" in compose
     assert "read_only: true" in compose
     assert "sealed" not in compose.lower()
     assert "checker" not in compose.lower()
+    assert "/solution/" not in compose
+    assert "/tests/" not in compose
     assert "docker.sock" not in compose

--- a/server/tests/test_coding_worker_harness_v3.py
+++ b/server/tests/test_coding_worker_harness_v3.py
@@ -1590,6 +1590,77 @@ def test_worker_facts_preserve_recovered_platform_failures_from_the_event_ledger
     assert derive_diagnostics(facts).platform_coordination_failures == 1
 
 
+@pytest.mark.parametrize(
+    ("reason", "expected_stage", "expected_coordination_failures"),
+    (
+        ("tool_broker_internal_error", HarnessFailureStage.HARNESS, 1),
+        ("operation_result_unknown", HarnessFailureStage.HARNESS, 1),
+        ("tool_request_invalid", HarnessFailureStage.TOOL_VALIDATION, 0),
+    ),
+)
+def test_worker_task_ledger_distinguishes_platform_tool_failures_from_input_validation(
+    reason: str,
+    expected_stage: HarnessFailureStage,
+    expected_coordination_failures: int,
+) -> None:
+    task_id = f"task_{reason}"
+    run_binding, export_binding = _worker_binding(task_id)
+    trajectory = {
+        "schema_version": "ATIF-v1.7",
+        "session_id": task_id,
+        "agent": {"name": "modelmirror-worker"},
+        "steps": [{"source": "user", "message": "test instruction"}],
+    }
+    export = {
+        "task": {
+            "task_id": task_id,
+            "state": "failed",
+            "reason": reason,
+            "spec": export_binding["spec"],
+        },
+        "artifact_index": export_binding["artifact_index"],
+        "workspace_tree_hash": export_binding["workspace_tree_hash"],
+        "operation_index": [],
+        "questions": [],
+        "subtask_index": [],
+    }
+    task_state_event = ModelMirrorWorkerAgent._ledger_event(
+        {
+            "sequence": 41,
+            "event_type": "task_state",
+            "payload": {
+                "from": "running",
+                "to": "failed",
+                "reason": reason,
+            },
+        }
+    )
+    assert task_state_event is not None
+
+    facts = HarnessFactSet.model_validate(
+        ModelMirrorWorkerAgent._facts(
+            export=export,
+            events=[task_state_event],
+            approvals=(),
+            trajectory=trajectory,
+            run_binding=run_binding,
+        )
+    )
+    diagnostics = derive_diagnostics(facts)
+
+    assert facts.coordination == (
+        HarnessCoordinationFact(
+            evidence_id=f"event_{task_id}_41",
+            stage=expected_stage,
+            failed=True,
+        ),
+    )
+    assert diagnostics.platform_coordination_failures == expected_coordination_failures
+    assert diagnostics.evidence["platform_coordination_failures"] == (
+        (f"event_{task_id}_41",) if expected_coordination_failures else ()
+    )
+
+
 def test_worker_facts_reject_cross_task_trajectory_and_export() -> None:
     run_binding, export_binding = _worker_binding("task_B")
     export = {
@@ -1711,6 +1782,17 @@ def test_worker_ledger_rejects_workspace_artifact_tree_mismatch(
     (
         ("compaction_failed", HarnessFailureStage.INTERACTION),
         ("shell_executor_failed", HarnessFailureStage.EXECUTOR),
+        ("harness_transport_unavailable", HarnessFailureStage.PROVIDER_TRANSPORT),
+        ("harness_protocol_invalid", HarnessFailureStage.PROVIDER_PROTOCOL),
+        ("harness_authentication_failed", HarnessFailureStage.PROVIDER_PROTOCOL),
+        ("harness_rate_limited", HarnessFailureStage.PROVIDER_PROTOCOL),
+        ("harness_policy_rejected", HarnessFailureStage.POLICY),
+        ("harness_budget_exhausted", HarnessFailureStage.BUDGET),
+        ("harness_interrupted", HarnessFailureStage.HARNESS),
+        ("control_plane_internal_error", HarnessFailureStage.HARNESS),
+        ("tool_broker_internal_error", HarnessFailureStage.HARNESS),
+        ("operation_result_unknown", HarnessFailureStage.HARNESS),
+        ("tool_request_invalid", HarnessFailureStage.TOOL_VALIDATION),
         ("turn_parked_compaction", None),
     ),
 )

--- a/server/tests/test_coding_worker_harness_v3.py
+++ b/server/tests/test_coding_worker_harness_v3.py
@@ -1804,6 +1804,49 @@ def test_worker_failure_stage_classifies_platform_control_reasons(
     assert observed == (stage.value if stage is not None else None)
 
 
+def test_r11_claude_restart_replay_uses_the_fault_boundary_not_projection_order() -> None:
+    replay_path = (
+        Path(__file__).parent
+        / "fixtures"
+        / "coding_worker_v20_replays"
+        / "r11_claude_approval_restart.json"
+    )
+    replay = json.loads(replay_path.read_text(encoding="utf-8"))
+    assert replay["schema_version"] == 1
+    assert replay["candidate_diff_sha256"] == (
+        "3e78fd2341e51e9608894e22a0d01351215498764a9fc63cfbd3ce658596c06b"
+    )
+
+    boundary = replay["restart_boundary_sequence"]
+    events = sorted(replay["events"], key=lambda item: item["sequence"])
+    assert len({item["sequence"] for item in events}) == len(events)
+    resumed = [
+        item["sequence"]
+        for item in events
+        if item["type"] == "turn_resumed" and item["sequence"] > boundary
+    ]
+    changed = [
+        item["sequence"]
+        for item in events
+        if item["type"] == "capability_changed" and item["sequence"] > boundary
+    ]
+    assert resumed and changed
+    assert resumed[0] < changed[0], "fixture must attack the old strict event ordering"
+    assert any(
+        item["type"] == "task_state" and item.get("state") == "completed"
+        for item in events
+    )
+    assert replay["metrics"]["evidence_passed"] == 1
+    for key in (
+        "unsettled_operations",
+        "duplicate_side_effects",
+        "orphaned_interactions",
+        "generic_failures",
+        "public_leaks",
+    ):
+        assert replay["metrics"][key] == 0
+
+
 def test_run_record_rejects_caller_supplied_zero_diagnostics() -> None:
     facts = _facts()
     forged = derive_diagnostics(

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -29,11 +29,15 @@ from server.coding_worker.opencode_provider import (
     TOOL_BROKER_MCP_NAME,
 )
 from server.coding_worker.store import CodingWorkerStore
-from server.coding_worker.sidecar import _provider_harness_identity
+from server.coding_worker.sidecar import (
+    _provider_from_environment,
+    _provider_harness_identity,
+)
 from server.coding_worker.tool_broker import ToolBroker
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 from server.coding_worker.provider import (
     ProviderEventKind,
+    ProviderFailureKind,
     ProviderOpenRequest,
     provider_message_with_repository_instructions,
     provider_tools_for_policy,
@@ -107,6 +111,25 @@ def test_harness_identity_observes_the_actual_opencode_cli(
         _provider_harness_identity(provider)
 
 
+def test_sidecar_passes_the_managed_proxy_to_opencode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CODING_WORKER_PROVIDER_KIND", "opencode")
+    monkeypatch.setenv("CODING_WORKER_ROUTE_ID", "coding/default")
+    monkeypatch.setenv("CODING_WORKER_MODEL_ID", "test-model")
+    monkeypatch.setenv("CODING_WORKER_MODEL_BASE_URL", "https://openrouter.ai/api/v1")
+    monkeypatch.setenv("CODING_WORKER_ROUTE_KEY", "ephemeral-route-key")
+    monkeypatch.setenv(
+        "CODING_WORKER_PROVIDER_PROXY_URL",
+        "http://task-token@provider-egress:8081",
+    )
+
+    provider = _provider_from_environment(tmp_path / "workspace", tmp_path / "runtime")
+
+    assert isinstance(provider, OpenCodeProvider)
+    assert provider._provider_proxy_url == "http://task-token@provider-egress:8081"
+
+
 def test_config_disables_direct_tools_plugins_sharing_and_supplier_surface(tmp_path: Path) -> None:
     provider = OpenCodeProvider(
         workspace_resolver=lambda _workspace_id: tmp_path,
@@ -142,6 +165,90 @@ def test_config_disables_direct_tools_plugins_sharing_and_supplier_surface(tmp_p
         "OPENCODE_DISABLE_LSP_DOWNLOAD": "1",
         "OPENCODE_DISABLE_SHARE": "1",
     }
+
+
+def test_provider_proxy_is_applied_without_bypassing_the_route_host(tmp_path: Path) -> None:
+    provider = OpenCodeProvider(
+        workspace_resolver=lambda _workspace_id: tmp_path,
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/default": _route()},
+        tool_broker_command=("python", "-m", "coding_worker.tool_mcp"),
+        provider_proxy_url="http://task-token@provider-egress:8081",
+    )
+
+    environment = provider._build_server_environment(
+        home=tmp_path / "home",
+        route=OpenCodeRoute(
+            route_id="coding/default",
+            model_id="test-model",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="ephemeral-route-key",
+        ),
+        password="server-password",
+        broker_environment={"CODING_WORKER_TASK_ID": "task-01"},
+        tool_allowlist=tuple(),
+    )
+
+    assert environment["HTTPS_PROXY"] == "http://task-token@provider-egress:8081"
+    assert environment["HTTP_PROXY"] == environment["HTTPS_PROXY"]
+    assert environment["NO_PROXY"] == "localhost,127.0.0.1"
+    assert "openrouter.ai" not in environment["NO_PROXY"]
+    assert environment["CODING_WORKER_ROUTE_KEY"] == "ephemeral-route-key"
+
+
+def test_route_rejects_a_concrete_chat_completion_endpoint() -> None:
+    with pytest.raises(ValueError, match="API root URL"):
+        OpenCodeRoute(
+            route_id="coding/default",
+            model_id="test-model",
+            base_url="http://new-api:3000/v1/chat/completions",
+            api_key="ephemeral-route-key",
+        )
+
+
+@pytest.mark.parametrize(
+    ("error", "failure"),
+    [
+        ({"data": {"statusCode": 401}}, ProviderFailureKind.AUTHENTICATION),
+        ({"data": {"statusCode": 429}}, ProviderFailureKind.RATE_LIMITED),
+        ({"message": "Credit balance is too low"}, ProviderFailureKind.BUDGET),
+        ({"data": {"statusCode": 404}}, ProviderFailureKind.INVALID_RESPONSE),
+    ],
+)
+def test_error_frame_uses_a_sanitized_failure_classification(
+    error: dict[str, object], failure: ProviderFailureKind
+) -> None:
+    event = OpenCodeProvider._map_event(
+        {
+            "type": "session.error",
+            "properties": {
+                "sessionID": "ses_test",
+                "error": error,
+                "raw_frame": "must-not-leak",
+            },
+        },
+        "ses_test",
+    )
+
+    assert event is not None and event.kind is ProviderEventKind.FAILED
+    assert event.data == {"failure_kind": failure.value}
+
+
+@pytest.mark.parametrize("marker", ("Aborted", "AbortError", "cancelled", "canceled"))
+def test_error_frame_maps_explicit_abort_to_cancelled(marker: str) -> None:
+    event = OpenCodeProvider._map_event(
+        {
+            "type": "session.error",
+            "properties": {
+                "sessionID": "ses_test",
+                "error": {"name": marker, "raw_frame": "must-not-leak"},
+            },
+        },
+        "ses_test",
+    )
+
+    assert event is not None and event.kind is ProviderEventKind.CANCELLED
+    assert event.data == {}
 
 
 def test_develop_provider_uses_atomic_changesets_not_legacy_file_writes() -> None:
@@ -310,6 +417,11 @@ async def test_headless_adapter_maps_events_cancel_and_checkpoint_without_public
     assert "Use a replace change" in prompt
     assert "Refresh the workspace tree hash" in prompt
     assert "the file's final newline" in prompt
+    assert "Frozen acceptance is platform-owned" in prompt
+    assert "Use run_check for checks returned by list_acceptance_checks" in prompt
+    assert "do not repeat that acceptance command" in prompt
+    assert "does not authorize a later verification call" in prompt
+    assert "run_command for an exact argv command that is not a frozen acceptance check" in prompt
     assert "run_shell mode is exactly inspect or mutate" in prompt
     assert "read_operation_output" in prompt
     assert "Never add ad-hoc debug" in prompt
@@ -333,6 +445,24 @@ async def test_headless_adapter_maps_events_cancel_and_checkpoint_without_public
     assert restored.task_id == session.task_id
     await provider.close(restored)
     assert closed == [True, True]
+
+
+def test_prompt_does_not_recommend_a_legacy_command_tool_when_not_available() -> None:
+    request = _request().model_copy(
+        update={
+            "tool_allowlist": tuple(
+                tool_name
+                for tool_name in _request().tool_allowlist
+                if tool_name != "run_command"
+            )
+        }
+    )
+
+    prompt = provider_message_with_repository_instructions(request, "continue")
+
+    assert "Prefer run_command" not in prompt
+    assert "Use run_check for checks returned by list_acceptance_checks" in prompt
+    assert "Use run_shell only for a task-authorized exact script" in prompt
 
 
 def test_provider_session_is_excluded_from_public_task_record() -> None:

--- a/server/tests/test_coding_worker_provider_rpc.py
+++ b/server/tests/test_coding_worker_provider_rpc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 from pathlib import Path
 
@@ -8,7 +9,10 @@ import pytest
 from cryptography.fernet import Fernet
 
 from server.coding_worker.broker_rpc import BrokerRPCServer
+from server.coding_worker.adapters import LegacyHarnessDriver
 from server.coding_worker.contracts import PolicyProfile, TaskBudget
+from server.coding_worker.harness_contracts import HarnessEventKind, HarnessOpenRequest
+from server.coding_worker.ports import CodingSubstrateError
 from server.coding_worker.provider import (
     FakeCodingAgentProvider,
     ProviderCapabilities,
@@ -18,6 +22,7 @@ from server.coding_worker.provider import (
     ProviderSession,
 )
 from server.coding_worker.provider_rpc import (
+    MAX_PROVIDER_RPC_BYTES,
     ProviderRPCError,
     ProviderRPCRequest,
     ProviderRPCServer,
@@ -28,11 +33,13 @@ from server.coding_worker.harness_v3 import (
     harness_code_bundle_sha256,
 )
 from server.coding_worker.harness_protocol import (
+    HarnessBinding,
     HarnessCapabilityState,
     HarnessDescriptor,
     HarnessPersistenceLevel,
     HarnessToolOwnership,
 )
+from server.coding_worker.service import CodingWorkerService
 from server.coding_worker.executor import (
     ExecutorRPCError,
     ExecutorRPCServer,
@@ -75,6 +82,85 @@ class _AbortTrackingProvider(FakeCodingAgentProvider):
         return True
 
 
+class _CloseRequiresQuiescentProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.message_started = asyncio.Event()
+        self.release_message = asyncio.Event()
+        self.active_messages = 0
+
+    async def message(self, session, text):
+        self.active_messages += 1
+        self.message_started.set()
+        try:
+            await self.release_message.wait()
+        finally:
+            self.active_messages -= 1
+        if False:  # pragma: no cover - keeps this an async generator
+            yield ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)
+
+    async def cancel(self, session):
+        return True
+
+    async def close(self, session):
+        if self.active_messages:
+            raise ValueError("provider message stream is still active")
+        await super().close(session)
+
+
+class _TerminalTrackingProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cancel_count = 0
+        self.message_count = 0
+
+    async def message(self, session, text):
+        self.message_count += 1
+        yield ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)
+
+    async def cancel(self, session):
+        self.cancel_count += 1
+        return True
+
+
+class _ManualProviderStream:
+    def __init__(self) -> None:
+        self._sent = False
+        self._release = asyncio.Event()
+        self.close_count = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._sent:
+            self._sent = True
+            return ProviderEvent(
+                kind=ProviderEventKind.MESSAGE,
+                data={"text": "provider turn started"},
+            )
+        await self._release.wait()
+        raise StopAsyncIteration
+
+    async def aclose(self) -> None:
+        self.close_count += 1
+        self._release.set()
+
+
+class _ManualStreamProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.stream = _ManualProviderStream()
+        self.interrupt_count = 0
+
+    def message(self, session, text):
+        return self.stream
+
+    async def interrupt_turn(self, session):
+        self.interrupt_count += 1
+        return True
+
+
 class _NoShellProvider(FakeCodingAgentProvider):
     async def capabilities(self) -> ProviderCapabilities:
         capabilities = await super().capabilities()
@@ -98,6 +184,67 @@ class _ConstantSessionProvider(FakeCodingAgentProvider):
         return session
 
 
+class _BoundaryFailureProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.failure_action: str | None = None
+        self.failure: Exception | None = None
+
+    def _fail(self, action: str) -> None:
+        if self.failure_action == action and self.failure is not None:
+            raise self.failure
+
+    async def open(self, request: ProviderOpenRequest) -> ProviderSession:
+        self._fail("open")
+        return await super().open(request)
+
+    async def restore(self, request, checkpoint):
+        self._fail("restore")
+        return await super().restore(request, checkpoint)
+
+    async def message(self, session, text):
+        self._fail("message")
+        async for event in super().message(session, text):
+            yield event
+
+    async def checkpoint(self, session):
+        self._fail("checkpoint")
+        return await super().checkpoint(session)
+
+    async def interrupt_turn(self, session):
+        self._fail("interrupt_turn")
+        return await super().interrupt_turn(session)
+
+    async def close(self, session):
+        self._fail("close")
+        await super().close(session)
+
+
+class _DelayedSecondTurnProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.turn_count = 0
+        self.first_stream_closed = asyncio.Event()
+        self.second_turn_started = asyncio.Event()
+        self.release_second_turn = asyncio.Event()
+
+    async def message(self, session, text):
+        self.turn_count += 1
+        if self.turn_count == 1:
+            try:
+                yield ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)
+            finally:
+                self.first_stream_closed.set()
+            return
+        self.second_turn_started.set()
+        await self.release_second_turn.wait()
+        yield ProviderEvent(
+            kind=ProviderEventKind.MESSAGE,
+            data={"text": "second turn remained active"},
+        )
+        yield ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)
+
+
 def _harness_descriptor() -> HarnessDescriptor:
     return HarnessDescriptor(
         protocol_id="modelmirror-provider-v4",
@@ -110,6 +257,314 @@ def _harness_descriptor() -> HarnessDescriptor:
             "checkpoint": HarnessCapabilityState(supported=True, available=True)
         },
     )
+
+
+def _harness_binding(task_id: str) -> HarnessBinding:
+    return HarnessBinding(
+        task_id=task_id,
+        route_id="coding/default",
+        slot_id="slot-a",
+        binding_sha256="b" * 64,
+        driver_generation=1,
+        descriptor=_harness_descriptor(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_v20_driver_replaces_supplier_tool_ids_before_public_events() -> None:
+    raw_operation_id = "toolu_supplier_private_1"
+    provider = FakeCodingAgentProvider(
+        script=(
+            ProviderEvent(
+                kind=ProviderEventKind.TOOL_STARTED,
+                data={
+                    "operation_id": raw_operation_id,
+                    "tool_name": "run_shell",
+                    "summary": "Tool execution started.",
+                },
+            ),
+            ProviderEvent(
+                kind=ProviderEventKind.TOOL_COMPLETED,
+                data={
+                    "operation_id": raw_operation_id,
+                    "tool_name": "run_shell",
+                    "summary": "Tool execution completed.",
+                    "success": True,
+                    "artifact_id": None,
+                },
+            ),
+            ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED),
+        )
+    )
+    task_id = "task_private_tool_id"
+    driver = LegacyHarnessDriver(provider)
+    request = HarnessOpenRequest.model_validate(
+        _request(task_id, "workspace_private_tool_id").model_dump(mode="json")
+    )
+    session = await driver.open(request, binding=_harness_binding(task_id))
+
+    events = [
+        event
+        async for event in driver.message(
+            session, "continue", turn_id="turn_private_tool_id"
+        )
+    ]
+
+    public_ids = [
+        str(event.data["operation_id"])
+        for event in events
+        if event.kind in {
+            HarnessEventKind.TOOL_STARTED,
+            HarnessEventKind.TOOL_COMPLETED,
+        }
+    ]
+    assert len(public_ids) == 2
+    assert public_ids[0] == public_ids[1]
+    assert public_ids[0].startswith("harness_call_")
+    assert raw_operation_id not in repr(events)
+    await driver.close(session)
+
+
+@pytest.mark.asyncio
+async def test_stale_stream_cleanup_cannot_interrupt_the_next_harness_turn() -> None:
+    task_id = "task_turn_cleanup"
+    provider = _DelayedSecondTurnProvider()
+    driver = LegacyHarnessDriver(provider)
+    request = HarnessOpenRequest.model_validate(
+        _request(task_id, "workspace_turn_cleanup").model_dump(mode="json")
+    )
+    session = await driver.open(request, binding=_harness_binding(task_id))
+
+    first_stream = driver.message(session, "first", turn_id="turn_first")
+    first_terminal = await anext(first_stream)
+    assert first_terminal.kind is HarnessEventKind.TURN_COMPLETED
+
+    second_stream = driver.message(session, "second", turn_id="turn_second")
+    second_event = asyncio.create_task(anext(second_stream))
+    await asyncio.wait_for(provider.second_turn_started.wait(), timeout=1)
+
+    # Reproduce the service boundary: the first generator is finalized only
+    # after the successor has already registered its turn.
+    await first_stream.aclose()
+    assert provider.first_stream_closed.is_set()
+    provider.release_second_turn.set()
+
+    assert (await asyncio.wait_for(second_event, timeout=1)).data == {
+        "text": "second turn remained active"
+    }
+    assert (await anext(second_stream)).kind is HarnessEventKind.TURN_COMPLETED
+    await second_stream.aclose()
+    await driver.close(session)
+
+
+@pytest.mark.asyncio
+async def test_harness_interrupt_deterministically_closes_nested_provider_stream() -> None:
+    task_id = "task_nested_stream_close"
+    provider = _ManualStreamProvider()
+    driver = LegacyHarnessDriver(provider)
+    request = HarnessOpenRequest.model_validate(
+        _request(task_id, "workspace_nested_stream_close").model_dump(mode="json")
+    )
+    session = await driver.open(request, binding=_harness_binding(task_id))
+    stream = driver.message(session, "continue", turn_id="turn_nested_stream_close")
+
+    assert (await anext(stream)).kind is HarnessEventKind.MESSAGE
+    await stream.aclose()
+    assert provider.stream.close_count == 0
+
+    assert await driver.interrupt_turn(session) is True
+    assert provider.interrupt_count == 1
+    assert provider.stream.close_count == 1
+
+    await driver.close(session)
+    assert provider.stream.close_count == 1
+
+
+async def _invoke_driver_boundary(
+    provider: _BoundaryFailureProvider,
+    action: str,
+    failure: Exception,
+    *,
+    v20: bool,
+) -> None:
+    task_id = f"task_{action}"
+    request = HarnessOpenRequest.model_validate(
+        _request(task_id, f"workspace_{action}").model_dump(mode="json")
+    )
+    driver = LegacyHarnessDriver(provider)
+    binding = _harness_binding(task_id) if v20 else None
+    if action == "open":
+        provider.failure_action = action
+        provider.failure = failure
+        await driver.open(request, binding=binding)
+        return
+
+    session = await driver.open(request, binding=binding)
+    checkpoint = await driver.checkpoint(session) if action == "restore" else None
+    provider.failure_action = action
+    provider.failure = failure
+    if action == "restore":
+        assert checkpoint is not None
+        await driver.restore(request, checkpoint, binding=binding)
+    elif action == "message":
+        await anext(driver.message(session, "continue", turn_id="turn_test"))
+    elif action == "checkpoint":
+        await driver.checkpoint(session)
+    elif action == "interrupt_turn":
+        await driver.interrupt_turn(session)
+    elif action == "close":
+        await driver.close(session)
+    else:  # pragma: no cover - test helper invariant
+        raise AssertionError(f"unsupported action: {action}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action", ("open", "restore", "message", "checkpoint", "interrupt_turn", "close")
+)
+@pytest.mark.parametrize(
+    ("failure", "expected_code"),
+    (
+        (ConnectionResetError("reset"), "harness_transport_unavailable"),
+        (ValueError("bad provider frame"), "harness_protocol_invalid"),
+        (RuntimeError("driver bug"), "harness_driver_internal"),
+    ),
+)
+async def test_v20_driver_lifecycle_classifies_boundary_failures(
+    action: str, failure: Exception, expected_code: str
+) -> None:
+    provider = _BoundaryFailureProvider()
+    with pytest.raises(CodingSubstrateError) as rejected:
+        await _invoke_driver_boundary(provider, action, failure, v20=True)
+    assert rejected.value.code == expected_code
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action", ("open", "restore", "message", "checkpoint", "interrupt_turn", "close")
+)
+async def test_legacy_driver_lifecycle_preserves_provider_reason(action: str) -> None:
+    provider = _BoundaryFailureProvider()
+    failure = ProviderRPCError("legacy failure", code="provider_failed")
+    with pytest.raises(ProviderRPCError) as rejected:
+        await _invoke_driver_boundary(provider, action, failure, v20=False)
+    assert rejected.value is failure
+    assert rejected.value.code == "provider_failed"
+
+
+@pytest.mark.asyncio
+async def test_provider_rpc_response_frames_distinguish_transport_and_protocol() -> None:
+    reader = asyncio.StreamReader(limit=MAX_PROVIDER_RPC_BYTES)
+    reader.feed_eof()
+    with pytest.raises(ProviderRPCError) as eof:
+        await ProviderSidecarClientPool._read(reader)
+    assert eof.value.code == "provider_transport_unavailable"
+
+    reader = asyncio.StreamReader(limit=MAX_PROVIDER_RPC_BYTES)
+    reader.feed_data(b"{invalid-json}\n")
+    with pytest.raises(ProviderRPCError) as malformed:
+        await ProviderSidecarClientPool._read(reader)
+    assert malformed.value.code == "provider_invalid_response"
+
+    reader = asyncio.StreamReader(limit=MAX_PROVIDER_RPC_BYTES)
+    reader.feed_data(b"x" * (MAX_PROVIDER_RPC_BYTES + 1) + b"\n")
+    with pytest.raises(ProviderRPCError) as oversize:
+        await ProviderSidecarClientPool._read(reader)
+    assert oversize.value.code == "provider_response_too_large"
+
+
+@pytest.mark.asyncio
+async def test_provider_rpc_first_frame_connection_reset_is_transport(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    workspace = WorkspaceBroker(tmp_path / "workspace", {}, id_key=b"r" * 32)
+    broker_rpc = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
+    pool = ProviderSidecarClientPool(
+        endpoints={"slot-a": "tcp:127.0.0.1:1"},
+        tokens={"slot-a": "r" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+        broker_rpc=broker_rpc,
+    )
+
+    class _ResetReader:
+        async def readline(self) -> bytes:
+            raise ConnectionResetError("first frame reset")
+
+    class _Writer:
+        def write(self, _data: bytes) -> None:
+            return None
+
+        async def drain(self) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+        async def wait_closed(self) -> None:
+            return None
+
+    async def reset_connection(_slot_id: str):
+        return _ResetReader(), _Writer()
+
+    monkeypatch.setattr(pool, "_connect", reset_connection)
+    with pytest.raises(ProviderRPCError) as reset:
+        await pool._call("slot-a", "capabilities", {})
+    assert reset.value.code == "provider_transport_unavailable"
+
+
+def test_checkpoint_failure_preserves_v20_driver_attribution() -> None:
+    failure = CodingSubstrateError(
+        "checkpoint transport failed",
+        code="harness_transport_unavailable",
+        status=503,
+    )
+    assert CodingWorkerService._checkpoint_failure_reason(
+        failure,
+        fallback="checkpoint_failed",
+        v20=True,
+    ) == "harness_transport_unavailable"
+    assert CodingWorkerService._checkpoint_failure_reason(
+        failure,
+        fallback="checkpoint_failed",
+        v20=False,
+    ) == "checkpoint_failed"
+
+
+def test_harness_v3_maps_driver_internal_failure_to_harness_stage() -> None:
+    from scripts.coding_worker_harbor_agent import ModelMirrorWorkerAgent
+
+    assert ModelMirrorWorkerAgent._failure_stage("harness_driver_internal") == "harness"
+
+
+@pytest.mark.asyncio
+async def test_capabilities_for_slots_probes_only_requested_slots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    workspace = WorkspaceBroker(tmp_path / "workspace", {}, id_key=b"c" * 32)
+    pool = ProviderSidecarClientPool(
+        endpoints={
+            "slot-a": "tcp:127.0.0.1:1",
+            "slot-b": "tcp:127.0.0.1:2",
+        },
+        tokens={"slot-a": "a" * 48, "slot-b": "b" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+        broker_rpc=BrokerRPCServer(
+            ToolBroker(store=store, workspace_broker=workspace)
+        ),
+    )
+    calls: list[str] = []
+
+    async def record(slot_id: str, _action: str, _payload: dict[str, object]):
+        calls.append(slot_id)
+        return (await FakeCodingAgentProvider().capabilities()).model_dump(mode="json")
+
+    monkeypatch.setattr(pool, "_call", record)
+    result = await pool.capabilities_for_slots(("slot-a",))
+
+    assert result["slot-a"] is not None
+    assert calls == ["slot-a"]
 
 
 @pytest.mark.asyncio
@@ -321,8 +776,9 @@ async def test_provider_pool_scopes_equal_private_session_ids_by_task(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("explicit_interrupt", (False, True))
 async def test_closing_provider_stream_aborts_the_unfinished_sidecar_turn(
-    tmp_path: Path,
+    tmp_path: Path, explicit_interrupt: bool,
 ) -> None:
     loop = asyncio.get_running_loop()
     previous_handler = loop.get_exception_handler()
@@ -355,6 +811,8 @@ async def test_closing_provider_stream_aborts_the_unfinished_sidecar_turn(
     first = await anext(stream)
     assert first.kind is ProviderEventKind.MESSAGE
 
+    if explicit_interrupt:
+        assert await pool.interrupt_turn(session) is True
     await stream.aclose()
     for _ in range(100):
         if provider.cancel_count == 1:
@@ -367,6 +825,97 @@ async def test_closing_provider_stream_aborts_the_unfinished_sidecar_turn(
     await broker_rpc.close()
     loop.set_exception_handler(previous_handler)
     assert unhandled == []
+
+
+@pytest.mark.asyncio
+async def test_closing_session_quiesces_sidecar_stream_before_reusing_slot(
+    tmp_path: Path,
+) -> None:
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    workspace = WorkspaceBroker(tmp_path / "workspace", {}, id_key=b"q" * 32)
+    broker_rpc = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
+    await broker_rpc.start_tcp_for_tests()
+    provider = _CloseRequiresQuiescentProvider()
+    server = ProviderRPCServer(provider, token="q" * 48)
+    endpoint = await server.start_tcp_for_tests()
+    pool = ProviderSidecarClientPool(
+        endpoints={"slot-a": endpoint},
+        tokens={"slot-a": "q" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+        broker_rpc=broker_rpc,
+    )
+    from server.tests.test_coding_worker_service import _request as task_request
+    from server.coding_worker.contracts import Origin, TaskSpec
+
+    task_ids = [
+        store.create_task(
+            TaskSpec(
+                **task_request(f"rpc-quiesce-{index}").model_dump(),
+                origin=Origin(module="test", object_id=f"rpc-quiesce-{index}"),
+            )
+        ).task_id
+        for index in range(2)
+    ]
+    first = await pool.open(_request(task_ids[0], "workspace_one"))
+    stream = pool.message(first, "continue")
+    pending = asyncio.create_task(anext(stream))
+    await asyncio.wait_for(provider.message_started.wait(), timeout=1)
+
+    assert await pool.cancel(first) is True
+    pending.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await pending
+    await stream.aclose()
+    await pool.close(first)
+
+    second = await pool.open(_request(task_ids[1], "workspace_two"))
+    await pool.close(second)
+    await server.close()
+    await broker_rpc.close()
+
+    assert provider.active_messages == 0
+
+
+@pytest.mark.asyncio
+async def test_closing_provider_stream_after_terminal_does_not_abort_next_turn(
+    tmp_path: Path,
+) -> None:
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    workspace = WorkspaceBroker(tmp_path / "workspace", {}, id_key=b"t" * 32)
+    broker_rpc = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
+    await broker_rpc.start_tcp_for_tests()
+    provider = _TerminalTrackingProvider()
+    server = ProviderRPCServer(provider, token="t" * 48)
+    endpoint = await server.start_tcp_for_tests()
+    pool = ProviderSidecarClientPool(
+        endpoints={"slot-a": endpoint},
+        tokens={"slot-a": "t" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+        broker_rpc=broker_rpc,
+    )
+    from server.tests.test_coding_worker_service import _request as task_request
+    from server.coding_worker.contracts import Origin, TaskSpec
+
+    task_id = store.create_task(
+        TaskSpec(
+            **task_request("rpc-terminal").model_dump(),
+            origin=Origin(module="test", object_id="rpc-terminal"),
+        )
+    ).task_id
+    session = await pool.open(_request(task_id, "workspace_terminal"))
+
+    first = pool.message(session, "first")
+    assert (await anext(first)).kind is ProviderEventKind.TURN_COMPLETED
+    await first.aclose()
+    second = [event async for event in pool.message(session, "second")]
+
+    assert [event.kind for event in second] == [ProviderEventKind.TURN_COMPLETED]
+    assert provider.message_count == 2
+    assert provider.cancel_count == 0
+
+    await pool.close(session)
+    await server.close()
+    await broker_rpc.close()
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_runtime.py
+++ b/server/tests/test_coding_worker_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import shutil
 from pathlib import Path
 
 import pytest
@@ -9,20 +10,225 @@ from server.coding_worker.contracts import (
     AcceptanceCheck,
     AcceptanceContract,
     Origin,
+    RuntimeProtocol,
     TaskCreateRequest,
+    TaskSpec,
     TaskState,
     WorkspaceSource,
 )
 from server.coding_worker.executor import ExecutorSidecarClientPool
+from server.coding_worker.harness_protocol import (
+    HarnessCapabilityState,
+    HarnessDescriptor,
+    HarnessPersistenceLevel,
+    HarnessToolOwnership,
+)
 from server.coding_worker.provider import FakeCodingAgentProvider
 from server.coding_worker.provider_rpc import ProviderRPCServer
 from server.coding_worker.runtime import (
     CodingWorkerRuntime,
     CodingWorkerRuntimeError,
+    _load_harness_v3_fixtures,
     _route_slots_from_environment,
+    _schedulable_route_slots,
+    configured_model_routes_from_environment,
 )
-from server.coding_worker.tool_broker import FrozenCheck
+from server.coding_worker.store import WorkerConflictError
+from server.coding_worker.tool_broker import FrozenCheck, frozen_approval_request_sha256
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter
+
+
+_PROVIDER_TOKENS = {"slot-a": "a" * 48, "slot-b": "b" * 48}
+_V17_PREREQUISITE_FLAGS = (
+    "CODING_WORKER_V16_ENABLED",
+    "CODING_WORKER_INTERACTION_ENABLED",
+    "CODING_WORKER_SESSION_CONTROLS_ENABLED",
+    "CODING_WORKER_SUBAGENTS_ENABLED",
+    "CODING_WORKER_V17_ENABLED",
+)
+_V20_REQUIRED_CAPABILITIES = {
+    name: HarnessCapabilityState(supported=True, available=True)
+    for name in (
+        "cancel",
+        "checkpoint",
+        "interrupt",
+        "restore",
+        "streaming",
+        "tool_boundaries",
+        "usage",
+    )
+}
+
+
+def test_harness_v3_loader_freezes_visible_and_scenario_approvals() -> None:
+    bundle = (
+        Path(__file__).resolve().parents[2]
+        / "benchmarks/coding-worker-v18/fixture-bundle.json"
+    )
+    _, _, rules = _load_harness_v3_fixtures(bundle)
+    key = (
+        "builtin",
+        "v18-session-restart-command-reconcile",
+        "a75b3fdf3e5f4fd76f38c5a0252d0e43d2297c52bdfbc239f930b98f5b0b3d89",
+    )
+    observed = {rule.request_sha256 for rule in rules[key]}
+    assert frozen_approval_request_sha256(
+        "run_shell",
+        {
+            "script": "python -m build_index",
+            "cwd": ".",
+            "mode": "mutate",
+            "timeout_seconds": 120,
+        },
+    ) in observed
+    assert frozen_approval_request_sha256(
+        "run_command",
+        {
+            "argv": [
+                "python",
+                "-m",
+                "unittest",
+                "discover",
+                "-s",
+                "visible_tests",
+                "-v",
+            ],
+            "timeout_seconds": 180,
+        },
+    ) in observed
+
+
+def test_harness_v3_loader_rejects_tampered_scenario(tmp_path: Path) -> None:
+    benchmark = (
+        Path(__file__).resolve().parents[2] / "benchmarks/coding-worker-v18"
+    )
+    copied = tmp_path / "coding-worker-v18"
+    shutil.copytree(benchmark, copied)
+    scenario = copied / "tasks/session-restart-command-reconcile/scenario.json"
+    scenario.write_text(
+        scenario.read_text(encoding="utf-8").replace(
+            "python -m build_index", "python -m untrusted"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CodingWorkerRuntimeError) as invalid:
+        _load_harness_v3_fixtures(copied / "fixture-bundle.json")
+    assert invalid.value.code == "coding_worker_config_invalid"
+
+
+def _v20_descriptor() -> HarnessDescriptor:
+    return HarnessDescriptor(
+        protocol_id="modelmirror-provider-v4",
+        protocol_version="4",
+        implementation_version="fake-runtime-v20",
+        schema_sha256="d" * 64,
+        tool_ownership=HarnessToolOwnership.BROKER_ONLY,
+        persistence=HarnessPersistenceLevel.SESSION_RESUME,
+        capabilities=_V20_REQUIRED_CAPABILITIES,
+    )
+
+
+def _enable_v20(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CODING_WORKER_HARNESS_V20_ENABLED", "true")
+    for name in _V17_PREREQUISITE_FLAGS:
+        monkeypatch.setenv(name, "true")
+
+
+async def _start_provider_servers(
+    blockers: dict[str, asyncio.Event],
+    *,
+    limited_slots: frozenset[str] = frozenset(),
+) -> tuple[dict[str, ProviderRPCServer], dict[str, str]]:
+    class LimitedFakeProvider(FakeCodingAgentProvider):
+        async def capabilities(self):
+            value = await super().capabilities()
+            return value.model_copy(update={"supports_steering": False})
+
+    servers = {
+        slot: ProviderRPCServer(
+            (
+                LimitedFakeProvider(block=blockers[slot])
+                if slot in limited_slots
+                else FakeCodingAgentProvider(block=blockers[slot])
+            ),
+            token=_PROVIDER_TOKENS[slot],
+            harness_descriptor=_v20_descriptor(),
+        )
+        for slot in blockers
+    }
+    endpoints = {
+        slot: await server.start_tcp_for_tests() for slot, server in servers.items()
+    }
+    return servers, endpoints
+
+
+def _runtime(
+    tmp_path: Path,
+    endpoints: dict[str, str],
+    *,
+    route_slots: dict[str, tuple[str, ...]],
+    schedulable_route_slots: dict[str, tuple[str, ...]],
+    disabled_model_routes: tuple[str, ...] = (),
+    disabled_slot_ids: tuple[str, ...] = (),
+    max_active_tasks: int = 2,
+) -> CodingWorkerRuntime:
+    return CodingWorkerRuntime(
+        storage_root=tmp_path / "control",
+        slot_roots={
+            "slot-a": tmp_path / "slot-a",
+            "slot-b": tmp_path / "slot-b",
+        },
+        source_adapters={
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {("source", "h0"): {"main.py": b"print('ok')\n"}}
+            )
+        },
+        frozen_checks={
+            "syntax": FrozenCheck(
+                check_id="syntax", argv=("python", "-m", "py_compile", "main.py")
+            )
+        },
+        provider_endpoints=endpoints,
+        provider_tokens=_PROVIDER_TOKENS,
+        broker_socket_path=None,
+        sidecar_uid=-1,
+        sidecar_gid=-1,
+        max_active_tasks=max_active_tasks,
+        route_slots=route_slots,
+        schedulable_route_slots=schedulable_route_slots,
+        new_task_model_routes=tuple(schedulable_route_slots),
+        disabled_model_routes=disabled_model_routes,
+        disabled_slot_ids=disabled_slot_ids,
+        capability_route_slots=schedulable_route_slots,
+    )
+
+
+def _request(client_task_id: str, model_route: str) -> TaskCreateRequest:
+    return TaskCreateRequest(
+        client_task_id=client_task_id,
+        objective="Keep the task running for deterministic route inspection.",
+        workspace_source=WorkspaceSource(
+            kind="manifest", source_id="source", revision="h0"
+        ),
+        acceptance=AcceptanceContract(
+            contract_id="syntax",
+            required_checks=(
+                AcceptanceCheck(check_id="syntax", label="syntax", kind="command"),
+            ),
+        ),
+        model_route=model_route,
+    )
+
+
+async def _wait_running(runtime: CodingWorkerRuntime, task_id: str):
+    task = await runtime.service.wait_for(
+        task_id,
+        lambda item: item.state
+        not in {TaskState.QUEUED, TaskState.PREPARING},
+    )
+    assert task.state is TaskState.RUNNING, (task.state, task.reason)
+    return task
 
 
 @pytest.mark.asyncio
@@ -145,3 +351,615 @@ def test_route_slot_catalog_is_strict_and_provider_neutral(
     with pytest.raises(CodingWorkerRuntimeError) as caught:
         _route_slots_from_environment(("slot-a", "slot-b"))
     assert caught.value.code == "coding_worker_config_invalid"
+
+
+@pytest.mark.parametrize(
+    ("route_slots", "expected"),
+    (
+        (
+            '{"coding/default":["slot-a"],"coding/quality":["slot-b"]}',
+            ("coding/default",),
+        ),
+        (
+            '{"coding/default":["slot-b"],"coding/quality":["slot-a"]}',
+            ("coding/quality",),
+        ),
+        (
+            '{"coding/default":["slot-a","slot-b"],"coding/quality":["slot-b"]}',
+            ("coding/default",),
+        ),
+    ),
+)
+def test_disabled_provider_routes_are_derived_from_declared_slots(
+    monkeypatch: pytest.MonkeyPatch, route_slots: str, expected: tuple[str, ...]
+) -> None:
+    monkeypatch.setenv(
+        "CODING_WORKER_MODEL_ROUTES", "coding/default,coding/quality"
+    )
+    monkeypatch.setenv("CODING_WORKER_ROUTE_SLOTS_JSON", route_slots)
+    monkeypatch.setenv("CODING_WORKER_CLAUDE_SLOT_IDS", "slot-b")
+    monkeypatch.setenv("CODING_WORKER_CLAUDE_ENABLED", "false")
+    assert configured_model_routes_from_environment() == expected
+    monkeypatch.delenv("CODING_WORKER_ROUTE_SLOTS_JSON")
+    assert configured_model_routes_from_environment() == ()
+    monkeypatch.setenv("CODING_WORKER_CLAUDE_ENABLED", "true")
+    assert configured_model_routes_from_environment() == (
+        "coding/default",
+        "coding/quality",
+    )
+
+
+@pytest.mark.asyncio
+async def test_disabled_claude_only_gates_new_tasks_and_background_observation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(
+        "CODING_WORKER_MODEL_ROUTES", "coding/default,coding/quality"
+    )
+    monkeypatch.setenv(
+        "CODING_WORKER_ROUTE_SLOTS_JSON",
+        '{"coding/default":["slot-a"],"coding/quality":["slot-b"]}',
+    )
+    monkeypatch.setenv("CODING_WORKER_CLAUDE_SLOT_IDS", "slot-b")
+    monkeypatch.setenv("CODING_WORKER_CLAUDE_ENABLED", "false")
+    route_slots = _route_slots_from_environment(("slot-a", "slot-b"))
+    assert route_slots == {
+        "coding/default": ("slot-a",),
+        "coding/quality": ("slot-b",),
+    }
+    admitted = configured_model_routes_from_environment()
+    capability_routes = {"coding/default": ("slot-a",)}
+
+    blockers = {slot: asyncio.Event() for slot in ("slot-a", "slot-b")}
+    servers = {
+        slot: ProviderRPCServer(
+            FakeCodingAgentProvider(block=blockers[slot]), token=token
+        )
+        for slot, token in {"slot-a": "a" * 48, "slot-b": "b" * 48}.items()
+    }
+    endpoints = {
+        slot: await server.start_tcp_for_tests() for slot, server in servers.items()
+    }
+
+    runtime = CodingWorkerRuntime(
+        storage_root=tmp_path / "control",
+        slot_roots={
+            "slot-a": tmp_path / "slot-a",
+            "slot-b": tmp_path / "slot-b",
+        },
+        source_adapters={
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {("source", "h0"): {"main.py": b"print('ok')\n"}}
+            )
+        },
+        frozen_checks={
+            "syntax": FrozenCheck(
+                check_id="syntax", argv=("python", "-m", "py_compile", "main.py")
+            )
+        },
+        provider_endpoints=endpoints,
+        provider_tokens={"slot-a": "a" * 48, "slot-b": "b" * 48},
+        broker_socket_path=None,
+        sidecar_uid=-1,
+        sidecar_gid=-1,
+        route_slots=route_slots,
+        new_task_model_routes=admitted,
+        disabled_model_routes=("coding/quality",),
+        capability_route_slots=capability_routes,
+    )
+    observed: list[tuple[str, ...]] = []
+    original_capabilities = runtime.harness_supervisor.capabilities_for_slots
+    original_descriptors = runtime.harness_supervisor.harness_descriptors_for_slots
+
+    async def capabilities(slot_ids: tuple[str, ...]) -> object:
+        observed.append(tuple(slot_ids))
+        return await original_capabilities(slot_ids)
+
+    async def descriptors(slot_ids: tuple[str, ...]) -> object:
+        observed.append(tuple(slot_ids))
+        return await original_descriptors(slot_ids)
+
+    monkeypatch.setattr(
+        runtime.harness_supervisor, "capabilities_for_slots", capabilities
+    )
+    monkeypatch.setattr(
+        runtime.harness_supervisor, "harness_descriptors_for_slots", descriptors
+    )
+    source = WorkspaceSource(kind="manifest", source_id="source", revision="h0")
+    historical_request = TaskCreateRequest(
+        client_task_id="historical-quality",
+        objective="resume historical quality task",
+        workspace_source=source,
+        acceptance=AcceptanceContract(
+            contract_id="syntax",
+            required_checks=(
+                AcceptanceCheck(check_id="syntax", label="syntax", kind="command"),
+            ),
+        ),
+        model_route="coding/quality",
+    )
+    origin = Origin(module="test", object_id="route-gate")
+    historical = runtime.store.create_task(
+        TaskSpec(**historical_request.model_dump(), origin=origin)
+    )
+
+    try:
+        retried = await runtime.substrate.control_plane.create_task(
+            origin, historical_request
+        )
+        assert retried.task_id == historical.task_id
+        with pytest.raises(WorkerConflictError) as rejected:
+            await runtime.substrate.control_plane.create_task(
+                origin,
+                historical_request.model_copy(
+                    update={"client_task_id": "new-quality"}
+                ),
+            )
+        assert rejected.value.code == "model_route_unavailable"
+
+        await runtime.start()
+        parked_historical = await runtime.service.wait_for(
+            historical.task_id, lambda item: item.state is TaskState.INTERRUPTED
+        )
+        assert parked_historical.reason == "model_route_disabled"
+        assert parked_historical.workspace_id is None
+
+        default_task = await runtime.substrate.control_plane.create_task(
+            origin,
+            historical_request.model_copy(
+                update={
+                    "client_task_id": "new-default",
+                    "model_route": "coding/default",
+                }
+            ),
+        )
+        running_default = await runtime.service.wait_for(
+            default_task.task_id, lambda item: item.state is TaskState.RUNNING
+        )
+        assert running_default.workspace_id is not None
+        assert (
+            runtime.workspace_broker.workspace_slot(running_default.workspace_id)
+            == "slot-a"
+        )
+        assert observed
+        assert all(slot_ids == ("slot-a",) for slot_ids in observed)
+        await runtime.service.cancel(default_task.task_id)
+    finally:
+        await runtime.close()
+
+    monkeypatch.setenv("CODING_WORKER_CLAUDE_ENABLED", "true")
+    enabled_runtime = CodingWorkerRuntime(
+        storage_root=tmp_path / "control",
+        slot_roots={
+            "slot-a": tmp_path / "slot-a",
+            "slot-b": tmp_path / "slot-b",
+        },
+        source_adapters={
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {("source", "h0"): {"main.py": b"print('ok')\n"}}
+            )
+        },
+        frozen_checks={
+            "syntax": FrozenCheck(
+                check_id="syntax", argv=("python", "-m", "py_compile", "main.py")
+            )
+        },
+        provider_endpoints=endpoints,
+        provider_tokens={"slot-a": "a" * 48, "slot-b": "b" * 48},
+        broker_socket_path=None,
+        sidecar_uid=-1,
+        sidecar_gid=-1,
+        route_slots=route_slots,
+        new_task_model_routes=("coding/default", "coding/quality"),
+        capability_route_slots=route_slots,
+    )
+    try:
+        await enabled_runtime.start()
+        resumed = await enabled_runtime.substrate.control_plane.resume(
+            historical.task_id
+        )
+        assert resumed.state is TaskState.QUEUED
+        running_historical = await enabled_runtime.service.wait_for(
+            historical.task_id, lambda item: item.state is TaskState.RUNNING
+        )
+        assert running_historical.workspace_id is not None
+        assert (
+            enabled_runtime.workspace_broker.workspace_slot(
+                running_historical.workspace_id
+            )
+            == "slot-b"
+        )
+        await enabled_runtime.service.cancel(historical.task_id)
+    finally:
+        await enabled_runtime.close()
+        for server in servers.values():
+            await server.close()
+
+
+def test_schedulable_route_slots_remove_only_disabled_slots() -> None:
+    assert _schedulable_route_slots(
+        {
+            "coding/default": ("slot-a", "slot-b"),
+            "coding/quality": ("slot-b",),
+        },
+        frozenset({"slot-b"}),
+    ) == {"coding/default": ("slot-a",)}
+
+
+@pytest.mark.asyncio
+async def test_disabled_slot_never_runs_mixed_route_and_parks_bound_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_v20(monkeypatch)
+    blockers = {"slot-a": asyncio.Event(), "slot-b": asyncio.Event()}
+    servers, endpoints = await _start_provider_servers(
+        blockers, limited_slots=frozenset({"slot-b"})
+    )
+    full_routes = {
+        "coding/occupy": ("slot-a",),
+        "coding/mixed": ("slot-a", "slot-b"),
+        "coding/quality": ("slot-b",),
+    }
+    origin = Origin(module="test", object_id="mixed-route")
+    enabled = _runtime(
+        tmp_path,
+        endpoints,
+        route_slots=full_routes,
+        schedulable_route_slots=full_routes,
+    )
+    try:
+        await enabled.start()
+        selected_superset = await enabled.substrate.control_plane.create_task(
+            origin, _request("mixed-selected-superset", "coding/mixed")
+        )
+        selected_superset = await _wait_running(
+            enabled, selected_superset.task_id
+        )
+        assert selected_superset.workspace_id is not None
+        assert (
+            enabled.workspace_broker.workspace_slot(selected_superset.workspace_id)
+            == "slot-a"
+        )
+        await enabled.service.cancel(selected_superset.task_id)
+
+        occupy = await enabled.substrate.control_plane.create_task(
+            origin, _request("occupy-enabled", "coding/occupy")
+        )
+        await _wait_running(enabled, occupy.task_id)
+        historical = await enabled.substrate.control_plane.create_task(
+            origin, _request("mixed-history", "coding/mixed")
+        )
+        historical = await _wait_running(enabled, historical.task_id)
+        assert historical.workspace_id is not None
+        assert (
+            enabled.workspace_broker.workspace_slot(historical.workspace_id)
+            == "slot-b"
+        )
+        snapshot = enabled.store.get_task_capability_snapshot(historical.task_id)
+        assert snapshot is not None
+        assert snapshot.snapshot["harness_protocol"] == "v20"
+
+    finally:
+        await enabled.close()
+
+    enabled.store.transition(historical.task_id, TaskState.QUEUED)
+    await servers.pop("slot-b").close()
+    active_routes = {
+        "coding/occupy": ("slot-a",),
+        "coding/mixed": ("slot-a",),
+    }
+    disabled = _runtime(
+        tmp_path,
+        endpoints,
+        route_slots=full_routes,
+        schedulable_route_slots=active_routes,
+        disabled_model_routes=("coding/quality",),
+        disabled_slot_ids=("slot-b",),
+    )
+    try:
+        await disabled.start()
+        historical = await disabled.service.wait_for(
+            historical.task_id, lambda item: item.state is TaskState.INTERRUPTED
+        )
+        assert historical.reason == "model_route_disabled"
+        assert historical.workspace_id is not None
+
+        occupy = await disabled.substrate.control_plane.create_task(
+            origin, _request("occupy-disabled", "coding/occupy")
+        )
+        await _wait_running(disabled, occupy.task_id)
+        mixed = await disabled.substrate.control_plane.create_task(
+            origin, _request("mixed-disabled", "coding/mixed")
+        )
+        await asyncio.sleep(0.1)
+        assert disabled.store.get_task(mixed.task_id).state is TaskState.QUEUED
+        assert disabled.store.get_task(mixed.task_id).workspace_id is None
+
+        await disabled.service.cancel(occupy.task_id)
+        mixed = await _wait_running(disabled, mixed.task_id)
+        assert mixed.workspace_id is not None
+        assert disabled.workspace_broker.workspace_slot(mixed.workspace_id) == "slot-a"
+        descriptors = disabled.store.get_task_capability_snapshot(
+            mixed.task_id
+        ).snapshot["harness_descriptors"]
+        assert [item["slot_id"] for item in descriptors] == ["slot-a"]
+        await disabled.service.cancel(mixed.task_id)
+    finally:
+        await disabled.close()
+        for server in servers.values():
+            await server.close()
+
+
+@pytest.mark.asyncio
+async def test_v20_disabled_route_reopens_same_store_on_original_slot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_v20(monkeypatch)
+    monkeypatch.setenv("CODING_WORKER_CLAUDE_ENABLED", "true")
+    blockers = {"slot-a": asyncio.Event(), "slot-b": asyncio.Event()}
+    servers, endpoints = await _start_provider_servers(blockers)
+    full_routes = {
+        "coding/default": ("slot-a",),
+        "coding/quality": ("slot-b",),
+    }
+    origin = Origin(module="test", object_id="v20-route-resume")
+    request = _request("quality-history-v20", "coding/quality")
+    enabled = _runtime(
+        tmp_path,
+        endpoints,
+        route_slots=full_routes,
+        schedulable_route_slots=full_routes,
+    )
+    try:
+        await enabled.start()
+        task = await enabled.substrate.control_plane.create_task(origin, request)
+        task = await _wait_running(enabled, task.task_id)
+        assert task.workspace_id is not None
+        workspace_id = task.workspace_id
+        assert enabled.workspace_broker.workspace_slot(workspace_id) == "slot-b"
+        before = enabled.store.get_task_capability_snapshot(task.task_id)
+        assert before is not None
+        before_generation = before.snapshot["harness_descriptors"][0][
+            "observation"
+        ]["sidecar_generation"]
+    finally:
+        await enabled.close()
+
+    old_slot_b = servers.pop("slot-b")
+    await old_slot_b.close()
+    monkeypatch.setenv("CODING_WORKER_CLAUDE_ENABLED", "false")
+    disabled = _runtime(
+        tmp_path,
+        endpoints,
+        route_slots=full_routes,
+        schedulable_route_slots={"coding/default": ("slot-a",)},
+        disabled_model_routes=("coding/quality",),
+        disabled_slot_ids=("slot-b",),
+    )
+    try:
+        await disabled.start()
+        assert disabled.store.get_task(task.task_id).state is TaskState.INTERRUPTED
+        assert (
+            await disabled.substrate.control_plane.create_task(origin, request)
+        ).task_id == task.task_id
+        with pytest.raises(WorkerConflictError) as new_task:
+            await disabled.substrate.control_plane.create_task(
+                origin, _request("new-quality-disabled", "coding/quality")
+            )
+        assert new_task.value.code == "model_route_unavailable"
+        with pytest.raises(WorkerConflictError) as disabled_resume:
+            await disabled.substrate.control_plane.resume(task.task_id)
+        assert disabled_resume.value.code == "harness_v20_route_unavailable"
+        assert disabled.store.get_task(task.task_id).state is TaskState.INTERRUPTED
+    finally:
+        await disabled.close()
+
+    replacement = ProviderRPCServer(
+        FakeCodingAgentProvider(block=asyncio.Event()),
+        token=_PROVIDER_TOKENS["slot-b"],
+        harness_descriptor=_v20_descriptor(),
+    )
+    endpoints = dict(endpoints)
+    endpoints["slot-b"] = await replacement.start_tcp_for_tests()
+    servers["slot-b"] = replacement
+    monkeypatch.setenv("CODING_WORKER_CLAUDE_ENABLED", "true")
+    restored = _runtime(
+        tmp_path,
+        endpoints,
+        route_slots=full_routes,
+        schedulable_route_slots=full_routes,
+    )
+    try:
+        await restored.start()
+        resumed = await restored.substrate.control_plane.resume(task.task_id)
+        assert resumed.state is TaskState.QUEUED
+        refreshed = restored.store.get_task_capability_snapshot(task.task_id)
+        assert refreshed is not None
+        after_generation = refreshed.snapshot["harness_descriptors"][0][
+            "observation"
+        ]["sidecar_generation"]
+        assert after_generation != before_generation
+        assert refreshed.binding_sha256 != before.binding_sha256
+
+        running = await _wait_running(restored, task.task_id)
+        assert running.workspace_id == workspace_id
+        assert restored.workspace_broker.workspace_slot(workspace_id) == "slot-b"
+        await restored.service.cancel(task.task_id)
+    finally:
+        await restored.close()
+        for server in servers.values():
+            await server.close()
+
+
+@pytest.mark.asyncio
+async def test_unbound_v20_resume_requires_unchanged_frozen_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_v20(monkeypatch)
+    blockers = {"slot-a": asyncio.Event(), "slot-b": asyncio.Event()}
+    servers, endpoints = await _start_provider_servers(blockers)
+    routes = {
+        "coding/occupy-a": ("slot-a",),
+        "coding/occupy-b": ("slot-b",),
+        "coding/mixed": ("slot-a", "slot-b"),
+    }
+    origin = Origin(module="test", object_id="unbound-v20")
+    runtime = _runtime(
+        tmp_path,
+        endpoints,
+        route_slots=routes,
+        schedulable_route_slots=routes,
+    )
+    try:
+        await runtime.start()
+        occupy_a = await runtime.substrate.control_plane.create_task(
+            origin, _request("unbound-occupy-a", "coding/occupy-a")
+        )
+        occupy_b = await runtime.substrate.control_plane.create_task(
+            origin, _request("unbound-occupy-b", "coding/occupy-b")
+        )
+        await _wait_running(runtime, occupy_a.task_id)
+        await _wait_running(runtime, occupy_b.task_id)
+        unbound = await runtime.substrate.control_plane.create_task(
+            origin, _request("unbound-mixed", "coding/mixed")
+        )
+        assert unbound.state is TaskState.QUEUED and unbound.workspace_id is None
+        assert (await runtime.service.pause(unbound.task_id)).state is TaskState.PAUSED
+        assert (await runtime.service.resume(unbound.task_id)).state is TaskState.QUEUED
+        assert (await runtime.service.pause(unbound.task_id)).state is TaskState.PAUSED
+    finally:
+        await runtime.close()
+
+    changed_routes = {
+        "coding/occupy-a": ("slot-a",),
+        "coding/occupy-b": ("slot-b",),
+        "coding/mixed": ("slot-a",),
+    }
+    changed = _runtime(
+        tmp_path,
+        endpoints,
+        route_slots=changed_routes,
+        schedulable_route_slots=changed_routes,
+    )
+    try:
+        await changed.start()
+        with pytest.raises(WorkerConflictError) as rejected:
+            await changed.service.resume(unbound.task_id)
+        assert rejected.value.code == "harness_binding_changed"
+        assert changed.store.get_task(unbound.task_id).state is TaskState.PAUSED
+    finally:
+        await changed.close()
+        for server in servers.values():
+            await server.close()
+
+
+@pytest.mark.asyncio
+async def test_v20_creation_requires_complete_v17_protocol_flags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_v20(monkeypatch)
+    blockers = {"slot-a": asyncio.Event(), "slot-b": asyncio.Event()}
+    servers, endpoints = await _start_provider_servers(blockers)
+    routes = {
+        "coding/default": ("slot-a",),
+        "coding/quality": ("slot-b",),
+    }
+    runtime = _runtime(
+        tmp_path,
+        endpoints,
+        route_slots=routes,
+        schedulable_route_slots=routes,
+    )
+    origin = Origin(module="test", object_id="v20-prerequisites")
+    illegal_request = _request("historical-v20-v16", "coding/default")
+    illegal = runtime.store.create_task(
+        TaskSpec(**illegal_request.model_dump(), origin=origin),
+        capability_binding_sha256="a" * 64,
+        capability_snapshot={"harness_protocol": "v20"},
+        capability_observed_at=1.0,
+        capability_expires_at=2.0,
+        runtime_protocol=RuntimeProtocol.V16,
+    )
+    try:
+        original_admit = runtime.workspace_broker.admit
+        original_capabilities = runtime.harness_supervisor.capabilities_for_slots
+        original_descriptors = runtime.harness_supervisor.harness_descriptors_for_slots
+        calls = {"admit": 0, "supervisor": 0}
+
+        async def tracked_admit(source):
+            calls["admit"] += 1
+            return await original_admit(source)
+
+        async def tracked_capabilities(slot_ids):
+            calls["supervisor"] += 1
+            return await original_capabilities(slot_ids)
+
+        async def tracked_descriptors(slot_ids):
+            calls["supervisor"] += 1
+            return await original_descriptors(slot_ids)
+
+        monkeypatch.setattr(runtime.workspace_broker, "admit", tracked_admit)
+        monkeypatch.setattr(
+            runtime.harness_supervisor, "capabilities_for_slots", tracked_capabilities
+        )
+        monkeypatch.setattr(
+            runtime.harness_supervisor,
+            "harness_descriptors_for_slots",
+            tracked_descriptors,
+        )
+        monkeypatch.setenv(_V17_PREREQUISITE_FLAGS[0], "false")
+        with pytest.raises(WorkerConflictError) as preflight:
+            await runtime.substrate.control_plane.create_task(
+                origin, _request("preflight-before-io", "coding/default")
+            )
+        assert preflight.value.code == "harness_v20_prerequisites_disabled"
+        assert calls == {"admit": 0, "supervisor": 0}
+        monkeypatch.setattr(runtime.workspace_broker, "admit", original_admit)
+        monkeypatch.setattr(
+            runtime.harness_supervisor,
+            "capabilities_for_slots",
+            original_capabilities,
+        )
+        monkeypatch.setattr(
+            runtime.harness_supervisor,
+            "harness_descriptors_for_slots",
+            original_descriptors,
+        )
+        for name in _V17_PREREQUISITE_FLAGS:
+            monkeypatch.setenv(name, "true")
+        await runtime.start()
+        illegal = await runtime.service.wait_for(
+            illegal.task_id, lambda item: item.state is TaskState.INTERRUPTED
+        )
+        assert illegal.reason == "harness_v20_prerequisites_disabled"
+        with pytest.raises(WorkerConflictError) as historical_resume:
+            await runtime.service.resume(illegal.task_id)
+        assert historical_resume.value.code == "harness_v20_prerequisites_disabled"
+
+        for index, missing in enumerate(_V17_PREREQUISITE_FLAGS):
+            for name in _V17_PREREQUISITE_FLAGS:
+                monkeypatch.setenv(name, "true")
+            monkeypatch.setenv(missing, "false")
+            with pytest.raises(WorkerConflictError) as rejected:
+                await runtime.substrate.control_plane.create_task(
+                    origin, _request(f"missing-prerequisite-{index}", "coding/default")
+                )
+            assert rejected.value.code == "harness_v20_prerequisites_disabled"
+
+        for name in _V17_PREREQUISITE_FLAGS:
+            monkeypatch.setenv(name, "true")
+        existing_request = _request("v20-idempotent-prerequisite", "coding/default")
+        existing = await runtime.substrate.control_plane.create_task(
+            origin, existing_request
+        )
+        await _wait_running(runtime, existing.task_id)
+        monkeypatch.setenv("CODING_WORKER_INTERACTION_ENABLED", "false")
+        retried = await runtime.substrate.control_plane.create_task(
+            origin, existing_request
+        )
+        assert retried.task_id == existing.task_id
+        await runtime.service.cancel(existing.task_id)
+    finally:
+        await runtime.close()
+        for server in servers.values():
+            await server.close()

--- a/server/tests/test_coding_worker_runtime.py
+++ b/server/tests/test_coding_worker_runtime.py
@@ -620,7 +620,13 @@ async def test_disabled_slot_never_runs_mixed_route_and_parks_bound_history(
             enabled.workspace_broker.workspace_slot(selected_superset.workspace_id)
             == "slot-a"
         )
+        assert selected_superset.task_id in enabled.service._active
         await enabled.service.cancel(selected_superset.task_id)
+        assert enabled.harness_driver._sessions == {}
+        assert enabled.provider._sessions == {}
+        assert servers["slot-a"]._active_task_id is None
+        assert servers["slot-a"]._active_session is None
+        assert servers["slot-a"]._message_tasks == {}
 
         occupy = await enabled.substrate.control_plane.create_task(
             origin, _request("occupy-enabled", "coding/occupy")

--- a/server/tests/test_coding_worker_sdk.py
+++ b/server/tests/test_coding_worker_sdk.py
@@ -19,12 +19,15 @@ from server.coding_worker.adapters import (
 from server.coding_worker.ports import CodingSubstrateHandle
 from server.coding_worker.sdk import CodingWorkerModuleClient, CodingWorkerSDKError
 from server.coding_worker.service import CodingWorkerService
-from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.store import CodingWorkerStore, WorkerConflictError
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
 
 def _client(
     tmp_path: Path,
+    *,
+    service_routes: tuple[str, ...] | None = None,
+    module_routes: frozenset[str] = frozenset({"coding/default"}),
 ) -> tuple[CodingWorkerModuleClient, CodingSubstrateHandle]:
     store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
     provider = FakeCodingAgentProvider()
@@ -41,6 +44,7 @@ def _client(
         ),
         provider=LegacyHarnessDriver(provider),
         harness_supervisor=LegacyHarnessSupervisor(provider),
+        new_task_model_routes=service_routes,
     )
     substrate = legacy_substrate_from_service(service)
     return CodingWorkerModuleClient(
@@ -48,7 +52,7 @@ def _client(
         substrate=substrate,
         source_kinds=frozenset({"manifest"}),
         check_ids=frozenset({"python-tests"}),
-        model_routes=frozenset({"coding/default"}),
+        model_routes=module_routes,
         context_validators={"artifact": lambda value: value == "artifact_context"},
     ), substrate
 
@@ -117,6 +121,23 @@ async def test_module_client_rejects_unregistered_execution_inputs(
     with pytest.raises(CodingWorkerSDKError) as raised:
         await client.create_task(business_object_id="skill_01", request=request)
     assert raised.value.code == expected
+
+
+@pytest.mark.asyncio
+async def test_module_route_allowed_by_policy_but_disabled_by_runtime_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    client, _substrate = _client(
+        tmp_path,
+        service_routes=("coding/default",),
+        module_routes=frozenset({"coding/default", "coding/quality"}),
+    )
+    request = _request().model_copy(update={"model_route": "coding/quality"})
+
+    with pytest.raises(WorkerConflictError) as rejected:
+        await client.create_task(business_object_id="skill_01", request=request)
+
+    assert rejected.value.code == "model_route_unavailable"
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import hashlib
 import json
 import sys
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from cryptography.fernet import Fernet
@@ -15,6 +17,7 @@ from server.coding_worker.adapters import LegacyHarnessDriver, LegacyHarnessSupe
 from server.coding_worker.contracts import (
     AcceptanceCheck,
     AcceptanceContract,
+    ApprovalStatus,
     OperationState,
     Origin,
     PolicyProfile,
@@ -42,6 +45,7 @@ from server.coding_worker.provider import (
     ProviderCapabilities,
     ProviderEvent,
     ProviderEventKind,
+    ProviderFailureKind,
     ProviderCheckpoint,
     ProviderCheckpointCompatibility,
     ProviderOpenRequest,
@@ -49,13 +53,97 @@ from server.coding_worker.provider import (
 )
 from server.coding_worker.service import CodingWorkerService
 from server.coding_worker.store import CodingWorkerStore, WorkerConflictError
-from server.coding_worker.tool_broker import FrozenCheck, ToolBroker, ToolBrokerError
+from server.coding_worker.tool_broker import (
+    FrozenCheck,
+    ToolBroker,
+    ToolBrokerError,
+)
 from server.coding_worker.workspace import (
     InMemoryWorkspaceSourceAdapter,
     WorkspaceBroker,
     WorkspaceError,
     WorkspaceSourceUnavailableError,
 )
+
+
+_V20_PREREQUISITE_FLAGS = (
+    "CODING_WORKER_V16_ENABLED",
+    "CODING_WORKER_INTERACTION_ENABLED",
+    "CODING_WORKER_SESSION_CONTROLS_ENABLED",
+    "CODING_WORKER_SUBAGENTS_ENABLED",
+    "CODING_WORKER_V17_ENABLED",
+)
+
+
+def _enable_v20(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CODING_WORKER_HARNESS_V20_ENABLED", "true")
+    for name in _V20_PREREQUISITE_FLAGS:
+        monkeypatch.setenv(name, "true")
+
+
+@pytest.mark.asyncio
+async def test_outer_cancellation_retrieves_driver_exception_that_finished_same_tick(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = _service(tmp_path, FakeCodingAgentProvider())
+    request = _request("cancel-finished-driver")
+    task = service.store.create_task(
+        TaskSpec(
+            **request.model_dump(),
+            origin=Origin(module="test", object_id="cancel-finished-driver"),
+        )
+    )
+    service.store.transition(task.task_id, TaskState.PREPARING)
+    task = service.store.transition(task.task_id, TaskState.RUNNING)
+
+    async def fail_driver(*_args: object, **_kwargs: object) -> None:
+        raise WorkerConflictError("late driver failure", code="task_state_conflict")
+
+    real_sleep = asyncio.sleep
+
+    async def cancel_outer_after_driver_finishes(
+        futures: set[asyncio.Task[object]], *, timeout: float
+    ) -> set[asyncio.Task[object]]:
+        del timeout
+        while not all(item.done() for item in futures):
+            await real_sleep(0)
+        current = asyncio.current_task()
+        assert current is not None
+        current.cancel()
+        await real_sleep(0)
+        raise AssertionError("cancelled task continued")
+
+    monkeypatch.setattr(service, "_drive_session_steps", fail_driver)
+    monkeypatch.setattr(
+        "server.coding_worker.service.asyncio.wait",
+        cancel_outer_after_driver_finishes,
+    )
+    loop = asyncio.get_running_loop()
+    reported: list[dict[str, object]] = []
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: reported.append(context))
+    try:
+        runner = asyncio.create_task(
+            service._drive_session(
+                task,
+                object(),  # type: ignore[arg-type]
+                resume_phase=None,
+                resume_context=None,
+                completed_turns=0,
+                message_cursor=0,
+            )
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await runner
+        del runner
+        gc.collect()
+        await real_sleep(0)
+        assert not any(
+            context.get("message") == "Task exception was never retrieved"
+            for context in reported
+        )
+    finally:
+        loop.set_exception_handler(previous_handler)
 
 
 class _V20Supervisor:
@@ -115,6 +203,23 @@ class _NoUsageProvider(FakeCodingAgentProvider):
         return (await super().capabilities()).model_copy(
             update={"supports_usage": False}
         )
+
+
+class _StalledProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.never_progress = asyncio.Event()
+        self.stream_closed = asyncio.Event()
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        try:
+            await self.never_progress.wait()
+        finally:
+            self.stream_closed.set()
+        if False:  # pragma: no cover - keeps this an async generator
+            yield ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)
 
 
 def _request(client_task_id: str) -> TaskCreateRequest:
@@ -405,6 +510,14 @@ class _V17TurnParkingProvider(FakeCodingAgentProvider):
         assert self.store is not None
         self.messages.append(text)
         if len(self.messages) == 1:
+            yield ProviderEvent(
+                kind=ProviderEventKind.TOOL_STARTED,
+                data={
+                    "operation_id": "provider-call-v17-approval",
+                    "tool_name": "run_command",
+                    "summary": "waiting for exact approval",
+                },
+            )
             turn = self.store.current_turn_transaction(session.task_id)
             assert turn is not None
             self.store.create_approval(
@@ -429,6 +542,132 @@ class _V17TurnParkingProvider(FakeCodingAgentProvider):
     async def interrupt_turn(self, session: ProviderSession) -> bool:
         self.interruptions += 1
         return await super().interrupt_turn(session)
+
+
+class _InterruptFailureParkingProvider(_V17TurnParkingProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cancel_calls = 0
+        self.checkpoint_calls = 0
+        self.close_calls = 0
+
+    async def interrupt_turn(self, session: ProviderSession) -> bool:
+        self.interruptions += 1
+        raise OSError("simulated interrupt transport loss")
+
+    async def cancel(self, session: ProviderSession) -> bool:
+        self.cancel_calls += 1
+        return await super().cancel(session)
+
+    async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
+        self.checkpoint_calls += 1
+        return await super().checkpoint(session)
+
+    async def close(self, session: ProviderSession) -> None:
+        self.close_calls += 1
+        await super().close(session)
+
+
+class _UnfenceableInterruptParkingProvider(_InterruptFailureParkingProvider):
+    async def cancel(self, session: ProviderSession) -> bool:
+        self.cancel_calls += 1
+        raise OSError("simulated cancel transport loss")
+
+    async def close(self, session: ProviderSession) -> None:
+        self.close_calls += 1
+        raise OSError("simulated close transport loss")
+
+
+class _ShutdownParkingProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.store: CodingWorkerStore | None = None
+        self.checkpoint_calls = 0
+        self.message_calls = 0
+        self.parking_checkpoint_started = asyncio.Event()
+        self.release_parking_checkpoint = asyncio.Event()
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        assert self.store is not None
+        self.message_calls += 1
+        turn = self.store.current_turn_transaction(session.task_id)
+        assert turn is not None
+        self.store.create_approvals_and_begin_turn_parking(
+            task_id=session.task_id,
+            turn_id=turn.turn_id,
+            requests=(
+                (
+                    "operation-shutdown-parking"
+                    if self.message_calls == 1
+                    else "operation-shutdown-parking-replayed",
+                    "command",
+                    {"argv": ["pytest"]},
+                ),
+            ),
+        )
+        yield ProviderEvent(
+            kind=ProviderEventKind.MESSAGE,
+            data={"text": "late provider text after the durable barrier"},
+        )
+
+    async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
+        self.checkpoint_calls += 1
+        if self.checkpoint_calls > 1:
+            self.parking_checkpoint_started.set()
+            await self.release_parking_checkpoint.wait()
+        return await super().checkpoint(session)
+
+
+class _HangingCloseProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__(block=asyncio.Event())
+        self.close_started = asyncio.Event()
+        self.never_close = asyncio.Event()
+
+    async def close(self, session: ProviderSession) -> None:
+        self.close_started.set()
+        await self.never_close.wait()
+
+
+class _CancellationResistantProvider(_HangingCloseProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cancel_started = asyncio.Event()
+        self.release_cancel = asyncio.Event()
+
+    async def cancel(self, session: ProviderSession) -> bool:
+        self.cancel_started.set()
+        try:
+            await self.release_cancel.wait()
+        except asyncio.CancelledError:
+            await self.release_cancel.wait()
+        return True
+
+
+class _FailureDuringCancelProvider(FakeCodingAgentProvider):
+    """Reproduce an abort frame racing the cancel API response."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.cancel_started = asyncio.Event()
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        await self.cancel_started.wait()
+        yield ProviderEvent(
+            kind=ProviderEventKind.FAILED,
+            data={"failure_kind": ProviderFailureKind.UNAVAILABLE.value},
+        )
+
+    async def cancel(self, session: ProviderSession) -> bool:
+        self.cancel_started.set()
+        # Give the in-flight provider stream a chance to publish the abort
+        # frame before the cancel RPC returns, matching OpenCode's behavior.
+        await asyncio.sleep(0.05)
+        return True
 
 
 class _SlowCloseV17TurnParkingProvider(_V17TurnParkingProvider):
@@ -621,7 +860,7 @@ async def test_exact_idempotent_retry_ignores_current_source_and_provider_outage
 async def test_v20_new_task_requires_frozen_broker_only_descriptor(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("CODING_WORKER_HARNESS_V20_ENABLED", "true")
+    _enable_v20(monkeypatch)
     service = _service(tmp_path, FakeCodingAgentProvider())
 
     with pytest.raises(WorkerConflictError) as rejected:
@@ -639,7 +878,7 @@ async def test_v20_new_task_requires_frozen_broker_only_descriptor(
 async def test_v20_rejects_descriptor_capability_mismatch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("CODING_WORKER_HARNESS_V20_ENABLED", "true")
+    _enable_v20(monkeypatch)
     provider = _NoUsageProvider()
     service = _service(tmp_path, provider)
     service.harness_supervisor = _V20Supervisor(provider)
@@ -663,7 +902,7 @@ async def test_v20_snapshot_binds_descriptor_and_disable_interrupts_without_down
     provider = FakeCodingAgentProvider(block=blocker)
     service = _service(tmp_path, provider)
     service.harness_supervisor = _V20Supervisor(provider)
-    monkeypatch.setenv("CODING_WORKER_HARNESS_V20_ENABLED", "true")
+    _enable_v20(monkeypatch)
     assert (await service.harness_supervisor.harness_descriptors_for_slots(("*",)))[
         "*"
     ].descriptor.tool_ownership is HarnessToolOwnership.BROKER_ONLY
@@ -708,6 +947,39 @@ async def test_v20_snapshot_binds_descriptor_and_disable_interrupts_without_down
 
 
 @pytest.mark.asyncio
+async def test_v20_stalled_harness_stream_is_transport_failure_not_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import server.coding_worker.service as service_module
+
+    monkeypatch.setattr(
+        service_module, "V20_HARNESS_EVENT_STALL_SECONDS", 0.05, raising=False
+    )
+    provider = _StalledProvider()
+    service = _service(tmp_path, provider)
+    service.harness_supervisor = _V20Supervisor(provider)
+    _enable_v20(monkeypatch)
+
+    try:
+        task = await service.create_task(
+            Origin(module="test", object_id="v20-stream-stall"),
+            _request("v20-stream-stall"),
+        )
+        failed = await asyncio.wait_for(
+            service.wait_for(
+                task.task_id, lambda item: item.state is TaskState.FAILED
+            ),
+            timeout=1,
+        )
+        await asyncio.wait_for(provider.stream_closed.wait(), timeout=1)
+
+        assert failed.reason == "harness_transport_unavailable"
+        assert service.store.budget_usage(task.task_id).active_seconds < 1
+    finally:
+        await service.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_v20_translation_preserves_legacy_projection_without_side_effect_replay(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -716,9 +988,9 @@ async def test_v20_translation_preserves_legacy_projection_without_side_effect_r
         service = _service(tmp_path / label, provider)
         if v20:
             service.harness_supervisor = _V20Supervisor(provider)
-        monkeypatch.setenv(
-            "CODING_WORKER_HARNESS_V20_ENABLED", "true" if v20 else "false"
-        )
+            _enable_v20(monkeypatch)
+        else:
+            monkeypatch.setenv("CODING_WORKER_HARNESS_V20_ENABLED", "false")
         task = await service.create_task(
             Origin(module="test", object_id=label), _request(label)
         )
@@ -742,6 +1014,145 @@ async def test_v20_translation_preserves_legacy_projection_without_side_effect_r
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure_kind", "expected_reason"),
+    (
+        (ProviderFailureKind.UNAVAILABLE, "harness_transport_unavailable"),
+        (ProviderFailureKind.AUTHENTICATION, "harness_authentication_failed"),
+        (ProviderFailureKind.RATE_LIMITED, "harness_rate_limited"),
+        (ProviderFailureKind.INVALID_RESPONSE, "harness_protocol_invalid"),
+        (ProviderFailureKind.POLICY, "harness_policy_rejected"),
+        (ProviderFailureKind.BUDGET, "harness_budget_exhausted"),
+        (ProviderFailureKind.INTERRUPTED, "harness_interrupted"),
+    ),
+)
+async def test_v20_failed_event_preserves_neutral_failure_attribution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: ProviderFailureKind,
+    expected_reason: str,
+) -> None:
+    provider = FakeCodingAgentProvider(
+        script=(
+            ProviderEvent(
+                kind=ProviderEventKind.FAILED,
+                data={"failure_kind": failure_kind.value},
+            ),
+        )
+    )
+    service = _service(tmp_path, provider)
+    service.harness_supervisor = _V20Supervisor(provider)
+    _enable_v20(monkeypatch)
+
+    task = await service.create_task(
+        Origin(module="test", object_id=f"v20-{failure_kind.value}"),
+        _request(f"v20-{failure_kind.value}"),
+    )
+    failed = await service.wait_for(
+        task.task_id, lambda item: item.state is TaskState.FAILED
+    )
+
+    assert failed.reason == expected_reason
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_legacy_failed_event_keeps_provider_failed_reason(tmp_path: Path) -> None:
+    provider = FakeCodingAgentProvider(
+        script=(
+            ProviderEvent(
+                kind=ProviderEventKind.FAILED,
+                data={"failure_kind": ProviderFailureKind.AUTHENTICATION.value},
+            ),
+        )
+    )
+    service = _service(tmp_path, provider)
+
+    task = await service.create_task(
+        Origin(module="test", object_id="legacy-failed"),
+        _request("legacy-failed"),
+    )
+    failed = await service.wait_for(
+        task.task_id, lambda item: item.state is TaskState.FAILED
+    )
+
+    assert failed.reason == "provider_failed"
+    await service.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("raw_code", "fallback", "expected_reason"),
+    (
+        ("provider_failed", "worker_failed", "harness_transport_unavailable"),
+        ("provider_unauthorized", "worker_failed", "harness_authentication_failed"),
+        ("provider_invalid_response", "worker_failed", "harness_protocol_invalid"),
+        ("tool_failed", "worker_failed", "tool_broker_internal_error"),
+        ("executor_failed", "worker_failed", "executor_runtime_failed"),
+        (None, "worker_failed", "control_plane_internal_error"),
+    ),
+)
+def test_v20_generic_failures_are_normalized_without_changing_legacy(
+    raw_code: str | None, fallback: str, expected_reason: str
+) -> None:
+    assert (
+        CodingWorkerService._normalize_failure_reason(
+            raw_code, fallback=fallback, v20=True
+        )
+        == expected_reason
+    )
+    assert CodingWorkerService._normalize_failure_reason(
+        raw_code, fallback=fallback, v20=False
+    ) == (raw_code or fallback)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "expected_code"),
+    (
+        (RuntimeError("unexpected broker failure"), "tool_broker_internal_error"),
+        (
+            ToolBrokerError("executor failed", code="executor_failed"),
+            "executor_runtime_failed",
+        ),
+    ),
+)
+async def test_v20_broker_operation_records_attributable_failure_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: Exception,
+    expected_code: str,
+) -> None:
+    blocker = asyncio.Event()
+    provider = FakeCodingAgentProvider(block=blocker)
+    service, broker = _service_with_harness(tmp_path, provider)
+    service.harness_supervisor = _V20Supervisor(provider)
+    _enable_v20(monkeypatch)
+    task = await service.create_task(
+        Origin(module="test", object_id=expected_code),
+        _request(expected_code),
+    )
+    await service.wait_for(task.task_id, lambda item: item.state is TaskState.RUNNING)
+
+    async def fail_dispatch(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise failure
+
+    monkeypatch.setattr(broker, "_dispatch", fail_dispatch)
+    operation_id = f"operation_{expected_code}"
+    with pytest.raises(ToolBrokerError) as rejected:
+        await broker.execute(
+            task_id=task.task_id,
+            operation_id=operation_id,
+            tool_name="list_files",
+            arguments={},
+        )
+
+    assert rejected.value.code == expected_code
+    assert service.store.get_operation(operation_id).result == {"code": expected_code}
+    await service.cancel(task.task_id)
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_v20_explicit_resume_atomically_rebinds_compatible_generation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -749,7 +1160,7 @@ async def test_v20_explicit_resume_atomically_rebinds_compatible_generation(
     provider = FakeCodingAgentProvider(block=blocker)
     service = _service(tmp_path, provider)
     service.harness_supervisor = _V20Supervisor(provider)
-    monkeypatch.setenv("CODING_WORKER_HARNESS_V20_ENABLED", "true")
+    _enable_v20(monkeypatch)
     task = await service.create_task(
         Origin(module="test", object_id="v20-rebind"), _request("v20-rebind")
     )
@@ -916,6 +1327,16 @@ async def test_v17_turn_parks_once_and_resumes_exact_checkpoint(
     assert transaction.barrier is TurnBarrier.APPROVAL
     assert transaction.checkpoint_id is not None
     assert provider.interruptions == 1
+    provider_tool_entries = [
+        item
+        for item in service.store.list_session_ledger(task.task_id)
+        if item.operation_id == "provider-call-v17-approval"
+    ]
+    assert [item.kind for item in provider_tool_entries] == [
+        SessionLedgerKind.TOOL_STARTED,
+        SessionLedgerKind.TOOL_FINISHED,
+    ]
+    assert provider_tool_entries[-1].payload["result_state"] == "unknown"
     assistants = [
         item
         for item in service.store.list_messages(task.task_id)
@@ -937,6 +1358,271 @@ async def test_v17_turn_parks_once_and_resumes_exact_checkpoint(
     )
     assert transaction.state is TurnTransactionState.COMPLETED
     await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_v20_interrupt_failure_fences_session_before_closing_tool_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_v20(monkeypatch)
+    provider = _InterruptFailureParkingProvider()
+    service = _service(tmp_path, provider)
+    service.harness_supervisor = _V20Supervisor(provider)
+    provider.store = service.store
+    task = await service.create_task(
+        Origin(module="test", object_id="v20-interrupt-failure"),
+        _request("v20-interrupt-failure"),
+    )
+
+    blocked = await service.wait_for(
+        task.task_id,
+        lambda item: item.state is TaskState.BLOCKED,
+    )
+    assert blocked.reason == "harness_transport_unavailable"
+    provider_tool_entries = [
+        item
+        for item in service.store.list_session_ledger(task.task_id)
+        if item.kind in {
+            SessionLedgerKind.TOOL_STARTED,
+            SessionLedgerKind.TOOL_FINISHED,
+        }
+        and item.payload["tool_name"] == "run_command"
+    ]
+    assert {item.operation_id for item in provider_tool_entries} == {
+        provider_tool_entries[0].operation_id
+    }
+    assert provider_tool_entries[0].operation_id.startswith("harness_call_")
+    assert "provider-call-v17-approval" not in repr(provider_tool_entries)
+    assert provider_tool_entries[0].turn_id is not None
+    transaction = service.store.get_turn_transaction(
+        task.task_id, provider_tool_entries[0].turn_id
+    )
+    assert transaction.state is TurnTransactionState.INTERRUPTED
+    assert provider.interruptions == 1
+    assert provider.cancel_calls == 1
+    assert provider.close_calls == 1
+    assert provider.checkpoint_calls == 1
+    assert [item.kind for item in provider_tool_entries] == [
+        SessionLedgerKind.TOOL_STARTED,
+        SessionLedgerKind.TOOL_FINISHED,
+    ]
+    assert provider_tool_entries[-1].payload["result_state"] == "unknown"
+    assert service.store.list_operations(task.task_id) == []
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_v20_unconfirmed_interrupt_keeps_tool_boundary_open_and_blocks_resume(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_v20(monkeypatch)
+    provider = _UnfenceableInterruptParkingProvider()
+    service = _service(tmp_path, provider)
+    service.harness_supervisor = _V20Supervisor(provider)
+    provider.store = service.store
+    task = await service.create_task(
+        Origin(module="test", object_id="v20-unfenceable-interrupt"),
+        _request("v20-unfenceable-interrupt"),
+    )
+
+    blocked = await service.wait_for(
+        task.task_id,
+        lambda item: item.state is TaskState.BLOCKED,
+    )
+    assert blocked.reason == "harness_interrupted"
+    provider_tool_entries = [
+        item
+        for item in service.store.list_session_ledger(task.task_id)
+        if item.kind in {
+            SessionLedgerKind.TOOL_STARTED,
+            SessionLedgerKind.TOOL_FINISHED,
+        }
+        and item.payload["tool_name"] == "run_command"
+    ]
+    assert [item.kind for item in provider_tool_entries] == [
+        SessionLedgerKind.TOOL_STARTED
+    ]
+    assert provider_tool_entries[0].operation_id.startswith("harness_call_")
+    assert "provider-call-v17-approval" not in repr(provider_tool_entries)
+    assert provider.interruptions == 1
+    assert provider.cancel_calls == 1
+    assert provider.close_calls == 1
+    assert provider.checkpoint_calls == 1
+    with pytest.raises(WorkerConflictError) as resume_rejected:
+        await service.resume(task.task_id)
+    assert resume_rejected.value.code == "turn_not_parked"
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_gives_parking_turn_time_to_reach_durable_checkpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in (
+        "CODING_WORKER_V16_ENABLED",
+        "CODING_WORKER_INTERACTION_ENABLED",
+        "CODING_WORKER_SESSION_CONTROLS_ENABLED",
+        "CODING_WORKER_SUBAGENTS_ENABLED",
+        "CODING_WORKER_V17_ENABLED",
+    ):
+        monkeypatch.setenv(name, "true")
+    provider = _ShutdownParkingProvider()
+    service = _service(tmp_path, provider)
+    provider.store = service.store
+    task = await service.create_task(
+        Origin(module="test", object_id="shutdown-parking-grace"),
+        _request("shutdown-parking-grace"),
+    )
+    await asyncio.wait_for(provider.parking_checkpoint_started.wait(), timeout=2)
+    parking = service.store.current_turn_transaction(task.task_id)
+    assert parking is not None
+    assert parking.state is TurnTransactionState.PARKING
+    entry_checkpoint_id = parking.checkpoint_id
+
+    shutdown = asyncio.create_task(service.shutdown())
+    await asyncio.sleep(0.05)
+    assert not shutdown.done()
+    provider.release_parking_checkpoint.set()
+    await asyncio.wait_for(shutdown, timeout=2)
+
+    parked = service.store.current_turn_transaction(task.task_id)
+    assert parked is not None
+    assert parked.turn_id == parking.turn_id
+    assert parked.state is TurnTransactionState.PARKED
+    assert parked.barrier is TurnBarrier.APPROVAL
+    assert parked.checkpoint_id is not None
+    assert parked.checkpoint_id != entry_checkpoint_id
+    assert service.store.get_task(task.task_id).state is TaskState.WAITING_APPROVAL
+    approval = service.store.list_approvals(task.task_id)[0]
+    decided = service.store.decide_approval(approval.approval_id, approved=True)
+    assert decided.status is ApprovalStatus.APPROVED
+    assert service.store.get_task(task.task_id).state is TaskState.QUEUED
+    resuming = service.store.current_turn_transaction(task.task_id)
+    assert resuming is not None
+    assert resuming.turn_id == parking.turn_id
+    assert resuming.state is TurnTransactionState.RESUMING
+
+
+@pytest.mark.asyncio
+async def test_shutdown_timeout_preserves_unsettled_parking_intent_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in (
+        "CODING_WORKER_V16_ENABLED",
+        "CODING_WORKER_INTERACTION_ENABLED",
+        "CODING_WORKER_SESSION_CONTROLS_ENABLED",
+        "CODING_WORKER_SUBAGENTS_ENABLED",
+        "CODING_WORKER_V17_ENABLED",
+    ):
+        monkeypatch.setenv(name, "true")
+    monkeypatch.setattr(
+        "server.coding_worker.service.TURN_PARKING_SHUTDOWN_GRACE_SECONDS",
+        0.01,
+    )
+    provider = _ShutdownParkingProvider()
+    service = _service(tmp_path, provider)
+    provider.store = service.store
+    task = await service.create_task(
+        Origin(module="test", object_id="shutdown-parking-timeout"),
+        _request("shutdown-parking-timeout"),
+    )
+    await asyncio.wait_for(provider.parking_checkpoint_started.wait(), timeout=2)
+    parking = service.store.current_turn_transaction(task.task_id)
+    assert parking is not None
+    assert parking.state is TurnTransactionState.PARKING
+    checkpoint_id = parking.checkpoint_id
+
+    await asyncio.wait_for(service.shutdown(), timeout=2)
+
+    interrupted = service.store.get_task(task.task_id)
+    assert interrupted.state is TaskState.INTERRUPTED
+    assert interrupted.reason == "turn_checkpoint_failed"
+    preserved = service.store.current_turn_transaction(task.task_id)
+    assert preserved is not None
+    assert preserved.turn_id == parking.turn_id
+    assert preserved.state is TurnTransactionState.PARKING
+    assert preserved.barrier is TurnBarrier.APPROVAL
+    assert preserved.checkpoint_id == checkpoint_id
+    approval = service.store.list_approvals(task.task_id)[0]
+    assert approval.status is ApprovalStatus.PENDING
+    assert not any(
+        event.type == "turn_interrupted"
+        for event in service.store.list_events(task.task_id)
+    )
+    orphan = service.store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash=parking.workspace_tree_hash,
+        payload={"phase": "waiting_approval", "orphaned_before_turn_bind": True},
+    )
+    assert service.store.latest_checkpoint(task.task_id) == orphan
+    assert orphan.checkpoint_id != parking.checkpoint_id
+    provider.release_parking_checkpoint.set()
+    resumed = await service.resume(task.task_id)
+    assert resumed.state is TaskState.QUEUED
+    reparked_task = await service.wait_for(
+        task.task_id,
+        lambda item: item.state is TaskState.WAITING_APPROVAL,
+    )
+    assert reparked_task.reason == "turn_parked_approval"
+    reparked = service.store.current_turn_transaction(task.task_id)
+    assert reparked is not None
+    assert reparked.turn_id == parking.turn_id
+    assert reparked.state is TurnTransactionState.PARKED
+    assert len(service.store.list_approvals(task.task_id)) == 1
+    assert provider.message_calls == 1
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_recancels_runner_stuck_in_harness_close(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "server.coding_worker.service.TURN_PARKING_SHUTDOWN_GRACE_SECONDS",
+        0.01,
+    )
+    provider = _HangingCloseProvider()
+    service = _service(tmp_path, provider)
+    task = await service.create_task(
+        Origin(module="test", object_id="shutdown-hanging-close"),
+        _request("shutdown-hanging-close"),
+    )
+    await service.wait_for(task.task_id, lambda item: item.state is TaskState.RUNNING)
+
+    await asyncio.wait_for(service.shutdown(), timeout=1)
+
+    assert provider.close_started.is_set()
+    interrupted = service.store.get_task(task.task_id)
+    assert interrupted.state is TaskState.INTERRUPTED
+    assert interrupted.reason == "service_shutdown"
+
+
+@pytest.mark.asyncio
+async def test_shutdown_fails_bounded_when_harness_cancel_swallows_cancellation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "server.coding_worker.service.TURN_PARKING_SHUTDOWN_GRACE_SECONDS",
+        0.01,
+    )
+    provider = _CancellationResistantProvider()
+    service = _service(tmp_path, provider)
+    task = await service.create_task(
+        Origin(module="test", object_id="shutdown-stubborn-cancel"),
+        _request("shutdown-stubborn-cancel"),
+    )
+    await service.wait_for(task.task_id, lambda item: item.state is TaskState.RUNNING)
+
+    with pytest.raises(RuntimeError, match="harness_cancel"):
+        await asyncio.wait_for(service.shutdown(), timeout=1)
+
+    assert provider.cancel_started.is_set()
+    assert provider.close_started.is_set()
+    interrupted = service.store.get_task(task.task_id)
+    assert interrupted.state is TaskState.INTERRUPTED
+    provider.release_cancel.set()
+    provider.never_close.set()
+    await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio
@@ -1333,6 +2019,132 @@ async def test_v17_approved_operation_executes_once_before_provider_resume(
         "operation_v17_approved_resume",
         "operation_v17_approved_resume_second",
     ]
+
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_v20_unknown_reconcile_events_are_store_atomic_and_failure_can_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, broker = _service_with_harness(tmp_path, FakeCodingAgentProvider())
+    approvals: dict[str, SimpleNamespace] = {}
+
+    async def unknown_shell(
+        suffix: str, *, receipt: bool, v20: bool = True
+    ) -> tuple[str, str]:
+        request = _request(suffix)
+        observed_at = time.time()
+        task = service.store.create_task(
+            TaskSpec(
+                **request.model_dump(),
+                origin=Origin(module="test", object_id=suffix),
+            ),
+            runtime_protocol=RuntimeProtocol.V17,
+            capability_binding_sha256="a" * 64 if v20 else None,
+            capability_snapshot={"harness_protocol": "v20"} if v20 else None,
+            capability_observed_at=observed_at if v20 else None,
+            capability_expires_at=observed_at + 30 if v20 else None,
+        )
+        workspace = await service.workspace_broker.prepare(request.workspace_source)
+        service.store.transition(task.task_id, TaskState.PREPARING)
+        service.store.transition(
+            task.task_id, TaskState.RUNNING, workspace_id=workspace.workspace_id
+        )
+        turn_id = f"turn_{suffix}"
+        service.store.open_turn_transaction(
+            task_id=task.task_id,
+            turn_id=turn_id,
+            workspace_tree_hash=workspace.baseline_tree_hash,
+        )
+        operation_id = f"operation_{suffix}"
+        arguments = {
+            "script": "true",
+            "cwd": ".",
+            "mode": "mutate",
+            "timeout_seconds": 30,
+        }
+        operation_request = {
+            "arguments": arguments,
+            "workspace_id": workspace.workspace_id,
+        }
+        service.store.create_operation(
+            task_id=task.task_id,
+            operation_id=operation_id,
+            tool_name="run_shell",
+            intent_sha256=broker._intent_sha256("run_shell", operation_request),
+            request=operation_request,
+            turn_id=turn_id,
+        )
+        service.store.transition_operation(operation_id, OperationState.RUNNING)
+        service.store.transition_operation(operation_id, OperationState.UNKNOWN)
+        if receipt:
+            service.store.create_artifact(
+                task_id=task.task_id,
+                media_type="application/json",
+                content=json.dumps(
+                    {
+                        "changeset_expected": False,
+                        "changes": [],
+                        "public_result": {"exit_code": 0},
+                    }
+                ).encode(),
+                metadata={"kind": "shell_result", "operation_id": operation_id},
+            )
+        approvals[task.task_id] = SimpleNamespace(
+            operation_id=operation_id,
+            status=ApprovalStatus.APPROVED,
+            lease=SimpleNamespace(lease_id=f"lease_{suffix}"),
+        )
+        return task.task_id, turn_id
+
+    monkeypatch.setattr(
+        service.store,
+        "list_approvals",
+        lambda task_id: [approvals[task_id]],
+    )
+    failed_task_id, failed_turn_id = await unknown_shell(
+        "v20_failed_reconcile", receipt=False
+    )
+    summary = await service._resume_approved_operation(
+        failed_task_id, turn_id=failed_turn_id
+    )
+
+    assert "completed once" not in summary
+    assert "new operation_id" in summary
+    assert "re-approval" in summary
+    assert [
+        item.payload["state"]
+        for item in service.store.list_events(failed_task_id)
+        if item.type == "operation_reconciled"
+    ] == [OperationState.FAILED.value]
+
+    completed_task_id, completed_turn_id = await unknown_shell(
+        "v20_completed_reconcile", receipt=True
+    )
+    completed_summary = await service._resume_approved_operation(
+        completed_task_id, turn_id=completed_turn_id
+    )
+    assert "completed once" in completed_summary
+    assert [
+        item.payload["state"]
+        for item in service.store.list_events(completed_task_id)
+        if item.type == "operation_reconciled"
+    ] == [OperationState.COMPLETED.value]
+
+    legacy_task_id, legacy_turn_id = await unknown_shell(
+        "legacy_failed_reconcile", receipt=False, v20=False
+    )
+    legacy_summary = await service._resume_approved_operation(
+        legacy_task_id, turn_id=legacy_turn_id
+    )
+    assert "completed once" in legacy_summary
+    assert "Do not execute it again" in legacy_summary
+    assert [
+        item.payload["state"]
+        for item in service.store.list_events(legacy_task_id)
+        if item.type == "operation_reconciled"
+    ] == [OperationState.FAILED.value, OperationState.FAILED.value]
     await service.shutdown()
 
 
@@ -1419,6 +2231,30 @@ async def test_two_tasks_run_and_third_is_durably_queued(tmp_path: Path) -> None
             task.task_id, lambda item: item.state is TaskState.BLOCKED
         )
         assert terminal.reason == "acceptance_runner_pending"
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_user_cancel_wins_over_concurrent_provider_abort_frame(
+    tmp_path: Path,
+) -> None:
+    provider = _FailureDuringCancelProvider()
+    service = _service(tmp_path, provider)
+    task = await service.create_task(
+        Origin(module="test", object_id="cancel-abort-race"),
+        _request("cancel-abort-race"),
+    )
+    await service.wait_for(task.task_id, lambda item: item.state is TaskState.RUNNING)
+
+    cancelled = await service.cancel(task.task_id)
+
+    assert cancelled.state is TaskState.CANCELLED
+    assert cancelled.reason == "user_cancelled"
+    assert service.store.get_task(task.task_id).state is TaskState.CANCELLED
+    assert not any(
+        event.type == "task_state" and event.payload.get("to") == "failed"
+        for event in service.store.list_events(task.task_id)
+    )
     await service.shutdown()
 
 
@@ -1550,6 +2386,29 @@ async def test_provider_request_binds_tree_and_policy_tool_allowlist(
     rebound = service.workspace_broker.repository_instructions(workspace_id)
     assert rebound[0].content == root_rule.decode("utf-8")
     assert "network" not in request.tool_allowlist
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_v20_provider_request_excludes_legacy_command_tool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_v20(monkeypatch)
+    provider = _OpenTrackingProvider()
+    service = _service(tmp_path, provider)
+    service.harness_supervisor = _V20Supervisor(provider)
+    request = _request("v20-professional-shell").model_copy(
+        update={"policy_profile": PolicyProfile.DEVELOP}
+    )
+
+    task = await service.create_task(
+        Origin(module="test", object_id="v20-professional-shell"), request
+    )
+    await service.wait_for(task.task_id, lambda item: item.state is TaskState.BLOCKED)
+
+    assert provider.open_request is not None
+    assert "run_shell" in provider.open_request.tool_allowlist
+    assert "run_command" not in provider.open_request.tool_allowlist
     await service.shutdown()
 
 

--- a/server/tests/test_coding_worker_shell.py
+++ b/server/tests/test_coding_worker_shell.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
+import json
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -13,10 +16,15 @@ from server.coding_worker.contracts import (
     OperationState,
     Origin,
     PolicyProfile,
+    RuntimeProtocol,
     TaskSpec,
     TaskState,
+    TurnBarrier,
+    TurnTransactionState,
     WorkspaceSource,
 )
+from server.coding_worker.changeset import ChangesetError
+from server.coding_worker.executor import ExecutorRPCError
 from server.coding_worker.store import CodingWorkerStore
 from server.coding_worker.tool_broker import ToolBroker, ToolBrokerError
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
@@ -50,6 +58,8 @@ async def _broker(
     *,
     profile: PolicyProfile,
     harness_faults_enabled: bool = False,
+    runtime_protocol: RuntimeProtocol = RuntimeProtocol.V16,
+    harness_v20: bool = False,
 ) -> tuple[ToolBroker, CodingWorkerStore, str, Path, AsyncMock]:
     monkeypatch.setenv("CODING_WORKER_V15_ENABLED", "true")
     monkeypatch.setenv("CODING_WORKER_SHELL_ENABLED", "true")
@@ -65,6 +75,7 @@ async def _broker(
     )
     prepared = await workspace.prepare(source)
     store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
+    observed_at = time.time()
     task = store.create_task(
         TaskSpec(
             client_task_id="shell-client",
@@ -81,12 +92,23 @@ async def _broker(
             ),
             policy_profile=profile,
             model_route="coding/default",
-        )
+        ),
+        runtime_protocol=runtime_protocol,
+        capability_binding_sha256="a" * 64 if harness_v20 else None,
+        capability_snapshot={"harness_protocol": "v20"} if harness_v20 else None,
+        capability_observed_at=observed_at if harness_v20 else None,
+        capability_expires_at=observed_at + 30 if harness_v20 else None,
     )
     store.transition(task.task_id, TaskState.PREPARING)
     store.transition(
         task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id
     )
+    if runtime_protocol is RuntimeProtocol.V17:
+        store.open_turn_transaction(
+            task_id=task.task_id,
+            turn_id="turn_shell_transport",
+            workspace_tree_hash=workspace.current_tree_hash(prepared.workspace_id),
+        )
     executor = AsyncMock()
     broker = ToolBroker(
         store=store,
@@ -147,6 +169,85 @@ async def _approve(
         expected_state=TaskState.WAITING_APPROVAL,
     )
     return lease.lease_id
+
+
+@pytest.mark.parametrize(
+    "script",
+    (
+        "cd /worker-data/workspaces/workspace_deadbeef/repo && pytest",
+        r"python C:\private\repo\test.py",
+        r"type \\host\share\test.py",
+        "cat file:///private/repo/result.txt",
+        "python ~/repo/test.py",
+    ),
+)
+@pytest.mark.asyncio
+async def test_shell_rejects_absolute_paths_before_approval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    script: str,
+) -> None:
+    broker, store, task_id, _, executor = await _broker(
+        tmp_path, monkeypatch, profile=PolicyProfile.DEVELOP
+    )
+
+    with pytest.raises(ToolBrokerError) as rejected:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="absolute_path",
+            tool_name="run_shell",
+            arguments={
+                "script": script,
+                "cwd": ".",
+                "mode": "inspect",
+                "timeout_seconds": 120,
+            },
+        )
+
+    assert rejected.value.code == "workspace_path_invalid"
+    assert store.list_approvals(task_id) == []
+    operation = store.get_operation("absolute_path")
+    assert operation.state is OperationState.FAILED
+    assert operation.result == {"code": "workspace_path_invalid"}
+    executor.run_shell.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "script",
+    (
+        "python -m pytest tests/test_cache.py -v 2>&1",
+        "sed -n '/foo/p' src/a.txt",
+        "grep '/api/' src/a.txt",
+    ),
+)
+@pytest.mark.asyncio
+async def test_shell_allows_workspace_relative_paths_to_reach_approval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    script: str,
+) -> None:
+    broker, store, task_id, _, executor = await _broker(
+        tmp_path, monkeypatch, profile=PolicyProfile.DEVELOP
+    )
+    arguments = {
+        "script": script,
+        "cwd": ".",
+        "mode": "inspect",
+        "timeout_seconds": 120,
+    }
+
+    with pytest.raises(ToolBrokerError) as required:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="relative_path",
+            tool_name="run_shell",
+            arguments=arguments,
+        )
+
+    assert required.value.code == "approval_required"
+    approval = store.list_approvals(task_id)[-1]
+    assert approval.operation_id == "relative_path"
+    executor.run_shell.assert_not_awaited()
 
 
 def _shell_result(
@@ -358,8 +459,11 @@ async def test_failed_shell_never_publishes_clone_changes(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("receipt_available", (True, False))
 async def test_shell_applied_unknown_reconciles_without_rerunning_executor(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    receipt_available: bool,
 ) -> None:
     broker, store, task_id, repository, executor = await _broker(
         tmp_path, monkeypatch, profile=PolicyProfile.DEVELOP
@@ -425,6 +529,26 @@ async def test_shell_applied_unknown_reconciles_without_rerunning_executor(
     assert unknown.value.code == "operation_result_unknown"
     assert store.get_operation("shell_unknown").state is OperationState.UNKNOWN
     assert repository.joinpath("app.py").read_bytes() == changed
+
+    if not receipt_available:
+        visible_artifacts = [
+            item
+            for item in store.list_artifacts(task_id)
+            if item.metadata.get("kind") != "shell_result"
+        ]
+        monkeypatch.setattr(
+            store, "list_artifacts", lambda _task_id: visible_artifacts
+        )
+        with pytest.raises(ToolBrokerError) as still_unknown:
+            broker.reconcile("shell_unknown")
+        assert still_unknown.value.code == "operation_result_unknown"
+        assert store.get_operation("shell_unknown").state is OperationState.UNKNOWN
+        assert broker.changesets.has_transaction(
+            workspace_id=str(store.get_task(task_id).workspace_id),
+            operation_id="shell_unknown",
+        )
+        assert executor.run_shell.await_count == 1
+        return
 
     reconciled = broker.reconcile("shell_unknown")
     assert reconciled.state is OperationState.COMPLETED
@@ -496,3 +620,405 @@ async def test_harness_executor_reset_after_changeset_requires_exact_reconcile(
     assert reconciled.state is OperationState.COMPLETED
     assert reconciled.data["changeset"]["state"] == "applied"
     assert executor.run_shell.await_count == 1
+
+
+@pytest.mark.parametrize(
+    "failure",
+    (
+        ExecutorRPCError("EOF", code="executor_invalid_response"),
+        ConnectionResetError("reset"),
+        asyncio.TimeoutError("timeout"),
+        json.JSONDecodeError("invalid frame", "{", 1),
+    ),
+)
+def test_v20_shell_transport_failures_are_uncertain(failure: Exception) -> None:
+    assert ToolBroker._shell_executor_result_uncertain(failure) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    (
+        UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid frame"),
+        ValueError("Separator is not found, and chunk exceed the limit"),
+    ),
+)
+async def test_v20_mutate_unclassified_post_dispatch_failure_is_unknown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: Exception,
+) -> None:
+    broker, store, task_id, _, executor = await _broker(
+        tmp_path,
+        monkeypatch,
+        profile=PolicyProfile.DEVELOP,
+        runtime_protocol=RuntimeProtocol.V17,
+        harness_v20=True,
+    )
+    monkeypatch.setattr(broker, "_authorize", lambda *_args, **_kwargs: None)
+    executor.run_shell.side_effect = failure
+
+    with pytest.raises(ToolBrokerError) as unknown:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="shell_unclassified_transport",
+            tool_name="run_shell",
+            arguments={
+                "script": "python fix.py",
+                "cwd": ".",
+                "mode": "mutate",
+                "timeout_seconds": 60,
+            },
+        )
+
+    assert unknown.value.code == "operation_result_unknown"
+    assert (
+        store.get_operation("shell_unclassified_transport").state
+        is OperationState.UNKNOWN
+    )
+    turn = store.current_turn_transaction(task_id)
+    assert turn is not None
+    assert (turn.state, turn.barrier) == (
+        TurnTransactionState.PARKING,
+        TurnBarrier.OPERATION_UNKNOWN,
+    )
+    assert executor.run_shell.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_v20_mutate_structured_pre_dispatch_rejection_is_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    broker, store, task_id, _, executor = await _broker(
+        tmp_path,
+        monkeypatch,
+        profile=PolicyProfile.DEVELOP,
+        runtime_protocol=RuntimeProtocol.V17,
+        harness_v20=True,
+    )
+    monkeypatch.setattr(broker, "_authorize", lambda *_args, **_kwargs: None)
+    executor.run_shell.side_effect = ExecutorRPCError(
+        "Executor rejected the request before dispatch.",
+        code="executor_request_invalid",
+    )
+
+    with pytest.raises(ToolBrokerError) as rejected:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="shell_structured_rejection",
+            tool_name="run_shell",
+            arguments={
+                "script": "python fix.py",
+                "cwd": ".",
+                "mode": "mutate",
+                "timeout_seconds": 60,
+            },
+        )
+
+    assert rejected.value.code == "executor_request_invalid"
+    assert (
+        store.get_operation("shell_structured_rejection").state
+        is OperationState.FAILED
+    )
+    turn = store.current_turn_transaction(task_id)
+    assert turn is not None and turn.state is TurnTransactionState.OPEN
+
+
+@pytest.mark.asyncio
+async def test_v20_shell_changeset_rollback_failure_stays_unknown_until_reconciled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    broker, store, task_id, repository, executor = await _broker(
+        tmp_path,
+        monkeypatch,
+        profile=PolicyProfile.DEVELOP,
+        runtime_protocol=RuntimeProtocol.V17,
+        harness_v20=True,
+    )
+    monkeypatch.setattr(broker, "_authorize", lambda *_args, **_kwargs: None)
+    old = repository.joinpath("app.py").read_bytes()
+    changed = b"print('partially-published')\n"
+    executor.run_shell.return_value = _shell_result(
+        broker,
+        store,
+        task_id,
+        mode="mutate",
+        output="",
+        changes=[
+            {
+                "kind": "write",
+                "path": "app.py",
+                "expected_sha256": hashlib.sha256(old).hexdigest(),
+                "content": changed.decode(),
+                "content_sha256": hashlib.sha256(changed).hexdigest(),
+            }
+        ],
+    )
+
+    def interrupt_publication(index: int) -> None:
+        if index == 0:
+            raise OSError("simulated interruption after first install")
+
+    original_rollback = broker.changesets._rollback
+
+    def fail_rollback(*_args: object) -> None:
+        raise ChangesetError(
+            "Rollback result is unknown.", code="changeset_rollback_failed"
+        )
+
+    broker.changesets.fault_hook = interrupt_publication
+    monkeypatch.setattr(broker.changesets, "_rollback", fail_rollback)
+
+    with pytest.raises(ToolBrokerError) as unknown:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="shell_rollback_unknown",
+            tool_name="run_shell",
+            arguments={
+                "script": "python fix.py",
+                "cwd": ".",
+                "mode": "mutate",
+                "timeout_seconds": 60,
+            },
+        )
+
+    assert unknown.value.code == "operation_result_unknown"
+    assert store.get_operation("shell_rollback_unknown").state is OperationState.UNKNOWN
+    assert repository.joinpath("app.py").read_bytes() == changed
+    workspace_id = str(store.get_task(task_id).workspace_id)
+    assert broker.changesets.has_transaction(
+        workspace_id=workspace_id, operation_id="shell_rollback_unknown"
+    )
+    turn = store.current_turn_transaction(task_id)
+    assert turn is not None
+    assert (turn.state, turn.barrier) == (
+        TurnTransactionState.PARKING,
+        TurnBarrier.OPERATION_UNKNOWN,
+    )
+
+    with pytest.raises(ToolBrokerError) as still_unknown:
+        broker.reconcile("shell_rollback_unknown")
+    assert still_unknown.value.code == "changeset_rollback_failed"
+    assert store.get_operation("shell_rollback_unknown").state is OperationState.UNKNOWN
+
+    monkeypatch.setattr(broker.changesets, "_rollback", original_rollback)
+    broker.changesets.fault_hook = None
+    with pytest.raises(ToolBrokerError) as rolled_back:
+        broker.reconcile("shell_rollback_unknown")
+    assert rolled_back.value.code == "changeset_rolled_back"
+    assert store.get_operation("shell_rollback_unknown").state is OperationState.FAILED
+    assert repository.joinpath("app.py").read_bytes() == old
+
+
+@pytest.mark.asyncio
+async def test_v20_shell_unprovable_changeset_journal_is_unknown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    broker, store, task_id, repository, executor = await _broker(
+        tmp_path,
+        monkeypatch,
+        profile=PolicyProfile.DEVELOP,
+        runtime_protocol=RuntimeProtocol.V17,
+        harness_v20=True,
+    )
+    monkeypatch.setattr(broker, "_authorize", lambda *_args, **_kwargs: None)
+    old = repository.joinpath("app.py").read_bytes()
+    changed = b"print('must-not-be-published')\n"
+    executor.run_shell.return_value = _shell_result(
+        broker,
+        store,
+        task_id,
+        mode="mutate",
+        output="",
+        changes=[
+            {
+                "kind": "write",
+                "path": "app.py",
+                "expected_sha256": hashlib.sha256(old).hexdigest(),
+                "content": changed.decode(),
+                "content_sha256": hashlib.sha256(changed).hexdigest(),
+            }
+        ],
+    )
+    repository.parent.joinpath("changesets").symlink_to(
+        repository, target_is_directory=True
+    )
+
+    with pytest.raises(ToolBrokerError) as unknown:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="shell_unprovable_journal",
+            tool_name="run_shell",
+            arguments={
+                "script": "python fix.py",
+                "cwd": ".",
+                "mode": "mutate",
+                "timeout_seconds": 60,
+            },
+        )
+
+    assert unknown.value.code == "operation_result_unknown"
+    assert (
+        store.get_operation("shell_unprovable_journal").state
+        is OperationState.UNKNOWN
+    )
+    assert repository.joinpath("app.py").read_bytes() == old
+    turn = store.current_turn_transaction(task_id)
+    assert turn is not None
+    assert (turn.state, turn.barrier) == (
+        TurnTransactionState.PARKING,
+        TurnBarrier.OPERATION_UNKNOWN,
+    )
+    assert executor.run_shell.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_v20_mutate_transport_loss_parks_reconciles_and_retries_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    broker, store, task_id, _, executor = await _broker(
+        tmp_path,
+        monkeypatch,
+        profile=PolicyProfile.DEVELOP,
+        runtime_protocol=RuntimeProtocol.V17,
+        harness_v20=True,
+    )
+    monkeypatch.setattr(broker, "_authorize", lambda *_args, **_kwargs: None)
+    arguments = {
+        "script": "node fix.mjs",
+        "cwd": ".",
+        "mode": "mutate",
+        "timeout_seconds": 60,
+    }
+    operation_id = "shell_transport_unknown"
+    executor.run_shell.side_effect = ExecutorRPCError(
+        "Executor response ended before a receipt.",
+        code="executor_invalid_response",
+    )
+
+    with pytest.raises(ToolBrokerError) as unknown:
+        await broker.execute(
+            task_id=task_id,
+            operation_id=operation_id,
+            tool_name="run_shell",
+            arguments=arguments,
+        )
+    assert unknown.value.code == "operation_result_unknown"
+    assert store.get_operation(operation_id).state is OperationState.UNKNOWN
+    turn = store.current_turn_transaction(task_id)
+    task = store.get_task(task_id)
+    assert turn is not None and task.workspace_id is not None
+    assert (turn.state, turn.barrier) == (
+        TurnTransactionState.PARKING,
+        TurnBarrier.OPERATION_UNKNOWN,
+    )
+
+    checkpoint = store.create_checkpoint(
+        task_id=task_id,
+        workspace_tree_hash=broker.workspace_broker.current_tree_hash(
+            task.workspace_id
+        ),
+        payload={"phase": "operation_unknown"},
+    )
+    store.park_turn_transaction(
+        task_id=task_id,
+        turn_id=turn.turn_id,
+        checkpoint_id=checkpoint.checkpoint_id,
+    )
+    store.transition(
+        task_id,
+        TaskState.INTERRUPTED,
+        reason="operation_result_unknown",
+        expected_state=TaskState.RUNNING,
+    )
+    store.settle_parked_turn(
+        task_id=task_id,
+        barrier=TurnBarrier.OPERATION_UNKNOWN,
+        expected_state=TaskState.INTERRUPTED,
+    )
+    store.transition(task_id, TaskState.PREPARING)
+    store.transition(task_id, TaskState.RUNNING)
+
+    reconciled = await broker.execute(
+        task_id=task_id,
+        operation_id=operation_id,
+        tool_name="run_shell",
+        arguments=arguments,
+    )
+    assert reconciled.state is OperationState.FAILED
+    assert reconciled.data == {"code": "shell_result_unavailable"}
+    assert executor.run_shell.await_count == 1
+
+    executor.run_shell.side_effect = None
+    executor.run_shell.return_value = _shell_result(
+        broker, store, task_id, mode="mutate", output=""
+    )
+    retried = await broker.execute(
+        task_id=task_id,
+        operation_id="shell_transport_retry",
+        tool_name="run_shell",
+        arguments=arguments,
+    )
+    assert retried.state is OperationState.COMPLETED
+    assert executor.run_shell.await_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("runtime_protocol", "harness_v20", "mode", "failure", "expected_code"),
+    (
+        (
+            RuntimeProtocol.V17,
+            True,
+            "inspect",
+            ConnectionResetError("reset"),
+            "executor_transport_failed",
+        ),
+        (
+            RuntimeProtocol.V16,
+            False,
+            "mutate",
+            ExecutorRPCError("EOF", code="executor_invalid_response"),
+            "executor_invalid_response",
+        ),
+        (
+            RuntimeProtocol.V17,
+            True,
+            "inspect",
+            ExecutorRPCError("failed", code="executor_failed"),
+            "executor_runtime_failed",
+        ),
+    ),
+)
+async def test_v20_inspect_and_legacy_mutate_transport_fail_explicitly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_protocol: RuntimeProtocol,
+    harness_v20: bool,
+    mode: str,
+    failure: Exception,
+    expected_code: str,
+) -> None:
+    broker, store, task_id, _, executor = await _broker(
+        tmp_path,
+        monkeypatch,
+        profile=PolicyProfile.DEVELOP,
+        runtime_protocol=runtime_protocol,
+        harness_v20=harness_v20,
+    )
+    monkeypatch.setattr(broker, "_authorize", lambda *_args, **_kwargs: None)
+    executor.run_shell.side_effect = failure
+    with pytest.raises(ToolBrokerError) as failed:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="shell_explicit_failure",
+            tool_name="run_shell",
+            arguments={
+                "script": "pytest -q",
+                "cwd": ".",
+                "mode": mode,
+                "timeout_seconds": 60,
+            },
+        )
+    assert failed.value.code == expected_code
+    assert store.get_operation("shell_explicit_failure").state is OperationState.FAILED

--- a/server/tests/test_coding_worker_source_adapters.py
+++ b/server/tests/test_coding_worker_source_adapters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 from pathlib import Path
 import subprocess
@@ -11,6 +12,7 @@ from server.coding_worker.contracts import WorkspaceSource
 from server.coding_worker.source_adapters import (
     BuiltinGitWorkspaceSourceAdapter,
     HostSnapshotWorkspaceSourceAdapter,
+    ProjectSnapshotLeaseGate,
     ProjectSnapshotWorkspaceSourceAdapter,
 )
 from server.coding_worker.workspace import (
@@ -59,6 +61,45 @@ class FakeProjectSource:
     async def import_uploaded(self, **payload: str) -> dict[str, object]:
         self.imports.append(payload)
         return dict(self.lease)
+
+
+class SingleLeaseProjectSource(FakeProjectSource):
+    def __init__(self, lease: dict[str, object]) -> None:
+        super().__init__(lease)
+        self.active = False
+        self.max_active = 0
+
+    async def acquire(
+        self, project_id: str, *, expected_head: str | None = None
+    ) -> dict[str, object]:
+        if self.active:
+            raise RuntimeError("snapshot_busy")
+        self.active = True
+        self.max_active = max(self.max_active, 1)
+        self.acquired.append((project_id, expected_head))
+        await asyncio.sleep(0.02)
+        return {**self.lease, "project_id": project_id, "head": expected_head}
+
+    async def release(self, project_id: str, lease_id: str) -> bool:
+        assert self.active is True
+        self.active = False
+        return await super().release(project_id, lease_id)
+
+
+class CancelledAcquireProjectSource(SingleLeaseProjectSource):
+    def __init__(self, lease: dict[str, object]) -> None:
+        super().__init__(lease)
+        self.first_acquire_started = asyncio.Event()
+
+    async def acquire(
+        self, project_id: str, *, expected_head: str | None = None
+    ) -> dict[str, object]:
+        self.acquired.append((project_id, expected_head))
+        if not self.active:
+            self.active = True
+            self.first_acquire_started.set()
+            await asyncio.Event().wait()
+        return {**self.lease, "project_id": project_id, "head": expected_head}
 
 
 class FakeProjectHost:
@@ -230,6 +271,71 @@ async def test_project_snapshot_adapter_copies_exact_lease_and_releases(
     assert [(item.path, item.content) for item in snapshot.files] == sorted(files.items())
     assert client.acquired == [(source.source_id, source.revision)]
     assert client.released == [(source.source_id, "lease_1")]
+
+
+@pytest.mark.asyncio
+async def test_project_snapshot_adapter_serializes_complete_single_lease_lifecycle(
+    tmp_path: Path,
+) -> None:
+    files = {"README.md": b"hello\n"}
+    lease = _lease("local_clone", files)
+    client = SingleLeaseProjectSource(lease)
+    gate = ProjectSnapshotLeaseGate()
+    adapter = ProjectSnapshotWorkspaceSourceAdapter(
+        client,
+        _source_root(tmp_path, files),
+        lease_gate=gate,
+    )
+    sources = [
+        WorkspaceSource(
+            kind="manifest",
+            source_id="local-" + marker * 24,
+            revision=str(lease["head"]),
+        )
+        for marker in ("1", "2")
+    ]
+
+    snapshots = await asyncio.gather(*(adapter.acquire(source) for source in sources))
+
+    assert [snapshot.source for snapshot in snapshots] == sources
+    assert client.acquired == [
+        (source.source_id, source.revision) for source in sources
+    ]
+    assert client.released == [
+        (source.source_id, "lease_1") for source in sources
+    ]
+    assert client.active is False
+
+
+@pytest.mark.asyncio
+async def test_project_snapshot_adapter_reconciles_cancelled_acquire_side_effect(
+    tmp_path: Path,
+) -> None:
+    files = {"README.md": b"hello\n"}
+    lease = _lease("local_clone", files)
+    client = CancelledAcquireProjectSource(lease)
+    source = WorkspaceSource(
+        kind="manifest",
+        source_id=str(lease["project_id"]),
+        revision=str(lease["head"]),
+    )
+    task = asyncio.create_task(
+        ProjectSnapshotWorkspaceSourceAdapter(
+            client, _source_root(tmp_path, files)
+        ).acquire(source)
+    )
+    await client.first_acquire_started.wait()
+
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert client.acquired == [
+        (source.source_id, source.revision),
+        (source.source_id, source.revision),
+    ]
+    assert client.released == [(source.source_id, "lease_1")]
+    assert client.active is False
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_store.py
+++ b/server/tests/test_coding_worker_store.py
@@ -9,6 +9,7 @@ from cryptography.fernet import Fernet
 from server.coding_worker.contracts import (
     AcceptanceCheck,
     AcceptanceContract,
+    ApprovalStatus,
     Origin,
     OperationState,
     RuntimeProtocol,
@@ -76,6 +77,55 @@ def test_idempotency_key_rejects_changed_intent(tmp_path: Path) -> None:
     with pytest.raises(WorkerConflictError) as raised:
         store.create_task(_spec(objective="Different"))
     assert raised.value.code == "task_intent_conflict"
+
+
+def test_cancel_atomically_settles_pending_approval_and_revokes_lease(
+    tmp_path: Path,
+) -> None:
+    store = CodingWorkerStore(tmp_path / "worker", master_key=Fernet.generate_key())
+    task = store.create_task(_spec())
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING)
+    approved = store.create_approval(
+        task_id=task.task_id,
+        operation_id="operation_cancel_approved",
+        capability="shell",
+        request={
+            "operation_id": "operation_cancel_approved",
+            "script_sha256": "b" * 64,
+            "cwd": ".",
+            "mode": "inspect",
+            "timeout_seconds": 60,
+            "network_scope_sha256": None,
+        },
+    )
+    assert (
+        store.decide_approval(approved.approval_id, approved=True).status
+        is ApprovalStatus.APPROVED
+    )
+    assert store.has_active_lease(task.task_id)
+    pending = store.create_approval(
+        task_id=task.task_id,
+        operation_id="operation_cancel_pending",
+        capability="shell",
+        request={"script_sha256": "a" * 64},
+    )
+
+    cancelled = store.transition(task.task_id, TaskState.CANCELLED)
+
+    assert cancelled.state is TaskState.CANCELLED
+    assert store.get_approval(pending.approval_id).status is ApprovalStatus.CANCELLED
+    assert store.get_approval(approved.approval_id).status is ApprovalStatus.APPROVED
+    assert not store.has_active_lease(task.task_id)
+    events = store.list_events(task.task_id)
+    assert [event.type for event in events[-2:]] == [
+        "approval_decided",
+        "task_state",
+    ]
+    assert events[-2].payload == {
+        "approval_id": pending.approval_id,
+        "status": "cancelled",
+    }
 
 
 def test_v17_turn_transaction_parks_and_rejects_new_operations(tmp_path: Path) -> None:
@@ -247,6 +297,56 @@ def test_restart_preserves_durably_parked_v17_approval_turn(tmp_path: Path) -> N
     assert resumed_turn.checkpoint_id == checkpoint.checkpoint_id
 
 
+def test_restart_canonicalizes_parked_approval_before_task_waiting_state(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "worker"
+    key = Fernet.generate_key()
+    store = CodingWorkerStore(root, master_key=key)
+    task = store.create_task(_spec(), runtime_protocol=RuntimeProtocol.V17)
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING)
+    turn = store.open_turn_transaction(
+        task_id=task.task_id,
+        turn_id="turn_v17_parked_before_waiting",
+        workspace_tree_hash="a" * 64,
+    )
+    approvals = store.create_approvals_and_begin_turn_parking(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        requests=(("operation-v17-parked-crash", "command", {"argv": ["pytest"]}),),
+    )
+    checkpoint = store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash="a" * 64,
+        payload={"phase": "waiting_approval"},
+    )
+    store.park_turn_transaction(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        checkpoint_id=checkpoint.checkpoint_id,
+    )
+    assert store.get_task(task.task_id).state is TaskState.RUNNING
+
+    restarted = CodingWorkerStore(root, master_key=key)
+
+    waiting = restarted.get_task(task.task_id)
+    assert waiting.state is TaskState.WAITING_APPROVAL
+    assert waiting.reason == "turn_parked_approval"
+    parked = restarted.current_turn_transaction(task.task_id)
+    assert parked is not None
+    assert parked.turn_id == turn.turn_id
+    assert parked.state is TurnTransactionState.PARKED
+    assert parked.checkpoint_id == checkpoint.checkpoint_id
+    decided = restarted.decide_approval(approvals[0].approval_id, approved=True)
+    assert decided.status is ApprovalStatus.APPROVED
+    assert restarted.get_task(task.task_id).state is TaskState.QUEUED
+    resuming = restarted.current_turn_transaction(task.task_id)
+    assert resuming is not None
+    assert resuming.turn_id == turn.turn_id
+    assert resuming.state is TurnTransactionState.RESUMING
+
+
 def test_restart_interrupts_v17_parking_before_checkpoint(tmp_path: Path) -> None:
     root = tmp_path / "worker"
     key = Fernet.generate_key()
@@ -273,6 +373,68 @@ def test_restart_interrupts_v17_parking_before_checkpoint(tmp_path: Path) -> Non
     assert restarted.get_turn_transaction(
         task.task_id, turn.turn_id
     ).state is TurnTransactionState.INTERRUPTED
+
+
+def test_restart_preserves_interrupted_parking_with_entry_checkpoint(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "worker"
+    key = Fernet.generate_key()
+    store = CodingWorkerStore(root, master_key=key)
+    task = store.create_task(_spec(), runtime_protocol=RuntimeProtocol.V17)
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING)
+    turn = store.open_turn_transaction(
+        task_id=task.task_id,
+        turn_id="turn_v17_parking_entry_restart",
+        workspace_tree_hash="a" * 64,
+    )
+    entry = store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash="a" * 64,
+        payload={"phase": "turn_open"},
+    )
+    store.bind_turn_recovery_checkpoint(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        checkpoint_id=entry.checkpoint_id,
+    )
+    approvals = store.create_approvals_and_begin_turn_parking(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        requests=(("operation-v17-parking-entry", "command", {"argv": ["pytest"]}),),
+    )
+    orphan = store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash="a" * 64,
+        payload={"phase": "waiting_approval"},
+    )
+
+    restarted = CodingWorkerStore(root, master_key=key)
+
+    interrupted = restarted.get_task(task.task_id)
+    assert interrupted.state is TaskState.INTERRUPTED
+    assert interrupted.reason == "turn_checkpoint_failed"
+    preserved = restarted.current_turn_transaction(task.task_id)
+    assert preserved is not None
+    assert preserved.turn_id == turn.turn_id
+    assert preserved.state is TurnTransactionState.PARKING
+    assert preserved.barrier is TurnBarrier.APPROVAL
+    assert preserved.checkpoint_id == entry.checkpoint_id
+    assert restarted.latest_checkpoint(task.task_id) == orphan
+    assert restarted.get_checkpoint(task.task_id, entry.checkpoint_id) == entry
+    assert restarted.list_approvals(task.task_id) == list(approvals)
+    resumed = restarted.resume_interrupted_parking_turn(
+        task_id=task.task_id,
+        turn_id=turn.turn_id,
+        checkpoint_id=entry.checkpoint_id,
+    )
+    assert resumed.state is TaskState.QUEUED
+    retrying = restarted.current_turn_transaction(task.task_id)
+    assert retrying is not None
+    assert retrying.turn_id == turn.turn_id
+    assert retrying.state is TurnTransactionState.RESUMING
+    assert len(restarted.list_approvals(task.task_id)) == 1
 
 
 @pytest.mark.parametrize(

--- a/server/tests/test_coding_worker_subtasks.py
+++ b/server/tests/test_coding_worker_subtasks.py
@@ -719,6 +719,87 @@ def test_provider_parks_immediately_after_delegation_and_resumes_after_release(
     asyncio.run(scenario())
 
 
+def test_start_reconciles_completed_subtasks_after_parent_parking_crash(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        root = tmp_path / "worker"
+        key = Fernet.generate_key()
+        store = CodingWorkerStore(root, master_key=key)
+        parent = store.create_task(_spec(), runtime_protocol=RuntimeProtocol.V17)
+        store.transition(parent.task_id, TaskState.PREPARING)
+        store.transition(parent.task_id, TaskState.RUNNING)
+        relation = _create(
+            store,
+            parent.task_id,
+            client_subtask_id="completed-before-parent-park",
+            kind=SubtaskKind.EXPLORE,
+        )
+        store.finish_subtask(
+            relation.child_task_id,
+            result_tree_hash="2" * 64,
+            changed_paths=(),
+            summary="Inspected the requested module.",
+        )
+        turn = store.open_turn_transaction(
+            task_id=parent.task_id,
+            turn_id="turn_parent_subtasks_restart",
+            workspace_tree_hash="1" * 64,
+        )
+        store.begin_turn_parking(
+            task_id=parent.task_id,
+            turn_id=turn.turn_id,
+            barrier=TurnBarrier.SUBTASKS,
+        )
+        checkpoint = store.create_checkpoint(
+            task_id=parent.task_id,
+            workspace_tree_hash="1" * 64,
+            payload={"phase": "waiting_subtasks"},
+        )
+        store.park_turn_transaction(
+            task_id=parent.task_id,
+            turn_id=turn.turn_id,
+            checkpoint_id=checkpoint.checkpoint_id,
+        )
+
+        restarted = CodingWorkerStore(root, master_key=key)
+        assert restarted.get_task(parent.task_id).state is TaskState.WAITING_SUBTASKS
+        adapter = InMemoryWorkspaceSourceAdapter(
+            {("source", "revision"): {"main.py": b"print('ok')\n"}}
+        )
+        workspace_broker = WorkspaceBroker(
+            root, {"manifest": adapter}, id_key=b"s" * 32
+        )
+        service = _service_with_legacy_provider(
+            store=restarted,
+            workspace_broker=workspace_broker,
+            provider=FakeCodingAgentProvider(),
+        )
+
+        await service.start()
+
+        assert restarted.get_task(parent.task_id).state is TaskState.QUEUED
+        resuming = restarted.current_turn_transaction(parent.task_id)
+        assert resuming is not None
+        assert resuming.turn_id == turn.turn_id
+        assert resuming.state is TurnTransactionState.RESUMING
+        summary = service._subtask_results_message(parent.task_id)
+        assert [
+            item.content
+            for item in restarted.list_messages(parent.task_id)
+            if item.role == "system" and item.content == summary
+        ] == [summary]
+        service._resume_parent_after_subtasks(parent.task_id)
+        assert [
+            item.content
+            for item in restarted.list_messages(parent.task_id)
+            if item.role == "system" and item.content == summary
+        ] == [summary]
+        await service.shutdown()
+
+    asyncio.run(scenario())
+
+
 def test_inspect_parent_cannot_delegate_implementation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -27,7 +27,13 @@ from server.coding_worker.store import CodingWorkerStore
 from server.coding_worker.process_manager import BackgroundProcessManager
 from server.coding_worker.network_policy import EgressPolicy
 from server.coding_worker.executor import SidecarExecutor
-from server.coding_worker.tool_broker import FrozenCheck, ToolBroker, ToolBrokerError
+from server.coding_worker.tool_broker import (
+    FrozenApprovalRule,
+    FrozenCheck,
+    ToolBroker,
+    ToolBrokerError,
+    frozen_approval_request_sha256,
+)
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
 
@@ -36,6 +42,10 @@ async def _broker(
     *,
     profile: PolicyProfile = PolicyProfile.DEVELOP,
     runtime_protocol: RuntimeProtocol = RuntimeProtocol.V16,
+    frozen_approval_rules: dict[
+        tuple[str, str, str], tuple[FrozenApprovalRule, ...]
+    ]
+    | None = None,
 ) -> tuple[ToolBroker, CodingWorkerStore, str, Path]:
     source = WorkspaceSource(kind="manifest", source_id="source", revision="h0")
     workspace = WorkspaceBroker(
@@ -80,6 +90,7 @@ async def _broker(
         frozen_checks={
             "syntax": FrozenCheck(check_id="syntax", argv=(sys.executable, "-m", "py_compile", "app.py"))
         },
+        frozen_approval_rules=frozen_approval_rules,
     )
     return broker, store, task.task_id, workspace.repository_path(prepared.workspace_id)
 
@@ -766,6 +777,51 @@ async def test_command_requires_exact_once_lease_and_denies_shell_remote_and_env
                 lease_id=denied_lease.lease_id,
             )
         assert error.value.code == "command_denied"
+
+
+@pytest.mark.asyncio
+async def test_evaluation_command_fails_before_creating_approval(
+    tmp_path: Path,
+) -> None:
+    allowed = {
+        "argv": ["python", "-m", "pytest", "-q"],
+        "timeout_seconds": 180,
+    }
+    broker, store, task_id, _ = await _broker(
+        tmp_path,
+        frozen_approval_rules={
+            ("manifest", "source", "h0"): (
+                FrozenApprovalRule(
+                    request_sha256=frozen_approval_request_sha256(
+                        "run_command", allowed
+                    ),
+                    acceptance_check_id="syntax",
+                ),
+            )
+        },
+    )
+    with pytest.raises(ToolBrokerError) as rejected:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="not-frozen-command",
+            tool_name="run_command",
+            arguments={
+                "argv": ["python", "-c", "print('not frozen')"],
+                "timeout_seconds": 180,
+            },
+        )
+    assert rejected.value.code == "evaluation_command_not_allowed"
+    assert store.list_approvals(task_id) == []
+
+    with pytest.raises(ToolBrokerError) as approval:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="frozen-command",
+            tool_name="run_command",
+            arguments=allowed,
+        )
+    assert approval.value.code == "approval_required"
+    assert len(store.list_approvals(task_id)) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 摘要

- 收敛 V20 Harness 的流生命周期、审批重启、取消竞态、未知副作用对账与稳定错误归因。
- 修复 Project Source 多来源检查的串行阻塞，同时保持清单顺序、exact revision 与安全错误语义。
- 修复 Claude replace 在 Provider 私有 cwd 提前失败的问题，使其在权威 Workspace 内通过原子 changeset 校验和发布。
- 加入脱敏 Claude 审批重启回放，按真实故障边界验证恢复，而非依赖公共投影事件的偶然顺序。

## 自动门禁

- Coding Worker 与 Project Source：625 passed, 5 skipped。
- Agent Workspace、Coding Runtime 与 Project Host：439 passed, 9 skipped。
- 后端最终全量：4799 passed, 29 skipped。
- 前端：116 files / 678 tests；production build 通过。
- 主 Worker 与 V20 evaluation Compose config 通过。
- V18 compile/Fake smoke 通过；8 条、四类别，摘要保持 472b88ae9de93f3816de84bc40d07e7c192ec82c4eca6cb67ef2f56dc60a1df3。
- 五类 sidecar/evaluation 镜像均为 UID/GID 65532:65532；固定运行时无网络版本探针通过。
- diff、秘密候选、禁止产物扫描通过；13 个逻辑提交均不超过 5 个文件。

## 已知边界

- 状态保持 Experimental。
- 只执行过一次经授权的 Claude 审批重启真实任务；没有完成 OpenCode/Claude 四项矩阵。
- 未运行 calibration、parity、certification、48/288 对照，不宣称能力提升、接近或等效。
- 生产 Server 仍显式使用 root，属于既有部署偏差；本 PR 不掩盖也不扩大修复。
- 客户端锁文件未变化；npm ci 报告 5 个既有 audit 项，本 PR 不升级依赖。
- 不进入 V21，不包含公共 API、数据库或 runtime protocol 迁移。