### PR TITLE
fix: 收口 RAG 可信评测与 Formal 门禁

### DIFF
--- a/client/src/pages/KnowledgeEvaluationPage.tsx
+++ b/client/src/pages/KnowledgeEvaluationPage.tsx
@@ -43,7 +43,8 @@ interface EvaluationCase {
   query: string;
   expected_refs: ExpectedReference[];
   expected_no_result?: boolean;
-  review_status?: "not_required" | "pending" | "approved";
+  review_status?: "not_required" | "pending" | "approved" | "rejected";
+  review_evidence?: Record<string, unknown>;
   targeting?: Record<string, unknown>;
   tags: string[];
   notes: string;
@@ -72,6 +73,8 @@ interface EvaluationSetVersion extends EvaluationSet {
   source_revision: number;
   checksum: string;
   published_at: number;
+  benchmark_contract_version?: "rag-gold-v1" | "rag-gold-v2";
+  qualification_manifest?: Record<string, unknown>;
 }
 
 interface GatePolicy {
@@ -86,6 +89,9 @@ interface GatePolicy {
   min_citation_coverage: number;
   max_p95_latency_ratio: number;
   max_p95_latency_ms: number;
+  max_paired_primary_regression: number;
+  paired_confidence_level: number;
+  require_comparable_corpus: boolean;
   require_zero_errors: boolean;
 }
 
@@ -130,6 +136,10 @@ interface EvaluationRun {
   eval_set_id: string;
   eval_set_version?: number | null;
   baseline_version_id?: string | null;
+  run_mode?: "diagnostic" | "formal";
+  metric_contract_version?: string;
+  comparability?: { comparable?: boolean; same_corpus?: boolean; reason?: string | null };
+  paired_confidence?: Record<string, unknown>;
   target_results: TargetResult[];
   evidence_qualification?: {
     status: "qualified" | "diagnostic_only";
@@ -170,6 +180,13 @@ function timestamp(value: number) {
   return new Date(value * 1000).toLocaleString("zh-CN", { hour12: false });
 }
 
+function leakageWarningThreshold(item: EvaluationCase) {
+  const warning = item.targeting?.leakage_warning;
+  if (!warning || typeof warning !== "object") return null;
+  const threshold = Number((warning as { threshold?: unknown }).threshold);
+  return Number.isFinite(threshold) ? threshold : null;
+}
+
 export default function KnowledgeEvaluationPage() {
   const { kbId = "" } = useParams();
   const importRef = useRef<HTMLInputElement>(null);
@@ -185,6 +202,8 @@ export default function KnowledgeEvaluationPage() {
   const [selectedRun, setSelectedRun] = useState<EvaluationRun | null>(null);
   const [selectedVersions, setSelectedVersions] = useState<string[]>([]);
   const [baselineVersionId, setBaselineVersionId] = useState("");
+  const [runMode, setRunMode] = useState<"diagnostic" | "formal">("diagnostic");
+  const [adminCsrfToken, setAdminCsrfToken] = useState("");
   const [newSetName, setNewSetName] = useState("");
   const [query, setQuery] = useState("");
   const [tags, setTags] = useState("");
@@ -197,21 +216,30 @@ export default function KnowledgeEvaluationPage() {
   const [notice, setNotice] = useState("");
   const [acknowledgeCalibrationWarnings, setAcknowledgeCalibrationWarnings] = useState(false);
   const [caseEvidence, setCaseEvidence] = useState<Record<string, Array<Record<string, unknown>>>>({});
+  const [reviewReasons, setReviewReasons] = useState<Record<string, string>>({});
   const [calibrationJob, setCalibrationJob] = useState<{ job_id: string; status: string; error?: string | null } | null>(null);
 
   const selectedSet = useMemo(
     () => evaluationSets.find((item) => item.eval_set_id === selectedSetId) ?? null,
     [evaluationSets, selectedSetId],
   );
-  const pendingNoResultReviewCount = useMemo(
-    () => selectedSet?.cases.filter((item) => item.expected_no_result && item.review_status !== "approved").length ?? 0,
+  const pendingReviewCount = useMemo(
+    () => selectedSet?.cases.filter((item) => item.review_status !== "approved" || !item.review_evidence).length ?? 0,
     [selectedSet],
   );
 
   useEffect(() => {
     if (!kbId) return;
     void loadWorkspace();
+    void loadAdminSession();
   }, [kbId]);
+
+  async function loadAdminSession() {
+    const response = await fetch("/api/router/admin/session");
+    if (!response.ok) return setAdminCsrfToken("");
+    const session = await response.json().catch(() => null);
+    setAdminCsrfToken(session?.authenticated && session?.csrf_token ? String(session.csrf_token) : "");
+  }
 
   useEffect(() => {
     if (!selectedSetId) {
@@ -417,13 +445,17 @@ export default function KnowledgeEvaluationPage() {
     setError("");
     const response = await fetch("/api/rag/evaluation-runs", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(runMode === "formal" && adminCsrfToken ? { "X-ModelMirror-CSRF": adminCsrfToken } : {}),
+      },
       body: JSON.stringify({
         eval_set_id: selectedSet.eval_set_id,
         eval_set_version: selectedEvaluationVersion === "draft" ? null : Number(selectedEvaluationVersion),
         targets: selectedVersions.map((versionId) => ({ version_id: versionId })),
         baseline_version_id: selectedVersions.includes(baselineVersionId) ? baselineVersionId : null,
         ks: [1, 3, 5, 10],
+        run_mode: runMode,
       }),
     });
     const data = await response.json().catch(() => null);
@@ -471,27 +503,27 @@ export default function KnowledgeEvaluationPage() {
     setCaseEvidence((current) => ({ ...current, [caseId]: data.evidence ?? [] }));
   }
 
-  async function approveNoResultCase(item: EvaluationCase) {
-    if (!selectedSet || !item.expected_no_result) return;
-    const response = await fetch(`/api/rag/evaluation-sets/${encodeURIComponent(selectedSet.eval_set_id)}/cases/${encodeURIComponent(item.case_id)}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
+  async function reviewCase(item: EvaluationCase, decision: "approved" | "rejected") {
+    if (!selectedSet) return;
+    if (!adminCsrfToken) return setError("请先在设置页完成 Provider 管理员配对，再提交人工审核结论。");
+    const leakageWarning = leakageWarningThreshold(item) != null;
+    const suppliedReason = String(reviewReasons[item.case_id] || "").trim();
+    if (decision === "approved" && leakageWarning && !suppliedReason) {
+      return setError("该样例存在原文重合警告，请填写逐条审核理由后再批准。");
+    }
+    const response = await fetch(`/api/rag/evaluation-sets/${encodeURIComponent(selectedSet.eval_set_id)}/cases/${encodeURIComponent(item.case_id)}/review`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-ModelMirror-CSRF": adminCsrfToken },
       body: JSON.stringify({
         expected_revision: selectedSet.revision,
-        case: {
-          query: item.query,
-          expected_no_result: true,
-          expected_refs: [],
-          review_status: "approved",
-          tags: item.tags,
-          notes: item.notes,
-        },
+        decision,
+        reason: suppliedReason || (decision === "approved" ? "已在评测审核工作台核对固定证据。" : "人工审核拒绝。"),
       }),
     });
     const data = await response.json().catch(() => null);
-    if (!response.ok) return setError(errorMessage(data, "无答案样例确认失败。"));
+    if (!response.ok) return setError(errorMessage(data, "样例审核失败。"));
     await reloadSets(selectedSet.eval_set_id);
-    setNotice("无答案样例已确认；评测集已变更，需要重新校准。" );
+    setNotice(decision === "approved" ? "审核结论已由服务器记录。" : "样例已拒绝，不能进入 Formal Gold。" );
   }
 
   async function recalibrateGeneratedSet() {
@@ -546,7 +578,10 @@ export default function KnowledgeEvaluationPage() {
     setBusy(`promote:${versionId}`);
     const response = await fetch(`/api/rag/pipeline/versions/${encodeURIComponent(versionId)}/promote`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(adminCsrfToken ? { "X-ModelMirror-CSRF": adminCsrfToken } : {}),
+      },
       body: JSON.stringify({ evaluation_run_id: selectedRun.run_id }),
     });
     const data = await response.json().catch(() => null);
@@ -614,8 +649,8 @@ export default function KnowledgeEvaluationPage() {
                 </select>
                 <button className="rounded-lg border border-white/10 px-3 py-2 text-sm text-slate-200 disabled:opacity-40" disabled={!selectedSet} onClick={() => importRef.current?.click()} type="button">导入</button>
                 {selectedSet?.origin === "generated" && selectedSet.calibration?.status === "warning" ? <label className="flex items-center gap-2 text-xs text-amber-100"><input checked={acknowledgeCalibrationWarnings} onChange={(event) => setAcknowledgeCalibrationWarnings(event.target.checked)} type="checkbox" />确认校准警告</label> : null}
-                {selectedSet?.origin === "generated" ? <button className="rounded-lg border border-cyan-300/25 px-3 py-2 text-sm font-semibold text-cyan-100 disabled:opacity-40" disabled={pendingNoResultReviewCount > 0 || busy === "calibration" || Boolean(calibrationJob && !["completed", "failed", "cancelled"].includes(calibrationJob.status))} onClick={() => void recalibrateGeneratedSet()} type="button">{selectedSet.calibration?.status === "awaiting_review" ? "开始真实校准" : "重新校准"}</button> : null}
-                <button className="rounded-lg border border-emerald-300/25 bg-emerald-300/10 px-3 py-2 text-sm font-semibold text-emerald-100 disabled:opacity-40" disabled={!selectedSet?.cases.length || busy === "publish-set" || (selectedSet?.origin === "generated" && (!["calibrated", "warning"].includes(String(selectedSet.calibration?.status || "")) || pendingNoResultReviewCount > 0 || (selectedSet.calibration?.status === "warning" && !acknowledgeCalibrationWarnings)))} onClick={() => void publishEvaluationSet()} type="button">发布版本</button>
+                {selectedSet?.origin === "generated" ? <button className="rounded-lg border border-cyan-300/25 px-3 py-2 text-sm font-semibold text-cyan-100 disabled:opacity-40" disabled={pendingReviewCount > 0 || busy === "calibration" || Boolean(calibrationJob && !["completed", "failed", "cancelled"].includes(calibrationJob.status))} onClick={() => void recalibrateGeneratedSet()} type="button">{selectedSet.calibration?.status === "awaiting_review" ? "开始真实校准" : "重新校准"}</button> : null}
+                <button className="rounded-lg border border-emerald-300/25 bg-emerald-300/10 px-3 py-2 text-sm font-semibold text-emerald-100 disabled:opacity-40" disabled={!selectedSet?.cases.length || busy === "publish-set" || (selectedSet?.origin === "generated" && (!["calibrated", "warning"].includes(String(selectedSet.calibration?.status || "")) || pendingReviewCount > 0 || (selectedSet.calibration?.status === "warning" && !acknowledgeCalibrationWarnings)))} onClick={() => void publishEvaluationSet()} type="button">发布版本</button>
                 <input accept=".json,.csv,application/json,text/csv" className="hidden" onChange={(event) => { const file = event.target.files?.[0]; if (file) void importCases(file); event.target.value = ""; }} ref={importRef} type="file" />
               </div>
             </div>
@@ -675,8 +710,9 @@ export default function KnowledgeEvaluationPage() {
             <div className="mt-5 max-h-[360px] divide-y divide-white/10 overflow-y-auto border-t border-white/10">
               {selectedSet?.cases.length ? selectedSet.cases.map((item, index) => (
                 <div className="py-3" key={item.case_id}>
-                  <div className="flex gap-3"><span className="text-xs font-semibold text-slate-500">{index + 1}</span><p className="min-w-0 flex-1 text-sm text-slate-100">{item.query}</p>{selectedSet.origin === "generated" ? <button className="text-xs text-cyan-100" onClick={() => void loadCaseEvidence(item.case_id)} type="button">{caseEvidence[item.case_id] ? "收起证据" : item.expected_no_result ? "查看近邻语料" : "查看 Gold"}</button> : null}{selectedSet.origin === "generated" && item.expected_no_result && item.review_status !== "approved" ? <button className="text-xs text-amber-100 disabled:cursor-not-allowed disabled:opacity-35" disabled={!caseEvidence[item.case_id]?.length} onClick={() => void approveNoResultCase(item)} type="button">确认无答案</button> : null}<button className="text-xs text-rose-200" onClick={() => void deleteCase(item.case_id)} type="button">删除</button></div>
-                  <p className="mt-2 pl-7 text-xs text-slate-500">{item.expected_no_result ? "期望无结果" : `${item.expected_refs.length} 个期望引用 · ${[...new Set(item.expected_refs.map((ref) => ref.match_mode || "legacy"))].join(" / ")}`} · {item.tags.join(" · ") || "未标记"}</p>
+                  <div className="flex gap-3"><span className="text-xs font-semibold text-slate-500">{index + 1}</span><p className="min-w-0 flex-1 text-sm text-slate-100">{item.query}</p>{selectedSet.origin === "generated" ? <button className="text-xs text-cyan-100" onClick={() => void loadCaseEvidence(item.case_id)} type="button">{caseEvidence[item.case_id] ? "收起证据" : item.expected_no_result ? "查看近邻语料" : "查看 Gold"}</button> : null}{selectedSet.origin === "generated" && item.review_status !== "approved" ? <><button className="text-xs text-emerald-100 disabled:cursor-not-allowed disabled:opacity-35" disabled={!caseEvidence[item.case_id]?.length || !adminCsrfToken} onClick={() => void reviewCase(item, "approved")} type="button">批准</button><button className="text-xs text-rose-200 disabled:cursor-not-allowed disabled:opacity-35" disabled={!caseEvidence[item.case_id]?.length || !adminCsrfToken} onClick={() => void reviewCase(item, "rejected")} type="button">拒绝</button></> : null}<button className="text-xs text-rose-200" onClick={() => void deleteCase(item.case_id)} type="button">删除</button></div>
+                  <p className="mt-2 pl-7 text-xs text-slate-500">{item.expected_no_result ? "期望无结果" : `${item.expected_refs.length} 个期望引用 · ${[...new Set(item.expected_refs.map((ref) => ref.match_mode || "legacy"))].join(" / ")}`} · {String(item.targeting?.query_type || "未分类")} · {String(item.targeting?.locale || "未知语言")} · {item.tags.join(" · ") || "未标记"}</p>
+                  {leakageWarningThreshold(item) != null ? <div className="mt-2 ml-7 rounded-md border border-amber-300/25 bg-amber-300/10 p-2"><p className="text-[11px] text-amber-100">检测到至少 {leakageWarningThreshold(item)} 个归一化连续字符与证据重合；批准前必须填写独立审核理由。</p><input className="mt-2 w-full rounded border border-amber-300/20 bg-surface-950 px-2 py-1.5 text-xs text-white" onChange={(event) => setReviewReasons((current) => ({ ...current, [item.case_id]: event.target.value }))} placeholder="说明为何该重合不构成答案泄漏" value={reviewReasons[item.case_id] || ""} /></div> : null}
                   {caseEvidence[item.case_id] ? <div className="mt-2 ml-7 space-y-2 border-l border-cyan-300/20 pl-3">{item.expected_no_result ? <p className="text-[11px] text-amber-100">近邻语料只用于确认问题与语料易混淆；请确认其中确实没有该问题的答案。</p> : null}{caseEvidence[item.case_id].map((evidence, evidenceIndex) => <div className="text-xs" key={`${item.case_id}:${evidenceIndex}`}><p className="font-semibold text-slate-200">{String(evidence.document_name || evidence.document_id || "Gold evidence")}{evidence.page_number ? ` · p${evidence.page_number}` : ""}</p><p className="mt-1 whitespace-pre-wrap text-slate-500">{String(evidence.text || "")}</p></div>)}</div> : null}
                 </div>
               )) : <p className="py-10 text-center text-sm text-slate-500">尚无评估问题</p>}
@@ -691,9 +727,16 @@ export default function KnowledgeEvaluationPage() {
             <label className="mt-3 block text-xs text-slate-400">评测数据版本
               <select className="mt-1 w-full rounded-lg border border-white/10 bg-surface-950 px-3 py-2 text-sm text-white" onChange={(event) => setSelectedEvaluationVersion(event.target.value)} value={selectedEvaluationVersion}>
                 <option value="draft">草稿 revision {selectedSet?.revision ?? "-"}（兼容模式）</option>
-                {evaluationSetVersions.map((item) => <option key={item.version_id} value={String(item.version)}>不可变 v{item.version} · {item.cases.length} cases</option>)}
+                {evaluationSetVersions.map((item) => <option key={item.version_id} value={String(item.version)}>不可变 v{item.version} · {item.cases.length} cases · {item.benchmark_contract_version ?? "legacy"}</option>)}
               </select>
             </label>
+            <label className="mt-3 block text-xs text-slate-400">运行模式
+              <select className="mt-1 w-full rounded-lg border border-white/10 bg-surface-950 px-3 py-2 text-sm text-white" onChange={(event) => setRunMode(event.target.value as "diagnostic" | "formal")} value={runMode}>
+                <option value="diagnostic">Diagnostic（兼容诊断）</option>
+                <option value="formal">Formal（固定 42 条与同语料门禁）</option>
+              </select>
+            </label>
+            {runMode === "formal" && !adminCsrfToken ? <p className="mt-2 text-xs text-amber-100">Formal 需要先在设置页完成 Provider 管理员配对，然后刷新本页。</p> : null}
             <div className="mt-3 divide-y divide-white/10 rounded-lg border border-white/10">
               {versions.map((version) => {
                 const checked = selectedVersions.includes(version.version_id);
@@ -706,7 +749,7 @@ export default function KnowledgeEvaluationPage() {
                 );
               })}
             </div>
-            <button className="mt-3 w-full rounded-lg bg-cyan-300 px-4 py-2.5 text-sm font-bold text-surface-950 disabled:opacity-40" disabled={!selectedSet?.cases.length || selectedVersions.length === 0 || busy === "run"} onClick={() => void createRun()} type="button">运行离线评估</button>
+            <button className="mt-3 w-full rounded-lg bg-cyan-300 px-4 py-2.5 text-sm font-bold text-surface-950 disabled:opacity-40" disabled={!selectedSet?.cases.length || selectedVersions.length === 0 || busy === "run" || (runMode === "formal" && (selectedEvaluationVersion === "draft" || selectedVersions.length !== 2 || !selectedVersions.includes(baselineVersionId) || !adminCsrfToken))} onClick={() => void createRun()} type="button">{runMode === "formal" ? "运行 Formal 评估" : "运行离线诊断"}</button>
 
             <div className="mt-5 border-t border-white/10 pt-4">
               <div className="flex items-center justify-between"><h3 className="text-sm font-semibold text-white">Promotion Gate</h3><button className="text-xs font-semibold text-hire-100 disabled:opacity-40" disabled={!gate || busy === "gate"} onClick={() => void saveGate()} type="button">保存</button></div>
@@ -720,6 +763,7 @@ export default function KnowledgeEvaluationPage() {
                   <label className="text-xs text-slate-400">Precision@5 最大回退<input className="mt-1 w-full rounded-lg border border-white/10 bg-surface-950 px-2 py-2 text-sm text-white" max={1} min={0} onChange={(event) => setGate({ ...gate, max_citation_precision_at_5_regression: Number(event.target.value) })} step={0.01} type="number" value={gate.max_citation_precision_at_5_regression} /></label>
                   <label className="text-xs text-slate-400">P95 延迟倍数<input className="mt-1 w-full rounded-lg border border-white/10 bg-surface-950 px-2 py-2 text-sm text-white" max={10} min={1} onChange={(event) => setGate({ ...gate, max_p95_latency_ratio: Number(event.target.value) })} step={0.1} type="number" value={gate.max_p95_latency_ratio} /></label>
                   <label className="text-xs text-slate-400">P95 绝对上限（ms）<input className="mt-1 w-full rounded-lg border border-white/10 bg-surface-950 px-2 py-2 text-sm text-white" max={120000} min={1} onChange={(event) => setGate({ ...gate, max_p95_latency_ms: Number(event.target.value) })} step={50} type="number" value={gate.max_p95_latency_ms} /></label>
+                  <label className="text-xs text-slate-400">配对主指标最大回退<input className="mt-1 w-full rounded-lg border border-white/10 bg-surface-950 px-2 py-2 text-sm text-white" max={1} min={0} onChange={(event) => setGate({ ...gate, max_paired_primary_regression: Number(event.target.value) })} step={0.01} type="number" value={gate.max_paired_primary_regression} /></label>
                 </div>
               ) : null}
             </div>
@@ -735,7 +779,7 @@ export default function KnowledgeEvaluationPage() {
 
         <section className="surface-panel overflow-hidden rounded-lg border border-white/10">
           <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-4 py-3">
-            <div><div className="flex items-center gap-2"><h2 className="text-sm font-semibold text-white">评估结果</h2>{selectedRun?.evidence_qualification ? <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${selectedRun.evidence_qualification.qualified ? "border-emerald-300/30 text-emerald-200" : "border-amber-300/30 text-amber-100"}`}>{selectedRun.evidence_qualification.qualified ? "qualified" : "diagnostic_only"}</span> : null}</div><p className="mt-1 text-xs text-slate-500">{selectedRun ? `${selectedRun.status} · ${selectedRun.progress}% · ${selectedRun.run_id}` : "选择或运行一次评估"}</p>{selectedRun?.evidence_qualification && !selectedRun.evidence_qualification.qualified ? <p className="mt-1 text-xs text-amber-100">仅供诊断：正式门禁要求 30 条稳定 Gold 正例与 12 条已审核困难负例。</p> : null}</div>
+            <div><div className="flex items-center gap-2"><h2 className="text-sm font-semibold text-white">评估结果</h2>{selectedRun?.run_mode ? <span className="rounded-full border border-white/15 px-2 py-0.5 text-[10px] font-semibold text-slate-300">{selectedRun.run_mode}</span> : null}{selectedRun?.evidence_qualification ? <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${selectedRun.evidence_qualification.qualified ? "border-emerald-300/30 text-emerald-200" : "border-amber-300/30 text-amber-100"}`}>{selectedRun.evidence_qualification.qualified ? "qualified" : "diagnostic_only"}</span> : null}</div><p className="mt-1 text-xs text-slate-500">{selectedRun ? `${selectedRun.status} · ${selectedRun.progress}% · ${selectedRun.run_id}` : "选择或运行一次评估"}</p>{selectedRun?.evidence_qualification && !selectedRun.evidence_qualification.qualified ? <p className="mt-1 text-xs text-amber-100">仅供诊断：正式门禁要求已发布 rag-gold-v2、42 条可信审核证据与同一语料快照。</p> : null}</div>
             {selectedRun?.error ? <span className="text-xs text-rose-200">{selectedRun.error}</span> : null}
           </div>
           {selectedRun?.target_results.length ? (

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -225,6 +225,14 @@ Knowledge Evaluation Set 现在支持不可变递增版本。运行可显式固�
 `eval_set_version`；草稿后续编辑或归档不会改写已有版本和报告。未传版本时继续按旧
 revision 快照运行并保留 stale 规则。
 
+评测运行默认是 `diagnostic`，用于历史数据、子集和单目标排障；它不能形成新的晋级证据。
+`formal` 只接受已发布且通过完整资格校验的 `rag-gold-v2`，并要求恰好一个 baseline 和
+一个 candidate、相同 `corpus_snapshot_hash`、完整目标指纹及固定 `rag-eval-v2` 执行清单。
+执行按固定 seed 将每题的 baseline/candidate 相邻交错；每个声明槽位只调用一次，进程恢复
+时未闭合槽位记为失败而不自动重试。质量指标使用固定分母，失败样例以零分计入对应正/负
+样例分母，失败耗时也进入延迟分布；任何执行错误都会阻断晋级。正式比较还要求配对主指标
+95% bootstrap 置信区间下界不低于 `-0.03`。
+
 无答案样例使用 `expected_no_result=true` 且必须没有 Gold 引用。Recall、MRR、nDCG 与
 Citation 只聚合有答案样例；无答案样例单独报告 `no_result_accuracy` 与
 `false_positive_rate`。标准 Pack 建议 Gate 为 Recall@5 0.70、Citation Coverage 0.70、
@@ -236,19 +244,25 @@ No-result Accuracy 0.80，但不会自动推广候选索引。
 评测草稿。它与标准 Pack 的分工不同：标准 Pack 回归检索引擎，定向 Gold 才用于判断某个
 具体知识库及其候选索引是否满足真实内容范围。
 
-- Target 固定 `kb_id + pipeline_version_id`、文档 hash、Processor/Chunk/Retrieval Profile
-  和 source block checksum；活动指针变化不会改写运行目标。
+- 生成来源记录固定 `kb_id + pipeline_version_id`，Gold 身份另以语料文档 ID/content hash、
+  source block ID/内容 hash 组成的 `corpus_snapshot` 固定；其 checksum 不包含 embedding、
+  retrieval 或 chunk 索引参数，因此同一语料上的不同检索实现可以比较。
+- v2 provenance 必须记录生成模型、seed、Prompt 合同 hash、证据内容 hash、Blueprint hash
+  和脱敏调用回执。只有单次 initial 调用成功且未使用 repair 的数据可进入 Formal；缺字段、
+  历史 v1 或修复后生成的数据仍可留作 diagnostic，但不会被升级为晋级证据。
 - 服务端按文档和块分层抽样，最多向用户选择的生成模型发送 40 个、每个 1,200 字符且总计
   48,000 字符的证据单元。Job 只保存证据 ID、hash 和引用映射。
-- Blueprint 固定题型、语言、难度、Gold evidence 和逐块 query marker。模型只生成问题、
-  精确 anchor quote 和公开理由；问题必须包含每个 Gold block 的至少一个固定 marker，
-  否则按“无针对性的通用问题”拒绝。
+- Blueprint 固定题型、语言、难度和 Gold evidence。模型只生成问题、精确 anchor quote 和
+  公开理由；语义改写与跨语言题不再要求复制原文 marker。问题与证据出现归一化连续复制
+  32 字符会直接拒绝，较短重合按题型产生泄漏 warning，并要求人工批准时填写理由。
 - Gold 由服务端映射为 `match_mode=source_block`，生成时 chunk ID 只作诊断。模型不能生成、
   替换或扩展 document/chunk/source-block ID。
 - 自动校准只运行固定索引的真实检索并标记 Rank 1、Rank 2–5、Rank 6–10 和 Top-10 miss；
   它不会按当前 Top-K 改写 Gold。过易、漏召回或无答案误召回达到阈值时产生 warning。
-- `calibrated` 可发布；`warning` 需要显式确认；`pending / failed / stale` 阻断发布。生成的
-  无答案题必须逐题人工确认，编辑后立即 stale 并需要重新校准。
+- 新生成用例均为 `pending`。正式 `rag-gold-v2` 要求 30 条正例与 12 条语料近邻困难负例
+  全部通过受信 UI 逐条批准；服务器记录审核时间、revision、认证角色及语义 checksum。
+  编辑 query、Gold、targeting 或标签会清除审核结论；拒绝、待审、伪困难负例、重复/近重复、
+  覆盖失衡或 source block 过度复用均阻断发布。历史 v1 仍可读取，但只作 legacy/diagnostic。
 
 入口位于 `/rag/:kbId/evaluation`。预检和任务 API 复用 `/api/benchmarks/generations/*` 与
 `/api/benchmarks/calibrations/*`；可信管理侧可按需读取每条 Gold 的最多 2,000 字符受限证据。
@@ -276,4 +290,3 @@ npm.cmd run build
 ```
 
 新增后端包必须同步复制到 `server/Dockerfile`，并在共享栈空闲后通过真实镜像重建验证。
-

--- a/docs/RAG_INTEGRATION.md
+++ b/docs/RAG_INTEGRATION.md
@@ -2,12 +2,38 @@
 
 本文件说明模镜本地 RAG 模块的架构、API、扩展方式和测试方法。该模块位于 `server/rag/`，前端入口为 `/rag`，聊天页可选择知识库进行检索增强问答。
 
-最后更新日期：2026-08-17
+最后更新日期：2026-08-26
 
 > **当前状态：** `/rag` 是 ModelMirror 本地主路径。知识流水线已支持候选版本、
 > 人工激活/回滚、Processor、可选视觉理解、向量 + FTS5 双索引、检索评测和
 > Promotion Gate。下方按日期保留的段落是增量记录；较早段落中的“planned”
 > 只代表当时状态。
+
+## 2026-08-26 P0：可信 Gold 与 Formal 评测合同
+
+知识评测新增 `diagnostic | formal` 两种运行模式。默认 `diagnostic` 保持旧记录、子集和
+单目标排障兼容，但不能授权候选晋级。`formal` 必须显式选择一个已发布、资格完整的
+`rag-gold-v2`，且恰好包含一个 baseline 和一个 candidate；两者必须与 Gold 的
+`corpus_snapshot_hash` 相同，并提供版本、Processor、Retrieval、Embedding 与 Rerank 身份。
+Formal 不接受请求级 Retrieval override，避免实际执行参数与不可变目标清单错位。
+
+`rag-gold-v2` 的语料身份由不可变文档 ID/content hash 和 source block ID/内容 hash 组成，
+快照不包含正文，也不绑定 embedding、retrieval 或 chunk 索引参数。30 条正例和 12 条
+语料近邻困难负例必须全部通过认证管理会话和 CSRF 保护的审核接口逐条批准；服务器记录
+revision、审核时间、角色和 case checksum。修改题目、Gold、targeting 或标签会自动清除
+审核。生成器不再强制语义改写/跨语言题复制原文 marker；连续复制 32 个归一化字符直接
+阻断，较短重合触发需要逐条填写理由的泄漏警告。v2 provenance 还绑定生成模型、seed、
+Prompt 合同、证据内容、Blueprint 与单次 initial 调用回执；自动 repair 后的数据只作诊断。
+
+Formal 执行使用固定 seed 将每题的 baseline/candidate 调用相邻交错，每个声明槽位只执行
+一次。进程崩溃后，已领取但未闭合的槽位按失败及真实已耗时记账，不会自动重复外部调用。
+Recall、Citation、No-result Accuracy 和延迟均使用预声明固定分母；失败正/负例以零分计入
+对应质量分母，失败耗时进入 P95，且 `error_count > 0` 必然阻断。门禁除绝对指标外，还要求
+按正负类型与语言分层的 10,000 次确定性配对 bootstrap 95% CI 下界不低于 `-0.03`。
+
+真实 Gold 生成、Embedding、Rerank 或 Formal 调用仍需每次单独授权；本地诊断、发布和候选
+构建不会自动激活索引。回滚本轮代码只需撤销对应提交，不需要迁移或重写历史评测记录；
+v1 与旧运行继续只读展示为 legacy/diagnostic。
 
 ## 2026-08-17 P0：Embedding 请求与生效合同
 

--- a/server/benchmarks/api.py
+++ b/server/benchmarks/api.py
@@ -376,12 +376,11 @@ async def create_calibration(payload: BenchmarkCalibrationRequest) -> dict[str, 
             pending_reviews = [
                 case
                 for case in dataset.get("cases") or []
-                if case.get("expected_no_result")
-                and str(case.get("review_status") or "pending") != "approved"
+                if str(case.get("review_status") or "pending") != "approved"
             ]
             if pending_reviews:
                 raise EvaluationStateError(
-                    "Approve every corpus-near no-result case before calibration."
+                    "Approve every generated case before calibration."
                 )
             preflight = await _to_thread(
                 get_knowledge_benchmark_generation_service().preflight,

--- a/server/benchmarks/executor.py
+++ b/server/benchmarks/executor.py
@@ -671,6 +671,13 @@ class BenchmarkJobExecutor:
                 dataset_revision=existing["revision"],
                 warnings=target_warnings,
             )
+            if await self._hold_knowledge_generation_for_review(
+                job_id=job["job_id"],
+                dataset=existing,
+                snapshot=snapshot,
+                reference=reference,
+            ):
+                return
             await self._start_knowledge_evaluation(
                 job_id=job["job_id"],
                 dataset=existing,
@@ -788,7 +795,7 @@ class BenchmarkJobExecutor:
             generated["description"],
             cases=generated["cases"],
             provenance={
-                "generator": "modelmirror-targeted-rag-benchmark-v1",
+                "generator": "modelmirror-targeted-rag-benchmark-v2",
                 "generation_purpose": str(
                     request.get("generation_purpose") or "general"
                 ),
@@ -801,6 +808,7 @@ class BenchmarkJobExecutor:
                 "source_summary_hash": snapshot["source_summary_hash"],
                 "evidence_hash": context["evidence_hash"],
                 "blueprint_hash": context["blueprint_hash"],
+                "prompt_contract_hash": context["prompt_contract_hash"],
                 "seed": int(request.get("seed") or 0),
                 "repair_used": repair_used,
                 "generation_attempts": copy.deepcopy(attempts),
@@ -844,36 +852,12 @@ class BenchmarkJobExecutor:
             dataset_id=dataset["eval_set_id"],
             dataset_revision=dataset["revision"],
         )
-        pending_reviews = [
-            case
-            for case in dataset.get("cases") or []
-            if case.get("expected_no_result")
-            and str(case.get("review_status") or "pending") != "approved"
-        ]
-        if pending_reviews:
-            calibration = {
-                "status": "awaiting_review",
-                "dataset_revision": int(dataset["revision"]),
-                "target_reference": copy.deepcopy(reference),
-                "target_checksum": snapshot["checksum"],
-                "pending_review_count": len(pending_reviews),
-                "reason": (
-                    "Approve every corpus-near no-result case before starting "
-                    "real retrieval calibration."
-                ),
-            }
-            await asyncio.to_thread(
-                self.rag_evaluation_store.set_calibration,
-                dataset["eval_set_id"],
-                expected_revision=int(dataset["revision"]),
-                calibration=calibration,
-            )
-            await asyncio.to_thread(
-                self.store.update_job,
-                job["job_id"],
-                status="completed",
-                calibration=calibration,
-            )
+        if await self._hold_knowledge_generation_for_review(
+            job_id=job["job_id"],
+            dataset=dataset,
+            snapshot=snapshot,
+            reference=reference,
+        ):
             return
         await self._start_knowledge_evaluation(
             job_id=job["job_id"],
@@ -881,6 +865,48 @@ class BenchmarkJobExecutor:
             snapshot=snapshot,
             reference=reference,
         )
+
+    async def _hold_knowledge_generation_for_review(
+        self,
+        *,
+        job_id: str,
+        dataset: dict[str, Any],
+        snapshot: dict[str, Any],
+        reference: dict[str, Any],
+    ) -> bool:
+        pending_reviews = [
+            case
+            for case in dataset.get("cases") or []
+            if str(case.get("review_status") or "pending") != "approved"
+        ]
+        if not pending_reviews:
+            return False
+        calibration = {
+            "status": "awaiting_review",
+            "dataset_revision": int(dataset["revision"]),
+            "target_reference": copy.deepcopy(reference),
+            "target_checksum": snapshot["checksum"],
+            "pending_review_count": len(pending_reviews),
+            "reason": (
+                "Approve every generated case before starting real retrieval "
+                "calibration."
+            ),
+        }
+        await asyncio.to_thread(
+            self.rag_evaluation_store.set_calibration,
+            dataset["eval_set_id"],
+            expected_revision=int(dataset["revision"]),
+            calibration=calibration,
+        )
+        await asyncio.to_thread(
+            self.store.update_job,
+            job_id,
+            status="completed",
+            calibration=calibration,
+            dataset_id=dataset["eval_set_id"],
+            dataset_revision=int(dataset["revision"]),
+        )
+        return True
 
     async def _run_knowledge_calibration(self, job: dict[str, Any]) -> None:
         if self.knowledge_service is None or self.rag_evaluation_store is None:

--- a/server/benchmarks/knowledge_generation.py
+++ b/server/benchmarks/knowledge_generation.py
@@ -22,6 +22,7 @@ KNOWLEDGE_COVERAGE = (
 MAX_EVIDENCE_UNITS = 40
 MAX_EVIDENCE_CHARS = 48_000
 MAX_EVIDENCE_UNIT_CHARS = 1_200
+KNOWLEDGE_PROMPT_CONTRACT_VERSION = "rag-gold-generation-prompt-v2"
 
 
 class KnowledgeBenchmarkGenerationService:
@@ -311,9 +312,11 @@ class KnowledgeBenchmarkGenerationService:
                 "locale": locales[index % len(locales)],
                 "difficulty": self._difficulty(index, positives),
                 "required_evidence_ids": [item["evidence_id"] for item in required],
-                "required_query_marker_groups": [
-                    self._query_markers(item) for item in required
-                ],
+                "required_query_marker_groups": (
+                    []
+                    if coverage in {"paraphrase", "cross_language"}
+                    else [self._query_markers(item) for item in required]
+                ),
                 "expected_no_result": False,
             }
             if coverage == "confusable_content" and len(evidence_wheel) > 1:
@@ -346,11 +349,21 @@ class KnowledgeBenchmarkGenerationService:
                         "evidence_id": item["evidence_id"],
                         "chunk_id": item["chunk_id"],
                         "source_block_id": item["source_block_id"],
+                        "text_hash": self._checksum(str(item.get("text") or "")),
                     }
                     for item in sampled
                 ]
             ),
             "blueprint_hash": self._checksum(blueprints),
+            "prompt_contract_hash": self._checksum(
+                {
+                    "contract_version": KNOWLEDGE_PROMPT_CONTRACT_VERSION,
+                    "coverage": list(KNOWLEDGE_COVERAGE),
+                    "long_copy_block_chars": 32,
+                    "semantic_warning_chars": 12,
+                    "other_warning_chars": 24,
+                }
+            ),
         }
 
     def generation_prompt(
@@ -414,9 +427,10 @@ class KnowledgeBenchmarkGenerationService:
             f"Create exactly {case_count} cases in blueprint order. Seed={seed}. "
             f"Locales={locales}. Keep each query between 3 and 4000 characters. "
             "For positive cases evidence_ids must exactly equal required_evidence_ids. "
-            "The query must contain at least one exact token from every corresponding "
-            "required_query_marker_groups entry. Preserve these target markers even for "
-            "paraphrase and cross-language cases. "
+            "When required_query_marker_groups is non-empty, the query must contain at "
+            "least one exact token from every corresponding entry. Paraphrase and "
+            "cross-language cases intentionally omit marker requirements and must use "
+            "semantic grounding plus the exact anchor quote contract instead. "
             "For no-result cases evidence_ids and anchor_quotes must be empty.\n\n"
             f"Fixed target summary:\n{json.dumps(self.public_target(snapshot), ensure_ascii=False)}\n\n"
             f"Server blueprints:\n{json.dumps(context['blueprints'], ensure_ascii=False)}\n\n"
@@ -510,6 +524,27 @@ class KnowledgeBenchmarkGenerationService:
                         raise BenchmarkGenerationError(
                             f"Case {index + 1} query is not specific to every assigned evidence block."
                         )
+                warning_threshold = (
+                    12
+                    if str(blueprint.get("query_type") or "")
+                    in {"paraphrase", "cross_language"}
+                    else 24
+                )
+                leakage_warning = False
+                for evidence_id in required_ids:
+                    evidence = evidence_by_id.get(evidence_id)
+                    evidence_key = self._normalize_text(
+                        str((evidence or {}).get("text") or "")
+                    )
+                    if self._has_common_window(query_key, evidence_key, 32):
+                        raise BenchmarkGenerationError(
+                            f"Case {index + 1} copies too much source text into the query."
+                        )
+                    leakage_warning = leakage_warning or self._has_common_window(
+                        query_key, evidence_key, warning_threshold
+                    )
+            else:
+                leakage_warning = False
             quotes = list(raw_case.get("anchor_quotes") or [])
             if expected_no_result:
                 if evidence_ids or quotes:
@@ -560,7 +595,7 @@ class KnowledgeBenchmarkGenerationService:
                             "relevance": 3 if ref_index == 0 else 2,
                         }
                     )
-                review_status = "not_required"
+                review_status = "pending"
             rationale = str(raw_case.get("rationale") or "").strip()[:500]
             context_refs = [
                 {
@@ -595,6 +630,14 @@ class KnowledgeBenchmarkGenerationService:
                         "difficulty": blueprint["difficulty"],
                         "evidence_ids": required_ids,
                         "context_refs": context_refs,
+                        "leakage_warning": (
+                            {
+                                "threshold": warning_threshold,
+                                "reason_required": True,
+                            }
+                            if leakage_warning
+                            else None
+                        ),
                     },
                 }
             )
@@ -733,6 +776,16 @@ class KnowledgeBenchmarkGenerationService:
     @staticmethod
     def _normalize_text(value: str) -> str:
         return re.sub(r"[^\w\u3400-\u9fff]+", "", str(value).casefold())
+
+    @staticmethod
+    def _has_common_window(left: str, right: str, size: int) -> bool:
+        if size <= 0 or len(left) < size or len(right) < size:
+            return False
+        shorter, longer = (left, right) if len(left) <= len(right) else (right, left)
+        return any(
+            shorter[index : index + size] in longer
+            for index in range(len(shorter) - size + 1)
+        )
 
     @staticmethod
     def _extract_json(raw: str) -> dict[str, Any]:

--- a/server/model_router/admin_auth.py
+++ b/server/model_router/admin_auth.py
@@ -20,6 +20,8 @@ from pydantic import BaseModel, Field, SecretStr
 PAIRING_SECRET_ENV = "MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET"
 COOKIE_NAME = "modelmirror_provider_admin"
 COOKIE_PATH = "/api/router"
+RAG_COOKIE_NAME = "modelmirror_rag_admin"
+RAG_COOKIE_PATH = "/api/rag"
 SESSION_TTL_SECONDS = 8 * 60 * 60
 MIN_PAIRING_SECRET_CHARS = 32
 MAX_SESSIONS = 128
@@ -162,6 +164,15 @@ class ProviderAdminAuth:
             samesite="strict",
             path=COOKIE_PATH,
         )
+        response.set_cookie(
+            RAG_COOKIE_NAME,
+            token,
+            max_age=SESSION_TTL_SECONDS,
+            httponly=True,
+            secure=secure,
+            samesite="strict",
+            path=RAG_COOKIE_PATH,
+        )
         return AdminSessionResponse(
             configured=True,
             authenticated=True,
@@ -199,7 +210,7 @@ class ProviderAdminAuth:
 
     def logout(self, request: Request, response: Response) -> None:
         self.require_csrf(request)
-        token = request.cookies.get(COOKIE_NAME, "")
+        token = self._token_from_request(request)
         if token:
             with self._lock:
                 self._sessions.pop(self._token_hash(token), None)
@@ -208,9 +219,10 @@ class ProviderAdminAuth:
             self._source_fingerprint(self._client_key(request)),
         )
         response.delete_cookie(COOKIE_NAME, path=COOKIE_PATH, samesite="strict")
+        response.delete_cookie(RAG_COOKIE_NAME, path=RAG_COOKIE_PATH, samesite="strict")
 
     def _session_from_request(self, request: Request) -> _Session | None:
-        token = request.cookies.get(COOKIE_NAME, "")
+        token = self._token_from_request(request)
         if not token:
             return None
         now = time.time()
@@ -218,6 +230,14 @@ class ProviderAdminAuth:
         with self._lock:
             self._purge_expired(now)
             return self._sessions.get(token_hash)
+
+    @staticmethod
+    def _token_from_request(request: Request) -> str:
+        return str(
+            request.cookies.get(COOKIE_NAME)
+            or request.cookies.get(RAG_COOKIE_NAME)
+            or ""
+        )
 
     def _active_failures(self, client_key: str, now: float) -> deque[float]:
         failures = self._failures[client_key]

--- a/server/rag/api.py
+++ b/server/rag/api.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any, Literal
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 try:
@@ -15,6 +15,17 @@ try:
 except ModuleNotFoundError:
     from file_assets.service import FileAssetServiceError
     from file_assets.validation import FileValidationError
+
+try:
+    from server.model_router.admin_auth import (
+        ProviderControlPrincipal,
+        require_provider_admin_csrf,
+    )
+except ModuleNotFoundError:
+    from model_router.admin_auth import (
+        ProviderControlPrincipal,
+        require_provider_admin_csrf,
+    )
 
 from .rag_service import (
     DocumentDeletionError,
@@ -48,6 +59,7 @@ from .evaluation import (
     EvaluationSetNotFoundError,
     EvaluationStateError,
     KnowledgeEvaluationStore,
+    validate_formal_run_admission,
 )
 from .evaluation_executor import KnowledgeEvaluationExecutor
 from .strategy_router import (
@@ -716,7 +728,7 @@ class EvaluationCaseInput(BaseModel):
     expected_refs: list[EvaluationReferenceInput] = Field(default_factory=list, max_length=50)
     expected_no_result: bool = False
     review_status: str = Field(
-        default="not_required", pattern="^(not_required|pending|approved)$"
+        default="not_required", pattern="^(not_required|pending|approved|rejected)$"
     )
     tags: list[str] = Field(default_factory=list, max_length=20)
     notes: str = Field(default="", max_length=1000)
@@ -727,6 +739,10 @@ class EvaluationCaseInput(BaseModel):
             raise ValueError("No-result cases cannot define expected references.")
         if not self.expected_no_result and not self.expected_refs:
             raise ValueError("Answerable cases require expected references.")
+        if self.review_status in {"approved", "rejected"}:
+            raise ValueError(
+                "Case review decisions require the authenticated review endpoint."
+            )
         if not self.expected_no_result and self.review_status != "not_required":
             raise ValueError("Only no-result cases can require manual review.")
         return self
@@ -767,6 +783,12 @@ class EvaluationCaseUpdateRequest(BaseModel):
     case: EvaluationCaseInput
 
 
+class EvaluationCaseReviewRequest(BaseModel):
+    expected_revision: int = Field(ge=1)
+    decision: Literal["approved", "rejected"]
+    reason: str = Field(default="", max_length=1000)
+
+
 class EvaluationTargetInput(BaseModel):
     version_id: str = Field(min_length=1, max_length=200)
     label: str | None = Field(default=None, max_length=120)
@@ -779,6 +801,7 @@ class EvaluationRunCreateRequest(BaseModel):
     targets: list[EvaluationTargetInput] = Field(min_length=1, max_length=5)
     baseline_version_id: str | None = Field(default=None, max_length=200)
     ks: list[int] = Field(default_factory=lambda: [1, 3, 5, 10], min_length=1, max_length=8)
+    run_mode: Literal["diagnostic", "formal"] = "diagnostic"
 
 
 class EvaluationGateUpdateRequest(BaseModel):
@@ -794,6 +817,9 @@ class EvaluationGateUpdateRequest(BaseModel):
     min_citation_coverage: float = Field(default=0, ge=0, le=1)
     max_p95_latency_ratio: float = Field(ge=1, le=10)
     max_p95_latency_ms: float = Field(default=1500, ge=1, le=120_000)
+    max_paired_primary_regression: float = Field(default=0.03, ge=0, le=1)
+    paired_confidence_level: float = Field(default=0.95, gt=0, lt=1)
+    require_comparable_corpus: bool = True
     require_zero_errors: bool = True
 
 
@@ -1867,17 +1893,31 @@ async def publish_evaluation_set(
     payload: EvaluationSetPublishRequest,
 ) -> dict[str, Any]:
     try:
+        evaluation_set = get_evaluation_store().get_set(eval_set_id)
+        corpus_snapshot: dict[str, Any] | None = None
+        if str(evaluation_set.get("origin") or "manual") == "generated":
+            pipeline_version_id = str(
+                (evaluation_set.get("provenance") or {}).get(
+                    "pipeline_version_id"
+                )
+                or ""
+            )
+            if pipeline_version_id:
+                corpus_snapshot = get_rag_service().pipeline_corpus_snapshot(
+                    pipeline_version_id
+                )
         return get_evaluation_store().publish_set(
             eval_set_id,
             expected_revision=payload.expected_revision,
             release_notes=payload.release_notes,
             acknowledge_calibration_warnings=payload.acknowledge_calibration_warnings,
+            corpus_snapshot=corpus_snapshot,
         )
     except EvaluationSetNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except EvaluationRevisionError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    except (EvaluationStateError, ValueError) as exc:
+    except (EvaluationStateError, PipelineJobStateError, ValueError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
@@ -1929,6 +1969,30 @@ async def update_evaluation_case(
             case_id,
             expected_revision=payload.expected_revision,
             values=payload.case.model_dump(),
+        )
+    except EvaluationSetNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except EvaluationRevisionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/evaluation-sets/{eval_set_id}/cases/{case_id}/review")
+async def review_evaluation_case(
+    eval_set_id: str,
+    case_id: str,
+    payload: EvaluationCaseReviewRequest,
+    principal: ProviderControlPrincipal = Depends(require_provider_admin_csrf),
+) -> dict[str, Any]:
+    try:
+        return get_evaluation_store().review_case(
+            eval_set_id,
+            case_id,
+            expected_revision=payload.expected_revision,
+            decision=payload.decision,
+            reason=payload.reason,
+            reviewer={"tenant_id": principal.tenant_id, "role": principal.role},
         )
     except EvaluationSetNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -2103,7 +2167,10 @@ async def update_evaluation_gate(
 
 
 @router.post("/evaluation-runs")
-async def create_evaluation_run(payload: EvaluationRunCreateRequest) -> dict[str, Any]:
+async def create_evaluation_run(
+    payload: EvaluationRunCreateRequest,
+    request: Request,
+) -> dict[str, Any]:
     try:
         evaluation_set = get_evaluation_store().get_set(payload.eval_set_id)
         evaluation_version = (
@@ -2114,6 +2181,12 @@ async def create_evaluation_run(payload: EvaluationRunCreateRequest) -> dict[str
             else None
         )
         evaluation_snapshot = evaluation_version or evaluation_set
+        if payload.run_mode == "formal":
+            require_provider_admin_csrf(request)
+            if evaluation_version is None:
+                raise ValueError(
+                    "Formal evaluation requires an explicit published evaluation version."
+                )
         if not evaluation_snapshot.get("cases"):
             raise ValueError("Evaluation set snapshot must contain at least one case.")
         if evaluation_version is None and evaluation_set.get("status") != "active":
@@ -2133,6 +2206,11 @@ async def create_evaluation_run(payload: EvaluationRunCreateRequest) -> dict[str
                 raise ValueError("All evaluation versions must belong to the evaluation knowledge base.")
             if version.get("status") not in {"ready", "active"}:
                 raise ValueError("Only ready or active knowledge versions can be evaluated.")
+            corpus_snapshot = (
+                get_rag_service().pipeline_corpus_snapshot(target.version_id)
+                if payload.run_mode == "formal"
+                else None
+            )
             targets.append(
                 {
                     "target_id": target.version_id,
@@ -2143,7 +2221,19 @@ async def create_evaluation_run(payload: EvaluationRunCreateRequest) -> dict[str
                     "version_evidence": get_rag_service().pipeline_version_evidence(
                         target.version_id
                     ),
+                    "corpus_snapshot_hash": (
+                        str(corpus_snapshot.get("checksum") or "")
+                        if corpus_snapshot is not None
+                        else None
+                    ),
                 }
+            )
+        formal_admission: dict[str, Any] | None = None
+        if payload.run_mode == "formal":
+            formal_admission = validate_formal_run_admission(
+                evaluation_snapshot,
+                targets,
+                baseline_version_id=payload.baseline_version_id,
             )
         run = get_evaluation_store().create_run(
             evaluation_set=evaluation_set,
@@ -2152,6 +2242,12 @@ async def create_evaluation_run(payload: EvaluationRunCreateRequest) -> dict[str
             baseline_version_id=payload.baseline_version_id,
             ks=evaluation_ks,
             gate_policy=get_evaluation_store().get_gate_policy(str(evaluation_set["kb_id"])),
+            run_mode=payload.run_mode,
+            execution_manifest=(formal_admission or {}).get("execution_manifest"),
+            comparability=(formal_admission or {}).get("comparability"),
+            evidence_qualification=(formal_admission or {}).get(
+                "evidence_qualification"
+            ),
         )
         get_evaluation_executor().notify()
         return run
@@ -2159,7 +2255,7 @@ async def create_evaluation_run(payload: EvaluationRunCreateRequest) -> dict[str
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except PipelineVersionNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ValueError as exc:
+    except (PipelineJobStateError, ValueError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 

--- a/server/rag/evaluation.py
+++ b/server/rag/evaluation.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+import hmac
 import math
 import os
+import random
+import re
 import threading
 import time
 import uuid
@@ -42,6 +45,14 @@ class EvaluationPromotionError(EvaluationError):
 
 
 DEFAULT_KS = [1, 3, 5, 10]
+FORMAL_POSITIVE_QUERY_TYPES = (
+    "factual_lookup",
+    "paraphrase",
+    "section_context",
+    "cross_language",
+    "multi_evidence",
+    "confusable_content",
+)
 DEFAULT_GATE_POLICY: dict[str, Any] = {
     "mode": "advisory",
     "min_recall_at_5": 0.8,
@@ -53,6 +64,9 @@ DEFAULT_GATE_POLICY: dict[str, Any] = {
     "min_citation_coverage": 0.0,
     "max_p95_latency_ratio": 2.0,
     "max_p95_latency_ms": 1500.0,
+    "max_paired_primary_regression": 0.03,
+    "paired_confidence_level": 0.95,
+    "require_comparable_corpus": True,
     "require_zero_errors": True,
 }
 
@@ -179,9 +193,21 @@ def aggregate_target_metrics(
 
     normalized_ks = sorted(set(ks or DEFAULT_KS))
     completed = [item for item in case_results if item.get("status") == "completed"]
-    positive = [item for item in completed if not item.get("expected_no_result")]
-    no_result_cases = [item for item in completed if item.get("expected_no_result")]
-    errors = [item for item in case_results if item.get("status") == "failed"]
+    failed = [item for item in case_results if item.get("status") != "completed"]
+    positive = [item for item in case_results if not item.get("expected_no_result")]
+    completed_positive = [
+        item for item in completed if not item.get("expected_no_result")
+    ]
+    failed_positive = [
+        item for item in failed if not item.get("expected_no_result")
+    ]
+    no_result_cases = [item for item in case_results if item.get("expected_no_result")]
+    completed_no_result = [
+        item for item in completed if item.get("expected_no_result")
+    ]
+    failed_no_result = [
+        item for item in failed if item.get("expected_no_result")
+    ]
     metric_names = [
         *(f"hit_at_{k}" for k in normalized_ks),
         *(f"recall_at_{k}" for k in normalized_ks),
@@ -193,7 +219,10 @@ def aggregate_target_metrics(
     ]
     metrics = {
         name: round(
-            sum(float(item.get("metrics", {}).get(name, 0.0)) for item in positive)
+            sum(
+                float(item.get("metrics", {}).get(name, 0.0))
+                for item in completed_positive
+            )
             / len(positive),
             6,
         )
@@ -201,40 +230,65 @@ def aggregate_target_metrics(
         else 0.0
         for name in metric_names
     }
-    latencies = sorted(float(item.get("latency_ms", 0.0)) for item in completed)
+    latencies = sorted(float(item.get("latency_ms", 0.0)) for item in case_results)
     metrics.update(
         {
             "case_count": len(case_results),
+            "expected_case_count": len(case_results),
             "completed_case_count": len(completed),
-            "error_count": len(errors),
+            "failed_case_count": len(failed),
+            "error_count": len(failed),
             "positive_case_count": len(positive),
+            "completed_positive_case_count": len(completed_positive),
+            "failed_positive_case_count": len(failed_positive),
+            "positive_quality_denominator": len(positive),
             "no_result_case_count": len(no_result_cases),
+            "completed_no_result_case_count": len(completed_no_result),
+            "failed_no_result_case_count": len(failed_no_result),
+            "no_result_quality_denominator": len(no_result_cases),
             "no_result_accuracy": round(
-                sum(float(item.get("metrics", {}).get("no_result_accuracy", 0.0)) for item in no_result_cases)
+                sum(
+                    float(item.get("metrics", {}).get("no_result_accuracy", 0.0))
+                    for item in completed_no_result
+                )
                 / len(no_result_cases),
                 6,
             ) if no_result_cases else 1.0,
             "false_positive_rate": round(
-                sum(float(item.get("metrics", {}).get("false_positive_rate", 0.0)) for item in no_result_cases)
+                (
+                    sum(
+                        float(item.get("metrics", {}).get("false_positive_rate", 0.0))
+                        for item in completed_no_result
+                    )
+                    + len(failed_no_result)
+                )
                 / len(no_result_cases),
                 6,
             ) if no_result_cases else 0.0,
             "no_result_rate": round(
-                sum(1 for item in completed if item.get("no_result")) / len(completed), 6
+                sum(1 for item in case_results if item.get("no_result"))
+                / len(case_results),
+                6,
             )
-            if completed
+            if case_results
             else 1.0,
             "positive_no_result_rate": round(
-                sum(1 for item in positive if item.get("no_result")) / len(positive), 6
+                sum(1 for item in positive if item.get("no_result"))
+                / len(positive),
+                6,
             )
             if positive
             else 0.0,
             "warning_rate": round(
-                sum(1 for item in completed if int(item.get("warning_count", 0)) > 0)
-                / len(completed),
+                sum(
+                    1
+                    for item in case_results
+                    if int(item.get("warning_count", 0)) > 0
+                )
+                / len(case_results),
                 6,
             )
-            if completed
+            if case_results
             else 0.0,
             "average_latency_ms": round(sum(latencies) / len(latencies), 3)
             if latencies
@@ -245,12 +299,110 @@ def aggregate_target_metrics(
     return metrics
 
 
+def paired_primary_confidence_report(
+    baseline_results: list[dict[str, Any]],
+    candidate_results: list[dict[str, Any]],
+    *,
+    cases: list[dict[str, Any]],
+    seed: str,
+    bootstrap_samples: int = 10_000,
+    confidence_level: float = 0.95,
+    max_regression: float = 0.03,
+) -> dict[str, Any]:
+    baseline_by_id = {
+        str(item.get("case_id") or ""): item for item in baseline_results
+    }
+    candidate_by_id = {
+        str(item.get("case_id") or ""): item for item in candidate_results
+    }
+    expected_ids = [str(case.get("case_id") or "") for case in cases]
+    missing = [
+        case_id
+        for case_id in expected_ids
+        if case_id not in baseline_by_id or case_id not in candidate_by_id
+    ]
+    failed = [
+        case_id
+        for case_id in expected_ids
+        if case_id in baseline_by_id
+        and case_id in candidate_by_id
+        and (
+            baseline_by_id[case_id].get("status") != "completed"
+            or candidate_by_id[case_id].get("status") != "completed"
+        )
+    ]
+    if missing or failed or not expected_ids:
+        return {
+            "contract_version": "rag-paired-confidence-v1",
+            "status": "insufficient",
+            "passed": False,
+            "missing_case_ids": missing,
+            "failed_case_ids": failed,
+            "reason": "paired_results_incomplete",
+        }
+
+    cases_by_id = {str(case.get("case_id") or ""): case for case in cases}
+
+    def primary_score(result: dict[str, Any], case: dict[str, Any]) -> float:
+        metrics = result.get("metrics") or {}
+        return float(
+            metrics.get("no_result_accuracy", 0.0)
+            if case.get("expected_no_result")
+            else metrics.get("recall_at_5", 0.0)
+        )
+
+    deltas = {
+        case_id: primary_score(candidate_by_id[case_id], cases_by_id[case_id])
+        - primary_score(baseline_by_id[case_id], cases_by_id[case_id])
+        for case_id in expected_ids
+    }
+    strata: dict[str, list[str]] = {}
+    for case_id in expected_ids:
+        case = cases_by_id[case_id]
+        case_type = "negative" if case.get("expected_no_result") else "positive"
+        locale = str((case.get("targeting") or {}).get("locale") or "unknown")
+        strata.setdefault(f"{case_type}:{locale}", []).append(case_id)
+    seed_value = int(_checksum({"seed": seed})[:16], 16)
+    rng = random.Random(seed_value)
+    samples: list[float] = []
+    for _ in range(max(1, int(bootstrap_samples))):
+        selected: list[str] = []
+        for key in sorted(strata):
+            values = strata[key]
+            selected.extend(rng.choice(values) for _ in range(len(values)))
+        samples.append(sum(deltas[case_id] for case_id in selected) / len(selected))
+    samples.sort()
+    tail = (1.0 - float(confidence_level)) / 2.0
+    lower = _percentile(samples, tail)
+    upper = _percentile(samples, 1.0 - tail)
+    point_delta = sum(deltas.values()) / len(deltas)
+    return {
+        "contract_version": "rag-paired-confidence-v1",
+        "status": "completed",
+        "passed": lower >= -float(max_regression),
+        "primary_metric": "recall_at_5_or_no_result_accuracy",
+        "point_delta": round(point_delta, 6),
+        "confidence_level": float(confidence_level),
+        "confidence_interval": {
+            "lower": round(lower, 6),
+            "upper": round(upper, 6),
+        },
+        "bootstrap_samples": len(samples),
+        "max_regression": float(max_regression),
+        "case_count": len(expected_ids),
+        "strata": {key: len(value) for key, value in sorted(strata.items())},
+    }
+
+
 def evaluate_promotion_gate(
     candidate: dict[str, Any],
     *,
     baseline: dict[str, Any] | None,
     policy: dict[str, Any] | None = None,
     evidence_qualification: dict[str, Any] | None = None,
+    paired_confidence: dict[str, Any] | None = None,
+    comparability: dict[str, Any] | None = None,
+    run_mode: str = "diagnostic",
 ) -> dict[str, Any]:
     """Evaluate absolute and regression thresholds for one candidate target."""
 
@@ -403,6 +555,39 @@ def evaluate_promotion_gate(
             }
         )
 
+    if run_mode == "formal":
+        comparable = bool((comparability or {}).get("comparable")) and bool(
+            (comparability or {}).get("same_corpus")
+        )
+        checks.append(
+            {
+                "id": "comparable_corpus",
+                "passed": comparable,
+                "actual": comparable,
+                "required": bool(effective["require_comparable_corpus"]),
+                "message": "Formal targets must share the immutable Gold corpus.",
+            }
+        )
+        paired = paired_confidence or {}
+        lower = float(
+            (paired.get("confidence_interval") or {}).get("lower", -1.0)
+        )
+        paired_passed = (
+            paired.get("status") == "completed"
+            and lower >= -float(effective["max_paired_primary_regression"])
+        )
+        checks.append(
+            {
+                "id": "paired_non_inferiority",
+                "passed": paired_passed,
+                "actual": round(lower, 6),
+                "threshold": -float(effective["max_paired_primary_regression"]),
+                "confidence_level": float(effective["paired_confidence_level"]),
+                "bootstrap_samples": int(paired.get("bootstrap_samples") or 0),
+                "message": "Paired primary-score CI must satisfy non-inferiority.",
+            }
+        )
+
     return {
         "passed": all(item["passed"] for item in checks),
         "mode": str(effective["mode"]),
@@ -470,6 +655,369 @@ def qualify_promotion_evidence(snapshot: dict[str, Any]) -> dict[str, Any]:
             "reviewed_hard_negative": reviewed_hard_negative_count,
         },
         "checks": checks,
+    }
+
+
+def qualify_formal_evidence(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Validate immutable rag-gold-v2 evidence without trusting stored labels."""
+
+    cases = [item for item in snapshot.get("cases", []) if isinstance(item, dict)]
+    positives = [item for item in cases if not bool(item.get("expected_no_result"))]
+    negatives = [item for item in cases if bool(item.get("expected_no_result"))]
+    corpus = snapshot.get("corpus_snapshot")
+    corpus = corpus if isinstance(corpus, dict) else {}
+    corpus_without_checksum = {
+        key: value for key, value in corpus.items() if key != "checksum"
+    }
+    corpus_checksum_valid = bool(corpus_without_checksum) and hmac.compare_digest(
+        str(corpus.get("checksum") or ""), _checksum(corpus_without_checksum)
+    )
+    provenance = snapshot.get("provenance")
+    provenance = provenance if isinstance(provenance, dict) else {}
+    attempts = provenance.get("generation_attempts")
+    attempts = attempts if isinstance(attempts, list) else []
+    provenance_hashes = (
+        str(provenance.get("target_checksum") or ""),
+        str(provenance.get("source_summary_hash") or ""),
+        str(provenance.get("evidence_hash") or ""),
+        str(provenance.get("blueprint_hash") or ""),
+        str(provenance.get("prompt_contract_hash") or ""),
+    )
+    generation_provenance_valid = (
+        provenance.get("generator") == "modelmirror-targeted-rag-benchmark-v2"
+        and bool(str(provenance.get("generation_job_id") or ""))
+        and bool(str(provenance.get("generator_model_id") or ""))
+        and isinstance(provenance.get("seed"), int)
+        and not isinstance(provenance.get("seed"), bool)
+        and all(re.fullmatch(r"[0-9a-f]{64}", value) for value in provenance_hashes)
+        and provenance.get("repair_used") is False
+        and len(attempts) == 1
+        and isinstance(attempts[0], dict)
+        and attempts[0].get("attempt") == "initial"
+        and not attempts[0].get("error_code")
+    )
+    block_refs: set[tuple[str, str]] = set()
+    corpus_documents: set[str] = set()
+    corpus_contains_text = False
+    for document in corpus.get("documents", []):
+        if not isinstance(document, dict):
+            continue
+        document_id = str(document.get("document_id") or "")
+        if not document_id:
+            continue
+        corpus_documents.add(document_id)
+        for block in document.get("source_blocks", []):
+            if isinstance(block, dict) and str(block.get("source_block_id") or ""):
+                corpus_contains_text = corpus_contains_text or "text" in block
+                block_refs.add((document_id, str(block["source_block_id"])))
+
+    def trusted_review(case: dict[str, Any]) -> bool:
+        evidence = case.get("review_evidence")
+        if not isinstance(evidence, dict):
+            return False
+        reviewer = evidence.get("reviewer")
+        return (
+            str(case.get("review_status") or "") == "approved"
+            and str(evidence.get("decision") or "") == "approved"
+            and str(evidence.get("source") or "") == "authenticated_ui"
+            and isinstance(reviewer, dict)
+            and bool(str(reviewer.get("tenant_id") or ""))
+            and bool(str(reviewer.get("role") or ""))
+            and isinstance(evidence.get("reviewed_at"), (int, float))
+            and int(evidence.get("dataset_revision") or 0) >= 1
+            and (
+                not (case.get("targeting") or {}).get("leakage_warning")
+                or bool(str(evidence.get("reason") or "").strip())
+            )
+            and hmac.compare_digest(
+                str(evidence.get("case_checksum") or ""),
+                _case_review_checksum(case),
+            )
+        )
+
+    stable_positive_refs: list[tuple[str, str]] = []
+    positive_refs_valid = True
+    for case in positives:
+        references = case.get("expected_refs") or []
+        if not references:
+            positive_refs_valid = False
+            continue
+        for reference in references:
+            if not isinstance(reference, dict):
+                positive_refs_valid = False
+                continue
+            key = (
+                str(reference.get("document_id") or ""),
+                str(reference.get("source_block_id") or ""),
+            )
+            stable_positive_refs.append(key)
+            if (
+                str(reference.get("match_mode") or "") != "source_block"
+                or not all(key)
+                or key not in block_refs
+            ):
+                positive_refs_valid = False
+
+    negative_contexts: list[tuple[str, str]] = []
+    hard_negatives_valid = True
+    for case in negatives:
+        tags = {str(tag) for tag in case.get("tags", [])}
+        contexts = (case.get("targeting") or {}).get("context_refs") or []
+        if "hard_negative" not in tags or "corpus_near" not in tags or len(contexts) != 1:
+            hard_negatives_valid = False
+            continue
+        context = contexts[0] if isinstance(contexts[0], dict) else {}
+        key = (
+            str(context.get("document_id") or ""),
+            str(context.get("source_block_id") or ""),
+        )
+        negative_contexts.append(key)
+        if not all(key) or key not in block_refs:
+            hard_negatives_valid = False
+
+    def locale_counts(items: list[dict[str, Any]]) -> dict[str, int]:
+        result = {"zh": 0, "en": 0}
+        for case in items:
+            raw_locale = str(
+                (case.get("targeting") or {}).get("locale") or ""
+            ).casefold().replace("_", "-")
+            locale = (
+                "zh"
+                if raw_locale == "zh" or raw_locale.startswith("zh-")
+                else "en"
+                if raw_locale == "en" or raw_locale.startswith("en-")
+                else raw_locale
+            )
+            if locale in result:
+                result[locale] += 1
+        return result
+
+    positive_locales = locale_counts(positives)
+    negative_locales = locale_counts(negatives)
+    positive_query_types = {
+        query_type: sum(
+            1
+            for case in positives
+            if str((case.get("targeting") or {}).get("query_type") or "")
+            == query_type
+        )
+        for query_type in FORMAL_POSITIVE_QUERY_TYPES
+    }
+    normalized_queries = [
+        " ".join(str(case.get("query") or "").casefold().split()) for case in cases
+    ]
+    query_tokens = [_formal_query_tokens(query) for query in normalized_queries]
+    has_near_duplicate = any(
+        bool(query_tokens[left] or query_tokens[right])
+        and len(query_tokens[left] & query_tokens[right])
+        / max(1, len(query_tokens[left] | query_tokens[right]))
+        >= 0.8
+        for left in range(len(query_tokens))
+        for right in range(left + 1, len(query_tokens))
+    )
+    positive_documents = {
+        document_id for document_id, _ in stable_positive_refs if document_id
+    }
+    per_document: dict[str, int] = {}
+    for document_id, _ in stable_positive_refs:
+        per_document[document_id] = per_document.get(document_id, 0) + 1
+    max_document_share = (
+        max(per_document.values(), default=0) / len(positives) if positives else 1.0
+    )
+    source_block_counts: dict[tuple[str, str], int] = {}
+    for key in stable_positive_refs:
+        source_block_counts[key] = source_block_counts.get(key, 0) + 1
+
+    checks = [
+        {
+            "id": "gold_contract_v2",
+            "passed": snapshot.get("benchmark_contract_version") == "rag-gold-v2",
+        },
+        {
+            "id": "promotion_evidence_role",
+            "passed": snapshot.get("benchmark_role") == "promotion_evidence",
+        },
+        {
+            "id": "generation_provenance",
+            "passed": generation_provenance_valid,
+        },
+        {
+            "id": "immutable_evaluation_version",
+            "passed": bool(snapshot.get("version_id") and snapshot.get("published_at")),
+        },
+        {
+            "id": "published_checksum",
+            "passed": hmac.compare_digest(
+                str(snapshot.get("checksum") or ""), _published_gold_checksum(snapshot)
+            ),
+        },
+        {
+            "id": "corpus_snapshot",
+            "passed": corpus.get("contract_version") == "rag-corpus-snapshot-v1"
+            and corpus_checksum_valid
+            and bool(corpus_documents)
+            and not corpus_contains_text,
+        },
+        {"id": "exact_case_counts", "passed": len(positives) == 30 and len(negatives) == 12},
+        {
+            "id": "trusted_case_reviews",
+            "passed": len(cases) == 42 and all(trusted_review(case) for case in cases),
+        },
+        {
+            "id": "stable_source_block_gold",
+            "passed": positive_refs_valid and len(stable_positive_refs) >= len(positives),
+        },
+        {
+            "id": "hard_negative_contexts",
+            "passed": hard_negatives_valid
+            and len(negative_contexts) == 12
+            and len(set(negative_contexts)) == 12,
+        },
+        {
+            "id": "locale_balance",
+            "passed": positive_locales == {"zh": 15, "en": 15}
+            and negative_locales == {"zh": 6, "en": 6},
+        },
+        {
+            "id": "positive_query_type_balance",
+            "passed": positive_query_types
+            == {query_type: 5 for query_type in FORMAL_POSITIVE_QUERY_TYPES},
+        },
+        {
+            "id": "document_coverage",
+            "passed": positive_documents == corpus_documents and max_document_share <= 0.4,
+        },
+        {
+            "id": "source_block_reuse",
+            "passed": max(source_block_counts.values(), default=0) <= 2,
+        },
+        {
+            "id": "unique_queries",
+            "passed": len(normalized_queries) == 42
+            and len(set(normalized_queries)) == len(normalized_queries)
+            and not has_near_duplicate,
+        },
+    ]
+    qualified = all(bool(check["passed"]) for check in checks)
+    return {
+        "version": "rag-formal-evidence-v2",
+        "status": "qualified" if qualified else "diagnostic_only",
+        "qualified": qualified,
+        "counts": {
+            "total": len(cases),
+            "positive": len(positives),
+            "hard_negative": len(negatives),
+            "trusted_reviews": sum(1 for case in cases if trusted_review(case)),
+            "positive_query_types": positive_query_types,
+        },
+        "checks": checks,
+    }
+
+
+def validate_formal_run_admission(
+    evaluation_version: dict[str, Any],
+    targets: list[dict[str, Any]],
+    *,
+    baseline_version_id: str | None,
+) -> dict[str, Any]:
+    qualification = qualify_formal_evidence(evaluation_version)
+    if not qualification["qualified"]:
+        raise ValueError("Formal evaluation requires qualified rag-gold-v2 evidence.")
+    if len(targets) != 2 or len({str(item.get("version_id") or "") for item in targets}) != 2:
+        raise ValueError("Formal evaluation requires exactly one baseline and one candidate.")
+    version_ids = {str(item.get("version_id") or "") for item in targets}
+    if not baseline_version_id or baseline_version_id not in version_ids:
+        raise ValueError("Formal evaluation requires one explicit baseline target.")
+
+    expected_corpus = str(
+        (evaluation_version.get("corpus_snapshot") or {}).get("checksum") or ""
+    )
+    corpus_hashes = {str(item.get("corpus_snapshot_hash") or "") for item in targets}
+    if not expected_corpus or corpus_hashes != {expected_corpus}:
+        raise ValueError(
+            "Formal baseline and candidate must use the same immutable corpus as Gold."
+        )
+
+    manifest_targets: list[dict[str, Any]] = []
+    for target in targets:
+        if target.get("retrieval"):
+            raise ValueError(
+                "Formal evaluation does not allow per-run retrieval overrides."
+            )
+        evidence = target.get("version_evidence")
+        evidence = evidence if isinstance(evidence, dict) else {}
+        effective = (evidence.get("embedding") or {}).get("effective") or {}
+        processor = evidence.get("processor")
+        processor = processor if isinstance(processor, dict) else {}
+        retrieval = evidence.get("retrieval")
+        retrieval = retrieval if isinstance(retrieval, dict) else {}
+        required_hashes = (
+            str(evidence.get("version_fingerprint") or ""),
+            str(evidence.get("configuration_fingerprint") or ""),
+            str(processor.get("fingerprint") or ""),
+        )
+        if (
+            evidence.get("schema_version") != "rag-version-evidence-v1"
+            or str(evidence.get("version_id") or "")
+            != str(target.get("version_id") or "")
+            or any(re.fullmatch(r"[0-9a-f]{64}", value) is None for value in required_hashes)
+            or not str(effective.get("provider") or "")
+            or not str(effective.get("model") or "")
+            or int(effective.get("dimension") or 0) <= 0
+            or not str(processor.get("mode") or "")
+            or not retrieval
+        ):
+            raise ValueError("Formal evaluation target identity is incomplete.")
+        rerank = {
+            "enabled": bool(retrieval.get("rerank_enabled")),
+            "provider": str(retrieval.get("rerank_provider") or "none"),
+            "model": str(retrieval.get("rerank_model") or ""),
+            "top_n": int(retrieval.get("rerank_top_n") or 0),
+        }
+        manifest_targets.append(
+            {
+                "version_id": str(target["version_id"]),
+                "role": (
+                    "baseline"
+                    if str(target["version_id"]) == baseline_version_id
+                    else "candidate"
+                ),
+                "version_fingerprint": required_hashes[0],
+                "configuration_fingerprint": required_hashes[1],
+                "corpus_snapshot_hash": expected_corpus,
+                "processor": _copy(processor),
+                "embedding": _copy(effective),
+                "retrieval": _copy(retrieval),
+                "rerank": rerank,
+            }
+        )
+    manifest_targets.sort(key=lambda item: item["role"])
+    seed = _checksum(
+        {
+            "evaluation_checksum": evaluation_version.get("checksum"),
+            "corpus_snapshot_hash": expected_corpus,
+            "targets": manifest_targets,
+        }
+    )
+    return {
+        "evidence_qualification": qualification,
+        "comparability": {
+            "contract_version": "rag-comparability-v1",
+            "comparable": True,
+            "same_corpus": True,
+            "corpus_snapshot_hash": expected_corpus,
+            "reason": None,
+        },
+        "execution_manifest": {
+            "contract_version": "rag-eval-v2",
+            "metric_contract_version": "rag-metrics-v2",
+            "evaluation_version_id": evaluation_version.get("version_id"),
+            "evaluation_checksum": evaluation_version.get("checksum"),
+            "corpus_snapshot_hash": expected_corpus,
+            "execution_seed": seed,
+            "order_contract": "paired-interleaved-sha256-v1",
+            "targets": manifest_targets,
+        },
     }
 
 
@@ -591,6 +1139,7 @@ class KnowledgeEvaluationStore:
         expected_revision: int,
         release_notes: str = "",
         acknowledge_calibration_warnings: bool = False,
+        corpus_snapshot: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         with self._lock:
             data = self._read_unlocked()
@@ -639,6 +1188,23 @@ class KnowledgeEvaluationStore:
             ) + 1
             now = time.time()
             version_id = f"evalsetver_{uuid.uuid4().hex}"
+            qualification_manifest = {
+                "contract_version": "rag-gold-qualification-v2",
+                "case_count": len(cases),
+                "positive_case_count": sum(
+                    1 for case in cases if not case.get("expected_no_result")
+                ),
+                "hard_negative_count": sum(
+                    1 for case in cases if case.get("expected_no_result")
+                ),
+                "trusted_review_count": sum(
+                    1
+                    for case in cases
+                    if isinstance(case.get("review_evidence"), dict)
+                    and case["review_evidence"].get("source")
+                    == "authenticated_ui"
+                ),
+            }
             version = {
                 "version_id": version_id,
                 "eval_set_id": eval_set_id,
@@ -659,9 +1225,31 @@ class KnowledgeEvaluationStore:
                     catalog_ref=dict(item.get("catalog_ref") or {}),
                 ),
                 "release_notes": str(release_notes or "")[:1000],
-                "checksum": _checksum({"cases": cases, "coverage": item.get("coverage") or {}}),
+                "benchmark_contract_version": "rag-gold-v2",
+                "corpus_snapshot": _copy(corpus_snapshot or {}),
+                "qualification_manifest": qualification_manifest,
                 "published_at": now,
             }
+            version["checksum"] = _published_gold_checksum(version)
+            formal_qualification = qualify_formal_evidence(version)
+            if not formal_qualification["qualified"]:
+                version["benchmark_contract_version"] = "rag-gold-v1"
+                version["qualification_manifest"] = {
+                    **qualification_manifest,
+                    "status": "diagnostic_only",
+                    "failed_checks": [
+                        check["id"]
+                        for check in formal_qualification["checks"]
+                        if not check["passed"]
+                    ],
+                }
+            else:
+                version["qualification_manifest"] = {
+                    **qualification_manifest,
+                    "status": "qualified",
+                    "failed_checks": [],
+                }
+            version["checksum"] = _published_gold_checksum(version)
             data["versions"][version_id] = version
             item["latest_version"] = version_number
             item["updated_at"] = now
@@ -786,10 +1374,74 @@ class KnowledgeEvaluationStore:
             if index is None:
                 raise EvaluationSetNotFoundError("Knowledge evaluation case not found.")
             merged = {**item["cases"][index], **values, "case_id": case_id}
+            merged.pop("review_evidence", None)
+            merged["review_status"] = (
+                "pending" if bool(merged.get("expected_no_result")) else "not_required"
+            )
             item["cases"][index] = self._normalize_case(merged, preserve_id=True)
             self._touch_set(item)
             self._write_unlocked(data)
             return _copy(item)
+
+    def review_case(
+        self,
+        eval_set_id: str,
+        case_id: str,
+        *,
+        expected_revision: int,
+        decision: str,
+        reason: str,
+        reviewer: dict[str, str],
+    ) -> dict[str, Any]:
+        if decision not in {"approved", "rejected"}:
+            raise ValueError("Evaluation review decision is invalid.")
+        clean_reviewer = {
+            "tenant_id": str(reviewer.get("tenant_id") or "")[:160],
+            "role": str(reviewer.get("role") or "")[:80],
+        }
+        if not all(clean_reviewer.values()):
+            raise ValueError("Evaluation review requires an authenticated reviewer.")
+        with self._lock:
+            data = self._read_unlocked()
+            item = self._set_or_raise(data, eval_set_id)
+            self._check_revision(item, expected_revision)
+            case = next(
+                (
+                    value
+                    for value in item.get("cases", [])
+                    if value.get("case_id") == case_id
+                ),
+                None,
+            )
+            if not isinstance(case, dict):
+                raise EvaluationSetNotFoundError(
+                    "Knowledge evaluation case not found."
+                )
+            item["revision"] = int(item.get("revision", 0)) + 1
+            item["updated_at"] = time.time()
+            calibration = item.get("calibration")
+            if isinstance(calibration, dict) and calibration:
+                calibration["dataset_revision"] = int(item["revision"])
+            case["review_status"] = decision
+            if (
+                decision == "approved"
+                and (case.get("targeting") or {}).get("leakage_warning")
+                and not str(reason or "").strip()
+            ):
+                raise ValueError(
+                    "Leakage warnings require an explicit human review reason."
+                )
+            case["review_evidence"] = {
+                "decision": decision,
+                "reviewed_at": time.time(),
+                "dataset_revision": int(item["revision"]),
+                "source": "authenticated_ui",
+                "reviewer": clean_reviewer,
+                "reason": str(reason or "").strip()[:1000],
+                "case_checksum": _case_review_checksum(case),
+            }
+            self._write_unlocked(data)
+            return self._set_payload(item)
 
     def delete_case(
         self,
@@ -820,7 +1472,15 @@ class KnowledgeEvaluationStore:
         gate_policy: dict[str, Any],
         evaluation_set_version: dict[str, Any] | None = None,
         case_ids: list[str] | None = None,
+        run_mode: str = "diagnostic",
+        execution_manifest: dict[str, Any] | None = None,
+        comparability: dict[str, Any] | None = None,
+        evidence_qualification: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        if run_mode not in {"diagnostic", "formal"}:
+            raise ValueError("Evaluation run_mode is invalid.")
+        if run_mode == "formal" and case_ids is not None:
+            raise EvaluationStateError("Formal evaluation cannot run a case subset.")
         now = time.time()
         snapshot = _copy(evaluation_set_version or evaluation_set)
         if case_ids is not None:
@@ -854,7 +1514,23 @@ class KnowledgeEvaluationStore:
                 else None
             ),
             "eval_set_snapshot": snapshot,
-            "evidence_qualification": qualify_promotion_evidence(snapshot),
+            "run_mode": run_mode,
+            "metric_contract_version": (
+                "rag-metrics-v2" if run_mode == "formal" else "rag-metrics-v1"
+            ),
+            "evidence_qualification": _copy(
+                evidence_qualification or qualify_promotion_evidence(snapshot)
+            ),
+            "execution_manifest": _copy(execution_manifest or {}),
+            "comparability": _copy(
+                comparability
+                or {
+                    "contract_version": "rag-comparability-v1",
+                    "comparable": False,
+                    "same_corpus": False,
+                    "reason": "diagnostic_run",
+                }
+            ),
             "case_ids": [
                 str(case.get("case_id") or "") for case in snapshot.get("cases", [])
             ],
@@ -866,6 +1542,7 @@ class KnowledgeEvaluationStore:
             "progress": 0,
             "cancel_requested": False,
             "case_results": {},
+            "inflight_slots": {},
             "target_results": [],
             "run_registry_id": None,
             "error": None,
@@ -920,12 +1597,99 @@ class KnowledgeEvaluationStore:
             data = self._read_unlocked()
             for run in data["runs"].values():
                 if run.get("status") == "running":
+                    for slot in list((run.get("inflight_slots") or {}).values()):
+                        if not isinstance(slot, dict):
+                            continue
+                        target_id = str(slot.get("target_id") or "")
+                        case_id = str(slot.get("case_id") or "")
+                        if not target_id or not case_id:
+                            continue
+                        case = next(
+                            (
+                                item
+                                for item in run.get("eval_set_snapshot", {}).get(
+                                    "cases", []
+                                )
+                                if str(item.get("case_id") or "") == case_id
+                            ),
+                            {},
+                        )
+                        results = run.setdefault("case_results", {}).setdefault(
+                            target_id, {}
+                        )
+                        results.setdefault(
+                            case_id,
+                            {
+                                "status": "failed",
+                                "metrics": {},
+                                "latency_ms": round(
+                                    max(
+                                        0.0,
+                                        time.time()
+                                        - float(slot.get("claimed_at") or time.time()),
+                                    )
+                                    * 1000,
+                                    3,
+                                ),
+                                "source_count": 0,
+                                "expected_count": len(
+                                    case.get("expected_refs") or []
+                                ),
+                                "matched_expected_count": 0,
+                                "expected_no_result": bool(
+                                    case.get("expected_no_result")
+                                ),
+                                "no_result": True,
+                                "warning_count": 0,
+                                "warnings": [],
+                                "ranking": [],
+                                "error": (
+                                    "Interrupted evaluation call was not retried."
+                                ),
+                                "case_id": case_id,
+                            },
+                        )
+                    run["inflight_slots"] = {}
                     run["status"] = "queued"
                     run["updated_at"] = time.time()
                     recovered += 1
             if recovered:
                 self._write_unlocked(data)
         return recovered
+
+    def claim_case_slot(
+        self,
+        run_id: str,
+        target_id: str,
+        case_id: str,
+    ) -> bool:
+        with self._lock:
+            data = self._read_unlocked()
+            run = self._run_or_raise(data, run_id)
+            existing = (
+                run.get("case_results", {}).get(target_id, {}).get(case_id)
+            )
+            if isinstance(existing, dict):
+                return False
+            inflight = run.setdefault("inflight_slots", {})
+            if any(
+                isinstance(slot, dict)
+                and str(slot.get("target_id") or "") == target_id
+                and str(slot.get("case_id") or "") == case_id
+                for slot in inflight.values()
+            ):
+                return False
+            slot_id = _checksum(
+                {"run_id": run_id, "target_id": target_id, "case_id": case_id}
+            )
+            inflight[slot_id] = {
+                "target_id": target_id,
+                "case_id": case_id,
+                "claimed_at": time.time(),
+            }
+            run["updated_at"] = time.time()
+            self._write_unlocked(data)
+            return True
 
     def request_cancel(self, run_id: str) -> dict[str, Any]:
         with self._lock:
@@ -956,6 +1720,16 @@ class KnowledgeEvaluationStore:
             run = self._run_or_raise(data, run_id)
             target_results = run.setdefault("case_results", {}).setdefault(target_id, {})
             target_results[case_id] = _copy(result)
+            inflight = run.setdefault("inflight_slots", {})
+            run["inflight_slots"] = {
+                slot_id: slot
+                for slot_id, slot in inflight.items()
+                if not (
+                    isinstance(slot, dict)
+                    and str(slot.get("target_id") or "") == target_id
+                    and str(slot.get("case_id") or "") == case_id
+                )
+            }
             total = max(1, len(run["targets"]) * len(run["eval_set_snapshot"]["cases"]))
             completed = sum(len(items) for items in run["case_results"].values())
             run["progress"] = min(99, int(completed * 100 / total))
@@ -970,6 +1744,8 @@ class KnowledgeEvaluationStore:
         self,
         run_id: str,
         target_results: list[dict[str, Any]],
+        *,
+        paired_confidence: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         return self._update_run(
             run_id,
@@ -977,6 +1753,7 @@ class KnowledgeEvaluationStore:
                 "status": "succeeded",
                 "progress": 100,
                 "target_results": _copy(target_results),
+                "paired_confidence": _copy(paired_confidence or {}),
                 "completed_at": time.time(),
                 "error": None,
             },
@@ -1029,6 +1806,14 @@ class KnowledgeEvaluationStore:
         run = self.get_run(evaluation_run_id)
         if run["status"] != "succeeded" or run["kb_id"] != kb_id:
             raise EvaluationPromotionError("Evaluation run is not a successful run for this knowledge base.")
+        if (
+            str(run.get("run_mode") or "diagnostic") != "formal"
+            or str(run.get("metric_contract_version") or "") != "rag-metrics-v2"
+            or not bool((run.get("comparability") or {}).get("comparable"))
+        ):
+            raise EvaluationPromotionError(
+                "Candidate promotion requires a comparable Formal rag-eval-v2 run."
+            )
         if run.get("eval_set_version") is None:
             current_set = self.get_set(str(run["eval_set_id"]))
             if int(current_set["revision"]) != int(run["eval_set_revision"]):
@@ -1091,7 +1876,7 @@ class KnowledgeEvaluationStore:
                     "catalog_anchor_key": _optional_string(reference.get("catalog_anchor_key"), 200),
                 }
             )
-        return {
+        normalized = {
             "case_id": str(raw.get("case_id")) if preserve_id and raw.get("case_id") else f"evalcase_{uuid.uuid4().hex}",
             "query": query,
             "expected_refs": normalized_refs,
@@ -1103,6 +1888,10 @@ class KnowledgeEvaluationStore:
             "notes": str(raw.get("notes") or "")[:1000],
             "targeting": _safe_targeting(raw.get("targeting")),
         }
+        review_evidence = raw.get("review_evidence")
+        if isinstance(review_evidence, dict):
+            normalized["review_evidence"] = _copy(review_evidence)
+        return normalized
 
     def _touch_set(self, item: dict[str, Any]) -> None:
         item["revision"] = int(item.get("revision", 0)) + 1
@@ -1218,12 +2007,23 @@ def _source_matches_reference(source: dict[str, Any], reference: dict[str, Any])
 
 def _normalize_review_status(value: Any, *, expected_no_result: bool) -> str:
     status = str(value or ("pending" if expected_no_result else "not_required")).strip()
-    allowed = {"not_required", "pending", "approved"}
+    allowed = {"not_required", "pending", "approved", "rejected"}
     if status not in allowed:
         raise ValueError("Evaluation case review_status is invalid.")
-    if not expected_no_result and status != "not_required":
-        raise ValueError("Only no-result cases can require manual review.")
     return status
+
+
+def _case_review_checksum(case: dict[str, Any]) -> str:
+    return _checksum(
+        {
+            "case_id": str(case.get("case_id") or ""),
+            "query": str(case.get("query") or ""),
+            "expected_refs": case.get("expected_refs") or [],
+            "expected_no_result": bool(case.get("expected_no_result")),
+            "tags": case.get("tags") or [],
+            "targeting": case.get("targeting") or {},
+        }
+    )
 
 
 def _safe_targeting(value: Any) -> dict[str, Any]:
@@ -1253,10 +2053,27 @@ def _safe_targeting(value: Any) -> dict[str, Any]:
             for item in context_refs
             if isinstance(item, dict)
             and item.get("document_id")
-            and item.get("chunk_id")
             and item.get("source_block_id")
         ][:3] if isinstance(context_refs, list) else [],
+        "leakage_warning": (
+            {
+                "threshold": max(
+                    1,
+                    min(
+                        int((value.get("leakage_warning") or {}).get("threshold") or 0),
+                        32,
+                    ),
+                ),
+                "reason_required": True,
+            }
+            if isinstance(value.get("leakage_warning"), dict)
+            else None
+        ),
     }
+
+
+def _formal_query_tokens(value: str) -> set[str]:
+    return set(re.findall(r"[a-z0-9]+|[\u3400-\u9fff]", value.casefold()))
 
 
 def _ndcg_at_k(
@@ -1292,6 +2109,8 @@ def _validate_gate_policy(policy: dict[str, Any]) -> dict[str, Any]:
         "max_no_result_increase",
         "min_no_result_accuracy",
         "min_citation_coverage",
+        "max_paired_primary_regression",
+        "paired_confidence_level",
     ]
     for key in bounded:
         value = float(policy[key])
@@ -1306,6 +2125,9 @@ def _validate_gate_policy(policy: dict[str, Any]) -> dict[str, Any]:
     if absolute_latency < 1 or absolute_latency > 120_000:
         raise ValueError("max_p95_latency_ms must be between 1 and 120000.")
     policy["max_p95_latency_ms"] = absolute_latency
+    policy["require_comparable_corpus"] = bool(
+        policy.get("require_comparable_corpus", True)
+    )
     policy["require_zero_errors"] = bool(policy.get("require_zero_errors", True))
     return policy
 
@@ -1434,6 +2256,22 @@ def _checksum(value: Any) -> str:
 
     payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _published_gold_checksum(snapshot: dict[str, Any]) -> str:
+    return _checksum(
+        {
+            "benchmark_contract_version": snapshot.get(
+                "benchmark_contract_version"
+            ),
+            "cases": snapshot.get("cases") or [],
+            "coverage": snapshot.get("coverage") or {},
+            "provenance": snapshot.get("provenance") or {},
+            "calibration": snapshot.get("calibration") or {},
+            "corpus_snapshot": snapshot.get("corpus_snapshot") or {},
+            "qualification_manifest": snapshot.get("qualification_manifest") or {},
+        }
+    )
 
 
 def _safe_error(value: Any) -> str:

--- a/server/rag/evaluation_executor.py
+++ b/server/rag/evaluation_executor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import time
 from typing import Any
@@ -10,11 +11,40 @@ from .evaluation import (
     aggregate_target_metrics,
     evaluate_promotion_gate,
     evaluate_retrieval_case,
+    paired_primary_confidence_report,
 )
 from .rag_service import RagService
 
 
 logger = logging.getLogger(__name__)
+
+
+def _execution_slots(
+    run: dict[str, Any],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    targets = list(run.get("targets") or [])
+    cases = list((run.get("eval_set_snapshot") or {}).get("cases") or [])
+    if str(run.get("run_mode") or "diagnostic") != "formal":
+        return [(target, case) for target in targets for case in cases]
+    seed = str((run.get("execution_manifest") or {}).get("execution_seed") or "")
+    cases.sort(
+        key=lambda case: hashlib.sha256(
+            f"{seed}:case:{case.get('case_id')}".encode("utf-8")
+        ).hexdigest()
+    )
+    slots: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for case in cases:
+        paired_targets = sorted(
+            targets,
+            key=lambda target: hashlib.sha256(
+                (
+                    f"{seed}:case:{case.get('case_id')}:"
+                    f"target:{target.get('target_id')}"
+                ).encode("utf-8")
+            ).hexdigest(),
+        )
+        slots.extend((target, case) for target in paired_targets)
+    return slots
 
 
 class KnowledgeEvaluationExecutor:
@@ -87,7 +117,7 @@ class KnowledgeEvaluationExecutor:
                 },
             )
             max_k = max(run["ks"])
-            for target in run["targets"]:
+            for target, case in _execution_slots(run):
                 target_id = str(target["target_id"])
                 target_top_k = max_k
                 if bool(target.get("respect_profile_top_k")):
@@ -98,70 +128,92 @@ class KnowledgeEvaluationExecutor:
                             max_k,
                         ),
                     )
-                for case in run["eval_set_snapshot"]["cases"]:
-                    case_id = str(case["case_id"])
-                    current = self.store.get_run(run_id)
-                    if self.store.cancel_requested(run_id):
-                        self.store.complete_cancel(run_id)
-                        await self._finish_registry(registry_id, "cancelled", "Cancelled by user.")
-                        return
-                    existing = current.get("case_results", {}).get(target_id, {}).get(case_id)
-                    if isinstance(existing, dict):
-                        continue
-                    started = time.perf_counter()
-                    try:
-                        retrieval = await self.service.query_pipeline_version(
-                            str(target["version_id"]),
-                            str(case["query"]),
-                            top_k=target_top_k,
-                            retrieval={
-                                **dict(target.get("retrieval") or {}),
-                                "top_k": target_top_k,
-                            },
-                            generate_answer=False,
-                        )
-                        case_result = evaluate_retrieval_case(
-                            list(retrieval.get("sources") or []),
-                            list(case.get("expected_refs") or []),
-                            ks=list(run["ks"]),
-                            latency_ms=(time.perf_counter() - started) * 1000,
-                            warnings=list(retrieval.get("warnings") or []),
-                            expected_no_result=bool(case.get("expected_no_result")),
-                            retrieval_receipt=dict(retrieval.get("retrieval") or {}),
-                        )
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception as exc:
-                        logger.warning(
-                            "Knowledge evaluation case failed run=%s target=%s case=%s",
-                            run_id,
-                            target_id,
-                            case_id,
-                            exc_info=True,
-                        )
-                        case_result = {
-                            "status": "failed",
-                            "metrics": {},
-                            "latency_ms": round((time.perf_counter() - started) * 1000, 3),
-                            "source_count": 0,
-                            "expected_count": len(case.get("expected_refs") or []),
-                            "matched_expected_count": 0,
-                            "expected_no_result": bool(case.get("expected_no_result")),
-                            "no_result": True,
-                            "warning_count": 0,
-                            "warnings": [],
-                            "ranking": [],
-                            "error": self.service._safe_pipeline_error(exc),
-                        }
-                    case_result.update(
-                        {
-                            "case_id": case_id,
-                            "query_preview": str(case["query"])[:160],
-                        }
+                case_id = str(case["case_id"])
+                current = self.store.get_run(run_id)
+                if self.store.cancel_requested(run_id):
+                    self.store.complete_cancel(run_id)
+                    await self._finish_registry(registry_id, "cancelled", "Cancelled by user.")
+                    return
+                existing = current.get("case_results", {}).get(target_id, {}).get(case_id)
+                if isinstance(existing, dict):
+                    continue
+                if not self.store.claim_case_slot(run_id, target_id, case_id):
+                    continue
+                started = time.perf_counter()
+                try:
+                    retrieval = await self.service.query_pipeline_version(
+                        str(target["version_id"]),
+                        str(case["query"]),
+                        top_k=target_top_k,
+                        retrieval={
+                            **dict(target.get("retrieval") or {}),
+                            "top_k": target_top_k,
+                        },
+                        generate_answer=False,
                     )
-                    self.store.record_case_result(run_id, target_id, case_id, case_result)
+                    case_result = evaluate_retrieval_case(
+                        list(retrieval.get("sources") or []),
+                        list(case.get("expected_refs") or []),
+                        ks=list(run["ks"]),
+                        latency_ms=(time.perf_counter() - started) * 1000,
+                        warnings=list(retrieval.get("warnings") or []),
+                        expected_no_result=bool(case.get("expected_no_result")),
+                        retrieval_receipt=dict(retrieval.get("retrieval") or {}),
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "Knowledge evaluation case failed run=%s target=%s case=%s",
+                        run_id,
+                        target_id,
+                        case_id,
+                        exc_info=True,
+                    )
+                    case_result = {
+                        "status": "failed",
+                        "metrics": {},
+                        "latency_ms": round(
+                            (time.perf_counter() - started) * 1000, 3
+                        ),
+                        "source_count": 0,
+                        "expected_count": len(case.get("expected_refs") or []),
+                        "matched_expected_count": 0,
+                        "expected_no_result": bool(case.get("expected_no_result")),
+                        "no_result": True,
+                        "warning_count": 0,
+                        "warnings": [],
+                        "ranking": [],
+                        "error": self.service._safe_pipeline_error(exc),
+                    }
+                case_result.update(
+                    {
+                        "case_id": case_id,
+                        "query_preview": str(case["query"])[:160],
+                    }
+                )
+                self.store.record_case_result(run_id, target_id, case_id, case_result)
 
             completed = self.store.get_run(run_id)
+            if str(completed.get("run_mode") or "diagnostic") == "formal":
+                expected_case_ids = {
+                    str(case["case_id"])
+                    for case in completed["eval_set_snapshot"]["cases"]
+                }
+                incomplete_targets = [
+                    str(target["target_id"])
+                    for target in completed["targets"]
+                    if set(
+                        completed.get("case_results", {}).get(
+                            str(target["target_id"]), {}
+                        )
+                    )
+                    != expected_case_ids
+                ]
+                if incomplete_targets:
+                    raise ValueError(
+                        "Formal evaluation did not record every declared execution slot."
+                    )
             aggregates: list[dict[str, Any]] = []
             for target in completed["targets"]:
                 target_id = str(target["target_id"])
@@ -179,15 +231,70 @@ class KnowledgeEvaluationExecutor:
                     }
                 )
 
-            baseline = next(
+            baseline_target = next(
                 (
-                    item["metrics"]
+                    item
                     for item in aggregates
                     if item["version_id"] == completed.get("baseline_version_id")
                 ),
                 None,
             )
+            baseline = baseline_target["metrics"] if baseline_target else None
+            paired_confidence: dict[str, Any] | None = None
+            if str(completed.get("run_mode") or "diagnostic") == "formal":
+                candidate_target = next(
+                    (
+                        item
+                        for item in aggregates
+                        if item["version_id"]
+                        != completed.get("baseline_version_id")
+                    ),
+                    None,
+                )
+                if baseline_target is None or candidate_target is None:
+                    raise ValueError(
+                        "Formal evaluation lost its baseline/candidate pairing."
+                    )
+                policy = dict(completed["gate_policy"])
+                paired_confidence = paired_primary_confidence_report(
+                    baseline_target["case_results"],
+                    candidate_target["case_results"],
+                    cases=list(completed["eval_set_snapshot"]["cases"]),
+                    seed=str(
+                        (completed.get("execution_manifest") or {}).get(
+                            "execution_seed"
+                        )
+                        or ""
+                    ),
+                    confidence_level=float(
+                        policy.get("paired_confidence_level") or 0.95
+                    ),
+                    max_regression=float(
+                        policy.get("max_paired_primary_regression") or 0.03
+                    ),
+                )
             for item in aggregates:
+                item_paired_confidence = paired_confidence
+                if (
+                    paired_confidence is not None
+                    and item["version_id"] == completed.get("baseline_version_id")
+                ):
+                    item_paired_confidence = {
+                        "contract_version": "rag-paired-confidence-v1",
+                        "status": "completed",
+                        "passed": True,
+                        "point_delta": 0.0,
+                        "confidence_level": float(
+                            completed["gate_policy"].get(
+                                "paired_confidence_level", 0.95
+                            )
+                        ),
+                        "confidence_interval": {"lower": 0.0, "upper": 0.0},
+                        "bootstrap_samples": int(
+                            paired_confidence.get("bootstrap_samples") or 0
+                        ),
+                    }
+                item["paired_confidence"] = item_paired_confidence
                 item["promotion_gate"] = evaluate_promotion_gate(
                     item["metrics"],
                     baseline=baseline if item["version_id"] != completed.get("baseline_version_id") else item["metrics"],
@@ -195,8 +302,15 @@ class KnowledgeEvaluationExecutor:
                     evidence_qualification=dict(
                         completed.get("evidence_qualification") or {}
                     ),
+                    paired_confidence=item_paired_confidence,
+                    comparability=dict(completed.get("comparability") or {}),
+                    run_mode=str(completed.get("run_mode") or "diagnostic"),
                 )
-            final = self.store.complete_run(run_id, aggregates)
+            final = self.store.complete_run(
+                run_id,
+                aggregates,
+                paired_confidence=paired_confidence,
+            )
             await self._checkpoint(
                 registry_id,
                 event_type="knowledge_evaluation.completed",

--- a/server/rag/lexical_store.py
+++ b/server/rag/lexical_store.py
@@ -38,6 +38,7 @@ class LexicalChunk:
     row_range: str | None = None
     visual_kind: str | None = None
     source_block_id: str | None = None
+    source_block_hash: str | None = None
 
 
 @dataclass(slots=True)
@@ -61,6 +62,7 @@ class LexicalSearchResult:
     row_range: str | None = None
     visual_kind: str | None = None
     source_block_id: str | None = None
+    source_block_hash: str | None = None
 
 
 class SqliteLexicalStore:
@@ -89,8 +91,8 @@ class SqliteLexicalStore:
                         chunk_id, namespace, doc_id, document_name, text, chunk_index,
                         parent_chunk_id, parent_text, chunk_type, start_char, end_char
                         , page_number, slide, heading_path_json, sheet, row_range,
-                        visual_kind, source_block_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        visual_kind, source_block_id, source_block_hash
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         chunk.chunk_id,
@@ -111,6 +113,7 @@ class SqliteLexicalStore:
                         chunk.row_range,
                         chunk.visual_kind,
                         chunk.source_block_id,
+                        chunk.source_block_hash,
                     ),
                 )
                 connection.execute(
@@ -163,6 +166,7 @@ class SqliteLexicalStore:
                 row_range=str(row["row_range"]) if row["row_range"] else None,
                 visual_kind=str(row["visual_kind"]) if row["visual_kind"] else None,
                 source_block_id=str(row["source_block_id"]) if row["source_block_id"] else None,
+                source_block_hash=str(row["source_block_hash"]) if row["source_block_hash"] else None,
             )
             for index, row in enumerate(rows)
         ]
@@ -223,6 +227,7 @@ class SqliteLexicalStore:
                     , row_range TEXT
                     , visual_kind TEXT
                     , source_block_id TEXT
+                    , source_block_hash TEXT
                 )
                 """
             )
@@ -237,6 +242,7 @@ class SqliteLexicalStore:
                 ("row_range", "TEXT"),
                 ("visual_kind", "TEXT"),
                 ("source_block_id", "TEXT"),
+                ("source_block_hash", "TEXT"),
             ):
                 if name not in columns:
                     connection.execute(f"ALTER TABLE rag_chunks ADD COLUMN {name} {sql_type}")

--- a/server/rag/pipeline_executor.py
+++ b/server/rag/pipeline_executor.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -502,6 +504,11 @@ class KnowledgePipelineExecutor:
                                 if len(source_blocks) == 1
                                 else None
                             ),
+                            "source_block_hash": (
+                                _source_block_hash(source_blocks[0].get("text"))
+                                if len(source_blocks) == 1
+                                else None
+                            ),
                         }
                     )
                 continue
@@ -511,7 +518,8 @@ class KnowledgePipelineExecutor:
             for block in raw_blocks:
                 if not isinstance(block, dict):
                     continue
-                block_text = str(block.get("text") or "").strip()
+                raw_block_text = str(block.get("text") or "")
+                block_text = raw_block_text.strip()
                 if not block_text:
                     continue
                 heading_path = list(
@@ -563,6 +571,7 @@ class KnowledgePipelineExecutor:
                                 else None
                             ),
                             "source_block_id": block.get("block_id"),
+                            "source_block_hash": _source_block_hash(raw_block_text),
                         }
                     )
         if not chunks:
@@ -669,6 +678,7 @@ class KnowledgePipelineExecutor:
                 "row_range": item.get("row_range"),
                 "visual_kind": item.get("visual_kind"),
                 "source_block_id": item.get("source_block_id"),
+                "source_block_hash": item.get("source_block_hash"),
             }
             vector_chunks.append(
                 VectorChunk(
@@ -697,3 +707,17 @@ class KnowledgePipelineExecutor:
         self.service.lexical_store.add_chunks(lexical_chunks)
         if self.service.lexical_store.count_namespace(namespace) != len(lexical_chunks):
             raise RuntimeError("Full-text index count does not match the vector candidate index.")
+
+
+def _source_block_hash(value: Any) -> str | None:
+    text = str(value or "")
+    if not text.strip():
+        return None
+    encoded = json.dumps(
+        text,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -3712,13 +3712,21 @@ class RagService:
         source_manifest_fingerprint = self._mapping_sha256(
             {"sources": list(version.get("source_summary") or [])}
         )
+        processor_profile = dict(version.get("processor_profile") or {})
+        vision_profile = dict(version.get("vision_profile") or {})
+        processor_fingerprint = self._mapping_sha256(
+            {
+                "processor": processor_profile,
+                "vision": vision_profile,
+            }
+        )
         configuration_fingerprint = self._mapping_sha256(
             {
                 "index_schema_version": int(version.get("index_schema_version") or 1),
                 "embedding": safe_embedding,
                 "retrieval": retrieval,
-                "processor": dict(version.get("processor_profile") or {}),
-                "vision": dict(version.get("vision_profile") or {}),
+                "processor": processor_profile,
+                "vision": vision_profile,
             }
         )
         version_fingerprint = self._mapping_sha256(
@@ -3738,12 +3746,222 @@ class RagService:
             "index_schema_version": int(version.get("index_schema_version") or 1),
             "document_count": int(version.get("document_count") or 0),
             "chunk_count": int(version.get("chunk_count") or 0),
+            "processor": {
+                "mode": str(processor_profile.get("mode") or ""),
+                "vision_enabled": bool(vision_profile.get("enabled")),
+                "fingerprint": processor_fingerprint,
+            },
             "embedding": safe_embedding,
             "retrieval": retrieval,
             "source_manifest_fingerprint": source_manifest_fingerprint,
             "configuration_fingerprint": configuration_fingerprint,
             "version_fingerprint": version_fingerprint,
         }
+
+    def _pipeline_corpus_provenance(
+        self,
+        version_id: str,
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, dict[str, Any]]]:
+        version = self.get_pipeline_version(version_id)
+        if (
+            version.get("status") not in {"ready", "active"}
+            or version.get("vector_index_ready") is not True
+            or not str(version.get("job_id") or "")
+        ):
+            raise PipelineJobStateError(
+                "Pipeline version cannot provide a stable corpus snapshot."
+            )
+        index_owner_id = str(version.get("index_owner_version_id") or version_id)
+        index_owner = version
+        if index_owner_id != version_id:
+            try:
+                index_owner = self.get_pipeline_version(index_owner_id)
+            except PipelineVersionNotFoundError as exc:
+                raise PipelineJobStateError(
+                    "Pipeline version corpus provenance is inconsistent."
+                ) from exc
+            if (
+                str(version.get("base_version_id") or "") != index_owner_id
+                or index_owner.get("kb_id") != version.get("kb_id")
+                or index_owner.get("status") not in {"ready", "active"}
+                or index_owner.get("vector_index_ready") is not True
+                or str(index_owner.get("namespace") or "")
+                != str(version.get("namespace") or "")
+                or str(index_owner.get("job_id") or "")
+                != str(version.get("job_id") or "")
+                or str(index_owner.get("index_owner_version_id") or index_owner_id)
+                != index_owner_id
+            ):
+                raise PipelineJobStateError(
+                    "Pipeline version corpus provenance is inconsistent."
+                )
+        job = self.get_pipeline_job(str(index_owner["job_id"]))
+        if (
+            str(job.get("candidate_version_id") or "") != index_owner_id
+            or str(job.get("candidate_namespace") or "")
+            != str(index_owner.get("namespace") or "")
+            or str(job.get("status") or "") != "succeeded"
+        ):
+            raise PipelineJobStateError(
+                "Pipeline version corpus provenance is inconsistent."
+            )
+        raw_results = [
+            item
+            for item in job.get("document_results", [])
+            if isinstance(item, dict) and str(item.get("source_id") or "")
+        ]
+        results = {
+            str(item.get("source_id") or ""): item for item in raw_results
+        }
+        if len(results) != len(raw_results):
+            raise PipelineJobStateError(
+                "Pipeline version corpus provenance is inconsistent."
+            )
+        return version, job, results
+
+    @staticmethod
+    def _representative_source_block_chunk(chunks: list[Any]) -> Any:
+        return min(
+            chunks,
+            key=lambda item: (
+                0 if str(item.chunk_type or "") in {"parent", "standard"} else 1,
+                -len(str(item.text or "")),
+                int(item.chunk_index),
+                str(item.chunk_id),
+            ),
+        )
+
+    def pipeline_corpus_snapshot(self, version_id: str) -> dict[str, Any]:
+        """Rebuild and verify the exact source-block corpus behind an index."""
+
+        version, _, results = self._pipeline_corpus_provenance(version_id)
+        documents: list[dict[str, Any]] = []
+        seen_documents: set[str] = set()
+        index_owner = str(version.get("index_owner_version_id") or version_id)
+        for source in version.get("source_summary", []):
+            if not isinstance(source, dict):
+                raise PipelineJobStateError(
+                    "Pipeline version source provenance is invalid."
+                )
+            document_id = str(source.get("source_id") or "")
+            result = results.get(document_id)
+            content_hash = str(
+                source.get("content_hash")
+                or (result or {}).get("content_hash")
+                or ""
+            )
+            if (
+                not document_id
+                or document_id in seen_documents
+                or not re.fullmatch(r"[0-9a-f]{64}", content_hash)
+            ):
+                raise PipelineJobStateError(
+                    "Pipeline version source provenance is invalid."
+                )
+            seen_documents.add(document_id)
+            artifact_key = str((result or {}).get("artifact_key") or "")
+            if not artifact_key or str((result or {}).get("status") or "") != "completed":
+                raise PipelineJobStateError(
+                    "Pipeline version processed source artifact is unavailable."
+                )
+            artifact_path = self._pipeline_processed_path(artifact_key)
+            try:
+                artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                raise PipelineJobStateError(
+                    "Pipeline version processed source artifact is unavailable."
+                ) from exc
+            processed = artifact.get("processed_document")
+            raw_blocks = processed.get("blocks") if isinstance(processed, dict) else None
+            if not isinstance(raw_blocks, list) or not raw_blocks:
+                raise PipelineJobStateError(
+                    "Pipeline version processed source blocks are unavailable."
+                )
+            chunks_by_block: dict[str, list[Any]] = {}
+            for chunk in self.vector_store.list_document_chunks(
+                f"{index_owner}_{document_id}"
+            ):
+                source_block_id = str(chunk.source_block_id or "")
+                if source_block_id:
+                    chunks_by_block.setdefault(source_block_id, []).append(chunk)
+            source_blocks: list[dict[str, str]] = []
+            seen_blocks: set[str] = set()
+            for raw_block in raw_blocks:
+                if not isinstance(raw_block, dict):
+                    raise PipelineJobStateError(
+                        "Pipeline version processed source block is invalid."
+                    )
+                source_block_id = str(raw_block.get("block_id") or "")
+                text = raw_block.get("text")
+                if (
+                    not source_block_id
+                    or source_block_id in seen_blocks
+                    or not isinstance(text, str)
+                    or not text.strip()
+                ):
+                    raise PipelineJobStateError(
+                        "Pipeline version processed source block is invalid."
+                    )
+                block_hash = self._canonical_sha256(text)
+                indexed_chunks = chunks_by_block.get(source_block_id) or []
+                stored_hashes = {
+                    str(chunk.source_block_hash or "")
+                    for chunk in indexed_chunks
+                    if str(chunk.source_block_hash or "")
+                }
+                if stored_hashes:
+                    index_matches = stored_hashes == {block_hash}
+                elif indexed_chunks:
+                    representative = self._representative_source_block_chunk(
+                        indexed_chunks
+                    )
+                    index_matches = text.strip() in str(
+                        representative.text or ""
+                    ).strip()
+                else:
+                    index_matches = False
+                if not index_matches:
+                    raise PipelineJobStateError(
+                        "Pipeline version source-block index is inconsistent."
+                    )
+                seen_blocks.add(source_block_id)
+                source_blocks.append(
+                    {
+                        "source_block_id": source_block_id,
+                        "block_hash": block_hash,
+                    }
+                )
+            if set(chunks_by_block) != seen_blocks:
+                raise PipelineJobStateError(
+                    "Pipeline version source-block index is inconsistent."
+                )
+            source_blocks.sort(key=lambda item: item["source_block_id"])
+            documents.append(
+                {
+                    "document_id": document_id,
+                    "document_hash": self._canonical_sha256(
+                        {
+                            "contract_version": "rag-document-identity-v1",
+                            "document_id": document_id,
+                            "content_hash": content_hash,
+                        }
+                    ),
+                    "content_hash": content_hash,
+                    "source_blocks": source_blocks,
+                }
+            )
+        if not documents or set(results) != seen_documents:
+            raise PipelineJobStateError(
+                "Pipeline version document set does not match its processed artifacts."
+            )
+        documents.sort(key=lambda item: item["document_id"])
+        corpus = {
+            "contract_version": "rag-corpus-snapshot-v1",
+            "knowledge_base_hash": self._canonical_sha256(str(version["kb_id"])),
+            "documents": documents,
+        }
+        corpus["checksum"] = self._canonical_sha256(corpus)
+        return json.loads(json.dumps(corpus))
 
     def pipeline_version_payload(
         self,
@@ -4250,8 +4468,12 @@ class RagService:
         return digest.hexdigest()
 
     def _mapping_sha256(self, value: dict[str, Any]) -> str:
+        return self._canonical_sha256(value)
+
+    def _canonical_sha256(self, value: Any) -> str:
         encoded = json.dumps(
             value,
+            allow_nan=False,
             ensure_ascii=False,
             sort_keys=True,
             separators=(",", ":"),

--- a/server/rag/vector_store.py
+++ b/server/rag/vector_store.py
@@ -37,6 +37,7 @@ class VectorChunk:
     row_range: str | None = None
     visual_kind: str | None = None
     source_block_id: str | None = None
+    source_block_hash: str | None = None
 
 
 @dataclass(slots=True)
@@ -59,6 +60,7 @@ class SearchResult:
     row_range: str | None = None
     visual_kind: str | None = None
     source_block_id: str | None = None
+    source_block_hash: str | None = None
 
 
 @dataclass(slots=True)
@@ -80,6 +82,7 @@ class StoredVectorChunk:
     row_range: str | None = None
     visual_kind: str | None = None
     source_block_id: str | None = None
+    source_block_hash: str | None = None
 
 
 class VectorStore(Protocol):
@@ -146,6 +149,7 @@ class LocalJsonVectorStore:
                     row_range=str(record.get("row_range") or "") or None,
                     visual_kind=str(record.get("visual_kind") or "") or None,
                     source_block_id=str(record.get("source_block_id") or "") or None,
+                    source_block_hash=str(record.get("source_block_hash") or "") or None,
                 )
             )
         return sorted(scored, key=lambda item: item.score, reverse=True)[:top_k]
@@ -180,6 +184,7 @@ class LocalJsonVectorStore:
                 row_range=str(record.get("row_range") or "") or None,
                 visual_kind=str(record.get("visual_kind") or "") or None,
                 source_block_id=str(record.get("source_block_id") or "") or None,
+                source_block_hash=str(record.get("source_block_hash") or "") or None,
             )
             for record in self._read_records()
             if record.get("doc_id") == doc_id
@@ -208,6 +213,7 @@ class LocalJsonVectorStore:
                 row_range=str(record.get("row_range") or "") or None,
                 visual_kind=str(record.get("visual_kind") or "") or None,
                 source_block_id=str(record.get("source_block_id") or "") or None,
+                source_block_hash=str(record.get("source_block_hash") or "") or None,
             )
         return None
 
@@ -281,6 +287,7 @@ class ChromaVectorStore:
                     "row_range": chunk.row_range or "",
                     "visual_kind": chunk.visual_kind or "",
                     "source_block_id": chunk.source_block_id or "",
+                    "source_block_hash": chunk.source_block_hash or "",
                     "updated_at": time.time(),
                 }
                 for chunk in chunks
@@ -347,6 +354,7 @@ class ChromaVectorStore:
                     row_range=str(metadata.get("row_range") or "") or None,
                     visual_kind=str(metadata.get("visual_kind") or "") or None,
                     source_block_id=str(metadata.get("source_block_id") or "") or None,
+                    source_block_hash=str(metadata.get("source_block_hash") or "") or None,
                 )
             )
         return results
@@ -405,6 +413,7 @@ class ChromaVectorStore:
                     row_range=str(metadata.get("row_range") or "") or None,
                     visual_kind=str(metadata.get("visual_kind") or "") or None,
                     source_block_id=str(metadata.get("source_block_id") or "") or None,
+                    source_block_hash=str(metadata.get("source_block_hash") or "") or None,
                 )
             )
         return chunks
@@ -461,6 +470,7 @@ class ChromaVectorStore:
             row_range=str(metadata.get("row_range") or "") or None,
             visual_kind=str(metadata.get("visual_kind") or "") or None,
             source_block_id=str(metadata.get("source_block_id") or "") or None,
+            source_block_hash=str(metadata.get("source_block_hash") or "") or None,
         )
 
     @classmethod
@@ -542,6 +552,7 @@ def _chunk_to_record(chunk: VectorChunk) -> dict[str, Any]:
         "row_range": chunk.row_range,
         "visual_kind": chunk.visual_kind,
         "source_block_id": chunk.source_block_id,
+        "source_block_hash": chunk.source_block_hash,
     }
 
 

--- a/server/tests/test_model_router_admin_auth.py
+++ b/server/tests/test_model_router_admin_auth.py
@@ -78,6 +78,11 @@ async def test_pairing_cookie_csrf_and_logout(
         assert "samesite=strict" in cookie
         assert "path=/api/router" in cookie
         assert "secure" not in cookie
+        set_cookies = [value.lower() for value in paired.headers.get_list("set-cookie")]
+        assert any(
+            "modelmirror_rag_admin=" in value and "path=/api/rag" in value
+            for value in set_cookies
+        )
         parsed_cookie = SimpleCookie()
         parsed_cookie.load(paired.headers["set-cookie"])
         assert parsed_cookie["modelmirror_provider_admin"].value not in paired.text

--- a/server/tests/test_rag_benchmark_generator.py
+++ b/server/tests/test_rag_benchmark_generator.py
@@ -288,6 +288,7 @@ def test_generation_contract_fixes_source_block_gold_and_reviews_no_result(tmp_p
 
     positive = [item for item in generated["cases"] if not item["expected_no_result"]]
     negative = [item for item in generated["cases"] if item["expected_no_result"]]
+    assert all(item["review_status"] == "pending" for item in generated["cases"])
     assert all(
         reference["match_mode"] == "source_block"
         and reference["chunk_id"]
@@ -298,6 +299,56 @@ def test_generation_contract_fixes_source_block_gold_and_reviews_no_result(tmp_p
     assert negative[0]["review_status"] == "pending"
     assert {"corpus_near", "hard_negative"}.issubset(negative[0]["tags"])
     assert negative[0]["targeting"]["context_refs"][0]["source_block_id"]
+
+
+def test_cross_language_generation_does_not_require_source_marker_copy(
+    tmp_path: Path,
+) -> None:
+    service, _ = _service(tmp_path)
+    snapshot, _ = service.snapshot_target(
+        {
+            "kind": "knowledge_version",
+            "kb_id": "kb_target",
+            "pipeline_version_id": "pipeline_v2",
+        }
+    )
+    context = service.prepare_generation(
+        snapshot=snapshot,
+        case_count=1,
+        locales=["zh", "en"],
+        requested_coverage=["cross_language"],
+        no_result_count=0,
+        seed=11,
+    )
+    blueprint = context["blueprints"][0]
+    evidence_id = blueprint["required_evidence_ids"][0]
+    evidence = context["evidence_by_id"][evidence_id]
+    generated = service.parse_generated_cases(
+        json.dumps(
+            {
+                "dataset": {
+                    "cases": [
+                        {
+                            "blueprint_id": blueprint["blueprint_id"],
+                            "query": "这项规定要求多长的发布审查周期？",
+                            "evidence_ids": [evidence_id],
+                            "anchor_quotes": [
+                                {
+                                    "evidence_id": evidence_id,
+                                    "quote": evidence["text"][:20],
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        ),
+        snapshot=snapshot,
+        context=context,
+        expected_count=1,
+    )
+
+    assert generated["cases"][0]["targeting"]["query_type"] == "cross_language"
 
 
 @pytest.mark.asyncio
@@ -363,11 +414,17 @@ async def test_strategy_tuning_generation_waits_for_hard_negative_review(
     negatives = [item for item in dataset["cases"] if item["expected_no_result"]]
     assert completed["status"] == "completed"
     assert completed["calibration"]["status"] == "awaiting_review"
+    assert completed["calibration"]["pending_review_count"] == 42
     assert completed["evaluation_run_id"] is None
     assert rag_executor.notifications == 0
     assert dataset["benchmark_role"] == "promotion_evidence"
+    assert dataset["provenance"]["generator"] == "modelmirror-targeted-rag-benchmark-v2"
+    assert len(dataset["provenance"]["prompt_contract_hash"]) == 64
+    assert dataset["provenance"]["repair_used"] is False
+    assert len(dataset["provenance"]["generation_attempts"]) == 1
     assert len(positives) == 30
     assert len(negatives) == 12
+    assert all(case["review_status"] == "pending" for case in dataset["cases"])
     assert all(
         reference["match_mode"] == "source_block"
         and reference["source_block_id"]
@@ -596,6 +653,14 @@ async def test_knowledge_preflight_and_evidence_api_are_bounded(
             coverage={},
             calibration={"status": "pending", "dataset_revision": 1},
         )
+        generated = store.review_case(
+            generated["eval_set_id"],
+            generated["cases"][0]["case_id"],
+            expected_revision=generated["revision"],
+            decision="approved",
+            reason="Fixed evidence reviewed for calibration.",
+            reviewer={"tenant_id": "local", "role": "provider_admin"},
+        )
         benchmark_jobs = BenchmarkJobStore(tmp_path / "api-benchmark-jobs")
         monkeypatch.setattr(benchmark_api, "_job_store", benchmark_jobs)
         monkeypatch.setattr(
@@ -603,7 +668,10 @@ async def test_knowledge_preflight_and_evidence_api_are_bounded(
         )
         calibration = await client.post(
             "/api/benchmarks/calibrations",
-            json={"dataset_id": generated["eval_set_id"], "dataset_revision": 1},
+            json={
+                "dataset_id": generated["eval_set_id"],
+                "dataset_revision": generated["revision"],
+            },
         )
         assert calibration.status_code == 200
         calibration_job = benchmark_jobs.require_job(calibration.json()["job_id"])
@@ -664,7 +732,7 @@ async def test_knowledge_preflight_and_evidence_api_are_bounded(
             json={"dataset_id": pending["eval_set_id"], "dataset_revision": 1},
         )
         assert blocked_calibration.status_code == 400
-        assert "approve every corpus-near" in blocked_calibration.text.lower()
+        assert "approve every generated case" in blocked_calibration.text.lower()
         assert len(benchmark_jobs.list_jobs()) == 1
 
         negative_case_id = pending["cases"][0]["case_id"]
@@ -772,13 +840,16 @@ async def test_generation_restart_reuses_dataset_without_second_model_call(
     assert claimed is not None
     await executor._run_knowledge_generation(claimed)
     first = job_store.require_job(created["job_id"])
-    assert first["status"] == "calibrating"
+    assert first["status"] == "completed"
+    assert first["calibration"]["status"] == "awaiting_review"
+    assert first["calibration"]["pending_review_count"] == 6
     assert first["dataset_id"]
     assert calls == 1
 
     await executor._run_knowledge_generation(first)
     second = job_store.require_job(created["job_id"])
-    assert second["status"] == "calibrating"
+    assert second["status"] == "completed"
+    assert second["calibration"]["status"] == "awaiting_review"
     assert second["dataset_id"] == first["dataset_id"]
     assert calls == 1
-    assert rag_executor.notifications == 2
+    assert rag_executor.notifications == 0

--- a/server/tests/test_rag_evaluation.py
+++ b/server/tests/test_rag_evaluation.py
@@ -7,6 +7,7 @@ import pytest
 import pytest_asyncio
 
 from server.main import app
+from server.model_router.admin_auth import reset_provider_admin_auth
 from server.rag.api import (
     set_evaluation_executor_for_tests,
     set_pipeline_executor_for_tests,
@@ -20,9 +21,14 @@ from server.rag.evaluation import (
     aggregate_target_metrics,
     evaluate_promotion_gate,
     evaluate_retrieval_case,
+    paired_primary_confidence_report,
+    qualify_formal_evidence,
     qualify_promotion_evidence,
+    validate_formal_run_admission,
+    _case_review_checksum,
+    _published_gold_checksum,
 )
-from server.rag.evaluation_executor import KnowledgeEvaluationExecutor
+from server.rag.evaluation_executor import KnowledgeEvaluationExecutor, _execution_slots
 from server.rag.pipeline_executor import KnowledgePipelineExecutor
 from server.rag.rag_service import RagService
 from server.rag.vector_store import LocalJsonVectorStore
@@ -102,6 +108,315 @@ async def _execute_draft(
     job = (await client.get(f"/api/rag/pipeline/jobs/{response.json()['job_id']}")).json()
     assert job["status"] == "succeeded", job
     return job
+
+
+@pytest.mark.asyncio
+async def test_case_review_requires_authenticated_server_evidence(
+    evaluation_runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _, _, _, _ = evaluation_runtime
+    pairing_secret = "rag-review-test-secret-at-least-32-characters"
+    monkeypatch.setenv(
+        "MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", pairing_secret
+    )
+    reset_provider_admin_auth()
+    try:
+        kb_id = await _create_kb(client, "review-auth")
+        created = (
+            await client.post(
+                "/api/rag/evaluation-sets",
+                json={"kb_id": kb_id, "name": "review-auth"},
+            )
+        ).json()
+        injected = await client.post(
+            f"/api/rag/evaluation-sets/{created['eval_set_id']}/cases",
+            json={
+                "expected_revision": created["revision"],
+                "case": {
+                    "query": "Which source contains the answer?",
+                    "expected_refs": [{"document_id": "doc-a"}],
+                    "review_status": "approved",
+                },
+            },
+        )
+        assert injected.status_code == 422
+
+        added = (
+            await client.post(
+                f"/api/rag/evaluation-sets/{created['eval_set_id']}/cases",
+                json={
+                    "expected_revision": created["revision"],
+                    "case": {
+                        "query": "Which source contains the answer?",
+                        "expected_refs": [{"document_id": "doc-a"}],
+                    },
+                },
+            )
+        ).json()
+        case_id = added["cases"][0]["case_id"]
+        review_url = (
+            f"/api/rag/evaluation-sets/{created['eval_set_id']}"
+            f"/cases/{case_id}/review"
+        )
+        review_payload = {
+            "expected_revision": added["revision"],
+            "decision": "approved",
+            "reason": "Source evidence checked in the review workbench.",
+        }
+        unauthenticated = await client.post(review_url, json=review_payload)
+        assert unauthenticated.status_code == 401
+        assert unauthenticated.json()["detail"]["code"] == "admin_session_required"
+
+        paired = await client.post(
+            "/api/router/admin/session",
+            headers={"Origin": "http://localhost"},
+            json={"pairing_secret": pairing_secret},
+        )
+        assert paired.status_code == 200
+        missing_csrf = await client.post(review_url, json=review_payload)
+        assert missing_csrf.status_code == 403
+
+        reviewed = await client.post(
+            review_url,
+            headers={"X-ModelMirror-CSRF": paired.json()["csrf_token"]},
+            json=review_payload,
+        )
+        assert reviewed.status_code == 200, reviewed.text
+        reviewed_case = reviewed.json()["cases"][0]
+        assert reviewed_case["review_status"] == "approved"
+        evidence = reviewed_case["review_evidence"]
+        assert evidence["decision"] == "approved"
+        assert evidence["source"] == "authenticated_ui"
+        assert evidence["reviewer"] == {
+            "tenant_id": "local",
+            "role": "provider_admin",
+        }
+        assert evidence["dataset_revision"] == reviewed.json()["revision"]
+        assert len(evidence["case_checksum"]) == 64
+        assert isinstance(evidence["reviewed_at"], float)
+
+        edited = await client.patch(
+            f"/api/rag/evaluation-sets/{created['eval_set_id']}/cases/{case_id}",
+            json={
+                "expected_revision": reviewed.json()["revision"],
+                "case": {
+                    "query": "Which exact source contains the answer?",
+                    "expected_refs": [{"document_id": "doc-a"}],
+                },
+            },
+        )
+        assert edited.status_code == 200, edited.text
+        edited_case = edited.json()["cases"][0]
+        assert edited_case["review_status"] == "not_required"
+        assert "review_evidence" not in edited_case
+    finally:
+        reset_provider_admin_auth()
+
+
+@pytest.mark.asyncio
+async def test_formal_api_runs_only_published_reviewed_same_corpus_gold(
+    evaluation_runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, service, pipeline_executor, evaluation_executor, _ = evaluation_runtime
+    pairing_secret = "formal-api-test-secret-at-least-32-characters"
+    monkeypatch.setenv(
+        "MODEL_MIRROR_PROVIDER_ADMIN_PAIRING_SECRET", pairing_secret
+    )
+    reset_provider_admin_auth()
+    try:
+        kb_id = await _create_kb(client, "formal-api")
+        document_ids = []
+        for document_index in range(3):
+            paragraphs = [
+                (
+                    f"Document {document_index} evidence block {block_index}. "
+                    f"Stable marker D{document_index}B{block_index} and supporting detail."
+                )
+                for block_index in range(20)
+            ]
+            document_ids.append(
+                await _upload_text(
+                    client,
+                    kb_id,
+                    f"formal-{document_index}.txt",
+                    "\n\n".join(paragraphs),
+                )
+            )
+        baseline_job = await _execute_draft(
+            client, pipeline_executor, kb_id, document_ids
+        )
+        candidate_job = await _execute_draft(
+            client, pipeline_executor, kb_id, document_ids
+        )
+        baseline_id = str(baseline_job["candidate_version_id"])
+        candidate_id = str(candidate_job["candidate_version_id"])
+        corpus = service.pipeline_corpus_snapshot(baseline_id)
+        blocks_by_document = {
+            str(document["document_id"]): list(document["source_blocks"])
+            for document in corpus["documents"]
+        }
+        assert all(len(blocks) >= 14 for blocks in blocks_by_document.values())
+
+        chunk_by_block: dict[tuple[str, str], str] = {}
+        for document_id in document_ids:
+            indexed_id = f"{baseline_id}_{document_id}"
+            for chunk in service.vector_store.list_document_chunks(indexed_id):
+                key = (document_id, str(chunk.source_block_id or ""))
+                if key[1] and key not in chunk_by_block:
+                    chunk_by_block[key] = str(chunk.chunk_id)
+
+        cases: list[dict] = []
+        ordered_documents = sorted(blocks_by_document)
+        for document_offset, document_id in enumerate(ordered_documents):
+            blocks = blocks_by_document[document_id]
+            for local_index in range(10):
+                global_index = document_offset * 10 + local_index
+                block_id = str(blocks[local_index]["source_block_id"])
+                cases.append(
+                    {
+                        "query": f"Stable answer query {global_index}",
+                        "expected_refs": [
+                            {
+                                "document_id": document_id,
+                                "source_block_id": block_id,
+                                "match_mode": "source_block",
+                            }
+                        ],
+                        "expected_no_result": False,
+                        "tags": ["positive"],
+                        "targeting": {
+                            "locale": "zh" if global_index % 2 == 0 else "en",
+                            "query_type": [
+                                "factual_lookup",
+                                "paraphrase",
+                                "section_context",
+                                "cross_language",
+                                "multi_evidence",
+                                "confusable_content",
+                            ][global_index // 5],
+                        },
+                    }
+                )
+            for local_index in range(4):
+                global_index = document_offset * 4 + local_index
+                block_id = str(blocks[10 + local_index]["source_block_id"])
+                cases.append(
+                    {
+                        "query": f"Absent nearby policy {global_index}",
+                        "expected_refs": [],
+                        "expected_no_result": True,
+                        "review_status": "pending",
+                        "tags": ["hard_negative", "corpus_near"],
+                        "targeting": {
+                            "locale": "zh" if global_index % 2 == 0 else "en",
+                            "context_refs": [
+                                {
+                                    "document_id": document_id,
+                                    "source_block_id": block_id,
+                                    "chunk_id": chunk_by_block[
+                                        (document_id, block_id)
+                                    ],
+                                }
+                            ],
+                        },
+                    }
+                )
+        store = evaluation_executor.store
+        evaluation_set = store.create_generated_set(
+            kb_id,
+            "Formal reviewed Gold",
+            "",
+            cases=cases,
+            provenance={
+                "generator": "modelmirror-targeted-rag-benchmark-v2",
+                "generation_job_id": "local-formal-e2e",
+                "generator_model_id": "local-no-network-fixture",
+                "target_checksum": "d" * 64,
+                "source_summary_hash": "e" * 64,
+                "evidence_hash": "f" * 64,
+                "blueprint_hash": "1" * 64,
+                "prompt_contract_hash": "2" * 64,
+                "seed": 11,
+                "repair_used": False,
+                "generation_attempts": [
+                    {"attempt": "initial", "error_code": None, "diagnostics": {}}
+                ],
+                "pipeline_version_id": baseline_id,
+            },
+            coverage={},
+            calibration={"status": "calibrated", "dataset_revision": 1},
+            benchmark_role="promotion_evidence",
+        )
+        for case in evaluation_set["cases"]:
+            evaluation_set = store.review_case(
+                evaluation_set["eval_set_id"],
+                case["case_id"],
+                expected_revision=evaluation_set["revision"],
+                decision="approved",
+                reason="Fixed local test evidence reviewed.",
+                reviewer={"tenant_id": "local", "role": "provider_admin"},
+            )
+
+        published = await client.post(
+            f"/api/rag/evaluation-sets/{evaluation_set['eval_set_id']}/publish",
+            json={"expected_revision": evaluation_set["revision"]},
+        )
+        assert published.status_code == 200, published.text
+        assert published.json()["benchmark_contract_version"] == "rag-gold-v2"
+        assert published.json()["qualification_manifest"]["status"] == "qualified"
+        assert "Stable marker" not in published.text
+
+        unauthenticated = await client.post(
+            "/api/rag/evaluation-runs",
+            json={
+                "eval_set_id": evaluation_set["eval_set_id"],
+                "eval_set_version": 1,
+                "targets": [
+                    {"version_id": baseline_id},
+                    {"version_id": candidate_id},
+                ],
+                "baseline_version_id": baseline_id,
+                "run_mode": "formal",
+            },
+        )
+        assert unauthenticated.status_code == 401
+        paired = await client.post(
+            "/api/router/admin/session",
+            headers={"Origin": "http://localhost"},
+            json={"pairing_secret": pairing_secret},
+        )
+        assert paired.status_code == 200
+        created = await client.post(
+            "/api/rag/evaluation-runs",
+            headers={"X-ModelMirror-CSRF": paired.json()["csrf_token"]},
+            json={
+                "eval_set_id": evaluation_set["eval_set_id"],
+                "eval_set_version": 1,
+                "targets": [
+                    {"version_id": baseline_id},
+                    {"version_id": candidate_id},
+                ],
+                "baseline_version_id": baseline_id,
+                "run_mode": "formal",
+            },
+        )
+        assert created.status_code == 200, created.text
+        assert created.json()["comparability"]["comparable"] is True
+        assert created.json()["execution_manifest"]["contract_version"] == "rag-eval-v2"
+        assert await evaluation_executor.run_once() is True
+        completed = store.get_run(created.json()["run_id"])
+        assert completed["status"] == "succeeded"
+        assert completed["run_mode"] == "formal"
+        assert completed["metric_contract_version"] == "rag-metrics-v2"
+        assert completed["paired_confidence"]["bootstrap_samples"] == 10_000
+        assert all(
+            target["metrics"]["expected_case_count"] == 42
+            for target in completed["target_results"]
+        )
+    finally:
+        reset_provider_admin_auth()
 
 
 def test_evaluation_metrics_match_stable_references_and_rankings() -> None:
@@ -194,6 +509,308 @@ def test_promotion_gate_rejects_diagnostic_only_evidence() -> None:
     )
     assert evidence_check["passed"] is False
     assert gate["passed"] is False
+
+
+def _formal_gold_snapshot() -> dict:
+    cases: list[dict] = []
+    query_types = [
+        "factual_lookup",
+        "paraphrase",
+        "section_context",
+        "cross_language",
+        "multi_evidence",
+        "confusable_content",
+    ]
+    for index in range(30):
+        case = {
+            "case_id": f"positive-{index}",
+            "query": f"Answerable question {index}",
+            "expected_refs": [
+                {
+                    "document_id": f"doc-{index % 3}",
+                    "source_block_id": f"answer-block-{index}",
+                    "match_mode": "source_block",
+                    "relevance": 1,
+                }
+            ],
+            "expected_no_result": False,
+            "review_status": "approved",
+            "tags": ["positive"],
+            "targeting": {
+                "locale": "en" if index % 2 else "zh",
+                "query_type": query_types[index // 5],
+            },
+        }
+        case["review_evidence"] = {
+            "decision": "approved",
+            "reviewed_at": 1_000.0 + index,
+            "dataset_revision": index + 2,
+            "source": "authenticated_ui",
+            "reviewer": {"tenant_id": "local", "role": "provider_admin"},
+            "reason": "reviewed",
+            "case_checksum": _case_review_checksum(case),
+        }
+        cases.append(case)
+    for index in range(12):
+        case = {
+            "case_id": f"negative-{index}",
+            "query": f"Unanswerable nearby question {index}",
+            "expected_refs": [],
+            "expected_no_result": True,
+            "review_status": "approved",
+            "tags": ["hard_negative", "corpus_near"],
+            "targeting": {
+                "locale": "en" if index % 2 else "zh",
+                "context_refs": [
+                    {
+                        "document_id": f"doc-{index % 3}",
+                        "source_block_id": f"context-block-{index}",
+                    }
+                ],
+            },
+        }
+        case["review_evidence"] = {
+            "decision": "approved",
+            "reviewed_at": 2_000.0 + index,
+            "dataset_revision": index + 32,
+            "source": "authenticated_ui",
+            "reviewer": {"tenant_id": "local", "role": "provider_admin"},
+            "reason": "answer absence checked",
+            "case_checksum": _case_review_checksum(case),
+        }
+        cases.append(case)
+    corpus = {
+        "contract_version": "rag-corpus-snapshot-v1",
+        "knowledge_base_hash": "a" * 64,
+        "documents": [
+            {
+                "document_id": f"doc-{document_index}",
+                "content_hash": f"{document_index + 1}" * 64,
+                "document_hash": f"{document_index + 4}" * 64,
+                "source_blocks": [
+                    *[
+                        {
+                            "source_block_id": f"answer-block-{case_index}",
+                            "block_hash": "b" * 64,
+                        }
+                        for case_index in range(30)
+                        if case_index % 3 == document_index
+                    ],
+                    *[
+                        {
+                            "source_block_id": f"context-block-{case_index}",
+                            "block_hash": "c" * 64,
+                        }
+                        for case_index in range(12)
+                        if case_index % 3 == document_index
+                    ],
+                ],
+            }
+            for document_index in range(3)
+        ],
+    }
+    from hashlib import sha256
+    import json
+
+    corpus["checksum"] = sha256(
+        json.dumps(
+            corpus, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+    ).hexdigest()
+    snapshot = {
+        "version_id": "evalsetver-formal",
+        "published_at": 3_000.0,
+        "benchmark_contract_version": "rag-gold-v2",
+        "benchmark_role": "promotion_evidence",
+        "cases": cases,
+        "coverage": {},
+        "provenance": {
+            "generator": "modelmirror-targeted-rag-benchmark-v2",
+            "generation_job_id": "benchmark-job-formal",
+            "generator_model_id": "test-generator",
+            "target_checksum": "d" * 64,
+            "source_summary_hash": "e" * 64,
+            "evidence_hash": "f" * 64,
+            "blueprint_hash": "1" * 64,
+            "prompt_contract_hash": "2" * 64,
+            "seed": 7,
+            "repair_used": False,
+            "generation_attempts": [
+                {"attempt": "initial", "error_code": None, "diagnostics": {}}
+            ],
+        },
+        "calibration": {},
+        "corpus_snapshot": corpus,
+    }
+    snapshot["checksum"] = _published_gold_checksum(snapshot)
+    return snapshot
+
+
+def test_formal_evidence_fails_closed_on_tampering_or_legacy_contract() -> None:
+    snapshot = _formal_gold_snapshot()
+    qualified = qualify_formal_evidence(snapshot)
+    assert qualified["qualified"] is True
+    assert qualified["status"] == "qualified"
+
+    snapshot["cases"][0]["query"] = "tampered after review"
+    tampered = qualify_formal_evidence(snapshot)
+    assert tampered["qualified"] is False
+    assert {
+        check["id"] for check in tampered["checks"] if not check["passed"]
+    } >= {"published_checksum", "trusted_case_reviews"}
+
+    provenance_tampered = _formal_gold_snapshot()
+    provenance_tampered["provenance"]["prompt_contract_hash"] = "0" * 64
+    assert qualify_formal_evidence(provenance_tampered)["qualified"] is False
+
+    legacy = _formal_gold_snapshot()
+    legacy["benchmark_contract_version"] = "rag-gold-v1"
+    legacy["checksum"] = _published_gold_checksum(legacy)
+    rejected = qualify_formal_evidence(legacy)
+    assert rejected["qualified"] is False
+    assert next(
+        check for check in rejected["checks"] if check["id"] == "gold_contract_v2"
+    )["passed"] is False
+
+
+def test_formal_evidence_rejects_coverage_imbalance_and_near_duplicates() -> None:
+    imbalanced = _formal_gold_snapshot()
+    for case in imbalanced["cases"][:30]:
+        case["targeting"]["query_type"] = "factual_lookup"
+        case["review_evidence"]["case_checksum"] = _case_review_checksum(case)
+    imbalanced["checksum"] = _published_gold_checksum(imbalanced)
+    qualification = qualify_formal_evidence(imbalanced)
+    assert qualification["qualified"] is False
+    assert next(
+        check
+        for check in qualification["checks"]
+        if check["id"] == "positive_query_type_balance"
+    )["passed"] is False
+
+    duplicated = _formal_gold_snapshot()
+    duplicated["cases"][0]["query"] = (
+        "one two three four five six seven eight nine alpha"
+    )
+    duplicated["cases"][1]["query"] = (
+        "one two three four five six seven eight nine beta"
+    )
+    for case in duplicated["cases"][:2]:
+        case["review_evidence"]["case_checksum"] = _case_review_checksum(case)
+    duplicated["checksum"] = _published_gold_checksum(duplicated)
+    qualification = qualify_formal_evidence(duplicated)
+    assert qualification["qualified"] is False
+    assert next(
+        check for check in qualification["checks"] if check["id"] == "unique_queries"
+    )["passed"] is False
+
+
+def test_leakage_warning_approval_requires_a_human_reason(tmp_path: Path) -> None:
+    store = KnowledgeEvaluationStore(tmp_path / "evaluation.json")
+    evaluation_set = store.create_generated_set(
+        "kb-a",
+        "leakage warning",
+        "",
+        cases=[
+            {
+                "query": "semantic query",
+                "expected_refs": [
+                    {
+                        "document_id": "doc-a",
+                        "source_block_id": "block-a",
+                        "match_mode": "source_block",
+                    }
+                ],
+                "targeting": {
+                    "query_type": "paraphrase",
+                    "locale": "en",
+                    "leakage_warning": {"threshold": 12},
+                },
+            }
+        ],
+        provenance={},
+        coverage={},
+        calibration={"status": "calibrated", "dataset_revision": 1},
+    )
+    with pytest.raises(ValueError, match="explicit human review reason"):
+        store.review_case(
+            evaluation_set["eval_set_id"],
+            evaluation_set["cases"][0]["case_id"],
+            expected_revision=1,
+            decision="approved",
+            reason="",
+            reviewer={"tenant_id": "local", "role": "provider_admin"},
+        )
+
+
+def test_formal_admission_requires_same_corpus_and_complete_target_identity() -> None:
+    snapshot = _formal_gold_snapshot()
+    corpus_checksum = snapshot["corpus_snapshot"]["checksum"]
+
+    def target(version_id: str, fingerprint: str) -> dict:
+        return {
+            "target_id": version_id,
+            "version_id": version_id,
+            "retrieval": {},
+            "corpus_snapshot_hash": corpus_checksum,
+            "version_evidence": {
+                "schema_version": "rag-version-evidence-v1",
+                "version_id": version_id,
+                "version_fingerprint": fingerprint,
+                "configuration_fingerprint": fingerprint[::-1],
+                "processor": {
+                    "mode": "general",
+                    "vision_enabled": False,
+                    "fingerprint": "c" * 64,
+                },
+                "embedding": {
+                    "effective": {
+                        "provider": "local",
+                        "model": "hash-embedding",
+                        "dimension": 128,
+                    }
+                },
+                "retrieval": {"mode": "hybrid"},
+            },
+        }
+
+    baseline = target("pipeline-baseline", "a" * 64)
+    candidate = target("pipeline-candidate", "b" * 64)
+    admitted = validate_formal_run_admission(
+        snapshot,
+        [baseline, candidate],
+        baseline_version_id="pipeline-baseline",
+    )
+    assert admitted["comparability"]["comparable"] is True
+    assert admitted["execution_manifest"]["contract_version"] == "rag-eval-v2"
+    assert len(admitted["execution_manifest"]["execution_seed"]) == 64
+    assert admitted["execution_manifest"]["targets"][0]["processor"]["mode"] == "general"
+    assert "rerank" in admitted["execution_manifest"]["targets"][0]
+
+    candidate["retrieval"] = {"top_k": 3}
+    with pytest.raises(ValueError, match="per-run retrieval overrides"):
+        validate_formal_run_admission(
+            snapshot,
+            [baseline, candidate],
+            baseline_version_id="pipeline-baseline",
+        )
+    candidate["retrieval"] = {}
+
+    candidate["corpus_snapshot_hash"] = "f" * 64
+    with pytest.raises(ValueError, match="same immutable corpus"):
+        validate_formal_run_admission(
+            snapshot,
+            [baseline, candidate],
+            baseline_version_id="pipeline-baseline",
+        )
+
+    candidate = target("pipeline-candidate", "b" * 64)
+    candidate["version_evidence"].pop("configuration_fingerprint")
+    with pytest.raises(ValueError, match="target identity"):
+        validate_formal_run_admission(
+            snapshot,
+            [baseline, candidate],
+            baseline_version_id="pipeline-baseline",
+        )
 
 
 def test_promotion_evidence_requires_30_stable_positives_and_12_hard_negatives() -> None:
@@ -381,6 +998,60 @@ def test_source_block_and_no_result_metrics_are_aggregated_separately() -> None:
     assert aggregate["false_positive_rate"] == 0.5
 
 
+def test_failed_cases_remain_in_quality_and_latency_denominators() -> None:
+    positive = evaluate_retrieval_case(
+        [{"chunk_id": "answer", "source_document_id": "doc-a", "score": 0.9}],
+        [{"document_id": "doc-a"}],
+        ks=[1, 5, 10],
+        latency_ms=10.0,
+    )
+    negative = evaluate_retrieval_case(
+        [],
+        [],
+        ks=[1, 5, 10],
+        expected_no_result=True,
+        latency_ms=20.0,
+    )
+    failed_positive = {
+        "status": "failed",
+        "metrics": {},
+        "latency_ms": 2_000.0,
+        "expected_no_result": False,
+        "no_result": True,
+        "warning_count": 0,
+    }
+    failed_negative = {
+        "status": "failed",
+        "metrics": {},
+        "latency_ms": 3_000.0,
+        "expected_no_result": True,
+        "no_result": True,
+        "warning_count": 0,
+    }
+
+    aggregate = aggregate_target_metrics(
+        [positive, failed_positive, negative, failed_negative],
+        ks=[1, 5, 10],
+    )
+
+    assert aggregate["case_count"] == 4
+    assert aggregate["completed_case_count"] == 2
+    assert aggregate["failed_case_count"] == 2
+    assert aggregate["positive_case_count"] == 2
+    assert aggregate["completed_positive_case_count"] == 1
+    assert aggregate["failed_positive_case_count"] == 1
+    assert aggregate["no_result_case_count"] == 2
+    assert aggregate["completed_no_result_case_count"] == 1
+    assert aggregate["failed_no_result_case_count"] == 1
+    assert aggregate["positive_quality_denominator"] == 2
+    assert aggregate["no_result_quality_denominator"] == 2
+    assert aggregate["recall_at_5"] == 0.5
+    assert aggregate["citation_precision_at_5"] == 0.1
+    assert aggregate["no_result_accuracy"] == 0.5
+    assert aggregate["false_positive_rate"] == 0.5
+    assert aggregate["p95_latency_ms"] == 3_000.0
+
+
 def test_default_gate_rejects_false_positive_no_result_behavior() -> None:
     positive = evaluate_retrieval_case(
         [{"chunk_id": "answer", "source_document_id": "doc-a", "score": 0.9}],
@@ -488,7 +1159,12 @@ def test_promotion_gate_does_not_penalize_correct_no_result_abstention() -> None
     assert gate["passed"] is True
 
 
-def test_evaluation_store_persists_revisions_runs_and_recovery(tmp_path: Path) -> None:
+def test_evaluation_store_persists_revisions_runs_and_recovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = [1_000.0]
+    monkeypatch.setattr("server.rag.evaluation.time.time", lambda: clock[0])
     path = tmp_path / "evaluations.json"
     store = KnowledgeEvaluationStore(path)
     evaluation_set = store.create_set("kb-a", "Regression set")
@@ -517,11 +1193,108 @@ def test_evaluation_store_persists_revisions_runs_and_recovery(tmp_path: Path) -
         gate_policy=store.get_gate_policy("kb-a"),
     )
     assert store.claim_next_run()["status"] == "running"
+    case_id = updated["cases"][0]["case_id"]
+    assert store.claim_case_slot(run["run_id"], "version-a", case_id) is True
+    clock[0] += 2.0
 
     reloaded = KnowledgeEvaluationStore(path)
     assert reloaded.get_set(evaluation_set["eval_set_id"])["cases"][0]["query"].startswith("Where")
     assert reloaded.recover_runs() == 1
-    assert reloaded.get_run(run["run_id"])["status"] == "queued"
+    recovered = reloaded.get_run(run["run_id"])
+    assert recovered["status"] == "queued"
+    interrupted = recovered["case_results"]["version-a"][case_id]
+    assert interrupted["status"] == "failed"
+    assert interrupted["error"] == "Interrupted evaluation call was not retried."
+    assert interrupted["latency_ms"] == 2_000.0
+    assert recovered["inflight_slots"] == {}
+
+
+def test_formal_execution_slots_are_deterministic_and_case_paired() -> None:
+    run = {
+        "run_mode": "formal",
+        "execution_manifest": {"execution_seed": "a" * 64},
+        "targets": [
+            {"target_id": "baseline"},
+            {"target_id": "candidate"},
+        ],
+        "eval_set_snapshot": {
+            "cases": [
+                {"case_id": "case-a"},
+                {"case_id": "case-b"},
+                {"case_id": "case-c"},
+            ]
+        },
+    }
+    first = _execution_slots(run)
+    second = _execution_slots(run)
+
+    assert first == second
+    assert len(first) == 6
+    for index in range(0, len(first), 2):
+        assert first[index][1]["case_id"] == first[index + 1][1]["case_id"]
+        assert {
+            first[index][0]["target_id"], first[index + 1][0]["target_id"]
+        } == {"baseline", "candidate"}
+
+
+def test_paired_confidence_gate_rejects_uncertain_non_inferiority() -> None:
+    cases = [
+        {
+            "case_id": f"case-{index}",
+            "expected_no_result": index >= 30,
+            "targeting": {"locale": "zh" if index % 2 == 0 else "en"},
+        }
+        for index in range(42)
+    ]
+
+    def result(case: dict, score: float) -> dict:
+        return {
+            "case_id": case["case_id"],
+            "status": "completed",
+            "expected_no_result": case["expected_no_result"],
+            "metrics": (
+                {"no_result_accuracy": score}
+                if case["expected_no_result"]
+                else {"recall_at_5": score}
+            ),
+        }
+
+    baseline = [result(case, 1.0) for case in cases]
+    candidate = [result(case, 0.0 if index == 0 else 1.0) for index, case in enumerate(cases)]
+    first = paired_primary_confidence_report(
+        baseline, candidate, cases=cases, seed="b" * 64
+    )
+    second = paired_primary_confidence_report(
+        baseline, candidate, cases=cases, seed="b" * 64
+    )
+    assert first == second
+    assert first["point_delta"] >= -0.03
+    assert first["confidence_interval"]["lower"] < -0.03
+    assert first["passed"] is False
+
+    metrics = {
+        "recall_at_5": 1.0,
+        "mrr_at_10": 1.0,
+        "citation_precision_at_5": 0.2,
+        "citation_coverage": 1.0,
+        "no_result_accuracy": 1.0,
+        "positive_no_result_rate": 0.0,
+        "p95_latency_ms": 10.0,
+        "error_count": 0,
+    }
+    gate = evaluate_promotion_gate(
+        metrics,
+        baseline=metrics,
+        evidence_qualification={"qualified": True, "status": "qualified"},
+        paired_confidence=first,
+        comparability={"comparable": True, "same_corpus": True},
+        run_mode="formal",
+    )
+    assert gate["passed"] is False
+    paired_check = next(
+        check for check in gate["checks"] if check["id"] == "paired_non_inferiority"
+    )
+    assert paired_check["passed"] is False
 
 
 def test_evaluation_set_versions_are_immutable_and_pin_run_snapshot(tmp_path: Path) -> None:
@@ -711,6 +1484,8 @@ async def test_evaluation_api_runs_versions_and_enforces_required_gate(
     evidence = candidate["version_evidence"]
     assert evidence["version_id"] == candidate_version
     assert evidence["version_fingerprint"]
+    assert evidence["processor"]["mode"] == "general"
+    assert len(evidence["processor"]["fingerprint"]) == 64
     assert evidence["embedding"]["effective"]["provider"] == "hash"
     assert evidence["embedding"]["effective"]["model"] == "deterministic-hash-v1"
     receipt = candidate["case_results"][0]["retrieval_receipt"]

--- a/server/tests/test_rag_pipeline_execute.py
+++ b/server/tests/test_rag_pipeline_execute.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import io
+import hashlib
+import json
 from pathlib import Path
 
 import httpx
@@ -14,8 +16,12 @@ from server.rag.api import (
     set_rag_service_for_tests,
 )
 from server.rag.embedder import EmbeddingClient
-from server.rag.pipeline_executor import KnowledgePipelineExecutor
-from server.rag.rag_service import KnowledgeWriteProposalConflictError, RagService
+from server.rag.pipeline_executor import KnowledgePipelineExecutor, _source_block_hash
+from server.rag.rag_service import (
+    KnowledgeWriteProposalConflictError,
+    PipelineJobStateError,
+    RagService,
+)
 from server.rag.vector_store import LocalJsonVectorStore
 from server.xpert_runtime.run_registry import RunRegistry
 from server.xperts.api import set_xpert_context_store_for_tests
@@ -95,6 +101,60 @@ async def execute_current_draft(
     completed = (await client.get(f"/api/rag/pipeline/jobs/{created['job_id']}")).json()
     assert completed["status"] == "succeeded"
     return completed
+
+
+def test_source_block_hash_preserves_exact_corpus_text() -> None:
+    text = "  stable evidence block\n"
+    canonical = json.dumps(
+        text,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+    assert _source_block_hash(text) == hashlib.sha256(canonical).hexdigest()
+    assert _source_block_hash(text) != hashlib.sha256(text.encode("utf-8")).hexdigest()
+    assert _source_block_hash(" \n\t") is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_corpus_snapshot_binds_artifact_and_index(
+    pipeline_runtime,
+) -> None:
+    client, service, executor, _, _ = pipeline_runtime
+    kb_id = await create_kb(client, "corpus identity")
+    document_id = await upload_text(
+        client,
+        kb_id,
+        "identity.txt",
+        "Immutable corpus evidence binds this exact source block.",
+    )
+    job = await execute_current_draft(
+        client,
+        executor,
+        kb_id,
+        source_document_ids=[document_id],
+    )
+    version_id = str(job["candidate_version_id"])
+
+    snapshot = service.pipeline_corpus_snapshot(version_id)
+    assert snapshot["contract_version"] == "rag-corpus-snapshot-v1"
+    assert len(snapshot["documents"]) == 1
+    assert len(snapshot["documents"][0]["source_blocks"]) == 1
+    assert len(snapshot["checksum"]) == 64
+    assert service.pipeline_corpus_snapshot(version_id) == snapshot
+
+    stored_job = service.get_pipeline_job(str(job["job_id"]))
+    artifact_path = service._pipeline_processed_path(  # noqa: SLF001
+        stored_job["document_results"][0]["artifact_key"]
+    )
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    artifact["processed_document"]["blocks"][0]["text"] = "tampered"
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    with pytest.raises(PipelineJobStateError, match="source-block index is inconsistent"):
+        service.pipeline_corpus_snapshot(version_id)
 
 
 def test_knowledge_write_proposal_persists_deduplicates_and_checks_revision(


### PR DESCRIPTION
## 摘要

本 PR 收口 RAG 第三轮可信评测与 Formal 晋级门禁实现，重点修复固定分母、配对可比执行、Gold 与语料证据谱系、人工审核及失败恢复。默认保持 Draft；本 PR 不代表真实产品晋级门禁已经通过。

## 关键变更

- Formal 质量指标使用固定预期分母：失败正负例均按 0 计入质量指标，失败耗时进入延迟分布，并显式记录 expected、completed、failed 与 quality denominator。
- 使用 SHA-256 Seed 生成确定性的 case/target 配对交错顺序，并增加按类型和语言分层、10000 次 bootstrap 的 95% CI 非劣性门禁。
- Formal 强制 rag-gold-v2、恰好 baseline 与 candidate、相同 corpus snapshot、完整执行指纹，拒绝请求级检索覆盖参数；历史证据继续只作 diagnostic/legacy 展示。
- 增加不可变 source-block corpus snapshot 与内容哈希；索引同时持久化 source block hash，旧索引缺失身份时 fail closed。
- 42 条 Gold 新生成结果统一进入 pending；发布依赖逐条人工审核、来源绑定、反泄漏、去重、覆盖与困难负例质量检查。
- 增加 RAG 范围的 HttpOnly、SameSite Strict 管理员会话，以及审核批准/拒绝 UI；编辑已审用例会清除旧审核状态。
- 运行崩溃恢复把进行中调用记为失败并计入实际耗时，不自动重试。
- 同步更新 Benchmark 与 RAG 运维文档。

## 验证证据

- 后端 Formal/Gold/Managed Embedding/Managed Rerank/Workload/Admin 交叉回归：115 passed。
- RAG/Knowledge/Benchmark 定向回归：330 passed，4543 deselected。
- 前端全测：120 files、716 tests passed。
- RagPage 定向测试：14 passed。
- 前端生产构建：通过；保留既有大 chunk 警告。
- Router p95 精确复测：1 passed。
- 提交前 diff check、冲突标记扫描、敏感模式扫描：通过，0 命中。

## 已知限制与验收边界

- 未调用真实 Provider 额度，未运行新的真实 Formal，未物化或激活候选，未部署或迁移共享数据。
- 因此本 PR 证明的是评测合同与门禁实现，不证明候选已达到真实晋级指标。
- 尚无单次全量后端全绿记录：一次出现 Windows/宿主资源导致 PDF 线程本地存储分配失败，另一次出现 Router 650 候选 p95 抖动；两个精确用例随后均独立通过，相关定向套件全绿。CI 结果应作为合并前的最终全量基线。
- 回滚方式为撤销本提交；无数据库或索引迁移，无需数据回滚。