### PR TITLE
fix: 恢复主线测试绿灯

### DIFF
--- a/client/src/components/ModelCard.test.ts
+++ b/client/src/components/ModelCard.test.ts
@@ -117,7 +117,7 @@ describe("ModelCard document input presentation", () => {
 describe("ModelCard decision-first layout", () => {
   it("shows a compact UTC pricing schedule for time-priced models", () => {
     const model = models.find(
-      (candidate) => candidate.id === "deepseek/deepseek-v4-pro-0813",
+      (candidate) => candidate.id === "deepseek/deepseek-v4-flash-vision-exp",
     );
     expect(model).toBeDefined();
 
@@ -137,8 +137,8 @@ describe("ModelCard decision-first layout", () => {
     );
 
     expect(screen.getByText("当前输入薪资")).toBeInTheDocument();
-    expect(screen.getByText("UTC 分时价格 · 4 个时段")).toBeInTheDocument();
-    expect(screen.getByText("10:00–次日 01:00")).toBeInTheDocument();
+    expect(screen.getByText("UTC 分时价格 · 5 个时段")).toBeInTheDocument();
+    expect(screen.getByText("10:00–次日 00:00")).toBeInTheDocument();
   });
 
   it("prioritizes task and input capabilities without obsolete region or fake talent labels", () => {

--- a/client/src/utils/tokenPricing.test.ts
+++ b/client/src/utils/tokenPricing.test.ts
@@ -51,7 +51,7 @@ describe("tokenPricingForPrompt", () => {
 
   it("selects the live UTC price with inclusive start and exclusive end", () => {
     const model = models.find(
-      (candidate) => candidate.id === "deepseek/deepseek-v4-pro-0813",
+      (candidate) => candidate.id === "deepseek/deepseek-v4-flash-vision-exp",
     );
     expect(model).toBeDefined();
 
@@ -64,16 +64,16 @@ describe("tokenPricingForPrompt", () => {
       utc_end: 400,
     });
     expect(priceCnyForUtcTime(model!, highPriceAtStart)).toEqual({
-      input: 8.94,
-      output: 26.81,
+      input: 2.98,
+      output: 8.94,
     });
     expect(priceCnyForUtcTime(model!, lowPriceAtEnd)).toEqual({
-      input: 4.47,
-      output: 13.4,
+      input: 1.49,
+      output: 4.47,
     });
     expect(pricingWindowForUtcTime(model!, overnightPrice)).toMatchObject({
       utc_start: 1000,
-      utc_end: 100,
+      utc_end: 0,
     });
   });
 });

--- a/server/tests/test_skill_creator_middleware_handoff.py
+++ b/server/tests/test_skill_creator_middleware_handoff.py
@@ -854,7 +854,11 @@ async def test_plugin_preset_cannot_inject_creator_handoff(
         get_version=lambda _plugin_id, _version: version,
     )
 
+    provider_calls = 0
+
     async def fake_collect(*_args, **_kwargs):
+        nonlocal provider_calls
+        provider_calls += 1
         return "analysis completed"
 
     monkeypatch.setattr(main_module, "workflow_execution_store", execution_store)
@@ -894,7 +898,12 @@ async def test_plugin_preset_cannot_inject_creator_handoff(
         for item in events
     )
     assert not any(item.get("event") == "skill_creator_handoff" for item in events)
-    assert any(item.get("event") == "workflow_end" for item in events)
+    assert not any(item.get("event") == "workflow_end" for item in events)
+    error = next(item for item in events if item.get("event") == "error")
+    persisted = execution_store.require(error["task_id"])
+    assert persisted.status == "failed"
+    assert persisted.error == "skill_creator_handoff_unavailable"
+    assert provider_calls == 0
     assert session_store.list() == []
 
 


### PR DESCRIPTION
## Summary
- replace stale time-window pricing fixtures with a catalog model that still has five real UTC pricing windows
- preserve inclusive-start, exclusive-end, and overnight-window assertions
- update the plugin middleware injection regression to require fail-closed execution, no provider call, no workflow completion, and failed durable state
- leave production pricing, workflow runtime, Registry, NodeContract, API, Store, and capability audit unchanged

This is PR 1 of Workflow R2.7. The RSS trigger PR will start from fresh `main` only after this PR is merged.

## Validation
- `npm.cmd run test:run -- src/components/ModelCard.test.ts src/utils/tokenPricing.test.ts` — 14 passed
- targeted Skill Creator middleware tests — 2 passed
- `npm.cmd run test:run` — 737 passed
- `npm.cmd run typecheck` — passed
- `npm.cmd run build` — passed
- Agency Worker core and upstream suite — 75 core tests plus all upstream checks passed
- `python -m pytest server/tests/ -q` in the local Linux test image after the same Agency Worker build prerequisite as CI — 4932 passed, 29 skipped
- `git diff --check` — passed

## Help Center Impact
None. This PR changes only stale regression fixtures and assertions; it does not change any user-visible behavior, workflow contract, UI text, navigation, or documented task steps.