### PR TITLE
fix: 补齐 RAG V3 索引身份与后端就绪合同

### DIFF
--- a/client/src/pages/RagPage.tsx
+++ b/client/src/pages/RagPage.tsx
@@ -119,6 +119,8 @@ interface PipelineDraftResponse {
   index_schema_version: number;
   embedding_profile: Record<string, unknown>;
   retrieval_profile: Record<string, unknown>;
+  index_contract?: Record<string, unknown>;
+  vector_backend_readiness?: VectorBackendReadiness;
   stages: PipelineDraftStage[];
   stage_count: number;
 }
@@ -208,7 +210,7 @@ interface RetrievalCapabilities {
   version: string;
   index_schema_version: number;
   modes: string[];
-  vector: { available: boolean; backend: string };
+  vector: VectorBackendReadiness & { available: boolean; backend: string };
   fulltext: { available: boolean; backend: string };
   embedding: { provider: string; model: string; dimension: number; degraded: boolean };
   rerank: {
@@ -217,6 +219,14 @@ interface RetrievalCapabilities {
     api_model: string;
     llm_model: string;
   };
+}
+
+interface VectorBackendReadiness {
+  configured_backend: string;
+  effective_backend: string;
+  ready: boolean;
+  reason_code: string | null;
+  distance_contract: string;
 }
 
 interface PipelineJobStage {
@@ -291,6 +301,8 @@ interface PipelineVersion {
   retrieval_profile?: Record<string, unknown>;
   vector_index_ready?: boolean;
   lexical_index_ready?: boolean;
+  index_contract?: Record<string, unknown>;
+  vector_backend_readiness?: VectorBackendReadiness;
   created_at: number;
   activated_at: number | null;
 }
@@ -681,6 +693,12 @@ function formatConfigValue(value: unknown) {
 
 function isUnknownRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function pipelineIndexUsesVector(indexContract?: Record<string, unknown>): boolean | null {
+  const vector = indexContract?.vector;
+  if (!isUnknownRecord(vector) || typeof vector.required !== "boolean") return null;
+  return vector.required;
 }
 
 export async function readError(response: Response) {
@@ -2432,7 +2450,7 @@ export default function RagPage() {
                             <div className="mt-4 border-t border-white/10 pt-4">
                               <div className="flex items-center justify-between gap-3">
                                 <p className="text-xs font-semibold text-white">分块与分段</p>
-                                <span className="text-[10px] uppercase text-slate-500">schema v{pipelineDraft?.index_schema_version ?? 2}</span>
+                                <span className="text-[10px] uppercase text-slate-500">schema v{pipelineDraft?.index_schema_version ?? 3}</span>
                               </div>
                               <div className="mt-3 grid gap-3 sm:grid-cols-2">
                                 <label className="block">
@@ -2478,22 +2496,29 @@ export default function RagPage() {
                                 </label>
                               </div>
                               {pipelineDraft ? (
-                                <p
-                                  className={`mt-2 text-[11px] leading-5 ${
-                                    effectiveEmbeddingProfile.ready === false
-                                      ? "text-amber-200"
-                                      : "text-slate-500"
-                                  }`}
-                                >
-                                  请求：{String(requestedEmbeddingProfile.provider || "未设置")} / {String(requestedEmbeddingProfile.model || "未设置")}
-                                  {" · "}
-                                  生效：{String(effectiveEmbeddingProfile.provider || "未设置")} / {String(effectiveEmbeddingProfile.model || "未设置")}
-                                  {effectiveEmbeddingProfile.ready === false
-                                    ? "（不可用，预检与执行将被阻止）"
-                                    : effectiveEmbeddingProfile.degraded
-                                      ? "（显式降级模式）"
-                                      : ""}
-                                </p>
+                                <div className="mt-2 space-y-1 text-[11px] leading-5">
+                                  <p className={effectiveEmbeddingProfile.ready === false ? "text-amber-200" : "text-slate-500"}>
+                                    请求：{String(requestedEmbeddingProfile.provider || "未设置")} / {String(requestedEmbeddingProfile.model || "未设置")}
+                                    {" · "}
+                                    生效：{String(effectiveEmbeddingProfile.provider || "未设置")} / {String(effectiveEmbeddingProfile.model || "未设置")}
+                                    {effectiveEmbeddingProfile.ready === false
+                                      ? "（不可用，预检与执行将被阻止）"
+                                      : effectiveEmbeddingProfile.degraded
+                                        ? "（显式降级模式）"
+                                        : ""}
+                                  </p>
+                                  {pipelineIndexUsesVector(pipelineDraft.index_contract) === false ? (
+                                    <p className="text-slate-500">向量后端：不适用（fulltext-only）</p>
+                                  ) : pipelineDraft.vector_backend_readiness ? (
+                                    <p className={pipelineDraft.vector_backend_readiness.ready ? "text-slate-500" : "text-amber-200"}>
+                                      向量后端：{pipelineDraft.vector_backend_readiness.configured_backend} → {pipelineDraft.vector_backend_readiness.effective_backend}
+                                      {" · "}{pipelineDraft.vector_backend_readiness.distance_contract}
+                                      {pipelineDraft.vector_backend_readiness.ready
+                                        ? ""
+                                        : `（不可用：${pipelineDraft.vector_backend_readiness.reason_code || "unknown"}）`}
+                                    </p>
+                                  ) : null}
+                                </div>
                               ) : null}
 
                               {pipelineDraftEdits.strategy === "recursive_character" ? (
@@ -2881,8 +2906,13 @@ export default function RagPage() {
                                         processor {String(versionItem.processor_profile?.mode ?? "general")} · {versionItem.block_count ?? 0} blocks · QA {versionItem.qa_count ?? 0} · Summary {versionItem.summary_count ?? 0}
                                       </p>
                                       <p className="mt-1 text-[10px] text-slate-500">
-                                        index schema v{versionItem.index_schema_version ?? 1} · vector {versionItem.vector_index_ready === false ? "incomplete" : "ready"} · fulltext {versionItem.lexical_index_ready ? "ready" : "legacy/off"}
+                                        index schema v{versionItem.index_schema_version ?? 1} · vector {pipelineIndexUsesVector(versionItem.index_contract) === false ? "not applicable" : versionItem.vector_index_ready === false ? "incomplete" : "ready"} · fulltext {versionItem.lexical_index_ready ? "ready" : "legacy/off"}
                                       </p>
+                                      {pipelineIndexUsesVector(versionItem.index_contract) !== false && versionItem.vector_backend_readiness ? (
+                                        <p className="mt-1 text-[10px] text-slate-500">
+                                          backend {versionItem.vector_backend_readiness.configured_backend} → {versionItem.vector_backend_readiness.effective_backend} · {versionItem.vector_backend_readiness.distance_contract}
+                                        </p>
+                                      ) : null}
                                     </div>
                                     <div className="flex gap-1.5">
                                       <button

--- a/docs/RAG_INTEGRATION.md
+++ b/docs/RAG_INTEGRATION.md
@@ -9,6 +9,24 @@
 > Promotion Gate。下方按日期保留的段落是增量记录；较早段落中的“planned”
 > 只代表当时状态。
 
+## 2026-08-26 P0：V3 索引身份与后端就绪合同
+
+新建 Knowledge Pipeline 统一使用 `index_schema_version=3`。Vector/Hybrid 候选的
+namespace 固定绑定 pipeline version、Embedding space fingerprint、实际向量维度和
+`cosine_v1` 距离合同；构建与查询必须使用相同身份。Chroma collection 显式使用 cosine，
+对外统一返回 `clamp(1 - cosine_distance, 0, 1)`；只有显式设置
+`RAG_VECTOR_STORE=local` 才会使用 LocalJSON，且采用相同 cosine score 合同。
+
+Chroma 缺失、初始化失败、collection identity 冲突或维度不符时，能力接口会返回脱敏的
+`configured_backend / effective_backend / ready / reason_code`，Vector/Hybrid 构建和查询
+fail-closed，不再静默创建 LocalJSON 索引。Pipeline Draft 与 Version 同时返回
+`index_contract` 和 `vector_backend_readiness`，不包含 endpoint、路径或凭据。
+
+Full-text-only V3 流水线将 Embedding 标记为 `not_applicable`：构建和查询均不调用
+Embedding，也不创建 vector namespace。所需 FTS5 namespace 缺失时返回 HTTP 409 和
+`rag_fulltext_index_unavailable`，不会切换到 Vector。历史 V2 collection 和活动版本保持
+只读查询兼容，但不能作为新 base 重建，也不能新激活或晋级；本轮不迁移或改写历史索引。
+
 ## 2026-08-26 P0：可信 Gold 与 Formal 评测合同
 
 知识评测新增 `diagnostic | formal` 两种运行模式。默认 `diagnostic` 保持旧记录、子集和
@@ -448,7 +466,7 @@ FastAPI RAG Router
         +--> document_parser.py  解析 TXT / Markdown / PDF
         +--> splitter.py         本地递归字符 / 父子分段与字符偏移
         +--> embedder.py         OpenAI-compatible Embedding API；显式 hash 仅用于本地/CI
-        +--> vector_store.py     ChromaDB 持久化，缺失依赖时 LocalJsonVectorStore fallback
+        +--> vector_store.py     ChromaDB 持久化；LocalJSON 仅在显式配置时启用
         +--> lexical_store.py    SQLite FTS5 与中英文规范化词元
         +--> reranker.py         专用 Rerank API / LLM JSON fail-open
         +--> OpenRouter Chat     生成 RAG 回答，缺失 key 时抽取式 fallback
@@ -458,7 +476,7 @@ FastAPI RAG Router
 
 ```text
 server/rag/uploads/       # 原始上传文件
-server/rag/storage/       # metadata.json、本地 fallback 索引
+server/rag/storage/       # metadata.json；本地向量索引仅在显式 local 配置时使用
 server/rag/storage/chroma_db 或 CHROMA_DB_PATH # ChromaDB 持久化目录
 ```
 

--- a/server/benchmarks/knowledge_executor.py
+++ b/server/benchmarks/knowledge_executor.py
@@ -319,6 +319,15 @@ class KnowledgeBenchmarkProvisioner:
         raw_cases: list[dict[str, Any]],
         document_ids: dict[str, str],
     ) -> list[dict[str, Any]]:
+        version = self.rag_service.get_pipeline_version(version_id)
+        retrieval_mode = str(
+            (version.get("retrieval_profile") or {}).get("mode") or "vector"
+        )
+        chunk_store = (
+            self.rag_service.lexical_store
+            if retrieval_mode == "fulltext"
+            else self.rag_service.vector_store
+        )
         resolved: list[dict[str, Any]] = []
         for raw_case in raw_cases:
             references: list[dict[str, Any]] = []
@@ -330,7 +339,7 @@ class KnowledgeBenchmarkProvisioner:
                         f"Gold document mapping is missing for {document_key}."
                     )
                 phrase = str(reference.get("anchor_phrase") or "")
-                chunks = self.rag_service.vector_store.list_document_chunks(
+                chunks = chunk_store.list_document_chunks(
                     f"{version_id}_{document_id}"
                 )
                 normalized_phrase = _normalize_anchor_text(phrase)

--- a/server/rag/api.py
+++ b/server/rag/api.py
@@ -40,6 +40,7 @@ from .rag_service import (
     PipelineJobNotFoundError,
     PipelineJobStateError,
     PipelineVersionNotFoundError,
+    RagRetrievalUnavailableError,
     ManagedEmbeddingRouteError,
     ManagedRagGenerationRouteError,
     ManagedRagRerankRouteError,
@@ -349,9 +350,11 @@ class PipelineDraftResponse(BaseModel):
     version: int
     updated_at: float
     editable: bool
-    index_schema_version: int = 2
+    index_schema_version: int = 3
     embedding_profile: dict[str, Any] = Field(default_factory=dict)
     retrieval_profile: dict[str, Any] = Field(default_factory=dict)
+    index_contract: dict[str, Any] = Field(default_factory=dict)
+    vector_backend_readiness: dict[str, Any] = Field(default_factory=dict)
     stages: list[PipelineDraftStagePayload]
     stage_count: int
 
@@ -613,6 +616,8 @@ class PipelineJobPayload(BaseModel):
     embedding_execution_mode: str = "legacy"
     embedding_space_fingerprint: str = ""
     provider_route_receipts: dict[str, Any] | None = None
+    index_contract: dict[str, Any] = Field(default_factory=dict)
+    vector_backend_readiness: dict[str, Any] = Field(default_factory=dict)
     created_at: float
     updated_at: float
     started_at: float | None = None
@@ -652,6 +657,8 @@ class PipelineVersionPayload(BaseModel):
     retrieval_profile: dict[str, Any] = Field(default_factory=dict)
     vector_index_ready: bool = True
     lexical_index_ready: bool = False
+    index_contract: dict[str, Any] = Field(default_factory=dict)
+    vector_backend_readiness: dict[str, Any] = Field(default_factory=dict)
     vision_profile: dict[str, Any] = Field(default_factory=dict)
     vision_page_count: int = 0
     vision_processed_page_count: int = 0
@@ -1400,9 +1407,13 @@ async def get_pipeline_draft(kb_id: str) -> PipelineDraftResponse:
             version=int(draft["version"]),
             updated_at=float(draft["updated_at"]),
             editable=bool(draft["editable"]),
-            index_schema_version=int(draft.get("index_schema_version", 2)),
+            index_schema_version=int(draft.get("index_schema_version", 3)),
             embedding_profile=dict(draft.get("embedding_profile") or {}),
             retrieval_profile=dict(draft.get("retrieval_profile") or {}),
+            index_contract=dict(draft.get("index_contract") or {}),
+            vector_backend_readiness=dict(
+                draft.get("vector_backend_readiness") or {}
+            ),
             stages=stages,
             stage_count=len(stages),
         )
@@ -1527,6 +1538,11 @@ async def execute_pipeline_graph(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except (PipelineJobStateError, PipelineGraphRevisionError) as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except RagRetrievalUnavailableError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
     except PipelineGraphValidationError as exc:
         raise HTTPException(
             status_code=400,
@@ -1568,9 +1584,13 @@ async def update_pipeline_draft(
             version=int(draft["version"]),
             updated_at=float(draft["updated_at"]),
             editable=bool(draft["editable"]),
-            index_schema_version=int(draft.get("index_schema_version", 2)),
+            index_schema_version=int(draft.get("index_schema_version", 3)),
             embedding_profile=dict(draft.get("embedding_profile") or {}),
             retrieval_profile=dict(draft.get("retrieval_profile") or {}),
+            index_contract=dict(draft.get("index_contract") or {}),
+            vector_backend_readiness=dict(
+                draft.get("vector_backend_readiness") or {}
+            ),
             stages=stages,
             stage_count=len(stages),
         )
@@ -1677,6 +1697,11 @@ async def execute_pipeline_draft(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except PipelineJobStateError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except RagRetrievalUnavailableError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
     except PipelineDraftValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
@@ -2349,6 +2374,11 @@ async def query_pipeline_version(
         return PipelineVersionQueryResponse.model_validate(result)
     except PipelineVersionNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RagRetrievalUnavailableError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
     except ManagedEmbeddingRouteError as exc:
         raise HTTPException(
             status_code=502,
@@ -2429,7 +2459,10 @@ async def promote_pipeline_version(
             evaluation_run_id=payload.evaluation_run_id,
             require_passed_run=True,
         )
-        version = get_rag_service().activate_pipeline_version(version_id)
+        version = get_rag_service().activate_pipeline_version(
+            version_id,
+            promotion=True,
+        )
         await get_pipeline_executor().record_job_event(
             str(stored["job_id"]),
             event_type="knowledge_pipeline.version_promoted",
@@ -2470,6 +2503,11 @@ async def create_pipeline_citations(payload: CitationAnchorRequest) -> CitationA
         )
     except KnowledgeBaseNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RagRetrievalUnavailableError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
     except ManagedEmbeddingRouteError as exc:
         raise HTTPException(
             status_code=502,
@@ -2508,6 +2546,11 @@ async def query_knowledge_base(payload: RagQueryRequest) -> RagQueryResponse:
         return RagQueryResponse.model_validate(result)
     except KnowledgeBaseNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RagRetrievalUnavailableError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
     except ManagedEmbeddingRouteError as exc:
         raise HTTPException(
             status_code=502,

--- a/server/rag/lexical_store.py
+++ b/server/rag/lexical_store.py
@@ -198,6 +198,48 @@ class SqliteLexicalStore:
             ).fetchone()
         return int(row[0] if row else 0)
 
+    def list_document_chunks(self, doc_id: str) -> list[LexicalChunk]:
+        """List stored lexical chunks without exposing FTS implementation details."""
+
+        with self._lock, self._connect() as connection:
+            rows = connection.execute(
+                "SELECT * FROM rag_chunks WHERE doc_id = ? ORDER BY chunk_index, chunk_id",
+                (doc_id,),
+            ).fetchall()
+        return [self._row_to_chunk(row) for row in rows]
+
+    def get_chunk(self, namespace: str, chunk_id: str) -> LexicalChunk | None:
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM rag_chunks WHERE namespace = ? AND chunk_id = ?",
+                (namespace, chunk_id),
+            ).fetchone()
+        return self._row_to_chunk(row) if row is not None else None
+
+    @staticmethod
+    def _row_to_chunk(row: sqlite3.Row) -> LexicalChunk:
+        return LexicalChunk(
+            chunk_id=str(row["chunk_id"]),
+            namespace=str(row["namespace"]),
+            doc_id=str(row["doc_id"]),
+            document_name=str(row["document_name"]),
+            text=str(row["text"]),
+            chunk_index=int(row["chunk_index"]),
+            parent_chunk_id=str(row["parent_chunk_id"]) if row["parent_chunk_id"] else None,
+            parent_text=str(row["parent_text"]) if row["parent_text"] else None,
+            chunk_type=str(row["chunk_type"] or "standard"),
+            start_char=int(row["start_char"] or 0),
+            end_char=int(row["end_char"] or 0),
+            page_number=int(row["page_number"]) if row["page_number"] else None,
+            slide=int(row["slide"]) if row["slide"] else None,
+            heading_path=decode_heading_path(row["heading_path_json"]),
+            sheet=str(row["sheet"]) if row["sheet"] else None,
+            row_range=str(row["row_range"]) if row["row_range"] else None,
+            visual_kind=str(row["visual_kind"]) if row["visual_kind"] else None,
+            source_block_id=str(row["source_block_id"]) if row["source_block_id"] else None,
+            source_block_hash=str(row["source_block_hash"]) if row["source_block_hash"] else None,
+        )
+
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(self.path, timeout=10)
         connection.row_factory = sqlite3.Row

--- a/server/rag/pipeline_executor.py
+++ b/server/rag/pipeline_executor.py
@@ -156,7 +156,8 @@ class KnowledgePipelineExecutor:
                 summary=f"Processing {len(job['sources'])} source files.",
                 metadata={"attempt": job["attempt"], "source_count": len(job["sources"])},
             )
-            self.service.vector_store.delete_knowledge_base(namespace)
+            if self._job_uses_vector(job):
+                self.service.vector_store.delete_knowledge_base(namespace)
             self.service.lexical_store.delete_namespace(namespace)
 
             await self._stage(job_id, "load", self._load_sources)
@@ -164,6 +165,9 @@ class KnowledgePipelineExecutor:
             parsed = await self._stage(job_id, "process", self._parse_sources)
             chunks = await self._stage(job_id, "chunk", self._chunk_sources, parsed)
             embeddings = await self._stage(job_id, "embed", self._embed_chunks, chunks)
+            namespace = str(
+                self.service.get_pipeline_job(job_id)["candidate_namespace"]
+            )
             await self._stage(job_id, "store", self._store_chunks, chunks, embeddings)
 
             version = self.service.complete_pipeline_job(
@@ -265,7 +269,9 @@ class KnowledgePipelineExecutor:
 
     def _discard_pipeline_candidate(self, job_id: str, namespace: str) -> bool:
         try:
-            self.service.vector_store.delete_knowledge_base(namespace)
+            job = self.service.get_pipeline_job(job_id)
+            if self._job_uses_vector(job):
+                self.service.vector_store.delete_knowledge_base(namespace)
             self.service.lexical_store.delete_namespace(namespace)
             self.service.cleanup_invalidated_pipeline_job(job_id)
         except Exception:
@@ -275,6 +281,22 @@ class KnowledgePipelineExecutor:
             )
             return False
         return True
+
+    @staticmethod
+    def _job_uses_vector(job: dict[str, Any]) -> bool:
+        snapshot = job.get("config_snapshot")
+        retrieval = snapshot.get("retrieval_profile") if isinstance(snapshot, dict) else None
+        return str((retrieval or {}).get("mode") or "hybrid") in {"vector", "hybrid"}
+
+    @staticmethod
+    def _job_uses_fulltext(job: dict[str, Any]) -> bool:
+        snapshot = job.get("config_snapshot")
+        retrieval = snapshot.get("retrieval_profile") if isinstance(snapshot, dict) else None
+        return str((retrieval or {}).get("mode") or "hybrid") in {
+            "vector",
+            "fulltext",
+            "hybrid",
+        }
 
     async def _stage(
         self,
@@ -585,6 +607,8 @@ class KnowledgePipelineExecutor:
         chunks: list[dict[str, Any]],
     ) -> list[list[float]]:
         job = self.service.get_pipeline_job(job_id)
+        if not self._job_uses_vector(job):
+            return []
         snapshot = job["config_snapshot"]
         profile = snapshot.get("embedding_profile", {}) if isinstance(snapshot, dict) else {}
         effective = profile.get("effective") if isinstance(profile, dict) else None
@@ -656,6 +680,12 @@ class KnowledgePipelineExecutor:
         namespace = str(job["candidate_namespace"])
         vector_chunks: list[VectorChunk] = []
         lexical_chunks: list[LexicalChunk] = []
+        uses_vector = self._job_uses_vector(job)
+        uses_fulltext = self._job_uses_fulltext(job)
+        if uses_vector and len(embeddings) != len(chunks):
+            raise EmbeddingError(
+                "Vector index input does not match the embedded chunk count."
+            )
         for position, item in enumerate(chunks):
             source = item["source"]
             source_id = str(source["source_id"])
@@ -680,32 +710,41 @@ class KnowledgePipelineExecutor:
                 "source_block_id": item.get("source_block_id"),
                 "source_block_hash": item.get("source_block_hash"),
             }
-            vector_chunks.append(
-                VectorChunk(
-                    id=chunk_id,
-                    kb_id=namespace,
-                    doc_id=doc_id,
-                    document_name=str(source["filename"]),
-                    text=str(item.get("index_text") or ""),
-                    embedding=embeddings[position],
-                    chunk_index=int(item["index"]),
-                    **common,
+            if uses_vector:
+                vector_chunks.append(
+                    VectorChunk(
+                        id=chunk_id,
+                        kb_id=namespace,
+                        doc_id=doc_id,
+                        document_name=str(source["filename"]),
+                        text=str(item.get("index_text") or ""),
+                        embedding=embeddings[position],
+                        chunk_index=int(item["index"]),
+                        **common,
+                    )
                 )
-            )
-            lexical_chunks.append(
-                LexicalChunk(
-                    chunk_id=chunk_id,
-                    namespace=namespace,
-                    doc_id=doc_id,
-                    document_name=str(source["filename"]),
-                    text=str(item.get("index_text") or ""),
-                    chunk_index=int(item["index"]),
-                    **common,
+            if uses_fulltext:
+                lexical_chunks.append(
+                    LexicalChunk(
+                        chunk_id=chunk_id,
+                        namespace=namespace,
+                        doc_id=doc_id,
+                        document_name=str(source["filename"]),
+                        text=str(item.get("index_text") or ""),
+                        chunk_index=int(item["index"]),
+                        **common,
+                    )
                 )
-            )
-        self.service.vector_store.add_chunks(vector_chunks)
-        self.service.lexical_store.add_chunks(lexical_chunks)
-        if self.service.lexical_store.count_namespace(namespace) != len(lexical_chunks):
+        if uses_vector:
+            self.service.vector_store.add_chunks(vector_chunks)
+            count_namespace = getattr(self.service.vector_store, "count_namespace", None)
+            if not callable(count_namespace):
+                raise RuntimeError("Vector backend cannot verify the stored index count.")
+            if int(count_namespace(namespace)) != len(vector_chunks):
+                raise RuntimeError("Vector index count does not match the embedded chunk count.")
+        if uses_fulltext:
+            self.service.lexical_store.add_chunks(lexical_chunks)
+        if uses_fulltext and self.service.lexical_store.count_namespace(namespace) != len(lexical_chunks):
             raise RuntimeError("Full-text index count does not match the vector candidate index.")
 
 

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -93,6 +93,8 @@ EMBEDDING_PROVIDER_HASH = "hash"
 EMBEDDING_PROVIDER_OPENAI_COMPATIBLE = "openai_compatible"
 EMBEDDING_PROVIDER_UNAVAILABLE = "unavailable"
 EMBEDDING_SPACE_CONTRACT_VERSION = "modelmirror-provider-embedding-space-v1"
+INDEX_SCHEMA_VERSION = 3
+VECTOR_DISTANCE_CONTRACT = "cosine_v1"
 _WARNING_CONTROL_CHARACTERS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 
 
@@ -179,6 +181,14 @@ class PipelineJobStateError(RagError):
 
 class PipelineGraphRevisionError(RagError):
     """Raised when a graph save uses a stale optimistic revision."""
+
+
+class RagRetrievalUnavailableError(RagError):
+    """Stable, credential-free fail-closed retrieval availability error."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 class ManagedEmbeddingRouteError(EmbeddingError):
@@ -1695,9 +1705,19 @@ class RagService:
             "version": int(draft.get("version", 1)),
             "updated_at": float(draft.get("updated_at", metadata["knowledge_bases"][kb_id]["updated_at"])),
             "editable": True,
-            "index_schema_version": int(draft.get("index_schema_version", 2)),
+            "index_schema_version": int(
+                draft.get("index_schema_version", INDEX_SCHEMA_VERSION)
+            ),
             "embedding_profile": json.loads(json.dumps(draft["embedding_profile"])),
             "retrieval_profile": json.loads(json.dumps(draft["retrieval_profile"])),
+            "index_contract": self._index_contract(
+                index_schema_version=int(
+                    draft.get("index_schema_version", INDEX_SCHEMA_VERSION)
+                ),
+                retrieval_profile=draft["retrieval_profile"],
+                embedding_profile=draft["embedding_profile"],
+            ),
+            "vector_backend_readiness": self._vector_backend_readiness(),
             "stages": [
                 {
                     "id": "stage_data_source",
@@ -1830,8 +1850,11 @@ class RagService:
                 "draft_id": str(draft["draft_id"]),
                 "version": next_draft_version,
                 "updated_at": now,
-                "index_schema_version": 2,
-                "embedding_profile": json.loads(json.dumps(compiled.embedding_profile)),
+                "index_schema_version": INDEX_SCHEMA_VERSION,
+                "embedding_profile": self._embedding_profile_for_retrieval(
+                    compiled.embedding_profile,
+                    compiled.retrieval_profile,
+                ),
                 "retrieval_profile": json.loads(json.dumps(compiled.retrieval_profile)),
                 "stages": json.loads(json.dumps(compiled.stage_updates)),
             }
@@ -2022,6 +2045,10 @@ class RagService:
             draft.get("embedding_profile"),
             embedding_profile,
         )
+        next_embedding = self._embedding_profile_for_retrieval(
+            next_embedding,
+            next_retrieval,
+        )
 
         if not isinstance(stage_updates, dict):
             raise PipelineDraftValidationError("pipeline draft stages must be an object.")
@@ -2050,7 +2077,7 @@ class RagService:
                 "draft_id": current["draft_id"],
                 "version": int(current.get("version", 1)) + 1,
                 "updated_at": now,
-                "index_schema_version": 2,
+                "index_schema_version": INDEX_SCHEMA_VERSION,
                 "embedding_profile": next_embedding,
                 "retrieval_profile": next_retrieval,
                 "stages": configs,
@@ -2094,6 +2121,10 @@ class RagService:
         vision_capabilities = self.vision_processor.capabilities()
         embedding_profile = dict(draft.get("embedding_profile") or {})
         embedding_effective = dict(embedding_profile.get("effective") or {})
+        retrieval_mode = str(
+            (draft.get("retrieval_profile") or {}).get("mode") or "hybrid"
+        )
+        vector_readiness = self._vector_backend_readiness()
         visual_document_count = int(
             vision_stage.get("metadata", {}).get("visual_document_count", 0)
         )
@@ -2110,6 +2141,11 @@ class RagService:
                 "Embedding provider is unavailable for the requested model "
                 f"{str(requested.get('model') or '(unset)')[:200]}; configure "
                 "EMBEDDING_API_KEY before executing this pipeline."
+            )
+        if retrieval_mode in {"vector", "hybrid"} and not vector_readiness["ready"]:
+            warnings.append(
+                "The configured vector backend is unavailable; vector and hybrid "
+                "pipeline execution is blocked."
             )
         if processor_mode in {"qa", "summary"} and not processor_capabilities.get(
             "llm_configured"
@@ -2387,7 +2423,12 @@ class RagService:
                 raise PipelineJobStateError(
                     f"Pipeline draft changed. Expected v{draft_version}, current v{draft['version']}."
                 )
-            self._ensure_embedding_profile_ready(draft["embedding_profile"])
+            retrieval_mode = str(
+                (draft.get("retrieval_profile") or {}).get("mode") or "hybrid"
+            )
+            if retrieval_mode in {"vector", "hybrid"}:
+                self._ensure_embedding_profile_ready(draft["embedding_profile"])
+                self._ensure_vector_backend_ready()
             graph = self._pipeline_graph_record(metadata, kb_id, draft)
             if graph_revision is not None and int(graph_revision) != int(graph["graph_revision"]):
                 raise PipelineGraphRevisionError(
@@ -2423,6 +2464,10 @@ class RagService:
                 if not isinstance(base_version, dict) or base_version.get("kb_id") != kb_id:
                     raise PipelineVersionNotFoundError(
                         "Base knowledge pipeline version was not found for this knowledge base."
+                    )
+                if int(base_version.get("index_schema_version") or 1) < INDEX_SCHEMA_VERSION:
+                    raise PipelineDraftValidationError(
+                        "Legacy V2 indexes are read-only and cannot be rebuilt."
                     )
                 base_job = metadata["pipeline_jobs"].get(str(base_version.get("job_id") or ""))
                 if not isinstance(base_job, dict):
@@ -2594,6 +2639,16 @@ class RagService:
             embedding_metadata = self._embedding_job_metadata(
                 draft["embedding_profile"]
             )
+            index_contract = self._index_contract(
+                index_schema_version=INDEX_SCHEMA_VERSION,
+                retrieval_profile=draft["retrieval_profile"],
+                embedding_profile=draft["embedding_profile"],
+            )
+            candidate_namespace = self._candidate_namespace(
+                kb_id,
+                candidate_version_id,
+                index_contract,
+            )
             job = {
                 "job_id": job_id,
                 "kb_id": kb_id,
@@ -2602,7 +2657,7 @@ class RagService:
                 "graph_id": str(graph["graph_id"]),
                 "graph_revision": int(graph["graph_revision"]),
                 "config_snapshot": {
-                    "index_schema_version": int(draft.get("index_schema_version", 2)),
+                    "index_schema_version": INDEX_SCHEMA_VERSION,
                     "graph_id": str(graph["graph_id"]),
                     "graph_revision": int(graph["graph_revision"]),
                     "stages": json.loads(json.dumps(draft["stages"])),
@@ -2610,6 +2665,7 @@ class RagService:
                     "vision_profile": vision_profile,
                     "embedding_profile": json.loads(json.dumps(draft["embedding_profile"])),
                     "retrieval_profile": json.loads(json.dumps(draft["retrieval_profile"])),
+                    "index_contract": json.loads(json.dumps(index_contract)),
                 },
                 "origin": self._safe_pipeline_origin(origin),
                 "base_version_id": base_version_id,
@@ -2619,7 +2675,9 @@ class RagService:
                 "stages": self._new_pipeline_job_stages(),
                 "candidate_version_id": candidate_version_id,
                 "candidate_version": candidate_version,
-                "candidate_namespace": f"{kb_id}::{candidate_version_id}",
+                "candidate_namespace": candidate_namespace,
+                "index_contract": json.loads(json.dumps(index_contract)),
+                "vector_backend_readiness": self._vector_backend_readiness(),
                 "run_id": None,
                 "attempt": 0,
                 "cancel_requested": False,
@@ -2664,9 +2722,9 @@ class RagService:
                 raise PipelineVersionNotFoundError(
                     "A ready or active base knowledge version is required for tuning."
                 )
-            if int(base_version.get("index_schema_version") or 1) < 2:
+            if int(base_version.get("index_schema_version") or 1) < INDEX_SCHEMA_VERSION:
                 raise PipelineDraftValidationError(
-                    "RAG strategy tuning requires an index schema v2 base version."
+                    "RAG strategy tuning requires an index schema v3 base version."
                 )
             base_job = metadata["pipeline_jobs"].get(str(base_version.get("job_id") or ""))
             if not isinstance(base_job, dict) or not base_job.get("sources"):
@@ -2700,6 +2758,20 @@ class RagService:
                 ).payload()
             except ValueError as exc:
                 raise PipelineDraftValidationError(str(exc)) from exc
+            embedding_profile = self._validated_embedding_profile(
+                config_snapshot.get("embedding_profile")
+                if isinstance(config_snapshot.get("embedding_profile"), dict)
+                else None,
+                None,
+            )
+            config_snapshot["embedding_profile"] = self._embedding_profile_for_retrieval(
+                embedding_profile,
+                config_snapshot["retrieval_profile"],
+            )
+            retrieval_mode = str(config_snapshot["retrieval_profile"].get("mode") or "hybrid")
+            if retrieval_mode in {"vector", "hybrid"}:
+                self._ensure_embedding_profile_ready(config_snapshot["embedding_profile"])
+                self._ensure_vector_backend_ready()
             processor_profile = json.loads(
                 json.dumps(stages.get("stage_processor") or {})
             )
@@ -2793,6 +2865,18 @@ class RagService:
             embedding_metadata = self._embedding_job_metadata(
                 config_snapshot.get("embedding_profile")
             )
+            index_contract = self._index_contract(
+                index_schema_version=INDEX_SCHEMA_VERSION,
+                retrieval_profile=config_snapshot["retrieval_profile"],
+                embedding_profile=config_snapshot["embedding_profile"],
+            )
+            config_snapshot["index_schema_version"] = INDEX_SCHEMA_VERSION
+            config_snapshot["index_contract"] = json.loads(json.dumps(index_contract))
+            candidate_namespace = self._candidate_namespace(
+                kb_id,
+                candidate_version_id,
+                index_contract,
+            )
             job = {
                 "job_id": job_id,
                 "kb_id": kb_id,
@@ -2809,7 +2893,9 @@ class RagService:
                 "stages": self._new_pipeline_job_stages(),
                 "candidate_version_id": candidate_version_id,
                 "candidate_version": candidate_version,
-                "candidate_namespace": f"{kb_id}::{candidate_version_id}",
+                "candidate_namespace": candidate_namespace,
+                "index_contract": json.loads(json.dumps(index_contract)),
+                "vector_backend_readiness": self._vector_backend_readiness(),
                 "run_id": None,
                 "attempt": 0,
                 "cancel_requested": False,
@@ -2924,7 +3010,8 @@ class RagService:
                 if job.get("status") != "running":
                     continue
                 namespace = str(job.get("candidate_namespace") or "")
-                self.vector_store.delete_knowledge_base(namespace)
+                if self._pipeline_job_uses_vector(job):
+                    self.vector_store.delete_knowledge_base(namespace)
                 self.lexical_store.delete_namespace(namespace)
                 if str(job.get("embedding_execution_mode") or "") == "managed":
                     try:
@@ -2980,6 +3067,37 @@ class RagService:
             if recovered:
                 self._write_metadata_unlocked(metadata)
             return recovered
+
+    @staticmethod
+    def _pipeline_job_uses_vector(job: dict[str, Any]) -> bool:
+        snapshot = (
+            job.get("config_snapshot")
+            if isinstance(job.get("config_snapshot"), dict)
+            else {}
+        )
+        index_contract = (
+            snapshot.get("index_contract")
+            if isinstance(snapshot.get("index_contract"), dict)
+            else job.get("index_contract")
+            if isinstance(job.get("index_contract"), dict)
+            else {}
+        )
+        vector_contract = (
+            index_contract.get("vector")
+            if isinstance(index_contract.get("vector"), dict)
+            else {}
+        )
+        if "required" in vector_contract:
+            return bool(vector_contract["required"])
+        retrieval_profile = (
+            snapshot.get("retrieval_profile")
+            if isinstance(snapshot.get("retrieval_profile"), dict)
+            else {}
+        )
+        return str(retrieval_profile.get("mode") or "hybrid") in {
+            "vector",
+            "hybrid",
+        }
 
     def set_pipeline_job_run_id(self, job_id: str, run_id: str) -> None:
         self._update_pipeline_job(job_id, lambda job: job.update({"run_id": run_id}))
@@ -3479,7 +3597,8 @@ class RagService:
         namespace = str(job.get("candidate_namespace") or "")
         try:
             if namespace:
-                self.vector_store.delete_knowledge_base(namespace)
+                if self._pipeline_job_uses_vector(job):
+                    self.vector_store.delete_knowledge_base(namespace)
                 self.lexical_store.delete_namespace(namespace)
             for path in (
                 self.pipeline_sources_dir / job_id,
@@ -3559,6 +3678,25 @@ class RagService:
                 for result in job.get("document_results", [])
                 if isinstance(result, dict)
             ]
+            index_contract = dict(
+                job["config_snapshot"].get("index_contract")
+                or job.get("index_contract")
+                or self._index_contract(
+                    index_schema_version=int(
+                        job["config_snapshot"].get("index_schema_version", 1)
+                    ),
+                    retrieval_profile=dict(
+                        job["config_snapshot"].get("retrieval_profile") or {}
+                    ),
+                    embedding_profile=dict(
+                        job["config_snapshot"].get("embedding_profile") or {}
+                    ),
+                )
+            )
+            vector_required = bool((index_contract.get("vector") or {}).get("required"))
+            lexical_ready = self.lexical_store.count_namespace(
+                str(job["candidate_namespace"])
+            ) > 0
             version = {
                 "version_id": str(job["candidate_version_id"]),
                 "kb_id": str(job["kb_id"]),
@@ -3584,8 +3722,12 @@ class RagService:
                 "retrieval_profile": json.loads(
                     json.dumps(job["config_snapshot"].get("retrieval_profile", {}))
                 ),
-                "vector_index_ready": True,
-                "lexical_index_ready": True,
+                "index_contract": json.loads(json.dumps(index_contract)),
+                "vector_backend_readiness": json.loads(
+                    json.dumps(job.get("vector_backend_readiness") or {})
+                ),
+                "vector_index_ready": vector_required,
+                "lexical_index_ready": lexical_ready,
                 "source_summary": [
                     {
                         key: value
@@ -3763,9 +3905,17 @@ class RagService:
         version_id: str,
     ) -> tuple[dict[str, Any], dict[str, Any], dict[str, dict[str, Any]]]:
         version = self.get_pipeline_version(version_id)
+        retrieval_mode = str(
+            (version.get("retrieval_profile") or {}).get("mode") or "vector"
+        )
+        index_ready = (
+            version.get("lexical_index_ready") is True
+            if retrieval_mode == "fulltext"
+            else version.get("vector_index_ready") is True
+        )
         if (
             version.get("status") not in {"ready", "active"}
-            or version.get("vector_index_ready") is not True
+            or not index_ready
             or not str(version.get("job_id") or "")
         ):
             raise PipelineJobStateError(
@@ -3780,11 +3930,19 @@ class RagService:
                 raise PipelineJobStateError(
                     "Pipeline version corpus provenance is inconsistent."
                 ) from exc
+            owner_mode = str(
+                (index_owner.get("retrieval_profile") or {}).get("mode") or "vector"
+            )
+            owner_ready = (
+                index_owner.get("lexical_index_ready") is True
+                if owner_mode == "fulltext"
+                else index_owner.get("vector_index_ready") is True
+            )
             if (
                 str(version.get("base_version_id") or "") != index_owner_id
                 or index_owner.get("kb_id") != version.get("kb_id")
                 or index_owner.get("status") not in {"ready", "active"}
-                or index_owner.get("vector_index_ready") is not True
+                or not owner_ready
                 or str(index_owner.get("namespace") or "")
                 != str(version.get("namespace") or "")
                 or str(index_owner.get("job_id") or "")
@@ -3878,9 +4036,13 @@ class RagService:
                     "Pipeline version processed source blocks are unavailable."
                 )
             chunks_by_block: dict[str, list[Any]] = {}
-            for chunk in self.vector_store.list_document_chunks(
-                f"{index_owner}_{document_id}"
-            ):
+            chunk_store = (
+                self.lexical_store
+                if str((version.get("retrieval_profile") or {}).get("mode") or "vector")
+                == "fulltext"
+                else self.vector_store
+            )
+            for chunk in chunk_store.list_document_chunks(f"{index_owner}_{document_id}"):
                 source_block_id = str(chunk.source_block_id or "")
                 if source_block_id:
                     chunks_by_block.setdefault(source_block_id, []).append(chunk)
@@ -3977,7 +4139,12 @@ class RagService:
         payload["active"] = str(active_id or "") == str(version.get("version_id"))
         return payload
 
-    def activate_pipeline_version(self, version_id: str) -> dict[str, Any]:
+    def activate_pipeline_version(
+        self,
+        version_id: str,
+        *,
+        promotion: bool = False,
+    ) -> dict[str, Any]:
         with self._metadata_lock:
             metadata = self._read_metadata_unlocked()
             version = metadata["pipeline_versions"].get(version_id)
@@ -3990,6 +4157,13 @@ class RagService:
             kb_id = str(version["kb_id"])
             self._ensure_kb_exists(metadata, kb_id)
             previous_id = metadata["pipeline_active_versions"].get(kb_id)
+            if (
+                int(version.get("index_schema_version") or 1) < INDEX_SCHEMA_VERSION
+                and (promotion or previous_id != version_id)
+            ):
+                raise PipelineJobStateError(
+                    "Legacy V2 indexes remain readable but cannot be newly activated or promoted."
+                )
             if previous_id and previous_id in metadata["pipeline_versions"]:
                 metadata["pipeline_versions"][previous_id]["status"] = "ready"
             version["status"] = "active"
@@ -4005,8 +4179,15 @@ class RagService:
         version = self.get_pipeline_version(version_id)
         chunk_count = max(0, int(version.get("chunk_count") or 0))
         embedding_profile = version.get("embedding_profile") or {}
-        dimension = max(1, int(embedding_profile.get("dimension") or 1))
-        estimated_vector_bytes = chunk_count * dimension * 4
+        vector_required = bool(
+            ((version.get("index_contract") or {}).get("vector") or {}).get("required")
+        )
+        dimension = (
+            max(1, int(embedding_profile.get("dimension") or 1))
+            if vector_required
+            else 0
+        )
+        estimated_vector_bytes = chunk_count * dimension * 4 if vector_required else 0
         estimated_lexical_bytes = chunk_count * 256
         job = self.get_pipeline_job(str(version.get("job_id") or ""))
         started_at = job.get("started_at")
@@ -4320,6 +4501,20 @@ class RagService:
             job["embedding_space_fingerprint"] = str(
                 profile.get("embedding_space_fingerprint") or ""
             )
+            if int(snapshot.get("index_schema_version") or 1) >= INDEX_SCHEMA_VERSION:
+                index_contract = self._index_contract(
+                    index_schema_version=INDEX_SCHEMA_VERSION,
+                    retrieval_profile=dict(snapshot.get("retrieval_profile") or {}),
+                    embedding_profile=profile,
+                )
+                namespace = self._candidate_namespace(
+                    str(job.get("kb_id") or ""),
+                    str(job.get("candidate_version_id") or ""),
+                    index_contract,
+                )
+                snapshot["index_contract"] = json.loads(json.dumps(index_contract))
+                job["index_contract"] = json.loads(json.dumps(index_contract))
+                job["candidate_namespace"] = namespace
 
         self._update_pipeline_job(job_id, update)
 
@@ -4742,6 +4937,10 @@ class RagService:
             )
         namespace = str(version.get("namespace") or kb_id) if isinstance(version, dict) else kb_id
         chunk = self.vector_store.get_chunk(namespace, chunk_id)
+        if chunk is None and isinstance(version, dict) and str(
+            (version.get("retrieval_profile") or {}).get("mode") or "vector"
+        ) in {"fulltext", "hybrid"}:
+            chunk = self.lexical_store.get_chunk(namespace, chunk_id)
         if chunk is None:
             raise DocumentNotFoundError("Knowledge chunk was not found in the active version.")
         if self._indexed_document_is_deleted(
@@ -5309,9 +5508,50 @@ class RagService:
         lexical_results: list[LexicalSearchResult] = []
         provider_route_receipts: dict[str, Any] | None = None
         execution_mode = "local_non_model"
-        resolved_embedding_profile = self._resolved_embedding_profile_for_query(
-            embedding_profile
+        is_v3 = "::v3::" in namespace
+        if config.mode == "fulltext" and is_v3:
+            resolved_embedding_profile = self._embedding_profile_not_applicable(
+                dict(embedding_profile or self._default_embedding_profile())
+            )
+        else:
+            resolved_embedding_profile = self._resolved_embedding_profile_for_query(
+                embedding_profile
+            )
+
+        if config.mode in {"vector", "hybrid"}:
+            self._ensure_vector_backend_ready()
+            if str(
+                (resolved_embedding_profile.get("effective") or {}).get("reason")
+                or ""
+            ) == "provider_embedding_index_rebuild_required":
+                raise ManagedEmbeddingRouteError(
+                    "provider_embedding_index_rebuild_required",
+                    "Managed Embedding requires an explicit index rebuild before use.",
+                )
+            self._ensure_embedding_profile_ready(resolved_embedding_profile)
+            if is_v3:
+                self._ensure_v3_query_embedding_contract(
+                    namespace,
+                    resolved_embedding_profile,
+                )
+                count_namespace = getattr(self.vector_store, "count_namespace", None)
+                if callable(count_namespace) and int(count_namespace(namespace)) <= 0:
+                    raise RagRetrievalUnavailableError(
+                        "rag_vector_index_unavailable",
+                        "The required vector index is unavailable.",
+                    )
+        lexical_count = (
+            self.lexical_store.count_namespace(namespace)
+            if config.mode in {"fulltext", "hybrid"}
+            else 0
         )
+        lexical_available = lexical_count > 0 or (lexical_ready and not is_v3)
+        if config.mode in {"fulltext", "hybrid"} and not lexical_available:
+            if is_v3:
+                raise RagRetrievalUnavailableError(
+                    "rag_fulltext_index_unavailable",
+                    "The required full-text index is unavailable.",
+                )
 
         async def query_vector_candidates() -> list[SearchResult]:
             nonlocal provider_route_receipts, execution_mode
@@ -5320,14 +5560,20 @@ class RagService:
                 resolved_embedding_profile,
                 version_reference=namespace,
             )
-            return self.vector_store.query(namespace, query_embedding, candidate_count)
+            try:
+                return self.vector_store.query(namespace, query_embedding, candidate_count)
+            except RuntimeError as exc:
+                raise RagRetrievalUnavailableError(
+                    "rag_vector_index_unavailable",
+                    "The required vector index is unavailable or incompatible.",
+                ) from exc
 
         if config.mode in {"vector", "hybrid"}:
             vector_results = await query_vector_candidates()
         if config.mode in {"fulltext", "hybrid"}:
             if lexical_ready or self.lexical_store.count_namespace(namespace) > 0:
                 lexical_results = self.lexical_store.query(namespace, clean_question, candidate_count)
-            else:
+            elif not is_v3:
                 warnings.append("Full-text index is unavailable for this legacy version; vector retrieval was used.")
 
         deleted_document_ids = self._deleted_document_ids()
@@ -5350,7 +5596,12 @@ class RagService:
         vector_candidates = [self._candidate_from_vector(item) for item in vector_results]
         lexical_candidates = [self._candidate_from_lexical(item) for item in lexical_results]
         effective_config = config
-        if config.mode == "fulltext" and not lexical_candidates and not lexical_ready:
+        if (
+            not is_v3
+            and config.mode == "fulltext"
+            and not lexical_candidates
+            and not lexical_ready
+        ):
             effective_config = RetrievalConfig.from_mapping(
                 {**config.payload(), "mode": "vector", "rerank_enabled": config.rerank_enabled}
             )
@@ -5902,14 +6153,185 @@ class RagService:
         best = results[0]
         return f"根据知识库资料：{best.context_text}"
 
+    def _vector_backend_readiness(self) -> dict[str, Any]:
+        readiness = getattr(self.vector_store, "readiness", None)
+        if callable(readiness):
+            try:
+                payload = dict(readiness())
+            except Exception:
+                payload = {
+                    "configured_backend": os.getenv("RAG_VECTOR_STORE", "chroma").strip().lower(),
+                    "effective_backend": "unavailable",
+                    "ready": False,
+                    "reason_code": "vector_backend_readiness_failed",
+                    "distance_contract": VECTOR_DISTANCE_CONTRACT,
+                }
+        else:
+            payload = {
+                "configured_backend": "injected",
+                "effective_backend": self.vector_store.__class__.__name__,
+                "ready": True,
+                "reason_code": None,
+                "distance_contract": VECTOR_DISTANCE_CONTRACT,
+            }
+        return {
+            "configured_backend": str(payload.get("configured_backend") or "unknown"),
+            "effective_backend": str(payload.get("effective_backend") or "unavailable"),
+            "ready": bool(payload.get("ready")),
+            "reason_code": str(payload.get("reason_code") or "") or None,
+            "distance_contract": str(
+                payload.get("distance_contract") or VECTOR_DISTANCE_CONTRACT
+            ),
+        }
+
+    @staticmethod
+    def _embedding_profile_not_applicable(profile: dict[str, Any]) -> dict[str, Any]:
+        value = json.loads(json.dumps(profile))
+        requested = dict(value.get("requested") or {})
+        value.update(
+            {
+                "provider": "none",
+                "model": "",
+                "dimension": 0,
+                "degraded": False,
+                "ready": True,
+                "reason": None,
+                "embedding_space_fingerprint": "",
+                "requested": requested,
+                "effective": {
+                    "provider": "none",
+                    "model": "",
+                    "dimension": 0,
+                    "degraded": False,
+                    "ready": True,
+                    "reason": None,
+                    "access_mode": "not_applicable",
+                    "status": "not_applicable",
+                },
+            }
+        )
+        return value
+
+    def _embedding_profile_for_retrieval(
+        self,
+        profile: dict[str, Any],
+        retrieval_profile: dict[str, Any],
+    ) -> dict[str, Any]:
+        if str(retrieval_profile.get("mode") or "hybrid") == "fulltext":
+            return self._embedding_profile_not_applicable(profile)
+        return json.loads(json.dumps(profile))
+
+    @staticmethod
+    def _index_contract(
+        *,
+        index_schema_version: int,
+        retrieval_profile: dict[str, Any],
+        embedding_profile: dict[str, Any],
+    ) -> dict[str, Any]:
+        mode = str(retrieval_profile.get("mode") or "hybrid")
+        vector_required = mode in {"vector", "hybrid"}
+        effective = dict(embedding_profile.get("effective") or {})
+        return {
+            "contract_version": (
+                "rag-index-contract-v3"
+                if int(index_schema_version) >= INDEX_SCHEMA_VERSION
+                else "legacy_v2"
+            ),
+            "index_schema_version": int(index_schema_version),
+            "retrieval_mode": mode,
+            "vector": {
+                "required": vector_required,
+                "embedding_space_fingerprint": (
+                    str(embedding_profile.get("embedding_space_fingerprint") or "")
+                    if vector_required
+                    else ""
+                ),
+                "dimension": int(effective.get("dimension") or 0) if vector_required else 0,
+                "distance_contract": (
+                    VECTOR_DISTANCE_CONTRACT if vector_required else "not_applicable"
+                ),
+            },
+            "lexical": {
+                "required": mode in {"fulltext", "hybrid"},
+                "backend": "sqlite_fts5",
+            },
+        }
+
+    @staticmethod
+    def _candidate_namespace(
+        kb_id: str,
+        version_id: str,
+        index_contract: dict[str, Any],
+    ) -> str:
+        vector = dict(index_contract.get("vector") or {})
+        if not bool(vector.get("required")):
+            return f"{kb_id}::v3::{version_id}::fulltext"
+        fingerprint = str(vector.get("embedding_space_fingerprint") or "")
+        dimension = int(vector.get("dimension") or 0)
+        distance_contract = str(vector.get("distance_contract") or "")
+        if (
+            not re.fullmatch(r"[0-9a-f]{64}", fingerprint)
+            or dimension <= 0
+            or distance_contract != VECTOR_DISTANCE_CONTRACT
+        ):
+            raise PipelineDraftValidationError(
+                "V3 vector index requires a complete embedding space identity."
+            )
+        return (
+            f"{kb_id}::v3::{version_id}::{fingerprint}::"
+            f"dim-{dimension}::{VECTOR_DISTANCE_CONTRACT}"
+        )
+
+    def _ensure_vector_backend_ready(self) -> dict[str, Any]:
+        readiness = self._vector_backend_readiness()
+        if (
+            not readiness["ready"]
+            or readiness["distance_contract"] != VECTOR_DISTANCE_CONTRACT
+        ):
+            raise RagRetrievalUnavailableError(
+                "rag_vector_backend_unavailable",
+                "The configured vector backend is unavailable for this pipeline.",
+            )
+        return readiness
+
+    @staticmethod
+    def _ensure_v3_query_embedding_contract(
+        namespace: str,
+        embedding_profile: dict[str, Any],
+    ) -> None:
+        parts = namespace.split("::")
+        if len(parts) < 6 or parts[-5] != "v3" or parts[-1] != VECTOR_DISTANCE_CONTRACT:
+            raise RagRetrievalUnavailableError(
+                "rag_vector_index_contract_mismatch",
+                "The V3 vector index identity is invalid.",
+            )
+        effective = dict(embedding_profile.get("effective") or {})
+        expected_fingerprint = parts[-3]
+        expected_dimension = parts[-2]
+        if (
+            str(embedding_profile.get("embedding_space_fingerprint") or "")
+            != expected_fingerprint
+        ):
+            raise RagRetrievalUnavailableError(
+                "rag_embedding_fingerprint_mismatch",
+                "The query embedding identity does not match the V3 index.",
+            )
+        if expected_dimension != f"dim-{int(effective.get('dimension') or 0)}":
+            raise RagRetrievalUnavailableError(
+                "rag_embedding_dimension_mismatch",
+                "The query embedding dimension does not match the V3 index.",
+            )
+
     def retrieval_capabilities(self) -> dict[str, Any]:
         rerank = self.reranker.capabilities()
+        vector = self._vector_backend_readiness()
         return {
-            "version": "rag-retrieval-capabilities-v2",
-            "index_schema_version": 2,
+            "version": "rag-retrieval-capabilities-v3",
+            "index_schema_version": INDEX_SCHEMA_VERSION,
             "vector": {
-                "available": True,
-                "backend": self.vector_store.__class__.__name__,
+                "available": vector["ready"],
+                "backend": vector["effective_backend"],
+                **vector,
             },
             "fulltext": {
                 "available": True,
@@ -6044,6 +6466,16 @@ class RagService:
         stored_fingerprint = str(
             stored_profile.get("embedding_space_fingerprint") or ""
         )
+        if (
+            isinstance(stored_effective, dict)
+            and str(stored_effective.get("provider") or "")
+            == EMBEDDING_PROVIDER_HASH
+            and bool(stored_effective.get("ready"))
+            and stored_fingerprint
+        ):
+            # Hash is an explicit, local execution contract. Rebuild it from the
+            # immutable stored profile rather than the mutable process default.
+            return json.loads(json.dumps(stored_profile))
         if (
             managed_mode == "managed_required"
             and (
@@ -6301,6 +6733,7 @@ class RagService:
                 "degraded": True,
                 "ready": True,
                 "reason": None,
+                "access_mode": "local_hash",
             }
         else:
             reason: str | None = None
@@ -6364,6 +6797,7 @@ class RagService:
                     "degraded": False,
                     "ready": True,
                     "reason": None,
+                    "access_mode": "legacy",
                 }
         return {
             "provider": effective["provider"],
@@ -6603,6 +7037,8 @@ class RagService:
             if access_mode == "managed"
             else "local_non_model"
             if access_mode == "local_hash"
+            else "not_applicable"
+            if access_mode == "not_applicable"
             else "legacy"
         )
         return {
@@ -6681,13 +7117,18 @@ class RagService:
         defaults = self._default_pipeline_draft_stages()
         draft = metadata["pipeline_drafts"].get(kb_id)
         if not isinstance(draft, dict):
+            retrieval_profile = RetrievalConfig().payload()
+            embedding_profile = self._default_embedding_profile()
             return {
                 "draft_id": f"draft_{kb_id}",
                 "version": 1,
                 "updated_at": metadata["knowledge_bases"][kb_id]["updated_at"],
-                "index_schema_version": 2,
-                "embedding_profile": self._default_embedding_profile(),
-                "retrieval_profile": RetrievalConfig().payload(),
+                "index_schema_version": INDEX_SCHEMA_VERSION,
+                "embedding_profile": self._embedding_profile_for_retrieval(
+                    embedding_profile,
+                    retrieval_profile,
+                ),
+                "retrieval_profile": retrieval_profile,
                 "stages": defaults,
             }
 
@@ -6710,18 +7151,27 @@ class RagService:
                 except PipelineDraftValidationError:
                     continue
 
+        retrieval_profile = RetrievalConfig.from_mapping(
+            draft.get("retrieval_profile")
+            if isinstance(draft.get("retrieval_profile"), dict)
+            else None
+        ).payload()
+        embedding_profile = self._validated_embedding_profile(
+            draft.get("embedding_profile")
+            if isinstance(draft.get("embedding_profile"), dict)
+            else None,
+            None,
+        )
         return {
             "draft_id": str(draft.get("draft_id") or f"draft_{kb_id}"),
             "version": int(draft.get("version") or 1),
             "updated_at": float(draft.get("updated_at") or metadata["knowledge_bases"][kb_id]["updated_at"]),
-            "index_schema_version": 2,
-            "embedding_profile": self._validated_embedding_profile(
-                draft.get("embedding_profile") if isinstance(draft.get("embedding_profile"), dict) else None,
-                None,
+            "index_schema_version": INDEX_SCHEMA_VERSION,
+            "embedding_profile": self._embedding_profile_for_retrieval(
+                embedding_profile,
+                retrieval_profile,
             ),
-            "retrieval_profile": RetrievalConfig.from_mapping(
-                draft.get("retrieval_profile") if isinstance(draft.get("retrieval_profile"), dict) else None
-            ).payload(),
+            "retrieval_profile": retrieval_profile,
             "stages": stages,
         }
 

--- a/server/rag/vector_store.py
+++ b/server/rag/vector_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -106,9 +107,15 @@ class VectorStore(Protocol):
     def get_chunk(self, kb_id: str, chunk_id: str) -> StoredVectorChunk | None:
         """Read one chunk from an explicit knowledge-base namespace."""
 
+    def readiness(self) -> dict[str, Any]:
+        """Return a credential-free backend readiness receipt."""
+
+    def count_namespace(self, kb_id: str) -> int:
+        """Return the number of vectors in an explicit namespace."""
+
 
 class LocalJsonVectorStore:
-    """Small persistent vector store used as a no-network fallback and in tests."""
+    """Small persistent vector store used only when explicitly configured."""
 
     def __init__(self, storage_path: Path) -> None:
         self.storage_path = storage_path
@@ -118,17 +125,46 @@ class LocalJsonVectorStore:
         records = self._read_records()
         existing_ids = {record["id"] for record in records}
         for chunk in chunks:
+            contract = _v3_namespace_contract(chunk.kb_id)
+            if contract is not None and len(chunk.embedding) != contract["dimension"]:
+                raise RuntimeError(
+                    "V3 vector write does not match the index dimension contract."
+                )
             if chunk.id in existing_ids:
                 continue
             records.append(_chunk_to_record(chunk))
         self._write_records(records)
 
+    def readiness(self) -> dict[str, Any]:
+        return {
+            "configured_backend": "local",
+            "effective_backend": "local_json",
+            "ready": True,
+            "reason_code": None,
+            "distance_contract": "cosine_v1",
+        }
+
+    def count_namespace(self, kb_id: str) -> int:
+        return sum(1 for record in self._read_records() if record.get("kb_id") == kb_id)
+
     def query(self, kb_id: str, embedding: list[float], top_k: int) -> list[SearchResult]:
+        contract = _v3_namespace_contract(kb_id)
+        if contract is not None and len(embedding) != contract["dimension"]:
+            raise RuntimeError(
+                "V3 vector query does not match the index dimension contract."
+            )
         scored: list[SearchResult] = []
         for record in self._read_records():
             if record.get("kb_id") != kb_id:
                 continue
-            score = cosine_similarity(embedding, [float(value) for value in record["embedding"]])
+            stored_embedding = [float(value) for value in record["embedding"]]
+            if contract is not None and len(stored_embedding) != contract["dimension"]:
+                raise RuntimeError(
+                    "V3 stored vector does not match the index dimension contract."
+                )
+            score = cosine_similarity(embedding, stored_embedding)
+            if contract is not None:
+                score = min(1.0, max(0.0, score))
             scored.append(
                 SearchResult(
                     chunk_id=record["id"],
@@ -238,6 +274,7 @@ class ChromaVectorStore:
 
     _LEGACY_COLLECTION = "modelmirror_rag_chunks"
     _NAMESPACE_COLLECTION_PREFIX = "modelmirror_rag_v2_"
+    _V3_NAMESPACE_COLLECTION_PREFIX = "modelmirror_rag_v3_"
 
     def __init__(self, persist_path: Path) -> None:
         try:
@@ -252,6 +289,24 @@ class ChromaVectorStore:
         # because Chroma fixes a collection's dimension on its first insert.
         self._collection = self._client.get_or_create_collection(self._LEGACY_COLLECTION)
 
+    def readiness(self) -> dict[str, Any]:
+        return {
+            "configured_backend": "chroma",
+            "effective_backend": "chroma",
+            "ready": True,
+            "reason_code": None,
+            "distance_contract": "cosine_v1",
+        }
+
+    def count_namespace(self, kb_id: str) -> int:
+        collection = self._namespace_collection(kb_id, create=False)
+        if collection is not None:
+            return int(collection.count())
+        if _is_v3_namespace(kb_id):
+            return 0
+        response = self._collection.get(where={"kb_id": kb_id}, include=[])
+        return len(response.get("ids") or [])
+
     def add_chunks(self, chunks: list[VectorChunk]) -> None:
         if not chunks:
             return
@@ -259,6 +314,14 @@ class ChromaVectorStore:
         for chunk in chunks:
             grouped.setdefault(chunk.kb_id, []).append(chunk)
         for namespace, namespace_chunks in grouped.items():
+            contract = _v3_namespace_contract(namespace)
+            if contract is not None and any(
+                len(chunk.embedding) != contract["dimension"]
+                for chunk in namespace_chunks
+            ):
+                raise RuntimeError(
+                    "V3 vector write does not match the index dimension contract."
+                )
             collection = self._namespace_collection(namespace, create=True)
             if collection is None:  # pragma: no cover - create=True is total.
                 raise RuntimeError("Unable to create the Chroma namespace collection.")
@@ -297,7 +360,15 @@ class ChromaVectorStore:
     def query(self, kb_id: str, embedding: list[float], top_k: int) -> list[SearchResult]:
         collection = self._namespace_collection(kb_id, create=False)
         if collection is not None and collection.count() > 0:
-            return self._query_collection(collection, kb_id, embedding, top_k)
+            return self._query_collection(
+                collection,
+                kb_id,
+                embedding,
+                top_k,
+                v3=_is_v3_namespace(kb_id),
+            )
+        if _is_v3_namespace(kb_id):
+            raise RuntimeError("V3 vector namespace is unavailable.")
         return self._query_collection(
             self._collection,
             kb_id,
@@ -314,7 +385,12 @@ class ChromaVectorStore:
         top_k: int,
         *,
         legacy: bool = False,
+        v3: bool = False,
     ) -> list[SearchResult]:
+        if v3:
+            contract = _v3_namespace_contract(kb_id)
+            if contract is None or len(embedding) != contract["dimension"]:
+                raise RuntimeError("V3 vector query does not match the index dimension contract.")
         query: dict[str, Any] = {
             "query_embeddings": [embedding],
             "n_results": top_k,
@@ -341,7 +417,11 @@ class ChromaVectorStore:
                     doc_id=str(metadata.get("doc_id", "")),
                     document_name=str(metadata.get("document_name", "")),
                     text=str(documents[index] if index < len(documents) else ""),
-                    score=1.0 / (1.0 + max(distance, 0.0)),
+                    score=(
+                        min(1.0, max(0.0, 1.0 - distance))
+                        if v3
+                        else 1.0 / (1.0 + max(distance, 0.0))
+                    ),
                     parent_chunk_id=str(metadata.get("parent_chunk_id") or "") or None,
                     parent_text=str(metadata.get("parent_text") or "") or None,
                     chunk_type=str(metadata.get("chunk_type") or "standard"),
@@ -365,7 +445,7 @@ class ChromaVectorStore:
 
     def delete_knowledge_base(self, kb_id: str) -> None:
         collection_name = self._namespace_collection_name(kb_id)
-        if self._get_collection(collection_name) is not None:
+        if self._namespace_collection(kb_id, create=False) is not None:
             self._client.delete_collection(collection_name)
         self._collection.delete(where={"kb_id": kb_id})
 
@@ -476,7 +556,12 @@ class ChromaVectorStore:
     @classmethod
     def _namespace_collection_name(cls, namespace: str) -> str:
         digest = hashlib.sha256(namespace.encode("utf-8")).hexdigest()[:32]
-        return f"{cls._NAMESPACE_COLLECTION_PREFIX}{digest}"
+        prefix = (
+            cls._V3_NAMESPACE_COLLECTION_PREFIX
+            if _is_v3_namespace(namespace)
+            else cls._NAMESPACE_COLLECTION_PREFIX
+        )
+        return f"{prefix}{digest}"
 
     def _namespace_collection(self, namespace: str, *, create: bool) -> Any | None:
         if not hasattr(self, "_client"):
@@ -485,18 +570,46 @@ class ChromaVectorStore:
             return self._collection if create else None
         name = self._namespace_collection_name(namespace)
         if not create:
-            return self._get_collection(name)
+            collection = self._get_collection(name)
+            if collection is not None:
+                self._validate_namespace_collection(namespace, collection)
+            return collection
+        v3_contract = _v3_namespace_contract(namespace)
+        metadata: dict[str, Any] = {
+            "modelmirror_namespace": namespace,
+            "modelmirror_schema_version": 3 if v3_contract else 2,
+        }
+        if v3_contract:
+            metadata.update(
+                {
+                    "hnsw:space": "cosine",
+                    "modelmirror_dimension": v3_contract["dimension"],
+                    "modelmirror_distance_contract": "cosine_v1",
+                }
+            )
         collection = self._client.get_or_create_collection(
             name,
-            metadata={
-                "modelmirror_namespace": namespace,
-                "modelmirror_schema_version": 2,
-            },
+            metadata=metadata,
         )
-        stored_namespace = str((collection.metadata or {}).get("modelmirror_namespace") or "")
+        self._validate_namespace_collection(namespace, collection)
+        return collection
+
+    @staticmethod
+    def _validate_namespace_collection(namespace: str, collection: Any) -> None:
+        v3_contract = _v3_namespace_contract(namespace)
+        stored_metadata = collection.metadata or {}
+        stored_namespace = str(stored_metadata.get("modelmirror_namespace") or "")
         if stored_namespace and stored_namespace != namespace:
             raise RuntimeError("Chroma namespace collection identity collision.")
-        return collection
+        if v3_contract and (
+            int(stored_metadata.get("modelmirror_schema_version") or 0) != 3
+            or int(stored_metadata.get("modelmirror_dimension") or 0)
+            != v3_contract["dimension"]
+            or str(stored_metadata.get("modelmirror_distance_contract") or "")
+            != "cosine_v1"
+            or str(stored_metadata.get("hnsw:space") or "") != "cosine"
+        ):
+            raise RuntimeError("Chroma namespace collection contract mismatch.")
 
     def _get_collection(self, name: str) -> Any | None:
         try:
@@ -508,8 +621,10 @@ class ChromaVectorStore:
         collections: list[Any] = []
         for item in self._client.list_collections():
             name = item if isinstance(item, str) else str(getattr(item, "name", ""))
-            if name != self._LEGACY_COLLECTION and not name.startswith(
-                self._NAMESPACE_COLLECTION_PREFIX
+            if (
+                name != self._LEGACY_COLLECTION
+                and not name.startswith(self._NAMESPACE_COLLECTION_PREFIX)
+                and not name.startswith(self._V3_NAMESPACE_COLLECTION_PREFIX)
             ):
                 continue
             collection = self._get_collection(name)
@@ -518,17 +633,82 @@ class ChromaVectorStore:
         return collections
 
 
+class UnavailableVectorStore:
+    """Fail-closed vector backend used when the configured backend is unavailable."""
+
+    def __init__(self, configured_backend: str, reason_code: str) -> None:
+        self.configured_backend = configured_backend
+        self.reason_code = reason_code
+
+    def readiness(self) -> dict[str, Any]:
+        return {
+            "configured_backend": self.configured_backend,
+            "effective_backend": "unavailable",
+            "ready": False,
+            "reason_code": self.reason_code,
+            "distance_contract": "cosine_v1",
+        }
+
+    def add_chunks(self, chunks: list[VectorChunk]) -> None:
+        if chunks:
+            self._raise_unavailable()
+
+    def query(self, kb_id: str, embedding: list[float], top_k: int) -> list[SearchResult]:
+        self._raise_unavailable()
+
+    def delete_document(self, doc_id: str) -> None:
+        self._raise_unavailable()
+
+    def delete_knowledge_base(self, kb_id: str) -> None:
+        self._raise_unavailable()
+
+    def list_document_chunks(self, doc_id: str) -> list[StoredVectorChunk]:
+        return []
+
+    def get_chunk(self, kb_id: str, chunk_id: str) -> StoredVectorChunk | None:
+        return None
+
+    def count_namespace(self, kb_id: str) -> int:
+        return 0
+
+    def _raise_unavailable(self) -> None:
+        raise RuntimeError(f"Vector backend unavailable: {self.reason_code}")
+
+
 def create_vector_store(storage_dir: Path) -> VectorStore:
-    """Create the configured vector store, falling back to local JSON if needed."""
+    """Create only the explicitly configured vector backend, failing closed."""
 
     backend = os.getenv("RAG_VECTOR_STORE", "chroma").strip().lower()
     if backend == "local":
         return LocalJsonVectorStore(storage_dir / "vector_index.json")
 
+    if backend != "chroma":
+        return UnavailableVectorStore(backend or "chroma", "vector_backend_unsupported")
+
     try:
         return ChromaVectorStore(Path(os.getenv("CHROMA_DB_PATH", str(storage_dir / "chroma_db"))))
     except Exception:
-        return LocalJsonVectorStore(storage_dir / "vector_index.json")
+        return UnavailableVectorStore("chroma", "vector_backend_initialization_failed")
+
+
+def _is_v3_namespace(namespace: str) -> bool:
+    return _v3_namespace_contract(namespace) is not None
+
+
+def _v3_namespace_contract(namespace: str) -> dict[str, Any] | None:
+    parts = namespace.split("::")
+    if len(parts) < 6 or parts[-5] != "v3" or parts[-1] != "cosine_v1":
+        return None
+    dimension_part = parts[-2]
+    if not dimension_part.startswith("dim-"):
+        return None
+    try:
+        dimension = int(dimension_part[4:])
+    except ValueError:
+        return None
+    if dimension <= 0 or not re.fullmatch(r"[0-9a-f]{64}", parts[-3]):
+        return None
+    return {"dimension": dimension, "embedding_space_fingerprint": parts[-3]}
 
 
 def _chunk_to_record(chunk: VectorChunk) -> dict[str, Any]:

--- a/server/tests/test_rag_benchmark_standard.py
+++ b/server/tests/test_rag_benchmark_standard.py
@@ -66,9 +66,8 @@ async def test_managed_rag_benchmark_builds_real_indexes_and_immutable_gold(
     assert state["resolved_case_count"] == 40
     assert state["version_evidence"]["version_id"] == state["version_id"]
     assert state["version_evidence"]["version_fingerprint"]
-    assert state["version_evidence"]["embedding"]["effective"]["model"] == (
-        "deterministic-hash-v1"
-    )
+    assert state["version_evidence"]["embedding"]["effective"]["provider"] == "none"
+    assert state["version_evidence"]["embedding"]["effective"]["model"] == ""
 
     kb_id = str(state["kb_id"])
     knowledge_base = next(item for item in service.list_knowledge_bases() if item["id"] == kb_id)
@@ -79,9 +78,10 @@ async def test_managed_rag_benchmark_builds_real_indexes_and_immutable_gold(
     active = service.get_active_pipeline_version(kb_id)
     assert active is not None
     assert active["version_id"] == state["version_id"]
-    assert active["vector_index_ready"] is True
+    assert active["vector_index_ready"] is False
     assert active["lexical_index_ready"] is True
-    assert active["embedding_profile"]["provider"] == "hash"
+    assert active["embedding_profile"]["provider"] == "none"
+    assert active["embedding_profile"]["effective"]["status"] == "not_applicable"
     assert active["retrieval_profile"]["mode"] == "fulltext"
     assert active["processor_profile"]["mode"] == "general"
 

--- a/server/tests/test_rag_embedding_contract.py
+++ b/server/tests/test_rag_embedding_contract.py
@@ -1,0 +1,800 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.main import app
+from server.rag.api import (
+    set_pipeline_executor_for_tests,
+    set_rag_service_for_tests,
+)
+from server.rag.embedder import EmbeddingClient
+from server.rag.pipeline_executor import KnowledgePipelineExecutor
+from server.rag.rag_service import (
+    PipelineDraftValidationError,
+    PipelineJobStateError,
+    RagRetrievalUnavailableError,
+    RagService,
+)
+from server.rag.vector_store import (
+    ChromaVectorStore,
+    LocalJsonVectorStore,
+    UnavailableVectorStore,
+    VectorChunk,
+    create_vector_store,
+)
+
+
+class CountingEmbeddingClient(EmbeddingClient):
+    def __init__(self, *, dimension: int = 8) -> None:
+        super().__init__(
+            api_base="https://embedding.invalid/v1",
+            api_key="test-key",
+            model="test-embedding-model",
+            dimension=dimension,
+        )
+        self.call_count = 0
+
+    async def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        self.call_count += 1
+        return [
+            [1.0, *([0.0] * (self.dimension - 1))]
+            for _ in texts
+        ]
+
+
+@pytest_asyncio.fixture
+async def contract_runtime(tmp_path: Path):
+    embedder = CountingEmbeddingClient()
+    vector_store = LocalJsonVectorStore(tmp_path / "storage" / "vectors.json")
+    service = RagService(
+        storage_dir=tmp_path / "storage",
+        uploads_dir=tmp_path / "uploads",
+        embedder=embedder,
+        vector_store=vector_store,
+        llm_enabled=False,
+    )
+    executor = KnowledgePipelineExecutor(service, poll_interval=0.01)
+    set_rag_service_for_tests(service)
+    set_pipeline_executor_for_tests(executor)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        yield client, service, executor, embedder, vector_store
+    set_pipeline_executor_for_tests(None)
+    set_rag_service_for_tests(None)
+
+
+async def _create_pipeline_source(client: httpx.AsyncClient) -> tuple[str, str]:
+    kb_response = await client.post(
+        "/api/rag/knowledge_bases",
+        json={"name": "P0 embedding contract"},
+    )
+    assert kb_response.status_code == 200, kb_response.text
+    kb_id = str(kb_response.json()["id"])
+    document_response = await client.post(
+        f"/api/rag/knowledge_bases/{kb_id}/documents",
+        files={
+            "file": (
+                "contract.txt",
+                b"A full-text-only pipeline must never dispatch an embedding request.",
+                "text/plain",
+            )
+        },
+    )
+    assert document_response.status_code == 200, document_response.text
+    return kb_id, str(document_response.json()["id"])
+
+
+async def _execute_draft(
+    client: httpx.AsyncClient,
+    executor: KnowledgePipelineExecutor,
+    kb_id: str,
+    document_id: str,
+) -> dict:
+    draft = (await client.get(f"/api/rag/pipeline/draft?kb_id={kb_id}")).json()
+    created = await client.post(
+        f"/api/rag/pipeline/draft/{kb_id}/execute",
+        json={
+            "draft_version": draft["version"],
+            "source_document_ids": [document_id],
+            "xpert_file_refs": [],
+        },
+    )
+    assert created.status_code == 200, created.text
+    assert await executor.run_once() is True
+    job = await client.get(
+        f"/api/rag/pipeline/jobs/{created.json()['job_id']}"
+    )
+    assert job.status_code == 200, job.text
+    assert job.json()["status"] == "succeeded", job.text
+    return job.json()
+
+
+def test_chroma_initialization_failure_is_not_silently_local(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RAG_VECTOR_STORE", "chroma")
+
+    def fail_chroma(_: Path) -> object:
+        raise RuntimeError("synthetic chroma initialization failure")
+
+    monkeypatch.setattr("server.rag.vector_store.ChromaVectorStore", fail_chroma)
+    store = create_vector_store(tmp_path)
+
+    assert not isinstance(store, LocalJsonVectorStore)
+    assert store.readiness()["ready"] is False
+    assert store.readiness()["reason_code"] == "vector_backend_initialization_failed"
+
+
+def test_explicit_local_backend_is_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RAG_VECTOR_STORE", "local")
+    service = RagService(
+        storage_dir=tmp_path / "storage",
+        uploads_dir=tmp_path / "uploads",
+        embedder=CountingEmbeddingClient(),
+        llm_enabled=False,
+    )
+
+    capabilities = service.retrieval_capabilities()
+    assert capabilities["index_schema_version"] == 3
+    assert capabilities["vector"]["configured_backend"] == "local"
+    assert capabilities["vector"]["effective_backend"] == "local_json"
+    assert capabilities["vector"]["ready"] is True
+    assert capabilities["vector"]["distance_contract"] == "cosine_v1"
+
+
+def test_v3_chroma_and_local_share_clamped_cosine_score_contract(tmp_path: Path) -> None:
+    namespace = f"kb_contract::v3::kpv_contract::{'a' * 64}::dim-2::cosine_v1"
+
+    class FakeCollection:
+        metadata: dict = {}
+
+        def count(self) -> int:
+            return 1
+
+        def query(self, **_kwargs: object) -> dict:
+            return {
+                "ids": [["chunk"]],
+                "documents": [["contract text"]],
+                "metadatas": [[{"doc_id": "doc", "document_name": "doc.txt"}]],
+                "distances": [[0.25]],
+            }
+
+    chroma = object.__new__(ChromaVectorStore)
+    collection = FakeCollection()
+    chroma._namespace_collection = lambda *_args, **_kwargs: collection  # type: ignore[method-assign]
+    assert chroma.query(namespace, [1.0, 0.0], 1)[0].score == pytest.approx(0.75)
+
+    local = LocalJsonVectorStore(tmp_path / "vectors.json")
+    local.add_chunks(
+        [
+            VectorChunk(
+                id="negative",
+                kb_id=namespace,
+                doc_id="doc",
+                document_name="doc.txt",
+                text="opposite",
+                embedding=[-1.0, 0.0],
+                chunk_index=0,
+            )
+        ]
+    )
+    assert local.query(namespace, [1.0, 0.0], 1)[0].score == 0.0
+
+
+@pytest.mark.parametrize(
+    "stored_metadata, expected_message",
+    [
+        (
+            {
+                "modelmirror_namespace": "different-namespace",
+                "modelmirror_schema_version": 3,
+                "modelmirror_dimension": 2,
+                "modelmirror_distance_contract": "cosine_v1",
+            },
+            "identity collision",
+        ),
+        (
+            {
+                "modelmirror_schema_version": 3,
+                "modelmirror_dimension": 3,
+                "modelmirror_distance_contract": "cosine_v1",
+            },
+            "contract mismatch",
+        ),
+        (
+            {
+                "hnsw:space": "l2",
+                "modelmirror_schema_version": 3,
+                "modelmirror_dimension": 2,
+                "modelmirror_distance_contract": "cosine_v1",
+            },
+            "contract mismatch",
+        ),
+    ],
+)
+def test_v3_chroma_rejects_existing_collection_identity_conflicts(
+    stored_metadata: dict,
+    expected_message: str,
+) -> None:
+    namespace = f"kb_contract::v3::kpv_contract::{'a' * 64}::dim-2::cosine_v1"
+    stored_metadata = {
+        "modelmirror_namespace": namespace,
+        "hnsw:space": "cosine",
+        **stored_metadata,
+    }
+
+    class FakeCollection:
+        metadata = stored_metadata
+
+    class FakeClient:
+        def get_or_create_collection(self, _name: str, *, metadata: dict) -> FakeCollection:
+            assert metadata["hnsw:space"] == "cosine"
+            return FakeCollection()
+
+    chroma = object.__new__(ChromaVectorStore)
+    chroma._client = FakeClient()
+    with pytest.raises(RuntimeError, match=expected_message):
+        chroma._namespace_collection(namespace, create=True)
+
+
+def test_v3_chroma_rejects_persisted_contract_conflict_on_read() -> None:
+    namespace = f"kb_contract::v3::kpv_contract::{'a' * 64}::dim-2::cosine_v1"
+
+    class FakeCollection:
+        metadata = {
+            "modelmirror_namespace": namespace,
+            "hnsw:space": "l2",
+            "modelmirror_schema_version": 3,
+            "modelmirror_dimension": 2,
+            "modelmirror_distance_contract": "cosine_v1",
+        }
+
+        def count(self) -> int:
+            return 1
+
+    class FakeClient:
+        def get_collection(self, _name: str) -> FakeCollection:
+            return FakeCollection()
+
+    chroma = object.__new__(ChromaVectorStore)
+    chroma._client = FakeClient()
+    with pytest.raises(RuntimeError, match="contract mismatch"):
+        chroma.count_namespace(namespace)
+
+
+def test_v3_chroma_refuses_delete_when_persisted_identity_conflicts() -> None:
+    namespace = f"kb_contract::v3::kpv_contract::{'a' * 64}::dim-2::cosine_v1"
+
+    class FakeCollection:
+        metadata = {
+            "modelmirror_namespace": "different-namespace",
+            "hnsw:space": "cosine",
+            "modelmirror_schema_version": 3,
+            "modelmirror_dimension": 2,
+            "modelmirror_distance_contract": "cosine_v1",
+        }
+
+        def delete(self, **_kwargs: object) -> None:
+            return None
+
+    class FakeClient:
+        deleted: list[str] = []
+
+        def get_collection(self, _name: str) -> FakeCollection:
+            return FakeCollection()
+
+        def delete_collection(self, name: str) -> None:
+            self.deleted.append(name)
+
+    chroma = object.__new__(ChromaVectorStore)
+    chroma._client = FakeClient()
+    chroma._collection = FakeCollection()
+    with pytest.raises(RuntimeError, match="identity collision"):
+        chroma.delete_knowledge_base(namespace)
+    assert chroma._client.deleted == []
+
+
+def test_v3_local_store_rejects_query_and_persisted_dimension_mismatch(
+    tmp_path: Path,
+) -> None:
+    namespace = f"kb_contract::v3::kpv_contract::{'a' * 64}::dim-2::cosine_v1"
+    local = LocalJsonVectorStore(tmp_path / "vectors.json")
+    local.add_chunks(
+        [
+            VectorChunk(
+                id="chunk",
+                kb_id=namespace,
+                doc_id="doc",
+                document_name="doc.txt",
+                text="contract text",
+                embedding=[1.0, 0.0],
+                chunk_index=0,
+            )
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="query.*dimension contract"):
+        local.query(namespace, [1.0, 0.0, 0.0], 1)
+
+    records = local._read_records()
+    records[0]["embedding"] = [1.0, 0.0, 0.0]
+    local._write_records(records)
+    with pytest.raises(RuntimeError, match="stored vector.*dimension contract"):
+        local.query(namespace, [1.0, 0.0], 1)
+
+
+def test_real_chroma_v3_collection_persists_cosine_contract(tmp_path: Path) -> None:
+    namespace = f"kb_contract::v3::kpv_contract::{'b' * 64}::dim-2::cosine_v1"
+    store = ChromaVectorStore(tmp_path / "chroma")
+    store.add_chunks(
+        [
+            VectorChunk(
+                id="chunk",
+                kb_id=namespace,
+                doc_id="doc",
+                document_name="doc.txt",
+                text="contract text",
+                embedding=[1.0, 0.0],
+                chunk_index=0,
+            )
+        ]
+    )
+
+    collection = store._namespace_collection(namespace, create=False)
+    assert collection is not None
+    assert collection.metadata["hnsw:space"] == "cosine"
+    assert collection.metadata["modelmirror_dimension"] == 2
+    assert collection.metadata["modelmirror_distance_contract"] == "cosine_v1"
+    assert store.count_namespace(namespace) == 1
+    assert store.query(namespace, [1.0, 0.0], 1)[0].score == pytest.approx(1.0)
+
+    reopened = ChromaVectorStore(tmp_path / "chroma")
+    assert reopened.count_namespace(namespace) == 1
+    assert reopened.query(namespace, [1.0, 0.0], 1)[0].chunk_id == "chunk"
+    reopened.delete_knowledge_base(namespace)
+    assert reopened.count_namespace(namespace) == 0
+
+
+@pytest.mark.asyncio
+async def test_unavailable_vector_backend_blocks_vector_but_not_fulltext_pipeline(
+    tmp_path: Path,
+) -> None:
+    embedder = CountingEmbeddingClient()
+    service = RagService(
+        storage_dir=tmp_path / "storage",
+        uploads_dir=tmp_path / "uploads",
+        embedder=embedder,
+        vector_store=UnavailableVectorStore(
+            "chroma",
+            "vector_backend_initialization_failed",
+        ),
+        llm_enabled=False,
+    )
+    kb = service.create_knowledge_base("backend readiness")
+    document = await service.upload_document(
+        kb["id"],
+        "source.txt",
+        b"A fulltext pipeline remains independent of the vector backend.",
+        pipeline_only=True,
+    )
+    draft = service.get_pipeline_draft(kb["id"])
+    with pytest.raises(RagRetrievalUnavailableError) as blocked:
+        service.create_pipeline_job(
+            kb["id"],
+            draft_version=draft["version"],
+            source_document_ids=[document["id"]],
+        )
+    assert blocked.value.code == "rag_vector_backend_unavailable"
+
+    fulltext = service.update_pipeline_draft(
+        kb["id"],
+        {},
+        retrieval_profile={"mode": "fulltext"},
+    )
+    job = service.create_pipeline_job(
+        kb["id"],
+        draft_version=fulltext["version"],
+        source_document_ids=[document["id"]],
+    )
+    assert await KnowledgePipelineExecutor(service).run_once() is True
+    completed = service.get_pipeline_job(job["job_id"])
+    assert completed["status"] == "succeeded"
+    assert embedder.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_fulltext_pipeline_recovery_does_not_touch_unavailable_vector_backend(
+    tmp_path: Path,
+) -> None:
+    service = RagService(
+        storage_dir=tmp_path / "storage",
+        uploads_dir=tmp_path / "uploads",
+        embedder=CountingEmbeddingClient(),
+        vector_store=UnavailableVectorStore(
+            "chroma",
+            "vector_backend_initialization_failed",
+        ),
+        llm_enabled=False,
+    )
+    kb = service.create_knowledge_base("fulltext recovery")
+    document = await service.upload_document(
+        kb["id"],
+        "recovery.txt",
+        b"Fulltext recovery must remain independent of vector readiness.",
+        pipeline_only=True,
+    )
+    draft = service.update_pipeline_draft(
+        kb["id"],
+        {},
+        retrieval_profile={"mode": "fulltext"},
+    )
+    job = service.create_pipeline_job(
+        kb["id"],
+        draft_version=draft["version"],
+        source_document_ids=[document["id"]],
+    )
+    service._update_pipeline_job(
+        job["job_id"],
+        lambda current: current.update({"status": "running"}),
+    )
+
+    assert service.recover_pipeline_jobs() == 1
+    assert service.get_pipeline_job(job["job_id"])["status"] == "queued"
+
+
+@pytest.mark.asyncio
+async def test_fulltext_pipeline_cleanup_does_not_touch_unavailable_vector_backend(
+    tmp_path: Path,
+) -> None:
+    service = RagService(
+        storage_dir=tmp_path / "storage",
+        uploads_dir=tmp_path / "uploads",
+        embedder=CountingEmbeddingClient(),
+        vector_store=UnavailableVectorStore(
+            "chroma",
+            "vector_backend_initialization_failed",
+        ),
+        llm_enabled=False,
+    )
+    kb = service.create_knowledge_base("fulltext cleanup")
+    document = await service.upload_document(
+        kb["id"],
+        "cleanup.txt",
+        b"Fulltext cleanup must remain independent of vector readiness.",
+        pipeline_only=True,
+    )
+    draft = service.update_pipeline_draft(
+        kb["id"],
+        {},
+        retrieval_profile={"mode": "fulltext"},
+    )
+    job = service.create_pipeline_job(
+        kb["id"],
+        draft_version=draft["version"],
+        source_document_ids=[document["id"]],
+    )
+    service._update_pipeline_job(
+        job["job_id"],
+        lambda current: current.update(
+            {
+                "status": "cancelled",
+                "deletion_invalidated": True,
+            }
+        ),
+    )
+
+    service.cleanup_invalidated_pipeline_job(job["job_id"])
+
+    cleaned = service.get_pipeline_job(job["job_id"])
+    assert cleaned["deletion_artifacts_purged"] is True
+    assert cleaned["deletion_cleanup_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_vector_pipeline_does_not_publish_when_backend_drops_vectors(
+    tmp_path: Path,
+) -> None:
+    class DroppingVectorStore(LocalJsonVectorStore):
+        def add_chunks(self, chunks: list[VectorChunk]) -> None:
+            return None
+
+    embedder = CountingEmbeddingClient()
+    vector_store = DroppingVectorStore(tmp_path / "storage" / "vectors.json")
+    service = RagService(
+        storage_dir=tmp_path / "storage",
+        uploads_dir=tmp_path / "uploads",
+        embedder=embedder,
+        vector_store=vector_store,
+        llm_enabled=False,
+    )
+    kb = service.create_knowledge_base("vector write verification")
+    document = await service.upload_document(
+        kb["id"],
+        "source.txt",
+        b"A ready vector version must prove that every chunk was stored.",
+        pipeline_only=True,
+    )
+    draft = service.get_pipeline_draft(kb["id"])
+    job = service.create_pipeline_job(
+        kb["id"],
+        draft_version=draft["version"],
+        source_document_ids=[document["id"]],
+    )
+
+    assert await KnowledgePipelineExecutor(service).run_once() is True
+    completed = service.get_pipeline_job(job["job_id"])
+    assert completed["status"] == "failed"
+    assert "Vector index count" in str(completed["error"])
+    assert service.list_pipeline_versions(kb["id"]) == []
+
+
+@pytest.mark.asyncio
+async def test_fulltext_pipeline_builds_without_embedding_or_vector_namespace(
+    contract_runtime,
+) -> None:
+    client, service, executor, embedder, vector_store = contract_runtime
+    kb_id, document_id = await _create_pipeline_source(client)
+    embedder.call_count = 0
+    draft_response = await client.patch(
+        f"/api/rag/pipeline/draft/{kb_id}",
+        json={"retrieval_profile": {"mode": "fulltext"}},
+    )
+    assert draft_response.status_code == 200, draft_response.text
+    draft = draft_response.json()
+    assert draft["index_schema_version"] == 3
+    assert draft["embedding_profile"]["effective"]["status"] == "not_applicable"
+    assert draft["index_contract"]["vector"]["required"] is False
+
+    job = await _execute_draft(client, executor, kb_id, document_id)
+    version_id = str(job["candidate_version_id"])
+    version = service.get_pipeline_version(version_id)
+
+    assert embedder.call_count == 0
+    assert all(
+        record.get("kb_id") != version["namespace"]
+        for record in vector_store._read_records()
+    )
+    assert version["index_schema_version"] == 3
+    assert version["vector_index_ready"] is False
+    assert version["lexical_index_ready"] is True
+    assert version["embedding_profile"]["effective"]["status"] == "not_applicable"
+    assert version["index_contract"]["vector"]["required"] is False
+    assert service.lexical_store.count_namespace(str(version["namespace"])) > 0
+
+    query_response = await client.post(
+        f"/api/rag/pipeline/versions/{version_id}/query",
+        json={"question": "full-text-only pipeline"},
+    )
+    assert query_response.status_code == 200, query_response.text
+    assert query_response.json()["sources"]
+    assert embedder.call_count == 0
+
+    service.activate_pipeline_version(version_id)
+    active_query = await client.post(
+        "/api/rag/query",
+        json={"kb_id": kb_id, "question": "full-text-only pipeline"},
+    )
+    assert active_query.status_code == 200, active_query.text
+    assert active_query.json()["sources"]
+    citations = await client.post(
+        "/api/rag/pipeline/citations",
+        json={"kb_id": kb_id, "question": "full-text-only pipeline"},
+    )
+    assert citations.status_code == 200, citations.text
+    assert citations.json()["citation_count"] > 0
+    assert embedder.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_fulltext_missing_index_fails_closed_without_embedding(
+    contract_runtime,
+) -> None:
+    client, service, executor, embedder, _ = contract_runtime
+    kb_id, document_id = await _create_pipeline_source(client)
+    embedder.call_count = 0
+    draft_response = await client.patch(
+        f"/api/rag/pipeline/draft/{kb_id}",
+        json={"retrieval_profile": {"mode": "fulltext"}},
+    )
+    assert draft_response.status_code == 200, draft_response.text
+    job = await _execute_draft(client, executor, kb_id, document_id)
+    version_id = str(job["candidate_version_id"])
+    version = service.get_pipeline_version(version_id)
+    service.lexical_store.delete_namespace(str(version["namespace"]))
+
+    response = await client.post(
+        f"/api/rag/pipeline/versions/{version_id}/query",
+        json={"question": "What must never be dispatched?"},
+    )
+
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"]["code"] == "rag_fulltext_index_unavailable"
+    assert embedder.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_v3_vector_namespace_binds_embedding_space_and_distance(
+    contract_runtime,
+) -> None:
+    client, service, executor, embedder, _ = contract_runtime
+    kb_id, document_id = await _create_pipeline_source(client)
+    embedder.call_count = 0
+    job = await _execute_draft(client, executor, kb_id, document_id)
+    version = service.get_pipeline_version(str(job["candidate_version_id"]))
+    effective = version["embedding_profile"]["effective"]
+
+    assert embedder.call_count == 1
+    assert version["index_schema_version"] == 3
+    assert version["index_contract"]["vector"] == {
+        "required": True,
+        "embedding_space_fingerprint": version["embedding_space_fingerprint"],
+        "dimension": effective["dimension"],
+        "distance_contract": "cosine_v1",
+    }
+    namespace = str(version["namespace"])
+    assert "::v3::" in namespace
+    assert version["embedding_space_fingerprint"] in namespace
+    assert f"::dim-{effective['dimension']}::" in namespace
+    assert namespace.endswith("::cosine_v1")
+
+
+@pytest.mark.asyncio
+async def test_model_endpoint_and_dimension_changes_get_distinct_namespaces(
+    contract_runtime,
+) -> None:
+    client, service, executor, embedder, _ = contract_runtime
+    kb_id, document_id = await _create_pipeline_source(client)
+    embedder.call_count = 0
+
+    first_job = await _execute_draft(client, executor, kb_id, document_id)
+    first = service.get_pipeline_version(str(first_job["candidate_version_id"]))
+
+    embedder.model = "test-embedding-model-v2"
+    model_draft = await client.patch(
+        f"/api/rag/pipeline/draft/{kb_id}",
+        json={
+            "embedding_profile": {
+                "provider": "openai_compatible",
+                "model": "test-embedding-model-v2",
+            }
+        },
+    )
+    assert model_draft.status_code == 200, model_draft.text
+    second_job = await _execute_draft(client, executor, kb_id, document_id)
+    second = service.get_pipeline_version(str(second_job["candidate_version_id"]))
+
+    embedder.api_base = "https://other-embedding.invalid/v1"
+    endpoint_draft = await client.patch(
+        f"/api/rag/pipeline/draft/{kb_id}",
+        json={},
+    )
+    assert endpoint_draft.status_code == 200, endpoint_draft.text
+    third_job = await _execute_draft(client, executor, kb_id, document_id)
+    third = service.get_pipeline_version(str(third_job["candidate_version_id"]))
+
+    embedder.dimension = 16
+    dimension_draft = await client.patch(
+        f"/api/rag/pipeline/draft/{kb_id}",
+        json={},
+    )
+    assert dimension_draft.status_code == 200, dimension_draft.text
+    fourth_job = await _execute_draft(client, executor, kb_id, document_id)
+    fourth = service.get_pipeline_version(str(fourth_job["candidate_version_id"]))
+
+    assert len(
+        {first["namespace"], second["namespace"], third["namespace"], fourth["namespace"]}
+    ) == 4
+    assert len(
+        {
+            first["embedding_space_fingerprint"],
+            second["embedding_space_fingerprint"],
+            third["embedding_space_fingerprint"],
+            fourth["embedding_space_fingerprint"],
+        }
+    ) == 4
+    assert {
+        first["embedding_profile"]["effective"]["dimension"],
+        second["embedding_profile"]["effective"]["dimension"],
+        third["embedding_profile"]["effective"]["dimension"],
+        fourth["embedding_profile"]["effective"]["dimension"],
+    } == {8, 16}
+
+    conflicting = dict(third["index_contract"])
+    conflicting["vector"] = dict(conflicting["vector"])
+    conflicting["vector"]["distance_contract"] = "dot_product_v1"
+    with pytest.raises(PipelineDraftValidationError):
+        service._candidate_namespace(kb_id, "kpv_conflict", conflicting)
+
+
+@pytest.mark.asyncio
+async def test_active_v2_remains_readable_but_cannot_be_rebuilt_or_newly_activated(
+    contract_runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, service, _executor, _embedder, _ = contract_runtime
+    kb_id, document_id = await _create_pipeline_source(client)
+    profile = service._default_embedding_profile()
+    legacy_id = "kpv_legacy_active"
+    blocked_id = "kpv_legacy_blocked"
+    base = {
+        "version_id": legacy_id,
+        "kb_id": kb_id,
+        "version": 1,
+        "status": "active",
+        "namespace": kb_id,
+        "draft_id": f"draft_{kb_id}",
+        "draft_version": 1,
+        "index_schema_version": 2,
+        "embedding_profile": profile,
+        "embedding_space_fingerprint": profile["embedding_space_fingerprint"],
+        "retrieval_profile": {"mode": "vector", "top_k": 2},
+        "vector_index_ready": True,
+        "lexical_index_ready": False,
+        "source_summary": [],
+        "document_count": 1,
+        "chunk_count": 1,
+        "job_id": "legacy-job",
+        "created_at": 1.0,
+        "activated_at": 1.0,
+    }
+    with service._metadata_lock:
+        metadata = service._read_metadata_unlocked()
+        metadata["pipeline_versions"][legacy_id] = dict(base)
+        metadata["pipeline_versions"][blocked_id] = {
+            **base,
+            "version_id": blocked_id,
+            "version": 2,
+            "status": "ready",
+            "activated_at": None,
+        }
+        metadata["pipeline_active_versions"][kb_id] = legacy_id
+        service._write_metadata_unlocked(metadata)
+
+    result = await service.query_pipeline_version(
+        legacy_id,
+        "full-text-only pipeline",
+        generate_answer=False,
+    )
+    assert result["sources"]
+    assert service.activate_pipeline_version(legacy_id)["active"] is True
+    with pytest.raises(PipelineJobStateError, match="Legacy V2"):
+        service.activate_pipeline_version(blocked_id)
+
+    class AllowingEvaluationStore:
+        def assert_promotion_allowed(self, **_kwargs: object) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "server.rag.api.get_evaluation_store",
+        lambda: AllowingEvaluationStore(),
+    )
+    activation = await client.post(
+        f"/api/rag/pipeline/versions/{legacy_id}/activate",
+    )
+    assert activation.status_code == 200, activation.text
+    promotion = await client.post(
+        f"/api/rag/pipeline/versions/{legacy_id}/promote",
+        json={"evaluation_run_id": "eval_synthetic_pass"},
+    )
+    assert promotion.status_code == 409, promotion.text
+    assert "Legacy V2" in str(promotion.json()["detail"])
+
+    draft = service.get_pipeline_draft(kb_id)
+    with pytest.raises(PipelineDraftValidationError, match="read-only"):
+        service.create_pipeline_job(
+            kb_id,
+            draft_version=draft["version"],
+            source_document_ids=[document_id],
+            base_version_id=legacy_id,
+        )

--- a/server/tests/test_rag_pipeline.py
+++ b/server/tests/test_rag_pipeline.py
@@ -114,7 +114,7 @@ async def test_rag_pipeline_draft_empty_knowledge_base(client: httpx.AsyncClient
     assert stages["data_source"]["item_count"] == 0
     assert stages["processor"]["item_count"] == 0
     assert stages["chunker"]["item_count"] == 0
-    assert data["index_schema_version"] == 2
+    assert data["index_schema_version"] == 3
     assert data["retrieval_profile"]["mode"] == "hybrid"
     assert data["embedding_profile"]["degraded"] is True
     assert data["embedding_profile"]["requested"] == {
@@ -128,6 +128,7 @@ async def test_rag_pipeline_draft_empty_knowledge_base(client: httpx.AsyncClient
         "degraded": True,
         "ready": True,
         "reason": None,
+        "access_mode": "local_hash",
     }
     assert stages["chunker"]["config"]["strategy"] == "recursive_character"
     assert stages["chunker"]["config"]["chunk_size"] == 500
@@ -344,6 +345,7 @@ def test_rag_pipeline_records_ready_requested_and_effective_embedding(
         "degraded": False,
         "ready": True,
         "reason": None,
+        "access_mode": "legacy",
     }
     assert profile["provider"] == "openai_compatible"
     assert profile["model"] == "baai/bge-m3"
@@ -354,7 +356,7 @@ async def test_rag_retrieval_capabilities_are_safe(client: httpx.AsyncClient) ->
     response = await client.get("/api/rag/retrieval-capabilities")
     assert response.status_code == 200, response.text
     data = response.json()
-    assert data["index_schema_version"] == 2
+    assert data["index_schema_version"] == 3
     assert data["fulltext"]["backend"] == "sqlite_fts5"
     assert data["modes"] == ["vector", "fulltext", "hybrid"]
     serialized = str(data).lower()

--- a/server/tests/test_rag_retrieval_v2.py
+++ b/server/tests/test_rag_retrieval_v2.py
@@ -218,7 +218,7 @@ async def test_v2_candidate_builds_dual_index_and_lifts_parent_context(tmp_path:
     assert await executor.run_once() is True
     completed = service.get_pipeline_job(job["job_id"])
     version = service.get_pipeline_version(completed["candidate_version_id"])
-    assert version["index_schema_version"] == 2
+    assert version["index_schema_version"] == 3
     assert version["vector_index_ready"] is True
     assert version["lexical_index_ready"] is True
     assert service.lexical_store.count_namespace(version["namespace"]) == version["chunk_count"]


### PR DESCRIPTION
## 变更摘要

- 新建 Knowledge Pipeline 默认使用 V3 索引身份，namespace 绑定 pipeline version、Embedding fingerprint、实际维度和 cosine_v1 距离合同。
- Chroma/LocalJSON 统一外部 cosine similarity；Chroma 初始化、持久化 identity、维度或距离合同异常时 fail-closed，不再静默切换 LocalJSON。
- Fulltext-only 构建、查询、恢复和清理不调用 Embedding 或 vector backend；缺失 FTS 索引返回结构化 409。
- 历史 V2 保持只读查询兼容，但禁止新建、重建和 promotion；新增后端 readiness/index contract API 与 UI 回执。
- 增加写入计数、重启读取、删除身份、维度、promotion 与 lifecycle 证伪回归。

## 验证

- server/tests/test_rag_embedding_contract.py: 19 passed
- RAG/Knowledge/Benchmark 定向回归: 349 passed, 4576 deselected
- m-r 后端分段: 1371 passed, 14 skipped
- RagPage.test.ts: 14 passed
- 
pm.cmd run build: passed
- Python compile、diff check、敏感信息扫描: passed

## 安全与兼容边界

- 未调用真实 Provider 或消耗真实额度。
- 未修改或迁移活动 V2 索引、RAG storage、共享容器或持久化数据。
- 未激活候选、部署或合并。
- 回滚仅需撤销本 PR，无数据回滚。