### PR TITLE
fix(rag): 补齐 V3 检索多样性与可重放诊断

### DIFF
--- a/client/src/content/help-center/helpContent.test.ts
+++ b/client/src/content/help-center/helpContent.test.ts
@@ -4,6 +4,7 @@ import {
   helpArticles,
   helpModules,
   helpSections,
+  ragDiversityBaseline,
   remoteMcpReviewBaseline,
   searchHelpContent,
   verifiedBaseline,
@@ -72,6 +73,9 @@ describe("help center content catalog", () => {
     expect(searchHelpContent("Kimi").some((entry) => entry.id === "start-with-a-model")).toBe(true);
     expect(searchHelpContent("配置").some((entry) => entry.id === "troubleshooting")).toBe(true);
     expect(searchHelpContent("RAG").some((entry) => entry.id === "workspace/rag")).toBe(true);
+    const ragTopic = helpModules.find((module) => module.id === "workspace")?.topics.find((topic) => topic.id === "rag");
+    expect(ragTopic?.verifiedCommit).toBe(ragDiversityBaseline.commit);
+    expect(ragTopic?.verifiedDate).toBe(ragDiversityBaseline.date);
     expect(searchHelpContent("Science").some((entry) => entry.id === "experimental/science")).toBe(true);
     expect(searchHelpContent("专家团").some((entry) => entry.id === "agents/expert-team")).toBe(true);
     expect(searchHelpContent("运行记录").some((entry) => entry.id === "runtime/run-records")).toBe(true);

--- a/client/src/content/help-center/index.ts
+++ b/client/src/content/help-center/index.ts
@@ -52,6 +52,8 @@ export interface HelpModuleTopic {
   productRoute?: string;
   badge?: string;
   keywords: string[];
+  verifiedCommit?: string;
+  verifiedDate?: string;
 }
 
 export interface HelpModule {
@@ -76,6 +78,7 @@ export type HelpSearchEntry = {
 
 export const verifiedBaseline = { commit: "cc49136c", date: "2026-08-26" };
 export const remoteMcpReviewBaseline = { commit: "27ab7de9", date: "2026-08-27" };
+export const ragDiversityBaseline = { commit: "f0150fb5", date: "2026-08-27" };
 
 export const helpContentTypeLabels: Record<HelpContentType, string> = {
   tutorial: "入门教程",
@@ -298,7 +301,7 @@ export const helpModules: HelpModule[] = [
     homeTopicIds: ["rag", "coding"],
     topics: [
       { id: "workflow", title: "经典工作流", summary: "在稳定画布中编排并试运行多步骤任务。", outcome: "把固定顺序、条件分支和资源调用组织成可重复流程。", points: ["经典画布是当前稳定工作流入口", "草稿可本地保存并通过后端试运行", "需要把确定性文本交给知识管理员时，可使用“知识写入提议”进入 Knowledge Inbox"], productRoute: "/workflow", keywords: ["工作流", "经典画布", "流程", "分支", "知识写入提议", "Knowledge Inbox"] },
-      { id: "rag", title: "RAG 知识库", summary: "创建资料库、上传文档，并让回答引用指定资料。", outcome: "知道什么时候使用自己的资料库，而不是普通聊天。", points: ["RAG 可以理解为先从指定资料找内容，再让模型回答", "当前空白页从“新建知识库”开始", "上传前确认资料权限和数据边界"], productRoute: "/rag", keywords: ["RAG", "知识库", "资料", "引用"] },
+      { id: "rag", title: "RAG 知识库", summary: "创建资料库、上传文档，并让回答引用指定资料。", outcome: "知道什么时候使用自己的资料库，而不是普通聊天。", points: ["RAG 可以理解为先从指定资料找内容，再让模型回答", "V3 检索会去除重复片段，并默认每份文档最多保留 2 条结果，避免单一文档占满结果列表", "当前空白页从“新建知识库”开始", "上传前确认资料权限和数据边界"], productRoute: "/rag", keywords: ["RAG", "知识库", "资料", "引用"], verifiedCommit: ragDiversityBaseline.commit, verifiedDate: ragDiversityBaseline.date },
       { id: "data-tables", title: "本地数据表", summary: "为私有工作流维护有固定字段的业务记录。", outcome: "创建数据表、发布 Schema，并管理本地记录。", points: ["数据表用于类型化业务记录", "Schema 以不可变版本发布", "字段和记录操作属于数据表内部条目，本轮不展开"], productRoute: "/data-tables", keywords: ["数据表", "Schema", "业务记录", "数据库"] },
       { id: "coding", title: "Coding", summary: "在只读实验工作台中查看项目并询问代码问题。", outcome: "理解当前入口的只读边界和启用状态。", points: ["当前页面说明只能读取项目并回答问题", "不能修改文件或运行命令", "页面显示“代码助手暂时不可用”时，应等待管理员启用"], productRoute: "/coding", keywords: ["Coding", "代码", "只读实验", "暂时不可用"] },
       { id: "settings", title: "系统设置", summary: "由授权人员管理 Provider、路由实验和其他服务连接。", outcome: "知道哪些设置需要交给有配置权限的人处理。", points: ["未配置时页面会明确提示", "Provider 管理和其他集成分区显示", "设置变更可能影响其他用户或产生外部费用"], productRoute: "/settings", badge: "管理员", keywords: ["设置", "Provider", "连接", "权限", "路由实验"] },

--- a/client/src/pages/HelpArticlePage.tsx
+++ b/client/src/pages/HelpArticlePage.tsx
@@ -175,7 +175,7 @@ function ModulePage({ module, topic }: { module: HelpModule; topic?: HelpModuleT
   return (
     <>
       <PageHeader eyebrow={module.title} summary={current.summary} title={current.title} />
-      <Metadata audience="适合准备使用这一模块的用户" minutes={3} />
+      <Metadata audience="适合准备使用这一模块的用户" minutes={3} verifiedCommit={current.verifiedCommit} verifiedDate={current.verifiedDate} />
       <div className="mt-9 max-w-[76ch] space-y-10">
         <section><h2 className="text-2xl font-bold text-white">你可以做什么</h2><p className="mt-3 text-base leading-8 text-slate-300">{current.outcome}</p><div className="mt-5 divide-y divide-white/[0.08] border-y border-white/[0.08]">{current.points.map((point) => <div className="flex gap-3 py-4" key={point}><span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-300" /><p className="text-base leading-7 text-slate-300">{point}</p></div>)}</div></section>
         <section><h2 className="text-2xl font-bold text-white">同一模块的其他功能</h2><div className="mt-4 divide-y divide-white/[0.08] border-y border-white/[0.08]">{module.topics.filter((item) => item.id !== current.id).map((item) => <Link className="group flex min-h-[72px] items-center gap-4 py-4" key={item.id} to={`/help/modules/${module.id}/${item.id}`}><span className="min-w-0 flex-1"><span className="block font-semibold text-slate-100 group-hover:text-cyan-100">{item.title}</span><span className="mt-1 block text-sm leading-6 text-slate-400">{item.summary}</span></span><ChevronRight aria-hidden="true" className="h-4 w-4 shrink-0 text-slate-600 group-hover:text-cyan-200" /></Link>)}</div></section>

--- a/docs/help-center/evidence/rag-diversity-f0150fb5.md
+++ b/docs/help-center/evidence/rag-diversity-f0150fb5.md
@@ -1,0 +1,56 @@
+# RAG P0 PR3：rebase 后验收记录
+
+日期：2026-08-27。基线：`f0150fb5daebcf5a4a70b0f350e6129dae7ff8d0`。
+本记录对应该基线上的 PR3 增量，不表示上述基线已包含本功能。
+
+## 范围与兼容
+
+- V3 在绝对相关性过滤后，依次执行规范化文本去重、source-block 主引用选择、可证明的重叠文本合并、文档上限和 Top-K。
+- `max_chunks_per_document` 默认为 2，可设置为 1–50；不同文档和不同 source block 的独立候选保持上游顺序，不引入 MMR 或新评分。
+- source-block 去重只选一个最高分主引用，但保留组内兄弟用于安全合并；无法证明字符跨度、文本重叠及页/结构身份一致时不合并。主 citation ID 保留，额外合并项记录为 `merged_chunk_ids`。
+- `candidate_stage_counts` 记录 raw、threshold、text_dedup、source_block_dedup、overlap_merge、document_limit、final；另记 `overlap_merged_chunk_count`。
+- V2 继续走旧 selection 路径，不新增默认文档上限。不调参、不新增依赖、不修改活动索引或历史数据。
+
+本批涉及 3 个后端文件、1 个专项测试、3 个帮助内容/展示文件及本记录。超过默认 5 文件的原因是公开字段、实际查询、纯选择器、证伪测试与同批帮助证据必须保持一致；未拆入其他行为合同。
+
+## 自动验收
+
+后端统一在 `modelmirror-server:latest` 一次性测试容器执行；`--network none`，仅挂载本批隔离工作树，不传入凭据，不挂载共享数据或 Docker socket。
+
+| 检查 | 命令 | 结果 |
+| --- | --- | --- |
+| 专项与兼容 | `python -m pytest server/tests/test_rag_retrieval_diversity.py server/tests/test_rag_retrieval_scoring.py server/tests/test_rag_retrieval_v2.py -q` | 通过：56 passed |
+| RAG / Knowledge / Benchmark | `python -m pytest server/tests/test_rag*.py server/tests/test_*knowledge*.py server/tests/test_benchmark*.py -q`（容器内 shell 展开） | 通过：337 passed，4 warnings |
+| 帮助内容 | `npm.cmd run test:run -- src/content/help-center/helpContent.test.ts` | 通过：5 passed |
+| 前端全测 | `npm.cmd run test:run` | 通过：123 files，750 tests |
+| 类型检查 | `npm.cmd run typecheck` | 通过；普通权限受 `C:\tmp` 两份生成型 tsbuildinfo 缓存 EPERM 阻断，删除精确缓存并仅提升该命令权限后通过，未改类型配置 |
+| 生产构建 | `npm.cmd run build` | 通过；保留既有 large-chunk warning |
+| 全量后端（最终 Diff） | `python -m pytest server/tests/ -q` | 失败：5020 passed，20 failed，29 skipped，6 warnings，1263.80s |
+| 干净主线失败归因 | 四个失败文件在同一基线的干净对照工作树复跑 | 通过归因：相同 20 failed，69 passed，4 warnings |
+
+全量中的 20 条失败位于 `test_agency_worker_bridge.py`、`test_expert_team_agency_execution.py`、`test_skill_finder.py`、`test_skill_semantic_rerank.py`。同一基线的干净对照工作树精确复现相同 20 条：`server/orchestration_worker/dist/main.js` 与该目录下的 TypeScript 依赖均不存在，导致 Worker 报 `Agency worker build output is unavailable`，并使三个 Node/TypeScript 对照测试无法加载。本批不修改这些模块、不跳过其测试。
+
+## 最终证伪攻击
+
+提交前不把既有绿测视为正确性证明，额外攻击了三个增量假设，并先观察红灯再修复：
+
+1. **V2 字段隔离**：显式提交 `max_chunks_per_document` 时，通用解析器原先会保留该 V3 字段；进一步通过 `absolute_relevance_v1` 覆盖时，V2 执行回执也会错误宣称存在文档上限。修复后 V2 配置出口始终移除该不可执行字段，不改变旧选择器和分数语义。
+2. **重叠链闭包**：最高分主 chunk 位于链尾时，一次顺序扫描会跳过尚未与主 chunk 相交、但可在中间 chunk 合并后证明连续的链首。修复为有界多轮闭包扫描，并对 3 个 chunk 的全部 6 种输入排列验证完整合并。
+3. **可重放性**：上述测试同时锁定主 citation ID、字符范围、合并 ID 集、合并数量以及 V2 payload，避免“内容看似正确但回执或兼容合同漂移”。
+
+这三项修复后重新运行 56 条专项/兼容测试与 337 条 RAG/Knowledge/Benchmark 回归，均通过。真实 Provider 调用未执行：本批变更位于 Provider 已返回候选之后的确定性选择阶段，外部 embedding/rerank 响应不能增加对这三个缺陷的判别力，反而会引入非确定性与额度消耗。
+
+## Help Center Impact
+
+- 影响：用户可见的 V3 去重及默认每文档最多 2 条结果。
+- 更新：`client/src/content/help-center/index.ts` 的 RAG 条目；单条目验证基线通过 `HelpArticlePage` 展示，不改写其他条目的历史验证基线。
+- 独立前端预览：本批工作树，loopback 端口 15432，无后端服务重建。
+- 可见操作：帮助首页 → 工作台与设置下的「RAG 知识库」→ 查看 V3 说明、日期和基线；返回首页后再次通过可见链接重放。
+- 实际结果：标题、去重说明、默认 2 条、`2026-08-27`、`f0150fb5` 均正确显示；返回帮助首页后再次通过可见链接重放成功，页面 error 日志为空。
+- 边界：本项只验证帮助页面及导航；未通过产品 UI 构建索引或执行检索，不等于真实模型质量或 P0 最终集成验收。未上传资料、未调用真实 Provider、未发送私有语料。
+
+## 提交边界与回退
+
+分支已重新同步至 `origin/main@f0150fb5`，保留上游 Provider Batch 帮助增量和本批 RAG 增量；既有 `stash@{1}` autostash 备份未被改动。本批只执行用户授权的 Commit、Push 和 PR 创建，不合并或部署。
+
+本批无数据迁移，回退仅撤销本批代码/帮助变更，不删除任何索引或历史数据。CI 状态以远端 PR 为准；五个顺序 PR 完成后的零真实调用隔离集成门禁仍未执行。

--- a/server/rag/api.py
+++ b/server/rag/api.py
@@ -247,6 +247,7 @@ class RagSourcePayload(_HeadingPathPayload):
     row_range: str | None = Field(default=None, max_length=80)
     visual_kind: str | None = None
     source_block_id: str | None = None
+    merged_chunk_ids: list[str] = Field(default_factory=list)
 
 
 class RetrievalOptionsPayload(BaseModel):
@@ -259,6 +260,7 @@ class RetrievalOptionsPayload(BaseModel):
     min_lexical_confidence: float | None = None
     min_rerank_score: float | None = None
     no_result_policy: Literal["absolute_relevance_v1"] | None = None
+    max_chunks_per_document: int | None = Field(default=None, ge=1, le=50)
     candidate_multiplier: int | None = None
     rerank_enabled: bool | None = None
     rerank_provider: str | None = None

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -49,6 +49,7 @@ from .retrieval import (
     RetrievalConfig,
     fuse_rankings,
     select_candidates,
+    select_v3_candidates,
 )
 from .source_metadata import normalize_heading_path
 from .processor_generator import (
@@ -5807,6 +5808,12 @@ class RagService:
                     )
                 ]
                 vector_candidates = [self._candidate_from_vector(item) for item in vector_results]
+        raw_candidate_count = len(
+            {
+                item.chunk_id
+                for item in vector_candidates + lexical_candidates
+            }
+        )
         (
             vector_candidates,
             lexical_candidates,
@@ -5953,19 +5960,37 @@ class RagService:
                     promotion_ineligibility_reasons.append("rerank_fail_open")
 
         deleted_document_ids = self._deleted_document_ids()
-        results = select_candidates(
-            [
-                item
-                for item in fused
-                if not self._indexed_document_is_deleted(
-                    str(item.doc_id), deleted_document_ids
-                )
-            ],
-            score_threshold=(
-                0.0 if config.uses_absolute_relevance else config.score_threshold
-            ),
-            top_k=config.top_k,
-        )
+        selection_input = [
+            item
+            for item in fused
+            if not self._indexed_document_is_deleted(
+                str(item.doc_id), deleted_document_ids
+            )
+        ]
+        candidate_stage_counts: dict[str, int] | None = None
+        overlap_merged_chunk_count = 0
+        if is_v3:
+            diversity_outcome = select_v3_candidates(
+                selection_input,
+                top_k=config.top_k,
+                max_chunks_per_document=int(
+                    config.max_chunks_per_document or 2
+                ),
+            )
+            results = diversity_outcome.items
+            candidate_stage_counts = {
+                "raw": raw_candidate_count,
+                **diversity_outcome.candidate_counts,
+            }
+            overlap_merged_chunk_count = (
+                diversity_outcome.overlap_merged_chunk_count
+            )
+        else:
+            results = select_candidates(
+                selection_input,
+                score_threshold=config.score_threshold,
+                top_k=config.top_k,
+            )
         if not results:
             return {
                 "answer": "没有在该知识库中找到相关内容，请尝试换一种问法或上传更多资料。",
@@ -5987,6 +6012,8 @@ class RagService:
                     embedding_profile=resolved_embedding_profile,
                     rejection_diagnostics=rejection_diagnostics,
                     promotion_ineligibility_reasons=promotion_ineligibility_reasons,
+                    candidate_stage_counts=candidate_stage_counts,
+                    overlap_merged_chunk_count=overlap_merged_chunk_count,
                 ),
             }
 
@@ -6037,6 +6064,7 @@ class RagService:
                     "row_range": result.row_range,
                     "visual_kind": result.visual_kind,
                     "source_block_id": result.source_block_id,
+                    "merged_chunk_ids": list(result.merged_chunk_ids),
                 }
                 for result in results
             ],
@@ -6057,6 +6085,8 @@ class RagService:
                 embedding_profile=resolved_embedding_profile,
                 rejection_diagnostics=rejection_diagnostics,
                 promotion_ineligibility_reasons=promotion_ineligibility_reasons,
+                candidate_stage_counts=candidate_stage_counts,
+                overlap_merged_chunk_count=overlap_merged_chunk_count,
             ),
         }
 
@@ -6638,7 +6668,12 @@ class RagService:
             merged["top_k"] = top_k
         if schema_version >= INDEX_SCHEMA_VERSION:
             return self._v3_retrieval_config_from_patch(merged, base=base)
-        return RetrievalConfig.from_mapping(merged, base=base)
+        legacy_config = RetrievalConfig.from_mapping(merged, base=base)
+        # V2 keeps its historical selector even when a diagnostic override
+        # requests the newer no-result policy. Do not advertise the V3-only
+        # document cap in a legacy execution receipt when it cannot run.
+        legacy_config.max_chunks_per_document = None
+        return legacy_config
 
     @staticmethod
     def _new_v3_retrieval_config() -> RetrievalConfig:
@@ -6748,6 +6783,8 @@ class RagService:
         embedding_profile: dict[str, Any],
         rejection_diagnostics: list[dict[str, Any]],
         promotion_ineligibility_reasons: list[str],
+        candidate_stage_counts: dict[str, int] | None,
+        overlap_merged_chunk_count: int,
     ) -> dict[str, Any]:
         effective = dict(embedding_profile.get("effective") or {})
         threshold_score_domain = "fused_score"
@@ -6764,7 +6801,7 @@ class RagService:
         ineligibility_reasons = list(
             dict.fromkeys(str(item) for item in promotion_ineligibility_reasons if item)
         )
-        return {
+        diagnostics = {
             **config.payload(),
             "vector_candidate_count": vector_count,
             "fulltext_candidate_count": fulltext_count,
@@ -6789,6 +6826,15 @@ class RagService:
                 embedding_profile.get("embedding_space_fingerprint") or ""
             ),
         }
+        if candidate_stage_counts is not None:
+            diagnostics["candidate_stage_counts"] = {
+                str(stage): max(0, int(count))
+                for stage, count in candidate_stage_counts.items()
+            }
+            diagnostics["overlap_merged_chunk_count"] = max(
+                0, int(overlap_merged_chunk_count)
+            )
+        return diagnostics
 
     def _resolved_embedding_profile_for_query(
         self,

--- a/server/rag/retrieval.py
+++ b/server/rag/retrieval.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import math
-from dataclasses import asdict, dataclass
+import unicodedata
+from dataclasses import asdict, dataclass, replace
 from typing import Any
 
 
@@ -26,6 +27,7 @@ class RetrievalConfig:
     min_lexical_confidence: float | None = None
     min_rerank_score: float | None = None
     no_result_policy: str = LEGACY_NO_RESULT_POLICY
+    max_chunks_per_document: int | None = None
     candidate_multiplier: int = 4
     rerank_enabled: bool = False
     rerank_provider: str = "auto"
@@ -86,6 +88,21 @@ class RetrievalConfig:
                 "retrieval.no_result_policy must be absolute_relevance_v1 or the legacy compatibility policy."
             )
 
+        raw_document_limit = current.get("max_chunks_per_document")
+        if no_result_policy != ABSOLUTE_NO_RESULT_POLICY:
+            max_chunks_per_document = None
+        elif raw_document_limit is None:
+            max_chunks_per_document = 2
+        else:
+            max_chunks_per_document = _coerce_int(
+                raw_document_limit,
+                "max_chunks_per_document",
+            )
+            if not 1 <= max_chunks_per_document <= 50:
+                raise ValueError(
+                    "retrieval.max_chunks_per_document must be between 1 and 50."
+                )
+
         multiplier = _coerce_int(current.get("candidate_multiplier"), "candidate_multiplier")
         if not 1 <= multiplier <= 10:
             raise ValueError("retrieval.candidate_multiplier must be between 1 and 10.")
@@ -114,6 +131,7 @@ class RetrievalConfig:
             min_lexical_confidence=min_lexical_confidence,
             min_rerank_score=min_rerank_score,
             no_result_policy=no_result_policy,
+            max_chunks_per_document=max_chunks_per_document,
             candidate_multiplier=multiplier,
             rerank_enabled=rerank_enabled,
             rerank_provider=provider,
@@ -168,6 +186,8 @@ class RetrievalConfig:
 
     def payload(self) -> dict[str, Any]:
         value = asdict(self)
+        if self.max_chunks_per_document is None:
+            value.pop("max_chunks_per_document", None)
         if self.uses_absolute_relevance:
             value.pop("score_threshold", None)
         else:
@@ -315,6 +335,7 @@ class RetrievalCandidate:
     fulltext_score: float | None = None
     fused_score: float = 0.0
     rerank_score: float | None = None
+    merged_chunk_ids: tuple[str, ...] = ()
 
     @property
     def score(self) -> float:
@@ -419,6 +440,176 @@ def select_candidates(
         if len(selected) >= top_k:
             break
     return selected
+
+
+@dataclass(slots=True)
+class DiversitySelectionOutcome:
+    items: list[RetrievalCandidate]
+    candidate_counts: dict[str, int]
+    overlap_merged_chunk_count: int = 0
+
+
+def select_v3_candidates(
+    items: list[RetrievalCandidate],
+    *,
+    top_k: int,
+    max_chunks_per_document: int,
+) -> DiversitySelectionOutcome:
+    """Apply the deterministic V3 diversity contract after absolute gating."""
+
+    if not 1 <= top_k <= 50:
+        raise ValueError("retrieval.top_k must be between 1 and 50.")
+    if not 1 <= max_chunks_per_document <= 50:
+        raise ValueError(
+            "retrieval.max_chunks_per_document must be between 1 and 50."
+        )
+
+    text_group_indexes: dict[str, int] = {}
+    text_groups: list[list[RetrievalCandidate]] = []
+    for item in items:
+        normalized_text = _normalized_candidate_text(item)
+        if not normalized_text:
+            text_groups.append([item])
+            continue
+        group_index = text_group_indexes.get(normalized_text)
+        if group_index is None:
+            text_group_indexes[normalized_text] = len(text_groups)
+            text_groups.append([item])
+        else:
+            text_groups[group_index].append(item)
+
+    text_deduplicated: list[RetrievalCandidate] = []
+    for group in text_groups:
+        text_deduplicated.append(_highest_score_candidate(group))
+
+    source_group_indexes: dict[tuple[str, str], int] = {}
+    source_groups: list[list[RetrievalCandidate]] = []
+    for item in text_deduplicated:
+        source_block_id = str(item.source_block_id or "").strip()
+        if not source_block_id:
+            source_groups.append([item])
+            continue
+        key = (item.doc_id, source_block_id)
+        group_index = source_group_indexes.get(key)
+        if group_index is None:
+            source_group_indexes[key] = len(source_groups)
+            source_groups.append([item])
+        else:
+            source_groups[group_index].append(item)
+
+    merged_items: list[RetrievalCandidate] = []
+    merged_chunk_count = 0
+    for group in source_groups:
+        primary = _highest_score_candidate(group)
+        merged = primary
+        pending = sorted(
+            (
+                sibling
+                for sibling in group
+                if sibling.chunk_id != primary.chunk_id
+            ),
+            key=lambda item: (item.start_char, item.end_char, item.chunk_id),
+        )
+        while pending:
+            remaining: list[RetrievalCandidate] = []
+            merged_in_pass = False
+            for sibling in pending:
+                combined = _merge_proven_overlap(merged, sibling)
+                if combined is None:
+                    remaining.append(sibling)
+                    continue
+                merged = combined
+                merged_chunk_count += 1
+                merged_in_pass = True
+            if not merged_in_pass:
+                break
+            pending = remaining
+        merged_items.append(merged)
+
+    document_counts: dict[str, int] = {}
+    document_limited: list[RetrievalCandidate] = []
+    for item in merged_items:
+        count = document_counts.get(item.doc_id, 0)
+        if count >= max_chunks_per_document:
+            continue
+        document_counts[item.doc_id] = count + 1
+        document_limited.append(item)
+
+    selected = document_limited[:top_k]
+    return DiversitySelectionOutcome(
+        items=selected,
+        candidate_counts={
+            "threshold": len(items),
+            "text_dedup": len(text_deduplicated),
+            "source_block_dedup": len(source_groups),
+            "overlap_merge": len(merged_items),
+            "document_limit": len(document_limited),
+            "final": len(selected),
+        },
+        overlap_merged_chunk_count=merged_chunk_count,
+    )
+
+
+def _normalized_candidate_text(item: RetrievalCandidate) -> str:
+    text = item.context_text or item.matched_text
+    return " ".join(unicodedata.normalize("NFKC", text).casefold().split())
+
+
+def _highest_score_candidate(
+    items: list[RetrievalCandidate],
+) -> RetrievalCandidate:
+    return min(items, key=lambda item: (-float(item.score), item.chunk_id))
+
+
+def _merge_proven_overlap(
+    primary: RetrievalCandidate,
+    sibling: RetrievalCandidate,
+) -> RetrievalCandidate | None:
+    if (
+        primary.doc_id != sibling.doc_id
+        or not primary.source_block_id
+        or primary.source_block_id != sibling.source_block_id
+        or primary.page_number != sibling.page_number
+        or primary.slide != sibling.slide
+        or primary.sheet != sibling.sheet
+        or primary.row_range != sibling.row_range
+        or primary.context_text != primary.matched_text
+        or sibling.context_text != sibling.matched_text
+    ):
+        return None
+    if (
+        primary.end_char <= primary.start_char
+        or sibling.end_char <= sibling.start_char
+        or len(primary.matched_text) != primary.end_char - primary.start_char
+        or len(sibling.matched_text) != sibling.end_char - sibling.start_char
+    ):
+        return None
+
+    if primary.start_char <= sibling.start_char:
+        earlier, later = primary, sibling
+    else:
+        earlier, later = sibling, primary
+    overlap = earlier.end_char - later.start_char
+    if overlap <= 0:
+        return None
+    if overlap > len(earlier.matched_text) or overlap > len(later.matched_text):
+        return None
+    if earlier.matched_text[-overlap:] != later.matched_text[:overlap]:
+        return None
+
+    combined_text = earlier.matched_text + later.matched_text[overlap:]
+    merged_ids = list(primary.merged_chunk_ids)
+    if sibling.chunk_id != primary.chunk_id:
+        merged_ids.append(sibling.chunk_id)
+    merged_ids.extend(sibling.merged_chunk_ids)
+    return replace(
+        primary,
+        matched_text=combined_text,
+        context_text=combined_text,
+        start_char=min(primary.start_char, sibling.start_char),
+        end_char=max(primary.end_char, sibling.end_char),
+        merged_chunk_ids=tuple(dict.fromkeys(merged_ids)),
+    )
 
 
 def _coerce_int(value: Any, name: str) -> int:

--- a/server/tests/test_rag_retrieval_diversity.py
+++ b/server/tests/test_rag_retrieval_diversity.py
@@ -1,0 +1,647 @@
+from __future__ import annotations
+
+from itertools import permutations
+from pathlib import Path
+
+import pytest
+
+from server.rag import retrieval as retrieval_module
+from server.rag.embedder import EmbeddingClient
+from server.rag.lexical_store import LexicalChunk, SqliteLexicalStore
+from server.rag.rag_service import RagService
+from server.rag.retrieval import RetrievalCandidate, RetrievalConfig
+from server.rag.vector_store import LocalJsonVectorStore
+
+
+def candidate(
+    chunk_id: str,
+    *,
+    doc_id: str,
+    text: str,
+    score: float,
+    source_block_id: str | None = None,
+    start_char: int = 0,
+    end_char: int | None = None,
+    page_number: int | None = 1,
+) -> RetrievalCandidate:
+    return RetrievalCandidate(
+        chunk_id=chunk_id,
+        doc_id=doc_id,
+        document_name=f"{doc_id}.txt",
+        matched_text=text,
+        context_text=text,
+        source_block_id=source_block_id,
+        start_char=start_char,
+        end_char=len(text) if end_char is None else end_char,
+        page_number=page_number,
+        fused_score=score,
+    )
+
+
+def select(
+    items: list[RetrievalCandidate],
+    *,
+    top_k: int = 10,
+    max_chunks_per_document: int = 2,
+):
+    return retrieval_module.select_v3_candidates(
+        items,
+        top_k=top_k,
+        max_chunks_per_document=max_chunks_per_document,
+    )
+
+
+def build_service(tmp_path: Path) -> RagService:
+    storage = tmp_path / "storage"
+    return RagService(
+        storage_dir=storage,
+        uploads_dir=tmp_path / "uploads",
+        embedder=EmbeddingClient(api_key="", dimension=64),
+        vector_store=LocalJsonVectorStore(storage / "vectors.json"),
+        lexical_store=SqliteLexicalStore(storage / "lexical.sqlite3"),
+        llm_enabled=False,
+    )
+
+
+def test_v3_defaults_to_two_chunks_per_document_and_validates_the_limit() -> None:
+    config = RetrievalConfig.from_mapping(
+        {"no_result_policy": "absolute_relevance_v1"}
+    )
+
+    assert config.max_chunks_per_document == 2
+    assert config.payload()["max_chunks_per_document"] == 2
+    with pytest.raises(ValueError, match="max_chunks_per_document"):
+        RetrievalConfig.from_mapping(
+            {
+                "no_result_policy": "absolute_relevance_v1",
+                "max_chunks_per_document": 0,
+            }
+        )
+
+
+def test_v2_payload_and_selection_contract_do_not_gain_the_v3_limit(
+    tmp_path: Path,
+) -> None:
+    config = RetrievalConfig.from_mapping(
+        {"mode": "vector", "score_threshold": 0.25}
+    )
+
+    assert config.max_chunks_per_document is None
+    assert "max_chunks_per_document" not in config.payload()
+
+    explicit_v3_limit = RetrievalConfig.from_mapping(
+        {
+            "mode": "vector",
+            "score_threshold": 0.25,
+            "max_chunks_per_document": 7,
+        }
+    )
+    assert explicit_v3_limit.max_chunks_per_document is None
+    assert "max_chunks_per_document" not in explicit_v3_limit.payload()
+
+    service = build_service(tmp_path)
+    version = {
+        "index_schema_version": 2,
+        "retrieval_profile": {
+            "mode": "vector",
+            "score_threshold": 0.25,
+        },
+    }
+    legacy_override = service._retrieval_config_for_version(
+        version,
+        {
+            "no_result_policy": "absolute_relevance_v1",
+            "max_chunks_per_document": 7,
+        },
+        top_k=None,
+    )
+    assert legacy_override.max_chunks_per_document is None
+    assert "max_chunks_per_document" not in legacy_override.payload()
+
+
+def test_normalized_text_and_source_block_duplicates_cannot_fill_top_k() -> None:
+    outcome = select(
+        [
+            candidate(
+                "primary",
+                doc_id="doc-a",
+                text="Alpha   BETA",
+                score=0.99,
+                source_block_id="block-a",
+            ),
+            candidate(
+                "text-duplicate",
+                doc_id="doc-b",
+                text="  alpha beta  ",
+                score=0.98,
+                source_block_id="block-b",
+            ),
+            candidate(
+                "block-duplicate",
+                doc_id="doc-a",
+                text="different child text",
+                score=0.97,
+                source_block_id="block-a",
+                page_number=2,
+            ),
+            candidate(
+                "independent",
+                doc_id="doc-b",
+                text="independent evidence",
+                score=0.96,
+                source_block_id="block-c",
+            ),
+        ]
+    )
+
+    assert [item.chunk_id for item in outcome.items] == ["primary", "independent"]
+    assert outcome.candidate_counts == {
+        "threshold": 4,
+        "text_dedup": 3,
+        "source_block_dedup": 2,
+        "overlap_merge": 2,
+        "document_limit": 2,
+        "final": 2,
+    }
+
+
+def test_document_limit_prevents_one_document_from_saturating_top_ten() -> None:
+    items = [
+        candidate(
+            f"doc-a-{index}",
+            doc_id="doc-a",
+            text=f"evidence a {index}",
+            score=1 - index / 100,
+            source_block_id=f"block-a-{index}",
+        )
+        for index in range(12)
+    ]
+    items.extend(
+        candidate(
+            f"doc-{index}",
+            doc_id=f"doc-{index}",
+            text=f"evidence {index}",
+            score=0.5 - index / 100,
+            source_block_id=f"block-{index}",
+        )
+        for index in range(1, 10)
+    )
+
+    outcome = select(items, top_k=10, max_chunks_per_document=2)
+
+    assert len(outcome.items) == 10
+    assert sum(item.doc_id == "doc-a" for item in outcome.items) == 2
+    assert outcome.candidate_counts["document_limit"] == 11
+    assert outcome.candidate_counts["final"] == 10
+
+
+def test_two_distinct_source_blocks_from_one_document_remain_available() -> None:
+    outcome = select(
+        [
+            candidate(
+                "evidence-one",
+                doc_id="doc-a",
+                text="first fact",
+                score=0.9,
+                source_block_id="block-one",
+            ),
+            candidate(
+                "evidence-two",
+                doc_id="doc-a",
+                text="second fact",
+                score=0.8,
+                source_block_id="block-two",
+            ),
+            candidate(
+                "evidence-three",
+                doc_id="doc-a",
+                text="third fact",
+                score=0.7,
+                source_block_id="block-three",
+            ),
+        ],
+        max_chunks_per_document=2,
+    )
+
+    assert [item.chunk_id for item in outcome.items] == [
+        "evidence-one",
+        "evidence-two",
+    ]
+    assert outcome.candidate_counts["source_block_dedup"] == 3
+    assert outcome.candidate_counts["document_limit"] == 2
+
+
+def test_diversity_preserves_the_upstream_rank_between_independent_candidates() -> None:
+    outcome = select(
+        [
+            candidate(
+                "upstream-rank-one",
+                doc_id="doc-a",
+                text="rank one",
+                score=0.2,
+                source_block_id="block-a",
+            ),
+            candidate(
+                "upstream-rank-two",
+                doc_id="doc-b",
+                text="rank two",
+                score=0.9,
+                source_block_id="block-b",
+            ),
+        ]
+    )
+
+    assert [item.chunk_id for item in outcome.items] == [
+        "upstream-rank-one",
+        "upstream-rank-two",
+    ]
+
+
+def test_overlap_merge_keeps_highest_score_primary_and_document_order_text() -> None:
+    outcome = select(
+        [
+            candidate(
+                "primary",
+                doc_id="doc-a",
+                text="fghijklmno",
+                score=0.9,
+                source_block_id="block-a",
+                start_char=5,
+                end_char=15,
+            ),
+            candidate(
+                "earlier-sibling",
+                doc_id="doc-a",
+                text="abcdefghij",
+                score=0.8,
+                source_block_id="block-a",
+                start_char=0,
+                end_char=10,
+            ),
+        ]
+    )
+
+    assert len(outcome.items) == 1
+    merged = outcome.items[0]
+    assert merged.chunk_id == "primary"
+    assert merged.matched_text == "abcdefghijklmno"
+    assert merged.context_text == "abcdefghijklmno"
+    assert (merged.start_char, merged.end_char) == (0, 15)
+    assert merged.merged_chunk_ids == ("earlier-sibling",)
+    assert outcome.overlap_merged_chunk_count == 1
+
+
+def test_overlap_chain_is_complete_and_independent_of_candidate_order() -> None:
+    chain = [
+        candidate(
+            "left",
+            doc_id="doc-a",
+            text="abcdefghij",
+            score=0.7,
+            source_block_id="block-a",
+            start_char=0,
+            end_char=10,
+        ),
+        candidate(
+            "middle",
+            doc_id="doc-a",
+            text="fghijklmno",
+            score=0.8,
+            source_block_id="block-a",
+            start_char=5,
+            end_char=15,
+        ),
+        candidate(
+            "right-primary",
+            doc_id="doc-a",
+            text="klmnopqrst",
+            score=0.9,
+            source_block_id="block-a",
+            start_char=10,
+            end_char=20,
+        ),
+    ]
+
+    receipts = []
+    for ordering in permutations(chain):
+        outcome = select(list(ordering))
+        assert len(outcome.items) == 1
+        merged = outcome.items[0]
+        receipts.append(
+            (
+                merged.chunk_id,
+                merged.matched_text,
+                merged.start_char,
+                merged.end_char,
+                frozenset(merged.merged_chunk_ids),
+                outcome.overlap_merged_chunk_count,
+            )
+        )
+
+    assert set(receipts) == {
+        (
+            "right-primary",
+            "abcdefghijklmnopqrst",
+            0,
+            20,
+            frozenset({"left", "middle"}),
+            2,
+        )
+    }
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        (
+            candidate(
+                "page-one",
+                doc_id="doc-a",
+                text="abcdefghij",
+                score=0.9,
+                source_block_id="block-a",
+                start_char=0,
+                end_char=10,
+                page_number=1,
+            ),
+            candidate(
+                "page-two",
+                doc_id="doc-a",
+                text="fghijklmno",
+                score=0.8,
+                source_block_id="block-a",
+                start_char=5,
+                end_char=15,
+                page_number=2,
+            ),
+        ),
+        (
+            candidate(
+                "block-one",
+                doc_id="doc-a",
+                text="abcdefghij",
+                score=0.9,
+                source_block_id="block-one",
+                start_char=0,
+                end_char=10,
+            ),
+            candidate(
+                "block-two",
+                doc_id="doc-a",
+                text="fghijklmno",
+                score=0.8,
+                source_block_id="block-two",
+                start_char=5,
+                end_char=15,
+            ),
+        ),
+        (
+            candidate(
+                "unproven-one",
+                doc_id="doc-a",
+                text="abcdefghij",
+                score=0.9,
+                source_block_id="block-a",
+                start_char=0,
+                end_char=10,
+            ),
+            candidate(
+                "unproven-two",
+                doc_id="doc-a",
+                text="XXXXXklmno",
+                score=0.8,
+                source_block_id="block-a",
+                start_char=5,
+                end_char=15,
+            ),
+        ),
+        (
+            candidate(
+                "range-one",
+                doc_id="doc-a",
+                text="abcdefghij",
+                score=0.9,
+                source_block_id="block-a",
+                start_char=0,
+                end_char=100,
+            ),
+            candidate(
+                "range-two",
+                doc_id="doc-a",
+                text="fghijklmno",
+                score=0.8,
+                source_block_id="block-a",
+                start_char=95,
+                end_char=105,
+            ),
+        ),
+    ],
+)
+def test_cross_page_cross_block_or_unproven_overlap_is_not_merged(
+    left: RetrievalCandidate,
+    right: RetrievalCandidate,
+) -> None:
+    outcome = select([left, right])
+
+    assert outcome.overlap_merged_chunk_count == 0
+    assert all(item.merged_chunk_ids == () for item in outcome.items)
+
+
+def test_stage_counts_and_order_are_deterministic_and_attribute_drops() -> None:
+    items = [
+        candidate(
+            "z",
+            doc_id="doc-a",
+            text="same text",
+            score=0.8,
+            source_block_id="block-z",
+        ),
+        candidate(
+            "a",
+            doc_id="doc-b",
+            text="same   text",
+            score=0.8,
+            source_block_id="block-a",
+        ),
+        candidate(
+            "b",
+            doc_id="doc-b",
+            text="other text",
+            score=0.7,
+            source_block_id="block-b",
+        ),
+        candidate(
+            "c",
+            doc_id="doc-b",
+            text="third text",
+            score=0.6,
+            source_block_id="block-c",
+        ),
+    ]
+
+    first = select(items, top_k=2, max_chunks_per_document=1)
+    second = select(list(items), top_k=2, max_chunks_per_document=1)
+
+    assert [item.chunk_id for item in first.items] == ["a"]
+    assert [item.chunk_id for item in second.items] == ["a"]
+    assert first.candidate_counts == second.candidate_counts == {
+        "threshold": 4,
+        "text_dedup": 3,
+        "source_block_dedup": 3,
+        "overlap_merge": 3,
+        "document_limit": 1,
+        "final": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_v3_query_exposes_replayable_diversity_stage_counts(
+    tmp_path: Path,
+) -> None:
+    service = build_service(tmp_path)
+    kb = service.create_knowledge_base("diversity diagnostics")
+    namespace = f"{kb['id']}::v3::fulltext"
+    chunks = [
+        LexicalChunk(
+            chunk_id="a-one",
+            namespace=namespace,
+            doc_id="doc-a",
+            document_name="a.txt",
+            text="ORBIT alpha",
+            chunk_index=0,
+            source_block_id="block-a",
+            start_char=0,
+            end_char=11,
+            page_number=1,
+        ),
+        LexicalChunk(
+            chunk_id="a-two",
+            namespace=namespace,
+            doc_id="doc-a",
+            document_name="a.txt",
+            text="ORBIT beta",
+            chunk_index=1,
+            source_block_id="block-a",
+            start_char=20,
+            end_char=30,
+            page_number=2,
+        ),
+        LexicalChunk(
+            chunk_id="a-three",
+            namespace=namespace,
+            doc_id="doc-a",
+            document_name="a.txt",
+            text="ORBIT gamma",
+            chunk_index=2,
+            source_block_id="block-b",
+            start_char=40,
+            end_char=51,
+            page_number=3,
+        ),
+        LexicalChunk(
+            chunk_id="b-one",
+            namespace=namespace,
+            doc_id="doc-b",
+            document_name="b.txt",
+            text="ORBIT delta",
+            chunk_index=0,
+            source_block_id="block-c",
+            start_char=0,
+            end_char=11,
+            page_number=1,
+        ),
+    ]
+    service.lexical_store.add_chunks(chunks)
+    config = RetrievalConfig.from_mapping(
+        {
+            "mode": "fulltext",
+            "top_k": 5,
+            "min_lexical_confidence": 0.0,
+            "no_result_policy": "absolute_relevance_v1",
+            "max_chunks_per_document": 1,
+        }
+    )
+
+    result = await service._query_namespace(
+        kb["id"],
+        namespace,
+        "ORBIT",
+        config=config,
+        lexical_ready=True,
+        generate_answer=False,
+    )
+
+    assert len(result["sources"]) == 2
+    assert result["retrieval"]["candidate_stage_counts"] == {
+        "raw": 4,
+        "threshold": 4,
+        "text_dedup": 4,
+        "source_block_dedup": 3,
+        "overlap_merge": 3,
+        "document_limit": 2,
+        "final": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_v3_query_returns_safe_overlap_merge_receipt(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+    kb = service.create_knowledge_base("overlap receipt")
+    namespace = f"{kb['id']}::v3::fulltext"
+    service.lexical_store.add_chunks(
+        [
+            LexicalChunk(
+                chunk_id="earlier",
+                namespace=namespace,
+                doc_id="doc-a",
+                document_name="a.txt",
+                text="prefix ORBIT",
+                chunk_index=0,
+                source_block_id="block-a",
+                start_char=0,
+                end_char=12,
+                page_number=1,
+            ),
+            LexicalChunk(
+                chunk_id="later",
+                namespace=namespace,
+                doc_id="doc-a",
+                document_name="a.txt",
+                text="ORBIT suffix",
+                chunk_index=1,
+                source_block_id="block-a",
+                start_char=7,
+                end_char=19,
+                page_number=1,
+            ),
+        ]
+    )
+    config = RetrievalConfig.from_mapping(
+        {
+            "mode": "fulltext",
+            "top_k": 5,
+            "min_lexical_confidence": 0.0,
+            "no_result_policy": "absolute_relevance_v1",
+        }
+    )
+
+    result = await service._query_namespace(
+        kb["id"],
+        namespace,
+        "ORBIT",
+        config=config,
+        lexical_ready=True,
+        generate_answer=False,
+    )
+
+    assert len(result["sources"]) == 1
+    source = result["sources"][0]
+    assert source["matched_text"] == "prefix ORBIT suffix"
+    assert source["text"] == "prefix ORBIT suffix"
+    assert (source["start_char"], source["end_char"]) == (0, 19)
+    assert len(source["merged_chunk_ids"]) == 1
+    assert {source["chunk_id"], *source["merged_chunk_ids"]} == {
+        "earlier",
+        "later",
+    }
+    assert result["retrieval"]["overlap_merged_chunk_count"] == 1


### PR DESCRIPTION
# 变更摘要

## 目标与事实依据

- 单一目标：补齐 RAG V3 检索结果的确定性去重、source-block 主引用、安全重叠合并、每文档上限及可重放阶段计数。
- 事实证据：既有实现允许重复 chunk 占满 Top-K；提交前证伪进一步复现了 V2 回执泄漏、链式重叠无法闭包合并和合并证据不完整。
- 待确认项：本 PR 只证明执行合同与兼容性，不证明真实模型质量；P0 五个 PR 完成后的隔离 Docker 总门禁仍待后续执行。

## 变更内容

- V3 在绝对相关性过滤后依次执行规范化文本去重、source-block 主引用选择、安全重叠合并、`max_chunks_per_document` 和 Top-K。
- 默认每文档最多 2 条；保留不同 source block 的多证据结果，不引入 MMR 或新评分。
- 返回 `merged_chunk_ids`、各阶段 candidate count 和合并数量，空结果同样保留 diagnostics。
- V2 继续走旧选择器，并从 legacy 回执移除不可执行的 V3 文档上限字段。
- 同 PR 更新 RAG Help 条目、独立验证基线和验收记录。

## 范围声明

- 允许修改：3 个 RAG 后端文件、1 个专项测试、3 个 Help 文件、1 份证据记录。
- 明确不改：阈值数值、融合/Rerank/Embedding 合同、活动索引、共享数据、部署配置。
- 公共 API/SSE 变化：兼容新增 `max_chunks_per_document` 请求字段、`merged_chunk_ids` source 字段和 V3 diagnostics；V2 行为保持不变。
- 持久化/迁移影响：无。
- 新增或升级依赖：无。

影响类型：

- [x] 前端页面或交互
- [x] 后端 API
- [ ] Chat / Workflow / Xpert 执行
- [ ] MCP / Toolset / 子进程
- [x] RAG / Knowledge / Data X
- [ ] 持久化数据或迁移
- [ ] Docker / Sidecar / 网络
- [ ] 公开 App/API 或凭据
- [ ] 纯文档

## 验收标准

### 正常路径

- Given：V3 已通过绝对相关性过滤的重复、同 source-block 和多文档候选。
- When：执行结果选择。
- Then：按固定阶段去重/安全合并/文档限额后再截取 Top-K，主 citation 与回执可重放。

### 失败路径

- Given：V2 显式提交 V3 字段，或候选跨页、跨 source-block、字符范围/文本重叠不可证明。
- When：解析配置或尝试合并。
- Then：V2 不宣称执行 V3 上限；不安全候选不会被误合并。

## 验证证据

| 检查 | 状态 | 实际命令或人工步骤 | 结果摘要 |
| --- | --- | --- | --- |
| 前端生产构建 | 通过 | `cd client && npm.cmd run build` | 3161 modules；保留既有 large-chunk warning |
| 后端语法 | 通过 | `python -m py_compile server/rag/api.py server/rag/rag_service.py server/rag/retrieval.py server/tests/test_rag_retrieval_diversity.py` | 通过 |
| 目标测试 | 通过 | 56 条专项兼容；337 条 RAG/Knowledge/Benchmark | 56 passed；337 passed，4 warnings |
| 前端全测/类型 | 通过 | `npm.cmd run test:run`；`npm.cmd run typecheck` | 123 files / 750 tests；类型通过 |
| 全量测试 | 失败 | `python -m pytest server/tests/ -q` | 5020 passed，20 failed，29 skipped；同 SHA 干净主线精确复现相同 20 failed / 69 passed |
| Docker/健康检查 | 不适用 | 一次性 `--network none` 测试容器 | 未启动共享 Compose 或产品服务 |
| 人工验收 | 通过 | Help 首页 → RAG 条目 → 返回首页 → 再次进入 | 标题、默认 2 条、日期、`f0150fb5` 正确；error 日志 0 |
| 敏感信息扫描 | 通过 | 对 staged 增量扫描密钥模式 | 无命中 |

全量 20 条既有失败仅位于 Agency Worker/Expert Team/Skill Python-TypeScript 对照测试，原因是测试镜像缺少 `server/orchestration_worker/dist/main.js` 与对应 TypeScript 依赖；详见 `docs/help-center/evidence/rag-diversity-f0150fb5.md`。

## Harness 与安全检查

- [x] 已阅读 `AGENTS.md`、任务相关文档和测试。
- [x] 已检查工作树，未覆盖或回滚用户改动。
- [x] 实际变更没有超出声明范围；8 文件为 API、实现、测试、Help 与证据的同一合同闭环。
- [x] 未提交 `.env`、密钥、token、日志、运行存储、上传、索引、构建产物或 APK。
- [x] 本次未新增依赖。
- [x] 正常、错误、空态及兼容路径已按适用范围验证；外部 Provider/超时/重启不属于本批后处理合同。
- [x] 已执行 `git diff --check` 并审查完整 Diff。
- [x] 相关 Help 与验收记录已更新。

## 风险、未完成项与回退

- 剩余风险：尚未执行五个 P0 PR 完成后的零真实调用隔离 Docker 总门禁；本 PR 不证明真实检索模型质量。
- 未运行/未完成：未调用真实 Provider；未修改或重建任何索引；CI 等待远端运行。
- 停止条件或后续人工决定：PR 评审/CI 通过后再由用户决定是否合并并进入 PR4。

回退步骤：

1. Revert 本 PR 提交。
2. V2 与现有索引无需数据回滚。
3. 不删除任何历史索引或评测记录。

## 截图 / 录屏

未附截图：本批仅为 Help 文案与元数据展示，无布局变更；已在当前基线隔离预览中通过可见链接两次重放，并在验收记录保存路径、文本、基线和 error=0 证据。

## Help Center Impact（必填）

- 是否影响用户体验：`Yes`
- 受影响的用户任务与入口：`/help/modules/workspace/rag`，用户理解 V3 去重及默认每文档最多 2 条结果。
- 同一 PR 更新的帮助文章与截图：更新 Help 模块条目、验证元数据及测试；无截图，原因见上节。
- 验证基线 commit 与日期：`f0150fb5`，2026-08-27。
- 预览器实操路径与实际结果：帮助首页 → RAG 知识库 → 返回帮助首页 → 再次进入；文本和基线正确，error 日志 0。
- 未验证边界：未通过产品 UI 构建索引或执行真实检索；未调用真实 Provider。