### PR TITLE
R7C: unify managed RAG generation paths

### DIFF
--- a/client/src/components/RagExecutionNotice.test.tsx
+++ b/client/src/components/RagExecutionNotice.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RagExecutionNotice } from "./RagExecutionNotice";
+
+describe("RagExecutionNotice", () => {
+  it("labels explicit local fallback without presenting it as model success", () => {
+    render(<RagExecutionNotice executionMode="local_non_model" />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("本地非模型降级");
+    expect(screen.getByRole("status")).toHaveTextContent("不代表模型调用成功");
+  });
+
+  it("does not add a warning to managed or legacy answers", () => {
+    const { rerender } = render(<RagExecutionNotice executionMode="managed" />);
+    expect(screen.queryByRole("status")).toBeNull();
+
+    rerender(<RagExecutionNotice executionMode="legacy" />);
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/client/src/components/RagExecutionNotice.tsx
+++ b/client/src/components/RagExecutionNotice.tsx
@@ -1,0 +1,21 @@
+export type RagExecutionMode = "managed" | "legacy" | "local_non_model";
+
+export function RagExecutionNotice({
+  executionMode,
+}: {
+  executionMode?: RagExecutionMode;
+}) {
+  if (executionMode !== "local_non_model") return null;
+
+  return (
+    <div
+      className="mb-3 rounded-lg border border-amber-300/30 bg-amber-300/10 px-3 py-2 text-amber-100"
+      role="status"
+    >
+      <p className="text-xs font-semibold">本地非模型降级</p>
+      <p className="mt-1 text-xs leading-5">
+        Managed Provider 调用未成功，已按控制面策略使用本地抽取式结果；这不代表模型调用成功。
+      </p>
+    </div>
+  );
+}

--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -41,6 +41,10 @@ import ChatFileComposer, {
   type PreparedChatFile,
 } from "../components/ChatFileComposer";
 import FileOutputTray from "../components/FileOutputTray";
+import {
+  RagExecutionNotice,
+  type RagExecutionMode,
+} from "../components/RagExecutionNotice";
 import ChatVisualAnalysisPanel, {
   type ChatVisualAnalysisState,
 } from "../components/ChatVisualAnalysisPanel";
@@ -421,6 +425,7 @@ interface ChatMessage {
   displayContent: string;
   images?: UploadedImage[];
   routeReceipt?: RouteReceipt;
+  ragExecutionMode?: RagExecutionMode;
   audio?: AssistantMessageAudio;
   videoContext?: VideoUnderstandingContext;
   files?: Array<{
@@ -503,6 +508,8 @@ interface RagSource {
 interface RagQueryResponse {
   answer: string;
   sources: RagSource[];
+  execution_mode?: RagExecutionMode;
+  fallback_reason_codes?: string[];
 }
 
 interface InstalledSkill extends TrustSelectableSkill {
@@ -1296,6 +1303,10 @@ const MessageBubble = memo(function MessageBubble({
               </button>
             ))}
           </div>
+        ) : null}
+
+        {!isUser ? (
+          <RagExecutionNotice executionMode={message.ragExecutionMode} />
         ) : null}
 
         {cleanedContent ? (
@@ -3181,6 +3192,7 @@ function ChatConversationPage() {
                   ...message,
                   content: answer,
                   displayContent: answer,
+                  ragExecutionMode: data.execution_mode,
                 }
             : message,
           ),

--- a/client/src/pages/RagPage.tsx
+++ b/client/src/pages/RagPage.tsx
@@ -1,6 +1,10 @@
 import { type DragEvent, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import PageContainer from "../components/PageContainer";
+import {
+  RagExecutionNotice,
+  type RagExecutionMode,
+} from "../components/RagExecutionNotice";
 import XlsxDestinationChooser, {
   isXlsxFile,
 } from "../components/XlsxDestinationChooser";
@@ -302,6 +306,8 @@ interface PipelineVersionQueryResponse {
   version: number;
   answer: string;
   warnings: string[];
+  execution_mode?: RagExecutionMode;
+  fallback_reason_codes?: string[];
   retrieval: Record<string, unknown>;
   sources: Array<{
     chunk_id: string;
@@ -2915,7 +2921,10 @@ export default function RagPage() {
                                     {String(pipelinePreview.retrieval.mode ?? pipelineDraftEdits.retrievalMode)} · Top-{String(pipelinePreview.retrieval.top_k ?? pipelineDraftEdits.topK)}
                                   </span>
                                 </div>
-                                <p className="mt-2 line-clamp-5 text-xs leading-5 text-slate-200">{pipelinePreview.answer}</p>
+                                <div className="mt-2">
+                                  <RagExecutionNotice executionMode={pipelinePreview.execution_mode} />
+                                  <p className="line-clamp-5 text-xs leading-5 text-slate-200">{pipelinePreview.answer}</p>
+                                </div>
                                 {pipelinePreview.warnings.length > 0 ? (
                                   <div className="mt-2 rounded-md border border-amber-300/20 bg-amber-300/10 px-2.5 py-2 text-[11px] leading-5 text-amber-100">
                                     {pipelinePreview.warnings.map((warning) => <p key={warning}>{warning}</p>)}

--- a/server/model_router/rag_generation_gateway.py
+++ b/server/model_router/rag_generation_gateway.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from typing import Any, Literal
+
+import httpx
+
+from .service import ModelRouterService, RouterServiceError
+from .workflow_gateway import (
+    ManagedWorkflowGateway,
+    ManagedWorkflowNodeRun,
+    ManagedWorkflowRoutingError,
+)
+from .workload_control import (
+    PROVIDER_WORKLOAD_CONTRACT_VERSION,
+    ProviderWorkloadCallService,
+)
+
+
+RAG_QUERY_ENTRY_ID = "rag_query_generate"
+RAG_PROCESSOR_ENTRY_ID = "rag_processor_generate"
+RagGenerationEntryId = Literal[
+    "rag_query_generate",
+    "rag_processor_generate",
+]
+RagGenerationRoutingMode = Literal[
+    "legacy",
+    "managed_required",
+    "degraded_required",
+]
+
+
+class ManagedRagGenerationError(RuntimeError):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        status_code: int = 409,
+        receipt: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+        self.receipt = receipt
+
+
+class ManagedRagGenerationGateway:
+    """RAG adapter over the already qualified one-dispatch unary transport."""
+
+    def __init__(
+        self,
+        call_service: ProviderWorkloadCallService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self.call_service = call_service
+        self._workflow_gateway = ManagedWorkflowGateway(
+            call_service,
+            client_factory=client_factory,
+        )
+
+    @classmethod
+    def for_router(
+        cls,
+        router_service: ModelRouterService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> "ManagedRagGenerationGateway":
+        return cls(
+            ProviderWorkloadCallService(router_service),
+            client_factory=client_factory,
+        )
+
+    def routing_mode(self, entry_id: RagGenerationEntryId) -> RagGenerationRoutingMode:
+        control = self.call_service.control
+        if not control.feature_enabled(entry_id):
+            return "legacy"
+        policy = control.get_policy(entry_id)
+        if policy.configured_status == "legacy":
+            return "legacy"
+        if policy.effective_status == "managed_required":
+            return "managed_required"
+        return "degraded_required"
+
+    def exact_model_id(
+        self,
+        entry_id: RagGenerationEntryId,
+        execution_shape: Literal["chat_text_unary", "chat_json_object"],
+        *,
+        requested_model: str | None = None,
+    ) -> str:
+        policy = self.call_service.control.get_policy(entry_id)
+        if policy.effective_status != "managed_required":
+            raise ManagedRagGenerationError(
+                "provider_workload_policy_not_active",
+                "RAG Managed Provider 策略未就绪。",
+                receipt=self.blocked_receipt(
+                    entry_id, "provider_workload_policy_not_active"
+                ),
+            )
+        clean_requested = str(requested_model or "").strip()
+        models = sorted(
+            {
+                item.model_id
+                for item in policy.bindings
+                if item.execution_shape == execution_shape
+                and item.valid
+                and (not clean_requested or item.model_id == clean_requested)
+            }
+        )
+        if not models:
+            code = "provider_workload_binding_missing"
+            raise ManagedRagGenerationError(
+                code,
+                "RAG 入口缺少该精确模型与执行形态的合格 Binding。",
+                receipt=self.blocked_receipt(entry_id, code),
+            )
+        if len(models) != 1:
+            code = "provider_workload_binding_ambiguous"
+            raise ManagedRagGenerationError(
+                code,
+                "RAG 入口存在多个可选模型，无法确定唯一 Managed Binding。",
+                receipt=self.blocked_receipt(entry_id, code),
+            )
+        return models[0]
+
+    def local_fallback_mode(self, entry_id: RagGenerationEntryId) -> str:
+        return str(
+            self.call_service.control.get_policy(entry_id).local_fallback_mode
+            or "none"
+        )
+
+    def start_run(
+        self,
+        entry_id: RagGenerationEntryId,
+        *,
+        parent_run_reference: str,
+        stable: bool,
+    ) -> "ManagedRagGenerationRun":
+        if self.routing_mode(entry_id) != "managed_required":
+            code = "provider_workload_policy_not_active"
+            raise ManagedRagGenerationError(
+                code,
+                "RAG Managed Provider 策略未就绪，调用已在派发前阻断。",
+                receipt=self.blocked_receipt(entry_id, code),
+            )
+        clean_parent = parent_run_reference.strip()
+        if not clean_parent:
+            clean_parent = f"rag:{entry_id}:{uuid.uuid4().hex}"
+        try:
+            run_id = (
+                self.call_service.start_stable_run(
+                    entry_id,
+                    parent_run_reference=clean_parent,
+                )
+                if stable
+                else self.call_service.start_run(
+                    entry_id,
+                    parent_run_reference=clean_parent,
+                )
+            )
+        except RouterServiceError as exc:
+            raise ManagedRagGenerationError(
+                exc.code,
+                "RAG Managed Provider 运行已存在或资格失效，系统不会重放。",
+                status_code=exc.status_code,
+                receipt=self.blocked_receipt(entry_id, exc.code),
+            ) from exc
+        delegate = ManagedWorkflowNodeRun(
+            self._workflow_gateway,
+            entry_id,  # type: ignore[arg-type]
+            run_id,
+        )
+        return ManagedRagGenerationRun(entry_id, delegate)
+
+    @staticmethod
+    def blocked_receipt(
+        entry_id: RagGenerationEntryId,
+        reason_code: str,
+    ) -> dict[str, Any]:
+        return {
+            "contract_version": PROVIDER_WORKLOAD_CONTRACT_VERSION,
+            "entry_id": entry_id,
+            "routing_mode": "managed_required",
+            "run_reference": "blocked_before_dispatch",
+            "status": "failed",
+            "call_count": 0,
+            "reason_codes": [reason_code],
+            "calls": [],
+        }
+
+
+class ManagedRagGenerationRun:
+    def __init__(
+        self,
+        entry_id: RagGenerationEntryId,
+        delegate: ManagedWorkflowNodeRun,
+    ) -> None:
+        self.entry_id = entry_id
+        self._delegate = delegate
+
+    async def complete_text_unary(
+        self,
+        *,
+        logical_call_key: str,
+        call_sequence: int,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+    ) -> str:
+        try:
+            return await self._delegate.complete_text_unary(
+                logical_call_key=logical_call_key,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        except ManagedWorkflowRoutingError as exc:
+            raise self._closed_error(exc) from exc
+
+    async def complete_json_object(
+        self,
+        *,
+        logical_call_key: str,
+        call_sequence: int,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+    ) -> str:
+        try:
+            return await self._delegate.complete_json_object(
+                logical_call_key=logical_call_key,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        except ManagedWorkflowRoutingError as exc:
+            raise self._closed_error(exc) from exc
+
+    def finish_success(self) -> dict[str, Any]:
+        self._delegate.finish("passed")
+        return self._delegate.receipt_summary()
+
+    def finish_failure(self, reason_code: str) -> dict[str, Any]:
+        status = (
+            "uncertain"
+            if any(call.status == "uncertain" for call in self._delegate.calls)
+            else "failed"
+        )
+        self._delegate.finish(status, reason_code=reason_code)
+        return self._delegate.receipt_summary()
+
+    def finish_cancelled(self) -> dict[str, Any]:
+        self._delegate.finish(
+            "cancelled",
+            reason_code="provider_workload_call_cancelled",
+        )
+        return self._delegate.receipt_summary()
+
+    def receipt_summary(self) -> dict[str, Any]:
+        return self._delegate.receipt_summary()
+
+    def _closed_error(
+        self,
+        exc: ManagedWorkflowRoutingError,
+    ) -> ManagedRagGenerationError:
+        return ManagedRagGenerationError(
+            exc.code,
+            "RAG Managed Provider 调用失败，系统未重试或切换目标。",
+            status_code=exc.status_code,
+            receipt=(
+                exc.receipt
+                if isinstance(exc.receipt, dict)
+                else self._delegate.receipt_summary()
+            ),
+        )

--- a/server/model_router/workload_control.py
+++ b/server/model_router/workload_control.py
@@ -158,6 +158,8 @@ DATA_PLANE_INTEGRATED_ENTRIES: frozenset[ProviderWorkloadEntryId] = frozenset(
         "fusion",
         "route_agent",
         "team_chat",
+        "rag_query_generate",
+        "rag_processor_generate",
         "rag_embedding",
     }
 )

--- a/server/rag/api.py
+++ b/server/rag/api.py
@@ -30,6 +30,7 @@ from .rag_service import (
     PipelineJobStateError,
     PipelineVersionNotFoundError,
     ManagedEmbeddingRouteError,
+    ManagedRagGenerationRouteError,
     RagService,
     UnsupportedDocumentError,
 )
@@ -491,6 +492,8 @@ class ProcessorPreviewResponse(BaseModel):
     warnings: list[str]
     blocks: list[dict[str, Any]]
     generated_items: list[dict[str, Any]]
+    execution_mode: Literal["managed", "legacy"] = "legacy"
+    provider_route_receipts: dict[str, Any] | None = None
 
 
 class PipelinePreflightStagePayload(BaseModel):
@@ -570,6 +573,8 @@ class PipelineDocumentResultPayload(BaseModel):
     vision_block_count: int = 0
     vision_warnings: list[str] = Field(default_factory=list)
     vision_error: str | None = None
+    execution_mode: Literal["managed", "legacy"] = "legacy"
+    provider_route_receipts: dict[str, Any] | None = None
 
 
 class PipelineJobPayload(BaseModel):
@@ -661,6 +666,7 @@ class PipelineVersionQueryResponse(BaseModel):
     warnings: list[str] = Field(default_factory=list)
     execution_mode: Literal["managed", "legacy", "local_non_model"] = "legacy"
     provider_route_receipts: dict[str, Any] | None = None
+    fallback_reason_codes: list[str] = Field(default_factory=list)
     retrieval: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -2251,6 +2257,16 @@ async def query_pipeline_version(
             status_code=502,
             detail={"code": exc.code, "message": str(exc)},
         ) from exc
+    except ManagedRagGenerationRouteError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": exc.code,
+                "message": str(exc),
+                "execution_mode": "managed",
+                "provider_route_receipts": exc.receipt,
+            },
+        ) from exc
     except PipelineDraftValidationError as exc:
         raise HTTPException(
             status_code=409,
@@ -2384,6 +2400,16 @@ async def query_knowledge_base(payload: RagQueryRequest) -> RagQueryResponse:
         raise HTTPException(
             status_code=502,
             detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except ManagedRagGenerationRouteError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": exc.code,
+                "message": str(exc),
+                "execution_mode": "managed",
+                "provider_route_receipts": exc.receipt,
+            },
         ) from exc
     except PipelineDraftValidationError as exc:
         raise HTTPException(

--- a/server/rag/processor_generator.py
+++ b/server/rag/processor_generator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import re
@@ -42,6 +43,24 @@ class GeneratedIndexItem:
 
 class ProcessorGenerationError(RuntimeError):
     """Raised when all configured generation targets or attempts fail."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "rag_processor_generation_failed",
+        receipt: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.receipt = receipt
+
+
+@dataclass(slots=True)
+class ProcessorGenerationOutcome:
+    items: list[GeneratedIndexItem]
+    execution_mode: str
+    provider_route_receipts: dict[str, Any] | None
 
 
 class ProcessorGenerationService:
@@ -123,6 +142,106 @@ class ProcessorGenerationService:
         for index, item in enumerate(generated[:max_items]):
             item.item_id = f"{mode}_{index}"
         return generated[:max_items]
+
+    async def generate_managed(
+        self,
+        document: ProcessedDocument,
+        *,
+        mode: str,
+        model_id: str,
+        max_items: int,
+        managed_run: Any,
+    ) -> ProcessorGenerationOutcome:
+        """Generate through one exact Managed Binding with no hidden retry."""
+
+        if mode not in {"qa", "summary"}:
+            return ProcessorGenerationOutcome([], "managed", None)
+        try:
+            source_blocks = [block for block in document.blocks if block.text.strip()]
+            if not source_blocks:
+                raise ProcessorGenerationError(
+                    "Document contains no blocks for generation.",
+                    code="rag_processor_document_empty",
+                )
+            compact = [
+                {
+                    "block_id": block.block_id,
+                    "kind": block.kind,
+                    "heading_path": block.heading_path,
+                    "page_number": block.page_number,
+                    "text": block.text[:5000],
+                }
+                for block in source_blocks[:100]
+            ]
+            if mode == "qa":
+                batches = self._block_batches(compact)
+            else:
+                summary_blocks: list[dict[str, Any]] = []
+                summary_chars = 0
+                for block in compact:
+                    size = len(str(block.get("text") or ""))
+                    if summary_blocks and summary_chars + size > 60_000:
+                        break
+                    summary_blocks.append(block)
+                    summary_chars += size
+                batches = [summary_blocks]
+
+            generated: list[GeneratedIndexItem] = []
+            for batch_index, batch in enumerate(batches):
+                remaining = max_items - len(generated)
+                if remaining <= 0:
+                    break
+                payload = self._payload(
+                    mode=mode,
+                    model_id=model_id,
+                    title=document.title,
+                    blocks=batch,
+                    max_items=remaining,
+                )
+                content = await managed_run.complete_json_object(
+                    logical_call_key=f"processor_batch:{batch_index}",
+                    call_sequence=batch_index + 1,
+                    model_id=model_id,
+                    messages=list(payload["messages"]),
+                    temperature=float(payload["temperature"]),
+                    max_tokens=int(payload["max_tokens"]),
+                )
+                data = _parse_json_object(content)
+                generated.extend(
+                    self._parse_items(
+                        data,
+                        document=document,
+                        mode=mode,
+                        max_items=remaining,
+                    )
+                )
+            if not generated:
+                raise ProcessorGenerationError(
+                    f"Processor model returned no valid {mode} items.",
+                    code="rag_processor_empty_result",
+                )
+            for index, item in enumerate(generated[:max_items]):
+                item.item_id = f"{mode}_{index}"
+            receipt = managed_run.finish_success()
+            return ProcessorGenerationOutcome(
+                generated[:max_items],
+                "managed",
+                receipt,
+            )
+        except asyncio.CancelledError:
+            managed_run.finish_cancelled()
+            raise
+        except Exception as exc:
+            code = str(getattr(exc, "code", "rag_processor_generation_failed"))
+            receipt = managed_run.finish_failure(code)
+            if isinstance(exc, ProcessorGenerationError):
+                exc.receipt = receipt
+                raise
+            raise ProcessorGenerationError(
+                "Managed Processor generation failed without retrying the batch.",
+                code=code,
+                receipt=receipt,
+            ) from exc
 
     async def _generate_batch(
         self,

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -49,7 +49,11 @@ from .retrieval import (
     select_candidates,
 )
 from .source_metadata import normalize_heading_path
-from .processor_generator import ProcessorGenerationService
+from .processor_generator import (
+    ProcessorGenerationError,
+    ProcessorGenerationOutcome,
+    ProcessorGenerationService,
+)
 from .pipeline_graph import (
     GraphValidationIssue,
     KnowledgePipelineCompileResult,
@@ -185,6 +189,21 @@ class ManagedEmbeddingRouteError(EmbeddingError):
         self.code = code
 
 
+class ManagedRagGenerationRouteError(RagError):
+    """Stable, redacted failure for a managed RAG generation operation."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        receipt: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.receipt = receipt
+
+
 class KnowledgeWriteProposalNotFoundError(RagError):
     """Raised when a knowledge write proposal does not exist."""
 
@@ -227,6 +246,7 @@ class RagService:
         processor_generator: ProcessorGenerationService | None = None,
         vision_processor: VisionUnderstandingService | None = None,
         managed_embedding_gateway: Any | None = None,
+        managed_generation_gateway: Any | None = None,
         llm_enabled: bool | None = None,
     ) -> None:
         root = Path(__file__).resolve().parent
@@ -257,6 +277,7 @@ class RagService:
         self.processor_generator = processor_generator or ProcessorGenerationService()
         self.vision_processor = vision_processor or VisionUnderstandingService()
         self.managed_embedding_gateway = managed_embedding_gateway
+        self.managed_generation_gateway = managed_generation_gateway
         self.splitter = splitter or TextSplitter(
             chunk_size=int(os.getenv("RAG_CHUNK_SIZE", "500")),
             chunk_overlap=int(os.getenv("RAG_CHUNK_OVERLAP", "50")),
@@ -2048,7 +2069,9 @@ class RagService:
         chunk_count = int(stages["stage_chunker"]["metadata"].get("chunk_count", 0))
         processor_config = dict(stages["stage_processor"].get("config") or {})
         processor_mode = str(processor_config.get("mode") or "general")
-        processor_capabilities = self.processor_generator.capabilities()
+        processor_capabilities = self._processor_generation_capabilities(
+            str(processor_config.get("model_id") or "")
+        )
         vision_stage = stages["stage_image_understanding"]
         vision_config = dict(vision_stage.get("config") or {})
         vision_capabilities = self.vision_processor.capabilities()
@@ -2153,7 +2176,7 @@ class RagService:
         }
 
     def processor_capabilities(self) -> dict[str, Any]:
-        generation = self.processor_generator.capabilities()
+        generation = self._processor_generation_capabilities()
         return {
             "version": "rag-processor-capabilities-v1",
             "parser": "structured_local_parser",
@@ -2176,6 +2199,45 @@ class RagService:
                 "preview_items": 20,
                 "preview_text_characters": 600,
             },
+        }
+
+    def _processor_generation_capabilities(
+        self,
+        model_id: str | None = None,
+    ) -> dict[str, Any]:
+        gateway = self._managed_generation_gateway()
+        if gateway is None or str(
+            gateway.routing_mode("rag_processor_generate")
+        ) == "legacy":
+            return self.processor_generator.capabilities()
+        if str(gateway.routing_mode("rag_processor_generate")) != "managed_required":
+            return {
+                "llm_configured": False,
+                "model": str(model_id or ""),
+                "targets": ["managed_degraded"],
+            }
+        if model_id is not None and not str(model_id).strip():
+            return {
+                "llm_configured": False,
+                "model": "",
+                "targets": ["managed"],
+            }
+        try:
+            exact_model = gateway.exact_model_id(
+                "rag_processor_generate",
+                "chat_json_object",
+                requested_model=model_id,
+            )
+        except Exception:
+            return {
+                "llm_configured": False,
+                "model": str(model_id or ""),
+                "targets": ["managed"],
+            }
+        return {
+            "llm_configured": True,
+            "model": exact_model,
+            "targets": ["managed"],
         }
 
     def vision_capabilities(self) -> dict[str, Any]:
@@ -2255,12 +2317,17 @@ class RagService:
             )
         except (DocumentParseError, OSError, UnicodeError) as exc:
             raise PipelineDraftValidationError(self._safe_pipeline_error(exc)) from exc
-        generated = await self.processor_generator.generate(
+        generation = await self._generate_processor_items(
             processed,
             mode=str(config.get("mode") or "general"),
             model_id=str(config.get("model_id") or ""),
             max_items=min(20, int(config.get("max_generated_items", 20))),
+            parent_run_reference=(
+                f"rag_processor:preview:{kb_id}:{document_id}:{uuid.uuid4().hex}"
+            ),
+            stable=False,
         )
+        generated = generation.items
         return {
             "kb_id": kb_id,
             "document_id": document_id,
@@ -2278,6 +2345,8 @@ class RagService:
             "generated_items": [
                 item.payload(max_text=600) for item in generated[:20]
             ],
+            "execution_mode": generation.execution_mode,
+            "provider_route_receipts": generation.provider_route_receipts,
         }
 
     def create_pipeline_job(
@@ -3193,12 +3262,15 @@ class RagService:
                         "Structured processor returned an unsupported document payload."
                     )
                 mode = str(profile.get("mode") or "general")
-                generated = await self.processor_generator.generate(
+                generation = await self._generate_processor_items(
                     document,
                     mode=mode,
                     model_id=str(profile.get("model_id") or ""),
                     max_items=int(profile.get("max_generated_items", 20)),
+                    parent_run_reference=f"rag_processor:job:{job_id}:{source_id}",
+                    stable=True,
                 )
+                generated = generation.items
                 artifact = {
                     "processed_document": document.payload(
                         include_text=True,
@@ -3226,6 +3298,10 @@ class RagService:
                     "warnings": list(document.warnings),
                     "error": None,
                     "duration_ms": duration_ms,
+                    "execution_mode": generation.execution_mode,
+                    "provider_route_receipts": (
+                        generation.provider_route_receipts
+                    ),
                 }
                 self._update_pipeline_document_result(
                     job_id,
@@ -3243,6 +3319,16 @@ class RagService:
                         "status": "failed",
                         "error": error,
                         "duration_ms": duration_ms,
+                        "execution_mode": (
+                            "managed"
+                            if isinstance(getattr(exc, "receipt", None), dict)
+                            else "legacy"
+                        ),
+                        "provider_route_receipts": (
+                            getattr(exc, "receipt", None)
+                            if isinstance(getattr(exc, "receipt", None), dict)
+                            else None
+                        ),
                     },
                 )
                 failed.append({"source_id": source_id, "error": error})
@@ -3315,6 +3401,16 @@ class RagService:
             if str(job.get("embedding_execution_mode") or "") == "managed":
                 raise PipelineJobStateError(
                     "Managed embedding evidence is immutable; create a new pipeline job "
+                    "instead of retrying this job."
+                )
+            if any(
+                isinstance(item, dict)
+                and str(item.get("execution_mode") or "") == "managed"
+                and isinstance(item.get("provider_route_receipts"), dict)
+                for item in job.get("document_results", [])
+            ):
+                raise PipelineJobStateError(
+                    "Managed processor evidence is immutable; create a new pipeline job "
                     "instead of retrying this job."
                 )
             job.update(
@@ -4969,6 +5065,7 @@ class RagService:
 
         candidate_count = min(200, config.top_k * config.candidate_multiplier)
         warnings: list[str] = []
+        fallback_reason_codes: list[str] = []
         vector_results: list[SearchResult] = []
         lexical_results: list[LexicalSearchResult] = []
         provider_route_receipts: dict[str, Any] | None = None
@@ -5107,6 +5204,7 @@ class RagService:
                 "answer": "没有在该知识库中找到相关内容，请尝试换一种问法或上传更多资料。",
                 "sources": [],
                 "warnings": warnings,
+                "fallback_reason_codes": fallback_reason_codes,
                 "execution_mode": execution_mode,
                 "provider_route_receipts": provider_route_receipts,
                 "retrieval": self._retrieval_diagnostics(
@@ -5123,7 +5221,26 @@ class RagService:
                 ),
             }
 
-        answer = await self._generate_answer(clean_question, results) if generate_answer else ""
+        if generate_answer:
+            (
+                answer,
+                generation_receipt,
+                generation_mode,
+                fallback_reason_codes,
+            ) = await self._generate_answer_with_control(
+                kb_id,
+                namespace,
+                clean_question,
+                results,
+            )
+            provider_route_receipts = self._merge_provider_route_receipts(
+                provider_route_receipts,
+                generation_receipt,
+            )
+            if generation_mode is not None:
+                execution_mode = generation_mode
+        else:
+            answer = ""
         return {
             "answer": answer,
             "sources": [
@@ -5154,6 +5271,7 @@ class RagService:
                 for result in results
             ],
             "warnings": warnings,
+            "fallback_reason_codes": fallback_reason_codes,
             "execution_mode": execution_mode,
             "provider_route_receipts": provider_route_receipts,
             "retrieval": self._retrieval_diagnostics(
@@ -5170,6 +5288,120 @@ class RagService:
             ),
         }
 
+    async def _generate_answer_with_control(
+        self,
+        kb_id: str,
+        namespace: str,
+        question: str,
+        results: list[RetrievalCandidate],
+    ) -> tuple[str, dict[str, Any] | None, str | None, list[str]]:
+        gateway = self._managed_generation_gateway()
+        if gateway is None or str(
+            gateway.routing_mode("rag_query_generate")
+        ) == "legacy":
+            return await self._generate_answer(question, results), None, None, []
+        if str(gateway.routing_mode("rag_query_generate")) != "managed_required":
+            code = "provider_workload_policy_not_active"
+            raise ManagedRagGenerationRouteError(
+                code,
+                "RAG Query 的 Managed Provider 策略已退化并失败关闭。",
+                receipt=gateway.blocked_receipt("rag_query_generate", code),
+            )
+
+        run: Any | None = None
+        try:
+            model_id = gateway.exact_model_id(
+                "rag_query_generate",
+                "chat_text_unary",
+            )
+            run = gateway.start_run(
+                "rag_query_generate",
+                parent_run_reference=(
+                    f"rag_query:{kb_id}:{namespace[:120]}:{uuid.uuid4().hex}"
+                ),
+                stable=False,
+            )
+            messages, temperature, max_tokens = await self._answer_request(
+                question,
+                results,
+            )
+            answer = await run.complete_text_unary(
+                logical_call_key="rag_query_answer:0",
+                call_sequence=1,
+                model_id=model_id,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+            return answer.strip(), run.finish_success(), "managed", []
+        except asyncio.CancelledError:
+            if run is not None:
+                run.finish_cancelled()
+            raise
+        except Exception as exc:
+            code = str(getattr(exc, "code", "rag_query_generation_failed"))
+            receipt = getattr(exc, "receipt", None)
+            if run is not None:
+                receipt = run.finish_failure(code)
+            if not isinstance(receipt, dict):
+                receipt = gateway.blocked_receipt("rag_query_generate", code)
+            if gateway.local_fallback_mode("rag_query_generate") == "extractive":
+                return (
+                    self._extractive_answer(results),
+                    receipt,
+                    "local_non_model",
+                    [code, "local_non_model_fallback"],
+                )
+            raise ManagedRagGenerationRouteError(
+                code,
+                "RAG Query 的 Managed Provider 调用失败，系统未重试或切换目标。",
+                receipt=receipt,
+            ) from exc
+
+    @staticmethod
+    def _merge_provider_route_receipts(
+        first: dict[str, Any] | None,
+        second: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        receipts = [item for item in (first, second) if isinstance(item, dict)]
+        if not receipts:
+            return None
+        if len(receipts) == 1:
+            return receipts[0]
+        calls = [
+            dict(call)
+            for receipt in receipts
+            for call in receipt.get("calls", [])
+            if isinstance(call, dict)
+        ]
+        reason_codes = list(
+            dict.fromkeys(
+                str(code)
+                for receipt in receipts
+                for code in receipt.get("reason_codes", [])
+                if str(code)
+            )
+        )
+        statuses = {str(receipt.get("status") or "") for receipt in receipts}
+        status = (
+            "uncertain"
+            if "uncertain" in statuses
+            else "failed"
+            if "failed" in statuses
+            else "passed"
+        )
+        return {
+            "contract_version": "modelmirror-provider-rag-route-receipts-v1",
+            "routing_mode": "composed",
+            "status": status,
+            "call_count": sum(
+                max(0, int(receipt.get("call_count") or 0)) for receipt in receipts
+            ),
+            "reason_codes": reason_codes,
+            "calls": calls,
+            "components": receipts,
+        }
+
     async def _generate_answer(
         self,
         question: str,
@@ -5179,6 +5411,53 @@ class RagService:
         if not self.llm_enabled or not api_key:
             return self._extractive_answer(results)
 
+        messages, temperature, max_tokens = await self._answer_request(
+            question,
+            results,
+        )
+        payload = {
+            "model": os.getenv("RAG_LLM_MODEL", os.getenv("OPENROUTER_TEXT_FALLBACK_MODEL", "deepseek/deepseek-chat")),
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "stream": False,
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": os.getenv("OPENROUTER_HTTP_REFERER", "http://localhost:5173"),
+            "X-Title": os.getenv("OPENROUTER_APP_TITLE", "ModelMirror"),
+        }
+        proxy = os.getenv("OPENROUTER_PROXY") or os.getenv("HTTPS_PROXY") or os.getenv("HTTP_PROXY")
+        client_kwargs: dict[str, Any] = {"timeout": httpx.Timeout(45.0, connect=15.0)}
+        if proxy:
+            client_kwargs["proxy"] = proxy
+
+        try:
+            async with httpx.AsyncClient(**client_kwargs) as client:
+                response = await client.post(
+                    "https://openrouter.ai/api/v1/chat/completions",
+                    headers=headers,
+                    json=payload,
+                )
+                response.raise_for_status()
+                data = response.json()
+        except Exception:
+            return self._extractive_answer(results)
+
+        choices = data.get("choices")
+        if isinstance(choices, list) and choices:
+            message = choices[0].get("message") if isinstance(choices[0], dict) else None
+            content = message.get("content") if isinstance(message, dict) else None
+            if isinstance(content, str) and content.strip():
+                return content.strip()
+        return self._extractive_answer(results)
+
+    async def _answer_request(
+        self,
+        question: str,
+        results: list[RetrievalCandidate],
+    ) -> tuple[list[dict[str, str]], float, int]:
         context = "\n\n".join(
             f"[来源：{result.document_name}]\n{result.context_text}" for result in results
         )
@@ -5214,46 +5493,14 @@ class RagService:
             f"<context>\n{context}\n</context>\n\n"
             f"用户问题：{question}"
         )
-        payload = {
-            "model": os.getenv("RAG_LLM_MODEL", os.getenv("OPENROUTER_TEXT_FALLBACK_MODEL", "deepseek/deepseek-chat")),
-            "messages": [
+        return (
+            [
                 {"role": "system", "content": "你是模镜的知识库问答助手，严谨、简洁，只基于给定资料回答。"},
                 {"role": "user", "content": prompt},
             ],
-            "temperature": float(os.getenv("RAG_TEMPERATURE", "0.2")),
-            "max_tokens": int(os.getenv("RAG_MAX_TOKENS", "1200")),
-            "stream": False,
-        }
-        headers = {
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-            "HTTP-Referer": os.getenv("OPENROUTER_HTTP_REFERER", "http://localhost:5173"),
-            "X-Title": os.getenv("OPENROUTER_APP_TITLE", "ModelMirror"),
-        }
-        proxy = os.getenv("OPENROUTER_PROXY") or os.getenv("HTTPS_PROXY") or os.getenv("HTTP_PROXY")
-        client_kwargs: dict[str, Any] = {"timeout": httpx.Timeout(45.0, connect=15.0)}
-        if proxy:
-            client_kwargs["proxy"] = proxy
-
-        try:
-            async with httpx.AsyncClient(**client_kwargs) as client:
-                response = await client.post(
-                    "https://openrouter.ai/api/v1/chat/completions",
-                    headers=headers,
-                    json=payload,
-                )
-                response.raise_for_status()
-                data = response.json()
-        except Exception:
-            return self._extractive_answer(results)
-
-        choices = data.get("choices")
-        if isinstance(choices, list) and choices:
-            message = choices[0].get("message") if isinstance(choices[0], dict) else None
-            content = message.get("content") if isinstance(message, dict) else None
-            if isinstance(content, str) and content.strip():
-                return content.strip()
-        return self._extractive_answer(results)
+            float(os.getenv("RAG_TEMPERATURE", "0.2")),
+            int(os.getenv("RAG_MAX_TOKENS", "1200")),
+        )
 
     def _extractive_answer(self, results: list[RetrievalCandidate]) -> str:
         best = results[0]
@@ -5736,6 +5983,125 @@ class RagService:
             ),
         }
 
+    def _managed_generation_gateway(self) -> Any | None:
+        if self.managed_generation_gateway is not None:
+            return self.managed_generation_gateway
+        enabled_values = (
+            os.getenv("MODEL_CONTROL_RAG_QUERY_ENABLED", ""),
+            os.getenv("MODEL_CONTROL_RAG_PROCESSOR_ENABLED", ""),
+        )
+        if not any(
+            value.strip().casefold() not in {"", "0", "false", "no", "off"}
+            for value in enabled_values
+        ):
+            return None
+        try:
+            try:
+                from server.model_router import get_model_router_service
+                from server.model_router.rag_generation_gateway import (
+                    ManagedRagGenerationGateway,
+                )
+            except ModuleNotFoundError:
+                from model_router import get_model_router_service
+                from model_router.rag_generation_gateway import (
+                    ManagedRagGenerationGateway,
+                )
+
+            self.managed_generation_gateway = ManagedRagGenerationGateway.for_router(
+                get_model_router_service()
+            )
+        except Exception as exc:
+            raise PipelineDraftValidationError(
+                "Managed RAG generation control plane is unavailable."
+            ) from exc
+        return self.managed_generation_gateway
+
+    async def _generate_processor_items(
+        self,
+        document: ProcessedDocument,
+        *,
+        mode: str,
+        model_id: str,
+        max_items: int,
+        parent_run_reference: str,
+        stable: bool,
+    ) -> ProcessorGenerationOutcome:
+        if mode not in {"qa", "summary"}:
+            return ProcessorGenerationOutcome(
+                await self.processor_generator.generate(
+                    document,
+                    mode=mode,
+                    model_id=model_id,
+                    max_items=max_items,
+                ),
+                "legacy",
+                None,
+            )
+        gateway = self._managed_generation_gateway()
+        if gateway is None or str(
+            gateway.routing_mode("rag_processor_generate")
+        ) == "legacy":
+            return ProcessorGenerationOutcome(
+                await self.processor_generator.generate(
+                    document,
+                    mode=mode,
+                    model_id=model_id,
+                    max_items=max_items,
+                ),
+                "legacy",
+                None,
+            )
+        if str(gateway.routing_mode("rag_processor_generate")) != "managed_required":
+            code = "provider_workload_policy_not_active"
+            raise ProcessorGenerationError(
+                "Managed RAG Processor policy is degraded and fails closed.",
+                code=code,
+                receipt=gateway.blocked_receipt("rag_processor_generate", code),
+            )
+        try:
+            clean_model_id = str(model_id or "").strip()
+            if not clean_model_id:
+                code = "provider_workload_model_required"
+                raise ProcessorGenerationError(
+                    "Managed RAG Processor requires an exact Draft model ID.",
+                    code=code,
+                    receipt=gateway.blocked_receipt(
+                        "rag_processor_generate",
+                        code,
+                    ),
+                )
+            exact_model = gateway.exact_model_id(
+                "rag_processor_generate",
+                "chat_json_object",
+                requested_model=clean_model_id,
+            )
+            run = gateway.start_run(
+                "rag_processor_generate",
+                parent_run_reference=parent_run_reference,
+                stable=stable,
+            )
+            return await self.processor_generator.generate_managed(
+                document,
+                mode=mode,
+                model_id=exact_model,
+                max_items=max_items,
+                managed_run=run,
+            )
+        except ProcessorGenerationError:
+            raise
+        except Exception as exc:
+            code = str(getattr(exc, "code", "rag_processor_generation_failed"))
+            receipt = getattr(exc, "receipt", None)
+            raise ProcessorGenerationError(
+                "Managed RAG Processor failed before dispatch.",
+                code=code,
+                receipt=(
+                    receipt
+                    if isinstance(receipt, dict)
+                    else gateway.blocked_receipt("rag_processor_generate", code)
+                ),
+            ) from exc
+
     def _managed_embedding_gateway(self) -> Any | None:
         if self.managed_embedding_gateway is not None:
             return self.managed_embedding_gateway
@@ -6020,7 +6386,9 @@ class RagService:
                         )
                     ], None
             if str(processor.get("mode") or "general") in {"qa", "summary"}:
-                capabilities = self.processor_generator.capabilities()
+                capabilities = self._processor_generation_capabilities(
+                    str(processor.get("model_id") or "")
+                )
                 if not bool(capabilities.get("llm_configured")):
                     processor_node = next(
                         (

--- a/server/tests/test_provider_workload_control.py
+++ b/server/tests/test_provider_workload_control.py
@@ -1480,7 +1480,7 @@ def test_r7_local_fallback_policy_is_explicit_and_entry_scoped(
         ),
     )
     assert policy.local_fallback_mode == "extractive"
-    assert policy.data_plane_integrated is False
+    assert policy.data_plane_integrated is True
     with pytest.raises(RouterServiceError) as invalid:
         control.update_policy(
             "rag_embedding",
@@ -1920,10 +1920,17 @@ async def test_workload_admin_api_is_session_and_csrf_protected_and_public_redac
         }
         assert len(r7_policies) == 6
         assert r7_policies["rag_embedding"]["data_plane_integrated"] is True
+        assert r7_policies["rag_query_generate"]["data_plane_integrated"] is True
+        assert r7_policies["rag_processor_generate"]["data_plane_integrated"] is True
         assert all(
             item["data_plane_integrated"] is False
             for entry_id, item in r7_policies.items()
-            if entry_id != "rag_embedding"
+            if entry_id
+            not in {
+                "rag_embedding",
+                "rag_query_generate",
+                "rag_processor_generate",
+            }
         )
         assert all(item["feature_enabled"] is False for item in r7_policies.values())
         assert all(item["local_fallback_mode"] == "none" for item in r7_policies.values())

--- a/server/tests/test_rag_managed_generation.py
+++ b/server/tests/test_rag_managed_generation.py
@@ -1,0 +1,516 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+import httpx
+import pytest
+
+from server.model_router.egress import ProviderEgressPolicy
+from server.model_router.rag_generation_gateway import ManagedRagGenerationGateway
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import (
+    ProviderWorkloadActivationRequest,
+    ProviderWorkloadBindingUpdate,
+    ProviderWorkloadPolicyUpdate,
+    RouterConnectionCreate,
+)
+from server.model_router.service import ModelRouterService
+from server.model_router.workload_control import (
+    PROVIDER_WORKLOAD_CONTRACT_VERSION,
+    ProviderWorkloadControlService,
+)
+from server.rag.embedder import EmbeddingClient
+from server.rag.lexical_store import SqliteLexicalStore
+from server.rag.processor_generator import ProcessorGenerationError
+from server.rag.rag_service import (
+    ManagedRagGenerationRouteError,
+    PipelineDraftValidationError,
+    PipelineJobStateError,
+    RagService,
+)
+from server.rag.vector_store import LocalJsonVectorStore
+
+
+MODEL_ID = "provider/rag-model"
+PROVIDER_SECRET = "managed-rag-provider-secret"
+
+
+def _profile(execution_shape: str) -> tuple[dict[str, object], str]:
+    value: dict[str, object] = {
+        "execution_shape": execution_shape,
+        "model_id": MODEL_ID,
+        "candidate_model_ids": [],
+        "judge_model_id": None,
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return value, fingerprint
+
+
+def _seed_certification(
+    repository: SQLiteRouterRepository,
+    *,
+    connection_id: str,
+    connection_fingerprint: str,
+    execution_shape: str,
+) -> None:
+    profile, profile_fingerprint = _profile(execution_shape)
+    certification, created = repository.claim_workload_certification(
+        "local",
+        certification_id=f"rag-{execution_shape}-cert",
+        connection_id=connection_id,
+        connection_fingerprint=connection_fingerprint,
+        contract_version=PROVIDER_WORKLOAD_CONTRACT_VERSION,
+        execution_shape=execution_shape,
+        requested_model=MODEL_ID,
+        profile=profile,
+        profile_fingerprint=profile_fingerprint,
+        idempotency_key_hash=hashlib.sha256(
+            f"rag-{execution_shape}".encode("utf-8")
+        ).hexdigest(),
+    )
+    assert created is True
+    repository.complete_workload_certification(
+        "local",
+        str(certification["id"]),
+        status="passed",
+        checks={
+            "content_observed": True,
+            "actual_model_verified": True,
+            "json_object_verified": execution_shape == "chat_json_object",
+        },
+        warning_codes=[],
+        actual_model=MODEL_ID,
+    )
+
+
+def _activate(
+    service: ModelRouterService,
+    connection_id: str,
+    *,
+    entry_id: str,
+    execution_shape: str,
+    local_fallback_mode: str = "none",
+) -> None:
+    control = ProviderWorkloadControlService(service)
+    saved = control.update_policy(
+        entry_id,  # type: ignore[arg-type]
+        ProviderWorkloadPolicyUpdate(
+            expected_revision=0,
+            local_fallback_mode=local_fallback_mode,  # type: ignore[arg-type]
+            bindings=[
+                ProviderWorkloadBindingUpdate(
+                    execution_shape=execution_shape,  # type: ignore[arg-type]
+                    model_id=MODEL_ID,
+                    connection_id=connection_id,
+                )
+            ],
+        ),
+    )
+    active = control.activate(
+        entry_id,  # type: ignore[arg-type]
+        ProviderWorkloadActivationRequest(
+            expected_revision=saved.revision,
+            no_open_p0_p1=True,
+            acknowledge_fail_closed=True,
+        ),
+    )
+    assert active.effective_status == "managed_required"
+
+
+def _managed_stack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response],
+    *,
+    query_fallback: str = "none",
+) -> tuple[RagService, SQLiteRouterRepository]:
+    repository = SQLiteRouterRepository(
+        tmp_path / "router",
+        master_key=b"r" * 32,
+    )
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Managed RAG",
+            kind="openai_compatible",
+            base_url="https://provider.example/v1",
+            api_key=PROVIDER_SECRET,
+            scopes=["chat"],
+        ),
+    )
+    repository.save_test_result(
+        "local",
+        connection.id,
+        health="online",
+        model_count=1,
+        checked_at="2026-08-26T00:00:00+00:00",
+    )
+    fingerprint = repository.connection_config_fingerprint("local", connection.id)
+    refresh_id = f"refresh-{connection.id}"
+    repository.claim_catalog_refresh(
+        "local",
+        refresh_id=refresh_id,
+        connection_id=connection.id,
+        connection_fingerprint=fingerprint,
+    )
+    repository.complete_catalog_refresh(
+        "local",
+        refresh_id,
+        connection_id=connection.id,
+        models=[
+            {
+                "model_id": MODEL_ID,
+                "normalized_model_id": MODEL_ID,
+                "capability_state": "declared",
+            }
+        ],
+        offerings=[],
+        model_count=1,
+        truncated=False,
+        catalog_fingerprint="rag-catalog",
+        observed_at="2026-08-26T00:00:00+00:00",
+    )
+    for execution_shape in ("chat_text_unary", "chat_json_object"):
+        _seed_certification(
+            repository,
+            connection_id=connection.id,
+            connection_fingerprint=fingerprint,
+            execution_shape=execution_shape,
+        )
+
+    router_service = ModelRouterService(
+        repository,
+        egress_policy=ProviderEgressPolicy(
+            resolver=lambda _host, _port: ["8.8.8.8"]
+        ),
+    )
+    monkeypatch.setenv("MODEL_CONTROL_RAG_QUERY_ENABLED", "true")
+    monkeypatch.setenv("MODEL_CONTROL_RAG_PROCESSOR_ENABLED", "true")
+    _activate(
+        router_service,
+        connection.id,
+        entry_id="rag_query_generate",
+        execution_shape="chat_text_unary",
+        local_fallback_mode=query_fallback,
+    )
+    _activate(
+        router_service,
+        connection.id,
+        entry_id="rag_processor_generate",
+        execution_shape="chat_json_object",
+    )
+    gateway = ManagedRagGenerationGateway.for_router(
+        router_service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=False,
+            trust_env=False,
+        ),
+    )
+    storage = tmp_path / "rag-storage"
+    return (
+        RagService(
+            storage_dir=storage,
+            uploads_dir=tmp_path / "rag-uploads",
+            embedder=EmbeddingClient(api_key="", dimension=64),
+            vector_store=LocalJsonVectorStore(storage / "vectors.json"),
+            lexical_store=SqliteLexicalStore(storage / "lexical.sqlite3"),
+            managed_generation_gateway=gateway,
+            llm_enabled=False,
+        ),
+        repository,
+    )
+
+
+async def _indexed_service(
+    service: RagService,
+    *,
+    text: str = "PRIVATE-RAG-QUESTION-CONTEXT belongs only in the RAG index.",
+) -> tuple[str, str]:
+    kb = service.create_knowledge_base("managed query")
+    document = await service.upload_document(
+        kb["id"],
+        "managed.txt",
+        text.encode("utf-8"),
+    )
+    return kb["id"], document["id"]
+
+
+@pytest.mark.asyncio
+async def test_managed_rag_query_uses_one_pinned_post_and_redacted_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "model": MODEL_ID,
+                "choices": [{"message": {"content": "MANAGED-RAG-ANSWER"}}],
+                "usage": {
+                    "prompt_tokens": 12,
+                    "completion_tokens": 3,
+                    "total_tokens": 15,
+                },
+            },
+        )
+
+    service, repository = _managed_stack(tmp_path, monkeypatch, handler)
+    kb_id, _ = await _indexed_service(service)
+    result = await service.query(
+        kb_id,
+        "PRIVATE-RAG-QUESTION",
+        top_k=1,
+        retrieval={"mode": "fulltext"},
+    )
+
+    assert result["answer"] == "MANAGED-RAG-ANSWER"
+    assert result["execution_mode"] == "managed"
+    assert result["provider_route_receipts"]["entry_id"] == "rag_query_generate"
+    assert result["provider_route_receipts"]["call_count"] == 1
+    assert len(requests) == 1
+    assert requests[0].url.host == "8.8.8.8"
+    assert requests[0].headers["host"] == "provider.example"
+    assert requests[0].extensions["sni_hostname"] == "provider.example"
+    database = repository.database_path.read_bytes()
+    assert b"PRIVATE-RAG-QUESTION" not in database
+    assert b"PRIVATE-RAG-QUESTION-CONTEXT" not in database
+    assert b"MANAGED-RAG-ANSWER" not in database
+    assert PROVIDER_SECRET.encode() not in database
+
+
+@pytest.mark.asyncio
+async def test_managed_rag_query_fails_closed_after_one_post_without_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(503, json={"error": "private upstream body"})
+
+    service, _ = _managed_stack(tmp_path, monkeypatch, handler)
+    kb_id, _ = await _indexed_service(service)
+
+    with pytest.raises(ManagedRagGenerationRouteError) as caught:
+        await service.query(
+            kb_id,
+            "PRIVATE-RAG-QUESTION",
+            top_k=1,
+            retrieval={"mode": "fulltext"},
+        )
+
+    assert len(requests) == 1
+    assert caught.value.receipt["call_count"] == 1
+    assert caught.value.receipt["calls"][0]["dispatched"] is True
+
+
+@pytest.mark.asyncio
+async def test_managed_rag_query_explicit_extractive_fallback_is_not_model_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(503, json={"error": "private upstream body"})
+
+    service, _ = _managed_stack(
+        tmp_path,
+        monkeypatch,
+        handler,
+        query_fallback="extractive",
+    )
+    kb_id, _ = await _indexed_service(service)
+    result = await service.query(
+        kb_id,
+        "PRIVATE-RAG-QUESTION",
+        top_k=1,
+        retrieval={"mode": "fulltext"},
+    )
+
+    assert len(requests) == 1
+    assert result["execution_mode"] == "local_non_model"
+    assert result["answer"].startswith("根据知识库资料：")
+    assert "local_non_model_fallback" in result["fallback_reason_codes"]
+    assert result["provider_route_receipts"]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_managed_rag_query_cancellation_closes_the_parent_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        raise asyncio.CancelledError
+
+    service, repository = _managed_stack(tmp_path, monkeypatch, handler)
+    kb_id, _ = await _indexed_service(service)
+
+    with pytest.raises(asyncio.CancelledError):
+        await service.query(
+            kb_id,
+            "PRIVATE-RAG-QUESTION",
+            top_k=1,
+            retrieval={"mode": "fulltext"},
+        )
+
+    evidence = repository.list_workload_receipts(
+        "local",
+        entry_id="rag_query_generate",
+    )
+    assert len(requests) == 1
+    assert evidence["runs"][0]["status"] == "cancelled"
+    assert evidence["calls"][0]["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_managed_processor_continue_on_error_never_replays_failed_document(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        payload = json.loads(request.content)
+        source = json.loads(payload["messages"][1]["content"])
+        title = str(source["title"])
+        block_id = str(source["blocks"][0]["block_id"])
+        if "bad" in title.casefold():
+            return httpx.Response(503, json={"error": "private processor body"})
+        return httpx.Response(
+            200,
+            json={
+                "model": MODEL_ID,
+                "choices": [
+                    {
+                        "message": {
+                            "content": json.dumps(
+                                {
+                                    "items": [
+                                        {
+                                            "question": "What is the code?",
+                                            "answer": "GOOD-42",
+                                            "block_ids": [block_id],
+                                        }
+                                    ]
+                                }
+                            )
+                        }
+                    }
+                ],
+            },
+        )
+
+    service, repository = _managed_stack(tmp_path, monkeypatch, handler)
+    kb = service.create_knowledge_base("managed processor")
+    bad = await service.upload_document(kb["id"], "bad.txt", b"BAD-PRIVATE-DOC")
+    good = await service.upload_document(kb["id"], "good.txt", b"GOOD-PRIVATE-DOC")
+    draft = service.update_pipeline_draft(
+        kb["id"],
+        {
+            "stage_processor": {
+                "mode": "qa",
+                "model_id": MODEL_ID,
+                "failure_policy": "continue_on_error",
+            }
+        },
+    )
+    job = service.create_pipeline_job(
+        kb["id"],
+        draft_version=draft["version"],
+        source_document_ids=[bad["id"], good["id"]],
+    )
+
+    completed = await service.process_pipeline_job_sources(job["job_id"])
+    results = service.get_pipeline_job(job["job_id"])["document_results"]
+
+    assert len(requests) == 2
+    assert len(completed) == 1
+    assert [item["status"] for item in results] == ["failed", "completed"]
+    assert all(item["execution_mode"] == "managed" for item in results)
+    assert results[0]["provider_route_receipts"]["call_count"] == 1
+    assert results[1]["provider_route_receipts"]["call_count"] == 1
+    database = repository.database_path.read_bytes()
+    assert b"BAD-PRIVATE-DOC" not in database
+    assert b"GOOD-PRIVATE-DOC" not in database
+    assert b"GOOD-42" not in database
+
+    service.fail_pipeline_job(job["job_id"], "synthetic job failure")
+    with pytest.raises(PipelineJobStateError, match="Managed processor evidence"):
+        service.retry_pipeline_job(job["job_id"])
+    assert len(requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_managed_processor_exact_draft_model_mismatch_blocks_before_post(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[httpx.Request] = []
+    service, _ = _managed_stack(
+        tmp_path,
+        monkeypatch,
+        lambda request: (
+            requests.append(request)
+            or httpx.Response(200, json={})
+        ),
+    )
+    kb_id, document_id = await _indexed_service(service)
+
+    with pytest.raises(ProcessorGenerationError) as caught:
+        await service.preview_pipeline_processor(
+            kb_id,
+            document_id,
+            {
+                "mode": "qa",
+                "model_id": "provider/not-bound",
+            },
+        )
+
+    assert caught.value.code == "provider_workload_binding_missing"
+    assert requests == []
+
+
+@pytest.mark.asyncio
+async def test_managed_processor_empty_draft_model_is_rejected_before_control_plane(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[httpx.Request] = []
+    service, _ = _managed_stack(
+        tmp_path,
+        monkeypatch,
+        lambda request: (
+            requests.append(request)
+            or httpx.Response(200, json={})
+        ),
+    )
+    kb_id, document_id = await _indexed_service(service)
+
+    with pytest.raises(PipelineDraftValidationError, match="model_id is invalid"):
+        await service.preview_pipeline_processor(
+            kb_id,
+            document_id,
+            {
+                "mode": "qa",
+                "model_id": "",
+            },
+        )
+
+    assert requests == []


### PR DESCRIPTION
## 摘要

- 将 RAG 问答生成接入精确 Managed Provider Binding，保持一次逻辑调用最多一次 Provider POST，并在派发后禁止远程回退。
- 将 RAG AI Processor 的 QA/摘要生成接入 JSON Object Managed 合同；每个文档批次独立记录脱敏 Receipt，失败批次不自动重放。
- 为 RAG 页面与 Chat RAG 路径增加 Managed、Legacy 与本地非模型降级提示，不改变现有响应字段和检索来源契约。
- 保持问题、文档片段、模型正文和凭据不进入 Provider 控制面存储。

## 验证

- R7C 聚焦后端测试：41 passed。
- R7C 前端组件测试：20 passed。
- 前端 typecheck 与 production build：通过。
- 后端全量：4644 passed、29 skipped；20 个失败均在相同基线复现，属于既有 Worker 构建产物和 Node/TypeScript 环境问题。
- 前端全量：679 passed；1 个无关 Skill 超时，隔离重跑 2 passed。
- Core、newAPI 与 Overlay Compose 配置验证：通过。
- git diff --check 与敏感信息扫描：通过。

## 真实预览验收

- 非流式文本与 JSON Object 资格认证各产生一次 Provider POST，均通过，无重试。
- RAG Query Smoke：一次 POST，execution_mode=managed，实际模型与绑定模型均为 openai/gpt-4.1-mini，Receipt call_count=1。
- AI Processor 单批次 Smoke：一次 POST，生成 2 条 QA，execution_mode=managed，Receipt call_count=1。
- 日志未发现第二 Provider、Legacy 回退或额外 POST；Router SQLite、WAL 与 SHM 未检出测试问题、文档正文或生成 QA 文本。

## 兼容与回滚

- Feature Flag 默认关闭；关闭 MODEL_CONTROL_RAG_QUERY_ENABLED 或 MODEL_CONTROL_RAG_PROCESSOR_ENABLED 并重启即可恢复原 Legacy 路径。
- 不改变 /api/chat、Catalog 数量、提示词选择器、多模态协议或 R7B Embedding 空间。
- 不删除 Router SQLite、RAG 索引、Pipeline Version 或预览数据。
