### PR TITLE
feature: 完成 MCP 远程认证运行时收口

### DIFF
--- a/client/src/components/McpHubPanel.test.tsx
+++ b/client/src/components/McpHubPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import McpHubPanel from "./McpHubPanel";
 
@@ -12,11 +12,126 @@ function json(payload: unknown, status = 200) {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
+function mockOAuthAuthorization() {
+  const candidateId = "mcphub_" + "a".repeat(32);
+  const session = { session_id: "", status: "pending", expires_at: 0, scopes: ["mcp:read"] };
+  const candidate = {
+    candidate_id: candidateId, server_name: "io.example/expiry", version: "1.0.0",
+    state: "draft", origin: "https://mcp.example.com", source_digest: "b".repeat(64),
+    schema_digest: "", tools: [], connected: false, activation_eligible: false,
+    oauth_discovery_available: true,
+  };
+  const oauth = () => ({
+    discovery: {
+      discovery_id: "discovery", discovery_fingerprint: "c".repeat(64), status: "active",
+      resource_uri: "https://mcp.example.com/mcp", issuer: "https://auth.example.com",
+      pkce_method: "S256", token_endpoint_origin: "https://auth.example.com",
+      recommended_scopes: ["mcp:read"], recommended_scope_digest: "d".repeat(64),
+      offline_access_available: false,
+    },
+    registration: {
+      registration_id: "registration", registration_digest: "e".repeat(64),
+      status: "active", mode: "pre_registered", client_id: "public-client", revision: 1,
+    },
+    authorization_session: session.session_id ? { ...session } : null,
+    token: null,
+  });
+  let created = 0;
+  const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.endsWith("/api/mcp/hub/status")) {
+      return json({ enabled: true, remote_enabled: true, snapshot_count: 0, snapshot_at: 1 });
+    }
+    if (url.endsWith("/api/mcp/remote-auth/oauth/status")) {
+      return json({
+        enabled: true, remote_auth_enabled: true, single_owner_acknowledged: true,
+        external_master_key_available: true, external_master_key_enforced: true, storage_ready: true,
+        authorization_enabled: true, token_storage_enabled: true, supported_registration_modes: ["pre_registered"],
+      });
+    }
+    if (url.includes("/api/mcp/hub/servers?")) return json({ items: [], total: 0, next_cursor: null });
+    if (url.endsWith("/api/mcp/hub/candidates")) return json({ items: [candidate] });
+    if (url.endsWith(`/candidates/${candidateId}/oauth`) && !init?.method) return json(oauth());
+    if (url.endsWith("/oauth/authorization-sessions") && init?.method === "POST") {
+      created += 1;
+      Object.assign(session, { session_id: `session-${created}`, status: "pending", expires_at: Date.now() / 1000 + 600 });
+      return json({ authorization_session: { ...session }, authorization_url: `https://auth.example.com/authorize?state=fresh-${created}` });
+    }
+    return json({ enabled: false });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { session, fetchMock };
+}
+
 describe("McpHubPanel", () => {
+  it.each(["server status", "elapsed deadline"])("replaces an expired OAuth link using %s without replaying the old session", async (expirySource) => {
+    const { session, fetchMock } = mockOAuthAuthorization();
+    render(<McpHubPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: "创建授权链接" }));
+    expect(await screen.findByRole("link", { name: "打开授权页面" })).toHaveAttribute("href", "https://auth.example.com/authorize?state=fresh-1");
+    if (expirySource === "server status") session.status = "expired";
+    else session.expires_at = Date.now() / 1000 - 1;
+    fireEvent.click(screen.getByRole("button", { name: "刷新授权状态" }));
+    expect(await screen.findByText("授权链接已过期")).toBeVisible();
+    expect(screen.queryByRole("link", { name: "打开授权页面" })).not.toBeInTheDocument();
+    expect(screen.getByText(/旧授权码不会重试/)).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "创建新授权链接" }));
+    expect(await screen.findByRole("link", { name: "打开授权页面" })).toHaveAttribute("href", "https://auth.example.com/authorize?state=fresh-2");
+    const writes = fetchMock.mock.calls.filter(([, init]) => init?.method);
+    expect(writes).toHaveLength(2);
+    for (const [url, init] of writes) {
+      expect(String(url)).toMatch(/\/oauth\/authorization-sessions$/);
+      expect(init?.method).toBe("POST");
+      expect(JSON.parse(String(init?.body))).toEqual({
+        expected_discovery_fingerprint: "c".repeat(64), expected_registration_digest: "e".repeat(64),
+        expected_scope_digest: "d".repeat(64), request_refresh_token: false,
+      });
+    }
+  });
+
+  it("expires an idle OAuth link without making a background request", async () => {
+    const { fetchMock } = mockOAuthAuthorization();
+    render(<McpHubPanel />);
+    const create = await screen.findByRole("button", { name: "创建授权链接" });
+    vi.useFakeTimers();
+    await act(async () => { fireEvent.click(create); });
+    expect(screen.getByRole("link", { name: "打开授权页面" })).toBeVisible();
+    const calls = fetchMock.mock.calls.length;
+    await act(async () => { vi.advanceTimersByTime(600_001); });
+    expect(screen.getByText("授权链接已过期")).toBeVisible();
+    expect(screen.queryByRole("link", { name: "打开授权页面" })).not.toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(calls);
+  });
+
+  it("blocks a late click before the browser expiry timer runs", async () => {
+    const { session, fetchMock } = mockOAuthAuthorization();
+    render(<McpHubPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: "创建授权链接" }));
+    const link = await screen.findByRole("link", { name: "打开授权页面" });
+    const calls = fetchMock.mock.calls.length;
+    vi.spyOn(Date, "now").mockReturnValue(session.expires_at * 1000 + 1);
+    expect(fireEvent.click(link)).toBe(false);
+    expect(screen.getByText("授权链接已过期")).toBeVisible();
+    expect(screen.queryByRole("link", { name: "打开授权页面" })).not.toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(calls);
+  });
+
+  it("never attaches an old URL to an authorization session created in another tab", async () => {
+    const { session } = mockOAuthAuthorization();
+    render(<McpHubPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: "创建授权链接" }));
+    await screen.findByRole("link", { name: "打开授权页面" });
+    session.session_id = "other-tab-session";
+    fireEvent.click(screen.getByRole("button", { name: "刷新授权状态" }));
+    expect(await screen.findByText(/授权链接只在创建时返回/)).toBeVisible();
+    expect(screen.queryByRole("link", { name: "打开授权页面" })).not.toBeInTheDocument();
+  });
+
   it("shows the disabled-by-default boundary without loading candidates", async () => {
     const fetchMock = vi.fn(() =>
       json({
@@ -505,6 +620,7 @@ describe("McpHubPanel", () => {
     remoteRevocationEnabled = true;
     fireEvent.click(within(card!).getByRole("button", { name: "刷新授权状态" }));
     expect(await within(card!).findByText(/revision 1/)).toBeVisible();
+    expect(within(card!).queryByRole("link", { name: "打开授权页面" })).not.toBeInTheDocument();
     fireEvent.click(within(card!).getByRole("button", { name: "刷新 Token" }));
     const refreshDialog = await screen.findByRole("alertdialog", { name: "刷新 OAuth Token" });
     expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith("/refresh"))).toBe(false);

--- a/client/src/components/McpHubPanel.tsx
+++ b/client/src/components/McpHubPanel.tsx
@@ -440,7 +440,8 @@ export default function McpHubPanel() {
   const [candidateOAuth, setCandidateOAuth] = useState<Record<string, CandidateOAuthSummary>>({});
   const [oauthClientIds, setOauthClientIds] = useState<Record<string, string>>({});
   const [oauthRefreshRequests, setOauthRefreshRequests] = useState<Record<string, boolean>>({});
-  const [oauthAuthorizationUrls, setOauthAuthorizationUrls] = useState<Record<string, string>>({});
+  const [oauthAuthorizationUrls, setOauthAuthorizationUrls] = useState<Record<string, { sessionId: string; url: string }>>({});
+  const [oauthClock, setOauthClock] = useState(Date.now);
   const [candidateAuthInputs, setCandidateAuthInputs] = useState<Record<string, CandidateAuthInput>>({});
   const [reviewStatus, setReviewStatus] = useState<HubReviewStatus | null>(null);
   const [reviewSelection, setReviewSelection] = useState<HubReviewSelection[]>([]);
@@ -536,6 +537,14 @@ export default function McpHubPanel() {
         if (entry.oauth !== null) nextCandidateOAuth[entry.candidateId] = entry.oauth;
       }
       setCandidateOAuth(nextCandidateOAuth);
+      setOauthAuthorizationUrls((currentUrls) => Object.fromEntries(
+        Object.entries(currentUrls).filter(([candidateId, link]) => {
+          const oauth = nextCandidateOAuth[candidateId];
+          const session = oauth?.authorization_session;
+          return session?.status === "pending" && session.expires_at * 1000 > Date.now()
+            && session.session_id === link.sessionId && oauth.token?.status !== "active";
+        }),
+      ));
       setCandidateErrors((currentErrors) => {
         const next = { ...currentErrors };
         for (const entry of oauthEntries) {
@@ -579,6 +588,25 @@ export default function McpHubPanel() {
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    const now = Date.now();
+    const deadlines = Object.values(candidateOAuth)
+      .filter((oauth) => oauth.authorization_session?.status === "pending" && oauth.token?.status !== "active")
+      .map((oauth) => oauth.authorization_session!.expires_at * 1000)
+      .filter((deadline) => deadline > now);
+    const updateClock = () => setOauthClock(Date.now());
+    const timer = deadlines.length ? window.setTimeout(
+      updateClock, Math.min(2_147_483_647, Math.max(1, Math.ceil(Math.min(...deadlines) - now))),
+    ) : undefined;
+    window.addEventListener("focus", updateClock);
+    document.addEventListener("visibilitychange", updateClock);
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener("focus", updateClock);
+      document.removeEventListener("visibilitychange", updateClock);
+    };
+  }, [candidateOAuth, oauthClock]);
 
   const refreshHubViews = useCallback(async () => {
     await refresh();
@@ -969,10 +997,15 @@ export default function McpHubPanel() {
                 const oauthDiscovery = oauth?.discovery || null;
                 const oauthRegistration = oauth?.registration || null;
                 const oauthAuthorizationSession = oauth?.authorization_session || null;
+                const oauthAuthorizationExpired = oauthAuthorizationSession?.status === "expired" || Boolean(
+                  oauthAuthorizationSession?.status === "pending" && oauthAuthorizationSession.expires_at * 1000 <= Date.now(),
+                );
                 const oauthToken = oauth?.token || null;
                 const oauthClientId = oauthClientIds[candidate.candidate_id] || "";
                 const requestOAuthRefresh = Boolean(oauthRefreshRequests[candidate.candidate_id]);
-                const oauthAuthorizationUrl = oauthAuthorizationUrls[candidate.candidate_id] || "";
+                const oauthAuthorizationLink = oauthAuthorizationUrls[candidate.candidate_id];
+                const oauthAuthorizationUrl = oauthAuthorizationLink?.sessionId === oauthAuthorizationSession?.session_id
+                  ? oauthAuthorizationLink?.url || "" : "";
                 const oauthRuntimeReady = !candidate.oauth_discovery_available || Boolean(
                   oauth?.runtime_eligible && remoteOAuthStatus?.runtime_enabled && candidate.activation_eligible,
                 );
@@ -1397,7 +1430,7 @@ export default function McpHubPanel() {
                                     </button>
                                   </div>
                                 </div>
-                              ) : oauthAuthorizationSession?.status === "pending" ? (
+                              ) : oauthAuthorizationSession?.status === "pending" && !oauthAuthorizationExpired ? (
                                 <div className="space-y-2">
                                   <p className="font-semibold text-violet-100">等待浏览器授权</p>
                                   <p>Scope：{oauthAuthorizationSession.scopes.join("、")}</p>
@@ -1405,6 +1438,12 @@ export default function McpHubPanel() {
                                     <a
                                       className="inline-flex min-h-9 items-center rounded-md border border-violet-300/25 px-3 font-semibold text-violet-100"
                                       href={oauthAuthorizationUrl}
+                                      onClick={(event) => {
+                                        if (oauthAuthorizationSession.expires_at * 1000 <= Date.now()) {
+                                          event.preventDefault();
+                                          setOauthClock(Date.now());
+                                        }
+                                      }}
                                       rel="noreferrer noopener"
                                       target="_blank"
                                     >
@@ -1434,7 +1473,11 @@ export default function McpHubPanel() {
                                         `oauth-cancel:${candidate.candidate_id}`,
                                         () => requestJson(`/api/mcp/hub/candidates/${candidate.candidate_id}/oauth/authorization-sessions/${oauthAuthorizationSession.session_id}`, { method: "DELETE" }),
                                         () => {
-                                          setOauthAuthorizationUrls((current) => ({ ...current, [candidate.candidate_id]: "" }));
+                                          setOauthAuthorizationUrls((current) => {
+                                            const next = { ...current };
+                                            delete next[candidate.candidate_id];
+                                            return next;
+                                          });
                                           setNotice(`${candidate.server_name} 的待授权会话已取消。`);
                                         },
                                         candidate.candidate_id,
@@ -1447,7 +1490,12 @@ export default function McpHubPanel() {
                                 </div>
                               ) : (
                                 <div className="space-y-2">
-                                  <p className="font-semibold text-violet-100">使用冻结 Scope 创建一次性授权</p>
+                                  {oauthAuthorizationExpired ? (
+                                    <div className="rounded-md border border-amber-300/20 bg-amber-300/10 px-3 py-2 text-amber-100" role="status">
+                                      <p className="font-semibold">授权链接已过期</p>
+                                      <p>本次授权未完成，旧链接已失效。请创建新授权链接；旧授权码不会重试。</p>
+                                    </div>
+                                  ) : <p className="font-semibold text-violet-100">使用冻结 Scope 创建一次性授权</p>}
                                   <p>将请求：{oauthDiscovery.recommended_scopes.length ? oauthDiscovery.recommended_scopes.join("、") : "不发送 scope 参数"}</p>
                                   {oauthDiscovery.offline_access_available ? (
                                     <label className="flex items-start gap-2 rounded border border-amber-300/20 bg-amber-300/5 px-2 py-2 text-amber-100">
@@ -1467,7 +1515,7 @@ export default function McpHubPanel() {
                                     disabled={!remoteOAuthAuthorizationOperational || Boolean(busy)}
                                     onClick={() => void run(
                                       `oauth-authorize:${candidate.candidate_id}`,
-                                      () => requestJson<{ authorization_url: string }>(`/api/mcp/hub/candidates/${candidate.candidate_id}/oauth/authorization-sessions`, {
+                                      () => requestJson<{ authorization_url: string; authorization_session: { session_id: string } }>(`/api/mcp/hub/candidates/${candidate.candidate_id}/oauth/authorization-sessions`, {
                                         method: "POST",
                                         headers: { "Content-Type": "application/json" },
                                         body: JSON.stringify({
@@ -1478,14 +1526,16 @@ export default function McpHubPanel() {
                                         }),
                                       }),
                                       (result) => {
-                                        setOauthAuthorizationUrls((current) => ({ ...current, [candidate.candidate_id]: result.authorization_url }));
+                                        setOauthAuthorizationUrls((current) => ({ ...current, [candidate.candidate_id]: {
+                                          sessionId: result.authorization_session.session_id, url: result.authorization_url,
+                                        } }));
                                         setNotice(`${candidate.server_name} 的一次性授权链接已创建。`);
                                       },
                                       candidate.candidate_id,
                                     )}
                                     type="button"
                                   >
-                                    创建授权链接
+                                    {oauthAuthorizationExpired ? "创建新授权链接" : "创建授权链接"}
                                   </button>
                                 </div>
                               )}

--- a/client/src/content/help-center/articles/review-remote-mcp-auth.md
+++ b/client/src/content/help-center/articles/review-remote-mcp-auth.md
@@ -17,16 +17,14 @@
 
 GitHub 固定远程项目要求静态 Bearer Token。运维者在“认证与复核”中核对固定 Origin，只保存供应商签发的 HTTPS Token，再让 Review Factory 读取工具列表并提出一次固定的代表调用。发布契约并显式激活后，一次 `search_code` Runtime 调用由用户逐次批准；Token 旋转会让旧契约状态漂移，撤销后旧会话不能继续使用。
 
-Tako Catalog 项目则要求目标绑定的全新 OAuth 授权。Hub 中已有的 Tako Token 不会复用到 Catalog；授权、代表读取、契约发布和显式激活完成后，一次 `tako_available_data` Runtime 调用由用户逐次批准。撤销后页面立即显示“已撤销、未激活”，激活按钮失效，但无秘密契约仍可导出审计。
-
-![Tako MCP 撤销 OAuth 后显示已撤销和未激活，Runtime 激活按钮不可用](/help-center/27ab7de9/catalog-tako-runtime-revoked.png)
+Notion Hub 候选通过标准 OAuth 授权。完成授权、代表读取、契约发布和显式激活后，ModelMirror 只发布人工确认的 `notion-get-teams` 读取工具，其他工具不会因 Registry 收录而进入 Runtime。
 
 ## 操作步骤
 
 1. 打开 [MCP 工具货架](/mcps)，找到标记为远程连接且需要认证的项目。你应该能看到“认证与复核”入口，而不是任意连接配置框。
 2. 打开“认证与复核”，核对固定 Origin、认证类型和“本地单主体”提示。Origin 与预期不一致时立即停止。
 3. 按页面显示的唯一认证方式继续：静态 Token 只填写供应商访问令牌；OAuth 先重新发现元数据，再检查 Issuer、资源和推荐 Scope。页面不会接受自定义 Header 或 Scope。
-4. 保存 Token 或完成 OAuth 回调后刷新状态。你应该只看到掩码、revision 或“Token 已加密保存”，不应再次看到明文。
+4. 保存 Token 或完成 OAuth 回调后刷新状态。你应该只看到掩码、revision 或“Token 已加密保存”，不应再次看到明文。若页面显示“授权链接已过期”，不要刷新旧回调页；点击“创建新授权链接”完成授权后再刷新状态。
 5. 创建受控复核批次，等待自动阶段完成。系统会冻结认证后的工具列表和 Schema，并在代表调用前暂停。
 6. 核对精确 Origin、工具、参数和风险提示后，批准一次代表调用；只选择已实测并人工确认为只读的工具，再发布本机不可变契约。
 7. 契约发布后显式点击“激活 Runtime”。在 AI Runtime 每次展示脱敏参数时重新确认；每份批准只能调用一次，工具调用不会自动重试。
@@ -49,6 +47,12 @@ Registry 只提供身份与发现元数据，不等于安全认证。ModelMirror
 ### Hub 里已经授权过同一服务，Catalog 还需要再授权吗？
 
 需要。凭据按主体、目标类型、目标 ID、resource、issuer 和策略指纹绑定。Hub candidate 的 Token 不能用于 Catalog project；目标变化必须重新授权，避免跨目标复用 Bearer。
+
+### Hub 显示“授权链接已过期”，该怎么办？
+
+返回 [MCP Hub](/mcps?view=hub) 的“我的 Hub 连接”，核对目标名称和固定 Origin。过期后不应再看到“打开授权页面”；请按操作步骤第 4 步创建新链接。不要刷新旧回调页，也不要重用旧授权链接或授权码。
+
+若授权链接由另一标签页创建，当前页面不会复用旧链接；按页面提示取消待授权会话并重新创建。成功时应显示 Token 已加密保存及当前 revision，但授权成功仍不等于复核通过或已激活。本机过期提示不改变服务端有效期，后台不会自动重新授权、换票或调用工具。
 
 ### 服务未先返回 Bearer challenge，为什么仍可能发现 OAuth？
 

--- a/client/src/content/help-center/index.ts
+++ b/client/src/content/help-center/index.ts
@@ -77,7 +77,7 @@ export type HelpSearchEntry = {
 };
 
 export const verifiedBaseline = { commit: "cc49136c", date: "2026-08-26" };
-export const remoteMcpReviewBaseline = { commit: "27ab7de9", date: "2026-08-27" };
+export const remoteMcpReviewBaseline = { commit: "821067a7", date: "2026-08-27" };
 export const ragDiversityBaseline = { commit: "f0150fb5", date: "2026-08-27" };
 
 export const helpContentTypeLabels: Record<HelpContentType, string> = {

--- a/docs/help-center/evidence/mcp-notion-closeout-821067a7.md
+++ b/docs/help-center/evidence/mcp-notion-closeout-821067a7.md
@@ -1,0 +1,23 @@
+# MCP Notion 收口验收证据
+
+- 验证基线：`main@821067a7`，日期 `2026-08-27`。
+- 独立预览：`127.0.0.1:15287`，使用独立容器、卷和测试端口；共享栈未重建。
+- 真实目标：官方 Registry `com.notion/mcp@1.0.1`，固定 Origin `https://mcp.notion.com`。
+- 真实认证：标准 OAuth 完成，页面仅显示“Token 已加密保存”、Scope `default` 和 revision，不显示 Token、授权码或回调地址。
+- 真实复核：隔离 `initialize`、`tools/list` 和 Schema freeze 通过；人工批准 `notion-get-teams {}` 代表读取并只执行一次，远程返回成功，临时会话与 capability 已清理。
+- 契约更新：上游聚合 Schema digest 变化但 28 个逐工具 Schema、工具名、Origin、source、OAuth policy 与 Scope 均未变化；本地契约通过不可变线性 revision 从旧指纹定向 supersede 到新指纹，仓库契约仍不可被本地覆盖，分叉和错误前驱继续 fail closed。
+- Runtime 证明：新的逐次审批只产生一条 `completed` execution-ledger 记录，`retry_on_failure=false`，错误码为空，结果 digest 为 `7ad480d768704c3284a4adc6e1756279c119a9a56fffb488a83d826ab4af6f87`；调用后候选保持 `active`、`connected=false`、无污染，证明成功路径也销毁一次性会话。
+- 发布边界：契约只允许 `notion-get-teams`，其他 27 个远程工具不进入 Runtime；候选已显式激活。
+- 页面重放：Notion 显示 `active`、已复核和加密 Token；旧授权链接不存在；控制台无错误。
+- OAuth 过期恢复：自动测试覆盖服务端 `expired`、客户端截止时间、晚点击和跨标签页新会话。过期链接被隐藏，用户只能创建新会话；旧授权码不重试。
+- 帮助重放：`/help/review-remote-mcp-auth` 可见“授权链接已过期”恢复说明，操作步骤仍保持 8 步上限。
+
+## 延期项
+
+- New Relic 保持 staged：本机到供应商登录与控制台域名不可达，未保存或伪造凭据。
+- Atlassian 保持 blocked：当前 Scope 含写入能力，不以只读名义放行。
+
+## 回退
+
+- 删除本轮前端状态判断和帮助补充即可恢复旧界面；不涉及数据库迁移。
+- 关闭远程契约 Runtime 开关会停止认证型远程工具；Notion 契约、无秘密审计证据和加密 Token 保留。

--- a/server/mcp/hub.py
+++ b/server/mcp/hub.py
@@ -2843,7 +2843,13 @@ class MCPHubService:
                     self._raise_remote_auth(exc)
             tools, digest = self._validate_tools(response.get("tools"))
             expected = str(candidate.get("schema_digest") or "")
-            if expected and digest != expected:
+            review_schema_refresh = (
+                allow_oauth_review
+                and candidate.get("state") == "drifted"
+                and candidate.get("taint_reason")
+                in {"hub_schema_drift", "hub_schema_recheck_failed"}
+            )
+            if expected and digest != expected and not review_schema_refresh:
                 raise HubError("远程工具 Schema 已漂移。", code="hub_schema_drift", status_code=409)
             session_id = str(response.get("session_id") or "")
             if not session_id:
@@ -3303,6 +3309,8 @@ class MCPHubService:
                 if isinstance(exc, HubUnknownOutcomeError):
                     raise
                 raise HubUnknownOutcomeError() from exc
+            finally:
+                await self._disconnect_live(clean_id)
 
 
 class CandidateCreateRequest(BaseModel):

--- a/server/mcp/hub_contracts.py
+++ b/server/mcp/hub_contracts.py
@@ -290,10 +290,12 @@ class HubContractRegistry:
             contracts.append(normalize_contract(raw))
         return contracts
 
-    def _local_contracts(self) -> list[HubReviewedContract]:
+    def _local_contracts(
+        self,
+    ) -> tuple[list[HubReviewedContract], set[tuple[str, str, str]]]:
         if self.local_store is None or not self.signing_key:
-            return []
-        contracts: list[HubReviewedContract] = []
+            return [], set()
+        rows_by_contract: dict[str, list[tuple[HubReviewedContract, str]]] = {}
         for row in self.local_store.list_local_contract_revisions(
             self.tenant_id, self.owner_id
         ):
@@ -305,12 +307,63 @@ class HubContractRegistry:
             expected = contract_signature(contract, self.signing_key)
             if not hmac.compare_digest(expected, str(row.get("signature") or "")):
                 continue
-            contracts.append(contract)
-        return contracts
+            rows_by_contract.setdefault(contract.contract_id, []).append(
+                (contract, str(row.get("supersedes_fingerprint") or ""))
+            )
+        heads: list[HubReviewedContract] = []
+        collisions: set[tuple[str, str, str]] = set()
+        for revisions in rows_by_contract.values():
+            by_fingerprint: dict[str, HubReviewedContract] = {}
+            predecessor_by_fingerprint: dict[str, str] = {}
+            invalid = False
+            for contract, predecessor in revisions:
+                fingerprint = contract.contract_fingerprint
+                current = by_fingerprint.get(fingerprint)
+                if current is not None and current.identity != contract.identity:
+                    invalid = True
+                    break
+                by_fingerprint[fingerprint] = contract
+                if predecessor:
+                    previous = predecessor_by_fingerprint.get(fingerprint)
+                    if previous is not None and previous != predecessor:
+                        invalid = True
+                        break
+                    predecessor_by_fingerprint[fingerprint] = predecessor
+            identities = {contract.identity for contract in by_fingerprint.values()}
+            if len(identities) != 1:
+                invalid = True
+            fingerprints = set(by_fingerprint)
+            if any(
+                predecessor not in fingerprints
+                for predecessor in predecessor_by_fingerprint.values()
+            ):
+                invalid = True
+            head_fingerprints = fingerprints - set(predecessor_by_fingerprint.values())
+            if len(head_fingerprints) != 1:
+                invalid = True
+            if not invalid:
+                head_fingerprint = next(iter(head_fingerprints))
+                visited: set[str] = set()
+                cursor = head_fingerprint
+                while cursor:
+                    if cursor in visited:
+                        invalid = True
+                        break
+                    visited.add(cursor)
+                    cursor = predecessor_by_fingerprint.get(cursor, "")
+                if visited != fingerprints:
+                    invalid = True
+            identity = next(iter(identities), None)
+            if invalid:
+                if identity is not None:
+                    collisions.add(identity)
+                continue
+            heads.append(by_fingerprint[head_fingerprint])
+        return heads, collisions
 
     def all(self) -> tuple[list[HubReviewedContract], set[tuple[str, str, str]]]:
         repository = self._repository_contracts()
-        local = self._local_contracts()
+        local, local_collisions = self._local_contracts()
         by_identity: dict[tuple[str, str, str], HubReviewedContract] = {}
         collisions: set[tuple[str, str, str]] = set()
         for contract in [*repository, *local]:
@@ -319,7 +372,13 @@ class HubContractRegistry:
                 by_identity[contract.identity] = contract
             elif current.contract_fingerprint != contract.contract_fingerprint:
                 collisions.add(contract.identity)
-        return list(by_identity.values()), collisions
+        return list(by_identity.values()), collisions | local_collisions
+
+    def is_repository_contract(self, contract: HubReviewedContract) -> bool:
+        return any(
+            item.contract_fingerprint == contract.contract_fingerprint
+            for item in self._repository_contracts()
+        )
 
     def lookup_identity(
         self, server_name: str, version: str, remote_url: str

--- a/server/mcp/hub_review.py
+++ b/server/mcp/hub_review.py
@@ -220,6 +220,7 @@ class MCPHubReviewStore:
                     evidence_digest TEXT NOT NULL DEFAULT '',
                     draft_contract_json TEXT NOT NULL DEFAULT '{}',
                     contract_fingerprint TEXT NOT NULL DEFAULT '',
+                    supersedes_fingerprint TEXT NOT NULL DEFAULT '',
                     error_code TEXT NOT NULL DEFAULT '',
                     created_at REAL NOT NULL,
                     updated_at REAL NOT NULL,
@@ -280,6 +281,7 @@ class MCPHubReviewStore:
                     contract_fingerprint TEXT NOT NULL,
                     contract_json TEXT NOT NULL,
                     signature TEXT NOT NULL,
+                    supersedes_fingerprint TEXT NOT NULL DEFAULT '',
                     created_at REAL NOT NULL
                 );
                 CREATE INDEX IF NOT EXISTS idx_hub_local_contract_identity
@@ -304,6 +306,24 @@ class MCPHubReviewStore:
             if "trigger" not in columns:
                 db.execute(
                     "ALTER TABLE hub_review_runs ADD COLUMN trigger TEXT NOT NULL DEFAULT 'manual'"
+                )
+            item_columns = {
+                str(row[1])
+                for row in db.execute("PRAGMA table_info(hub_review_items)").fetchall()
+            }
+            if "supersedes_fingerprint" not in item_columns:
+                db.execute(
+                    "ALTER TABLE hub_review_items ADD COLUMN supersedes_fingerprint TEXT NOT NULL DEFAULT ''"
+                )
+            revision_columns = {
+                str(row[1])
+                for row in db.execute(
+                    "PRAGMA table_info(hub_local_contract_revisions)"
+                ).fetchall()
+            }
+            if "supersedes_fingerprint" not in revision_columns:
+                db.execute(
+                    "ALTER TABLE hub_local_contract_revisions ADD COLUMN supersedes_fingerprint TEXT NOT NULL DEFAULT ''"
                 )
 
     @staticmethod
@@ -501,6 +521,7 @@ class MCPHubReviewStore:
         evidence_digest: str | None = None,
         draft_contract: dict[str, Any] | None = None,
         contract_fingerprint: str | None = None,
+        supersedes_fingerprint: str | None = None,
         error_code: str | None = None,
     ) -> None:
         updates: list[str] = ["updated_at=?"]
@@ -511,6 +532,7 @@ class MCPHubReviewStore:
             "candidate_id": candidate_id,
             "evidence_digest": evidence_digest,
             "contract_fingerprint": contract_fingerprint,
+            "supersedes_fingerprint": supersedes_fingerprint,
             "error_code": error_code,
         }
         for column, value in mapping.items():
@@ -751,12 +773,51 @@ class MCPHubReviewStore:
         owner_id: str,
         contract: HubReviewedContractV1,
         signature: str,
+        *,
+        supersedes_fingerprint: str = "",
     ) -> dict[str, Any]:
         revision_id = "hubrevision_" + uuid.uuid4().hex
         now = time.time()
         with self._lock, self._connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            rows = db.execute(
+                "SELECT contract_fingerprint,supersedes_fingerprint FROM hub_local_contract_revisions "
+                "WHERE tenant_id=? AND owner_id=? AND contract_id=? ORDER BY created_at,revision_id",
+                (tenant_id, owner_id, contract.contract_id),
+            ).fetchall()
+            current_heads = {
+                str(row["contract_fingerprint"])
+                for row in rows
+            } - {
+                str(row["supersedes_fingerprint"])
+                for row in rows
+                if str(row["supersedes_fingerprint"])
+            }
+            if len(current_heads) > 1:
+                raise HubError(
+                    "本机契约 revision 已分叉。",
+                    code="hub_contract_collision",
+                    status_code=409,
+                )
+            current_head = next(iter(current_heads), "")
+            if current_head and current_head != contract.contract_fingerprint:
+                if supersedes_fingerprint != current_head:
+                    raise HubError(
+                        "本机契约前驱已变化。",
+                        code="hub_contract_supersession_required",
+                        status_code=409,
+                    )
+            elif supersedes_fingerprint and supersedes_fingerprint != current_head:
+                raise HubError(
+                    "本机契约前驱无效。",
+                    code="hub_contract_supersession_required",
+                    status_code=409,
+                )
             db.execute(
-                "INSERT INTO hub_local_contract_revisions VALUES(?,?,?,?,?,?,?,?)",
+                "INSERT INTO hub_local_contract_revisions("
+                "revision_id,tenant_id,owner_id,contract_id,contract_fingerprint,"
+                "contract_json,signature,supersedes_fingerprint,created_at"
+                ") VALUES(?,?,?,?,?,?,?,?,?)",
                 (
                     revision_id,
                     tenant_id,
@@ -765,6 +826,7 @@ class MCPHubReviewStore:
                     contract.contract_fingerprint,
                     contract_export(contract).decode("utf-8").strip(),
                     signature,
+                    supersedes_fingerprint,
                     now,
                 ),
             )
@@ -772,6 +834,7 @@ class MCPHubReviewStore:
             "revision_id": revision_id,
             "contract_id": contract.contract_id,
             "contract_fingerprint": contract.contract_fingerprint,
+            "supersedes_fingerprint": supersedes_fingerprint,
             "created_at": now,
         }
 
@@ -1875,6 +1938,14 @@ class MCPHubReviewService:
             evidence.snapshot.version,
             evidence.snapshot.remote_url,
         )
+        supersedes_fingerprint = ""
+        reuse_existing = False
+        if reason == "hub_contract_collision":
+            raise HubError(
+                "同一身份的契约 revision 已冲突。",
+                code=reason,
+                status_code=409,
+            )
         if existing is not None and not reason:
             expected_policy = None
             if isinstance(evidence, HubEvidenceBundleV2):
@@ -1890,7 +1961,7 @@ class MCPHubReviewService:
                 if isinstance(evidence, HubEvidenceBundleV3)
                 else None
             )
-            if (
+            execution_changed = (
                 existing.schema_digest != evidence.schema_digest
                 or existing.tool_schema_digests != evidence.tool_schema_digests
                 or set(existing.allowed_tools) != set(unique_tools)
@@ -1904,10 +1975,19 @@ class MCPHubReviewService:
                     if isinstance(evidence, HubEvidenceBundleV3)
                     else ()
                 )
-            ):
-                raise HubError("同一身份的仓库契约不一致。", code="hub_contract_collision", status_code=409)
-            contract = existing
-        else:
+            )
+            if execution_changed:
+                if self.contracts.is_repository_contract(existing):
+                    raise HubError(
+                        "同一身份的仓库契约不一致。",
+                        code="hub_contract_collision",
+                        status_code=409,
+                    )
+                supersedes_fingerprint = existing.contract_fingerprint
+            else:
+                contract = existing
+                reuse_existing = True
+        if not reuse_existing:
             contract_fields: dict[str, Any] = {
                 "contract_id": stable_contract_id(
                     evidence.snapshot.server_name,
@@ -1965,6 +2045,7 @@ class MCPHubReviewService:
             state="approved",
             draft_contract=contract.model_dump(mode="json"),
             contract_fingerprint=contract.contract_fingerprint,
+            supersedes_fingerprint=supersedes_fingerprint,
             error_code="",
         )
         self._event(
@@ -1974,6 +2055,7 @@ class MCPHubReviewService:
             payload={
                 "decision": "approve",
                 "contract_fingerprint": contract.contract_fingerprint,
+                "supersedes_fingerprint": supersedes_fingerprint,
                 "unknown_oauth_scopes_acknowledged": bool(
                     isinstance(evidence, HubEvidenceBundleV3)
                     and evidence.scope_assessment.get("unknown_scopes")
@@ -2040,7 +2122,11 @@ class MCPHubReviewService:
         contract = normalize_contract(item["draft_contract"])
         signature = contract_signature(contract, self.signing_key)
         revision = self.store.add_local_contract_revision(
-            self.tenant_id, self.owner_id, contract, signature
+            self.tenant_id,
+            self.owner_id,
+            contract,
+            signature,
+            supersedes_fingerprint=str(item.get("supersedes_fingerprint") or ""),
         )
         self.store.add_revocation(
             self.tenant_id, self.owner_id, contract.contract_id, "restore", "published revision"

--- a/server/tests/smoke_mcp_hub_runtime_approval.py
+++ b/server/tests/smoke_mcp_hub_runtime_approval.py
@@ -213,9 +213,9 @@ async def run(
     )
     if result.is_error:
         raise RuntimeError("runtime_representative_call_failed")
-    connected_before_revoke = hub.get_candidate(candidate["candidate_id"])["connected"]
-    if not connected_before_revoke:
-        raise RuntimeError("runtime_session_not_connected")
+    connected_after_call = hub.get_candidate(candidate["candidate_id"])["connected"]
+    if connected_after_call:
+        raise RuntimeError("runtime_session_cleanup_failed")
 
     revoked_contract_id = ""
     disconnected_candidates: list[str] = []
@@ -233,7 +233,7 @@ async def run(
         if connected_after_revoke or remaining_tools:
             raise RuntimeError("contract_revocation_not_immediate")
     else:
-        connected_after_revoke = connected_before_revoke
+        connected_after_revoke = connected_after_call
         remaining_tools = [tool]
 
     output = result.output or ""
@@ -248,7 +248,7 @@ async def run(
         "retry_on_failure": False,
         "result_bytes": len(output.encode("utf-8")),
         "result_sha256": hashlib.sha256(output.encode("utf-8")).hexdigest(),
-        "connected_before_revoke": connected_before_revoke,
+        "connected_after_call": connected_after_call,
         "connected_after_revoke": connected_after_revoke,
         "revoked_contract_id": revoked_contract_id,
         "disconnected_candidates": disconnected_candidates,

--- a/server/tests/test_mcp_hub.py
+++ b/server/tests/test_mcp_hub.py
@@ -978,6 +978,9 @@ async def test_every_call_rechecks_schema_and_completed_approval_replays_cache(
     assert first["content"][0]["text"] == "result:safe"
     assert bridge.list_count == 1
     assert bridge.call_count == 1
+    assert service.get_candidate(candidate["candidate_id"])["connected"] is False
+    assert len(bridge.closed) == 1
+    assert len(bridge.revoked) == 1
 
     await service.disconnect(candidate["candidate_id"])
     replay = await service.execute(
@@ -1017,6 +1020,7 @@ async def test_expired_sidecar_session_reconnects_only_before_tool_call(
     assert bridge.list_count == 2
     assert bridge.call_count == 1
     assert service.get_candidate(candidate["candidate_id"])["state"] == "active"
+    assert service.get_candidate(candidate["candidate_id"])["connected"] is False
 
 
 @pytest.mark.asyncio
@@ -1060,6 +1064,66 @@ async def test_schema_drift_blocks_call_before_ledger_start(tmp_path: Path) -> N
     assert bridge.open_count == 1
     assert bridge.call_count == 0
     assert service.get_candidate(candidate["candidate_id"])["state"] == "drifted"
+
+
+@pytest.mark.asyncio
+async def test_oauth_review_can_refresh_only_schema_drifted_candidate(
+    tmp_path: Path,
+) -> None:
+    bridge = FakeBridge()
+    service = make_service(tmp_path, bridge=bridge)
+    candidate, runtime = await active_candidate(service)
+    old_schema_digest = candidate["schema_digest"]
+    bridge.tools = [
+        {
+            **TOOLS[0],
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "maxLength": 120},
+                },
+                "required": ["query"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+
+    with pytest.raises(HubError, match="Schema"):
+        await service.execute(
+            candidate_id=candidate["candidate_id"],
+            runtime_tool_name=runtime["name"],
+            upstream_tool_name=runtime["upstream_tool_name"],
+            arguments={"query": "safe"},
+            approval=approval_for(
+                service, candidate, runtime, {"query": "safe"}
+            ),
+        )
+    drifted = service.store.require_candidate(
+        candidate["candidate_id"], service.tenant_id, service.owner_id
+    )
+    assert drifted["state"] == "drifted"
+    assert drifted["taint_reason"] in {
+        "hub_schema_drift",
+        "hub_schema_recheck_failed",
+    }
+    assert bridge.call_count == 0
+
+    with pytest.raises(HubError) as source_drift:
+        await service._open_candidate(
+            {**drifted, "taint_reason": "hub_source_drift"},
+            allow_oauth_review=True,
+        )
+    assert source_drift.value.code == "hub_schema_drift"
+
+    try:
+        await service._open_candidate(drifted, allow_oauth_review=True)
+        refreshed = service.get_candidate(candidate["candidate_id"])
+        assert refreshed["state"] == "verified"
+        assert refreshed["taint_reason"] == ""
+        assert refreshed["schema_digest"] != old_schema_digest
+        assert bridge.call_count == 0
+    finally:
+        await service._disconnect_live(candidate["candidate_id"])
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_mcp_hub_review_factory.py
+++ b/server/tests/test_mcp_hub_review_factory.py
@@ -326,6 +326,81 @@ def test_contract_fingerprint_hmac_collision_and_revocation(tmp_path: Path) -> N
     assert valid.lookup_identity(*contract.identity)[1] == "hub_contract_revoked"
 
 
+def test_local_contract_revision_requires_linear_supersession(tmp_path: Path) -> None:
+    store = MCPHubReviewStore(MCPHubStore(tmp_path))
+    key = "contract-signing-key-with-more-than-32-bytes"
+    first = HubReviewedContractV1(
+        contract_id=stable_contract_id(
+            "io.example/contract", "1.0.0", "https://contract.example/mcp"
+        ),
+        server_name="io.example/contract",
+        version="1.0.0",
+        remote_url="https://contract.example/mcp",
+        origin="https://contract.example",
+        source_digest="3" * 64,
+        schema_digest="1" * 64,
+        tool_schema_digests={"search": "2" * 64},
+        allowed_tools=["search"],
+        tool_effects={"search": "read"},
+        limits={"max_result_bytes": 1024},
+        evidence_digest="4" * 64,
+    )
+    second = normalize_contract(
+        {
+            **first.model_dump(mode="json"),
+            "schema_digest": "5" * 64,
+            "evidence_digest": "6" * 64,
+            "contract_fingerprint": "",
+        }
+    )
+    store.add_local_contract_revision(
+        "tenant-a", "owner-a", first, contract_signature(first, key)
+    )
+
+    with pytest.raises(HubError) as stale:
+        store.add_local_contract_revision(
+            "tenant-a", "owner-a", second, contract_signature(second, key)
+        )
+    assert stale.value.code == "hub_contract_supersession_required"
+
+    revision = store.add_local_contract_revision(
+        "tenant-a",
+        "owner-a",
+        second,
+        contract_signature(second, key),
+        supersedes_fingerprint=first.contract_fingerprint,
+    )
+    assert revision["supersedes_fingerprint"] == first.contract_fingerprint
+    registry = HubContractRegistry(
+        local_store=store,
+        tenant_id="tenant-a",
+        owner_id="owner-a",
+        signing_key=key,
+        repository_dir=tmp_path / "empty",
+    )
+    loaded, reason = registry.lookup_identity(*first.identity)
+    assert reason == ""
+    assert loaded == second
+
+    third = normalize_contract(
+        {
+            **second.model_dump(mode="json"),
+            "schema_digest": "7" * 64,
+            "evidence_digest": "8" * 64,
+            "contract_fingerprint": "",
+        }
+    )
+    with pytest.raises(HubError) as wrong_predecessor:
+        store.add_local_contract_revision(
+            "tenant-a",
+            "owner-a",
+            third,
+            contract_signature(third, key),
+            supersedes_fingerprint=first.contract_fingerprint,
+        )
+    assert wrong_predecessor.value.code == "hub_contract_supersession_required"
+
+
 def test_v2_contract_freezes_auth_policy_without_changing_v1_loader() -> None:
     remote_url = "https://token.example/mcp"
     policy = RemoteAuthPolicyV1(


### PR DESCRIPTION
## 摘要

- 完成认证型远程 MCP 的 Runtime 收口：调用后统一销毁临时会话与 capability。
- 为本地复核契约加入不可变线性 supersession，保持仓库契约优先并对分叉、缺失前驱和多 head 失败关闭。
- 收紧 OAuth Schema 漂移复核触发条件，避免正常激活路径错误刷新复核证据。
- 完善 MCP Hub OAuth 过期会话恢复、人工验收提示与帮助中心证据。

## 真实验收证据

- 隔离预览环境完成 Notion OAuth 授权、Review Factory 复核、契约发布、激活和 Runtime 逐次审批调用。
- 仅放行 notion-get-teams，其他 27 个工具未进入契约。
- 新审批下代表调用只执行一次，execution ledger 状态为 completed，错误为空。
- 调用后候选保持 active 且 connected=false，证明成功路径也已清理临时会话。
- New Relic 保持 staged；Atlassian 因真实授权门槛未满足继续 blocked，未制造替代证据。

## 验证

- 关键后端：81 passed。
- 认证/目录相关定向后端：179 passed。
- Workflow contract：6 passed。
- 完整后端：4998 passed, 29 skipped。
- 前端完整测试：122 files / 751 tests passed。
- 最新主线衔接后：typecheck 通过；McpHubPanel 17 passed；生产 build 通过。
- orchestration worker：build 通过；75 个主测试及 upstream 测试通过。
- docker compose config --quiet、git diff --check、Secret 差异扫描均通过。

## Help Center Impact

- 更新远程 MCP 认证复核操作说明与验证基线。
- 增加 Notion 真实闭环验收证据，明确逐次审批、单工具 allowlist、会话清理和未覆盖边界。

## 边界与回退

- 未重建或修改共享栈，仅使用隔离预览环境。
- 未新增多租户 RBAC、任意 URL/Header、stdio 自定义连接或新认证方式。
- 可通过关闭统一 review/runtime 开关、撤销契约并断开候选回退；保留无秘密审计证据。