### PR TITLE
feature: 打通运行经验向 Creator 的安全晋级

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -239,6 +239,7 @@ try:
         configure_workspace_draft_install_guard,
         get_builtin_skill_library,
         get_skill_draft_store,
+        get_skill_lifecycle_store,
         get_skill_manager,
         get_skill_semantic_rerank_service,
         router as skills_router,
@@ -246,11 +247,13 @@ try:
     from server.skills.local_import_api import router as skill_local_import_router
     from server.skills.experience import (
         SkillExperienceCandidateStore,
+        SkillExperienceError,
         SkillExperienceService,
     )
     from server.skills.experience_api import (
         configure_skill_experience,
         configure_skill_experience_distillation,
+        configure_skill_experience_promotion,
         router as skill_experience_router,
     )
     from server.skills.experience_distillation import (
@@ -258,6 +261,7 @@ try:
         SkillExperienceDistillationService,
         WorkflowSkillExperienceDistillationExecutor,
     )
+    from server.skills.experience_promotion import SkillExperiencePromotionService
     from server.skills.trust_service import SkillRuntimeEnvironment
     from server.skills.creator_api import (
         configure_skill_creator,
@@ -377,15 +381,21 @@ except ModuleNotFoundError:
         configure_workspace_draft_install_guard,
         get_builtin_skill_library,
         get_skill_draft_store,
+        get_skill_lifecycle_store,
         get_skill_manager,
         get_skill_semantic_rerank_service,
         router as skills_router,
     )
     from skills.local_import_api import router as skill_local_import_router
-    from skills.experience import SkillExperienceCandidateStore, SkillExperienceService
+    from skills.experience import (
+        SkillExperienceCandidateStore,
+        SkillExperienceError,
+        SkillExperienceService,
+    )
     from skills.experience_api import (
         configure_skill_experience,
         configure_skill_experience_distillation,
+        configure_skill_experience_promotion,
         router as skill_experience_router,
     )
     from skills.experience_distillation import (
@@ -393,6 +403,7 @@ except ModuleNotFoundError:
         SkillExperienceDistillationService,
         WorkflowSkillExperienceDistillationExecutor,
     )
+    from skills.experience_promotion import SkillExperiencePromotionService
     from skills.trust_service import SkillRuntimeEnvironment
     from skills.creator_api import (
         configure_skill_creator,
@@ -2190,7 +2201,18 @@ skill_creator_service = SkillCreatorService(
     authoring_service,
     source_provider=skill_creator_source_provider,
 )
-skill_creator_handoff_service = SkillCreatorHandoffService(skill_creator_service)
+skill_experience_promotion_service = SkillExperiencePromotionService(
+    skill_experience_service,
+    skill_experience_candidate_store,
+    skill_creator_service,
+    get_skill_draft_store(),
+    get_skill_manager(),
+    get_skill_lifecycle_store(),
+)
+skill_creator_handoff_service = SkillCreatorHandoffService(
+    skill_creator_service,
+    promotion_service=skill_experience_promotion_service,
+)
 skill_creator_resource_plan_store = SkillResourcePlanStore(
     storage_dir=AGENT_TASK_STORAGE_DIR or None
 )
@@ -2255,6 +2277,7 @@ workflow_skill_creator_provider = AuthoringToolsetProvider(
 configure_runtime_authoring(authoring_service)
 configure_skill_experience(skill_experience_service)
 configure_skill_experience_distillation(skill_experience_distillation_service)
+configure_skill_experience_promotion(skill_experience_promotion_service)
 configure_skill_creator(skill_creator_service)
 configure_skill_creator_resource_planning(skill_creator_resource_planning_service)
 configure_skill_creator_resource_build(skill_creator_resource_build_service)
@@ -2265,14 +2288,17 @@ configure_skill_creator_evaluation_suite(skill_creator_evaluation_suite_service)
 configure_skill_creator_evolution(skill_creator_evolution_service)
 
 
-def require_creator_trigger_proposal_approval(proposal) -> None:
-    if not skill_creator_trigger_optimization_service.enabled:
-        return
+def require_creator_proposal_approval(proposal) -> None:
     if proposal.source_type != "skill_creator" or not proposal.creator_session_id:
         return
     try:
         session = skill_creator_session_store.require(proposal.creator_session_id)
-        if not skill_creator_trigger_optimization_service.requires_trigger(session):
+        _, draft = skill_creator_service.get_session(session.session_id)
+        skill_experience_promotion_service.require_update_draft_current(draft)
+        if (
+            not skill_creator_trigger_optimization_service.enabled
+            or not skill_creator_trigger_optimization_service.requires_trigger(session)
+        ):
             return
         plan = skill_creator_resource_plan_store.current_for_session(session.session_id)
         resource_binding = proposal.payload.get("creator_resource_build")
@@ -2292,10 +2318,14 @@ def require_creator_trigger_proposal_approval(proposal) -> None:
                 "The Creator proposal no longer matches its trigger-gated resource plan.",
                 code="skill_trigger_receipt_stale",
             )
-        _, draft = skill_creator_service.get_session(session.session_id)
         skill_creator_trigger_optimization_service.require_plan_gate(
             session, plan, draft
         )
+    except SkillExperienceError as exc:
+        raise AuthoringProposalValidationError(
+            str(exc),
+            code=str(getattr(exc, "code", "skill_experience_promotion_stale")),
+        ) from exc
     except SkillCreatorError as exc:
         raise AuthoringProposalValidationError(
             str(exc),
@@ -2304,7 +2334,7 @@ def require_creator_trigger_proposal_approval(proposal) -> None:
 
 
 authoring_service.skill_proposal_approval_guard = (
-    require_creator_trigger_proposal_approval
+    require_creator_proposal_approval
 )
 
 

--- a/server/skills/api.py
+++ b/server/skills/api.py
@@ -198,6 +198,20 @@ class SkillDraftActionRequest(BaseModel):
     )
 
 
+class SkillDraftInstallRequest(SkillDraftActionRequest):
+    target_skill_id: str | None = Field(default=None, min_length=1, max_length=240)
+    expected_current_version_id: str | None = Field(
+        default=None, min_length=1, max_length=240
+    )
+    expected_current_digest: str | None = Field(
+        default=None,
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+    )
+    confirmed: bool = False
+
+
 class SkillDraftPatchRequest(BaseModel):
     expected_revision: int = Field(ge=1)
     expected_digest: str = Field(
@@ -1059,7 +1073,7 @@ async def validate_skill_draft(draft_id: str, payload: SkillDraftActionRequest):
 
 
 @router.post("/drafts/{draft_id}/install")
-async def install_skill_draft(draft_id: str, payload: SkillDraftActionRequest):
+async def install_skill_draft(draft_id: str, payload: SkillDraftInstallRequest):
     try:
         store = get_skill_draft_store()
         manager = get_skill_manager()
@@ -1067,6 +1081,31 @@ async def install_skill_draft(draft_id: str, payload: SkillDraftActionRequest):
         def _install_locked(item):
             if _workspace_draft_install_guard is not None:
                 _workspace_draft_install_guard(item)
+            expected_update = (
+                item.update_target_skill_id,
+                item.update_expected_version_id,
+                item.update_expected_content_digest,
+            )
+            supplied_update = (
+                payload.target_skill_id,
+                payload.expected_current_version_id,
+                (
+                    payload.expected_current_digest.lower()
+                    if payload.expected_current_digest
+                    else None
+                ),
+            )
+            if any(expected_update):
+                if expected_update != supplied_update or not payload.confirmed:
+                    raise SkillValidationError(
+                        "Workspace Skill update target changed or was not confirmed.",
+                        code="skill_experience_promotion_stale",
+                    )
+            elif any(supplied_update):
+                raise SkillValidationError(
+                    "This Workspace Skill draft is not an approved update target.",
+                    code="skill_experience_update_target_invalid",
+                )
             decision = item.quality_decision
             return manager.install_workspace_draft(
                 draft_id=item.draft_id,
@@ -1078,6 +1117,11 @@ async def install_skill_draft(draft_id: str, payload: SkillDraftActionRequest):
                 quality_status=item.quality_status,
                 quality_decision_id=(decision.decision_id if decision else None),
                 quality_run_id=(decision.run_id if decision else None),
+                target_skill_id=item.update_target_skill_id,
+                predecessor_draft_id=item.predecessor_draft_id,
+                expected_current_version_id=item.update_expected_version_id,
+                expected_current_digest=item.update_expected_content_digest,
+                confirmed=payload.confirmed,
             )
 
         updated, installed = await asyncio.to_thread(
@@ -1097,10 +1141,20 @@ async def install_skill_draft(draft_id: str, payload: SkillDraftActionRequest):
     except SkillDraftError as exc:
         _raise_draft_error(exc)
     except SkillValidationError as exc:
-        if not str(exc.code or "").startswith("skill_trigger_"):
+        structured_prefixes = ("skill_trigger_", "skill_experience_", "skill_lifecycle_")
+        if not str(exc.code or "").startswith(structured_prefixes):
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         raise HTTPException(
-            status_code=400,
+            status_code=(
+                409
+                if exc.code
+                in {
+                    "skill_experience_promotion_stale",
+                    "skill_experience_update_target_invalid",
+                    "skill_experience_decision_required",
+                }
+                else 400
+            ),
             detail={
                 "code": str(exc.code or "skill_package_invalid"),
                 "message": str(exc),

--- a/server/skills/creator_handoff.py
+++ b/server/skills/creator_handoff.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from .creator_service import SkillCreatorService
 from .creator_store import (
@@ -11,6 +11,9 @@ from .creator_store import (
     SkillCreatorStorageError,
     SkillCreatorValidationError,
 )
+
+if TYPE_CHECKING:
+    from .experience_promotion import SkillExperiencePromotionService
 
 
 SKILL_CREATOR_HANDOFF_VERSION = "skill-creator-middleware-handoff-v1"
@@ -57,8 +60,10 @@ class SkillCreatorHandoffService:
         creator_service: SkillCreatorService,
         *,
         enabled: bool | None = None,
+        promotion_service: "SkillExperiencePromotionService | None" = None,
     ) -> None:
         self.creator_service = creator_service
+        self.promotion_service = promotion_service
         self.enabled = (
             os.getenv("SKILL_CREATOR_MIDDLEWARE_V2_ENABLED", "true")
             .strip()
@@ -84,6 +89,16 @@ class SkillCreatorHandoffService:
         if not clean_task_id or not clean_run_id or not clean_node_id or not clean_intent:
             raise SkillCreatorHandoffError("skill_creator_handoff_failed")
         try:
+            if (
+                self.promotion_service is not None
+                and self.promotion_service.enabled
+            ):
+                promoted = self.promotion_service.promote_trusted_handoff(
+                    task_id=clean_task_id,
+                    run_id=clean_run_id,
+                    intent=clean_intent,
+                )
+                return promoted.session
             return self.creator_service.create_or_get_workflow_handoff(
                 source_task_id=clean_task_id,
                 source_run_id=clean_run_id,
@@ -118,7 +133,20 @@ class SkillCreatorHandoffService:
             )
             raise SkillCreatorHandoffError(code) from exc
         except Exception as exc:
-            raise SkillCreatorHandoffError("skill_creator_handoff_failed") from exc
+            experience_code = str(getattr(exc, "code", ""))
+            if experience_code in {
+                "skill_experience_candidate_conflict",
+                "skill_experience_promotion_stale",
+            }:
+                code = "skill_creator_handoff_conflict"
+            elif experience_code in {
+                "skill_experience_disabled",
+                "skill_experience_store_unavailable",
+            }:
+                code = "skill_creator_handoff_unavailable"
+            else:
+                code = "skill_creator_handoff_failed"
+            raise SkillCreatorHandoffError(code) from exc
 
     @staticmethod
     def ready_event(

--- a/server/skills/creator_store.py
+++ b/server/skills/creator_store.py
@@ -93,6 +93,13 @@ class SkillCreatorSession:
     source_xpert_id: str | None = None
     source_conversation_id: str | None = None
     source_message_id: str | None = None
+    experience_candidate_id: str | None = None
+    experience_decision: Literal["create", "update"] | None = None
+    update_target_skill_id: str | None = None
+    predecessor_draft_id: str | None = None
+    experience_baseline_version_id: str | None = None
+    experience_baseline_content_digest: str | None = None
+    run_experience_case: dict[str, Any] | None = None
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
 
@@ -100,8 +107,8 @@ class SkillCreatorSession:
 class SkillCreatorSessionStore:
     """Atomic, fail-closed persistence for recoverable Creator sessions."""
 
-    SCHEMA_VERSION = 2
-    READABLE_SCHEMA_VERSIONS = frozenset({1, SCHEMA_VERSION})
+    SCHEMA_VERSION = 3
+    READABLE_SCHEMA_VERSIONS = frozenset({1, 2, SCHEMA_VERSION})
     MAX_SESSIONS = 500
     MAX_TEXT_BYTES = 64 * 1024
 
@@ -289,6 +296,144 @@ class SkillCreatorSessionStore:
             self._insert_unlocked(candidate)
             return self._copy(candidate)
 
+    def create_or_get_experience_promotion(
+        self,
+        *,
+        experience_candidate_id: str,
+        intent: str,
+        positive_examples: list[str],
+        near_miss_examples: list[str],
+        expected_output: str,
+        success_criteria: list[str],
+        selected_evidence: list[dict[str, str]],
+        evidence_preview_fingerprint: str,
+        source_kind: CreatorSourceKind,
+        source_task_id: str,
+        source_run_id: str,
+        source_xpert_id: str | None = None,
+        source_conversation_id: str | None = None,
+        source_message_id: str | None = None,
+        decision: Literal["create", "update"],
+        update_target_skill_id: str | None = None,
+        predecessor_draft_id: str | None = None,
+        baseline_version_id: str | None = None,
+        baseline_content_digest: str | None = None,
+        run_experience_case: dict[str, Any] | None = None,
+    ) -> SkillCreatorSession:
+        """Create or recover the one Creator session promoted from a run.
+
+        An untouched legacy capture or middleware handoff for the same trusted
+        source is hydrated in place. Edited sessions fail closed so a confirmed
+        experience brief never overwrites user work.
+        """
+
+        candidate = self._new_session(
+            mode="run",
+            intent=intent,
+            positive_examples=positive_examples,
+            near_miss_examples=near_miss_examples,
+            expected_output=expected_output,
+            success_criteria=success_criteria,
+            source_kind=source_kind,
+            source_task_id=source_task_id,
+            source_run_id=source_run_id,
+            source_xpert_id=source_xpert_id,
+            source_conversation_id=source_conversation_id,
+            source_message_id=source_message_id,
+            authoring_flow="resource",
+            trigger_required=True,
+        )
+        candidate.experience_candidate_id = self._required_identifier(
+            experience_candidate_id, "experience_candidate_id"
+        )
+        candidate.experience_decision = self._experience_decision(decision)
+        candidate.update_target_skill_id = self._optional_text(
+            update_target_skill_id, 200
+        )
+        candidate.predecessor_draft_id = self._optional_text(
+            predecessor_draft_id, 200
+        )
+        candidate.experience_baseline_version_id = self._optional_text(
+            baseline_version_id, 200
+        )
+        candidate.experience_baseline_content_digest = (
+            self._digest(baseline_content_digest, "baseline_content_digest")
+            if baseline_content_digest is not None
+            else None
+        )
+        candidate.evidence_preview_fingerprint = self._digest(
+            evidence_preview_fingerprint, "evidence_preview_fingerprint"
+        )
+        candidate.selected_evidence = self._evidence(selected_evidence)
+        candidate.evidence_confirmed = True
+        candidate.run_experience_case = self._experience_case(run_experience_case)
+        self._validate_experience_projection(candidate)
+        self._reject_credentials(candidate)
+        candidate.state = self._derive_state(candidate)
+
+        with self._lock:
+            self._ensure_writable_unlocked()
+            promotion_matches = [
+                item
+                for item in self._items.values()
+                if item.experience_candidate_id == candidate.experience_candidate_id
+            ]
+            if len(promotion_matches) > 1:
+                raise SkillCreatorConflictError(
+                    "Multiple Creator sessions match this experience candidate."
+                )
+            if promotion_matches:
+                existing = promotion_matches[0]
+                if self._experience_projection_matches(existing, candidate):
+                    return self._copy(existing)
+                raise SkillCreatorConflictError(
+                    "Creator experience promotion conflicts with an existing session."
+                )
+
+            source_matches = [
+                item
+                for item in self._items.values()
+                if self._stable_source_matches(item, candidate)
+            ]
+            if len(source_matches) > 1:
+                raise SkillCreatorConflictError(
+                    "Multiple Creator sessions match this runtime source."
+                )
+            if source_matches:
+                existing = source_matches[0]
+                if not self._is_hydratable_experience_session(existing):
+                    raise SkillCreatorConflictError(
+                        "Creator runtime source already has an edited session."
+                    )
+                previous = self._copy(existing)
+                for field_name in (
+                    "source_run_id",
+                    "authoring_flow",
+                    "trigger_required",
+                    "intent",
+                    "positive_examples",
+                    "near_miss_examples",
+                    "expected_output",
+                    "success_criteria",
+                    "selected_evidence",
+                    "evidence_preview_fingerprint",
+                    "evidence_confirmed",
+                    "experience_candidate_id",
+                    "experience_decision",
+                    "update_target_skill_id",
+                    "predecessor_draft_id",
+                    "experience_baseline_version_id",
+                    "experience_baseline_content_digest",
+                    "run_experience_case",
+                ):
+                    setattr(existing, field_name, getattr(candidate, field_name))
+                existing.state = self._derive_state(existing)
+                existing.session_revision += 1
+                existing.updated_at = time.time()
+                return self._save_or_restore_unlocked(existing, previous)
+            self._insert_unlocked(candidate)
+            return self._copy(candidate)
+
     def _new_session(
         self,
         *,
@@ -415,6 +560,22 @@ class SkillCreatorSessionStore:
         )
 
     @staticmethod
+    def _stable_source_matches(
+        existing: SkillCreatorSession,
+        candidate: SkillCreatorSession,
+    ) -> bool:
+        """Match one trusted task across a server-recorded run-id recovery."""
+
+        return (
+            existing.mode == "run"
+            and existing.source_kind == candidate.source_kind
+            and existing.source_task_id == candidate.source_task_id
+            and existing.source_xpert_id == candidate.source_xpert_id
+            and existing.source_conversation_id == candidate.source_conversation_id
+            and existing.source_message_id == candidate.source_message_id
+        )
+
+    @staticmethod
     def _is_pristine_run_capture(item: SkillCreatorSession) -> bool:
         return (
             item.mode == "run"
@@ -430,6 +591,48 @@ class SkillCreatorSessionStore:
             and not item.proposal_id
             and not item.draft_id
         )
+
+    @staticmethod
+    def _is_hydratable_experience_session(item: SkillCreatorSession) -> bool:
+        return (
+            item.mode == "run"
+            and item.session_revision == 1
+            and not item.experience_candidate_id
+            and not item.evidence_confirmed
+            and not item.selected_evidence
+            and not item.proposal_id
+            and not item.draft_id
+            and item.cases_revision == 0
+            and not item.active_evaluation_run_id
+            and not item.latest_evaluation_run_id
+            and item.review_state == "none"
+        )
+
+    @staticmethod
+    def _experience_projection_matches(
+        existing: SkillCreatorSession,
+        candidate: SkillCreatorSession,
+    ) -> bool:
+        fields = (
+            "authoring_flow",
+            "trigger_required",
+            "intent",
+            "positive_examples",
+            "near_miss_examples",
+            "expected_output",
+            "success_criteria",
+            "selected_evidence",
+            "evidence_preview_fingerprint",
+            "evidence_confirmed",
+            "experience_candidate_id",
+            "experience_decision",
+            "update_target_skill_id",
+            "predecessor_draft_id",
+            "experience_baseline_version_id",
+            "experience_baseline_content_digest",
+            "run_experience_case",
+        )
+        return all(getattr(existing, name) == getattr(candidate, name) for name in fields)
 
     def activate_resource_authoring(
         self,
@@ -924,6 +1127,83 @@ class SkillCreatorSessionStore:
         return str(value)
 
     @staticmethod
+    def _experience_decision(value: Any) -> Literal["create", "update"]:
+        if value not in {"create", "update"}:
+            raise SkillCreatorValidationError("Invalid experience promotion decision.")
+        return value
+
+    @classmethod
+    def _experience_case(cls, value: Any) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        if not isinstance(value, dict) or set(value) != {
+            "case_id",
+            "role",
+            "source",
+            "name",
+            "prompt",
+            "expected_behavior",
+            "fixtures",
+            "assertions",
+            "requirement_ids",
+            "required_resource_paths",
+            "workflow_step_ids",
+        }:
+            raise SkillCreatorValidationError("Invalid run experience regression case.")
+        if value.get("role") != "regression" or value.get("source") != "run_experience":
+            raise SkillCreatorValidationError("Invalid run experience regression case.")
+        result = {
+            "case_id": cls._required_identifier(value.get("case_id"), "case_id"),
+            "role": "regression",
+            "source": "run_experience",
+            "name": cls._text(value.get("name"), "case_name", maximum=300),
+            "prompt": cls._text(value.get("prompt"), "case_prompt", maximum=4_000),
+            "expected_behavior": cls._text(
+                value.get("expected_behavior"), "expected_behavior", maximum=4_000
+            ),
+            "fixtures": value.get("fixtures"),
+            "assertions": value.get("assertions"),
+            "requirement_ids": value.get("requirement_ids"),
+            "required_resource_paths": value.get("required_resource_paths"),
+            "workflow_step_ids": value.get("workflow_step_ids"),
+        }
+        for name in (
+            "fixtures",
+            "assertions",
+            "requirement_ids",
+            "required_resource_paths",
+            "workflow_step_ids",
+        ):
+            if result[name] != []:
+                raise SkillCreatorValidationError(
+                    "Run experience regression cases must be reviewed before adding coverage."
+                )
+        return result
+
+    @classmethod
+    def _validate_experience_projection(cls, item: SkillCreatorSession) -> None:
+        fields = (
+            item.update_target_skill_id,
+            item.predecessor_draft_id,
+            item.experience_baseline_version_id,
+            item.experience_baseline_content_digest,
+        )
+        if item.experience_candidate_id is None:
+            if item.experience_decision is not None or any(fields) or item.run_experience_case:
+                raise SkillCreatorValidationError("Incomplete experience promotion projection.")
+            return
+        if item.experience_decision == "update":
+            if not all(fields):
+                raise SkillCreatorValidationError("Incomplete Creator update target projection.")
+        elif item.experience_decision == "create":
+            if any(fields):
+                raise SkillCreatorValidationError(
+                    "New Creator sessions cannot bind an update target."
+                )
+        else:
+            raise SkillCreatorValidationError("Invalid experience promotion projection.")
+
+    @staticmethod
     def _validate_source(item: SkillCreatorSession) -> None:
         if item.mode == "blank":
             if item.source_kind != "blank" or any(
@@ -1191,6 +1471,33 @@ class SkillCreatorSessionStore:
         if not isinstance(item.evidence_confirmed, bool):
             raise ValueError("Invalid evidence_confirmed value.")
         item.selected_evidence = self._evidence(item.selected_evidence)
+        item.experience_candidate_id = self._optional_text(
+            item.experience_candidate_id, 200
+        )
+        item.experience_decision = (
+            self._experience_decision(item.experience_decision)
+            if item.experience_decision is not None
+            else None
+        )
+        item.update_target_skill_id = self._optional_text(
+            item.update_target_skill_id, 200
+        )
+        item.predecessor_draft_id = self._optional_text(
+            item.predecessor_draft_id, 200
+        )
+        item.experience_baseline_version_id = self._optional_text(
+            item.experience_baseline_version_id, 200
+        )
+        item.experience_baseline_content_digest = (
+            self._digest(
+                item.experience_baseline_content_digest,
+                "experience_baseline_content_digest",
+            )
+            if item.experience_baseline_content_digest is not None
+            else None
+        )
+        item.run_experience_case = self._experience_case(item.run_experience_case)
+        self._validate_experience_projection(item)
         item.state = self._derive_state(item) if item.state != "archived" else "archived"
         return item
 

--- a/server/skills/draft_store.py
+++ b/server/skills/draft_store.py
@@ -104,6 +104,11 @@ class WorkspaceSkillDraft:
     source_proposal_id: str | None = None
     source_apply_key: str | None = None
     creator_session_id: str | None = None
+    experience_candidate_id: str | None = None
+    predecessor_draft_id: str | None = None
+    update_target_skill_id: str | None = None
+    update_expected_version_id: str | None = None
+    update_expected_content_digest: str | None = None
     quality_required: bool = False
     quality_status: SkillQualityStatus = "not_evaluated"
     quality_decision: SkillQualityDecision | None = None
@@ -154,6 +159,11 @@ class WorkspaceSkillDraftStore:
         source_proposal_id: str | None = None,
         source_apply_key: str | None = None,
         creator_session_id: str | None = None,
+        experience_candidate_id: str | None = None,
+        predecessor_draft_id: str | None = None,
+        update_target_skill_id: str | None = None,
+        update_expected_version_id: str | None = None,
+        update_expected_content_digest: str | None = None,
         quality_required: bool = False,
         quality_status: SkillQualityStatus = "not_evaluated",
     ) -> WorkspaceSkillDraft:
@@ -166,12 +176,20 @@ class WorkspaceSkillDraftStore:
             files=files or {},
         )
         digest = self.compute_content_digest(**normalized)
+        update_projection = self._normalize_update_projection(
+            experience_candidate_id=experience_candidate_id,
+            predecessor_draft_id=predecessor_draft_id,
+            update_target_skill_id=update_target_skill_id,
+            update_expected_version_id=update_expected_version_id,
+            update_expected_content_digest=update_expected_content_digest,
+        )
         now = time.time()
         item = WorkspaceSkillDraft(
             draft_id=f"skilldraft_{uuid.uuid4().hex}",
             source_proposal_id=source_proposal_id,
             source_apply_key=source_apply_key,
             creator_session_id=creator_session_id,
+            **update_projection,
             quality_required=bool(quality_required),
             quality_status=quality_status,
             content_digest=digest,
@@ -226,6 +244,11 @@ class WorkspaceSkillDraftStore:
         description: str,
         skill_markdown: str,
         files: dict[str, str] | None = None,
+        experience_candidate_id: str | None = None,
+        predecessor_draft_id: str | None = None,
+        update_target_skill_id: str | None = None,
+        update_expected_version_id: str | None = None,
+        update_expected_content_digest: str | None = None,
     ) -> WorkspaceSkillDraft:
         """Create or replay the one manual draft owned by a Creator session."""
 
@@ -241,10 +264,21 @@ class WorkspaceSkillDraftStore:
                 )
                 expected_digest = self.compute_content_digest(**normalized)
                 first_snapshot = self._revisions.get(existing.draft_id, {}).get(1)
+                expected_projection = self._normalize_update_projection(
+                    experience_candidate_id=experience_candidate_id,
+                    predecessor_draft_id=predecessor_draft_id,
+                    update_target_skill_id=update_target_skill_id,
+                    update_expected_version_id=update_expected_version_id,
+                    update_expected_content_digest=update_expected_content_digest,
+                )
                 if (
                     first_snapshot is None
                     or not self._digests_equal(
                         first_snapshot.content_digest, expected_digest
+                    )
+                    or any(
+                        getattr(existing, field_name) != value
+                        for field_name, value in expected_projection.items()
                     )
                 ):
                     raise SkillDraftConflictError(
@@ -258,6 +292,11 @@ class WorkspaceSkillDraftStore:
                 skill_markdown=skill_markdown,
                 files=files or {},
                 creator_session_id=creator_session_id,
+                experience_candidate_id=experience_candidate_id,
+                predecessor_draft_id=predecessor_draft_id,
+                update_target_skill_id=update_target_skill_id,
+                update_expected_version_id=update_expected_version_id,
+                update_expected_content_digest=update_expected_content_digest,
                 quality_required=True,
                 quality_status="not_evaluated",
             )
@@ -671,26 +710,23 @@ class WorkspaceSkillDraftStore:
             ]
             if not matches:
                 return None
-            if len(matches) != 1:
-                raise SkillDraftStorageError(
-                    "Multiple Workspace drafts reference the same installed Skill ID."
-                )
-            item = matches[0]
-            previous = self._copy(item)
-            item.installed_skill_id = None
-            item.installed_content_revision = None
-            item.installed_content_digest = None
-            item.install_state = "not_installed"
-            if item.status != "archived":
-                item.status = "draft"
-            item.revision += 1
-            item.updated_at = time.time()
+            previous = {item.draft_id: self._copy(item) for item in matches}
+            now = time.time()
+            for item in matches:
+                item.installed_skill_id = None
+                item.installed_content_revision = None
+                item.installed_content_digest = None
+                item.install_state = "not_installed"
+                if item.status != "archived":
+                    item.status = "draft"
+                item.revision += 1
+                item.updated_at = now
             try:
                 self._save_unlocked()
             except BaseException:
-                self._items[item.draft_id] = previous
+                self._items.update(previous)
                 raise
-            return self._copy(item)
+            return self._copy(matches[-1])
 
     def mark_lifecycle_version_installed(
         self,
@@ -718,6 +754,12 @@ class WorkspaceSkillDraftStore:
                 and self._digests_equal(snapshot.content_digest, item.content_digest)
                 else "outdated"
             )
+            affected = [
+                candidate
+                for candidate in self._items.values()
+                if candidate.installed_skill_id == str(skill_id).strip()
+                and candidate.draft_id != item.draft_id
+            ]
             if (
                 item.installed_skill_id == str(skill_id).strip()
                 and item.installed_content_revision == snapshot.revision
@@ -726,20 +768,29 @@ class WorkspaceSkillDraftStore:
                 )
                 and item.install_state == install_state
                 and item.status == "installed"
+                and all(candidate.install_state == "outdated" for candidate in affected)
             ):
                 return self._copy(item)
-            previous = self._copy(item)
+            previous = {
+                candidate.draft_id: self._copy(candidate)
+                for candidate in [item, *affected]
+            }
+            now = time.time()
+            for candidate in affected:
+                candidate.install_state = "outdated"
+                candidate.revision += 1
+                candidate.updated_at = now
             item.installed_skill_id = str(skill_id).strip()
             item.installed_content_revision = snapshot.revision
             item.installed_content_digest = snapshot.content_digest
             item.install_state = install_state
             item.status = "installed"
             item.revision += 1
-            item.updated_at = time.time()
+            item.updated_at = now
             try:
                 self._save_unlocked()
             except BaseException:
-                self._items[draft_id] = previous
+                self._items.update(previous)
                 raise
             return self._copy(item)
 
@@ -789,8 +840,22 @@ class WorkspaceSkillDraftStore:
                     "Installed Workspace Skill digest does not match the reviewed draft."
                 )
 
-            previous = self._copy(item)
+            superseded = [
+                candidate
+                for candidate in self._items.values()
+                if candidate.draft_id != item.draft_id
+                and candidate.installed_skill_id == installed_skill_id
+            ]
+            previous = {
+                candidate.draft_id: self._copy(candidate)
+                for candidate in [item, *superseded]
+            }
             try:
+                now = time.time()
+                for candidate in superseded:
+                    candidate.install_state = "outdated"
+                    candidate.revision += 1
+                    candidate.updated_at = now
                 item.validation = self._bound_validation(item, validation)
                 item.needs_review = False
                 item.status = "installed"
@@ -799,10 +864,10 @@ class WorkspaceSkillDraftStore:
                 item.installed_content_digest = item.content_digest
                 item.install_state = "current"
                 item.revision += 1
-                item.updated_at = time.time()
+                item.updated_at = now
                 self._save_unlocked()
             except BaseException:
-                self._items[draft_id] = previous
+                self._items.update(previous)
                 raise
             return self._copy(item), install_result
 
@@ -1238,6 +1303,56 @@ class WorkspaceSkillDraftStore:
         }:
             raise SkillDraftValidationError(f"Invalid Skill quality status: {value}")
 
+    @classmethod
+    def _normalize_update_projection(
+        cls,
+        *,
+        experience_candidate_id: str | None,
+        predecessor_draft_id: str | None,
+        update_target_skill_id: str | None,
+        update_expected_version_id: str | None,
+        update_expected_content_digest: str | None,
+    ) -> dict[str, str | None]:
+        projection = {
+            "experience_candidate_id": cls._optional_text(experience_candidate_id),
+            "predecessor_draft_id": cls._optional_text(predecessor_draft_id),
+            "update_target_skill_id": cls._optional_text(update_target_skill_id),
+            "update_expected_version_id": cls._optional_text(
+                update_expected_version_id
+            ),
+            "update_expected_content_digest": cls._optional_text(
+                update_expected_content_digest
+            ),
+        }
+        update_fields = tuple(
+            projection[name]
+            for name in (
+                "predecessor_draft_id",
+                "update_target_skill_id",
+                "update_expected_version_id",
+                "update_expected_content_digest",
+            )
+        )
+        if any(update_fields) and not all(update_fields):
+            raise SkillDraftValidationError(
+                "Workspace Skill update target metadata is incomplete."
+            )
+        if any(update_fields) and projection["experience_candidate_id"] is None:
+            raise SkillDraftValidationError(
+                "Workspace Skill update requires an experience candidate binding."
+            )
+        digest = projection["update_expected_content_digest"]
+        if digest is not None:
+            clean_digest = digest.lower()
+            if len(clean_digest) != 64 or any(
+                character not in "0123456789abcdef" for character in clean_digest
+            ):
+                raise SkillDraftValidationError(
+                    "Workspace Skill update target digest is invalid."
+                )
+            projection["update_expected_content_digest"] = clean_digest
+        return projection
+
     @staticmethod
     def _require_quality_gate(item: WorkspaceSkillDraft) -> None:
         WorkspaceSkillDraftStore._require_creator_final_package(item)
@@ -1634,6 +1749,15 @@ class WorkspaceSkillDraftStore:
         quality_decision = self._decode_quality_decision(
             record.get("quality_decision")
         )
+        update_projection = self._normalize_update_projection(
+            experience_candidate_id=record.get("experience_candidate_id"),
+            predecessor_draft_id=record.get("predecessor_draft_id"),
+            update_target_skill_id=record.get("update_target_skill_id"),
+            update_expected_version_id=record.get("update_expected_version_id"),
+            update_expected_content_digest=record.get(
+                "update_expected_content_digest"
+            ),
+        )
         if quality_status in {"accepted", "eval_waived"}:
             decision_matches = bool(
                 quality_decision is not None
@@ -1663,6 +1787,7 @@ class WorkspaceSkillDraftStore:
             source_proposal_id=self._optional_text(record.get("source_proposal_id")),
             source_apply_key=self._optional_text(record.get("source_apply_key")),
             creator_session_id=self._optional_text(record.get("creator_session_id")),
+            **update_projection,
             quality_required=bool(record.get("quality_required", False)),
             quality_status=quality_status,
             quality_decision=quality_decision,

--- a/server/skills/experience.py
+++ b/server/skills/experience.py
@@ -161,7 +161,7 @@ class SkillExperienceAnalysisAttemptV1:
     base_revision: int
     base_digest: str
     status: ExperienceAnalysisStatus
-    executor_mode: Literal["model", "manual"]
+    executor_mode: Literal["model", "manual", "trusted_handoff"]
     error_code: str | None
     started_at: float
     finished_at: float | None = None
@@ -225,6 +225,18 @@ class SkillExperienceDecisionV1:
 
 
 @dataclass(frozen=True, slots=True)
+class SkillExperiencePromotionV1:
+    session_id: str
+    route: str
+    decision: Literal["create", "update"]
+    target_skill_id: str | None
+    target_draft_id: str | None
+    baseline_version_id: str | None
+    baseline_content_digest: str | None
+    promoted_at: float
+
+
+@dataclass(frozen=True, slots=True)
 class SkillExperienceCandidateV1:
     candidate_id: str
     version: str
@@ -247,6 +259,7 @@ class SkillExperienceCandidateV1:
     overlaps: tuple[SkillExperienceOverlapV1, ...] = ()
     overlap_fingerprint: str | None = None
     decision: SkillExperienceDecisionV1 | None = None
+    promotion: SkillExperiencePromotionV1 | None = None
     dismissal_reason: str | None = None
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
@@ -678,6 +691,127 @@ class SkillExperienceCandidateStore:
                     if decision.decision == "dismiss"
                     else None
                 ),
+            )
+
+    def prepare_trusted_handoff(
+        self,
+        candidate_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+        brief: DistilledSkillBriefV1,
+    ) -> SkillExperienceCandidateV1:
+        """Freeze a no-model Creator middleware brief for explicit handoff.
+
+        The workflow author already chose the Creator middleware, so its trusted
+        taskInput can become a manually sourced brief. This method never accepts
+        client-supplied source or target IDs and does not call a provider.
+        """
+
+        _validate_brief_instance(brief)
+        if not brief.complete:
+            raise SkillExperienceError(
+                "Trusted Creator handoff brief is incomplete.",
+                code="skill_experience_decision_required",
+            )
+        with self._lock:
+            self._ensure_readable_unlocked()
+            current = self._require_unlocked(candidate_id)
+            self._assert_expected(current, expected_revision, expected_digest)
+            if current.state == "promotion_ready":
+                if current.brief == brief and current.decision is not None:
+                    return copy.deepcopy(current)
+                raise SkillExperienceConflictError(
+                    "Skill experience already has another reviewed decision.",
+                    code="skill_experience_candidate_conflict",
+                )
+            if current.state != "captured" or not current.selected_evidence:
+                raise SkillExperienceConflictError(
+                    "Skill experience is not ready for a trusted Creator handoff.",
+                    code="skill_experience_candidate_conflict",
+                )
+            now = time.time()
+            analysis_key = _sha256(
+                {
+                    "candidate_id": current.candidate_id,
+                    "brief_digest": brief.digest,
+                    "mode": "trusted_creator_handoff",
+                }
+            )
+            attempt = SkillExperienceAnalysisAttemptV1(
+                attempt_id=f"skillexperienceanalysis_{uuid.uuid4().hex}",
+                analysis_key=analysis_key,
+                base_revision=current.revision,
+                base_digest=current.digest,
+                status="succeeded",
+                executor_mode="trusted_handoff",
+                error_code=None,
+                started_at=now,
+                finished_at=now,
+            )
+            overlap_fingerprint = _sha256(
+                {
+                    "candidate_id": current.candidate_id,
+                    "brief_digest": brief.digest,
+                    "overlaps": [],
+                }
+            )
+            decision = SkillExperienceDecisionV1(
+                decision="create",
+                target_skill_id=None,
+                target_draft_id=None,
+                override_reason=None,
+                new_boundary=None,
+                actor_kind="local_console",
+                decided_at=now,
+            )
+            return self._replace_unlocked(
+                current,
+                state="promotion_ready",
+                analysis_attempt=attempt,
+                brief=brief,
+                overlaps=(),
+                overlap_fingerprint=overlap_fingerprint,
+                decision=decision,
+            )
+
+    def mark_promoted(
+        self,
+        candidate_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+        promotion: SkillExperiencePromotionV1,
+    ) -> SkillExperienceCandidateV1:
+        _validate_promotion(promotion)
+        with self._lock:
+            self._ensure_readable_unlocked()
+            current = self._require_unlocked(candidate_id)
+            if current.state == "promoted" and current.promotion is not None:
+                if _promotion_identity(current.promotion) == _promotion_identity(
+                    promotion
+                ):
+                    return copy.deepcopy(current)
+                raise SkillExperienceConflictError(
+                    "Skill experience is already bound to another Creator promotion.",
+                    code="skill_experience_candidate_conflict",
+                )
+            self._assert_expected(current, expected_revision, expected_digest)
+            if (
+                current.state != "promotion_ready"
+                or current.decision is None
+                or current.decision.decision != promotion.decision
+                or current.decision.target_skill_id != promotion.target_skill_id
+                or current.decision.target_draft_id != promotion.target_draft_id
+            ):
+                raise SkillExperienceConflictError(
+                    "Skill experience promotion no longer matches the reviewed decision.",
+                    code="skill_experience_promotion_stale",
+                )
+            return self._replace_unlocked(
+                current,
+                state="promoted",
+                promotion=promotion,
             )
 
     def _replace_unlocked(
@@ -1254,6 +1388,7 @@ def _decode_candidate(raw: Any) -> SkillExperienceCandidateV1:
         "overlaps",
         "overlap_fingerprint",
         "decision",
+        "promotion",
         "dismissal_reason",
         "created_at",
         "updated_at",
@@ -1322,6 +1457,11 @@ def _decode_candidate(raw: Any) -> SkillExperienceCandidateV1:
         if raw.get("decision") is not None
         else None
     )
+    promotion = (
+        _decode_promotion(raw.get("promotion"))
+        if raw.get("promotion") is not None
+        else None
+    )
     candidate = SkillExperienceCandidateV1(
         candidate_id=_identifier(raw.get("candidate_id"), "candidate_id"),
         version=EXPERIENCE_CANDIDATE_VERSION,
@@ -1348,6 +1488,7 @@ def _decode_candidate(raw: Any) -> SkillExperienceCandidateV1:
         overlaps=overlaps,
         overlap_fingerprint=overlap_fingerprint,
         decision=decision,
+        promotion=promotion,
         dismissal_reason=(
             _bounded_text(raw.get("dismissal_reason"), "dismissal_reason", 1_000)
             if raw.get("dismissal_reason") is not None
@@ -1399,6 +1540,7 @@ def _decode_candidate(raw: Any) -> SkillExperienceCandidateV1:
             candidate.overlaps,
             candidate.overlap_fingerprint,
             candidate.decision,
+            candidate.promotion,
         )
     ):
         raise ValueError("captured candidate contains analysis state")
@@ -1416,6 +1558,16 @@ def _decode_candidate(raw: Any) -> SkillExperienceCandidateV1:
         or not candidate.brief.complete
     ):
         raise ValueError("invalid promotion-ready candidate")
+    if candidate.state == "promoted" and (
+        candidate.promotion is None
+        or candidate.decision is None
+        or candidate.promotion.decision != candidate.decision.decision
+        or candidate.promotion.target_skill_id != candidate.decision.target_skill_id
+        or candidate.promotion.target_draft_id != candidate.decision.target_draft_id
+    ):
+        raise ValueError("invalid promoted candidate")
+    if candidate.promotion is not None and candidate.state != "promoted":
+        raise ValueError("candidate promotion is in an invalid state")
     if candidate.decision is not None and candidate.state not in {
         "promotion_ready",
         "promoted",
@@ -1632,7 +1784,11 @@ def _decode_analysis_attempt(raw: Any) -> SkillExperienceAnalysisAttemptV1:
         raise ValueError("invalid analysis attempt")
     status = str(raw.get("status") or "")
     executor_mode = str(raw.get("executor_mode") or "")
-    if status not in _ANALYSIS_STATUSES or executor_mode not in {"model", "manual"}:
+    if status not in _ANALYSIS_STATUSES or executor_mode not in {
+        "model",
+        "manual",
+        "trusted_handoff",
+    }:
         raise ValueError("invalid analysis attempt state")
     started_at = float(raw.get("started_at") or 0)
     finished_at = (
@@ -1647,7 +1803,7 @@ def _decode_analysis_attempt(raw: Any) -> SkillExperienceAnalysisAttemptV1:
     ):
         raise ValueError("invalid analysis attempt timestamps")
     if (
-        (status == "succeeded" and executor_mode != "model")
+        (status == "succeeded" and executor_mode not in {"model", "trusted_handoff"})
         or (status == "manual_required" and executor_mode != "manual")
         or (status == "succeeded" and raw.get("error_code") is not None)
         or (status == "manual_required" and raw.get("error_code") is None)
@@ -1809,6 +1965,87 @@ def _decode_decision(raw: Any) -> SkillExperienceDecisionV1:
     )
     _validate_decision(decision)
     return decision
+
+
+def _decode_promotion(raw: Any) -> SkillExperiencePromotionV1:
+    if not isinstance(raw, dict) or set(raw) != {
+        "session_id",
+        "route",
+        "decision",
+        "target_skill_id",
+        "target_draft_id",
+        "baseline_version_id",
+        "baseline_content_digest",
+        "promoted_at",
+    }:
+        raise ValueError("invalid experience promotion")
+    promoted_at = float(raw.get("promoted_at") or 0)
+    promotion = SkillExperiencePromotionV1(
+        session_id=_identifier(raw.get("session_id"), "session_id"),
+        route=_bounded_text(raw.get("route"), "promotion_route", 500),
+        decision=str(raw.get("decision") or ""),  # type: ignore[arg-type]
+        target_skill_id=_optional_identifier(raw.get("target_skill_id"), "target_skill_id"),
+        target_draft_id=_optional_identifier(raw.get("target_draft_id"), "target_draft_id"),
+        baseline_version_id=_optional_identifier(
+            raw.get("baseline_version_id"), "baseline_version_id"
+        ),
+        baseline_content_digest=_optional_digest(
+            raw.get("baseline_content_digest"), "baseline_content_digest"
+        ),
+        promoted_at=promoted_at,
+    )
+    _validate_promotion(promotion)
+    return promotion
+
+
+def _validate_promotion(promotion: SkillExperiencePromotionV1) -> None:
+    if promotion.decision not in {"create", "update"}:
+        raise SkillExperienceError(
+            "Skill experience promotion is invalid.",
+            code="skill_experience_promotion_stale",
+        )
+    route_base = f"/skills/create/{promotion.session_id}"
+    if promotion.route != route_base and not promotion.route.startswith(
+        f"{route_base}?"
+    ):
+        raise SkillExperienceError(
+            "Skill experience promotion route is invalid.",
+            code="skill_experience_promotion_stale",
+        )
+    if not math.isfinite(promotion.promoted_at) or promotion.promoted_at <= 0:
+        raise SkillExperienceError(
+            "Skill experience promotion timestamp is invalid.",
+            code="skill_experience_promotion_stale",
+        )
+    update_fields = (
+        promotion.target_skill_id,
+        promotion.target_draft_id,
+        promotion.baseline_version_id,
+        promotion.baseline_content_digest,
+    )
+    if promotion.decision == "update":
+        if not all(update_fields):
+            raise SkillExperienceError(
+                "Skill experience update promotion is incomplete.",
+                code="skill_experience_promotion_stale",
+            )
+    elif any(update_fields):
+        raise SkillExperienceError(
+            "Skill experience create promotion cannot target an installed Skill.",
+            code="skill_experience_promotion_stale",
+        )
+
+
+def _promotion_identity(promotion: SkillExperiencePromotionV1) -> tuple[Any, ...]:
+    return (
+        promotion.session_id,
+        promotion.route,
+        promotion.decision,
+        promotion.target_skill_id,
+        promotion.target_draft_id,
+        promotion.baseline_version_id,
+        promotion.baseline_content_digest,
+    )
 
 
 def _validate_brief_instance(brief: DistilledSkillBriefV1) -> None:

--- a/server/skills/experience_api.py
+++ b/server/skills/experience_api.py
@@ -17,11 +17,15 @@ from .experience import (
     SkillExperienceStorageError,
 )
 from .experience_distillation import SkillExperienceDistillationService
+from .experience_promotion import SkillExperiencePromotionService
+from .creator_store import SkillCreatorSessionStore
+from .draft_store import WorkspaceSkillDraftStore
 
 
 router = APIRouter(prefix="/api/skills/experience", tags=["skill-experience"])
 _service: SkillExperienceService | None = None
 _distillation_service: SkillExperienceDistillationService | None = None
+_promotion_service: SkillExperiencePromotionService | None = None
 
 
 class ExperienceSourceRequest(BaseModel):
@@ -101,6 +105,13 @@ def configure_skill_experience_distillation(
     _distillation_service = service
 
 
+def configure_skill_experience_promotion(
+    service: SkillExperiencePromotionService | None,
+) -> None:
+    global _promotion_service
+    _promotion_service = service
+
+
 def get_skill_experience_service() -> SkillExperienceService:
     if _service is None:
         raise SkillExperienceStorageError(
@@ -124,6 +135,16 @@ def _require_distillation() -> SkillExperienceDistillationService:
             code="skill_experience_store_unavailable",
         )
     return _distillation_service
+
+
+def _require_promotion() -> SkillExperiencePromotionService:
+    _require_enabled()
+    if _promotion_service is None:
+        raise SkillExperienceStorageError(
+            "Skill experience promotion is unavailable.",
+            code="skill_experience_store_unavailable",
+        )
+    return _promotion_service
 
 
 def _api_error(exc: SkillExperienceError) -> HTTPException:
@@ -328,5 +349,35 @@ async def decide_skill_experience_candidate(
             new_boundary=payload.new_boundary,
         )
         return {"candidate": _serialize_candidate(candidate)}
+    except SkillExperienceError as exc:
+        raise _api_error(exc) from exc
+
+
+@router.post("/candidates/{candidate_id}/promote")
+async def promote_skill_experience_candidate(
+    candidate_id: str,
+    payload: ExperienceMutationRequest,
+) -> dict[str, Any]:
+    try:
+        service = _require_promotion()
+        result = await asyncio.to_thread(
+            service.promote,
+            candidate_id,
+            expected_revision=payload.expected_revision,
+            expected_digest=payload.expected_digest.lower(),
+        )
+        return {
+            "candidate": _serialize_candidate(result.candidate),
+            "creator_session_id": result.session.session_id,
+            "route": result.route,
+            "session": SkillCreatorSessionStore.serialize(result.session),
+            "draft": (
+                WorkspaceSkillDraftStore.serialize(
+                    result.draft, include_content=False
+                )
+                if result.draft is not None
+                else None
+            ),
+        }
     except SkillExperienceError as exc:
         raise _api_error(exc) from exc

--- a/server/skills/experience_promotion.py
+++ b/server/skills/experience_promotion.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from .creator_service import SkillCreatorService
+from .creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorError,
+    SkillCreatorSession,
+    SkillCreatorStorageError,
+)
+from .draft_store import (
+    SkillDraftConflictError,
+    SkillDraftError,
+    SkillDraftStorageError,
+    WorkspaceSkillDraft,
+    WorkspaceSkillDraftStore,
+)
+from .experience import (
+    SkillExperienceCandidateStore,
+    SkillExperienceCandidateV1,
+    SkillExperienceConflictError,
+    SkillExperienceError,
+    SkillExperiencePromotionV1,
+    SkillExperienceService,
+    SkillExperienceSource,
+    build_distilled_skill_brief,
+)
+from .lifecycle import SkillLifecycleError, SkillLifecycleStore
+from .skill_manager import SkillManager, SkillManagerError
+
+
+@dataclass(frozen=True, slots=True)
+class SkillExperiencePromotionResult:
+    candidate: SkillExperienceCandidateV1
+    session: SkillCreatorSession
+    draft: WorkspaceSkillDraft | None
+    route: str
+
+
+class SkillExperiencePromotionService:
+    """Promote one reviewed run experience into a recoverable Creator session."""
+
+    def __init__(
+        self,
+        experience_service: SkillExperienceService,
+        candidate_store: SkillExperienceCandidateStore,
+        creator_service: SkillCreatorService,
+        draft_store: WorkspaceSkillDraftStore,
+        skill_manager: SkillManager,
+        lifecycle_store: SkillLifecycleStore,
+    ) -> None:
+        self.experience_service = experience_service
+        self.candidate_store = candidate_store
+        self.creator_service = creator_service
+        self.draft_store = draft_store
+        self.skill_manager = skill_manager
+        self.lifecycle_store = lifecycle_store
+
+    @property
+    def enabled(self) -> bool:
+        return self.experience_service.enabled
+
+    def promote_trusted_handoff(
+        self,
+        *,
+        task_id: str,
+        run_id: str,
+        intent: str,
+    ) -> SkillExperiencePromotionResult:
+        """Promote an explicitly configured middleware taskInput without a model call."""
+
+        clean_intent = " ".join(str(intent or "").split())
+        if not clean_intent:
+            raise SkillExperienceError(
+                "Creator middleware task input is empty.",
+                code="skill_experience_source_invalid",
+            )
+        candidate, preview = self.experience_service.create_or_get(
+            SkillExperienceSource(
+                source_kind="workflow_classic",
+                source_task_id=str(task_id or "").strip(),
+                source_run_id=str(run_id or "").strip(),
+            )
+        )
+        if candidate.state == "promoted":
+            return self.promote(
+                candidate.candidate_id,
+                expected_revision=candidate.revision,
+                expected_digest=candidate.digest,
+            )
+        if candidate.state == "captured" and not candidate.selected_evidence:
+            candidate = self.experience_service.select_evidence(
+                candidate.candidate_id,
+                expected_revision=candidate.revision,
+                expected_digest=candidate.digest,
+                preview_fingerprint=preview.preview_fingerprint,
+                evidence_ids=[
+                    item.candidate_id
+                    for item in preview.candidates
+                    if item.default_selected
+                ],
+            )
+        if candidate.state == "captured":
+            brief = build_distilled_skill_brief(
+                {
+                    "suggestion": "create",
+                    "recommendation_reason": (
+                        "用户已在经典 Workflow 中显式配置 Creator handoff。"
+                    ),
+                    "no_skill_reason": None,
+                    "intent": clean_intent,
+                    "positive_examples": [
+                        clean_intent,
+                        "对同类输入重复执行上述流程，并保持相同的输出合同。",
+                    ],
+                    "negative_examples": [
+                        "与上述用途无关的普通问答或内容改写。",
+                        "只需记录一次性偏好、环境事实或临时状态的任务。",
+                    ],
+                    "expected_output": (
+                        "直接完成上述任务；缺少必要信息时列出待确认项，不编造事实。"
+                    ),
+                    "success_criteria": [
+                        "结果直接解决已声明的任务。",
+                        "缺失信息明确标记且不编造。",
+                    ],
+                    "reusable_steps": [
+                        "确认输入与边界。",
+                        "按声明用途执行可复用流程。",
+                        "核对输出合同并报告缺失项。",
+                    ],
+                    "failure_boundaries": [
+                        "缺少必要输入时停止并请求补充。"
+                    ],
+                    "resource_clues": [],
+                    "overfitting_risk": "不得写死本次运行的具体输入或输出。",
+                },
+                revision=1,
+                source="manual",
+            )
+            candidate = self.candidate_store.prepare_trusted_handoff(
+                candidate.candidate_id,
+                expected_revision=candidate.revision,
+                expected_digest=candidate.digest,
+                brief=brief,
+            )
+        return self.promote(
+            candidate.candidate_id,
+            expected_revision=candidate.revision,
+            expected_digest=candidate.digest,
+        )
+
+    def promote(
+        self,
+        candidate_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+    ) -> SkillExperiencePromotionResult:
+        try:
+            return self._promote(
+                candidate_id,
+                expected_revision=expected_revision,
+                expected_digest=expected_digest,
+            )
+        except SkillExperienceError:
+            raise
+        except (SkillCreatorStorageError, SkillDraftStorageError) as exc:
+            raise SkillExperienceError(
+                "Skill experience promotion storage is unavailable.",
+                code="skill_experience_store_unavailable",
+            ) from exc
+        except (SkillCreatorConflictError, SkillDraftConflictError) as exc:
+            raise SkillExperienceConflictError(
+                "Skill experience promotion conflicts with current Creator state.",
+                code="skill_experience_candidate_conflict",
+            ) from exc
+        except (SkillCreatorError, SkillDraftError) as exc:
+            raise SkillExperienceError(
+                "Skill experience promotion can no longer use the current Creator state.",
+                code="skill_experience_promotion_stale",
+            ) from exc
+
+    def _promote(
+        self,
+        candidate_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+    ) -> SkillExperiencePromotionResult:
+        current = self.experience_service.require_current_candidate(candidate_id)
+        if current.state == "promoted" and current.promotion is not None:
+            session, draft = self.creator_service.get_session(
+                current.promotion.session_id
+            )
+            return SkillExperiencePromotionResult(
+                candidate=current,
+                session=session,
+                draft=draft,
+                route=current.promotion.route,
+            )
+        if current.revision != int(expected_revision) or current.digest != str(
+            expected_digest or ""
+        ).strip().lower():
+            raise SkillExperienceConflictError(
+                "Skill experience candidate changed. Reload before promotion.",
+                code="skill_experience_candidate_conflict",
+                details={
+                    "current_revision": current.revision,
+                    "current_digest": current.digest,
+                },
+            )
+        if (
+            current.state != "promotion_ready"
+            or current.brief is None
+            or not current.brief.complete
+            or current.decision is None
+            or current.decision.decision not in {"create", "update"}
+        ):
+            raise SkillExperienceConflictError(
+                "Review and confirm the Skill experience decision before promotion.",
+                code="skill_experience_decision_required",
+            )
+
+        baseline = self._resolve_update_baseline(current)
+        selected_evidence = [
+            {
+                "candidate_id": item.evidence_id,
+                "kind": item.kind,
+                "title": item.title,
+                "summary": item.summary,
+                "content_hash": item.content_hash,
+            }
+            for item in current.selected_evidence
+        ]
+        session = self.creator_service.session_store.create_or_get_experience_promotion(
+            experience_candidate_id=current.candidate_id,
+            intent=current.brief.intent,
+            positive_examples=list(current.brief.positive_examples),
+            near_miss_examples=list(current.brief.negative_examples),
+            expected_output=current.brief.expected_output,
+            success_criteria=list(current.brief.success_criteria),
+            selected_evidence=selected_evidence,
+            evidence_preview_fingerprint=current.evidence_preview_fingerprint,
+            source_kind=current.source_kind,
+            source_task_id=current.source_task_id,
+            source_run_id=current.source_run_id,
+            source_xpert_id=current.source_xpert_id,
+            source_conversation_id=current.source_conversation_id,
+            source_message_id=current.source_message_id,
+            decision=current.decision.decision,
+            update_target_skill_id=(baseline["skill_id"] if baseline else None),
+            predecessor_draft_id=(baseline["draft_id"] if baseline else None),
+            baseline_version_id=(baseline["version_id"] if baseline else None),
+            baseline_content_digest=(baseline["content_digest"] if baseline else None),
+            run_experience_case=self._regression_case(current),
+        )
+
+        draft: WorkspaceSkillDraft | None = None
+        if baseline is not None:
+            package = baseline["package"]
+            draft = self.draft_store.create_creator_draft(
+                creator_session_id=session.session_id,
+                name=str(package["name"]),
+                slug=str(package["slug"]),
+                description=str(package["description"]),
+                skill_markdown=str(package["skill_markdown"]),
+                files=dict(package["files"]),
+                experience_candidate_id=current.candidate_id,
+                predecessor_draft_id=str(baseline["draft_id"]),
+                update_target_skill_id=str(baseline["skill_id"]),
+                update_expected_version_id=str(baseline["version_id"]),
+                update_expected_content_digest=str(baseline["content_digest"]),
+            )
+            session = self.creator_service.session_store.bind_draft(
+                session.session_id,
+                draft_id=draft.draft_id,
+                draft_state_revision=draft.revision,
+                content_revision=draft.content_revision,
+                content_digest=draft.content_digest,
+            )
+
+        route = f"/skills/create/{session.session_id}?step=2"
+        promotion = SkillExperiencePromotionV1(
+            session_id=session.session_id,
+            route=route,
+            decision=current.decision.decision,
+            target_skill_id=(str(baseline["skill_id"]) if baseline else None),
+            target_draft_id=(str(baseline["draft_id"]) if baseline else None),
+            baseline_version_id=(str(baseline["version_id"]) if baseline else None),
+            baseline_content_digest=(
+                str(baseline["content_digest"]) if baseline else None
+            ),
+            promoted_at=time.time(),
+        )
+        promoted = self.candidate_store.mark_promoted(
+            current.candidate_id,
+            expected_revision=current.revision,
+            expected_digest=current.digest,
+            promotion=promotion,
+        )
+        return SkillExperiencePromotionResult(
+            candidate=promoted,
+            session=session,
+            draft=draft,
+            route=route,
+        )
+
+    def require_update_draft_current(self, draft: WorkspaceSkillDraft | None) -> None:
+        """Fail closed when an experience update no longer targets its baseline."""
+
+        if draft is None or draft.update_target_skill_id is None:
+            return
+        values = (
+            draft.predecessor_draft_id,
+            draft.update_expected_version_id,
+            draft.update_expected_content_digest,
+        )
+        if not all(values):
+            raise SkillExperienceError(
+                "The Creator Skill update baseline is incomplete.",
+                code="skill_experience_promotion_stale",
+            )
+        try:
+            installed = self.skill_manager.get_installed_skill(
+                draft.update_target_skill_id
+            )
+            state = self.lifecycle_store.require_state(draft.update_target_skill_id)
+            version = self.lifecycle_store.require_version(
+                draft.update_expected_version_id or ""
+            )
+        except (SkillManagerError, SkillLifecycleError) as exc:
+            raise SkillExperienceError(
+                "The Creator Skill update baseline is unavailable.",
+                code="skill_experience_promotion_stale",
+            ) from exc
+        if (
+            installed.source_kind != "workspace_draft"
+            or installed.source_id != draft.predecessor_draft_id
+            or installed.content_digest != draft.update_expected_content_digest
+            or state.status != "active"
+            or state.current_version_id != draft.update_expected_version_id
+            or version.skill_id != draft.update_target_skill_id
+            or version.package_digest != draft.update_expected_content_digest
+            or version.source_kind != "workspace_draft"
+            or version.source_id != draft.predecessor_draft_id
+            or not self.skill_manager.installed_matches_lifecycle_version(
+                draft.update_target_skill_id,
+                draft.update_expected_version_id or "",
+            )
+        ):
+            raise SkillExperienceConflictError(
+                "The Creator Skill changed after this update was prepared.",
+                code="skill_experience_promotion_stale",
+            )
+
+    def _resolve_update_baseline(
+        self, candidate: SkillExperienceCandidateV1
+    ) -> dict[str, Any] | None:
+        decision = candidate.decision
+        if decision is None or decision.decision == "create":
+            return None
+        if not decision.target_skill_id or not decision.target_draft_id:
+            raise SkillExperienceError(
+                "The selected Creator Skill update target is incomplete.",
+                code="skill_experience_update_target_invalid",
+            )
+        try:
+            installed = self.skill_manager.get_installed_skill(decision.target_skill_id)
+            target_draft = self.draft_store.require(decision.target_draft_id)
+            state = self.lifecycle_store.require_state(decision.target_skill_id)
+            if state.status != "active" or not state.current_version_id:
+                raise SkillExperienceError(
+                    "The selected Creator Skill has no active immutable version.",
+                    code="skill_experience_promotion_stale",
+                )
+            version = self.lifecycle_store.require_version(state.current_version_id)
+        except SkillExperienceError:
+            raise
+        except (SkillManagerError, SkillDraftError, SkillLifecycleError) as exc:
+            raise SkillExperienceError(
+                "The selected Creator Skill update target is unavailable.",
+                code="skill_experience_update_target_invalid",
+            ) from exc
+        if (
+            installed.source_kind != "workspace_draft"
+            or installed.source_id != decision.target_draft_id
+            or target_draft.creator_session_id is None
+            or target_draft.status == "archived"
+            or target_draft.installed_skill_id != installed.skill_id
+            or version.source_kind != "workspace_draft"
+            or version.source_id != decision.target_draft_id
+            or version.source_revision is None
+            or version.package_digest != installed.content_digest
+        ):
+            raise SkillExperienceError(
+                "Only the current immutable version of a Workspace Creator Skill may be updated.",
+                code="skill_experience_update_target_invalid",
+            )
+        if not self.skill_manager.installed_matches_lifecycle_version(
+            installed.skill_id, version.version_id
+        ):
+            raise SkillExperienceConflictError(
+                "The installed Creator Skill bytes no longer match its immutable version.",
+                code="skill_experience_promotion_stale",
+            )
+        try:
+            snapshot = self.draft_store.require_revision_snapshot(
+                decision.target_draft_id,
+                revision=version.source_revision,
+                content_digest=version.package_digest,
+            )
+        except (SkillDraftConflictError, SkillDraftError) as exc:
+            raise SkillExperienceError(
+                "The selected Creator Skill baseline can no longer be reproduced.",
+                code="skill_experience_promotion_stale",
+            ) from exc
+        return {
+            "skill_id": installed.skill_id,
+            "draft_id": decision.target_draft_id,
+            "version_id": version.version_id,
+            "content_digest": version.package_digest,
+            "package": snapshot.package,
+        }
+
+    @staticmethod
+    def _regression_case(candidate: SkillExperienceCandidateV1) -> dict[str, Any]:
+        if candidate.brief is None:
+            raise SkillExperienceError(
+                "Skill experience brief is unavailable.",
+                code="skill_experience_promotion_stale",
+            )
+        prompt = (
+            candidate.brief.positive_examples[0]
+            if candidate.brief.positive_examples
+            else candidate.brief.intent
+        )
+        expected = candidate.brief.expected_output
+        if candidate.brief.success_criteria:
+            expected = f"{expected} 验收：{'；'.join(candidate.brief.success_criteria)}"
+        case_hash = hashlib.sha256(
+            f"{candidate.candidate_id}:{prompt}:{expected}".encode("utf-8")
+        ).hexdigest()[:20]
+        return {
+            "case_id": f"run_experience_{case_hash}",
+            "role": "regression",
+            "source": "run_experience",
+            "name": "本次成功运行的回归验证",
+            "prompt": prompt,
+            "expected_behavior": expected,
+            "fixtures": [],
+            "assertions": [],
+            "requirement_ids": [],
+            "required_resource_paths": [],
+            "workflow_step_ids": [],
+        }

--- a/server/skills/skill_manager.py
+++ b/server/skills/skill_manager.py
@@ -308,6 +308,11 @@ class SkillManager:
         quality_status: str | None = None,
         quality_decision_id: str | None = None,
         quality_run_id: str | None = None,
+        target_skill_id: str | None = None,
+        predecessor_draft_id: str | None = None,
+        expected_current_version_id: str | None = None,
+        expected_current_digest: str | None = None,
+        confirmed: bool = False,
     ) -> InstalledSkill:
         """Install or explicitly upgrade one reviewed Workspace Skill draft.
 
@@ -343,14 +348,46 @@ class SkillManager:
         files = normalized["files"]
         content_digest = compute_package_digest(skill_markdown, files)
         deterministic_skill_id = self._workspace_skill_id(clean_draft_id)
+        update_values = (
+            str(target_skill_id or "").strip(),
+            str(predecessor_draft_id or "").strip(),
+            str(expected_current_version_id or "").strip(),
+            str(expected_current_digest or "").strip().lower(),
+        )
+        is_targeted_update = any(update_values)
+        if is_targeted_update and not all(update_values):
+            raise SkillValidationError(
+                "Workspace Skill update target is incomplete.",
+                code="skill_experience_promotion_stale",
+            )
+        if is_targeted_update and not confirmed:
+            raise SkillValidationError(
+                "Workspace Skill update requires explicit confirmation.",
+                code="skill_experience_decision_required",
+            )
+        if is_targeted_update and not re.fullmatch(r"[a-f0-9]{64}", update_values[3]):
+            raise SkillValidationError(
+                "Workspace Skill update target digest is invalid.",
+                code="skill_experience_promotion_stale",
+            )
+        normalized_target_skill_id = (
+            self._validate_skill_id(update_values[0]) if is_targeted_update else None
+        )
         with self._lock:
             self._ensure_dirs()
             installed = self._read_metadata()
-            skill_id = self._find_workspace_skill_id(installed, clean_draft_id)
-            skill_id = skill_id or deterministic_skill_id
+            skill_id = (
+                normalized_target_skill_id
+                or self._find_workspace_skill_id(installed, clean_draft_id)
+                or deterministic_skill_id
+            )
             self._recover_workspace_install_receipt(skill_id, clean_draft_id)
             installed = self._read_metadata()
-            skill_id = self._find_workspace_skill_id(installed, clean_draft_id) or skill_id
+            skill_id = (
+                normalized_target_skill_id
+                or self._find_workspace_skill_id(installed, clean_draft_id)
+                or skill_id
+            )
             target_dir = self._safe_skill_dir(skill_id)
             previous_record = installed.get(skill_id)
             previous_metadata = (
@@ -378,8 +415,63 @@ class SkillManager:
                     and previous_metadata.content_digest == content_digest
                     and previous_metadata.package_subpath == clean_slug
                     and (target_dir / clean_slug / "SKILL.md").is_file()
+                    and (
+                        not is_targeted_update
+                        or previous_metadata.source_id == clean_draft_id
+                    )
                 ):
                     return previous_metadata
+            if is_targeted_update:
+                if previous_metadata is None or previous_record is None:
+                    raise SkillValidationError(
+                        "Workspace Skill update target is no longer installed.",
+                        code="skill_experience_promotion_stale",
+                    )
+                if previous_metadata.source_kind != "workspace_draft":
+                    raise SkillValidationError(
+                        "Only the selected Workspace Creator Skill may be updated.",
+                        code="skill_experience_update_target_invalid",
+                    )
+                if previous_metadata.source_id != update_values[1]:
+                    raise SkillValidationError(
+                        "Workspace Skill update target changed before installation.",
+                        code="skill_experience_promotion_stale",
+                    )
+                if (
+                    previous_content_digest != update_values[3]
+                    or previous_metadata.content_digest != update_values[3]
+                ):
+                    raise SkillValidationError(
+                        "Installed Workspace Skill changed before update.",
+                        code="skill_experience_promotion_stale",
+                    )
+                if not self._lifecycle_enabled():
+                    raise SkillValidationError(
+                        "Workspace Skill update requires lifecycle management.",
+                        code="skill_lifecycle_disabled",
+                    )
+                try:
+                    lifecycle_state = self.lifecycle_store.require_state(skill_id)
+                    lifecycle_version = self.lifecycle_store.require_version(
+                        update_values[2]
+                    )
+                except Exception as exc:
+                    raise SkillValidationError(
+                        "Workspace Skill lifecycle baseline is unavailable.",
+                        code="skill_experience_promotion_stale",
+                    ) from exc
+                if (
+                    lifecycle_state.status != "active"
+                    or lifecycle_state.current_version_id != update_values[2]
+                    or lifecycle_version.skill_id != skill_id
+                    or lifecycle_version.package_digest != update_values[3]
+                    or lifecycle_version.source_kind != "workspace_draft"
+                    or lifecycle_version.source_id != update_values[1]
+                ):
+                    raise SkillValidationError(
+                        "Workspace Skill lifecycle baseline changed before update.",
+                        code="skill_experience_promotion_stale",
+                    )
 
             transaction_id = uuid.uuid4().hex
             staging_dir = self.installed_dir / (
@@ -1741,6 +1833,28 @@ class SkillManager:
                     f"Skill '{normalized_skill_id}' is not installed"
                 )
             return self._installed_skill_from_record(record)
+
+    def installed_matches_lifecycle_version(
+        self, skill_id: str, version_id: str
+    ) -> bool:
+        """Verify metadata and installed bytes against one immutable version."""
+
+        if not self._lifecycle_enabled():
+            return False
+        normalized_skill_id = self._validate_skill_id(skill_id)
+        clean_version_id = str(version_id or "").strip()
+        if not clean_version_id:
+            return False
+        with self._lock:
+            try:
+                version = self.lifecycle_store.require_version(clean_version_id)
+                if version.skill_id != normalized_skill_id:
+                    return False
+                return self._lifecycle_installed_state_matches_version_unlocked(
+                    normalized_skill_id, clean_version_id
+                )
+            except Exception:
+                return False
 
     def require_activation(
         self,

--- a/server/tests/test_skill_experience_promotion.py
+++ b/server/tests/test_skill_experience_promotion.py
@@ -1,0 +1,1009 @@
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from server.skills import api as skills_api
+from server.skills import experience_api
+from server.skills.application_receipts import SkillApplicationReceiptStore
+from server.skills.creator_service import SkillCreatorService
+from server.skills.creator_handoff import (
+    SkillCreatorHandoffRequest,
+    SkillCreatorHandoffService,
+)
+from server.skills.creator_runtime import TrustedCreatorSourceProvider
+from server.skills.creator_store import SkillCreatorSessionStore, SkillCreatorStorageError
+from server.skills.draft_store import WorkspaceSkillDraftStore
+from server.skills.experience import (
+    SkillExperienceCandidateStore,
+    SkillExperienceConflictError,
+    SkillExperienceError,
+    SkillExperienceDecisionV1,
+    SkillExperienceService,
+    SkillExperienceSource,
+    build_distilled_skill_brief,
+)
+from server.skills.experience_promotion import SkillExperiencePromotionService
+from server.skills.lifecycle import SkillLifecycleStore
+from server.skills.skill_manager import SkillManager, SkillValidationError
+from server.xpert_runtime.authoring_service import AuthoringService
+from server.xpert_runtime.authoring_store import AuthoringProposalStore
+from server.xpert_runtime.execution_store import WorkflowExecutionStore
+from server.xperts import XpertStore
+from server.xperts.context import XpertContextStore
+
+
+SKILL_MD = """---
+name: release-review
+description: Review controlled release packages and report deterministic checks. Use when validating repeatable releases; do not use for general summaries.
+---
+
+# Release review
+
+## Purpose and boundaries
+
+Review a controlled release package without inventing missing facts.
+
+## Inputs and prerequisites
+
+Require the release manifest and package inventory.
+
+## Workflow
+
+1. Read the supplied release manifest.
+2. Compare each package entry with the declared rules.
+3. Record failures with evidence.
+4. Return the bounded report.
+
+## Output contract
+
+Return one status per check, supporting evidence, and unresolved inputs.
+
+## Quality checks
+
+Every conclusion must be traceable to supplied input.
+
+## Failure and degradation
+
+Stop and request the missing manifest instead of guessing.
+
+## Resources
+
+Use the bundled reference only when the workflow calls for release rules.
+"""
+
+
+def _runtime(tmp_path: Path):
+    executions = WorkflowExecutionStore(tmp_path / "executions")
+    contexts = XpertContextStore(tmp_path / "contexts")
+    receipts = SkillApplicationReceiptStore(tmp_path / "receipts")
+    candidates = SkillExperienceCandidateStore(tmp_path / "experience")
+    experience = SkillExperienceService(candidates, executions, contexts, receipts)
+    drafts = WorkspaceSkillDraftStore(tmp_path / "drafts")
+    creator_store = SkillCreatorSessionStore(tmp_path / "creator")
+    authoring = AuthoringService(
+        AuthoringProposalStore(tmp_path / "authoring"),
+        XpertStore(tmp_path / "xperts"),
+        drafts,
+        local_console_actor_id="promotion-test-console",
+    )
+    creator = SkillCreatorService(
+        creator_store,
+        drafts,
+        authoring,
+        enabled=True,
+        source_provider=TrustedCreatorSourceProvider(executions, contexts),
+    )
+    lifecycle = SkillLifecycleStore(tmp_path / "lifecycle", enabled=True)
+    manager = SkillManager(
+        installed_dir=tmp_path / "installed",
+        tmp_dir=tmp_path / "tmp",
+        lifecycle_store=lifecycle,
+    )
+    promotion = SkillExperiencePromotionService(
+        experience,
+        candidates,
+        creator,
+        drafts,
+        manager,
+        lifecycle,
+    )
+    return experience, candidates, executions, creator, drafts, manager, lifecycle, promotion
+
+
+def _promotion_ready(
+    experience: SkillExperienceService,
+    store: SkillExperienceCandidateStore,
+    executions: WorkflowExecutionStore,
+    *,
+    decision: str = "create",
+    target_skill_id: str | None = None,
+    target_draft_id: str | None = None,
+):
+    executions.create(
+        task_id="task-promotion",
+        run_id="run-promotion",
+        run_type="workflow",
+        source_kind="workflow_classic",
+        workflow={"id": "release-flow", "title": "发布检查"},
+        inputs={"user_input": "检查受控发布包并形成可复用流程"},
+    )
+    executions.append_event(
+        "task-promotion",
+        {"event": "node_completed", "node_id": "review", "tool_name": "rg"},
+    )
+    executions.complete("task-promotion", result="检查已完成")
+    candidate, preview = experience.create_or_get(
+        SkillExperienceSource(
+            source_kind="workflow_classic",
+            source_task_id="task-promotion",
+            source_run_id="run-promotion",
+        )
+    )
+    selected = experience.select_evidence(
+        candidate.candidate_id,
+        expected_revision=candidate.revision,
+        expected_digest=candidate.digest,
+        preview_fingerprint=preview.preview_fingerprint,
+        evidence_ids=[
+            item.candidate_id for item in preview.candidates if item.default_selected
+        ],
+    )
+    key = "a" * 64
+    analyzing, _ = store.begin_analysis(
+        selected.candidate_id,
+        expected_revision=selected.revision,
+        expected_digest=selected.digest,
+        analysis_key=key,
+    )
+    brief = build_distilled_skill_brief(
+        {
+            "suggestion": decision,
+            "recommendation_reason": "该流程可以在多次受控发布中复用。",
+            "no_skill_reason": None,
+            "intent": "检查受控发布包并输出可追溯报告",
+            "positive_examples": ["检查候选发布包", "核对发布清单"],
+            "negative_examples": ["普通文章摘要", "编辑宣传图片"],
+            "expected_output": "输出逐项检查结论和证据。",
+            "success_criteria": ["每项均有结论", "缺失内容不编造"],
+            "reusable_steps": ["读取清单", "逐项核对", "汇总结果"],
+            "failure_boundaries": ["缺少清单时停止"],
+            "resource_clues": ["发布规则可保存为 reference"],
+            "overfitting_risk": "不得写死某次发布路径。",
+        },
+        revision=1,
+        source="manual",
+    )
+    reviewed = store.complete_analysis(
+        analyzing.candidate_id,
+        attempt_id=analyzing.analysis_attempt.attempt_id,  # type: ignore[union-attr]
+        analysis_key=key,
+        brief=brief,
+        overlaps=(),
+        overlap_fingerprint="b" * 64,
+        executor_mode="manual",
+        error_code="skill_experience_analysis_unconfigured",
+    )
+    return store.decide(
+        reviewed.candidate_id,
+        expected_revision=reviewed.revision,
+        expected_digest=reviewed.digest,
+        decision=SkillExperienceDecisionV1(
+            decision=decision,  # type: ignore[arg-type]
+            target_skill_id=target_skill_id,
+            target_draft_id=target_draft_id,
+            override_reason=None,
+            new_boundary=None,
+            actor_kind="local_console",
+            decided_at=time.time(),
+        ),
+    )
+
+
+def test_create_promotion_hydrates_handoff_and_never_returns_blank_creator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_EXPERIENCE_PROMOTION_ENABLED", "true")
+    experience, store, executions, creator, drafts, _, _, promotion = _runtime(tmp_path)
+    ready = _promotion_ready(experience, store, executions)
+    handoff = creator.session_store.create_or_get_workflow_handoff(
+        intent="检查受控发布包并形成可复用流程",
+        positive_examples=["检查受控发布包并形成可复用流程"],
+        near_miss_examples=["普通摘要"],
+        expected_output="输出检查结果",
+        success_criteria=["不编造"],
+        source_task_id=ready.source_task_id,
+        source_run_id=ready.source_run_id,
+        trigger_required=True,
+    )
+
+    result = promotion.promote(
+        ready.candidate_id,
+        expected_revision=ready.revision,
+        expected_digest=ready.digest,
+    )
+    repeated = promotion.promote(
+        ready.candidate_id,
+        expected_revision=ready.revision,
+        expected_digest=ready.digest,
+    )
+
+    assert result.session.session_id == handoff.session_id == repeated.session.session_id
+    assert result.route.endswith("?step=2")
+    assert result.session.intent == ready.brief.intent
+    assert result.session.positive_examples == list(ready.brief.positive_examples)
+    assert result.session.evidence_confirmed is True
+    assert result.session.selected_evidence
+    assert result.session.authoring_flow == "resource"
+    assert result.session.trigger_required is True
+    assert result.session.run_experience_case["source"] == "run_experience"
+    assert result.session.proposal_id is None
+    assert result.draft is None
+    assert drafts.find_by_creator_session(result.session.session_id) is None
+    assert repeated.candidate.state == "promoted"
+    assert len(creator.session_store.list()) == 1
+
+
+def test_promotion_refuses_to_overwrite_an_edited_capture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_EXPERIENCE_PROMOTION_ENABLED", "true")
+    experience, store, executions, creator, _, _, _, promotion = _runtime(tmp_path)
+    ready = _promotion_ready(experience, store, executions)
+    captured = creator.session_store.create_or_get_run_capture(
+        source_kind="workflow_classic",
+        source_task_id=ready.source_task_id,
+        source_run_id=ready.source_run_id,
+    )
+    creator.session_store.update_definition(
+        captured.session_id,
+        expected_session_revision=captured.session_revision,
+        changes={"intent": "用户已编辑的定义"},
+    )
+
+    with pytest.raises(SkillExperienceConflictError) as exc_info:
+        promotion.promote(
+            ready.candidate_id,
+            expected_revision=ready.revision,
+            expected_digest=ready.digest,
+        )
+    assert exc_info.value.code == "skill_experience_candidate_conflict"
+
+
+def test_middleware_uses_candidate_promotion_without_a_second_model_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_EXPERIENCE_PROMOTION_ENABLED", "true")
+    experience, store, executions, creator, drafts, _, _, promotion = _runtime(tmp_path)
+    executions.create(
+        task_id="task-handoff",
+        run_id="run-handoff",
+        run_type="workflow",
+        source_kind="workflow_classic",
+        workflow={"id": "handoff-flow", "title": "经验交接"},
+        inputs={"user_input": "把发布检查沉淀为 Skill"},
+    )
+    executions.complete("task-handoff", result="需求分析完成")
+    # Simulate the ordinary capture button winning the race before middleware.
+    captured, _ = experience.create_or_get(
+        SkillExperienceSource(
+            source_kind="workflow_classic",
+            source_task_id="task-handoff",
+            source_run_id="run-handoff",
+        )
+    )
+    handoff = SkillCreatorHandoffService(
+        creator,
+        enabled=True,
+        promotion_service=promotion,
+    )
+
+    session = handoff.create_or_get(
+        task_id="task-handoff",
+        run_id="run-handoff",
+        request=SkillCreatorHandoffRequest(
+            node_id="creator-handoff",
+            intent="检查发布清单并输出可追溯报告",
+        ),
+    )
+    repeated = handoff.create_or_get(
+        task_id="task-handoff",
+        run_id="run-handoff",
+        request=SkillCreatorHandoffRequest(
+            node_id="creator-handoff",
+            intent="检查发布清单并输出可追溯报告",
+        ),
+    )
+
+    candidate = store.require(captured.candidate_id)
+    assert candidate.state == "promoted"
+    assert candidate.analysis_attempt is not None
+    assert candidate.analysis_attempt.executor_mode == "trusted_handoff"
+    assert candidate.analysis_attempt.status == "succeeded"
+    assert candidate.promotion is not None
+    assert session.session_id == repeated.session_id == candidate.promotion.session_id
+    assert session.intent == "检查发布清单并输出可追溯报告"
+    assert session.positive_examples and session.near_miss_examples
+    assert drafts.find_by_creator_session(session.session_id) is None
+    assert len(store.list_candidates()) == 1
+    assert len(creator.session_store.list()) == 1
+
+
+def test_middleware_preserves_legacy_handoff_while_promotion_flag_is_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_EXPERIENCE_PROMOTION_ENABLED", "false")
+    experience, store, executions, creator, drafts, _, _, promotion = _runtime(tmp_path)
+    executions.create(
+        task_id="task-disabled-handoff",
+        run_id="run-disabled-handoff",
+        run_type="workflow",
+        source_kind="workflow_classic",
+        workflow={"id": "handoff-flow", "title": "兼容交接"},
+        inputs={"user_input": "保留旧 Creator 交接"},
+    )
+    executions.complete("task-disabled-handoff", result="需求分析完成")
+    handoff = SkillCreatorHandoffService(
+        creator,
+        enabled=True,
+        promotion_service=promotion,
+    )
+
+    session = handoff.create_or_get(
+        task_id="task-disabled-handoff",
+        run_id="run-disabled-handoff",
+        request=SkillCreatorHandoffRequest(
+            node_id="creator-handoff",
+            intent="保留旧 Creator 交接",
+        ),
+    )
+
+    assert session.intent == "保留旧 Creator 交接"
+    assert session.experience_candidate_id is None
+    assert drafts.find_by_creator_session(session.session_id) is None
+    assert store.list_candidates() == []
+
+
+def test_recovered_run_rebinds_pristine_capture_by_stable_task_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_EXPERIENCE_PROMOTION_ENABLED", "true")
+    _, store, executions, creator, _, _, _, promotion = _runtime(tmp_path)
+    executions.create(
+        task_id="task-recovered-handoff",
+        run_id="run-before-recovery",
+        run_type="workflow",
+        source_kind="workflow_classic",
+        workflow={"id": "handoff-flow", "title": "恢复交接"},
+        inputs={"user_input": "沉淀恢复后的发布检查"},
+    )
+    executions.complete("task-recovered-handoff", result="需求分析完成")
+    captured = creator.session_store.create_or_get_run_capture(
+        source_kind="workflow_classic",
+        source_task_id="task-recovered-handoff",
+        source_run_id="run-before-recovery",
+    )
+    executions.update_run_id(
+        "task-recovered-handoff", run_id="run-after-recovery"
+    )
+    handoff = SkillCreatorHandoffService(
+        creator,
+        enabled=True,
+        promotion_service=promotion,
+    )
+
+    promoted = handoff.create_or_get(
+        task_id="task-recovered-handoff",
+        run_id="run-after-recovery",
+        request=SkillCreatorHandoffRequest(
+            node_id="creator-handoff",
+            intent="沉淀恢复后的发布检查",
+        ),
+    )
+
+    assert promoted.session_id == captured.session_id
+    assert promoted.source_run_id == "run-after-recovery"
+    assert promoted.experience_candidate_id
+    assert len(creator.session_store.list()) == 1
+    assert len(store.list_candidates()) == 1
+
+
+def test_private_xpert_promotion_preserves_message_scope_and_nonblank_brief(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_EXPERIENCE_PROMOTION_ENABLED", "true")
+    experience, store, executions, creator, _, _, _, promotion = _runtime(tmp_path)
+    contexts = experience.context_store
+    conversation = contexts.create_conversation("xpert-release", title="发布复盘")
+    contexts.append_message(
+        "xpert-release",
+        conversation.conversation_id,
+        role="user",
+        content="复盘本次发布检查",
+        source_task_id="task-xpert-promotion",
+        source_run_id="run-xpert-promotion",
+    )
+    assistant = contexts.append_message(
+        "xpert-release",
+        conversation.conversation_id,
+        role="assistant",
+        content="发布检查复盘完成",
+        source_task_id="task-xpert-promotion",
+        source_run_id="run-xpert-promotion",
+    )
+    executions.create(
+        task_id="task-xpert-promotion",
+        run_id="run-xpert-promotion",
+        run_type="xpert",
+        source_kind="xpert_chat",
+        workflow={"id": "xpert-release", "title": "发布复盘"},
+        inputs={"user_input": "复盘本次发布检查"},
+        runtime_metadata={
+            "xpert_id": "xpert-release",
+            "conversation_id": conversation.conversation_id,
+        },
+    )
+    executions.complete("task-xpert-promotion", result="发布检查复盘完成")
+    candidate, preview = experience.create_or_get(
+        SkillExperienceSource(
+            source_kind="xpert_chat",
+            source_task_id="task-xpert-promotion",
+            source_run_id="run-xpert-promotion",
+            source_xpert_id="xpert-release",
+            source_conversation_id=conversation.conversation_id,
+            source_message_id=assistant.message_id,
+        )
+    )
+    selected = experience.select_evidence(
+        candidate.candidate_id,
+        expected_revision=candidate.revision,
+        expected_digest=candidate.digest,
+        preview_fingerprint=preview.preview_fingerprint,
+        evidence_ids=[
+            item.candidate_id for item in preview.candidates if item.default_selected
+        ],
+    )
+    brief = build_distilled_skill_brief(
+        {
+            "suggestion": "create",
+            "recommendation_reason": "可复用发布复盘流程。",
+            "intent": "复盘发布检查并输出可追溯改进项",
+            "positive_examples": ["复盘发布检查", "总结发布质量问题"],
+            "negative_examples": ["普通文章摘要", "图片编辑"],
+            "expected_output": "输出证据、结论和改进项。",
+            "success_criteria": ["结论可追溯", "缺失信息不编造"],
+            "reusable_steps": ["收集证据", "定位原因", "形成改进项"],
+            "failure_boundaries": ["缺少运行证据时停止"],
+            "resource_clues": [],
+            "overfitting_risk": "不得写死本次发布标识。",
+        },
+        revision=1,
+        source="manual",
+    )
+    ready = store.prepare_trusted_handoff(
+        selected.candidate_id,
+        expected_revision=selected.revision,
+        expected_digest=selected.digest,
+        brief=brief,
+    )
+
+    result = promotion.promote(
+        ready.candidate_id,
+        expected_revision=ready.revision,
+        expected_digest=ready.digest,
+    )
+
+    assert result.session.source_kind == "xpert_chat"
+    assert result.session.source_xpert_id == "xpert-release"
+    assert result.session.source_conversation_id == conversation.conversation_id
+    assert result.session.source_message_id == assistant.message_id
+    assert result.session.intent == brief.intent
+    assert result.session.selected_evidence
+    assert result.draft is None
+    assert len(creator.session_store.list()) == 1
+
+
+def test_update_promotion_clones_current_lifecycle_version_and_preserves_skill_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_EXPERIENCE_PROMOTION_ENABLED", "true")
+    experience, store, executions, creator, drafts, manager, lifecycle, promotion = _runtime(
+        tmp_path
+    )
+    predecessor = drafts.create(
+        name="release-review",
+        slug="release-review",
+        description="Review controlled release packages.",
+        skill_markdown=SKILL_MD,
+        files={"references/rules.md": "# Release rules\n\nUse declared rules only.\n"},
+        creator_session_id="skillcreator-predecessor",
+    )
+    installed = manager.install_workspace_draft(
+        draft_id=predecessor.draft_id,
+        slug=predecessor.slug,
+        skill_markdown=predecessor.skill_markdown,
+        files=predecessor.files,
+        source_revision=predecessor.content_revision,
+    )
+    manager.finalize_lifecycle_transaction(installed.skill_id)
+    predecessor = drafts.mark_installed(
+        predecessor.draft_id,
+        expected_revision=predecessor.revision,
+        expected_digest=predecessor.content_digest,
+        skill_id=installed.skill_id,
+    )
+    baseline_state = lifecycle.require_state(installed.skill_id)
+    baseline_version = lifecycle.require_version(baseline_state.current_version_id or "")
+    ready = _promotion_ready(
+        experience,
+        store,
+        executions,
+        decision="update",
+        target_skill_id=installed.skill_id,
+        target_draft_id=predecessor.draft_id,
+    )
+
+    result = promotion.promote(
+        ready.candidate_id,
+        expected_revision=ready.revision,
+        expected_digest=ready.digest,
+    )
+    assert result.draft is not None
+    assert result.draft.draft_id != predecessor.draft_id
+    assert result.draft.content_digest == baseline_version.package_digest
+    assert result.draft.files == predecessor.files
+    assert result.draft.predecessor_draft_id == predecessor.draft_id
+    assert result.draft.update_target_skill_id == installed.skill_id
+    assert result.draft.update_expected_version_id == baseline_version.version_id
+    assert result.session.experience_baseline_version_id == baseline_version.version_id
+    assert result.session.proposal_id is None
+    assert result.session.cases_revision == 0
+    assert result.session.quality_status == "not_evaluated"
+    assert result.draft.quality_status == "not_evaluated"
+    promotion.require_update_draft_current(result.draft)
+
+    installed_reference = (
+        manager.installed_dir
+        / installed.skill_id
+        / predecessor.slug
+        / "references"
+        / "rules.md"
+    )
+    installed_reference.write_text("# Tampered rules\n", encoding="utf-8")
+    with pytest.raises(SkillExperienceConflictError) as tampered_info:
+        promotion.require_update_draft_current(result.draft)
+    assert tampered_info.value.code == "skill_experience_promotion_stale"
+    installed_reference.write_text(
+        "# Release rules\n\nUse declared rules only.\n", encoding="utf-8"
+    )
+    promotion.require_update_draft_current(result.draft)
+
+    changed = drafts.update(
+        result.draft.draft_id,
+        expected_revision=result.draft.revision,
+        expected_digest=result.draft.content_digest,
+        files={"references/rules.md": "# Release rules\n\nUse current declared rules only.\n"},
+    )
+    accepted = drafts.waive_evaluation(
+        changed.draft_id,
+        expected_revision=changed.revision,
+        expected_digest=changed.content_digest,
+        decision_id="decision-promotion-update",
+        actor_id="promotion-test-console",
+        reason="Synthetic regression fixture accepted for transaction coverage.",
+    )
+    with pytest.raises(SkillValidationError) as confirmation_info:
+        manager.install_workspace_draft(
+            draft_id=accepted.draft_id,
+            slug=accepted.slug,
+            skill_markdown=accepted.skill_markdown,
+            files=accepted.files,
+            source_revision=accepted.content_revision,
+            quality_required=True,
+            quality_status=accepted.quality_status,
+            quality_decision_id=accepted.quality_decision.decision_id,
+            target_skill_id=accepted.update_target_skill_id,
+            predecessor_draft_id=accepted.predecessor_draft_id,
+            expected_current_version_id=accepted.update_expected_version_id,
+            expected_current_digest=accepted.update_expected_content_digest,
+            confirmed=False,
+        )
+    assert confirmation_info.value.code == "skill_experience_decision_required"
+
+    previous_manager = skills_api._skill_manager
+    previous_draft_store = skills_api._skill_draft_store
+    previous_guard = skills_api._workspace_draft_install_guard
+    skills_api.set_skill_manager_for_tests(manager)
+    skills_api.set_skill_draft_store_for_tests(drafts)
+    skills_api.configure_workspace_draft_install_guard(None)
+    app = FastAPI()
+    app.include_router(skills_api.router)
+    try:
+        with TestClient(app) as client:
+            forged = client.post(
+                f"/api/skills/drafts/{accepted.draft_id}/install",
+                json={
+                    "expected_revision": accepted.revision,
+                    "expected_digest": accepted.content_digest,
+                    "target_skill_id": installed.skill_id,
+                    "expected_current_version_id": "skillversion-forged",
+                    "expected_current_digest": accepted.update_expected_content_digest,
+                    "confirmed": True,
+                },
+            )
+        assert forged.status_code == 409
+        assert forged.json()["detail"]["code"] == "skill_experience_promotion_stale"
+        assert manager.get_installed_skill(installed.skill_id).source_id == predecessor.draft_id
+        assert drafts.require(accepted.draft_id).install_state == "not_installed"
+    finally:
+        skills_api.set_skill_manager_for_tests(previous_manager)
+        skills_api.set_skill_draft_store_for_tests(previous_draft_store)
+        skills_api.configure_workspace_draft_install_guard(previous_guard)
+
+    updated_draft, updated_skill = drafts.install_current(
+        accepted.draft_id,
+        expected_revision=accepted.revision,
+        expected_digest=accepted.content_digest,
+        installer=lambda item: manager.install_workspace_draft(
+            draft_id=item.draft_id,
+            slug=item.slug,
+            skill_markdown=item.skill_markdown,
+            files=item.files,
+            source_revision=item.content_revision,
+            quality_required=True,
+            quality_status=item.quality_status,
+            quality_decision_id=item.quality_decision.decision_id,
+            target_skill_id=item.update_target_skill_id,
+            predecessor_draft_id=item.predecessor_draft_id,
+            expected_current_version_id=item.update_expected_version_id,
+            expected_current_digest=item.update_expected_content_digest,
+            confirmed=True,
+        ),
+    )
+    manager.finalize_lifecycle_transaction(updated_skill.skill_id)
+
+    assert updated_skill.skill_id == installed.skill_id
+    assert updated_draft.install_state == "current"
+    assert drafts.require(predecessor.draft_id).install_state == "outdated"
+    versions = lifecycle.list_versions(installed.skill_id)
+    assert len(versions) == 2
+    assert lifecycle.require_state(installed.skill_id).current_version_id != baseline_version.version_id
+    with pytest.raises(SkillExperienceConflictError) as stale_info:
+        promotion.require_update_draft_current(result.draft)
+    assert stale_info.value.code == "skill_experience_promotion_stale"
+
+    with pytest.raises(SkillValidationError) as install_stale_info:
+        manager.install_workspace_draft(
+            draft_id=result.draft.draft_id,
+            slug=result.draft.slug,
+            skill_markdown=result.draft.skill_markdown,
+            files=result.draft.files,
+            source_revision=result.draft.content_revision,
+            target_skill_id=result.draft.update_target_skill_id,
+            predecessor_draft_id=result.draft.predecessor_draft_id,
+            expected_current_version_id=result.draft.update_expected_version_id,
+            expected_current_digest=result.draft.update_expected_content_digest,
+            confirmed=True,
+        )
+    assert install_stale_info.value.code == "skill_experience_promotion_stale"
+
+    current_state = lifecycle.require_state(installed.skill_id)
+    rolled_back = manager.rollback_skill_version(
+        installed.skill_id,
+        baseline_version.version_id,
+        expected_state_revision=current_state.revision,
+        expected_current_version_id=current_state.current_version_id,
+        expected_package_digest=baseline_version.package_digest,
+        confirmed=True,
+    )
+    drafts.mark_lifecycle_version_installed(
+        predecessor.draft_id,
+        content_revision=baseline_version.source_revision or 0,
+        content_digest=baseline_version.package_digest,
+        skill_id=installed.skill_id,
+    )
+    manager.finalize_lifecycle_transaction(installed.skill_id)
+    assert rolled_back.skill_id == installed.skill_id
+    assert drafts.require(predecessor.draft_id).install_state == "current"
+    assert drafts.require(updated_draft.draft_id).install_state == "outdated"
+
+    manager.uninstall_skill(installed.skill_id)
+    drafts.mark_uninstalled_skill(installed.skill_id)
+    manager.finalize_lifecycle_transaction(installed.skill_id)
+    assert drafts.require(predecessor.draft_id).install_state == "not_installed"
+    assert drafts.require(updated_draft.draft_id).install_state == "not_installed"
+
+
+def test_targeted_update_rejects_cross_source_or_changed_baseline(
+    tmp_path: Path,
+) -> None:
+    lifecycle = SkillLifecycleStore(tmp_path / "lifecycle", enabled=True)
+    manager = SkillManager(
+        installed_dir=tmp_path / "installed",
+        tmp_dir=tmp_path / "tmp",
+        lifecycle_store=lifecycle,
+    )
+    with pytest.raises(SkillValidationError) as exc_info:
+        manager.install_workspace_draft(
+            draft_id="new-draft",
+            slug="release-review",
+            skill_markdown=SKILL_MD,
+            files={},
+            target_skill_id="missing-target",
+            predecessor_draft_id="old-draft",
+            expected_current_version_id="skillversion-missing",
+            expected_current_digest="a" * 64,
+            confirmed=True,
+        )
+    assert exc_info.value.code == "skill_experience_promotion_stale"
+
+
+def test_update_promotion_rejects_tampered_installed_bytes_before_session_creation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_EXPERIENCE_PROMOTION_ENABLED", "true")
+    experience, store, executions, creator, drafts, manager, _, promotion = _runtime(
+        tmp_path
+    )
+    predecessor = drafts.create(
+        name="release-review",
+        slug="release-review",
+        description="Review controlled release packages.",
+        skill_markdown=SKILL_MD,
+        files={"references/rules.md": "# Release rules\n\nUse declared rules only.\n"},
+        creator_session_id="skillcreator-predecessor",
+    )
+    installed = manager.install_workspace_draft(
+        draft_id=predecessor.draft_id,
+        slug=predecessor.slug,
+        skill_markdown=predecessor.skill_markdown,
+        files=predecessor.files,
+        source_revision=predecessor.content_revision,
+    )
+    manager.finalize_lifecycle_transaction(installed.skill_id)
+    predecessor = drafts.mark_installed(
+        predecessor.draft_id,
+        expected_revision=predecessor.revision,
+        expected_digest=predecessor.content_digest,
+        skill_id=installed.skill_id,
+    )
+    ready = _promotion_ready(
+        experience,
+        store,
+        executions,
+        decision="update",
+        target_skill_id=installed.skill_id,
+        target_draft_id=predecessor.draft_id,
+    )
+    target = (
+        manager.installed_dir
+        / installed.skill_id
+        / predecessor.slug
+        / "references"
+        / "rules.md"
+    )
+    target.write_text("# Tampered before promotion\n", encoding="utf-8")
+
+    with pytest.raises(SkillExperienceConflictError) as exc_info:
+        promotion.promote(
+            ready.candidate_id,
+            expected_revision=ready.revision,
+            expected_digest=ready.digest,
+        )
+
+    assert exc_info.value.code == "skill_experience_promotion_stale"
+    assert creator.session_store.list() == []
+    assert [item.draft_id for item in drafts.list()] == [predecessor.draft_id]
+
+
+def test_promotion_revalidates_source_before_creating_creator_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_EXPERIENCE_PROMOTION_ENABLED", "true")
+    experience, store, executions, creator, _, _, _, promotion = _runtime(tmp_path)
+    ready = _promotion_ready(experience, store, executions)
+    executions.update_run_id(ready.source_task_id, run_id="run-promotion-recovered")
+
+    with pytest.raises(SkillExperienceConflictError) as exc_info:
+        promotion.promote(
+            ready.candidate_id,
+            expected_revision=ready.revision,
+            expected_digest=ready.digest,
+        )
+
+    assert exc_info.value.code == "skill_experience_promotion_stale"
+    assert store.require(ready.candidate_id).state == "stale"
+    assert creator.session_store.list() == []
+
+
+def test_promotion_recovers_when_candidate_projection_write_was_interrupted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_EXPERIENCE_PROMOTION_ENABLED", "true")
+    experience, store, executions, creator, _, _, _, promotion = _runtime(tmp_path)
+    ready = _promotion_ready(experience, store, executions)
+    original = store.mark_promoted
+    calls = 0
+
+    def fail_once(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("simulated candidate projection interruption")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(store, "mark_promoted", fail_once)
+    with pytest.raises(OSError):
+        promotion.promote(
+            ready.candidate_id,
+            expected_revision=ready.revision,
+            expected_digest=ready.digest,
+        )
+    assert len(creator.session_store.list()) == 1
+    assert store.require(ready.candidate_id).state == "promotion_ready"
+
+    recovered = promotion.promote(
+        ready.candidate_id,
+        expected_revision=ready.revision,
+        expected_digest=ready.digest,
+    )
+    reloaded = SkillExperienceCandidateStore(store.storage_dir).require(
+        ready.candidate_id
+    )
+    assert recovered.candidate.state == reloaded.state == "promoted"
+    assert reloaded.promotion is not None
+    assert reloaded.promotion.session_id == recovered.session.session_id
+    assert len(creator.session_store.list()) == 1
+
+
+def test_update_promotion_recovers_after_draft_created_before_session_binding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_EXPERIENCE_PROMOTION_ENABLED", "true")
+    experience, store, executions, creator, drafts, manager, _, promotion = _runtime(
+        tmp_path
+    )
+    predecessor = drafts.create(
+        name="release-review",
+        slug="release-review",
+        description="Review controlled release packages.",
+        skill_markdown=SKILL_MD,
+        files={"references/rules.md": "# Release rules\n\nUse declared rules only.\n"},
+        creator_session_id="skillcreator-predecessor",
+    )
+    installed = manager.install_workspace_draft(
+        draft_id=predecessor.draft_id,
+        slug=predecessor.slug,
+        skill_markdown=predecessor.skill_markdown,
+        files=predecessor.files,
+        source_revision=predecessor.content_revision,
+    )
+    manager.finalize_lifecycle_transaction(installed.skill_id)
+    predecessor = drafts.mark_installed(
+        predecessor.draft_id,
+        expected_revision=predecessor.revision,
+        expected_digest=predecessor.content_digest,
+        skill_id=installed.skill_id,
+    )
+    ready = _promotion_ready(
+        experience,
+        store,
+        executions,
+        decision="update",
+        target_skill_id=installed.skill_id,
+        target_draft_id=predecessor.draft_id,
+    )
+    original_bind = creator.session_store.bind_draft
+    calls = 0
+
+    def fail_bind_once(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise SkillCreatorStorageError("simulated bind interruption")
+        return original_bind(*args, **kwargs)
+
+    monkeypatch.setattr(creator.session_store, "bind_draft", fail_bind_once)
+    with pytest.raises(SkillExperienceError) as exc_info:
+        promotion.promote(
+            ready.candidate_id,
+            expected_revision=ready.revision,
+            expected_digest=ready.digest,
+        )
+    assert exc_info.value.code == "skill_experience_store_unavailable"
+    session = creator.session_store.list()[0]
+    created = drafts.find_by_creator_session(session.session_id)
+    assert created is not None
+    assert session.draft_id is None
+    assert store.require(ready.candidate_id).state == "promotion_ready"
+
+    recovered = promotion.promote(
+        ready.candidate_id,
+        expected_revision=ready.revision,
+        expected_digest=ready.digest,
+    )
+    assert recovered.candidate.state == "promoted"
+    assert recovered.draft is not None
+    assert recovered.session.draft_id == recovered.draft.draft_id
+    assert len(creator.session_store.list()) == 1
+    assert len(
+        [
+            item
+            for item in drafts.list()
+            if item.creator_session_id == recovered.session.session_id
+        ]
+    ) == 1
+
+
+def test_concurrent_promotion_requests_converge_on_one_candidate_and_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_EXPERIENCE_PROMOTION_ENABLED", "true")
+    experience, store, executions, creator, _, _, _, promotion = _runtime(tmp_path)
+    ready = _promotion_ready(experience, store, executions)
+
+    def promote_once():
+        return promotion.promote(
+            ready.candidate_id,
+            expected_revision=ready.revision,
+            expected_digest=ready.digest,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first, second = list(pool.map(lambda _: promote_once(), range(2)))
+
+    assert first.session.session_id == second.session.session_id
+    assert first.candidate.candidate_id == second.candidate.candidate_id
+    assert first.candidate.state == second.candidate.state == "promoted"
+    assert len(creator.session_store.list()) == 1
+    assert len(store.list_candidates()) == 1
+
+
+def test_promote_api_returns_prefilled_session_and_idempotent_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SKILL_EXPERIENCE_PROMOTION_ENABLED", "true")
+    experience, store, executions, _, _, _, _, promotion = _runtime(tmp_path)
+    ready = _promotion_ready(experience, store, executions)
+    previous_service = experience_api._service
+    previous_promotion = experience_api._promotion_service
+    experience_api.configure_skill_experience(experience)
+    experience_api.configure_skill_experience_promotion(promotion)
+    app = FastAPI()
+    app.include_router(experience_api.router)
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                f"/api/skills/experience/candidates/{ready.candidate_id}/promote",
+                json={
+                    "expected_revision": ready.revision,
+                    "expected_digest": ready.digest,
+                },
+            )
+            assert response.status_code == 200, response.text
+            payload = response.json()
+            assert payload["creator_session_id"] == payload["session"]["session_id"]
+            assert payload["route"].endswith("?step=2")
+            assert payload["session"]["intent"]
+            assert payload["session"]["positive_examples"]
+            assert payload["draft"] is None
+
+            # Promoted retries are idempotent even when the caller only has the
+            # original decision revision from a lost HTTP response.
+            repeated = client.post(
+                f"/api/skills/experience/candidates/{ready.candidate_id}/promote",
+                json={
+                    "expected_revision": ready.revision,
+                    "expected_digest": ready.digest,
+                },
+            )
+            assert repeated.status_code == 200
+            assert repeated.json()["creator_session_id"] == payload["creator_session_id"]
+    finally:
+        experience_api.configure_skill_experience(previous_service)
+        experience_api.configure_skill_experience_promotion(previous_promotion)


### PR DESCRIPTION
## Summary

- 将已确认的运行经验幂等晋级为非空资源化 Creator Session，并生成待用户确认的 run_experience 回归案例草案
- 支持从当前 Workspace Creator Lifecycle 版本创建独立更新草稿，安装时保持稳定 Skill ID 与版本历史
- 统一 Creator Middleware、普通 capture 与手动晋级的 Candidate/Session 去重，不增加模型调用
- 在提案批准与安装前重新核验目标版本、实际安装字节和人工确认，拒绝来源漂移、客户端伪造及跨来源覆盖

## Falsification fixes

- 修复恢复运行仅 run ID 变化时按旧 run 去重造成重复 Creator Session
- 修复安装元数据正确但目录字节被篡改时过晚才发现的问题
- 验证跨 Store 中断、并发重试、Lifecycle 回滚/卸载和关闭开关兼容路径

## Validation

- `server/tests/test_skill_experience_promotion.py`: 14 passed（rebase 后）
- Creator/Middleware/Lifecycle/安装/来源针对性回归：79 passed
- Distillation 更新目标、重叠与决策门：6 passed
- Authoring、安装升级与 Skill 集成回归：28 passed
- `git diff --check`: passed

## Compatibility and rollback

- `SKILL_EXPERIENCE_PROMOTION_ENABLED` 默认仍为 false；PR4 才正式启用
- 关闭开关时 Creator Middleware 保持旧交接行为
- 无前端变化，不修改 Sandbox Sidecar、公共 Xpert App 或 Skill 包合同