### PR TITLE
fix: 补齐 RAG P0 绝对分数与无结果合同

### DIFF
--- a/client/src/pages/KnowledgePipelineCanvasPage.tsx
+++ b/client/src/pages/KnowledgePipelineCanvasPage.tsx
@@ -709,6 +709,7 @@ export default function KnowledgePipelineCanvasPage() {
 function NodeConfig({ node, onChange }: { node: GraphFlowNode; onChange: (patch: Record<string, unknown>) => void }) {
   const { kind, config } = node.data;
   const meta = NODE_META[kind];
+  const absoluteThresholdContract = config.no_result_policy === "absolute_relevance_v1";
   return (
     <div className="space-y-5">
       <div>
@@ -759,7 +760,19 @@ function NodeConfig({ node, onChange }: { node: GraphFlowNode; onChange: (patch:
           <SelectField label="检索模式" value={String(config.mode || "hybrid")} options={["vector", "fulltext", "hybrid"]} onChange={(value) => onChange({ mode: value })} />
           <NumberField label="向量权重 (%)" min={0} max={100} value={Math.round(Number(config.vector_weight ?? 0.7) * 100)} onChange={(value) => onChange({ vector_weight: value / 100, fulltext_weight: 1 - value / 100 })} />
           <NumberField label="Top-K" min={1} max={50} value={Number(config.top_k || 5)} onChange={(value) => onChange({ top_k: value })} />
-          <NumberField label="Score 阈值 (%)" min={0} max={100} value={Math.round(Number(config.score_threshold || 0) * 100)} onChange={(value) => onChange({ score_threshold: value / 100 })} />
+          {absoluteThresholdContract ? (
+            <>
+              {config.mode !== "fulltext" ? <OptionalNumberField label="最低向量相似度 (%)" min={0} max={100} value={typeof config.min_vector_similarity === "number" ? Math.round(config.min_vector_similarity * 100) : null} onChange={(value) => onChange({ min_vector_similarity: value === null ? null : value / 100 })} /> : null}
+              {config.mode !== "vector" ? <OptionalNumberField label="最低全文置信度 (%)" min={0} max={100} value={typeof config.min_lexical_confidence === "number" ? Math.round(config.min_lexical_confidence * 100) : null} onChange={(value) => onChange({ min_lexical_confidence: value === null ? null : value / 100 })} /> : null}
+              {config.rerank_enabled ? <OptionalNumberField label="最低 Rerank 分数 (%)" min={0} max={100} value={typeof config.min_rerank_score === "number" ? Math.round(config.min_rerank_score * 100) : null} onChange={(value) => onChange({ min_rerank_score: value === null ? null : value / 100 })} /> : null}
+            </>
+          ) : (
+            <div className="space-y-3 rounded-md border border-amber-300/20 bg-amber-300/5 p-3">
+              <NumberField label="Legacy fused score 阈值 (%)" min={0} max={100} value={Math.round(Number(config.score_threshold || 0) * 100)} onChange={(value) => onChange({ score_threshold: value / 100 })} />
+              <p className="text-[11px] leading-5 text-amber-100/70">历史兼容配置仅供诊断。切换后不会自动填写生产阈值。</p>
+              <button className="rounded-md border border-amber-300/30 px-3 py-2 text-xs font-semibold text-amber-100 hover:bg-amber-300/10" onClick={() => onChange({ no_result_policy: "absolute_relevance_v1", score_threshold: undefined, min_vector_similarity: null, min_lexical_confidence: null, min_rerank_score: null })} type="button">切换到 V3 绝对阈值合同</button>
+            </div>
+          )}
           <ToggleField label="启用 Rerank" checked={Boolean(config.rerank_enabled)} onChange={(value) => onChange({ rerank_enabled: value })} />
           <SelectField label="Rerank Provider" value={String(config.rerank_provider || "auto")} options={["auto", "api", "llm", "none"]} onChange={(value) => onChange({ rerank_provider: value })} />
           {config.rerank_enabled ? (
@@ -794,7 +807,7 @@ function defaultConfig(kind: GraphNodeKind): Record<string, unknown> {
   if (kind === "parent_child_chunker") return { strategy: "parent_child", parent_chunk_size: 1500, parent_chunk_overlap: 100, child_chunk_size: 400, child_chunk_overlap: 50, parent_separators: ["\n\n", "\n", ". ", " ", ""], child_separators: ["\n\n", "\n", ". ", " ", ""] };
   if (kind === "embedding") return { model: DEFAULT_EMBEDDING_MODEL_ID };
   if (kind === "dual_index") return { vector_enabled: true, fulltext_enabled: true };
-  if (kind === "retrieval") return { mode: "hybrid", vector_weight: 0.7, fulltext_weight: 0.3, top_k: 5, score_threshold: 0, candidate_multiplier: 4, rerank_enabled: false, rerank_provider: "auto", rerank_model: "", rerank_top_n: 5 };
+  if (kind === "retrieval") return { mode: "hybrid", vector_weight: 0.7, fulltext_weight: 0.3, top_k: 5, min_vector_similarity: null, min_lexical_confidence: null, min_rerank_score: null, no_result_policy: "absolute_relevance_v1", threshold_contract_status: "unconfigured", candidate_multiplier: 4, rerank_enabled: false, rerank_provider: "auto", rerank_model: "", rerank_top_n: 5 };
   if (kind === "image_understanding") return { enabled: true, provider: "openai_compatible_vlm", vision_model_id: "", pdf_page_strategy: "auto", render_dpi: 144, max_pages: 100, max_image_edge: 2048, failure_policy: "continue_on_error" };
   return {};
 }
@@ -859,6 +872,10 @@ function RerankModelField({ value, onChange }: { value: string; onChange: (value
 
 function NumberField({ label, value, min, max, onChange }: { label: string; value: number; min: number; max: number; onChange: (value: number) => void }) {
   return <label className="block text-xs font-semibold text-slate-300">{label}<input className="mt-2 w-full rounded-md border border-white/10 bg-surface-950 px-3 py-2 text-sm text-white outline-none focus:border-hire-300/50" max={max} min={min} onChange={(event) => onChange(Number(event.target.value))} type="number" value={value} /></label>;
+}
+
+function OptionalNumberField({ label, value, min, max, onChange }: { label: string; value: number | null; min: number; max: number; onChange: (value: number | null) => void }) {
+  return <label className="block text-xs font-semibold text-slate-300">{label}<input className="mt-2 w-full rounded-md border border-white/10 bg-surface-950 px-3 py-2 text-sm text-white outline-none focus:border-hire-300/50" max={max} min={min} onChange={(event) => onChange(event.target.value === "" ? null : Number(event.target.value))} placeholder="未配置" type="number" value={value ?? ""} /></label>;
 }
 
 function SelectField({ label, value, options, onChange }: { label: string; value: string; options: string[]; onChange: (value: string) => void }) {

--- a/client/src/pages/RagPage.test.ts
+++ b/client/src/pages/RagPage.test.ts
@@ -10,6 +10,7 @@ import RagPage, {
   isRagFileSelectionDisabled,
   ragUploadStatusLabel,
   readError,
+  retrievalProfileFromEdits,
 } from "./RagPage";
 
 function jsonResponse(payload: unknown, status = 200) {
@@ -204,6 +205,73 @@ function renderRagPageWithOfficeUploadError(
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+});
+
+describe("RAG V3 retrieval threshold serialization", () => {
+  const baseEdits = {
+    processorMode: "general" as const,
+    processorModelId: "",
+    processorFailurePolicy: "continue_on_error" as const,
+    extractTitle: true,
+    preserveTables: true,
+    preserveCodeBlocks: true,
+    removeRepeatedHeadersFooters: true,
+    maxGeneratedItems: "20",
+    strategy: "recursive_character" as const,
+    chunkSize: "500",
+    chunkOverlap: "50",
+    separators: "",
+    parentChunkSize: "1500",
+    parentChunkOverlap: "100",
+    parentSeparators: "",
+    childChunkSize: "400",
+    childChunkOverlap: "50",
+    childSeparators: "",
+    embeddingProvider: "hash" as const,
+    embeddingModel: "deterministic-hash-v1",
+    retrievalMode: "hybrid" as const,
+    vectorWeight: "0.7",
+    fulltextWeight: "0.3",
+    topK: "5",
+    scoreThreshold: "0.42",
+    candidateMultiplier: "4",
+    rerankEnabled: true,
+    rerankProvider: "api" as const,
+    rerankModel: "reranker",
+    rerankTopN: "5",
+  };
+
+  it("sends only absolute score domains for a V3 draft", () => {
+    const payload = retrievalProfileFromEdits({
+      ...baseEdits,
+      absoluteThresholdContract: true,
+      minVectorSimilarity: "0.71",
+      minLexicalConfidence: "0.63",
+      minRerankScore: "",
+    });
+
+    expect(payload).toMatchObject({
+      no_result_policy: "absolute_relevance_v1",
+      min_vector_similarity: 0.71,
+      min_lexical_confidence: 0.63,
+      min_rerank_score: null,
+    });
+    expect(payload).not.toHaveProperty("score_threshold");
+  });
+
+  it("keeps an explicit historical profile in the legacy score domain", () => {
+    const payload = retrievalProfileFromEdits({
+      ...baseEdits,
+      absoluteThresholdContract: false,
+      minVectorSimilarity: "",
+      minLexicalConfidence: "",
+      minRerankScore: "",
+    });
+
+    expect(payload).toMatchObject({ score_threshold: 0.42 });
+    expect(payload).not.toHaveProperty("no_result_policy");
+    expect(payload).not.toHaveProperty("min_vector_similarity");
+  });
 });
 
 describe("RAG structured API errors", () => {

--- a/client/src/pages/RagPage.tsx
+++ b/client/src/pages/RagPage.tsx
@@ -172,6 +172,10 @@ interface PipelineDraftEdits {
   fulltextWeight: string;
   topK: string;
   scoreThreshold: string;
+  absoluteThresholdContract: boolean;
+  minVectorSimilarity: string;
+  minLexicalConfidence: string;
+  minRerankScore: string;
   candidateMultiplier: string;
   rerankEnabled: boolean;
   rerankProvider: "none" | "auto" | "api" | "llm";
@@ -554,6 +558,45 @@ function numericProfileValue(profile: Record<string, unknown>, key: string, fall
   return Number.isFinite(value) ? value : fallback;
 }
 
+function optionalProfileValue(profile: Record<string, unknown>, key: string) {
+  const value = profile[key];
+  return typeof value === "number" && Number.isFinite(value) ? String(value) : "";
+}
+
+function optionalDraftNumber(value: string) {
+  const normalized = value.trim();
+  if (!normalized) return null;
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function retrievalProfileFromEdits(edits: PipelineDraftEdits) {
+  const common = {
+    mode: edits.retrievalMode,
+    vector_weight: Number(edits.vectorWeight),
+    fulltext_weight: Number(edits.fulltextWeight),
+    top_k: Number(edits.topK),
+    candidate_multiplier: Number(edits.candidateMultiplier),
+    rerank_enabled: edits.rerankEnabled,
+    rerank_provider: edits.rerankEnabled ? edits.rerankProvider : "none",
+    rerank_model: edits.rerankModel.trim(),
+    rerank_top_n: Number(edits.rerankTopN),
+  };
+  if (!edits.absoluteThresholdContract) {
+    return {
+      ...common,
+      score_threshold: Number(edits.scoreThreshold),
+    };
+  }
+  return {
+    ...common,
+    no_result_policy: "absolute_relevance_v1",
+    min_vector_similarity: optionalDraftNumber(edits.minVectorSimilarity),
+    min_lexical_confidence: optionalDraftNumber(edits.minLexicalConfidence),
+    min_rerank_score: optionalDraftNumber(edits.minRerankScore),
+  };
+}
+
 function embeddingProfileSection(
   profile: Record<string, unknown> | undefined,
   key: "requested" | "effective",
@@ -612,6 +655,10 @@ function draftEditsFromResponse(draft: PipelineDraftResponse): PipelineDraftEdit
     fulltextWeight: String(numericProfileValue(retrieval, "fulltext_weight", 0.3)),
     topK: String(numericProfileValue(retrieval, "top_k", 5)),
     scoreThreshold: String(numericProfileValue(retrieval, "score_threshold", 0)),
+    absoluteThresholdContract: retrieval.no_result_policy === "absolute_relevance_v1",
+    minVectorSimilarity: optionalProfileValue(retrieval, "min_vector_similarity"),
+    minLexicalConfidence: optionalProfileValue(retrieval, "min_lexical_confidence"),
+    minRerankScore: optionalProfileValue(retrieval, "min_rerank_score"),
     candidateMultiplier: String(numericProfileValue(retrieval, "candidate_multiplier", 4)),
     rerankEnabled: Boolean(retrieval.rerank_enabled),
     rerankProvider: provider,
@@ -801,6 +848,10 @@ export default function RagPage() {
     fulltextWeight: "0.3",
     topK: "5",
     scoreThreshold: "0",
+    absoluteThresholdContract: true,
+    minVectorSimilarity: "",
+    minLexicalConfidence: "",
+    minRerankScore: "",
     candidateMultiplier: "4",
     rerankEnabled: false,
     rerankProvider: "auto",
@@ -1205,20 +1256,7 @@ export default function RagPage() {
             provider: pipelineDraftEdits.embeddingProvider,
             model: pipelineDraftEdits.embeddingModel.trim(),
           },
-          retrieval_profile: {
-            mode: pipelineDraftEdits.retrievalMode,
-            vector_weight: Number(pipelineDraftEdits.vectorWeight),
-            fulltext_weight: Number(pipelineDraftEdits.fulltextWeight),
-            top_k: Number(pipelineDraftEdits.topK),
-            score_threshold: Number(pipelineDraftEdits.scoreThreshold),
-            candidate_multiplier: Number(pipelineDraftEdits.candidateMultiplier),
-            rerank_enabled: pipelineDraftEdits.rerankEnabled,
-            rerank_provider: pipelineDraftEdits.rerankEnabled
-              ? pipelineDraftEdits.rerankProvider
-              : "none",
-            rerank_model: pipelineDraftEdits.rerankModel.trim(),
-            rerank_top_n: Number(pipelineDraftEdits.rerankTopN),
-          },
+          retrieval_profile: retrievalProfileFromEdits(pipelineDraftEdits),
         }),
       });
       if (!response.ok) throw new Error(await readError(response));
@@ -1351,20 +1389,7 @@ export default function RagPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           question,
-          retrieval: {
-            mode: pipelineDraftEdits.retrievalMode,
-            vector_weight: Number(pipelineDraftEdits.vectorWeight),
-            fulltext_weight: Number(pipelineDraftEdits.fulltextWeight),
-            top_k: Number(pipelineDraftEdits.topK),
-            score_threshold: Number(pipelineDraftEdits.scoreThreshold),
-            candidate_multiplier: Number(pipelineDraftEdits.candidateMultiplier),
-            rerank_enabled: pipelineDraftEdits.rerankEnabled,
-            rerank_provider: pipelineDraftEdits.rerankEnabled
-              ? pipelineDraftEdits.rerankProvider
-              : "none",
-            rerank_model: pipelineDraftEdits.rerankModel.trim(),
-            rerank_top_n: Number(pipelineDraftEdits.rerankTopN),
-          },
+          retrieval: retrievalProfileFromEdits(pipelineDraftEdits),
         }),
       });
       if (!response.ok) throw new Error(await readError(response));
@@ -2597,16 +2622,25 @@ export default function RagPage() {
                                     <option value="fulltext">全文检索</option>
                                   </select>
                                 </label>
-                                <div className="grid grid-cols-2 gap-2">
-                                  <label className="block"><span className="text-xs font-medium text-slate-300">Top-K</span><input className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2 text-sm text-white outline-none focus:border-hire-300/50" min={1} max={50} onChange={(event) => setPipelineDraftEdits((current) => ({ ...current, topK: event.target.value }))} type="number" value={pipelineDraftEdits.topK} /></label>
-                                  <label className="block"><span className="text-xs font-medium text-slate-300">Score 阈值</span><input className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2 text-sm text-white outline-none focus:border-hire-300/50" min={0} max={1} step={0.05} onChange={(event) => setPipelineDraftEdits((current) => ({ ...current, scoreThreshold: event.target.value }))} type="number" value={pipelineDraftEdits.scoreThreshold} /></label>
-                                </div>
+                                <label className="block"><span className="text-xs font-medium text-slate-300">Top-K</span><input className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2 text-sm text-white outline-none focus:border-hire-300/50" min={1} max={50} onChange={(event) => setPipelineDraftEdits((current) => ({ ...current, topK: event.target.value }))} type="number" value={pipelineDraftEdits.topK} /></label>
                               </div>
                               <div className="mt-3 grid gap-3 sm:grid-cols-3">
                                 <label className="block"><span className="text-xs font-medium text-slate-300">向量权重</span><input className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2 text-sm text-white outline-none focus:border-hire-300/50" disabled={pipelineDraftEdits.retrievalMode !== "hybrid"} min={0} max={1} step={0.1} onChange={(event) => setPipelineDraftEdits((current) => ({ ...current, vectorWeight: event.target.value }))} type="number" value={pipelineDraftEdits.vectorWeight} /></label>
                                 <label className="block"><span className="text-xs font-medium text-slate-300">全文权重</span><input className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2 text-sm text-white outline-none focus:border-hire-300/50" disabled={pipelineDraftEdits.retrievalMode !== "hybrid"} min={0} max={1} step={0.1} onChange={(event) => setPipelineDraftEdits((current) => ({ ...current, fulltextWeight: event.target.value }))} type="number" value={pipelineDraftEdits.fulltextWeight} /></label>
                                 <label className="block"><span className="text-xs font-medium text-slate-300">候选倍数</span><input className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2 text-sm text-white outline-none focus:border-hire-300/50" min={1} max={10} onChange={(event) => setPipelineDraftEdits((current) => ({ ...current, candidateMultiplier: event.target.value }))} type="number" value={pipelineDraftEdits.candidateMultiplier} /></label>
                               </div>
+                              {pipelineDraftEdits.absoluteThresholdContract ? (
+                                <div className="mt-3 grid gap-3 sm:grid-cols-3">
+                                  {pipelineDraftEdits.retrievalMode !== "fulltext" ? <label className="block"><span className="text-xs font-medium text-slate-300">最低向量相似度</span><input className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2 text-sm text-white outline-none focus:border-hire-300/50" min={0} max={1} placeholder="未配置" step={0.01} onChange={(event) => setPipelineDraftEdits((current) => ({ ...current, minVectorSimilarity: event.target.value }))} type="number" value={pipelineDraftEdits.minVectorSimilarity} /></label> : null}
+                                  {pipelineDraftEdits.retrievalMode !== "vector" ? <label className="block"><span className="text-xs font-medium text-slate-300">最低全文置信度</span><input className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2 text-sm text-white outline-none focus:border-hire-300/50" min={0} max={1} placeholder="未配置" step={0.01} onChange={(event) => setPipelineDraftEdits((current) => ({ ...current, minLexicalConfidence: event.target.value }))} type="number" value={pipelineDraftEdits.minLexicalConfidence} /></label> : null}
+                                  {pipelineDraftEdits.rerankEnabled ? <label className="block"><span className="text-xs font-medium text-slate-300">最低 Rerank 分数</span><input className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2 text-sm text-white outline-none focus:border-hire-300/50" min={0} max={1} placeholder="未配置" step={0.01} onChange={(event) => setPipelineDraftEdits((current) => ({ ...current, minRerankScore: event.target.value }))} type="number" value={pipelineDraftEdits.minRerankScore} /></label> : null}
+                                </div>
+                              ) : (
+                                <div className="mt-3 rounded-lg border border-amber-300/20 bg-amber-300/5 p-3">
+                                  <label className="block"><span className="text-xs font-medium text-amber-100">Legacy fused score 阈值</span><input className="mt-2 w-full rounded-lg border border-amber-300/20 bg-ink-950/70 px-3 py-2 text-sm text-white outline-none focus:border-amber-300/50" min={0} max={1} step={0.05} onChange={(event) => setPipelineDraftEdits((current) => ({ ...current, scoreThreshold: event.target.value }))} type="number" value={pipelineDraftEdits.scoreThreshold} /><span className="mt-1 block text-[11px] text-amber-100/70">历史兼容配置，仅用于诊断，不能晋级。</span></label>
+                                  <button className="mt-3 rounded-lg border border-amber-300/30 px-3 py-2 text-xs font-semibold text-amber-100 hover:bg-amber-300/10" onClick={() => setPipelineDraftEdits((current) => ({ ...current, absoluteThresholdContract: true, minVectorSimilarity: "", minLexicalConfidence: "", minRerankScore: "" }))} type="button">切换到 V3 绝对阈值合同</button>
+                                </div>
+                              )}
                               <div className="mt-3 flex items-center justify-between gap-3 border-y border-white/10 py-3">
                                 <div><p className="text-xs font-medium text-slate-200">启用 Rerank</p><p className="mt-1 text-[11px] text-slate-500">失败时保留混合融合排序，并返回 warning。</p></div>
                                 <input checked={pipelineDraftEdits.rerankEnabled} className="h-4 w-4 accent-hire-300" onChange={(event) => setPipelineDraftEdits((current) => ({ ...current, rerankEnabled: event.target.checked }))} type="checkbox" />

--- a/docs/RAG_INTEGRATION.md
+++ b/docs/RAG_INTEGRATION.md
@@ -2,12 +2,41 @@
 
 本文件说明模镜本地 RAG 模块的架构、API、扩展方式和测试方法。该模块位于 `server/rag/`，前端入口为 `/rag`，聊天页可选择知识库进行检索增强问答。
 
-最后更新日期：2026-08-26
+最后更新日期：2026-08-27
 
 > **当前状态：** `/rag` 是 ModelMirror 本地主路径。知识流水线已支持候选版本、
 > 人工激活/回滚、Processor、可选视觉理解、向量 + FTS5 双索引、检索评测和
 > Promotion Gate。下方按日期保留的段落是增量记录；较早段落中的“planned”
 > 只代表当时状态。
+
+## 2026-08-27 P0：V3 绝对相关性与无结果合同
+
+新建 V3 草稿使用 `no_result_policy=absolute_relevance_v1`，并按检索路径分别配置
+`min_vector_similarity`、`min_lexical_confidence` 和可选 Rerank 的
+`min_rerank_score`。阈值不再作用于 RRF：Vector/Full-text 候选先在各自的绝对分数域
+完成准入，Hybrid 只融合至少通过一个通道的候选，RRF 仅决定通过候选的顺序。成功
+Rerank 后，`min_rerank_score` 是最终权威过滤；Provider 失败才退回通道准入后的融合
+排序，并在回执中标记 `rerank_fail_open` 和不可晋级。Rerank Provider 分数必须是
+`[0,1]` 内的有限值；非有限或越界分数按非法响应安全回退，不再静默 clamp。
+
+Full-text 的 V3 绝对分数只接受稀有度加权 term coverage。查询缺少有效 token 时，历史
+V2 仍可读取其 rank fallback，但 V3 会把该分数视为非绝对证据并拒绝，避免单候选因
+Rank 1 自动获得 1.0。
+
+阈值可以留空用于诊断，此时 `threshold_contract_status=unconfigured`，查询不会伪造
+默认生产阈值，但候选不能晋级。检索回执增加每个候选的原始通道分数、通过状态、脱敏
+拒绝原因、实际阈值分数域和本次晋级资格；过滤后无候选会返回真实空结果。V3 晋级要求
+所有当前模式所需阈值均已配置，并绑定独立的 `rag-threshold-calibration-v1` 证据；证据
+中的 `retrieval_profile_checksum` 必须与待晋级版本的完整检索配置一致，旧配置的校准证据
+不能复用到修改后的阈值或 Rerank 模型合同；`configuration_fingerprint` 还必须绑定
+版本的 Embedding、Processor 与检索配置，`source_manifest_fingerprint` 必须绑定校准时的
+语料清单，禁止跨执行配置或跨语料复用校准结论。
+
+历史 `score_threshold` 仍可单独读取和运行，明确标记为 legacy/diagnostic；它继续过滤
+Rerank 前的 `fused_score`。同一请求混用旧字段与任一新绝对阈值会被拒绝，legacy V3
+配置也不能晋级。已有 legacy 草稿可在 Pipeline UI 中显式切换合同，但系统不会迁移或
+猜测任何新阈值。既有 Strategy Tuner 仍只产生 legacy fused-score 诊断结果；在后续
+独立 tuning/calibration 集合同落地前，不把它提升为 V3 校准证据。
 
 ## 2026-08-26 P0：V3 索引身份与后端就绪合同
 
@@ -311,7 +340,7 @@ Preview 最多返回 20 个截断结构块或生成项，不写草稿、Job 或�
 
 ## 2026-07-13 增量：Advanced RAG Retrieval V2
 
-候选知识版本现在固定分块、Embedding 与检索 profile，并原子构建向量和 SQLite FTS5 双索引。`/rag` 可以配置递归字符分块或父子分段、有序分段标识符、Embedding 模型、全文/向量/混合检索、权重、Top-K、score 阈值、候选倍数和可选 Rerank。
+候选知识版本现在固定分块、Embedding 与检索 profile，并原子构建向量和 SQLite FTS5 双索引。`/rag` 可以配置递归字符分块或父子分段、有序分段标识符、Embedding 模型、全文/向量/混合检索、权重、Top-K、score 阈值、候选倍数和可选 Rerank。以下 `score_threshold` 示例只描述历史 V2/legacy 合同；新 V3 草稿使用本文顶部的绝对相关性字段。
 
 新增安全能力摘要：
 

--- a/server/rag/api.py
+++ b/server/rag/api.py
@@ -255,11 +255,29 @@ class RetrievalOptionsPayload(BaseModel):
     fulltext_weight: float | None = None
     top_k: int | None = None
     score_threshold: float | None = None
+    min_vector_similarity: float | None = None
+    min_lexical_confidence: float | None = None
+    min_rerank_score: float | None = None
+    no_result_policy: Literal["absolute_relevance_v1"] | None = None
     candidate_multiplier: int | None = None
     rerank_enabled: bool | None = None
     rerank_provider: str | None = None
     rerank_model: str | None = None
     rerank_top_n: int | None = None
+
+
+def _retrieval_options_patch(payload: RetrievalOptionsPayload) -> dict[str, Any]:
+    """Preserve explicit V3 threshold clears without changing other null semantics."""
+
+    value = payload.model_dump(exclude_none=True)
+    for field in {
+        "min_vector_similarity",
+        "min_lexical_confidence",
+        "min_rerank_score",
+    }:
+        if field in payload.model_fields_set and getattr(payload, field) is None:
+            value[field] = None
+    return value
 
 
 class RagQueryRequest(BaseModel):
@@ -655,6 +673,8 @@ class PipelineVersionPayload(BaseModel):
     embedding_space_fingerprint: str = ""
     provider_route_receipts: dict[str, Any] | None = None
     retrieval_profile: dict[str, Any] = Field(default_factory=dict)
+    threshold_contract_status: str = "legacy"
+    threshold_calibration_evidence: dict[str, Any] | None = None
     vector_index_ready: bool = True
     lexical_index_ready: bool = False
     index_contract: dict[str, Any] = Field(default_factory=dict)
@@ -1568,7 +1588,7 @@ async def update_pipeline_draft(
                 for stage_id, stage_update in payload.stages.items()
             },
             retrieval_profile=(
-                payload.retrieval_profile.model_dump(exclude_none=True)
+                _retrieval_options_patch(payload.retrieval_profile)
                 if payload.retrieval_profile
                 else None
             ),
@@ -2242,7 +2262,7 @@ async def create_evaluation_run(
                     "version_id": target.version_id,
                     "version": int(version["version"]),
                     "label": target.label or f"v{version['version']}",
-                    "retrieval": target.retrieval.model_dump(exclude_none=True) if target.retrieval else {},
+                    "retrieval": _retrieval_options_patch(target.retrieval) if target.retrieval else {},
                     "version_evidence": get_rag_service().pipeline_version_evidence(
                         target.version_id
                     ),
@@ -2358,7 +2378,7 @@ async def query_pipeline_version(
             payload.question,
             top_k=payload.top_k,
             retrieval=(
-                payload.retrieval.model_dump(exclude_none=True)
+                _retrieval_options_patch(payload.retrieval)
                 if payload.retrieval
                 else None
             ),
@@ -2429,7 +2449,10 @@ async def activate_pipeline_version(
             evaluation_run_id=payload.evaluation_run_id if payload else None,
             require_passed_run=bool(stored.get("promotion_required")),
         )
-        version = get_rag_service().activate_pipeline_version(version_id)
+        version = get_rag_service().activate_pipeline_version(
+            version_id,
+            promotion=bool(stored.get("promotion_required")),
+        )
         await get_pipeline_executor().record_job_event(
             str(stored["job_id"]),
             event_type="knowledge_pipeline.version_activated",
@@ -2491,7 +2514,7 @@ async def create_pipeline_citations(payload: CitationAnchorRequest) -> CitationA
             payload.question,
             top_k=payload.top_k,
             retrieval=(
-                payload.retrieval.model_dump(exclude_none=True)
+                _retrieval_options_patch(payload.retrieval)
                 if payload.retrieval
                 else None
             ),
@@ -2538,7 +2561,7 @@ async def query_knowledge_base(payload: RagQueryRequest) -> RagQueryResponse:
             payload.question,
             top_k=payload.top_k,
             retrieval=(
-                payload.retrieval.model_dump(exclude_none=True)
+                _retrieval_options_patch(payload.retrieval)
                 if payload.retrieval
                 else None
             ),

--- a/server/rag/lexical_store.py
+++ b/server/rag/lexical_store.py
@@ -50,6 +50,7 @@ class LexicalSearchResult:
     text: str
     score: float
     rank: int
+    score_contract: str = "weighted_term_coverage_v1"
     parent_chunk_id: str | None = None
     parent_text: str | None = None
     chunk_type: str = "standard"
@@ -154,6 +155,11 @@ class SqliteLexicalStore:
                     fallback_rank=index + 1,
                 ),
                 rank=index + 1,
+                score_contract=(
+                    "weighted_term_coverage_v1"
+                    if confidence_weights
+                    else "legacy_rank_fallback"
+                ),
                 parent_chunk_id=str(row["parent_chunk_id"]) if row["parent_chunk_id"] else None,
                 parent_text=str(row["parent_text"]) if row["parent_text"] else None,
                 chunk_type=str(row["chunk_type"] or "standard"),

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -43,6 +43,8 @@ from .embedder import EmbeddingClient, EmbeddingError
 from .lexical_store import LexicalChunk, LexicalSearchResult, SqliteLexicalStore
 from .reranker import RerankDocument, RerankItem, RerankOutcome, RerankService
 from .retrieval import (
+    ABSOLUTE_NO_RESULT_POLICY,
+    LEGACY_NO_RESULT_POLICY,
     RetrievalCandidate,
     RetrievalConfig,
     fuse_rankings,
@@ -2121,7 +2123,7 @@ class RagService:
             for stage_id, config in draft["stages"].items()
         }
         try:
-            next_retrieval = RetrievalConfig.from_mapping(
+            next_retrieval = self._v3_retrieval_config_from_patch(
                 retrieval_profile,
                 base=RetrievalConfig.from_mapping(draft.get("retrieval_profile")),
             ).payload()
@@ -2834,13 +2836,14 @@ class RagService:
                 chunker_profile,
             )
             try:
-                config_snapshot["retrieval_profile"] = RetrievalConfig.from_mapping(
+                base_retrieval = RetrievalConfig.from_mapping(
+                    config_snapshot.get("retrieval_profile")
+                    if isinstance(config_snapshot.get("retrieval_profile"), dict)
+                    else None
+                )
+                config_snapshot["retrieval_profile"] = self._v3_retrieval_config_from_patch(
                     retrieval_profile,
-                    base=RetrievalConfig.from_mapping(
-                        config_snapshot.get("retrieval_profile")
-                        if isinstance(config_snapshot.get("retrieval_profile"), dict)
-                        else None
-                    ),
+                    base=base_retrieval,
                 ).payload()
             except ValueError as exc:
                 raise PipelineDraftValidationError(str(exc)) from exc
@@ -3783,6 +3786,9 @@ class RagService:
             lexical_ready = self.lexical_store.count_namespace(
                 str(job["candidate_namespace"])
             ) > 0
+            retrieval_config = RetrievalConfig.from_mapping(
+                job["config_snapshot"].get("retrieval_profile")
+            )
             version = {
                 "version_id": str(job["candidate_version_id"]),
                 "kb_id": str(job["kb_id"]),
@@ -3807,6 +3813,12 @@ class RagService:
                 ),
                 "retrieval_profile": json.loads(
                     json.dumps(job["config_snapshot"].get("retrieval_profile", {}))
+                ),
+                "threshold_contract_status": retrieval_config.threshold_contract_status,
+                "threshold_calibration_evidence": json.loads(
+                    json.dumps(
+                        job["config_snapshot"].get("threshold_calibration_evidence")
+                    )
                 ),
                 "index_contract": json.loads(json.dumps(index_contract)),
                 "vector_backend_readiness": json.loads(
@@ -4222,6 +4234,10 @@ class RagService:
             for key, value in version.items()
             if key not in {"namespace", "config_snapshot"}
         }
+        payload["threshold_contract_status"] = RetrievalConfig.from_mapping(
+            version.get("retrieval_profile")
+        ).threshold_contract_status
+        payload.setdefault("threshold_calibration_evidence", None)
         payload["active"] = str(active_id or "") == str(version.get("version_id"))
         return payload
 
@@ -4250,6 +4266,8 @@ class RagService:
                 raise PipelineJobStateError(
                     "Legacy V2 indexes remain readable but cannot be newly activated or promoted."
                 )
+            if promotion:
+                self._assert_v3_threshold_promotion_ready(version)
             if previous_id and previous_id in metadata["pipeline_versions"]:
                 metadata["pipeline_versions"][previous_id]["status"] = "ready"
             version["status"] = "active"
@@ -4258,6 +4276,61 @@ class RagService:
             metadata["knowledge_bases"][kb_id]["updated_at"] = time.time()
             self._write_metadata_unlocked(metadata)
             return self.pipeline_version_payload(version, active_id=version_id)
+
+    def _assert_v3_threshold_promotion_ready(
+        self,
+        version: dict[str, Any],
+    ) -> None:
+        config = RetrievalConfig.from_mapping(version.get("retrieval_profile"))
+        if not config.uses_absolute_relevance:
+            raise PipelineJobStateError(
+                "V3 promotion requires the absolute relevance threshold contract."
+            )
+        if config.threshold_contract_status != "configured":
+            raise PipelineJobStateError(
+                "V3 promotion requires all mode-specific relevance thresholds."
+            )
+        evidence = version.get("threshold_calibration_evidence")
+        if not isinstance(evidence, dict):
+            raise PipelineJobStateError(
+                "V3 promotion requires independent threshold calibration evidence."
+            )
+        checksum = str(evidence.get("dataset_checksum") or "")
+        retrieval_profile_checksum = str(
+            evidence.get("retrieval_profile_checksum") or ""
+        )
+        expected_retrieval_profile_checksum = self._mapping_sha256(
+            config.payload()
+        )
+        version_evidence = self.pipeline_version_evidence(str(version["version_id"]))
+        expected_configuration_fingerprint = str(
+            version_evidence["configuration_fingerprint"]
+        )
+        expected_source_manifest_fingerprint = str(
+            version_evidence["source_manifest_fingerprint"]
+        )
+        raw_score_domains = evidence.get("score_domains")
+        score_domains = (
+            {str(item) for item in raw_score_domains}
+            if isinstance(raw_score_domains, list)
+            else set()
+        )
+        if (
+            evidence.get("contract_version") != "rag-threshold-calibration-v1"
+            or evidence.get("status") != "qualified"
+            or evidence.get("independent") is not True
+            or re.fullmatch(r"[0-9a-f]{64}", checksum) is None
+            or retrieval_profile_checksum != expected_retrieval_profile_checksum
+            or str(evidence.get("configuration_fingerprint") or "")
+            != expected_configuration_fingerprint
+            or str(evidence.get("source_manifest_fingerprint") or "")
+            != expected_source_manifest_fingerprint
+            or not isinstance(raw_score_domains, list)
+            or not set(config.required_threshold_score_domains).issubset(score_domains)
+        ):
+            raise PipelineJobStateError(
+                "V3 promotion threshold calibration evidence is incomplete or invalid."
+            )
 
     def pipeline_version_cost_summary(self, version_id: str) -> dict[str, Any]:
         """Return deterministic, explicitly estimated index cost metadata."""
@@ -5707,7 +5780,13 @@ class RagService:
             ]
 
         vector_candidates = [self._candidate_from_vector(item) for item in vector_results]
-        lexical_candidates = [self._candidate_from_lexical(item) for item in lexical_results]
+        lexical_candidates = [
+            self._candidate_from_lexical(
+                item,
+                require_absolute_score=is_v3 and config.uses_absolute_relevance,
+            )
+            for item in lexical_results
+        ]
         effective_config = config
         if (
             not is_v3
@@ -5728,10 +5807,33 @@ class RagService:
                     )
                 ]
                 vector_candidates = [self._candidate_from_vector(item) for item in vector_results]
+        (
+            vector_candidates,
+            lexical_candidates,
+            rejection_diagnostics,
+        ) = config.filter_absolute_channels(vector_candidates, lexical_candidates)
+        promotion_ineligibility_reasons: list[str] = []
+        if not is_v3:
+            promotion_ineligibility_reasons.append("legacy_index_schema")
+        elif not config.uses_absolute_relevance:
+            promotion_ineligibility_reasons.append("legacy_threshold_contract")
+        elif config.uses_absolute_relevance:
+            if config.threshold_contract_status != "configured":
+                promotion_ineligibility_reasons.append(
+                    "threshold_contract_unconfigured"
+                )
+            if any(
+                not bool(item.get("raw_score_contract_valid", True))
+                for item in rejection_diagnostics
+            ):
+                promotion_ineligibility_reasons.append(
+                    "missing_raw_channel_score"
+                )
         fused = fuse_rankings(vector_candidates, lexical_candidates, effective_config)
-        fused = [
-            item for item in fused if item.fused_score >= config.score_threshold
-        ]
+        if not config.uses_absolute_relevance:
+            fused = [
+                item for item in fused if item.fused_score >= config.score_threshold
+            ]
 
         rerank_provider = "none"
         rerank_model = ""
@@ -5789,6 +5891,55 @@ class RagService:
                 # Restoring the unranked tail makes rerank_top_n ineffective and
                 # systematically lowers fixed-cutoff citation precision.
                 fused = reranked
+                if (
+                    config.uses_absolute_relevance
+                    and config.min_rerank_score is not None
+                ):
+                    rerank_threshold = float(config.min_rerank_score)
+                    reranked_ids = {item.chunk_id for item in reranked}
+                    diagnostics_by_id = {
+                        str(item["chunk_id"]): item
+                        for item in rejection_diagnostics
+                    }
+                    for candidate in fused_before_rerank:
+                        current = diagnostics_by_id.setdefault(
+                            candidate.chunk_id,
+                            {
+                                "chunk_id": candidate.chunk_id,
+                                "vector_score": candidate.vector_score,
+                                "fulltext_score": candidate.fulltext_score,
+                                "vector_passed": None,
+                                "fulltext_passed": None,
+                                "accepted": True,
+                                "raw_score_contract_valid": True,
+                                "rejection_reason_codes": [],
+                            },
+                        )
+                        if candidate.chunk_id not in reranked_ids:
+                            current["rerank_score"] = None
+                            current["rerank_passed"] = False
+                            current["accepted"] = False
+                            current["rejection_reason_codes"] = [
+                                "rerank_not_returned"
+                            ]
+                    accepted_reranked: list[RetrievalCandidate] = []
+                    for candidate in reranked:
+                        current = diagnostics_by_id[candidate.chunk_id]
+                        current["rerank_score"] = candidate.rerank_score
+                        current["rerank_passed"] = bool(
+                            candidate.rerank_score is not None
+                            and float(candidate.rerank_score) >= rerank_threshold
+                        )
+                        current["accepted"] = current["rerank_passed"]
+                        current["rejection_reason_codes"] = (
+                            []
+                            if current["rerank_passed"]
+                            else ["below_min_rerank_score"]
+                        )
+                        if current["rerank_passed"]:
+                            accepted_reranked.append(candidate)
+                    rejection_diagnostics = list(diagnostics_by_id.values())
+                    fused = accepted_reranked
                 rerank_output_count = len(reranked)
                 rerank_tail_dropped = max(
                     0, len(fused_before_rerank) - rerank_output_count
@@ -5798,6 +5949,8 @@ class RagService:
                 # full fused ranking and surfaces the warning/receipt.
                 fused = fused_before_rerank
                 rerank_output_count = len(fused_before_rerank)
+                if config.uses_absolute_relevance:
+                    promotion_ineligibility_reasons.append("rerank_fail_open")
 
         deleted_document_ids = self._deleted_document_ids()
         results = select_candidates(
@@ -5808,7 +5961,9 @@ class RagService:
                     str(item.doc_id), deleted_document_ids
                 )
             ],
-            score_threshold=config.score_threshold,
+            score_threshold=(
+                0.0 if config.uses_absolute_relevance else config.score_threshold
+            ),
             top_k=config.top_k,
         )
         if not results:
@@ -5830,6 +5985,8 @@ class RagService:
                     rerank_tail_dropped=rerank_tail_dropped,
                     rerank_details=rerank_details,
                     embedding_profile=resolved_embedding_profile,
+                    rejection_diagnostics=rejection_diagnostics,
+                    promotion_ineligibility_reasons=promotion_ineligibility_reasons,
                 ),
             }
 
@@ -5898,6 +6055,8 @@ class RagService:
                 rerank_tail_dropped=rerank_tail_dropped,
                 rerank_details=rerank_details,
                 embedding_profile=resolved_embedding_profile,
+                rejection_diagnostics=rejection_diagnostics,
+                promotion_ineligibility_reasons=promotion_ineligibility_reasons,
             ),
         }
 
@@ -6462,7 +6621,8 @@ class RagService:
         *,
         top_k: int | None,
     ) -> RetrievalConfig:
-        if version and int(version.get("index_schema_version", 1)) >= 2:
+        schema_version = int(version.get("index_schema_version", 1)) if version else 1
+        if version and schema_version >= 2:
             base = RetrievalConfig.from_mapping(version.get("retrieval_profile"))
         else:
             base = RetrievalConfig.from_mapping(
@@ -6476,7 +6636,50 @@ class RagService:
         merged = dict(override or {})
         if top_k is not None:
             merged["top_k"] = top_k
+        if schema_version >= INDEX_SCHEMA_VERSION:
+            return self._v3_retrieval_config_from_patch(merged, base=base)
         return RetrievalConfig.from_mapping(merged, base=base)
+
+    @staticmethod
+    def _new_v3_retrieval_config() -> RetrievalConfig:
+        return RetrievalConfig.from_mapping(
+            {"no_result_policy": ABSOLUTE_NO_RESULT_POLICY}
+        )
+
+    @staticmethod
+    def _v3_retrieval_config_from_patch(
+        value: dict[str, Any] | None,
+        *,
+        base: RetrievalConfig,
+    ) -> RetrievalConfig:
+        patch = dict(value or {})
+        patch.pop("threshold_contract_status", None)
+        absolute_fields = {
+            "min_vector_similarity",
+            "min_lexical_confidence",
+            "min_rerank_score",
+        }
+        absolute_fields_present = any(field in patch for field in absolute_fields)
+        requests_absolute = (
+            absolute_fields_present
+            or patch.get("no_result_policy") == ABSOLUTE_NO_RESULT_POLICY
+        )
+        if "score_threshold" in patch and requests_absolute:
+            raise ValueError(
+                "retrieval.score_threshold is legacy V2-only and cannot be combined "
+                "with the V3 absolute relevance contract."
+            )
+        if "score_threshold" in patch and base.uses_absolute_relevance:
+            legacy_base = base.payload()
+            legacy_base["no_result_policy"] = LEGACY_NO_RESULT_POLICY
+            legacy_base["score_threshold"] = 0.0
+            base = RetrievalConfig.from_mapping(legacy_base)
+        if requests_absolute and not base.uses_absolute_relevance:
+            upgraded = base.payload()
+            upgraded.pop("score_threshold", None)
+            upgraded["no_result_policy"] = ABSOLUTE_NO_RESULT_POLICY
+            base = RetrievalConfig.from_mapping(upgraded)
+        return RetrievalConfig.from_mapping(patch, base=base)
 
     def _candidate_from_vector(self, item: SearchResult) -> RetrievalCandidate:
         return RetrievalCandidate(
@@ -6499,7 +6702,12 @@ class RagService:
             vector_score=item.score,
         )
 
-    def _candidate_from_lexical(self, item: LexicalSearchResult) -> RetrievalCandidate:
+    def _candidate_from_lexical(
+        self,
+        item: LexicalSearchResult,
+        *,
+        require_absolute_score: bool = False,
+    ) -> RetrievalCandidate:
         return RetrievalCandidate(
             chunk_id=item.chunk_id,
             doc_id=item.doc_id,
@@ -6517,7 +6725,12 @@ class RagService:
             row_range=item.row_range,
             visual_kind=item.visual_kind,
             source_block_id=item.source_block_id,
-            fulltext_score=item.score,
+            fulltext_score=(
+                item.score
+                if not require_absolute_score
+                or item.score_contract == "weighted_term_coverage_v1"
+                else None
+            ),
         )
 
     def _retrieval_diagnostics(
@@ -6533,8 +6746,24 @@ class RagService:
         rerank_tail_dropped: int,
         rerank_details: dict[str, Any],
         embedding_profile: dict[str, Any],
+        rejection_diagnostics: list[dict[str, Any]],
+        promotion_ineligibility_reasons: list[str],
     ) -> dict[str, Any]:
         effective = dict(embedding_profile.get("effective") or {})
+        threshold_score_domain = "fused_score"
+        if config.uses_absolute_relevance:
+            threshold_score_domain = (
+                "rerank_score"
+                if rerank_provider != "none"
+                and config.rerank_enabled
+                and config.min_rerank_score is not None
+                else "channel_absolute_scores"
+                if config.channel_thresholds_configured
+                else "unconfigured"
+            )
+        ineligibility_reasons = list(
+            dict.fromkeys(str(item) for item in promotion_ineligibility_reasons if item)
+        )
         return {
             **config.payload(),
             "vector_candidate_count": vector_count,
@@ -6546,7 +6775,13 @@ class RagService:
             "rerank_output_count": max(0, int(rerank_output_count)),
             "rerank_tail_dropped": max(0, int(rerank_tail_dropped)),
             **rerank_details,
-            "threshold_score_domain": "fused_score",
+            "threshold_score_domain": threshold_score_domain,
+            "threshold_contract_status": config.threshold_contract_status,
+            "rejection_diagnostics": json.loads(
+                json.dumps(rejection_diagnostics)
+            ),
+            "promotion_eligible": not ineligibility_reasons,
+            "promotion_ineligibility_reasons": ineligibility_reasons,
             "embedding_provider": str(effective.get("provider") or ""),
             "embedding_model": str(effective.get("model") or ""),
             "embedding_dimension": int(effective.get("dimension") or 0),
@@ -7230,7 +7465,7 @@ class RagService:
         defaults = self._default_pipeline_draft_stages()
         draft = metadata["pipeline_drafts"].get(kb_id)
         if not isinstance(draft, dict):
-            retrieval_profile = RetrievalConfig().payload()
+            retrieval_profile = self._new_v3_retrieval_config().payload()
             embedding_profile = self._default_embedding_profile()
             return {
                 "draft_id": f"draft_{kb_id}",
@@ -7338,7 +7573,7 @@ class RagService:
                 draft.get("embedding_profile"),
                 compiled.embedding_profile,
             )
-            retrieval = RetrievalConfig.from_mapping(
+            retrieval = self._v3_retrieval_config_from_patch(
                 compiled.retrieval_profile,
                 base=RetrievalConfig.from_mapping(draft.get("retrieval_profile")),
             ).payload()

--- a/server/rag/reranker.py
+++ b/server/rag/reranker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import os
 import re
 import time
@@ -445,19 +446,27 @@ def _parse_ranked_items(
     seen: set[int] = set()
     for raw in raw_results:
         if not isinstance(raw, dict):
-            continue
+            raise ValueError("Rerank provider returned an invalid result item.")
         try:
             index = int(raw.get("index"))
             score = float(raw.get("relevance_score", raw.get("score")))
-        except (TypeError, ValueError):
-            continue
-        if index < 0 or index >= len(documents) or index in seen:
-            continue
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "Rerank provider returned an invalid result item."
+            ) from exc
+        if (
+            index < 0
+            or index >= len(documents)
+            or index in seen
+            or not math.isfinite(score)
+            or not 0.0 <= score <= 1.0
+        ):
+            raise ValueError("Rerank provider returned an invalid result item.")
         seen.add(index)
         items.append(
             RerankItem(
                 chunk_id=documents[index].chunk_id,
-                score=max(0.0, min(1.0, score)),
+                score=score,
             )
         )
     if not items:

--- a/server/rag/retrieval.py
+++ b/server/rag/retrieval.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import math
 from dataclasses import asdict, dataclass
 from typing import Any
 
 
 RETRIEVAL_MODES = {"vector", "fulltext", "hybrid"}
 RERANK_PROVIDERS = {"none", "auto", "api", "llm"}
+LEGACY_NO_RESULT_POLICY = "legacy_fused_threshold_v2"
+ABSOLUTE_NO_RESULT_POLICY = "absolute_relevance_v1"
+NO_RESULT_POLICIES = {LEGACY_NO_RESULT_POLICY, ABSOLUTE_NO_RESULT_POLICY}
 RRF_CONSTANT = 60
 
 
@@ -18,6 +22,10 @@ class RetrievalConfig:
     fulltext_weight: float = 0.3
     top_k: int = 5
     score_threshold: float = 0.0
+    min_vector_similarity: float | None = None
+    min_lexical_confidence: float | None = None
+    min_rerank_score: float | None = None
+    no_result_policy: str = LEGACY_NO_RESULT_POLICY
     candidate_multiplier: int = 4
     rerank_enabled: bool = False
     rerank_provider: str = "auto"
@@ -58,6 +66,26 @@ class RetrievalConfig:
         if not 0 <= threshold <= 1:
             raise ValueError("retrieval.score_threshold must be between 0 and 1.")
 
+        min_vector_similarity = _coerce_optional_threshold(
+            current.get("min_vector_similarity"),
+            "min_vector_similarity",
+        )
+        min_lexical_confidence = _coerce_optional_threshold(
+            current.get("min_lexical_confidence"),
+            "min_lexical_confidence",
+        )
+        min_rerank_score = _coerce_optional_threshold(
+            current.get("min_rerank_score"),
+            "min_rerank_score",
+        )
+        no_result_policy = str(
+            current.get("no_result_policy") or LEGACY_NO_RESULT_POLICY
+        ).strip().lower()
+        if no_result_policy not in NO_RESULT_POLICIES:
+            raise ValueError(
+                "retrieval.no_result_policy must be absolute_relevance_v1 or the legacy compatibility policy."
+            )
+
         multiplier = _coerce_int(current.get("candidate_multiplier"), "candidate_multiplier")
         if not 1 <= multiplier <= 10:
             raise ValueError("retrieval.candidate_multiplier must be between 1 and 10.")
@@ -82,6 +110,10 @@ class RetrievalConfig:
             fulltext_weight=round(fulltext_weight, 6),
             top_k=top_k,
             score_threshold=threshold,
+            min_vector_similarity=min_vector_similarity,
+            min_lexical_confidence=min_lexical_confidence,
+            min_rerank_score=min_rerank_score,
+            no_result_policy=no_result_policy,
             candidate_multiplier=multiplier,
             rerank_enabled=rerank_enabled,
             rerank_provider=provider,
@@ -89,8 +121,176 @@ class RetrievalConfig:
             rerank_top_n=rerank_top_n,
         )
 
+    @property
+    def uses_absolute_relevance(self) -> bool:
+        return self.no_result_policy == ABSOLUTE_NO_RESULT_POLICY
+
+    @property
+    def required_threshold_score_domains(self) -> tuple[str, ...]:
+        if not self.uses_absolute_relevance:
+            return ()
+        domains: list[str] = []
+        if self.mode in {"vector", "hybrid"}:
+            domains.append("vector_similarity")
+        if self.mode in {"fulltext", "hybrid"}:
+            domains.append("lexical_confidence")
+        if self.rerank_enabled:
+            domains.append("rerank_score")
+        return tuple(domains)
+
+    @property
+    def threshold_contract_status(self) -> str:
+        if not self.uses_absolute_relevance:
+            return "legacy"
+        values = {
+            "vector_similarity": self.min_vector_similarity,
+            "lexical_confidence": self.min_lexical_confidence,
+            "rerank_score": self.min_rerank_score,
+        }
+        return (
+            "configured"
+            if all(values[domain] is not None for domain in self.required_threshold_score_domains)
+            else "unconfigured"
+        )
+
+    @property
+    def channel_thresholds_configured(self) -> bool:
+        if not self.uses_absolute_relevance:
+            return False
+        return (
+            self.min_vector_similarity is not None
+            if self.mode == "vector"
+            else self.min_lexical_confidence is not None
+            if self.mode == "fulltext"
+            else self.min_vector_similarity is not None
+            and self.min_lexical_confidence is not None
+        )
+
     def payload(self) -> dict[str, Any]:
-        return asdict(self)
+        value = asdict(self)
+        if self.uses_absolute_relevance:
+            value.pop("score_threshold", None)
+        else:
+            value.pop("min_vector_similarity", None)
+            value.pop("min_lexical_confidence", None)
+            value.pop("min_rerank_score", None)
+        value["threshold_contract_status"] = self.threshold_contract_status
+        return value
+
+    def filter_absolute_channels(
+        self,
+        vector_items: list[RetrievalCandidate],
+        fulltext_items: list[RetrievalCandidate],
+    ) -> tuple[
+        list[RetrievalCandidate],
+        list[RetrievalCandidate],
+        list[dict[str, Any]],
+    ]:
+        """Apply V3 absolute gates before RRF and return a text-free receipt."""
+
+        decisions: dict[str, dict[str, Any]] = {}
+
+        def decision(item: RetrievalCandidate) -> dict[str, Any]:
+            return decisions.setdefault(
+                item.chunk_id,
+                {
+                    "chunk_id": item.chunk_id,
+                    "vector_score": None,
+                    "fulltext_score": None,
+                    "vector_passed": None,
+                    "fulltext_passed": None,
+                    "accepted": True,
+                    "raw_score_contract_valid": True,
+                    "rejection_reason_codes": [],
+                },
+            )
+
+        for item in vector_items:
+            decision(item)["vector_score"] = item.vector_score
+        for item in fulltext_items:
+            decision(item)["fulltext_score"] = item.fulltext_score
+
+        if not self.uses_absolute_relevance:
+            return vector_items, fulltext_items, list(decisions.values())
+
+        valid_vector_items: list[RetrievalCandidate] = []
+        valid_lexical_items: list[RetrievalCandidate] = []
+        for item in vector_items:
+            score, reason = _absolute_candidate_score(
+                item.vector_score,
+                missing_reason="missing_vector_similarity",
+                invalid_reason="invalid_vector_similarity",
+            )
+            current = decision(item)
+            current["vector_score"] = score
+            if reason:
+                current["vector_passed"] = False
+                current["accepted"] = False
+                current["raw_score_contract_valid"] = False
+                current["rejection_reason_codes"].append(reason)
+            else:
+                item.vector_score = score
+                valid_vector_items.append(item)
+        for item in fulltext_items:
+            score, reason = _absolute_candidate_score(
+                item.fulltext_score,
+                missing_reason="missing_lexical_confidence",
+                invalid_reason="invalid_lexical_confidence",
+            )
+            current = decision(item)
+            current["fulltext_score"] = score
+            if reason:
+                current["fulltext_passed"] = False
+                current["accepted"] = False
+                current["raw_score_contract_valid"] = False
+                current["rejection_reason_codes"].append(reason)
+            else:
+                item.fulltext_score = score
+                valid_lexical_items.append(item)
+
+        if not self.channel_thresholds_configured:
+            valid_ids = {
+                item.chunk_id for item in valid_vector_items + valid_lexical_items
+            }
+            for chunk_id, current in decisions.items():
+                current["accepted"] = chunk_id in valid_ids
+            return valid_vector_items, valid_lexical_items, list(decisions.values())
+
+        vector_passed_ids: set[str] = set()
+        lexical_passed_ids: set[str] = set()
+        if self.mode in {"vector", "hybrid"}:
+            threshold = float(self.min_vector_similarity)
+            for item in valid_vector_items:
+                current = decision(item)
+                if float(item.vector_score) >= threshold:
+                    current["vector_passed"] = True
+                    vector_passed_ids.add(item.chunk_id)
+                else:
+                    current["vector_passed"] = False
+                    current["rejection_reason_codes"].append(
+                        "below_min_vector_similarity"
+                    )
+        if self.mode in {"fulltext", "hybrid"}:
+            threshold = float(self.min_lexical_confidence)
+            for item in valid_lexical_items:
+                current = decision(item)
+                if float(item.fulltext_score) >= threshold:
+                    current["fulltext_passed"] = True
+                    lexical_passed_ids.add(item.chunk_id)
+                else:
+                    current["fulltext_passed"] = False
+                    current["rejection_reason_codes"].append(
+                        "below_min_lexical_confidence"
+                    )
+
+        accepted_ids = vector_passed_ids | lexical_passed_ids
+        for chunk_id, current in decisions.items():
+            current["accepted"] = chunk_id in accepted_ids
+        return (
+            [item for item in valid_vector_items if item.chunk_id in vector_passed_ids],
+            [item for item in valid_lexical_items if item.chunk_id in lexical_passed_ids],
+            list(decisions.values()),
+        )
 
 
 @dataclass(slots=True)
@@ -237,6 +437,34 @@ def _coerce_float(value: Any, name: str) -> float:
         return float(value)
     except (TypeError, ValueError) as exc:
         raise ValueError(f"retrieval.{name} must be a number.") from exc
+
+
+def _coerce_optional_threshold(value: Any, name: str) -> float | None:
+    if value is None:
+        return None
+    threshold = _coerce_float(value, name)
+    if not 0 <= threshold <= 1:
+        raise ValueError(f"retrieval.{name} must be between 0 and 1.")
+    return threshold
+
+
+def _absolute_candidate_score(
+    value: Any,
+    *,
+    missing_reason: str,
+    invalid_reason: str,
+) -> tuple[float | None, str | None]:
+    if value is None:
+        return None, missing_reason
+    if isinstance(value, bool):
+        return None, invalid_reason
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return None, invalid_reason
+    if not math.isfinite(score) or not 0.0 <= score <= 1.0:
+        return None, invalid_reason
+    return score, None
 
 
 def _coerce_bool(value: Any, name: str) -> bool:

--- a/server/tests/test_rag_pipeline.py
+++ b/server/tests/test_rag_pipeline.py
@@ -229,6 +229,37 @@ async def test_rag_pipeline_draft_patch_persists_chunker_config(
 
 
 @pytest.mark.asyncio
+async def test_rag_pipeline_draft_patch_preserves_explicit_null_threshold(
+    client: httpx.AsyncClient,
+) -> None:
+    kb_id = await create_kb(client, "clear absolute threshold")
+
+    configured_response = await client.patch(
+        f"/api/rag/pipeline/draft/{kb_id}",
+        json={
+            "retrieval_profile": {
+                "mode": "fulltext",
+                "no_result_policy": "absolute_relevance_v1",
+                "min_lexical_confidence": 0.5,
+            }
+        },
+    )
+    assert configured_response.status_code == 200, configured_response.text
+    configured = configured_response.json()["retrieval_profile"]
+    assert configured["min_lexical_confidence"] == 0.5
+    assert configured["threshold_contract_status"] == "configured"
+
+    cleared_response = await client.patch(
+        f"/api/rag/pipeline/draft/{kb_id}",
+        json={"retrieval_profile": {"min_lexical_confidence": None}},
+    )
+    assert cleared_response.status_code == 200, cleared_response.text
+    cleared = cleared_response.json()["retrieval_profile"]
+    assert cleared["min_lexical_confidence"] is None
+    assert cleared["threshold_contract_status"] == "unconfigured"
+
+
+@pytest.mark.asyncio
 async def test_rag_pipeline_blocks_unavailable_requested_embedding(
     client: httpx.AsyncClient,
 ) -> None:

--- a/server/tests/test_rag_retrieval_scoring.py
+++ b/server/tests/test_rag_retrieval_scoring.py
@@ -1,0 +1,598 @@
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+import pytest
+
+from server.rag.embedder import EmbeddingClient
+from server.rag.lexical_store import LexicalChunk, SqliteLexicalStore
+from server.rag.rag_service import PipelineDraftValidationError, PipelineJobStateError, RagService
+from server.rag.reranker import RerankItem, RerankOutcome
+from server.rag.retrieval import RetrievalCandidate, RetrievalConfig
+from server.rag.vector_store import LocalJsonVectorStore
+
+
+def build_service(tmp_path: Path, *, reranker=None) -> RagService:
+    storage = tmp_path / "storage"
+    return RagService(
+        storage_dir=storage,
+        uploads_dir=tmp_path / "uploads",
+        embedder=EmbeddingClient(api_key="", dimension=64),
+        vector_store=LocalJsonVectorStore(storage / "vectors.json"),
+        lexical_store=SqliteLexicalStore(storage / "lexical.sqlite3"),
+        reranker=reranker,
+        llm_enabled=False,
+    )
+
+
+def candidate(
+    chunk_id: str,
+    *,
+    vector_score: float | None = None,
+    fulltext_score: float | None = None,
+    rerank_score: float | None = None,
+) -> RetrievalCandidate:
+    return RetrievalCandidate(
+        chunk_id=chunk_id,
+        doc_id=f"doc-{chunk_id}",
+        document_name=f"{chunk_id}.txt",
+        matched_text=chunk_id,
+        context_text=chunk_id,
+        vector_score=vector_score,
+        fulltext_score=fulltext_score,
+        rerank_score=rerank_score,
+    )
+
+
+def absolute_config(**updates: object) -> RetrievalConfig:
+    return RetrievalConfig.from_mapping(
+        {
+            "mode": "hybrid",
+            "min_vector_similarity": 0.8,
+            "min_lexical_confidence": 0.7,
+            "no_result_policy": "absolute_relevance_v1",
+            **updates,
+        }
+    )
+
+
+def test_new_v3_draft_is_explicitly_unconfigured_and_rejects_legacy_threshold_mix(
+    tmp_path: Path,
+) -> None:
+    service = build_service(tmp_path)
+    kb = service.create_knowledge_base("absolute contract")
+
+    draft = service.get_pipeline_draft(kb["id"])
+
+    assert draft["retrieval_profile"]["no_result_policy"] == "absolute_relevance_v1"
+    assert draft["retrieval_profile"]["threshold_contract_status"] == "unconfigured"
+    assert "score_threshold" not in draft["retrieval_profile"]
+
+    with pytest.raises(PipelineDraftValidationError, match="score_threshold"):
+        service.update_pipeline_draft(
+            kb["id"],
+            {},
+            retrieval_profile={
+                "score_threshold": 0.5,
+                "min_lexical_confidence": 0.5,
+            },
+        )
+    with pytest.raises(PipelineDraftValidationError, match="score_threshold"):
+        service.update_pipeline_draft(
+            kb["id"],
+            {},
+            retrieval_profile={
+                "score_threshold": 0.5,
+                "min_vector_similarity": None,
+            },
+        )
+
+    configured = service.update_pipeline_draft(
+        kb["id"],
+        {},
+        retrieval_profile={
+            "mode": "fulltext",
+            "min_lexical_confidence": 0.5,
+            "no_result_policy": "absolute_relevance_v1",
+        },
+    )
+    assert configured["retrieval_profile"]["threshold_contract_status"] == "configured"
+    cleared = service.update_pipeline_draft(
+        kb["id"],
+        {},
+        retrieval_profile={"min_lexical_confidence": None},
+    )
+    assert cleared["retrieval_profile"]["min_lexical_confidence"] is None
+    assert cleared["retrieval_profile"]["threshold_contract_status"] == "unconfigured"
+
+
+def test_old_threshold_only_is_explicit_legacy_diagnostic_for_v3(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+    kb = service.create_knowledge_base("legacy diagnostic")
+
+    draft = service.update_pipeline_draft(
+        kb["id"],
+        {},
+        retrieval_profile={"mode": "fulltext", "score_threshold": 0.4},
+    )
+
+    assert draft["retrieval_profile"]["score_threshold"] == 0.4
+    assert draft["retrieval_profile"]["threshold_contract_status"] == "legacy"
+    assert draft["retrieval_profile"]["no_result_policy"] == (
+        "legacy_fused_threshold_v2"
+    )
+
+
+def test_absolute_thresholds_reject_rank_one_and_are_tail_invariant() -> None:
+    config = absolute_config(
+        min_vector_similarity=1.0,
+        min_lexical_confidence=1.0,
+    )
+    shared_vector = candidate("shared", vector_score=0.99)
+    shared_lexical = candidate("shared", fulltext_score=0.99)
+
+    base_vector, base_lexical, base_receipt = config.filter_absolute_channels(
+        [shared_vector],
+        [shared_lexical],
+    )
+    tail_vector, tail_lexical, tail_receipt = config.filter_absolute_channels(
+        [shared_vector, candidate("tail", vector_score=0.01)],
+        [shared_lexical],
+    )
+
+    assert base_vector == []
+    assert base_lexical == []
+    assert tail_vector == []
+    assert tail_lexical == []
+    base = next(item for item in base_receipt if item["chunk_id"] == "shared")
+    expanded = next(item for item in tail_receipt if item["chunk_id"] == "shared")
+    assert base == expanded
+    assert base["accepted"] is False
+    assert set(base["rejection_reason_codes"]) == {
+        "below_min_vector_similarity",
+        "below_min_lexical_confidence",
+    }
+
+
+def test_hybrid_candidate_enters_rrf_only_through_channels_that_pass() -> None:
+    config = absolute_config()
+    vector_items, lexical_items, receipt = config.filter_absolute_channels(
+        [
+            candidate("vector-pass", vector_score=0.9),
+            candidate("lexical-pass", vector_score=0.2),
+        ],
+        [
+            candidate("vector-pass", fulltext_score=0.1),
+            candidate("lexical-pass", fulltext_score=0.9),
+        ],
+    )
+
+    assert [item.chunk_id for item in vector_items] == ["vector-pass"]
+    assert [item.chunk_id for item in lexical_items] == ["lexical-pass"]
+    assert all(item["accepted"] is True for item in receipt)
+
+
+def test_missing_required_raw_score_is_rejected_and_invalidates_receipt() -> None:
+    config = RetrievalConfig.from_mapping(
+        {
+            "mode": "vector",
+            "min_vector_similarity": 0.5,
+            "no_result_policy": "absolute_relevance_v1",
+        }
+    )
+
+    vector_items, _, receipt = config.filter_absolute_channels(
+        [candidate("missing", vector_score=None)],
+        [],
+    )
+
+    assert vector_items == []
+    assert receipt == [
+        {
+            "chunk_id": "missing",
+            "vector_score": None,
+            "fulltext_score": None,
+            "vector_passed": False,
+            "fulltext_passed": None,
+            "accepted": False,
+            "raw_score_contract_valid": False,
+            "rejection_reason_codes": ["missing_vector_similarity"],
+        }
+    ]
+
+
+def test_non_finite_or_out_of_range_channel_scores_fail_closed() -> None:
+    config = absolute_config(min_vector_similarity=0.0, min_lexical_confidence=0.0)
+
+    vector_items, lexical_items, receipt = config.filter_absolute_channels(
+        [candidate("bad-vector", vector_score=float("inf"))],
+        [candidate("bad-lexical", fulltext_score=1.1)],
+    )
+
+    assert vector_items == []
+    assert lexical_items == []
+    assert all(item["raw_score_contract_valid"] is False for item in receipt)
+    assert {reason for item in receipt for reason in item["rejection_reason_codes"]} == {
+        "invalid_vector_similarity",
+        "invalid_lexical_confidence",
+    }
+    json.dumps(receipt, allow_nan=False)
+
+
+def test_absolute_channel_decisions_are_threshold_and_tail_invariant() -> None:
+    rng = random.Random(20260827)
+    vector_threshold = 0.63
+    lexical_threshold = 0.41
+    config = absolute_config(
+        min_vector_similarity=vector_threshold,
+        min_lexical_confidence=lexical_threshold,
+    )
+    vector_scores = [0.0, vector_threshold, 1.0] + [rng.random() for _ in range(40)]
+    lexical_scores = [0.0, lexical_threshold, 1.0] + [rng.random() for _ in range(40)]
+    vector_items = [
+        candidate(f"vector-{index}", vector_score=score)
+        for index, score in enumerate(vector_scores)
+    ]
+    lexical_items = [
+        candidate(f"lexical-{index}", fulltext_score=score)
+        for index, score in enumerate(lexical_scores)
+    ]
+
+    accepted_vector, accepted_lexical, base_receipt = config.filter_absolute_channels(
+        vector_items,
+        lexical_items,
+    )
+    _, _, expanded_receipt = config.filter_absolute_channels(
+        vector_items + [candidate("irrelevant-vector-tail", vector_score=0.01)],
+        lexical_items + [candidate("irrelevant-lexical-tail", fulltext_score=0.01)],
+    )
+
+    assert {item.chunk_id for item in accepted_vector} == {
+        f"vector-{index}"
+        for index, score in enumerate(vector_scores)
+        if score >= vector_threshold
+    }
+    assert {item.chunk_id for item in accepted_lexical} == {
+        f"lexical-{index}"
+        for index, score in enumerate(lexical_scores)
+        if score >= lexical_threshold
+    }
+    base_by_id = {item["chunk_id"]: item for item in base_receipt}
+    expanded_by_id = {item["chunk_id"]: item for item in expanded_receipt}
+    assert all(expanded_by_id[chunk_id] == item for chunk_id, item in base_by_id.items())
+
+
+def test_unconfigured_diagnostic_contract_still_rejects_invalid_raw_scores() -> None:
+    config = RetrievalConfig.from_mapping(
+        {
+            "mode": "hybrid",
+            "min_vector_similarity": None,
+            "min_lexical_confidence": None,
+            "no_result_policy": "absolute_relevance_v1",
+        }
+    )
+
+    vector_items, lexical_items, receipt = config.filter_absolute_channels(
+        [candidate("invalid", vector_score=float("nan"))],
+        [candidate("valid", fulltext_score=0.25)],
+    )
+
+    assert vector_items == []
+    assert [item.chunk_id for item in lexical_items] == ["valid"]
+    decisions = {item["chunk_id"]: item for item in receipt}
+    assert decisions["invalid"]["accepted"] is False
+    assert decisions["invalid"]["raw_score_contract_valid"] is False
+    assert decisions["invalid"]["rejection_reason_codes"] == [
+        "invalid_vector_similarity"
+    ]
+    assert decisions["valid"]["accepted"] is True
+    json.dumps(receipt, allow_nan=False)
+
+
+@pytest.mark.asyncio
+async def test_v3_fulltext_does_not_treat_rank_fallback_as_absolute_confidence(
+    tmp_path: Path,
+) -> None:
+    service = build_service(tmp_path)
+    kb = service.create_knowledge_base("lexical rank fallback")
+    namespace = f"{kb['id']}::v3::fulltext"
+    service.lexical_store.add_chunks(
+        [
+            LexicalChunk(
+                chunk_id="rank-one",
+                namespace=namespace,
+                doc_id="doc-rank-one",
+                document_name="rank-one.txt",
+                text="x",
+                chunk_index=0,
+            )
+        ]
+    )
+    config = RetrievalConfig.from_mapping(
+        {
+            "mode": "fulltext",
+            "min_lexical_confidence": 1.0,
+            "no_result_policy": "absolute_relevance_v1",
+        }
+    )
+
+    result = await service._query_namespace(
+        kb["id"],
+        namespace,
+        "x",
+        config=config,
+        lexical_ready=True,
+        generate_answer=False,
+    )
+
+    assert result["sources"] == []
+    assert result["retrieval"]["promotion_eligible"] is False
+    assert result["retrieval"]["rejection_diagnostics"] == [
+        {
+            "chunk_id": "rank-one",
+            "vector_score": None,
+            "fulltext_score": None,
+            "vector_passed": None,
+            "fulltext_passed": False,
+            "accepted": False,
+            "raw_score_contract_valid": False,
+            "rejection_reason_codes": ["missing_lexical_confidence"],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_successful_rerank_uses_rerank_threshold_not_fused_score(
+    tmp_path: Path,
+) -> None:
+    class LowScoreReranker:
+        async def rerank(self, _query, documents, **_kwargs):
+            return RerankOutcome(
+                items=[RerankItem(documents[0].chunk_id, 0.2)],
+                provider="api",
+                model="contract-reranker",
+                requested_input_count=len(documents),
+                input_count=len(documents),
+                input_char_count=sum(len(item.text) for item in documents),
+                output_count=1,
+            )
+
+    service = build_service(tmp_path, reranker=LowScoreReranker())
+    kb = service.create_knowledge_base("rerank absolute score")
+    namespace = f"{kb['id']}::v3::fulltext"
+    service.lexical_store.add_chunks(
+        [
+            LexicalChunk(
+                chunk_id="candidate",
+                namespace=namespace,
+                doc_id="doc-candidate",
+                document_name="candidate.txt",
+                text="ORBIT evidence is present here",
+                chunk_index=0,
+            )
+        ]
+    )
+    config = RetrievalConfig.from_mapping(
+        {
+            "mode": "fulltext",
+            "top_k": 5,
+            "min_lexical_confidence": 0.1,
+            "min_rerank_score": 0.8,
+            "no_result_policy": "absolute_relevance_v1",
+            "rerank_enabled": True,
+            "rerank_provider": "api",
+        }
+    )
+
+    result = await service._query_namespace(
+        kb["id"],
+        namespace,
+        "ORBIT evidence",
+        config=config,
+        lexical_ready=True,
+        generate_answer=False,
+    )
+
+    assert result["sources"] == []
+    assert result["retrieval"]["threshold_score_domain"] == "rerank_score"
+    assert result["retrieval"]["rejection_diagnostics"][0]["rerank_passed"] is False
+
+
+@pytest.mark.asyncio
+async def test_rerank_failure_falls_back_to_absolute_channels_but_is_not_promotable(
+    tmp_path: Path,
+) -> None:
+    class FailedReranker:
+        async def rerank(self, _query, documents, **_kwargs):
+            return RerankOutcome(
+                items=[],
+                provider="none",
+                warning="rerank failed",
+                fallback_reason="api:http_status_503",
+                requested_input_count=len(documents),
+                input_count=len(documents),
+                input_char_count=sum(len(item.text) for item in documents),
+            )
+
+    service = build_service(tmp_path, reranker=FailedReranker())
+    kb = service.create_knowledge_base("rerank fallback")
+    namespace = f"{kb['id']}::v3::fulltext"
+    service.lexical_store.add_chunks(
+        [
+            LexicalChunk(
+                chunk_id="candidate",
+                namespace=namespace,
+                doc_id="doc-candidate",
+                document_name="candidate.txt",
+                text="ORBIT evidence is present here",
+                chunk_index=0,
+            )
+        ]
+    )
+    config = RetrievalConfig.from_mapping(
+        {
+            "mode": "fulltext",
+            "top_k": 5,
+            "min_lexical_confidence": 0.1,
+            "min_rerank_score": 0.8,
+            "no_result_policy": "absolute_relevance_v1",
+            "rerank_enabled": True,
+            "rerank_provider": "api",
+        }
+    )
+
+    result = await service._query_namespace(
+        kb["id"],
+        namespace,
+        "ORBIT evidence",
+        config=config,
+        lexical_ready=True,
+        generate_answer=False,
+    )
+
+    assert len(result["sources"]) == 1
+    assert result["retrieval"]["threshold_score_domain"] == "channel_absolute_scores"
+    assert result["retrieval"]["promotion_eligible"] is False
+    assert "rerank_fail_open" in result["retrieval"]["promotion_ineligibility_reasons"]
+
+
+def test_v3_promotion_requires_configured_thresholds_and_independent_calibration(
+    tmp_path: Path,
+) -> None:
+    service = build_service(tmp_path)
+    kb = service.create_knowledge_base("promotion threshold evidence")
+    version_id = "kpv_absolute_contract"
+    base_version = {
+        "version_id": version_id,
+        "kb_id": kb["id"],
+        "version": 1,
+        "status": "ready",
+        "namespace": f"{kb['id']}::v3::{version_id}::fulltext",
+        "draft_id": f"draft_{kb['id']}",
+        "draft_version": 1,
+        "index_schema_version": 3,
+        "retrieval_profile": {
+            "mode": "fulltext",
+            "min_lexical_confidence": None,
+            "no_result_policy": "absolute_relevance_v1",
+        },
+        "job_id": "job",
+        "source_summary": [
+            {
+                "source_id": "source-calibration",
+                "content_hash": "c" * 64,
+            }
+        ],
+        "created_at": 1.0,
+        "activated_at": None,
+    }
+    with service._metadata_lock:
+        metadata = service._read_metadata_unlocked()
+        metadata["pipeline_versions"][version_id] = base_version
+        service._write_metadata_unlocked(metadata)
+
+    with pytest.raises(PipelineJobStateError, match="thresholds"):
+        service.activate_pipeline_version(version_id, promotion=True)
+
+    with service._metadata_lock:
+        metadata = service._read_metadata_unlocked()
+        metadata["pipeline_versions"][version_id]["retrieval_profile"][
+            "min_lexical_confidence"
+        ] = 0.5
+        service._write_metadata_unlocked(metadata)
+
+    with pytest.raises(PipelineJobStateError, match="calibration"):
+        service.activate_pipeline_version(version_id, promotion=True)
+
+    with service._metadata_lock:
+        metadata = service._read_metadata_unlocked()
+        metadata["pipeline_versions"][version_id]["threshold_calibration_evidence"] = {
+            "contract_version": "rag-threshold-calibration-v1",
+            "status": "qualified",
+            "independent": True,
+            "dataset_checksum": "a" * 64,
+            "retrieval_profile_checksum": "b" * 64,
+            "score_domains": ["lexical_confidence"],
+        }
+        service._write_metadata_unlocked(metadata)
+
+    with pytest.raises(PipelineJobStateError, match="calibration"):
+        service.activate_pipeline_version(version_id, promotion=True)
+
+    version = service.get_pipeline_version(version_id)
+    expected_profile_checksum = service._mapping_sha256(
+        RetrievalConfig.from_mapping(version["retrieval_profile"]).payload()
+    )
+    with service._metadata_lock:
+        metadata = service._read_metadata_unlocked()
+        metadata["pipeline_versions"][version_id]["threshold_calibration_evidence"][
+            "retrieval_profile_checksum"
+        ] = expected_profile_checksum
+        service._write_metadata_unlocked(metadata)
+
+    with pytest.raises(PipelineJobStateError, match="calibration"):
+        service.activate_pipeline_version(version_id, promotion=True)
+
+    expected_configuration_fingerprint = service.pipeline_version_evidence(version_id)[
+        "configuration_fingerprint"
+    ]
+    with service._metadata_lock:
+        metadata = service._read_metadata_unlocked()
+        metadata["pipeline_versions"][version_id]["threshold_calibration_evidence"][
+            "configuration_fingerprint"
+        ] = expected_configuration_fingerprint
+        service._write_metadata_unlocked(metadata)
+
+    with pytest.raises(PipelineJobStateError, match="calibration"):
+        service.activate_pipeline_version(version_id, promotion=True)
+
+    expected_source_manifest_fingerprint = service.pipeline_version_evidence(version_id)[
+        "source_manifest_fingerprint"
+    ]
+    with service._metadata_lock:
+        metadata = service._read_metadata_unlocked()
+        metadata["pipeline_versions"][version_id]["threshold_calibration_evidence"][
+            "source_manifest_fingerprint"
+        ] = expected_source_manifest_fingerprint
+        metadata["pipeline_versions"][version_id]["threshold_calibration_evidence"][
+            "score_domains"
+        ] = None
+        service._write_metadata_unlocked(metadata)
+
+    with pytest.raises(PipelineJobStateError, match="calibration"):
+        service.activate_pipeline_version(version_id, promotion=True)
+
+    with service._metadata_lock:
+        metadata = service._read_metadata_unlocked()
+        metadata["pipeline_versions"][version_id]["threshold_calibration_evidence"][
+            "score_domains"
+        ] = ["lexical_confidence"]
+        metadata["pipeline_versions"][version_id]["source_summary"][0][
+            "content_hash"
+        ] = "d" * 64
+        service._write_metadata_unlocked(metadata)
+
+    with pytest.raises(PipelineJobStateError, match="calibration"):
+        service.activate_pipeline_version(version_id, promotion=True)
+
+    with service._metadata_lock:
+        metadata = service._read_metadata_unlocked()
+        metadata["pipeline_versions"][version_id]["source_summary"][0][
+            "content_hash"
+        ] = "c" * 64
+        service._write_metadata_unlocked(metadata)
+
+    promoted = service.activate_pipeline_version(version_id, promotion=True)
+    assert promoted["active"] is True
+
+
+def test_legacy_v2_score_threshold_remains_readable() -> None:
+    config = RetrievalConfig.from_mapping(
+        {"mode": "vector", "score_threshold": 0.75}
+    )
+
+    assert config.score_threshold == 0.75
+    assert config.payload()["score_threshold"] == 0.75
+    assert config.payload()["threshold_contract_status"] == "legacy"

--- a/server/tests/test_rag_retrieval_v2.py
+++ b/server/tests/test_rag_retrieval_v2.py
@@ -568,7 +568,8 @@ async def test_successful_rerank_top_n_does_not_restore_unranked_tail(
     assert result["retrieval"]["rerank_input_count"] == 8
     assert result["retrieval"]["rerank_output_count"] == 2
     assert result["retrieval"]["rerank_tail_dropped"] == 6
-    assert result["retrieval"]["threshold_score_domain"] == "fused_score"
+    assert result["retrieval"]["threshold_score_domain"] == "unconfigured"
+    assert result["retrieval"]["threshold_contract_status"] == "unconfigured"
     assert result["retrieval"]["rerank_requested_input_count"] == 8
     assert result["retrieval"]["rerank_timeout_budget_ms"] == 5_000
     assert result["retrieval"]["rerank_elapsed_ms"] == 12.5
@@ -809,8 +810,17 @@ async def test_auto_rerank_timeout_does_not_start_llm_fallback(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("response_kind", ["invalid_json", "empty_results"])
-async def test_invalid_or_empty_rerank_response_falls_back_safely(
+@pytest.mark.parametrize(
+    "response_kind",
+    [
+        "invalid_json",
+        "empty_results",
+        "non_finite_score",
+        "out_of_range_score",
+        "partially_invalid_scores",
+    ],
+)
+async def test_invalid_empty_or_non_finite_rerank_response_falls_back_safely(
     monkeypatch: pytest.MonkeyPatch,
     response_kind: str,
 ) -> None:
@@ -826,6 +836,29 @@ async def test_invalid_or_empty_rerank_response_falls_back_safely(
                 content=b"{not-json",
                 request=httpx.Request("POST", url),
             )
+        if response_kind == "non_finite_score":
+            return httpx.Response(
+                200,
+                json={"results": [{"index": 0, "relevance_score": "NaN"}]},
+                request=httpx.Request("POST", url),
+            )
+        if response_kind == "out_of_range_score":
+            return httpx.Response(
+                200,
+                json={"results": [{"index": 0, "relevance_score": 1.5}]},
+                request=httpx.Request("POST", url),
+            )
+        if response_kind == "partially_invalid_scores":
+            return httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {"index": 0, "relevance_score": 0.9},
+                        {"index": 1, "relevance_score": "NaN"},
+                    ]
+                },
+                request=httpx.Request("POST", url),
+            )
         return httpx.Response(
             200,
             json={"results": []},
@@ -835,7 +868,7 @@ async def test_invalid_or_empty_rerank_response_falls_back_safely(
     monkeypatch.setattr(httpx.AsyncClient, "post", post)
     outcome = await service.rerank(
         "safe fallback",
-        [RerankDocument("a", "alpha")],
+        [RerankDocument("a", "alpha"), RerankDocument("b", "beta")],
         provider="api",
         top_n=1,
     )


### PR DESCRIPTION
## Summary

- introduce the V3 absolute relevance contract with separate vector, lexical, and rerank score domains
- keep RRF as an ordering signal only and return true empty results when no candidate passes an absolute channel threshold
- make successful rerank Top-N authoritative, fail open only on provider failure, and reject invalid or partially invalid provider scores
- bind promotion calibration evidence to the retrieval profile, execution configuration, source manifest, and required score domains
- preserve V2 legacy score-threshold reads while exposing explicit V3 status, rejection diagnostics, and UI controls

## Strict falsification

The implementation was attacked before submission rather than treating existing green tests as proof. The adversarial cases found and closed were:

- NaN, Inf, boolean, missing, and out-of-range channel scores
- candidate-tail additions changing existing acceptance decisions
- calibration evidence reused across execution configurations or corpus manifests
- malformed score-domain evidence causing an uncontrolled exception
- partially invalid rerank responses being accepted as successful

## Validation

- `test_rag_retrieval_scoring.py` plus V2 compatibility: **41 passed**
- all RAG and Benchmark tests: **296 passed**
- full frontend: **739 passed**
- `RagPage` focused tests: **16 passed**
- production frontend build: **passed**
- Python syntax, staged diff check, and secret scan: **passed**
- full backend: **4955 passed, 20 failed, 29 skipped**

The same 20 failures were reproduced on a clean `origin/main@66e8ed0c` worktree with the same image: 14 Agency Worker build-output failures, 3 Expert Team Worker failures, and 3 TypeScript loader/runtime failures. The four-file baseline probe produced **69 passed, 20 failed**. No RAG or Benchmark test failed.

## Boundaries

- no real Provider or billed API call
- no active index, shared storage, migration, deployment, or persisted-data change
- no production threshold values inferred or tuned
- rollback is the single commit in this PR; no data rollback is required

This PR remains Draft pending review. It does not activate or promote any candidate.
