### PR TITLE
feature: 添加 AI Research V0.1 文献工作台

### DIFF
--- a/.github/workflows/ai-research.yml
+++ b/.github/workflows/ai-research.yml
@@ -1,4 +1,4 @@
-name: AI Research AR1
+name: AI Research V0.1
 
 on:
   pull_request:
@@ -6,12 +6,22 @@ on:
       - "extensions/ai-research/**"
       - ".dockerignore"
       - ".github/workflows/ai-research.yml"
+      - "server/main.py"
+      - "server/model_router/ai_research_bridge.py"
+      - "server/model_router/chat_stable.py"
+      - "server/tests/test_ai_research_bridge.py"
+      - "server/tests/test_provider_chat_stable_service.py"
   push:
     branches: [main]
     paths:
       - "extensions/ai-research/**"
       - ".dockerignore"
       - ".github/workflows/ai-research.yml"
+      - "server/main.py"
+      - "server/model_router/ai_research_bridge.py"
+      - "server/model_router/chat_stable.py"
+      - "server/tests/test_ai_research_bridge.py"
+      - "server/tests/test_provider_chat_stable_service.py"
 
 permissions:
   contents: read
@@ -22,7 +32,7 @@ concurrency:
 
 jobs:
   verify:
-    name: Boundary, contracts, images, and fixture smoke
+    name: Boundary, literature contracts, images, and fixture smoke
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -45,18 +55,22 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12.13"
-      - name: Verify AR1
+      - name: Install core server test dependencies
+        run: python -m pip install -r server/requirements.txt
+      - name: Verify restricted model bridge
+        run: python -m pytest server/tests/test_ai_research_bridge.py server/tests/test_provider_chat_stable_service.py -q
+      - name: Verify V0.1 development candidate
         working-directory: extensions/ai-research
-        run: bash scripts/verify.sh origin/main full
+        run: bash scripts/verify.sh origin/main full external-pull
       - name: Preserve module logs on failure
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ai-research-ar1-diagnostics
+          name: ai-research-v0-1-diagnostics
           path: extensions/ai-research/runtime/diagnostics
           if-no-files-found: ignore
           retention-days: 7
       - name: Stop optional module without deleting evidence volumes
         if: always()
         working-directory: extensions/ai-research
-        run: docker compose -f compose.yml --profile ai-research down
+        run: docker compose -f compose.yml --profile literature down

--- a/extensions/ai-research/.gitignore
+++ b/extensions/ai-research/.gitignore
@@ -1,6 +1,8 @@
 runtime/
+.venv/
 **/__pycache__/
 *.py[cod]
 .pytest_cache/
+control/ui-dist/
 ui/node_modules/
 ui/dist/

--- a/extensions/ai-research/AGENTS.md
+++ b/extensions/ai-research/AGENTS.md
@@ -1,20 +1,30 @@
-# ModelMirror AI Research AR1 collaboration rules
+# ModelMirror AI Research V0.1 collaboration rules
 
 These rules apply to every file under `extensions/ai-research/`.
 
+## Normative V0 roadmap
+
+- `AI_RESEARCH_V0_ROADMAP.md` is the normative product, upstream reuse, round sequencing, self-development boundary, and completion baseline for AI Research V0.
+- Every V0 task must identify its roadmap round, user-visible research action, reused upstream and source lock, ModelMirror-owned adapter scope, acceptance artifacts, and remaining stages.
+- Security, licensing, adaptation, isolation, and evidence are gates inside a product round. They do not replace user-visible capability or justify claiming a round complete.
+- A deviation requires a roadmap-defined necessary condition, a written Roadmap Amendment with evidence and the smallest viable change, and explicit user approval before implementation.
+
 ## Boundary
 
-- This directory is an optional, fixture-only engineering module. It is not a scientific benchmark, model integration, leaderboard, or production multi-tenant service.
+- This directory is an optional AI/Agent research extension. AR1 execution remains fixture-only; V0.1 additionally permits the approved live literature workflow through fixed Local Deep Research adapters.
+- Live literature capability must remain `scientificClaim=none`. It is not a scientific benchmark, leaderboard, autonomous research system, or production multi-tenant service.
 - The Research Console is module-local. Its source, lockfile, build, static output, and runtime must remain independent of the parent client.
-- Runtime code must not import, open, mount, or depend on parent `client/`, `server/`, configuration, credentials, databases, storage, or build outputs.
-- Parent changes are limited to `.dockerignore` and `.github/workflows/ai-research.yml`. Any other parent change requires a separate approved task.
+- Runtime code must not import, open, or mount parent `client/`, `server/`, databases, storage, credentials, or build outputs. The only parent runtime integration is the approved, bearer-authenticated local model bridge over HTTP.
+- Parent changes for V0.1 are limited to the model bridge under `server/model_router/`, minimal `server/main.py` registration, corresponding server tests, and the existing AI Research CI workflow.
 - Do not add this module to the root Compose file, root Python requirements, client dependencies, Plugin manifests, Studio routes, or default images.
-- Do not accept arbitrary commands, module paths, environment variables, model identifiers, prompts, uploads, provider keys, or EvalPack installation requests.
+- Do not accept arbitrary commands, module paths, environment variables, model identifiers, prompts, uploads, provider keys, search-engine settings, or EvalPack installation requests.
 
 ## Upstream reuse
 
 - Inspect AI is fixed to 0.3.260 and may only be driven through its public CLI, control CLI, and log CLI.
 - MLflow is fixed to 3.15.1 and may only be used through its documented server and client interfaces.
+- Local Deep Research is fixed to v1.10.6 and may only be driven through its documented HTTP/session routes. Do not import its Python package or inspect its encrypted database.
+- OpenAlex and Zotero access must flow through Local Deep Research. Zotero credentials never enter ModelMirror APIs, UI state, project files, or logs.
 - Do not patch upstream scientific tasks or scorers. Test fixtures must stay clearly labelled `fixture_only` and `harness_only`.
 - Keep exact dependency locks, source hashes, image digests, licenses, notices, and an auditable upgrade boundary.
 - UI dependencies must use exact versions and registry integrity locks. `workspace:`, `file:`, symlinks, and parent source imports are forbidden.
@@ -26,6 +36,7 @@ These rules apply to every file under `extensions/ai-research/`.
 - Persist `cancelRequested`, `cancelApplied`, and raw upstream terminal status separately.
 - Do not emit scientific metric names or claims. Allowed metrics are operational only.
 - No credentials, full host environment, parent physical paths, runtime databases, logs, or generated artifacts may be committed.
+- LDR passwords, session cookies, and CSRF tokens are memory-only. The scoped model-bridge token may be supplied independently to the core server and extension, but must never be persisted in `research.yaml`, the control ledger, MLflow, artifacts, or browser storage.
 
 ## Work method
 

--- a/extensions/ai-research/AI_RESEARCH_V0_ROADMAP.md
+++ b/extensions/ai-research/AI_RESEARCH_V0_ROADMAP.md
@@ -1,0 +1,381 @@
+# 模镜科研 V0 锁定路线图
+
+> 状态：**V0 规范性基线（Locked）**
+> 锁定日期：2026-08-24
+> 适用范围：`extensions/ai-research/` 在 V0 完整科研线形成前的产品、架构与分轮实施
+> 当前实现：V0.1 / `0.3.0-v0.1` 实施中；AR1 夹具仍为 `fixture_only`、`harness_only`，文献能力固定 `scientificClaim=none`
+
+本文是模镜科研 V0 的决策基线，不是愿景清单。后续实现计划、代码审查和批次验收必须以本文为参照。除本文“变更控制”列出的必要情形外，不得因实现者偏好、记忆、局部优化或临时技术兴趣改变产品主线、阶段顺序、开源组合或自研边界。
+
+本文锁定未来方向，但**不自行授权**当前 AR1 接入模型、数据、外部服务或真实 EvalPack。每一轮仍须单独制定任务卡、确认来源锁和许可证，并遵守当时获批的实施范围。
+
+## 1. 产品定义
+
+模镜科研 V0 的固定产品身份是：
+
+> **AI/Agent Research Project Workbench**：复用成熟开源项目，形成从研究问题到可复核成果包的一条完整 AI/Agent 科研主干。
+
+V0 面向真实的 AI、机器学习、大模型和 Agent 研究过程，而不是泛化到全部 AI4S 学科。它应让研究者在同一 Research Project 下完成：
+
+```text
+创建项目与研究问题
+→ 文献检索、导入与资料库
+→ 带引用的综述与研究缺口
+→ 候选假设、人工选择与实验协议
+→ Jupyter 交互工作区、代码、数据和基线
+→ R&D-Agent 提议—实现—反馈迭代
+→ Inspect / Inspect Evals 固定评测
+→ MLflow 参数、工程指标、trace 与制品
+→ Notebook 分析、图表、结论与局限
+→ Quarto HTML / PDF / DOCX 报告
+→ Git + DVC + source-lock + receipt 可复现成果包
+```
+
+Inspect、MLflow、证据账本和 AR1 Research Console 是执行与复核底座，不是产品中心。单个 EvalPack 是科研项目中的评测内容，不定义模镜科研的产品身份。
+
+## 2. 当前事实与产品缺口
+
+截至 AR1，已交付的是 fixture-only 工程底座：受控创建、排队、运行、取消、Inspect 原始终态、MLflow 记录、证据完整性、只读 Inspect View、网页复核和重启恢复。
+
+| 科研能力 | 当前状态 | V0 要达到的状态 |
+| --- | --- | --- |
+| 工程夹具执行、取消、证据 | 已有 AR0/AR1 底座 | 归入真实 Research Project |
+| Research Project | 已完成真实创建、运行、重启恢复与复核 | 可创建、恢复、导出项目 |
+| 文献检索、资料库、引用 | OpenAlex 真实检索及 Zotero 4/4 同步、索引、关联已验收 | 可检索、Zotero 导入、保存来源和引用 |
+| 综述与研究缺口 | 已有一项独立 OpenAlex 成果包完整性 `verified`；Zotero 关联项目因上游 Quarto/BibTeX 引用键不一致未通过 | 形成可追溯引用的综述文档 |
+| 假设与实验协议 | 未开始 | 候选假设、人工批准、冻结协议 |
+| Jupyter 科研工作区 | 未开始 | 可查看和操作代码、数据、Notebook |
+| AI/ML 研究迭代 | 未开始 | 通过上游 R&D-Agent 进行受控迭代 |
+| 真实模型/Agent 评测 | 未开始，仅工程夹具 | 接一个原版合格 EvalPack |
+| 实验追踪 | MLflow 工程底座已存在 | 与项目、迭代、评测和报告关联 |
+| 分析、报告、复现包 | 未开始 | 可分析、渲染和重放 |
+
+因此，AR1 不能被表述为“科研产品已成形”；准确表述是“完整科研线所需的执行与证据底座已存在”。只有 V0.1 至 V0.5 全部通过，才可声明形成完整科研线 V0。
+
+## 3. 固定开源组合
+
+### 3.1 主组合
+
+| 科研阶段 | 固定上游职责 | V0 复用方式 | 规划基线 |
+| --- | --- | --- | --- |
+| 全流程蓝图 | [Agent Laboratory](https://github.com/SamuelSchmidgall/AgentLaboratory) | 参考其文献、实验、报告阶段结构、角色、检查点和笔记格式；不作为唯一运行时 | MIT；调研 commit `d9017d90e329112d2a80b7712f37ee9094d2cd27` |
+| 文献与知识 | [Local Deep Research](https://github.com/LearningCircuit/local-deep-research) | 直接作为独立服务复用其检索、资料库、引用报告、历史、笔记和 Zotero 同步能力 | 项目 MIT；V0.1 经 A7 固定 `v1.10.6`、commit `641308272b2143df89c7a946051d2f05ca29b3c1`，官方镜像许可证另按 SBOM 处置 |
+| 文献数据与导入 | [OpenAlex](https://openalex.org/) 与 [Zotero Web API v3](https://www.zotero.org/support/dev/web_api/v3/start) | 通过 Local Deep Research 或固定适配调用；使用公开交换格式 | OpenAlex 数据/API CC0；不打包 Zotero AGPL 客户端源码 |
+| 假设与研发迭代 | [Microsoft R&D-Agent](https://github.com/microsoft/RD-Agent) | 直接复用 Research/Development 提议、实现和反馈循环；模镜只提供固定输入输出与受控运行包装 | MIT；候选版本 `v0.8.0`，调研 commit `6762f84f9bc0f5c6486c50a00e128a57ac6c3683` |
+| 交互计算 | [JupyterLab](https://github.com/jupyterlab/jupyterlab) | 使用上游工作区，不自研 Notebook 编辑器 | BSD-3-Clause；候选版本 `v4.6.3` |
+| 代码与数据版本 | [Git](https://git-scm.com/) + [DVC](https://github.com/iterative/dvc) | Git 管代码和文本；DVC 管数据与大制品，V0 使用模块本地命名卷 remote | DVC Apache-2.0；候选版本 `3.67.1` |
+| 评测 | [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) + [Inspect Evals](https://github.com/UKGovernmentBEIS/inspect_evals) | 沿用 Inspect 公共接口并只接一个通过资格门禁的原版 EvalPack | Inspect AI 当前固定 `0.3.260`；Inspect Evals MIT，候选版本 `v0.18.0` |
+| 追踪与证据 | [MLflow](https://github.com/mlflow/mlflow) + 模块账本/receipt | MLflow 记录参数、工程指标、trace 和 artifacts；账本保持生命周期与证据权威 | MLflow Apache-2.0，当前固定 `3.15.1` |
+| 分析 | Jupyter + [Polars](https://github.com/pola-rs/polars) / [DuckDB](https://github.com/duckdb/duckdb) | 作为 Notebook 分析库使用，不自研分析引擎 | 精确版本在 V0.5 实施时锁定 |
+| 报告发布 | [Quarto](https://github.com/quarto-dev/quarto-cli) | 从 Notebook、QMD、BibTeX 与 CSL 渲染 HTML/PDF/DOCX | MIT；候选版本 `v1.10.18` |
+
+表中的版本和 commit 是规划时的候选基线，不等于已经安装或纳入 `source-lock.json`。进入相应实施轮次时必须重新确认精确版本、依赖、镜像、许可证、可再分发性和兼容性，随后才写入来源锁；不得凭“最新版本”浮动安装。
+
+### 3.2 非默认与明确降级项
+
+- [Open Notebook](https://github.com/lfnovo/open-notebook)：适合笔记和多模态资料，但与 Local Deep Research 的资料库职责重叠，V0 不作为默认服务。
+- [PaperQA2](https://github.com/Future-House/paper-qa)：可在后续作为论文精读引擎候选，不替代完整文献工作台；调研候选版本 `v2026.08.12`，Apache-2.0。
+- STORM、GPT Researcher：与 Local Deep Research 主职责重叠，V0 不并行引入。
+- [AIDE](https://github.com/WecoAI/aideml)：在 R&D-Agent 无法满足固定 AI/ML 研发切口时作为窄化备选，不能无审批直接替换。
+- AI Scientist v2：仅作设计参考。其自定义 Source Code License、自动代码执行、GPU 与成本边界不适合作为 V0 默认分发组件。
+- SearXNG：V0 默认不单独部署，避免在已有文献检索主服务之外增加 AGPL 和运维面。
+
+## 4. 自研边界
+
+### 4.1 模镜允许拥有的控制面代码
+
+- `ResearchProject` 清单、阶段状态和统一导航外壳。
+- 模块服务启动、健康状态和经校验的深链接。
+- 固定、可版本化的输入输出适配器。
+- 面向既有模镜模型路由的本机 OpenAI 兼容控制桥；Provider key 仍留在模镜侧。
+- 项目文件索引、制品关联、source-lock 和 receipt 汇总。
+- 上游阶段间的显式交接和人工批准检查点。
+
+这些代码只承担控制面、适配、证据和安全约束，不承担科研方法本身。
+
+### 4.2 V0 禁止自研的科研能力
+
+- 论文搜索、排名、推荐算法或自有文献 RAG。
+- 自有科研规划器、假设生成算法或实验设计算法。
+- 自有代码/实验 Agent、模型算法或提示策略。
+- 自有 EvalPack、数据集、oracle、scorer、排行榜或科学指标。
+- 自有 Notebook 编辑器、实验追踪器、论文写作/排版引擎或数据版本器。
+
+若上游没有某项能力，V0 应显示“暂不支持”或延后，而不是临时补写一套自有科研逻辑。任何例外必须走本文第 9 节的路线变更流程。
+
+## 5. 开放交换格式与项目成果
+
+V0 不创造统一科研数据库，也不复制上游内部数据模型。阶段间使用可检查、可导出、可替换的开放文件与标识交接：
+
+| 对象 | 固定交换形式 |
+| --- | --- |
+| 项目控制面 | `research.yaml` + Markdown |
+| 文献 | BibTeX、RIS、CSL JSON、PDF 与来源 URL |
+| 综述 | Markdown + citation keys |
+| 假设与实验协议 | YAML + Markdown |
+| 代码与配置 | Git revision |
+| 数据与大制品 | DVC revision |
+| 交互分析 | `.ipynb` |
+| 评测 | Inspect EvalLog |
+| 追踪 | MLflow experiment/run/trace/artifact IDs |
+| 报告 | `.qmd`、HTML、PDF、DOCX |
+| 重放 | source-lock、receipt、Git/DVC revision 与 replay instructions |
+
+`research.yaml` 只是跨服务控制清单，不演变成新的工作流语言、科研算法描述语言或上游数据模型副本。
+
+## 6. 模块与服务架构
+
+模镜科研继续作为独立、可选、可拆分扩展，不进入默认主包。规划服务面为：
+
+- 现有执行/证据层：Control、Tracking、Worker、Inspect View。
+- 文献层：Local Deep Research 独立服务；V0 不默认附加 SearXNG。
+- 研发层：R&D-Agent + 受控 Linux/Docker sandbox。
+- 工作区层：JupyterLab + Git/DVC + 分析库 + Quarto。
+
+每层使用独立镜像、依赖、命名卷和显式 profile。默认 ModelMirror 镜像、根 Compose、`client/` 和 `server/` 不因安装源码而增大。Research Console 最终演化为项目控制台，但可以通过本机安全深链接打开成熟上游 UI；V0 不为“统一视觉”重写上游完整界面，也不要求 iframe。
+
+项目成果以项目目录和作用域挂载为中心；各上游服务保留自己的内部存储。V0 不引入跨服务统一主数据库。
+
+模型控制桥是 V0.1 的必要平台适配，不是产品主线：它为上游服务提供本机、固定身份、OpenAI 兼容入口，保护 Provider key；V0 不增加多租户、计费、预算、商业化配额或通用 S2S 平台。
+
+## 7. 固定分轮路线
+
+### 已完成底座
+
+- **AR0 / 0.1**：fixture-only Inspect 执行、终态、取消、账本、MLflow 与 evidence receipt。
+- **AR1 / 0.2**：fixture-only Research Console、运行/事件/证据/系统页面与 Inspect View。
+
+### V0.1：Research Project 与文献工作台
+
+**用户完成什么**：创建真实 AI/Agent 研究项目，填写研究问题，启动 Local Deep Research，检索论文、导入 Zotero、保存资料库，并生成带引用的综述和研究缺口。
+
+**复用组件**：Local Deep Research、OpenAlex、Zotero API；模镜实现 Research Project 控制清单、服务状态、固定交换适配和本机模型控制桥。
+
+**产品页面**：项目列表、项目概览、Sources/Library、Literature Review、服务状态。
+
+**验收产物**：
+
+- 可重启恢复的 `research.yaml`。
+- 至少一个真实 AI/Agent 主题的资料库。
+- `literature-review.md`、引用键和 `references.bib`。
+- 可核对的来源 URL、导入信息和 source bundle。
+
+### V0.2：候选假设与实验协议
+
+**用户完成什么**：从综述和研究缺口生成候选假设，人工选择一个假设，生成、编辑并冻结实验协议。
+
+**复用组件**：R&D-Agent Research 阶段；参考 Agent Laboratory 的阶段、角色、检查点与笔记格式，不自研科研 planner。
+
+**固定协议字段**：研究问题、批准假设、baseline、自变量、数据集、指标、计算约束、停止条件、预期制品和风险/局限。
+
+**产品页面**：Research Question、Candidate Hypotheses、Approved Hypothesis、Protocol、Checkpoint History。
+
+**验收产物**：版本化 `hypotheses.md`、人工批准事件、`experiment-protocol.yaml` 和协议哈希。未批准假设不得进入研发执行。
+
+### V0.3：Jupyter 工作区与 R&D 迭代
+
+**用户完成什么**：打开项目 Notebook，检查代码、数据和 baseline，启动 R&D-Agent Development 阶段，观察提议—实现—反馈迭代，并人工批准或拒绝每轮结果。
+
+**复用组件**：JupyterLab、R&D-Agent、Git、DVC 和受控 sandbox；不自研 Notebook 或代码 Agent。
+
+**产品页面**：Workspace、Code Revision、Data Revision、Experiment Iterations、单轮输入/输出/状态。
+
+**验收产物**：可打开的 `.ipynb`、Git commits、DVC revisions、每轮输入输出、运行日志、批准/拒绝记录和失败恢复证据。
+
+### V0.4：真实评测与实验追踪
+
+**用户完成什么**：在项目内选择一个合格的原版 EvalPack 和实验制品，通过 Inspect 运行固定小规模评测，查看样本进度、原始 EvalLog、MLflow 运行和证据完整性。
+
+**复用组件**：Inspect AI、Inspect Evals、MLflow 和现有 AR0/AR1 账本/receipt。AR1 控制台在本轮被接入 Research Project，而不是继续作为孤立 fixture 页面。
+
+**产品页面**：Evaluation Recipes、Evaluations、Sample Progress、Inspect View、MLflow Run、Evidence Integrity。
+
+**验收产物**：一个通过资格审计且未修改 scorer/task 的 EvalPack、固定配置、EvalLog、MLflow IDs、receipt 和项目关联。V0 不接第二个评测方向，不做排行榜或模型营销结论。
+
+### V0.5：分析、报告与重放
+
+**用户完成什么**：在 Notebook 中分析结果、生成图表、写出结论与局限，用 Quarto 渲染报告，并导出可重放成果包。
+
+**复用组件**：Jupyter、Polars/DuckDB、Quarto、Git、DVC、Inspect 和 MLflow。
+
+**产品页面**：Analysis、Report、Reproducibility Bundle、Replay Check。
+
+**验收产物**：
+
+- `analysis.ipynb`、`report.qmd`、`report.html`，以及按环境可选的 PDF/DOCX。
+- `references.bib`、图表和引用来源。
+- Git commit、DVC revisions、EvalLog、MLflow IDs、receipt、source-lock。
+- 可在干净环境执行的 replay instructions 与重放核验结果。
+
+V0.5 通过后，才可将产品声明提升为“复用开源项目形成了一条可操作、可复核、可重放的 AI/Agent 科研主干”。
+
+## 8. V0 明确不做
+
+- 多租户、RBAC、计费、预算、商业化配额与租户级审计。
+- Studio、主站默认导航、根 Compose 或默认安装包集成。
+- 公共排行榜、模型横向营销、自动科学结论或科研有效性宣传。
+- 自动投稿、同行评审、研究伦理自治或无人监督科研。
+- 多学科 AI4S、湿实验、物理仿真和领域专用科学基础设施。
+- GPU 集群调度、分布式训练平台和通用云资源编排。
+- 同时接入多个 R&D Agent、多个文献工作台或多个 EvalPack 方向。
+- 未经批准 fork 并修改上游科研逻辑，以自有实现填补上游缺口。
+
+## 9. 路线变更控制
+
+### 9.1 后续任务的强制引用
+
+任何 V0 实施计划或任务卡必须明确写出：
+
+1. 对应本文的目标轮次。
+2. 本轮结束时用户实际能完成的科研动作。
+3. 复用的上游项目和进入 source-lock 的精确版本/commit。
+4. 模镜仅承担的控制面或适配职责。
+5. 可检查的用户产物和验收命令。
+6. 尚未覆盖的后续阶段。
+
+审计、许可证、适配、隔离和证据是每轮的必要门禁，但不能替代该轮的产品功能与验收产物。若一个批次只增加门禁而没有推动对应用户动作，必须明确标记为子批次，不能宣称完成产品轮次。
+
+### 9.2 允许提出偏移的必要情形
+
+只有以下情形可以提出路线修订：
+
+1. 上游项目不可获得、已停止维护、存在不可接受的安全问题或与锁定运行环境实证不兼容。
+2. 许可证、数据许可、模型条款或可再分发条件与模块分发发生实质冲突。
+3. 复现性、正确性或质量门禁出现无法通过且无法在既定边界内修复的硬失败。
+4. 仓库已验证的现实架构使锁定方案无法实施，而非仅仅实现不便。
+5. 用户明确改变产品目标或批准路线修订。
+
+“实现更方便”“技术更新”“个人偏好”“想先做有表现力的页面”“想先补平台能力”或凭印象认为另一路线更好，都不是偏移理由。
+
+### 9.3 Roadmap Amendment 记录
+
+任何路线偏移在实施前必须先新增或更新一条 `Roadmap Amendment`，至少记录：
+
+- 日期、提出人和用户批准证据。
+- 触发事实及可复现实证。
+- 受影响的锁定条目和轮次。
+- 至少一个保持原路线的备选与被否决原因。
+- 最小必要偏移，而非顺带扩张。
+- 对完整用户旅程、开源复用边界、许可证、交付时间和回退的影响。
+- 新的验收产物、停止条件和回退方法。
+
+未经用户明确批准的 Amendment 只可作为提案，不得据此修改代码或宣称路线已经改变。
+
+## 10. 每轮停止与回退原则
+
+- 每轮必须独立可演示、可关闭、可保留成果文件并可回退到上一轮。
+- 新上游服务只有在显式 profile 启动时存在；停止扩展不得启动、停止或连接默认模镜服务。
+- 回退优先移除本轮 service/profile、适配器和导航入口，保留项目成果和命名卷；删除用户成果必须另行授权。
+- 任一 P0/P1、安全、许可证、证据冲突或真实用户旅程不通时，当前轮不得标记完成。
+- 当前 AR1 的 `fixture_only`、`harness_only` 边界持续有效，直到后续获批任务明确修改对应运行边界和来源锁。
+
+## 11. V0 完成定义
+
+只有同时满足以下条件，V0 才算完成：
+
+- 一个真实 AI/Agent Research Project 可从研究问题走到可重放报告，不依赖手工搬运不可追踪状态。
+- 文献、引用、假设、协议、代码、数据、评测、追踪、分析和报告均有开放、可检查的交接产物。
+- 科研方法能力来自已锁版本的开源上游；模镜自有代码未越过第 4 节边界。
+- 每个阶段保留人工检查点、原始上游事实、来源、版本和失败状态。
+- 干净环境可按成果包说明恢复关键制品并复核主要结论链路。
+- 模块仍可选、独立构建，不扩大默认模镜主包或默认运行面。
+- 产品文案准确说明上游来源、能力边界与未经证明的科学结论。
+
+## 12. Roadmap Amendment 台账
+
+后续修订只允许在此追加记录，不得通过无记录地改写旧决策隐藏路线变化。每条记录使用以下格式：
+
+```text
+Amendment ID / 日期：
+状态：提案 | 已批准 | 已拒绝 | 已回退
+用户批准证据：
+触发事实与复现证据：
+受影响条目/轮次：
+保持原路线的备选与否决原因：
+最小必要偏移：
+用户旅程、开源复用、许可证和交付影响：
+新验收产物与停止条件：
+回退方法：
+```
+
+### Amendment V0.1-A1 / 2026-08-25
+
+- **状态**：已批准。
+- **用户批准证据**：用户在收到“增加固定目标模型 relay、Control 改为仅 internal 网络”的最小修订说明后明确回复“批准”。
+- **触发事实与复现证据**：V0.1 Control 为直连宿主模型桥加入了可出站网络和 `host.docker.internal`，因此除应用层 URL 校验外仍拥有一般网络出口；把现有网络直接改为 `internal` 后又无法到达宿主桥，真实模型旅程会中断。
+- **受影响条目/轮次**：仅 V0.1 模型控制桥的运行拓扑和隔离验收；不改变 V0.1 产品动作、上游组合、固定模型或后续 V0.2–V0.5 顺序。
+- **保持原路线的备选与否决原因**：保留 Control 直连并依赖 URL allowlist，无法消除进程被利用后的通用出站面；只把网络设为 `internal` 会切断固定模型桥，不能完成真实文献旅程。
+- **最小必要偏移**：复用 Control 运行镜像增加无持久化、无公开端口的 `ai-research-model-relay` sidecar。Control、Tracking、Inspect View 和文献控制网络均为 internal；仅 relay 连接单独出站网络和固定本机 `/api/ai-research/v1` 目标。relay 仅接受 `models` 与 `chat/completions`，禁用环境代理、重定向、任意路径、查询参数和非 JSON/SSE 内容，并限制请求及响应大小。
+- **用户旅程、开源复用、许可证和交付影响**：用户旅程与 LDR/OpenAlex/Zotero 组合不变；不引入新依赖或第三方镜像，不改变许可证结论；增加一项显式 literature profile 服务和隔离验证时间。
+- **新验收产物与停止条件**：必须证明 Control 无 DNS/HTTP/宿主访问而 Control→relay 可达；relay 任意路径、查询和重定向均失败；固定桥请求保留流式响应并关闭上游连接。任一网络绕过或凭据泄漏存在时，V0.1 不进入可提交候选。
+- **回退方法**：停止 literature profile，移除 relay 服务与专用网络，并恢复原桥 URL；不删除项目、LDR、模型、MLflow 或 Inspect 卷。若回退恢复 Control 通用出站，则相应 P1 重新打开。
+
+### Amendment V0.1-A2 / 2026-08-25
+
+- **状态**：已批准。
+- **用户批准证据**：用户在收到 Amendment V0.1-A2 的阻塞事实、固定入口 gateway 最小方案及继续实施请求后明确回复“批准”。
+- **触发事实与复现证据**：Amendment V0.1-A1 将 Control 的全部网络设为 `internal` 后，Docker Compose 渲染仍含 `127.0.0.1:8890:8080`，但实际容器端口状态为 `{"8080/tcp":[]}`，宿主连接得到 `WinError 10061`。服务内部健康检查通过，证明失败位于 internal-only 容器的宿主发布边界，而非 Control 进程或端口变量。若把普通入口网络重新接回 Control，8790 可用但一般出站 P1 重新出现。
+- **受影响条目/轮次**：V0.1 Research Console 的本机入口和隔离拓扑；不改变科研产品动作、LDR/OpenAlex/Zotero 组合、数据格式或 V0.2–V0.5 顺序。
+- **保持原路线的备选与否决原因**：直接把 Control 接回非 internal 网络会推翻 A1 的隔离结论；要求用户通过 `docker exec` 操作会失去 Research Console 用户旅程；依赖宿主手工端口转发不可复现；引入 Nginx/Caddy 会增加新的第三方镜像、锁定和许可证面。
+- **最小必要偏移**：复用 Control 镜像增加无持久化的 `ai-research-console-gateway`。只有 gateway 连接本机入口网络并发布三个既有回环入口，同时连接对应 internal 网络；Control、Tracking 与 Inspect View 自身不发布端口且保持无宿主/公网路由。gateway 使用三个固定监听器，分别绑定 `ai-research-control:8080`、`ai-research-tracking:5000` 与 `ai-research-inspect-view:7575`，禁用环境代理、重定向和任意上游选择，对请求/响应、头、方法和大小做边界限制，并原样支持 SPA、轮询 API、登记成果下载及原有只读复核入口。
+- **用户旅程、开源复用、许可证和交付影响**：恢复计划锁定的 8790 Research Console；不引入生产依赖或第三方镜像；增加一个可选模块服务、一个入口网络及相应安全测试，预计仅影响 V0.1 收口。
+- **新验收产物与停止条件**：宿主→gateway→Control 的页面、API、深链和 artifact 下载成功；Control 公共 DNS、公共 IP 和宿主直连均失败；gateway 不能选择外部目标、不能转发未允许头、不能接受超限请求，且不泄漏 token。任一绕过存在时不进入可提交候选。
+- **当前验收证据**：使用独立 Compose 项目、独立回环端口和六个互不重叠的 `/28` 子网完成 Full；Console/API/成果链、MLflow outbox、Inspect View 递归 EvalLog、可选 View 降级、Worker/Control/Tracking 重启恢复与默认主包零增量均通过。合法本机 Inspect Origin 返回递归日志，伪造 Host/Origin 返回 400。该证据仅关闭 A2 入口与隔离假设，不关闭真实固定模型、OpenAlex、Zotero 和 LDR 许可证门禁。
+- **回退方法**：停止 profile，移除 console gateway 和入口网络；保留所有项目与证据卷。回退后 Console 不可从宿主访问，除非同时重新打开 A1 已关闭的 Control 通用出站 P1。
+
+### Amendment V0.1-A3 / 2026-08-26
+
+- **状态**：已批准。
+- **用户批准证据**：真实文献运行失败和最小修订方案说明后，用户明确回复“批准A3”。
+- **触发事实与复现证据**：首次真实运行 `lr_7a215aca0a474aa69101912f9f5c3553` 使用 LDR v1.10.5 的 `langgraph-agent`，LDR 向固定模型桥发送 `tools` 与 `max_completion_tokens=30000`；模型桥按冻结边界拒绝 `tools` 和未知字段并返回 422，LDR 将原始研究 `5f2bb80b-aefe-4084-8acb-1b5682a31cc8` 标记为 `failed`。LDR v1.10.5 自身把 `source-based` 列为正式策略，并在工具调用错误说明中明确该策略绕过 tool calling。
+- **受影响条目/轮次**：仅 V0.1 固定文献研究 profile 和模型桥的 OpenAI 文本 token 参数兼容；不改变 LDR/OpenAlex/Zotero 组合、固定模型、研究问题、来源与成果格式或 V0.2–V0.5 顺序。
+- **保持原路线的备选与否决原因**：继续使用 `langgraph-agent` 必须让模型桥转发和解释完整工具调用协议，违反 V0.1 明确拒绝 `tools` 的安全边界并扩大适配范围；修改 LDR 或自研 Agent 会违反上游原样复用与禁止自研科研算法的边界。
+- **最小必要偏移**：固定 LDR 原生策略改为 `source-based`，继续固定 OpenAlex、检索数量、迭代次数和 `public_only` egress。模型桥接受受同一 `1..32768` 上限约束的 `max_completion_tokens`，在转发前规范化为 `max_tokens`；两者同时提供时失败关闭。`tools`、多模态和其他未知字段继续拒绝。
+- **用户旅程、开源复用、许可证和交付影响**：真实文献检索、来源、引用综述和 Zotero 用户旅程保持不变；不新增依赖、镜像或许可证面。放弃 LDR 的自主工具选择，换为计划原本固定的 OpenAlex source-based 流程，减少不可控搜索引擎与工具调用。
+- **新验收产物与停止条件**：契约测试必须证明 token 别名受限、互斥且规范化，`tools` 仍被拒绝；真实重试必须显示 `source-based + openalex`，产生可核对来源和完整成果包。若 source-based 仍发出工具调用、固定搜索配置漂移或引用成果不一致，V0.1 继续停止。
+- **回退方法**：恢复固定策略为 `langgraph-agent` 并移除 token 别名字段；保留首次失败与后续尝试记录及所有项目卷。回退会重新打开已证实的 422 阻塞，除非另行批准扩大工具调用协议。
+
+### Amendment V0.1-A4 / 2026-08-26
+
+- **状态**：已批准。
+- **用户批准证据**：第二次真实运行的模型可靠性证据和最小固定 profile 修订说明后，用户明确回复“批准A4”。
+- **触发事实与复现证据**：A3 后的真实运行 `lr_5465478d4ae045daa39ae85fa55e08fc` 已确认使用 `source-based + openalex`，OpenAlex 多次返回 200 并产生真实候选；LDR 随后为 OpenAlex 自动启用 LLM relevance filter，并发分批调用固定免费模型。至少一项调用返回不符合 OpenAI completion 合同的响应，模型桥记录 `ai_research_bridge_invalid_response` 硬失败并按平台规则要求重新认证；后续请求 fail-closed，研究在 80% 以原始 `failed` 终止。多项其余响应正文为空，进一步表明该模型不适合并行索引筛选。
+- **受影响条目/轮次**：仅 V0.1 固定 OpenAlex profile 的上游原生相关性过滤设置和当前模型重新认证；不改变固定模型、OpenAlex 主检索、source-based 策略、来源包、模型桥门禁或后续轮次。
+- **保持原路线的备选与否决原因**：直接重试会再次触发同一并行过滤面且不能解释可靠性；放宽畸形响应硬失败会削弱平台控制面；立即更换模型会改变管理员已批准的固定模型；修改 LDR 并发代码或自研过滤器均越过上游复用边界。
+- **最小必要偏移**：通过 LDR v1.10.5 原生最高优先级设置 `search.engine.web.openalex.default_params.enable_llm_relevance_filter=false`，关闭 OpenAlex 的 LLM 二次筛选，继续采用 OpenAlex 原生 `relevance_score`、固定 15 条结果和 source-based 研究。重新运行既有 Chat certification 清除已解释的硬失败；模型桥仍拒绝畸形响应，问题生成和综述仍由固定模型完成。
+- **用户旅程、开源复用、许可证和交付影响**：不新增依赖、镜像、许可证或自有算法；减少并行模型调用和失败面，保留真实检索、来源、问题生成和综述。相关性排序由 OpenAlex 上游承担，不再由当前固定模型二次裁剪。
+- **新验收产物与停止条件**：固定 profile 契约必须证明该设置为 false；LDR 日志必须证明使用 per-engine setting 且未调度 relevance-filter LLM 批次；重新认证和第三次运行必须保留原始状态并产生成果包。若串行问题生成或报告仍出现畸形/空响应，则停止当前模型，未经新批准不得更换模型或放宽控制门禁。
+- **回退方法**：移除该 per-engine 设置并重新解锁 LDR，使其恢复 v1.10.5 默认自动过滤行为；保留两次失败记录、认证记录和所有项目卷。回退将重新暴露已证实的并行模型不可靠风险。
+
+### Amendment V0.1-A5 / 2026-08-28
+
+- **状态**：已批准；本条补记已执行的批准路线，不追溯改写 A3/A4。
+- **用户批准证据**：在后续真实旅程收口中，用户批准受限工具协议方案，并明确授权在不落盘 S2S token 的前提下为固定模型完成 Provider 配对、`chat_tools` 重认证和 LDR 解锁；随后多次明确回复“批准”“已配对”“已解锁”，并对真实成果执行人工验收。
+- **触发事实与复现证据**：后续实现与验收不再停留于 A3/A4 的 `source-based + chat_text` 假设，而是通过模镜既有模型控制面的 `chat_tools` 资格门禁，转发 LDR v1.10.5 `langgraph-agent` 的受限 OpenAI function-tool 协议。验收账本中运行 `lr_ddaebbcccb0e44a0b8b52abda7ebe421` 保留 `strategy=langgraph-agent`，上游与归一化 outcome 均为 `completed`，成果完整性为 `verified`。本次收口审计发现代码、真实证据与只记录到 A4 的路线图不一致，故追加本条。
+- **受影响条目/轮次**：仅 V0.1 固定模型桥的文本工具协议、资格门禁和固定文献策略；不开放任意用户工具、不改变 OpenAlex 主检索、Zotero/本地资料库、成果格式、模型选择或 V0.2–V0.5 顺序。
+- **保持 A4 路线的备选与否决原因**：强行把已验证代码回退到 `source-based` 会丢弃已获人工批准且已产生可复核成果的真实路径，并使代码、账本和运维认证再次分裂；继续让路线图声称“拒绝 tools”则会把实际扩大过的协议面隐藏在文档之外。修改或 fork LDR 以消除工具调用仍违反上游原样复用边界。
+- **最小必要偏移**：固定 profile 恢复 LDR 原生 `langgraph-agent`，但仍固定 `openalex`、15 条结果、`public_only` egress，并保留 A4 对 OpenAlex LLM relevance filter 的关闭。S2S 桥只接受有界的 OpenAI function tools：工具数量、名称、JSON Schema 形状与总大小受限；assistant tool call 必须引用已声明工具，每个 tool message 必须匹配未完成 call；未知字段、多模态、任意模型和超限请求继续失败关闭。带 tools 的请求必须通过 `chat_tools` 资格门禁，纯文本请求使用 `chat_text`。
+- **用户旅程、开源复用、许可证和交付影响**：仍由 LDR 负责搜索编排和工具调用，模镜只承担协议约束、固定模型路由、资格校验与审计；不新增依赖、镜像或许可证面。用户旅程仍是项目内启动文献研究，不获得工具选择或任意执行入口。
+- **新验收产物与停止条件**：契约测试必须覆盖工具声明、调用/响应配对、Schema 与请求总量边界、流式 tool-call 终态、`chat_tools` 资格失效和畸形上游响应；真实验收必须保留精确策略、OpenAlex 来源与成果哈希。任意未声明工具、能力门禁旁路、Provider key 泄漏或非固定模型可达均为停止条件。
+- **回退方法**：关闭 S2S 桥和 literature profile；如需回到 A4，必须另开修订把 profile、项目记录、桥协议和资格认证一起切回 `source-based + chat_text`，并重新完成真实旅程。不得仅删除工具字段而保留 `langgraph-agent`，也不得删除既有项目和成果卷。
+
+### Amendment V0.1-A6 / 2026-08-28
+
+- **状态**：已批准；仅调整可选扩展的帮助中心交付轮次，不改变产品能力。
+- **用户批准证据**：收口审计指出根级帮助中心门禁与 V0.1 固定的 `client/` 零增量边界冲突后，用户明确批准将该门禁推迟到 AR3/Studio 条件入口轮次，继续完成模块内收口。
+- **触发事实与复现证据**：根级治理要求所有用户可见变化在同一 PR 修改 `client/src/content/help-center/` 并附同基线截图；V0.1 同时锁定为未安装即不可见的独立可选扩展，禁止修改 `client/`、Studio 路由和默认主包。两项要求无法在本轮同时满足。
+- **受影响条目/轮次**：仅 V0.1 的主站帮助中心交付门禁和 AR3 的条件式 Studio 入口；不改变 Research Console、LDR/OpenAlex/Zotero 组合、成果格式、安全门禁或 V0.2–V0.5 顺序。
+- **最小必要偏移**：V0.1 继续以模块内 README 提供操作、限制、验收和回退说明，不修改主站帮助中心；AR3 在扩展已安装且健康时增加 Studio 条件入口的同一批次，必须补齐主站帮助文章、截图和从入口开始的真实预览重放。
+- **新验收产物与停止条件**：V0.1 必须继续证明 `client/` 逐文件哈希和默认 Compose 清单零增量，并在 PR 的 `Help Center Impact` 中明确引用本修订而不得声称 `None`。AR3 若缺少同一基线的帮助文章、截图和重放证据，不得创建或合并其 PR。
+- **回退方法**：如决定在 AR3 前提供主站入口，必须另开修订并在同一实现批次恢复根级帮助中心门禁；不得只增加入口而继续沿用本次延期。
+
+### Amendment V0.1-A7 / 2026-08-28
+
+- **状态**：已批准；升级候选必须先在全新隔离栈证伪，不等于 v1.10.6 已通过产品门禁。
+- **用户批准证据**：在真实 v1.10.5 Zotero 研究包的 Quarto/BibTeX 引用不一致被严格拒绝、且官方 v1.10.6 候选和剩余风险说明后，用户明确回复“批准升级并配置”。
+- **触发事实与复现证据**：运行 `lr_f5d2f764b1db410d8accddf8caca8e49` 的 LDR 原始状态为 `completed`，但真实 Quarto ZIP 的 QMD 有 939 个引用键、BibTeX/RIS 仅有 186 个来源条目，753 个引用键无对应 BibTeX。v1.10.5 QuartoExporter 会转换全文全部数字引用，却只从来源行生成 bibliography。官方 v1.10.6 发布说明和源码加入分组来源、去重与 Quarto/BibTeX 修复，但上游仍未提供最终的反向引用完整性保证。
+- **受影响条目/轮次**：仅 V0.1 的 LDR 版本、官方镜像、SBOM、API 契约和真实文献旅程；不改变固定模型、OpenAlex/Zotero 组合、模镜严格成果校验、模型桥、安全拓扑或 V0.2–V0.5 顺序。
+- **最小必要偏移**：来源锁提升到 `v1.10.6`、commit `641308272b2143df89c7a946051d2f05ca29b3c1`、linux/amd64 镜像 digest `sha256:b2c634291de8fb8d0662ab81a0b82ec17ab807109d20d57386042c5bdcd472e5` 和官方 SBOM `sha256:6f9c0e6f762763d2b34207a7638b65bedd37d818bd86e538483b21cb091c6315`。先使用新 Compose 项目和新卷验证；不得原地迁移现有验收资料卷来制造通过。
+- **许可证与分发影响**：v1.10.6 amd64 SBOM 为 438 个包，有效未知项由 37 增至 38，GPL/LGPL 声明仍为 100、AGPL 声明仍为 0。集成继续固定为 `external_pull_only`，镜像化、离线捆绑、修改或模镜再分发仍阻断。
+- **新验收产物与停止条件**：必须重新通过登录/CSRF、研究启动/状态/取消、Library、Zotero、Quarto/RIS 契约，使用真实固定模型完成 OpenAlex 与已索引 Zotero 集合旅程，并证明每个 QMD 引用键都存在于 BibTeX。若引用仍不一致、API 漂移、迁移要求无法回退、凭据泄漏或许可证门禁扩大，则保持 v1.10.5 现有卷不变并停止切换。
+- **回退方法**：隔离验证失败时移除 v1.10.6 候选配置并保留其独立卷用于取证；当前 v1.10.5 验收栈和所有既有卷不变。只有隔离验证通过后才允许另行切换当前验收栈，切换前必须创建并验证 LDR 自身的预迁移备份。

--- a/extensions/ai-research/LDR_LICENSE_DISPOSITION.md
+++ b/extensions/ai-research/LDR_LICENSE_DISPOSITION.md
@@ -1,0 +1,60 @@
+# Local Deep Research 镜像许可证处置
+
+## 结论
+
+Local Deep Research v1.10.6 的项目源码使用 MIT 许可证。固定的官方容器镜像
+`localdeepresearch/local-deep-research:1.10.6@sha256:b2c634291de8fb8d0662ab81a0b82ec17ab807109d20d57386042c5bdcd472e5`
+还包含 Debian、Python、npm 和其他运行时包，因此不能把整个镜像声明为 MIT。
+
+V0.1 采用 `external_pull_only`：Compose 只能从上游公共仓库按上述精确
+digest 拉取未修改镜像。模镜不构建、复制、镜像化、离线捆绑、修改或发布该
+镜像。内部运行必须随可选模块保留第三方 notice。
+
+这是一项工程分发门禁，不是对全部第三方许可证义务的法律意见。
+
+## SBOM 证据
+
+来源为上游 v1.10.6 发布附件
+`sbom-container-amd64.spdx.json`，SHA-256 为
+`6f9c0e6f762763d2b34207a7638b65bedd37d818bd86e538483b21cb091c6315`，
+大小 5,245,009 字节。
+
+| 项目 | 数量 | 解释 |
+| --- | ---: | --- |
+| 全部包 | 438 | PyPI 282、Debian 134、npm 5、generic 2、OCI 1、未分类 14 |
+| declared license 已知 | 378 | SBOM 提供了许可证声明 |
+| declared license 为 `NOASSERTION` | 60 | 不能仅由 declared 字段确认许可证 |
+| concluded license 为 `NOASSERTION` | 416 | SBOM 生成方没有作出结论，不等于 416 个许可证未知 |
+| declared 已知、concluded 未断言 | 378 | 可继续依据 declared 字段审计 |
+| declared 未断言、concluded 已知 | 22 | concluded 字段补足了声明 |
+| 两者均未断言 | 38 | 当前有效未知项，阻断镜像再分发候选 |
+| declared 表达式含 GPL/LGPL | 100 | Debian 98、PyPI 2；需要保留各包对应义务 |
+| declared 表达式含 AGPL | 0 | 仅表示 SBOM 明示字段未匹配，不能消除未知项风险 |
+
+两个 PyPI declared copyleft 项为 `autocommand@2.2.2`
+(`LicenseRef-LGPLv3`) 与 `tld@0.13.2`
+(`MPL-1.1 OR GPL-2.0-only OR LGPL-2.1-or-later`)。`pyphen@0.18.1`
+的 declared 与 concluded 字段均未断言，计入当前有效未知项。
+
+## 分发矩阵
+
+| 行为 | 决策 | 门禁 |
+| --- | --- | --- |
+| 从上游公共仓库按精确 digest 拉取原始镜像 | 允许 | 镜像名、tag、digest、SBOM 哈希和 Compose 形态必须全部匹配 |
+| 内部托管运行已拉取的原始镜像 | 有条件允许 | 随模块保留 notice，不得声称整个镜像为 MIT |
+| 推送到模镜或私有镜像仓库 | 阻断 | 需要完成逐包义务与有效未知项处置 |
+| 制作离线安装包或预装镜像 | 阻断 | 需要完成逐包义务、许可证文本与源代码提供要求 |
+| 修改或派生 LDR 镜像后分发 | 阻断 | 需要重新生成 SBOM 并完成完整许可证复核 |
+| 把整个镜像声明为 MIT | 禁止 | 项目许可证不能覆盖聚合镜像内的第三方组件 |
+
+## 自动门禁
+
+`scripts/validate_boundary.py --distribution-mode external-pull` 只验证当前允许
+路径，并拒绝 LDR `build:`、非上游镜像名、浮动 tag、错误 digest、私有或模镜
+registry、Dockerfile `FROM`/`COPY` LDR 镜像以及离线捆绑痕迹。
+
+`--distribution-mode redistributable-bundle` 是保留的失败门禁。在完成 38 个有效
+未知项、copyleft 义务、许可证文本和源代码提供方式的逐包处置前，它必须失败。
+
+升级 LDR 版本、digest 或 SBOM 时必须重新生成本文件中的证据与决策，不能沿用
+旧版本结论。

--- a/extensions/ai-research/README.md
+++ b/extensions/ai-research/README.md
@@ -1,31 +1,57 @@
 # 模镜科研 / ModelMirror AI Research
 
-AR1 是一个可选、同仓但独立构建的 AI/Agent 评测工程框架与操作控制台。它只证明受控运行、Inspect 终态归一化、取消、MLflow 证据持久化、网页复核和重启恢复，不代表模镜已接入模型或具备科研评测能力。
+V0.1 是一个可选、同仓但独立构建的 AI/Agent Research Project 工作台。它保留 AR1 的 fixture-only Inspect/MLflow 工程底座，并通过固定 Local Deep Research 适配增加真实文献检索、Zotero 资料库、带引用综述和可核对成果包；文献结果仍需人工复核，不构成科研结论。
+
+## V0 锁定路线
+
+[《模镜科研 V0 锁定路线图》](./AI_RESEARCH_V0_ROADMAP.md) 是本模块 V0 产品定义、开源组合、分轮实施和变更控制的规范性基线。V0.1 只落地 Research Project 与文献工作台，后续假设、研发、评测、分析和报告阶段保持不可用。
+
+## 当前候选状态
+
+- 项目、LDR 会话与运行适配、受限模型桥、成果包、Research Console 和自动化契约已经落地。现场验收已使用管理员固定的真实文本模型和 OpenAlex 完成一项 AI/Agent 文献研究；报告、来源和成果包在 Control/LDR 重启并重新解锁后保持可恢复，完整性为 `verified`。
+- LDR 本地资料库已用 4 篇人工上传的公开论文完成固定嵌入模型初始化、629 个分块、语义检索和重启后恢复；这条证据只证明本地索引链。
+- Zotero API key 配置和连接测试已成功；测试集合 `ModelMirror V0.1 Zotero Acceptance` 已同步 4 篇论文，使用固定本地嵌入模型完成 4/4 索引并关联到真实研究项目。该项目的上游研究达到 `completed`，但 LDR v1.10.5 的 Quarto ZIP 只有 186 个 BibTeX 条目，却在 QMD 中产生 939 个引用键，其中 753 个无对应条目。Control 保留原始 `completed`，拒绝该成果包并归类为 `infrastructure_error`；Zotero 同步、索引和关联门禁已有真实证据，完整成果包门禁仍未关闭。
+- 已按批准的 Amendment V0.1-A1 增加固定目标 `ai-research-model-relay`：Control 仅连接 internal 网络，不能直接解析或访问宿主及公网；relay 只暴露固定模型桥的 models/chat 两条路由。容器反证已确认 Control 的公共 DNS、公共 IP、HTTP 与宿主访问失败，同时固定 relay 路径可达。
+- 已按批准的 Amendment V0.1-A2 增加固定 `ai-research-console-gateway`，由单一受限进程承接原有 8790/8791/8793 回环入口；Control、Tracking 与 Inspect View 继续只连接 internal 网络且不直接发布端口。隔离 Full 已通过 Console/API/成果链、MLflow 同步及 Inspect View 递归 EvalLog 访问，伪造 Host/Origin 被拒绝；这项隔离证据本身不替代另行完成的真实文献旅程。
+- 已按批准并在收口时补记的 Amendment V0.1-A5 固定 `langgraph-agent + openalex`，模型桥只转发受 schema、大小、调用配对和 `chat_tools` 资格约束的 function-tool 协议；这不是任意工具入口，用户不能选择工具、模型或执行参数。该路径已产生一项完整性 `verified` 的真实成果包。
+- 已按批准的 Amendment V0.1-A6 将主站帮助中心更新推迟到 AR3 条件式 Studio 入口同批交付；V0.1 继续保持 `client/` 和默认主包零增量，模块内操作与限制由本 README 记录。
+- 已按批准的 Amendment V0.1-A7 将 LDR 候选来源锁提升到 v1.10.6；该版本必须在全新隔离栈完成同一真实 Zotero 成果包旅程后才可替换当前验收栈，版本升级本身不关闭引用完整性门禁。
+- LDR 项目源码为 MIT；官方镜像是包含操作系统与 Python 依赖的聚合物。当前只允许按精确 digest 从上游公共仓库外部拉取，不允许模镜镜像化、离线捆绑、修改或再分发该镜像。
 
 ## 明确限制
 
-- 只有 `success`、`task_error`、`long_running_cancel` 三个工程夹具。
-- 所有运行固定标记为 `fixture_only` 和 `harness_only`。
-- 不调用模型，不读取模镜配置或密钥，不安装 EvalPack，不产生科学分数。
-- 不修改或连接模镜主前后端；不会出现在 Studio、Plugin 或默认 Compose 中。
+- 工程运行仍只有 `success`、`task_error`、`long_running_cancel` 三个夹具；真实能力仅限独立的文献研究工作流。
+- AR1 工程夹具仍固定标记为 `fixture_only` 和 `harness_only`；文献研究固定为 `scientificClaim=none`。
+- 文献研究只通过默认关闭、管理员固定模型的受限 S2S 桥调用模镜控制面；扩展不读取 Provider key，不接受用户选择模型、prompt 或搜索参数。
+- 不安装 EvalPack，不产生科学分数；不会出现在 Studio、Plugin 或默认 Compose 中。
 - Research Console、MLflow UI 与 Inspect View 只绑定本机回环地址，不是多用户服务。
-- 为兼容 Docker Desktop 的回环端口发布，Control、Tracking 与 Inspect View 使用普通模块私有 bridge，并非出站阻断网络；只有 Worker 固定 `network_mode: none`。这些服务不挂载平台凭据。
+- LDR v1.10.6 官方镜像 SBOM 共 438 个包；60 个包的 declared license 为 `NOASSERTION`，416 个包的 concluded license 为 `NOASSERTION`，交叉后有 38 个有效未知项。`concluded=NOASSERTION` 不等于已确认未知许可证。精确口径和分发边界见 [`LDR_LICENSE_DISPOSITION.md`](./LDR_LICENSE_DISPOSITION.md)。
 
 ## 组件
 
 - `ai-research-control`：版本化 HTTP API、SQLite 控制账本、证据 outbox。
+- `ai-research-console-gateway`：无持久化的固定本机入口，只将 8790/8791/8793 分别转发给 Control、Tracking 与 Inspect View，不接受任意上游。
 - `ai-research-tracking`：MLflow 3.15.1、SQLite backend、本地 artifacts。
 - `ai-research-worker`：Inspect AI 0.3.260、无网 Linux worker、Unix socket 控制协议。
 - `ai-research-inspect-view`：复用 Worker 镜像、只读挂载 EvalLog 的 Inspect View。
+- `ai-research-model-relay`：不发布端口、禁用环境代理和重定向，只向本机固定 AI Research 模型桥转发受限模型请求。
+- `ai-research-ldr`：按 digest 拉取的 Local Deep Research v1.10.6，承载检索、Library、Zotero 与报告导出。
+- `ai-research-ldr-assets`：一次性下载并校验固定 revision 的本地嵌入模型。
 - `ui/`：独立 React/Vite/Tailwind 控制台；构建产物进入 Control 镜像，最终镜像不包含 Node 运行时。
 
 ## 显式启动
 
+操作员需要分别为主服务和扩展配置相同的短期 S2S token，并在主服务显式开启桥、固定文本模型。扩展不读取主服务 `.env`。随后显式启动：
+
 ```powershell
-docker compose -f extensions/ai-research/compose.yml --profile ai-research up -d --build
+docker compose -f extensions/ai-research/compose.yml --profile literature up -d --build
 ```
 
-Research Console 默认地址是 `http://127.0.0.1:8790`，MLflow 是 `http://127.0.0.1:8791`，Inspect View 是 `http://127.0.0.1:8793`。停止时不要附加 `-v`，以保留证据卷。
+Research Console 默认地址是 `http://127.0.0.1:8790`，MLflow 是 `http://127.0.0.1:8791`，LDR 是 `http://127.0.0.1:8792`，Inspect View 是 `http://127.0.0.1:8793`。停止时不要附加 `-v`，以保留项目、资料库、模型与证据卷。
+
+固定嵌入模型由 `ai-research-ldr-assets` 校验后保存在只读资产卷，LDR 内通过 `/data/models` 访问，`Local Search Embedding Model` 必须为 `/data/models/sentence-transformers/all-MiniLM-L6-v2`。早期本地预览若保存过 `/models/sentence-transformers/all-MiniLM-L6-v2`，需在 LDR Settings 中改为上述路径，并对受影响集合执行一次明确的重新索引；重新索引会重建向量索引，但不会删除原始文档。
+
+与其他本机实例并行验收时，可以通过 `AI_RESEARCH_COMPOSE_PROJECT` 使用独立 Compose 项目名，并通过 `AI_RESEARCH_CONTROL_PORT`、`AI_RESEARCH_MLFLOW_PORT`、`AI_RESEARCH_LDR_PORT` 和 `AI_RESEARCH_INSPECT_VIEW_PORT` 改用独立端口。若另一实例仍占用默认 `10.254.76.0/25`，还必须把 `AI_RESEARCH_TRACKING_SUBNET`、`AI_RESEARCH_INSPECT_VIEW_SUBNET`、`AI_RESEARCH_LITERATURE_CONTROL_SUBNET`、`AI_RESEARCH_LITERATURE_EGRESS_SUBNET`、`AI_RESEARCH_MODEL_BRIDGE_EGRESS_SUBNET` 和 `AI_RESEARCH_LOCAL_GATEWAY_SUBNET` 一并改为六个互不重叠且不与宿主冲突的 `/28`；不允许只改一部分。验收脚本会读取同一组端口，并拒绝任何非 HTTP loopback 的显式验收 URL，避免把本地测试误发到远程服务。
 
 ## 冻结接口
 
@@ -41,17 +67,30 @@ Research Console 默认地址是 `http://127.0.0.1:8790`，MLflow 是 `http://12
 - `GET /api/v1/runs/{runId}/evidence`
 - `GET /api/v1/runs/{runId}/artifacts/{artifactName}`
 - `POST /api/v1/runs/{runId}/cancel`
+- `POST /api/v1/projects`
+- `GET /api/v1/projects`
+- `GET /api/v1/projects/{projectId}`
+- `PATCH /api/v1/projects/{projectId}`
+- `GET|POST|DELETE /api/v1/literature/session[...]`
+- `POST /api/v1/projects/{projectId}/literature/runs`
+- `GET|POST /api/v1/projects/{projectId}/literature[...]`
+- `GET /api/v1/projects/{projectId}/sources`
+- `GET /api/v1/projects/{projectId}/review`
+- `GET /api/v1/projects/{projectId}/artifacts/{artifactName}`
+- `GET|POST /api/v1/literature/library[...]`
+- `GET|POST /api/v1/literature/zotero[...]`
 
-请求只允许固定 fixture、case、`local` 租户兼容位和幂等键。不存在任意命令、路径、上传、模型、prompt 或凭据入口。
+请求只允许固定夹具或固定文献 profile、项目字段和幂等键。不存在任意命令、路径、上传、模型、prompt、Provider key 或 Zotero key 入口。
 
 ## 验证
 
 ```powershell
 cd extensions/ai-research
-.\scripts\verify.ps1 -Base origin/main -Mode Full
+.\scripts\verify.ps1 -Base origin/main -Mode Full -DistributionMode ExternalPull
 ```
 
-完整验证会先运行独立 UI 的 `npm ci`、类型检查、Vitest 和生产构建，再主动攻击退出码误判、取消竞态、畸形日志、幂等冲突、MLflow 中断、路径逃逸、Worker 网络、SPA 回退和证据篡改。
+完整验证默认只启动 `ai-research` profile，运行独立 UI 的 `npm ci`、类型检查、Vitest 和生产构建，再主动攻击退出码误判、取消竞态、畸形日志、幂等冲突、MLflow 中断、路径逃逸、Worker 网络、SPA 回退和证据篡改。只有显式设置 `AI_RESEARCH_LIVE_ACCEPTANCE=1` 时才会增启 `literature` profile，并要求锁定 LDR 镜像、固定真实模型、OpenAlex 和用户授权的 Zotero 测试库；未设置时的 Full 通过不能替代 V0.1 真实旅程验收。
+边界检查必须显式声明分发模式：当前支持 `scripts/validate_boundary.py --distribution-mode external-pull`，它只允许 Compose 按精确公共上游 digest 拉取原始 LDR 镜像。`redistributable-bundle` 模式会在镜像再分发义务完成前按设计失败，不存在宽泛的许可证绕过开关。
 Windows 验证机需要 Python 3.12.13；若 `python`/`py -3.12` 不可用，请把
 `AI_RESEARCH_PYTHON` 指向精确的 Python 3.12.13 可执行文件。镜像内运行时仍由
 digest 与哈希锁固定，不读取宿主的模镜配置或密钥。

--- a/extensions/ai-research/THIRD_PARTY_NOTICES.md
+++ b/extensions/ai-research/THIRD_PARTY_NOTICES.md
@@ -11,6 +11,28 @@ ModelMirror AI Research is a ModelMirror optional module. The module name and pr
 | FastAPI | resolved and hash-locked with the control image | MIT | https://github.com/fastapi/fastapi |
 | Uvicorn | resolved and hash-locked with the control image | BSD-3-Clause | https://github.com/encode/uvicorn |
 | Python | 3.12.13 | PSF-2.0 | https://www.python.org/ |
+| Local Deep Research project | 1.10.6 | MIT | https://github.com/LearningCircuit/local-deep-research |
+| all-MiniLM-L6-v2 model asset | revision `1110a243fdf4706b3f48f1d95db1a4f5529b4d41` | Apache-2.0 | https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2 |
+
+The Local Deep Research project source is MIT. Its official container image is an
+aggregate work containing the project plus operating-system and Python packages,
+so the image is not represented as MIT-only. The optional service pulls the
+unmodified public image by its exact upstream digest. ModelMirror does not build,
+mirror, bundle, or publish that image.
+
+The official SPDX SBOM contains 436 packages. It records 100 declared GPL/LGPL
+matches, 60 packages whose declared license is `NOASSERTION`, and 413 packages
+whose concluded license is `NOASSERTION`. The last number does not mean that 413
+licenses are unknown: SPDX permits `NOASSERTION` when the producer did not make a
+license conclusion. Cross-checking declared and concluded values leaves 37
+packages with no declared or concluded license assertion. Exact counts, the SBOM
+hash, and the distribution-mode decision are recorded in `source-lock.json` and
+`LDR_LICENSE_DISPOSITION.md`.
+
+Use that pulls the exact public upstream digest is allowed with these notices.
+Mirroring, offline bundling, modifying, or distributing the image under a
+ModelMirror registry remains blocked until package-level obligations and the 37
+effective unknowns are disposed.
 
 ## Research Console runtime components
 
@@ -19,6 +41,8 @@ ModelMirror AI Research is a ModelMirror optional module. The module name and pr
 | React | 19.2.7 | MIT | https://github.com/facebook/react |
 | React Router DOM | 6.30.4 | MIT | https://github.com/remix-run/react-router |
 | Lucide React | 1.27.0 | ISC | https://github.com/lucide-icons/lucide |
+| React Markdown | 10.1.0 | MIT | https://github.com/remarkjs/react-markdown |
+| remark-gfm | 4.0.1 | MIT | https://github.com/remarkjs/remark-gfm |
 
 The console build toolchain is also locked in `ui/package-lock.json`. Its complete
 machine-readable license inventory is distributed as

--- a/extensions/ai-research/compose.yml
+++ b/extensions/ai-research/compose.yml
@@ -2,12 +2,12 @@ name: modelmirror-ai-research
 
 services:
   ai-research-control:
-    profiles: [ai-research]
+    profiles: [ai-research, literature]
     build:
       context: .
       dockerfile: control/Dockerfile
       target: runtime
-    image: modelmirror-ai-research-control:ar1
+    image: modelmirror-ai-research-control:v0.1
     command: ["python", "-m", "ai_research_control.app"]
     depends_on:
       ai-research-tracking:
@@ -17,6 +17,7 @@ services:
     networks:
       - tracking_internal
       - inspect_view_internal
+      - literature_control_internal
     user: "65532:65532"
     read_only: true
     cap_drop: [ALL]
@@ -25,8 +26,6 @@ services:
     pids_limit: 128
     mem_limit: 1g
     cpus: 1.0
-    ports:
-      - "127.0.0.1:${AI_RESEARCH_CONTROL_PORT:-8790}:8080"
     environment:
       AI_RESEARCH_CONTROL_DB: /data/control/control.db
       AI_RESEARCH_EVIDENCE_ROOT: /data/control/evidence
@@ -35,6 +34,12 @@ services:
       AI_RESEARCH_MLFLOW_URI: http://ai-research-tracking:5000
       AI_RESEARCH_MLFLOW_EXPERIMENT: modelmirror-ai-research-ar1
       AI_RESEARCH_INSPECT_VIEW_URI: http://ai-research-inspect-view:7575
+      AI_RESEARCH_PROJECTS_ROOT: /data/projects
+      AI_RESEARCH_LDR_URI: http://ai-research-ldr:5000
+      AI_RESEARCH_LDR_PUBLIC_URL: http://127.0.0.1:${AI_RESEARCH_LDR_PORT:-8792}
+      AI_RESEARCH_LITERATURE_MODEL_ID: ${AI_RESEARCH_LITERATURE_MODEL_ID:-}
+      AI_RESEARCH_MODEL_BRIDGE_URL: ${AI_RESEARCH_MODEL_BRIDGE_URL:-http://ai-research-model-relay:8090/api/ai-research/v1}
+      AI_RESEARCH_S2S_TOKEN: ${AI_RESEARCH_S2S_TOKEN:-}
       AI_RESEARCH_MLFLOW_PUBLIC_URL: http://127.0.0.1:${AI_RESEARCH_MLFLOW_PORT:-8791}
       AI_RESEARCH_INSPECT_VIEW_PUBLIC_URL: http://127.0.0.1:${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}
       AI_RESEARCH_ENABLE_DOCS: "0"
@@ -42,6 +47,7 @@ services:
       PYTHONUTF8: "1"
     volumes:
       - control_data:/data/control
+      - projects_data:/data/projects
       - inspect_logs:/data/inspect-logs:ro
       - worker_socket:/run/ai-research
     tmpfs:
@@ -55,13 +61,108 @@ services:
     restart: unless-stopped
     stop_grace_period: 20s
 
-  ai-research-tracking:
-    profiles: [ai-research]
+  ai-research-console-gateway:
+    profiles: [ai-research, literature]
     build:
       context: .
       dockerfile: control/Dockerfile
       target: runtime
-    image: modelmirror-ai-research-control:ar1
+    image: modelmirror-ai-research-control:v0.1
+    command: ["python", "-m", "ai_research_control.console_gateway"]
+    depends_on:
+      ai-research-control:
+        condition: service_healthy
+      ai-research-tracking:
+        condition: service_healthy
+      ai-research-inspect-view:
+        condition: service_healthy
+    networks:
+      - tracking_internal
+      - inspect_view_internal
+      - literature_control_internal
+      - local_gateway_ingress
+    user: "65532:65532"
+    read_only: true
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 64
+    mem_limit: 256m
+    cpus: 0.5
+    ports:
+      - "127.0.0.1:${AI_RESEARCH_CONTROL_PORT:-8790}:8080"
+      - "127.0.0.1:${AI_RESEARCH_MLFLOW_PORT:-8791}:8091"
+      - "127.0.0.1:${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}:8093"
+    environment:
+      AI_RESEARCH_CONSOLE_GATEWAY_CONTROL_URL: http://ai-research-control:8080
+      AI_RESEARCH_CONSOLE_GATEWAY_TRACKING_URL: http://ai-research-tracking:5000
+      AI_RESEARCH_CONSOLE_GATEWAY_INSPECT_URL: http://ai-research-inspect-view:7575
+      AI_RESEARCH_CONSOLE_GATEWAY_INSPECT_PUBLIC_PORT: ${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}
+      AI_RESEARCH_CONSOLE_GATEWAY_TIMEOUT_SECONDS: ${AI_RESEARCH_CONSOLE_GATEWAY_TIMEOUT_SECONDS:-180}
+      PYTHONUTF8: "1"
+    tmpfs:
+      - /tmp:rw,nosuid,nodev,noexec,size=64m,uid=65532,gid=65532,mode=0700
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; assert urllib.request.urlopen('http://127.0.0.1:8080/gateway-healthz', timeout=3).status == 200"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    restart: unless-stopped
+    stop_grace_period: 20s
+
+  ai-research-model-relay:
+    profiles: [literature]
+    build:
+      context: .
+      dockerfile: control/Dockerfile
+      target: runtime
+    image: modelmirror-ai-research-control:v0.1
+    command:
+      - python
+      - -m
+      - uvicorn
+      - ai_research_control.model_relay:app
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8090"
+      - --no-access-log
+    networks:
+      - literature_control_internal
+      - model_bridge_egress
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    user: "65532:65532"
+    read_only: true
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 64
+    mem_limit: 256m
+    cpus: 0.5
+    environment:
+      AI_RESEARCH_MODEL_RELAY_TARGET_URL: ${AI_RESEARCH_MODEL_RELAY_TARGET_URL:-http://host.docker.internal:8000/api/ai-research/v1}
+      AI_RESEARCH_MODEL_RELAY_TIMEOUT_SECONDS: ${AI_RESEARCH_MODEL_RELAY_TIMEOUT_SECONDS:-180}
+      PYTHONUTF8: "1"
+    tmpfs:
+      - /tmp:rw,nosuid,nodev,noexec,size=64m,uid=65532,gid=65532,mode=0700
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; assert urllib.request.urlopen('http://127.0.0.1:8090/healthz', timeout=3).status == 200"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    restart: unless-stopped
+    stop_grace_period: 20s
+
+  ai-research-tracking:
+    profiles: [ai-research, literature]
+    build:
+      context: .
+      dockerfile: control/Dockerfile
+      target: runtime
+    image: modelmirror-ai-research-control:v0.1
     command:
       - mlflow
       - server
@@ -88,8 +189,6 @@ services:
     pids_limit: 192
     mem_limit: 1g
     cpus: 1.0
-    ports:
-      - "127.0.0.1:${AI_RESEARCH_MLFLOW_PORT:-8791}:5000"
     environment:
       PYTHONUTF8: "1"
       MLFLOW_DISABLE_TELEMETRY: "true"
@@ -111,12 +210,12 @@ services:
     stop_grace_period: 30s
 
   ai-research-worker:
-    profiles: [ai-research]
+    profiles: [ai-research, literature]
     build:
       context: .
       dockerfile: worker/Dockerfile
       target: runtime
-    image: modelmirror-ai-research-worker:ar1
+    image: modelmirror-ai-research-worker:v0.1
     network_mode: none
     user: "65532:65532"
     read_only: true
@@ -155,12 +254,12 @@ services:
     stop_grace_period: 20s
 
   ai-research-inspect-view:
-    profiles: [ai-research]
+    profiles: [ai-research, literature]
     build:
       context: .
       dockerfile: worker/Dockerfile
       target: runtime
-    image: modelmirror-ai-research-worker:ar1
+    image: modelmirror-ai-research-worker:v0.1
     command:
       - inspect
       - view
@@ -178,6 +277,10 @@ services:
       - ai-research-inspect-view:7575
       - --trusted-host
       - 127.0.0.1:7575
+      - --trusted-host
+      - 127.0.0.1:${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}
+      - --trusted-host
+      - localhost:${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}
       - --unsafe-allow-unauthenticated
       - --log-dir
       - /data/inspect-logs
@@ -191,8 +294,6 @@ services:
     pids_limit: 128
     mem_limit: 512m
     cpus: 0.5
-    ports:
-      - "127.0.0.1:${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}:7575"
     volumes:
       - inspect_logs:/data/inspect-logs:ro
     tmpfs:
@@ -206,18 +307,113 @@ services:
     restart: unless-stopped
     stop_grace_period: 20s
 
+  ai-research-ldr-assets:
+    profiles: [literature]
+    image: localdeepresearch/local-deep-research:1.10.6@sha256:b2c634291de8fb8d0662ab81a0b82ec17ab807109d20d57386042c5bdcd472e5
+    entrypoint: ["python", "/opt/modelmirror/init_ldr_assets.py"]
+    user: "0:0"
+    read_only: true
+    cap_drop: [ALL]
+    cap_add: [DAC_OVERRIDE]
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 128
+    mem_limit: 2g
+    cpus: 1.0
+    environment:
+      AI_RESEARCH_LDR_MODEL_ROOT: /model-assets/sentence-transformers/all-MiniLM-L6-v2
+      AI_RESEARCH_LDR_MODEL_LINK: /data/models
+      HF_HOME: /tmp/huggingface
+      PYTHONUTF8: "1"
+    networks:
+      - literature_egress
+    volumes:
+      - ./scripts/init_ldr_assets.py:/opt/modelmirror/init_ldr_assets.py:ro
+      - ldr_models:/model-assets
+      - ldr_data:/data
+    tmpfs:
+      - /tmp:rw,nosuid,nodev,noexec,size=512m,mode=0700
+    restart: "no"
+
+  ai-research-ldr:
+    profiles: [literature]
+    image: localdeepresearch/local-deep-research:1.10.6@sha256:b2c634291de8fb8d0662ab81a0b82ec17ab807109d20d57386042c5bdcd472e5
+    depends_on:
+      ai-research-ldr-assets:
+        condition: service_completed_successfully
+    networks:
+      - literature_control_internal
+      - literature_egress
+    cap_drop: [ALL]
+    cap_add: [CHOWN, FOWNER, DAC_OVERRIDE, SETUID, SETGID]
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 512
+    mem_limit: 4g
+    cpus: 2.0
+    ports:
+      - "127.0.0.1:${AI_RESEARCH_LDR_PORT:-8792}:5000"
+    environment:
+      LDR_WEB_HOST: 0.0.0.0
+      LDR_WEB_PORT: "5000"
+      LDR_DATA_DIR: /data
+      LDR_APP_ALLOW_REGISTRATIONS: "true"
+      HF_HUB_OFFLINE: "1"
+      TRANSFORMERS_OFFLINE: "1"
+      SENTENCE_TRANSFORMERS_HOME: /data/models/sentence-transformers
+      PYTHONUTF8: "1"
+    volumes:
+      - ldr_data:/data
+      - ldr_models:/model-assets:ro
+    tmpfs:
+      - /tmp:rw,nosuid,nodev,noexec,size=512m,mode=1777
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; assert urllib.request.urlopen('http://127.0.0.1:5000/api/v1/health', timeout=8).status == 200"]
+      interval: 10s
+      timeout: 10s
+      retries: 18
+      start_period: 60s
+    restart: unless-stopped
+    stop_grace_period: 30s
+
 networks:
   tracking_internal:
+    internal: true
     ipam:
       config:
-        - subnet: 10.254.76.0/28
+        - subnet: ${AI_RESEARCH_TRACKING_SUBNET:-10.254.76.0/28}
   inspect_view_internal:
+    internal: true
     ipam:
       config:
-        - subnet: 10.254.76.16/28
+        - subnet: ${AI_RESEARCH_INSPECT_VIEW_SUBNET:-10.254.76.16/28}
+  literature_control_internal:
+    internal: true
+    ipam:
+      config:
+        - subnet: ${AI_RESEARCH_LITERATURE_CONTROL_SUBNET:-10.254.76.32/28}
+  literature_egress:
+    ipam:
+      config:
+        - subnet: ${AI_RESEARCH_LITERATURE_EGRESS_SUBNET:-10.254.76.48/28}
+  model_bridge_egress:
+    ipam:
+      config:
+        - subnet: ${AI_RESEARCH_MODEL_BRIDGE_EGRESS_SUBNET:-10.254.76.64/28}
+  local_gateway_ingress:
+    ipam:
+      config:
+        - subnet: ${AI_RESEARCH_LOCAL_GATEWAY_SUBNET:-10.254.76.80/28}
 
 volumes:
   control_data:
   tracking_data:
   inspect_logs:
   worker_socket:
+  projects_data:
+  ldr_data:
+  ldr_models:

--- a/extensions/ai-research/control/Dockerfile
+++ b/extensions/ai-research/control/Dockerfile
@@ -51,7 +51,7 @@ COPY --from=ui-build /ui/node_modules/react-router-dom/LICENSE.md /usr/share/doc
 COPY --from=ui-build /ui/node_modules/lucide-react/LICENSE /usr/share/doc/modelmirror-ai-research/licenses/lucide-react-ISC.txt
 COPY --chown=65532:65532 module-boundary.json source-lock.json THIRD_PARTY_NOTICES.md ./
 
-RUN mkdir -p /data/control/evidence /data/tracking/artifacts /run/ai-research /usr/share/doc/modelmirror-ai-research \
+RUN mkdir -p /data/control/evidence /data/projects /data/tracking/artifacts /run/ai-research /usr/share/doc/modelmirror-ai-research \
     && cp THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-ai-research/THIRD_PARTY_NOTICES.md \
     && chown -R 65532:65532 /data /run/ai-research /opt/modelmirror-ai-research
 
@@ -67,5 +67,7 @@ COPY requirements-test.lock /tmp/requirements-test.lock
 RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-test.lock \
     && python -m pip check
 COPY --chown=65532:65532 tests ./tests
+COPY --chown=65532:65532 scripts/acceptance.py scripts/init_ldr_assets.py scripts/literature_acceptance.py scripts/validate_boundary.py ./scripts/
+COPY --chown=65532:65532 compose.yml LDR_LICENSE_DISPOSITION.md ./
 USER 65532:65532
 CMD ["python", "-m", "pytest", "tests/control", "-q"]

--- a/extensions/ai-research/control/ai_research_control/app.py
+++ b/extensions/ai-research/control/ai_research_control/app.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Annotated, Any
 
 import uvicorn
-from fastapi import FastAPI, HTTPException, Query, Request, status
+from fastapi import FastAPI, HTTPException, Path as ApiPath, Query, Request, status
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
@@ -19,6 +19,7 @@ from .models import (
     EventView,
     EvidenceState,
     EvidenceView,
+    ModuleInfoView,
     Outcome,
     Phase,
     ReadyView,
@@ -29,6 +30,26 @@ from .models import (
     SystemView,
 )
 from .evidence import EvidenceError
+from .project_models import (
+    LiteratureOutcome,
+    LiteraturePhase,
+    ProjectCreateRequest,
+    ProjectListResponse,
+    ProjectUpdateRequest,
+    ProjectView,
+    LiteratureSessionView,
+    LiteratureRunCreateRequest,
+    LiteratureUnlockRequest,
+)
+from .ldr_client import (
+    LdrAuthenticationError,
+    LdrConflict,
+    LdrProtocolError,
+    LdrSessionExpired,
+    LdrUnavailable,
+)
+from .literature_artifacts import LiteratureArtifactError
+from .project_store import ProjectConflict, ProjectIntegrityError
 from .service import NotReady, ResearchService
 from .store import IdempotencyConflict
 
@@ -50,7 +71,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="ModelMirror AI Research",
-    version="0.2.0-ar1",
+    version="0.3.0-v0.1",
     docs_url="/docs" if settings.docs_enabled else None,
     redoc_url=None,
     openapi_url="/openapi.json" if settings.docs_enabled else None,
@@ -119,6 +140,31 @@ def to_view(run: dict[str, Any]) -> RunView:
     )
 
 
+def to_project_view(project: dict[str, Any]) -> ProjectView:
+    literature = project["literature"]
+    return ProjectView.model_validate(
+        {
+            "schemaVersion": project["schemaVersion"],
+            "projectId": project["projectId"],
+            "title": project["title"],
+            "researchQuestion": project["researchQuestion"],
+            "domain": project["domain"],
+            "currentStage": project["currentStage"],
+            "stages": project["stages"],
+            "literaturePhase": literature["phase"],
+            "literatureOutcome": literature["outcome"],
+            "activeRunId": literature["activeRunId"],
+            "completedRunId": literature["completedRunId"],
+            "collectionId": literature["collectionId"],
+            "profileId": literature["profileId"],
+            "modelId": literature["modelId"],
+            "attempts": literature["attempts"],
+            "createdAt": project["createdAt"],
+            "updatedAt": project["updatedAt"],
+        }
+    )
+
+
 @app.get("/healthz")
 async def healthz() -> dict[str, str]:
     return {"status": "alive"}
@@ -136,17 +182,15 @@ async def readyz(request: Request) -> ReadyView:
     return ReadyView(status="ready", checks=checks)
 
 
-@app.get("/api/v1/module")
-async def module_metadata() -> dict[str, Any]:
+@app.get("/api/v1/module", response_model=ModuleInfoView, response_model_by_alias=True)
+async def module_metadata() -> ModuleInfoView:
     boundary = json.loads(settings.module_boundary.read_text(encoding="utf-8"))
     source_lock = json.loads(settings.source_lock.read_text(encoding="utf-8"))
-    return {
+    return ModuleInfoView.model_validate({
         "moduleId": boundary["moduleId"],
         "moduleVersion": boundary["moduleVersion"],
         "apiVersion": boundary["apiVersion"],
         "workerProtocolVersion": boundary["workerProtocolVersion"],
-        "claimLevel": "harness_only",
-        "packStatus": "fixture_only",
         "fixtures": boundary["allowedFixtures"],
         "runtimes": source_lock["runtimes"],
         "capabilities": {
@@ -155,24 +199,382 @@ async def module_metadata() -> dict[str, Any]:
             "evidenceVerification": True,
             "inspectView": True,
             "mlflow": True,
+            "literatureResearch": True,
+            "openAlex": True,
+            "zoteroLibrary": True,
+            "literatureArtifactExport": True,
             "modelEvaluation": False,
             "multiTenant": False,
+        },
+        "capabilityClaims": {
+            "fixtureExecution": {
+                "enabled": True,
+                "claimLevel": "harness_only",
+                "packStatus": "fixture_only",
+            },
+            "literatureResearch": {
+                "enabled": True,
+                "scientificClaim": "none",
+                "acceptanceState": "pending_live_acceptance",
+                "workflowSource": "local_deep_research",
+            },
         },
         "links": {
             "mlflow": settings.mlflow_public_url,
             "inspectView": settings.inspect_view_public_url,
+            "localDeepResearch": settings.ldr_public_url,
         },
         "limitations": [
-            "no model or provider connection",
+            "one administrator-fixed text model through the restricted S2S bridge",
+            "literature workflow only; scientificClaim=none",
             "no scientific EvalPack or score",
             "local single-tenant compatibility mode only",
         ],
-    }
+    })
 
 
 @app.get("/api/v1/system", response_model=SystemView, response_model_by_alias=True)
 async def system_status(request: Request) -> SystemView:
     return SystemView.model_validate(await service(request).system_status())
+
+
+def literature_session_response(
+    value: dict[str, str | None], *, status_code: int = 200
+) -> JSONResponse:
+    view = LiteratureSessionView.model_validate(value)
+    return JSONResponse(
+        status_code=status_code,
+        content=view.model_dump(),
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@app.get(
+    "/api/v1/literature/session",
+    response_model=LiteratureSessionView,
+)
+async def get_literature_session(request: Request) -> Response:
+    try:
+        value = await service(request).literature_session()
+    except LdrUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return literature_session_response(value)
+
+
+@app.post(
+    "/api/v1/literature/session/unlock",
+    response_model=LiteratureSessionView,
+)
+async def unlock_literature_session(
+    payload: LiteratureUnlockRequest, request: Request
+) -> Response:
+    try:
+        value = await service(request).unlock_literature(
+            username=payload.username,
+            password=payload.password,
+        )
+    except (LdrAuthenticationError, LdrSessionExpired) as exc:
+        raise HTTPException(status_code=423, detail=str(exc)) from exc
+    except LdrConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (LdrUnavailable, LdrProtocolError, NotReady) as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return literature_session_response(value)
+
+
+@app.delete(
+    "/api/v1/literature/session",
+    response_model=LiteratureSessionView,
+)
+async def clear_literature_session(request: Request) -> Response:
+    value = await service(request).clear_literature_session()
+    return literature_session_response(value)
+
+
+@app.post(
+    "/api/v1/projects",
+    response_model=ProjectView,
+    response_model_by_alias=True,
+)
+async def create_project(payload: ProjectCreateRequest, request: Request) -> Response:
+    try:
+        project, created = await asyncio.to_thread(
+            service(request).projects.create,
+            title=payload.title,
+            research_question=payload.research_question,
+            idempotency_key=payload.idempotency_key,
+        )
+    except ProjectConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    view = to_project_view(project)
+    return JSONResponse(
+        status_code=201 if created else 200,
+        content=view.model_dump(by_alias=True),
+    )
+
+
+@app.get(
+    "/api/v1/projects",
+    response_model=ProjectListResponse,
+    response_model_by_alias=True,
+)
+async def list_projects(
+    request: Request,
+    cursor: str | None = None,
+    limit: Annotated[int, Query(ge=1, le=100)] = 50,
+    q: Annotated[str | None, Query(max_length=100)] = None,
+    literature_phase: Annotated[
+        LiteraturePhase | None, Query(alias="literaturePhase")
+    ] = None,
+    literature_outcome: Annotated[
+        LiteratureOutcome | None, Query(alias="literatureOutcome")
+    ] = None,
+) -> ProjectListResponse:
+    try:
+        projects = await asyncio.to_thread(
+            service(request).projects.list,
+            after_project_id=cursor,
+            limit=limit + 1,
+            query=q,
+            phase=literature_phase,
+            outcome=literature_outcome,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=422, detail="invalid cursor") from exc
+    except ProjectIntegrityError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    has_more = len(projects) > limit
+    visible = projects[:limit]
+    return ProjectListResponse(
+        items=[to_project_view(project) for project in visible],
+        nextCursor=visible[-1]["projectId"] if has_more and visible else None,
+    )
+
+
+@app.get(
+    "/api/v1/projects/{project_id}",
+    response_model=ProjectView,
+    response_model_by_alias=True,
+)
+async def get_project(project_id: str, request: Request) -> ProjectView:
+    try:
+        project = await asyncio.to_thread(service(request).projects.get, project_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="project not found") from exc
+    except ProjectIntegrityError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return to_project_view(project)
+
+
+@app.patch(
+    "/api/v1/projects/{project_id}",
+    response_model=ProjectView,
+    response_model_by_alias=True,
+)
+async def update_project(
+    project_id: str, payload: ProjectUpdateRequest, request: Request
+) -> ProjectView:
+    try:
+        project = await asyncio.to_thread(
+            service(request).projects.update,
+            project_id,
+            title=payload.title,
+            research_question=payload.research_question,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="project not found") from exc
+    except (ProjectConflict, ProjectIntegrityError) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return to_project_view(project)
+
+
+@app.post(
+    "/api/v1/projects/{project_id}/literature/runs",
+    response_model=ProjectView,
+    response_model_by_alias=True,
+)
+async def start_project_literature(
+    project_id: str, payload: LiteratureRunCreateRequest, request: Request
+) -> Response:
+    try:
+        project, created = await service(request).start_literature(
+            project_id,
+            idempotency_key=payload.idempotency_key,
+            collection_id=payload.collection_id,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="project not found") from exc
+    except (LdrSessionExpired, LdrAuthenticationError) as exc:
+        raise HTTPException(status_code=423, detail=str(exc)) from exc
+    except (ProjectConflict, LdrConflict) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (LdrUnavailable, LdrProtocolError, NotReady) as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    view = to_project_view(project)
+    return JSONResponse(
+        status_code=201 if created else 200,
+        content=view.model_dump(by_alias=True),
+    )
+
+
+@app.get(
+    "/api/v1/projects/{project_id}/literature",
+    response_model=ProjectView,
+    response_model_by_alias=True,
+)
+async def get_project_literature(project_id: str, request: Request) -> ProjectView:
+    return await get_project(project_id, request)
+
+
+@app.post(
+    "/api/v1/projects/{project_id}/literature/cancel",
+    response_model=ProjectView,
+    response_model_by_alias=True,
+)
+async def cancel_project_literature(project_id: str, request: Request) -> ProjectView:
+    try:
+        project = await service(request).cancel_literature(project_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="project not found") from exc
+    except (LdrSessionExpired, LdrAuthenticationError) as exc:
+        raise HTTPException(status_code=423, detail=str(exc)) from exc
+    except LdrConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (LdrUnavailable, LdrProtocolError) as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return to_project_view(project)
+
+
+@app.post(
+    "/api/v1/projects/{project_id}/literature/sync",
+    response_model=ProjectView,
+    response_model_by_alias=True,
+)
+async def sync_project_literature(project_id: str, request: Request) -> ProjectView:
+    try:
+        project = await service(request).sync_literature(project_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="project not found") from exc
+    except (LdrSessionExpired, LdrAuthenticationError) as exc:
+        raise HTTPException(status_code=423, detail=str(exc)) from exc
+    except ProjectConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (LdrUnavailable, LdrProtocolError) as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return to_project_view(project)
+
+
+@app.get("/api/v1/projects/{project_id}/sources")
+async def get_project_sources(project_id: str, request: Request) -> dict[str, Any]:
+    try:
+        return await service(request).literature_sources(project_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="project or result not found") from exc
+    except ProjectConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (ProjectIntegrityError, LiteratureArtifactError) as exc:
+        raise HTTPException(status_code=409, detail="result integrity check failed") from exc
+
+
+@app.get("/api/v1/projects/{project_id}/review")
+async def get_project_review(project_id: str, request: Request) -> dict[str, Any]:
+    try:
+        return await service(request).literature_review(project_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="project or result not found") from exc
+    except ProjectConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (ProjectIntegrityError, LiteratureArtifactError) as exc:
+        raise HTTPException(status_code=409, detail="result integrity check failed") from exc
+
+
+LITERATURE_ARTIFACT_MEDIA_TYPES = {
+    "literature-review.md": "text/markdown; charset=utf-8",
+    "upstream-quarto.zip": "application/zip",
+    "literature-review.qmd": "text/markdown; charset=utf-8",
+    "references.bib": "application/x-bibtex; charset=utf-8",
+    "references.ris": "application/x-research-info-systems; charset=utf-8",
+    "sources.json": "application/json",
+    "literature-receipt.json": "application/json",
+    "artifact-manifest.json": "application/json",
+}
+
+
+@app.get("/api/v1/projects/{project_id}/artifacts/{artifact_name}")
+async def download_literature_artifact(
+    project_id: str, artifact_name: str, request: Request
+) -> Response:
+    try:
+        content, digest = await service(request).literature_artifact(
+            project_id, artifact_name
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="artifact not found") from exc
+    except ProjectConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (ProjectIntegrityError, LiteratureArtifactError) as exc:
+        raise HTTPException(status_code=409, detail="artifact integrity check failed") from exc
+    return Response(
+        content=content,
+        media_type=LITERATURE_ARTIFACT_MEDIA_TYPES.get(
+            artifact_name, "application/octet-stream"
+        ),
+        headers={
+            "Content-Disposition": f'attachment; filename="{artifact_name}"',
+            "Cache-Control": "no-store",
+            "X-Content-SHA256": digest,
+        },
+    )
+
+
+@app.get("/api/v1/literature/library/collections")
+async def get_literature_collections(request: Request) -> dict[str, Any]:
+    try:
+        return await service(request).literature_collections()
+    except (LdrSessionExpired, LdrAuthenticationError) as exc:
+        raise HTTPException(status_code=423, detail=str(exc)) from exc
+    except (LdrUnavailable, LdrProtocolError) as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@app.post("/api/v1/literature/library/collections/{collection_id}/index")
+async def index_literature_collection(
+    collection_id: Annotated[
+        str,
+        ApiPath(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9_-]+$"),
+    ],
+    request: Request,
+) -> dict[str, Any]:
+    try:
+        return await service(request).index_literature_collection(collection_id)
+    except (LdrSessionExpired, LdrAuthenticationError) as exc:
+        raise HTTPException(status_code=423, detail=str(exc)) from exc
+    except (ProjectConflict, LdrConflict) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (LdrUnavailable, LdrProtocolError) as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@app.get("/api/v1/literature/zotero/status")
+async def get_literature_zotero_status(request: Request) -> dict[str, Any]:
+    try:
+        return await service(request).literature_zotero_status()
+    except (LdrSessionExpired, LdrAuthenticationError) as exc:
+        raise HTTPException(status_code=423, detail=str(exc)) from exc
+    except (LdrUnavailable, LdrProtocolError) as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@app.post("/api/v1/literature/zotero/sync")
+async def sync_literature_zotero(request: Request) -> dict[str, Any]:
+    try:
+        return await service(request).sync_literature_zotero()
+    except (LdrSessionExpired, LdrAuthenticationError) as exc:
+        raise HTTPException(status_code=423, detail=str(exc)) from exc
+    except LdrConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (LdrUnavailable, LdrProtocolError) as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 @app.post("/api/v1/runs", response_model=RunView, response_model_by_alias=True)

--- a/extensions/ai-research/control/ai_research_control/config.py
+++ b/extensions/ai-research/control/ai_research_control/config.py
@@ -26,6 +26,51 @@ def _loopback_url(value: str, *, variable: str) -> str:
     return f"http://{parsed.hostname}:{parsed.port}"
 
 
+def _internal_http_origin(
+    value: str, *, variable: str, allowed_hosts: set[str]
+) -> str:
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in allowed_hosts
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise ValueError(f"{variable} must target an approved internal HTTP origin")
+    try:
+        if parsed.port is None:
+            raise ValueError
+    except ValueError as exc:
+        raise ValueError(f"{variable} must include a valid port") from exc
+    return f"http://{parsed.hostname}:{parsed.port}"
+
+
+def _model_bridge_url(value: str) -> str:
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname
+        not in {"ai-research-model-relay", "127.0.0.1", "localhost"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path.rstrip("/") != "/api/ai-research/v1"
+    ):
+        raise ValueError(
+            "AI_RESEARCH_MODEL_BRIDGE_URL must target the internal model relay"
+        )
+    try:
+        if parsed.port is None:
+            raise ValueError
+    except ValueError as exc:
+        raise ValueError("AI_RESEARCH_MODEL_BRIDGE_URL must include a valid port") from exc
+    return f"http://{parsed.hostname}:{parsed.port}/api/ai-research/v1"
+
+
 @dataclass(frozen=True)
 class Settings:
     control_db: Path
@@ -38,6 +83,12 @@ class Settings:
     module_boundary: Path
     poll_seconds: float
     docs_enabled: bool
+    projects_root: Path | None = None
+    ldr_uri: str = "http://ai-research-ldr:5000"
+    ldr_public_url: str = "http://127.0.0.1:8792"
+    literature_model_id: str = ""
+    model_bridge_url: str = "http://ai-research-model-relay:8090/api/ai-research/v1"
+    model_bridge_token: str = ""
     inspect_view_uri: str = "http://ai-research-inspect-view:7575"
     mlflow_public_url: str = "http://127.0.0.1:8791"
     inspect_view_public_url: str = "http://127.0.0.1:8793"
@@ -70,6 +121,30 @@ class Settings:
                 0.1, min(float(os.environ.get("AI_RESEARCH_POLL_SECONDS", "0.5")), 5.0)
             ),
             docs_enabled=os.environ.get("AI_RESEARCH_ENABLE_DOCS", "0") == "1",
+            projects_root=Path(
+                os.environ.get("AI_RESEARCH_PROJECTS_ROOT", "/data/projects")
+            ),
+            ldr_uri=_internal_http_origin(
+                os.environ.get("AI_RESEARCH_LDR_URI", "http://ai-research-ldr:5000"),
+                variable="AI_RESEARCH_LDR_URI",
+                allowed_hosts={"ai-research-ldr", "127.0.0.1", "localhost"},
+            ),
+            ldr_public_url=_loopback_url(
+                os.environ.get("AI_RESEARCH_LDR_PUBLIC_URL", "http://127.0.0.1:8792"),
+                variable="AI_RESEARCH_LDR_PUBLIC_URL",
+            ),
+            literature_model_id=os.environ.get(
+                "AI_RESEARCH_LITERATURE_MODEL_ID", ""
+            ).strip(),
+            model_bridge_url=_model_bridge_url(
+                os.environ.get(
+                    "AI_RESEARCH_MODEL_BRIDGE_URL",
+                    "http://ai-research-model-relay:8090/api/ai-research/v1",
+                )
+            ),
+            model_bridge_token=os.environ.get(
+                "AI_RESEARCH_S2S_TOKEN", ""
+            ),
             inspect_view_uri=os.environ.get(
                 "AI_RESEARCH_INSPECT_VIEW_URI", "http://ai-research-inspect-view:7575"
             ).rstrip("/"),
@@ -88,3 +163,8 @@ class Settings:
     def prepare(self) -> None:
         self.control_db.parent.mkdir(parents=True, exist_ok=True)
         self.evidence_root.mkdir(parents=True, exist_ok=True)
+        self.resolved_projects_root.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def resolved_projects_root(self) -> Path:
+        return self.projects_root or self.control_db.parent / "projects"

--- a/extensions/ai-research/control/ai_research_control/console_gateway.py
+++ b/extensions/ai-research/control/ai_research_control/console_gateway.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import (
+    HTTPRedirectHandler,
+    ProxyHandler,
+    Request as UrlRequest,
+    build_opener,
+)
+
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+
+MAX_REQUEST_BYTES = 1024 * 1024
+MAX_RESPONSE_BYTES = 256 * 1024 * 1024
+CHUNK_BYTES = 64 * 1024
+ALLOWED_METHODS = ("GET", "HEAD", "POST", "PATCH", "DELETE")
+FORWARDED_REQUEST_HEADERS = {
+    "accept": "Accept",
+    "accept-language": "Accept-Language",
+    "content-type": "Content-Type",
+    "if-modified-since": "If-Modified-Since",
+    "if-none-match": "If-None-Match",
+    "origin": "Origin",
+    "range": "Range",
+}
+FORWARDED_RESPONSE_HEADERS = {
+    "accept-ranges",
+    "cache-control",
+    "content-disposition",
+    "content-length",
+    "content-range",
+    "content-security-policy",
+    "content-type",
+    "etag",
+    "last-modified",
+    "permissions-policy",
+    "referrer-policy",
+    "x-artifact-sha256",
+    "x-content-sha256",
+    "x-content-type-options",
+}
+
+
+class NoRedirect(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class GatewaySettings:
+    target: str
+    timeout_seconds: float
+    expose_health: bool = False
+    allowed_host_headers: tuple[str, ...] = ()
+
+
+def _timeout_from_env() -> float:
+    return max(
+        5.0,
+        min(
+            float(os.getenv("AI_RESEARCH_CONSOLE_GATEWAY_TIMEOUT_SECONDS", "180")),
+            600.0,
+        ),
+    )
+
+
+def validate_target(value: str, *, expected_host: str, expected_port: int) -> str:
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname != expected_host
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise ValueError("gateway target must be its fixed internal service")
+    try:
+        if parsed.port != expected_port:
+            raise ValueError
+    except ValueError as exc:
+        raise ValueError("gateway target must use its fixed internal port") from exc
+    return f"http://{expected_host}:{expected_port}"
+
+
+def settings_from_env(
+    variable: str,
+    *,
+    default: str,
+    expected_host: str,
+    expected_port: int,
+    expose_health: bool = False,
+) -> GatewaySettings:
+    return GatewaySettings(
+        target=validate_target(
+            os.getenv(variable, default),
+            expected_host=expected_host,
+            expected_port=expected_port,
+        ),
+        timeout_seconds=_timeout_from_env(),
+        expose_health=expose_health,
+    )
+
+
+def create_gateway_app(settings: GatewaySettings) -> FastAPI:
+    app = FastAPI(
+        title="ModelMirror AI Research Local Gateway",
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
+    )
+
+    if settings.expose_health:
+
+        @app.get("/gateway-healthz", include_in_schema=False)
+        async def gateway_healthz() -> dict[str, str]:
+            return {"status": "alive"}
+
+    @app.api_route(
+        "/{path:path}",
+        methods=list(ALLOWED_METHODS),
+        include_in_schema=False,
+    )
+    async def proxy(path: str, request: Request):
+        return await forward(request, settings)
+
+    return app
+
+
+async def read_bounded_body(request: Request) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > MAX_REQUEST_BYTES:
+            raise HTTPException(status_code=413, detail="gateway request exceeded size limit")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def forward(request: Request, settings: GatewaySettings):
+    body = b""
+    if request.method in {"POST", "PATCH", "DELETE"}:
+        body = await read_bounded_body(request)
+    elif request.headers.get("content-length") not in {None, "0"}:
+        raise HTTPException(status_code=400, detail="request body is forbidden")
+
+    raw_path = request.scope.get("raw_path", b"/")
+    if not isinstance(raw_path, bytes) or not raw_path.startswith(b"/"):
+        raise HTTPException(status_code=400, detail="invalid gateway path")
+    try:
+        path = raw_path.decode("ascii")
+        query = request.scope.get("query_string", b"").decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise HTTPException(status_code=400, detail="invalid gateway URL encoding") from exc
+    target_url = settings.target + path
+    if query:
+        target_url += "?" + query
+
+    headers: dict[str, str] = {}
+    if settings.allowed_host_headers:
+        host = request.headers.get("host", "").casefold()
+        allowed_hosts = {value.casefold() for value in settings.allowed_host_headers}
+        if host not in allowed_hosts:
+            raise HTTPException(status_code=400, detail="gateway host is not allowed")
+        headers["Host"] = host
+    for source, destination in FORWARDED_REQUEST_HEADERS.items():
+        value = request.headers.get(source)
+        if value and len(value) <= 4096 and "\r" not in value and "\n" not in value:
+            headers[destination] = value
+    if body:
+        headers["Content-Length"] = str(len(body))
+
+    upstream_request = UrlRequest(
+        target_url,
+        data=body if body else None,
+        headers=headers,
+        method=request.method,
+    )
+    try:
+        upstream = await asyncio.to_thread(
+            open_upstream,
+            upstream_request,
+            settings.timeout_seconds,
+        )
+    except URLError as exc:
+        raise HTTPException(status_code=503, detail="internal UI service unavailable") from exc
+
+    status_value = getattr(upstream, "status", None)
+    status = int(status_value if status_value is not None else upstream.getcode())
+    if 300 <= status < 400:
+        upstream.close()
+        raise HTTPException(status_code=502, detail="internal UI service redirected")
+
+    response_headers: dict[str, str] = {}
+    for name, value in upstream.headers.items():
+        lowered = name.casefold()
+        if (
+            lowered in FORWARDED_RESPONSE_HEADERS
+            and len(value) <= 4096
+            and "\r" not in value
+            and "\n" not in value
+        ):
+            response_headers[name] = value
+    content_length = response_headers.get("Content-Length") or response_headers.get(
+        "content-length"
+    )
+    if content_length is not None:
+        try:
+            if int(content_length) > MAX_RESPONSE_BYTES:
+                raise ValueError
+        except ValueError as exc:
+            upstream.close()
+            raise HTTPException(
+                status_code=502,
+                detail="internal UI response exceeded size limit",
+            ) from exc
+    response_headers.setdefault("X-Content-Type-Options", "nosniff")
+    response_headers.setdefault("Referrer-Policy", "no-referrer")
+    return StreamingResponse(
+        bounded_response(upstream),
+        status_code=status,
+        headers=response_headers,
+        media_type=None,
+    )
+
+
+def open_upstream(request: UrlRequest, timeout_seconds: float):
+    opener = build_opener(ProxyHandler({}), NoRedirect())
+    try:
+        return opener.open(request, timeout=timeout_seconds)
+    except HTTPError as exc:
+        return exc
+
+
+def bounded_response(upstream) -> Iterator[bytes]:
+    total = 0
+    try:
+        while True:
+            chunk = upstream.read(CHUNK_BYTES)
+            if not chunk:
+                return
+            total += len(chunk)
+            if total > MAX_RESPONSE_BYTES:
+                raise RuntimeError("internal UI response exceeded size limit")
+            yield chunk
+    finally:
+        upstream.close()
+
+
+def _apps() -> tuple[FastAPI, FastAPI, FastAPI]:
+    timeout = _timeout_from_env()
+    try:
+        inspect_public_port = int(
+            os.getenv("AI_RESEARCH_CONSOLE_GATEWAY_INSPECT_PUBLIC_PORT", "8793")
+        )
+        if not 1 <= inspect_public_port <= 65535:
+            raise ValueError
+    except ValueError as exc:
+        raise ValueError("Inspect gateway public port is invalid") from exc
+    console = settings_from_env(
+        "AI_RESEARCH_CONSOLE_GATEWAY_CONTROL_URL",
+        default="http://ai-research-control:8080",
+        expected_host="ai-research-control",
+        expected_port=8080,
+        expose_health=True,
+    )
+    tracking = settings_from_env(
+        "AI_RESEARCH_CONSOLE_GATEWAY_TRACKING_URL",
+        default="http://ai-research-tracking:5000",
+        expected_host="ai-research-tracking",
+        expected_port=5000,
+    )
+    inspect_view = settings_from_env(
+        "AI_RESEARCH_CONSOLE_GATEWAY_INSPECT_URL",
+        default="http://ai-research-inspect-view:7575",
+        expected_host="ai-research-inspect-view",
+        expected_port=7575,
+    )
+    return (
+        create_gateway_app(GatewaySettings(console.target, timeout, True)),
+        create_gateway_app(GatewaySettings(tracking.target, timeout)),
+        create_gateway_app(
+            GatewaySettings(
+                inspect_view.target,
+                timeout,
+                allowed_host_headers=(
+                    f"127.0.0.1:{inspect_public_port}",
+                    f"localhost:{inspect_public_port}",
+                ),
+            )
+        ),
+    )
+
+
+async def serve() -> None:
+    servers = [
+        uvicorn.Server(
+            uvicorn.Config(
+                app,
+                host="0.0.0.0",
+                port=port,
+                access_log=False,
+                proxy_headers=False,
+                server_header=False,
+                date_header=False,
+            )
+        )
+        for app, port in zip(_apps(), (8080, 8091, 8093), strict=True)
+    ]
+    for server in servers:
+        server.install_signal_handlers = lambda: None
+    await asyncio.gather(*(server.serve() for server in servers))
+
+
+if __name__ == "__main__":
+    asyncio.run(serve())

--- a/extensions/ai-research/control/ai_research_control/ldr_client.py
+++ b/extensions/ai-research/control/ai_research_control/ldr_client.py
@@ -1,0 +1,484 @@
+from __future__ import annotations
+
+import re
+from html.parser import HTMLParser
+from collections.abc import Callable
+from typing import Any
+
+import requests
+
+
+MAX_JSON_BYTES = 2 * 1024 * 1024
+MAX_HTML_BYTES = 512 * 1024
+MAX_EXPORT_BYTES = 64 * 1024 * 1024
+RUN_ID_RE = re.compile(r"^lr_[0-9a-f]{32}$")
+COLLECTION_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+RESEARCH_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+
+# Exact static engine registry shipped by locked LDR v1.10.6. Missing
+# agent_enabled settings default to True upstream, so every registry entry must
+# be written explicitly to keep the V0.1 tool surface closed by default.
+AGENT_TOOL_KEYS = (
+    "arxiv",
+    "brave",
+    "ddg",
+    "elasticsearch",
+    "exa",
+    "github",
+    "google_pse",
+    "guardian",
+    "gutenberg",
+    "mojeek",
+    "nasa_ads",
+    "openalex",
+    "openlibrary",
+    "paperless",
+    "pubchem",
+    "pubmed",
+    "scaleserp",
+    "searxng",
+    "semantic_scholar",
+    "serpapi",
+    "serper",
+    "sofya",
+    "stackexchange",
+    "tavily",
+    "tinyfish",
+    "wayback",
+    "wikinews",
+    "wikipedia",
+    "zenodo",
+)
+ENABLED_ACADEMIC_TOOLS = {"arxiv", "openalex", "semantic_scholar"}
+
+
+class LdrError(RuntimeError):
+    pass
+
+
+class LdrUnavailable(LdrError):
+    pass
+
+
+class LdrAuthenticationError(LdrError):
+    pass
+
+
+class LdrSessionExpired(LdrError):
+    pass
+
+
+class LdrConflict(LdrError):
+    pass
+
+
+class LdrProtocolError(LdrError):
+    pass
+
+
+class _CsrfInputParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.value: str | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.casefold() != "input":
+            return
+        values = {name.casefold(): value for name, value in attrs}
+        if values.get("name") == "csrf_token" and values.get("value"):
+            self.value = values["value"]
+
+
+class LdrClient:
+    """Bounded adapter for the locked Local Deep Research v1.10.6 HTTP API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        session: requests.Session | None = None,
+        session_factory: Callable[[], requests.Session] | None = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._session_factory = session_factory or self._new_session
+        self._session = session or self._session_factory()
+        self._csrf_token: str | None = None
+        self._username: str | None = None
+        self._was_unlocked = False
+
+    @staticmethod
+    def _new_session() -> requests.Session:
+        value = requests.Session()
+        value.trust_env = False
+        return value
+
+    @property
+    def username(self) -> str | None:
+        return self._username
+
+    def clear(self) -> None:
+        self._session.close()
+        self._session = self._session_factory()
+        self._csrf_token = None
+        self._username = None
+        self._was_unlocked = False
+
+    def probe(self) -> bool:
+        try:
+            response = self._session.get(
+                self.base_url + "/auth/check", timeout=(2.0, 3.0)
+            )
+        except requests.RequestException as exc:
+            raise LdrUnavailable("LDR is unavailable") from exc
+        return response.status_code in {200, 401}
+
+    def session_status(self) -> dict[str, str | None]:
+        try:
+            response = self._session.get(
+                self.base_url + "/auth/check", timeout=(2.0, 5.0)
+            )
+        except requests.RequestException as exc:
+            raise LdrUnavailable("LDR is unavailable") from exc
+        if response.status_code == 200:
+            value = self._json(response)
+            if value.get("authenticated") is True and isinstance(
+                value.get("username"), str
+            ):
+                self._username = value["username"]
+                self._was_unlocked = True
+                return {"status": "ready", "username": self._username}
+        if response.status_code == 401:
+            self._csrf_token = None
+            self._username = None
+            return {
+                "status": "expired" if self._was_unlocked else "locked",
+                "username": None,
+            }
+        self._raise_response(response, "checking LDR session")
+        raise LdrProtocolError("invalid LDR session response")
+
+    def unlock(self, username: str, password: str) -> dict[str, str | None]:
+        if not re.fullmatch(r"[A-Za-z0-9_-]{3,64}", username):
+            raise LdrAuthenticationError("invalid LDR username")
+        if not password or len(password) > 1024:
+            raise LdrAuthenticationError("invalid LDR password")
+
+        self._session.close()
+        self._session = self._session_factory()
+        self._csrf_token = None
+        self._username = None
+        try:
+            login_page = self._session.get(
+                self.base_url + "/auth/login", timeout=(3.0, 10.0)
+            )
+            self._bounded(login_page, MAX_HTML_BYTES)
+            if login_page.status_code != 200:
+                self._raise_response(login_page, "loading LDR login")
+            parser = _CsrfInputParser()
+            parser.feed(login_page.text)
+            if not parser.value:
+                raise LdrProtocolError("LDR login page omitted CSRF token")
+
+            login = self._session.post(
+                self.base_url + "/auth/login",
+                data={
+                    "username": username,
+                    "password": password,
+                    "csrf_token": parser.value,
+                },
+                allow_redirects=False,
+                timeout=(3.0, 20.0),
+            )
+        except requests.RequestException as exc:
+            raise LdrUnavailable("LDR login request failed") from exc
+        if login.status_code not in {200, 302, 303}:
+            if login.status_code in {400, 401, 429}:
+                raise LdrAuthenticationError("LDR credentials were rejected")
+            self._raise_response(login, "unlocking LDR")
+
+        check = self._session.get(
+            self.base_url + "/auth/check", timeout=(3.0, 10.0)
+        )
+        if check.status_code != 200:
+            raise LdrAuthenticationError("LDR credentials were rejected")
+        check_value = self._json(check)
+        if check_value.get("authenticated") is not True:
+            raise LdrAuthenticationError("LDR credentials were rejected")
+
+        csrf = self._session.get(
+            self.base_url + "/auth/csrf-token", timeout=(3.0, 10.0)
+        )
+        csrf_value = self._json(csrf)
+        token = csrf_value.get("csrf_token")
+        if not isinstance(token, str) or not token:
+            raise LdrProtocolError("LDR API CSRF token is missing")
+        self._csrf_token = token
+        self._username = username
+        self._was_unlocked = True
+        return {"status": "ready", "username": username}
+
+    def configure_fixed_profile(
+        self, *, model_id: str, bridge_url: str, bridge_token: str
+    ) -> None:
+        if not model_id or not bridge_url or not bridge_token:
+            raise LdrProtocolError("fixed literature model bridge is not configured")
+        settings: dict[str, Any] = {
+            "llm.provider": "openai_endpoint",
+            "llm.model": model_id,
+            "llm.openai_endpoint.url": bridge_url.rstrip("/"),
+            "llm.openai_endpoint.api_key": bridge_token,
+            "search.tool": "openalex",
+            "search.engine.web.openalex.default_params.enable_llm_relevance_filter": False,
+            "search.max_results": 15,
+            "search.iterations": 2,
+            "search.questions_per_iteration": 3,
+            "search.search_strategy": "langgraph-agent",
+            # search.iterations applies to pipeline strategies only. These are
+            # the real LangGraph bounds in LDR v1.10.6; values below the
+            # upstream minima silently expand to its defaults.
+            "langgraph_agent.max_iterations": 10,
+            "langgraph_agent.max_sub_iterations": 3,
+            "langgraph_agent.include_sub_research": False,
+            "langgraph_agent.max_subagent_workers": 1,
+            "policy.egress_scope": "public_only",
+            "embeddings.require_local": True,
+            "local_search_embedding_provider": "sentence_transformers",
+            "local_search_embedding_model": (
+                "/data/models/sentence-transformers/all-MiniLM-L6-v2"
+            ),
+        }
+        for engine in AGENT_TOOL_KEYS:
+            settings[f"search.engine.web.{engine}.agent_enabled"] = (
+                engine in ENABLED_ACADEMIC_TOOLS
+            )
+        response = self._request(
+            "POST", "/settings/save_all_settings", json=settings, timeout=(3.0, 30.0)
+        )
+        value = self._json(response)
+        if value.get("status") != "success":
+            raise LdrProtocolError("LDR rejected the fixed literature profile")
+
+    def start_research(
+        self,
+        *,
+        question: str,
+        control_run_id: str,
+        model_id: str,
+        bridge_url: str,
+        collection_id: str | None,
+    ) -> tuple[str, str]:
+        if not question.strip() or len(question) > 5000:
+            raise LdrProtocolError("invalid literature research question")
+        if not RUN_ID_RE.fullmatch(control_run_id):
+            raise LdrProtocolError("invalid literature control run id")
+        if collection_id and not COLLECTION_ID_RE.fullmatch(collection_id):
+            raise LdrProtocolError("invalid LDR collection id")
+        response = self._request(
+            "POST",
+            "/api/start_research",
+            json={
+                "query": question.strip(),
+                "mode": "deep",
+                "model_provider": "openai_endpoint",
+                "model": model_id,
+                "custom_endpoint": bridge_url.rstrip("/"),
+                # OpenAlex remains the primary engine. An eligible collection is
+                # exposed separately by LDR as a LangGraph specialized tool; using
+                # collection_<id> here would replace, rather than supplement, the
+                # locked academic search path.
+                "search_engine": "openalex",
+                "max_results": 15,
+                "iterations": 2,
+                "questions_per_iteration": 3,
+                "strategy": "langgraph-agent",
+                "policy_egress_scope": "public_only",
+                "metadata": {
+                    "modelmirror_literature_run_id": control_run_id,
+                    **(
+                        {"modelmirror_collection_id": collection_id}
+                        if collection_id
+                        else {}
+                    ),
+                },
+            },
+            timeout=(3.0, 30.0),
+        )
+        value = self._json(response)
+        research_id = value.get("research_id")
+        if value.get("status") not in {"success", "queued"} or not isinstance(
+            research_id, str
+        ) or not RESEARCH_ID_RE.fullmatch(research_id):
+            raise LdrProtocolError("LDR start response omitted research id")
+        return research_id, str(value["status"])
+
+    def find_research_by_run_id(self, control_run_id: str) -> str | None:
+        if not RUN_ID_RE.fullmatch(control_run_id):
+            raise LdrProtocolError("invalid literature control run id")
+        value = self._json(self._request("GET", "/api/history?limit=500"))
+        for item in value.get("items", []):
+            if not isinstance(item, dict):
+                continue
+            metadata = item.get("metadata")
+            if (
+                isinstance(metadata, dict)
+                and metadata.get("modelmirror_literature_run_id") == control_run_id
+                and isinstance(item.get("id"), str)
+            ):
+                research_id = item["id"]
+                if not RESEARCH_ID_RE.fullmatch(research_id):
+                    raise LdrProtocolError("LDR history returned an unsafe research id")
+                return research_id
+        return None
+
+    def research_status(self, research_id: str) -> dict[str, Any]:
+        self._validate_research_id(research_id)
+        return self._json(self._request("GET", f"/api/research/{research_id}/status"))
+
+    def report(self, research_id: str) -> dict[str, Any]:
+        self._validate_research_id(research_id)
+        return self._json(self._request("GET", f"/api/report/{research_id}"))
+
+    def terminate(self, research_id: str) -> dict[str, Any]:
+        self._validate_research_id(research_id)
+        return self._json(
+            self._request("POST", f"/api/terminate/{research_id}", json={})
+        )
+
+    def export(self, research_id: str, export_format: str) -> bytes:
+        self._validate_research_id(research_id)
+        if export_format not in {"quarto", "ris"}:
+            raise LdrProtocolError("unsupported LDR export format")
+        response = self._request(
+            "POST",
+            f"/api/v1/research/{research_id}/export/{export_format}",
+            json={},
+            timeout=(3.0, 60.0),
+        )
+        self._bounded(response, MAX_EXPORT_BYTES)
+        return response.content
+
+    def collections(self) -> list[dict[str, Any]]:
+        value = self._json(self._request("GET", "/library/api/collections"))
+        items = value.get("collections")
+        if value.get("success") is not True or not isinstance(items, list):
+            raise LdrProtocolError("invalid LDR collections response")
+        return [item for item in items if isinstance(item, dict)]
+
+    def zotero_config(self) -> dict[str, Any]:
+        return self._json(self._request("GET", "/library/api/zotero/config"))
+
+    def zotero_status(self) -> dict[str, Any]:
+        return self._json(self._request("GET", "/library/api/zotero/status"))
+
+    def zotero_sync(self) -> dict[str, Any]:
+        return self._json(
+            self._request("POST", "/library/api/zotero/sync", json={})
+        )
+
+    def index_collection(self, collection_id: str) -> list[dict[str, Any]]:
+        if not COLLECTION_ID_RE.fullmatch(collection_id):
+            raise LdrProtocolError("invalid LDR collection id")
+        response = self._request(
+            "GET",
+            f"/library/api/collections/{collection_id}/index",
+            stream=True,
+            timeout=(3.0, 300.0),
+        )
+        events: list[dict[str, Any]] = []
+        total = 0
+        for line in response.iter_lines(decode_unicode=True):
+            if not line or not line.startswith("data: "):
+                continue
+            encoded = line[6:].encode("utf-8")
+            total += len(encoded)
+            if total > MAX_JSON_BYTES or len(events) >= 10_000:
+                raise LdrProtocolError("LDR index event stream exceeded limits")
+            try:
+                import json
+
+                value = json.loads(encoded)
+            except (ValueError, UnicodeDecodeError) as exc:
+                raise LdrProtocolError("invalid LDR index event") from exc
+            if isinstance(value, dict):
+                events.append(value)
+        if not events or events[-1].get("type") not in {"complete", "error"}:
+            raise LdrProtocolError("LDR index stream ended without a terminal event")
+        return events
+
+    @staticmethod
+    def _validate_research_id(research_id: str) -> None:
+        if not isinstance(research_id, str) or not RESEARCH_ID_RE.fullmatch(
+            research_id
+        ):
+            raise LdrProtocolError("invalid LDR research id")
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> requests.Response:
+        headers = dict(kwargs.pop("headers", {}))
+        if method != "GET":
+            if not self._csrf_token:
+                raise LdrSessionExpired("LDR session is not unlocked")
+            self._refresh_csrf_token()
+            headers["X-CSRF-Token"] = self._csrf_token
+        try:
+            response = self._session.request(
+                method,
+                self.base_url + path,
+                headers=headers,
+                timeout=kwargs.pop("timeout", (3.0, 20.0)),
+                allow_redirects=False,
+                **kwargs,
+            )
+        except requests.RequestException as exc:
+            raise LdrUnavailable("LDR request failed") from exc
+        if response.status_code < 200 or response.status_code >= 300:
+            self._raise_response(response, "calling LDR")
+        return response
+
+    def _refresh_csrf_token(self) -> None:
+        try:
+            response = self._session.get(
+                self.base_url + "/auth/csrf-token", timeout=(3.0, 10.0)
+            )
+        except requests.RequestException as exc:
+            raise LdrUnavailable("LDR CSRF refresh failed") from exc
+        if response.status_code != 200:
+            self._raise_response(response, "refreshing LDR CSRF token")
+        value = self._json(response)
+        token = value.get("csrf_token")
+        if not isinstance(token, str) or not token:
+            raise LdrProtocolError("LDR API CSRF token is missing")
+        self._csrf_token = token
+
+    def _json(self, response: requests.Response) -> dict[str, Any]:
+        self._bounded(response, MAX_JSON_BYTES)
+        try:
+            value = response.json()
+        except ValueError as exc:
+            raise LdrProtocolError("LDR returned malformed JSON") from exc
+        if not isinstance(value, dict):
+            raise LdrProtocolError("LDR returned a non-object JSON response")
+        return value
+
+    @staticmethod
+    def _bounded(response: requests.Response, limit: int) -> None:
+        header = response.headers.get("content-length")
+        if header:
+            try:
+                if int(header) > limit:
+                    raise LdrProtocolError("LDR response exceeded size limit")
+            except ValueError as exc:
+                raise LdrProtocolError("LDR returned invalid content length") from exc
+        if len(response.content) > limit:
+            raise LdrProtocolError("LDR response exceeded size limit")
+
+    def _raise_response(self, response: requests.Response, operation: str) -> None:
+        if response.status_code == 401:
+            self._csrf_token = None
+            self._username = None
+            self._was_unlocked = True
+            raise LdrSessionExpired("LDR session expired")
+        if response.status_code in {409, 429}:
+            raise LdrConflict(f"LDR refused {operation}")
+        if response.status_code >= 500:
+            raise LdrUnavailable(f"LDR failed while {operation}")
+        raise LdrProtocolError(f"LDR rejected {operation}")

--- a/extensions/ai-research/control/ai_research_control/literature_artifacts.py
+++ b/extensions/ai-research/control/ai_research_control/literature_artifacts.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import io
+import json
+import os
+import re
+import stat
+import tempfile
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlsplit
+
+
+MAX_REPORT_BYTES = 16 * 1024 * 1024
+MAX_RIS_BYTES = 16 * 1024 * 1024
+MAX_ZIP_BYTES = 64 * 1024 * 1024
+MAX_UNCOMPRESSED_BYTES = 128 * 1024 * 1024
+MAX_ZIP_ENTRIES = 50
+MAX_ARTIFACT_BYTES = 128 * 1024 * 1024
+HTTPS_UPGRADE_HOSTS = {"arxiv.org"}
+FIXED_ARTIFACTS = {
+    "literature-review.md",
+    "upstream-quarto.zip",
+    "literature-review.qmd",
+    "references.bib",
+    "references.ris",
+    "sources.json",
+    "literature-receipt.json",
+}
+UPSTREAM_REPORT_ERROR_RE = re.compile(
+    r"(?mi)^\s*(?:"
+    r"Error:\s+(?:Error code:\s*[45]\d{2}\b|Final answer synthesis failed\b)"
+    r"|Research collected\s+\d+\s+sources but synthesis failed:"
+    r")"
+)
+
+
+class LiteratureArtifactError(RuntimeError):
+    pass
+
+
+def sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+class LiteratureArtifactStore:
+    def __init__(self, projects_root: Path) -> None:
+        self.projects_root = projects_root
+
+    def persist(
+        self,
+        *,
+        run_directory: Path,
+        project: dict[str, Any],
+        attempt: dict[str, Any],
+        report: dict[str, Any],
+        quarto_zip: bytes,
+        ris: bytes,
+    ) -> dict[str, dict[str, Any]]:
+        directory = self._confined_run_directory(run_directory)
+        content = report.get("content")
+        sources = report.get("sources")
+        if not isinstance(content, str) or not content.strip():
+            raise LiteratureArtifactError("LDR report is empty or malformed")
+        if UPSTREAM_REPORT_ERROR_RE.search(content):
+            raise LiteratureArtifactError(
+                "LDR report contains upstream generation errors"
+            )
+        markdown = content.encode("utf-8")
+        if len(markdown) > MAX_REPORT_BYTES:
+            raise LiteratureArtifactError("LDR report exceeds size limit")
+        normalized_sources = self._normalize_sources(sources)
+        sources_json = canonical_json(normalized_sources)
+        if not ris or len(ris) > MAX_RIS_BYTES:
+            raise LiteratureArtifactError("LDR RIS export is empty or oversized")
+        if not quarto_zip or len(quarto_zip) > MAX_ZIP_BYTES:
+            raise LiteratureArtifactError("LDR Quarto export is empty or oversized")
+        qmd, bib = self._extract_quarto(quarto_zip)
+        self._verify_citations(qmd, bib)
+
+        upstream_payloads = {
+            "literature-review.md": markdown,
+            "upstream-quarto.zip": quarto_zip,
+            "literature-review.qmd": qmd,
+            "references.bib": bib,
+            "references.ris": ris,
+            "sources.json": sources_json,
+        }
+        receipt = canonical_json(
+            {
+                "schemaVersion": 1,
+                "projectId": project["projectId"],
+                "literatureRunId": attempt["runId"],
+                "ldrResearchId": attempt.get("ldrResearchId"),
+                "ldrVersion": "1.10.6",
+                "ldrCommit": "641308272b2143df89c7a946051d2f05ca29b3c1",
+                "profileId": attempt["profileId"],
+                "modelId": attempt["modelId"],
+                "searchEngine": attempt["searchEngine"],
+                "strategy": attempt["strategy"],
+                "egress": attempt["egress"],
+                "collectionId": project["literature"].get("collectionId"),
+                "maxResults": attempt["maxResults"],
+                "iterations": attempt["iterations"],
+                "questionsPerIteration": attempt["questionsPerIteration"],
+                "rawStatus": attempt.get("rawStatus"),
+                "outcome": attempt.get("outcome"),
+                "createdAt": attempt.get("createdAt"),
+                "startedAt": attempt.get("startedAt"),
+                "cancelRequestedAt": attempt.get("cancelRequestedAt"),
+                "cancelAppliedAt": attempt.get("cancelAppliedAt"),
+                "terminalAt": attempt.get("terminalAt"),
+                "syncedAt": attempt.get("syncedAt"),
+                "sourceLockSha256": project["control"]["sourceLockSha256"],
+                "scientificClaim": "none",
+                "generatedBy": "upstream_local_deep_research",
+                "outputs": {
+                    name: {"sha256": sha256(value), "sizeBytes": len(value)}
+                    for name, value in sorted(upstream_payloads.items())
+                },
+            }
+        )
+        payloads = dict(upstream_payloads)
+        payloads["literature-receipt.json"] = receipt
+        manifest = {
+            name: {
+                "sha256": sha256(value),
+                "sizeBytes": len(value),
+            }
+            for name, value in sorted(payloads.items())
+        }
+        for name, value in payloads.items():
+            self._atomic_write(directory / name, value)
+        self._atomic_write(
+            directory / "artifact-manifest.json",
+            canonical_json({"schemaVersion": 1, "artifacts": manifest}),
+        )
+        self.verify(directory)
+        return manifest
+
+    def verify(self, run_directory: Path) -> dict[str, dict[str, Any]]:
+        directory = self._confined_run_directory(run_directory)
+        manifest_path = directory / "artifact-manifest.json"
+        raw = self._safe_read(manifest_path, MAX_ARTIFACT_BYTES)
+        try:
+            manifest = json.loads(raw)
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise LiteratureArtifactError("artifact manifest is malformed") from exc
+        if not isinstance(manifest, dict) or manifest.get("schemaVersion") != 1:
+            raise LiteratureArtifactError("artifact manifest schema is unsupported")
+        artifacts = manifest.get("artifacts")
+        if not isinstance(artifacts, dict) or set(artifacts) != FIXED_ARTIFACTS:
+            raise LiteratureArtifactError("artifact manifest has an unexpected file set")
+        for name, descriptor in artifacts.items():
+            if not isinstance(descriptor, dict):
+                raise LiteratureArtifactError("artifact descriptor is malformed")
+            content = self._safe_read(directory / name, MAX_ARTIFACT_BYTES)
+            if descriptor.get("sizeBytes") != len(content) or descriptor.get(
+                "sha256"
+            ) != sha256(content):
+                raise LiteratureArtifactError(f"artifact integrity failed: {name}")
+        return artifacts
+
+    def read_artifact(self, run_directory: Path, name: str) -> tuple[bytes, str]:
+        if name == "artifact-manifest.json":
+            content = self._safe_read(
+                self._confined_run_directory(run_directory) / name,
+                MAX_ARTIFACT_BYTES,
+            )
+            self.verify(run_directory)
+            return content, sha256(content)
+        if name not in FIXED_ARTIFACTS:
+            raise KeyError(name)
+        manifest = self.verify(run_directory)
+        content = self._safe_read(
+            self._confined_run_directory(run_directory) / name,
+            MAX_ARTIFACT_BYTES,
+        )
+        descriptor = manifest[name]
+        if descriptor["sizeBytes"] != len(content) or descriptor["sha256"] != sha256(
+            content
+        ):
+            raise LiteratureArtifactError(f"artifact integrity failed: {name}")
+        return content, descriptor["sha256"]
+
+    def sources(self, run_directory: Path) -> list[dict[str, Any]]:
+        raw, _ = self.read_artifact(run_directory, "sources.json")
+        value = json.loads(raw)
+        if not isinstance(value, list):
+            raise LiteratureArtifactError("sources artifact is malformed")
+        return value
+
+    def review(self, run_directory: Path) -> str:
+        raw, _ = self.read_artifact(run_directory, "literature-review.md")
+        return raw.decode("utf-8")
+
+    def _confined_run_directory(self, run_directory: Path) -> Path:
+        if self.projects_root.is_symlink():
+            raise LiteratureArtifactError("projects root must not be symbolic")
+        root = self.projects_root.resolve()
+        candidate = run_directory.absolute()
+        if candidate == root or not candidate.is_relative_to(root):
+            raise LiteratureArtifactError("run directory escapes projects root")
+        current = root
+        for part in candidate.relative_to(root).parts:
+            current /= part
+            if current.is_symlink():
+                raise LiteratureArtifactError(
+                    "run directory is unavailable or symbolic"
+                )
+        if not candidate.is_dir() or candidate.resolve() != candidate:
+            raise LiteratureArtifactError("run directory is unavailable or symbolic")
+        return candidate
+
+    @staticmethod
+    def _normalize_sources(value: object) -> list[dict[str, Any]]:
+        if not isinstance(value, list) or not value:
+            raise LiteratureArtifactError("LDR report did not provide sources")
+        result: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for entry in value:
+            if isinstance(entry, str):
+                entry = {"url": entry}
+            if not isinstance(entry, dict):
+                raise LiteratureArtifactError("LDR source is malformed")
+            url = entry.get("url")
+            if not isinstance(url, str):
+                raise LiteratureArtifactError("LDR source URL is missing")
+            parsed = urlsplit(url.strip())
+            hostname = (parsed.hostname or "").rstrip(".").lower()
+            original_url = parsed.geturl()
+            if (
+                parsed.scheme == "http"
+                and hostname in HTTPS_UPGRADE_HOSTS
+                and parsed.port is None
+            ):
+                parsed = parsed._replace(scheme="https")
+            if (
+                parsed.scheme != "https"
+                or not hostname
+                or parsed.username is not None
+                or parsed.password is not None
+                or hostname == "localhost"
+                or hostname.endswith((".localhost", ".local", ".internal"))
+            ):
+                raise LiteratureArtifactError("LDR source URL must be public HTTPS")
+            try:
+                address = ipaddress.ip_address(hostname)
+            except ValueError:
+                address = None
+            if address is not None and not address.is_global:
+                raise LiteratureArtifactError("LDR source URL must be public HTTPS")
+            normalized = parsed.geturl()
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            source = {
+                "url": normalized,
+                "title": str(entry.get("title") or "Untitled")[:500],
+                "index": entry.get("index"),
+            }
+            if original_url != normalized:
+                source["upstreamUrl"] = original_url
+            result.append(source)
+        if not result:
+            raise LiteratureArtifactError("LDR report did not provide usable sources")
+        return result
+
+    @staticmethod
+    def _extract_quarto(content: bytes) -> tuple[bytes, bytes]:
+        try:
+            archive = zipfile.ZipFile(io.BytesIO(content))
+        except (zipfile.BadZipFile, OSError) as exc:
+            raise LiteratureArtifactError("Quarto export is not a valid ZIP") from exc
+        with archive:
+            entries = archive.infolist()
+            if not entries or len(entries) > MAX_ZIP_ENTRIES:
+                raise LiteratureArtifactError("Quarto ZIP has an invalid entry count")
+            total = 0
+            seen_paths: set[str] = set()
+            qmd_entries: list[zipfile.ZipInfo] = []
+            bib_entries: list[zipfile.ZipInfo] = []
+            for entry in entries:
+                path = PurePosixPath(entry.filename)
+                mode = (entry.external_attr >> 16) & 0o170000
+                if (
+                    entry.is_dir()
+                    or mode == stat.S_IFLNK
+                    or "\\" in entry.filename
+                    or path.is_absolute()
+                    or ".." in path.parts
+                    or len(path.parts) != 1
+                ):
+                    raise LiteratureArtifactError("Quarto ZIP contains an unsafe entry")
+                normalized_path = path.as_posix()
+                if normalized_path in seen_paths:
+                    raise LiteratureArtifactError(
+                        "Quarto ZIP contains a duplicate filename"
+                    )
+                seen_paths.add(normalized_path)
+                total += entry.file_size
+                if total > MAX_UNCOMPRESSED_BYTES:
+                    raise LiteratureArtifactError("Quarto ZIP exceeds expansion limit")
+                if entry.compress_size == 0 and entry.file_size > 0:
+                    raise LiteratureArtifactError("Quarto ZIP has an invalid compression ratio")
+                if entry.compress_size and entry.file_size / entry.compress_size > 100:
+                    raise LiteratureArtifactError("Quarto ZIP compression ratio is unsafe")
+                if path.suffix.casefold() == ".qmd":
+                    qmd_entries.append(entry)
+                if path.name.casefold() == "references.bib":
+                    bib_entries.append(entry)
+            if len(qmd_entries) != 1 or len(bib_entries) != 1:
+                raise LiteratureArtifactError("Quarto ZIP must contain one QMD and references.bib")
+            qmd = archive.read(qmd_entries[0])
+            bib = archive.read(bib_entries[0])
+        if not qmd or not bib or len(qmd) > MAX_REPORT_BYTES or len(bib) > MAX_REPORT_BYTES:
+            raise LiteratureArtifactError("Quarto document or bibliography is invalid")
+        return qmd, bib
+
+    @staticmethod
+    def _verify_citations(qmd: bytes, bib: bytes) -> None:
+        try:
+            qmd_text = qmd.decode("utf-8")
+            bib_text = bib.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise LiteratureArtifactError("Quarto artifacts must be UTF-8") from exc
+        citation_surface = re.sub(
+            r"(?ms)^```[^\n]*\n.*?^```[ \t]*$",
+            "",
+            qmd_text,
+        )
+        cited = set(
+            re.findall(
+                r"(?<![\w@])@([A-Za-z0-9_.:+-]+)", citation_surface
+            )
+        )
+        bibliography = set(
+            re.findall(r"@[A-Za-z]+\s*\{\s*([^,\s]+)\s*,", bib_text)
+        )
+        missing = cited - bibliography
+        if missing:
+            raise LiteratureArtifactError(
+                f"Quarto citation keys are missing from BibTeX: {sorted(missing)[:5]}"
+            )
+
+    @staticmethod
+    def _atomic_write(path: Path, content: bytes) -> None:
+        if path.name not in FIXED_ARTIFACTS | {"artifact-manifest.json"}:
+            raise LiteratureArtifactError("unexpected artifact filename")
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=f".{path.name}-", suffix=".tmp", dir=path.parent
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, path)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+
+    @staticmethod
+    def _safe_read(path: Path, limit: int) -> bytes:
+        if not path.is_file() or path.is_symlink():
+            raise LiteratureArtifactError("artifact is missing or symbolic")
+        size = path.stat().st_size
+        if size > limit:
+            raise LiteratureArtifactError("artifact exceeds size limit")
+        content = path.read_bytes()
+        if len(content) != size:
+            raise LiteratureArtifactError("artifact changed while reading")
+        return content
+
+
+def canonical_json(value: object) -> bytes:
+    return (
+        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    ).encode("utf-8")

--- a/extensions/ai-research/control/ai_research_control/literature_runtime.py
+++ b/extensions/ai-research/control/ai_research_control/literature_runtime.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+from .ldr_client import (
+    LdrClient,
+    LdrConflict,
+    LdrProtocolError,
+    LdrSessionExpired,
+    LdrUnavailable,
+)
+from .literature_artifacts import LiteratureArtifactError, LiteratureArtifactStore
+from .project_store import ProjectConflict, ProjectStore
+
+
+MAX_RECONCILE_ATTEMPTS = 6
+MAX_STATUS_FAILURES = 3
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+class LiteratureRuntime:
+    def __init__(
+        self,
+        *,
+        projects: ProjectStore,
+        artifacts: LiteratureArtifactStore,
+        ldr: LdrClient,
+        model_id: str,
+        bridge_url: str,
+    ) -> None:
+        self.projects = projects
+        self.artifacts = artifacts
+        self.ldr = ldr
+        self.model_id = model_id
+        self.bridge_url = bridge_url.rstrip("/")
+        self._start_lock = asyncio.Lock()
+        self._sync_lock = asyncio.Lock()
+
+    async def start_run(
+        self,
+        project_id: str,
+        *,
+        idempotency_key: str,
+        collection_id: str | None,
+    ) -> tuple[dict[str, Any], bool]:
+        async with self._start_lock:
+            session = await asyncio.to_thread(self.ldr.session_status)
+            if session["status"] != "ready":
+                raise LdrSessionExpired("LDR session is not unlocked")
+            active = await asyncio.to_thread(self.projects.active_literature)
+            existing = next(
+                (
+                    (project, attempt)
+                    for project, attempt in active
+                    if project["projectId"] == project_id
+                    and attempt["idempotencyHash"]
+                    == __import__("hashlib").sha256(
+                        idempotency_key.encode("utf-8")
+                    ).hexdigest()
+                ),
+                None,
+            )
+            if existing is not None:
+                return existing[0], False
+            if active:
+                raise ProjectConflict("another literature research is active")
+            await self._require_exact_collection_scope(collection_id)
+
+            project, attempt, created = await asyncio.to_thread(
+                self.projects.begin_attempt,
+                project_id,
+                idempotency_key=idempotency_key,
+                model_id=self.model_id,
+                collection_id=collection_id,
+            )
+            if not created:
+                return project, False
+            try:
+                ldr_id, raw_start = await asyncio.to_thread(
+                    self.ldr.start_research,
+                    question=project["researchQuestion"],
+                    control_run_id=attempt["runId"],
+                    model_id=self.model_id,
+                    bridge_url=self.bridge_url,
+                    collection_id=collection_id,
+                )
+            except LdrConflict:
+                project, _ = await asyncio.to_thread(
+                    self.projects.update_attempt,
+                    project_id,
+                    attempt["runId"],
+                    {
+                        "phase": "terminal",
+                        "outcome": "failed",
+                        "rawStatus": "rejected",
+                        "terminalAt": utc_now(),
+                        "errorType": "upstream_rejected",
+                        "errorMessage": "LDR refused the fixed research request",
+                    },
+                )
+                raise
+            except (LdrUnavailable, LdrProtocolError):
+                # The upstream can accept the request before the response is
+                # lost or found malformed. Keep the durable queued attempt and
+                # reconcile it by the metadata marker on later ticks.
+                return project, True
+
+            phase = "queued" if raw_start == "queued" else "running"
+            project, _ = await asyncio.to_thread(
+                self.projects.update_attempt,
+                project_id,
+                attempt["runId"],
+                {
+                    "ldrResearchId": ldr_id,
+                    "phase": phase,
+                    "rawStatus": raw_start,
+                    "startedAt": utc_now() if phase == "running" else None,
+                },
+            )
+            return project, True
+
+    async def cancel(self, project_id: str) -> dict[str, Any]:
+        project = await asyncio.to_thread(self.projects.get, project_id)
+        run_id = project["literature"]["activeRunId"]
+        if not run_id:
+            return project
+        _, attempt = await asyncio.to_thread(
+            self.projects.update_attempt,
+            project_id,
+            run_id,
+            {"cancelRequestedAt": attempt_time(project, run_id, "cancelRequestedAt")},
+        )
+        ldr_id = attempt.get("ldrResearchId")
+        if not ldr_id:
+            try:
+                ldr_id = await asyncio.to_thread(
+                    self.ldr.find_research_by_run_id, run_id
+                )
+            except (LdrSessionExpired, LdrUnavailable):
+                return (await asyncio.to_thread(self.projects.get, project_id))
+            if ldr_id:
+                await asyncio.to_thread(
+                    self.projects.update_attempt,
+                    project_id,
+                    run_id,
+                    {"ldrResearchId": ldr_id},
+                )
+        if ldr_id and not attempt.get("cancelAppliedAt"):
+            try:
+                await asyncio.to_thread(self.ldr.terminate, ldr_id)
+            except (LdrSessionExpired, LdrUnavailable):
+                return (await asyncio.to_thread(self.projects.get, project_id))
+            project, _ = await asyncio.to_thread(
+                self.projects.update_attempt,
+                project_id,
+                run_id,
+                {"cancelAppliedAt": utc_now()},
+            )
+            return project
+        return await asyncio.to_thread(self.projects.get, project_id)
+
+    async def sync(self, project_id: str) -> dict[str, Any]:
+        project = await asyncio.to_thread(self.projects.get, project_id)
+        run_id = project["literature"].get("completedRunId")
+        if not run_id:
+            run_id = next(
+                (
+                    attempt["runId"]
+                    for attempt in reversed(project["literature"]["attempts"])
+                    if attempt.get("rawStatus") == "completed"
+                    and attempt.get("ldrResearchId")
+                ),
+                None,
+            )
+        if not run_id:
+            raise ProjectConflict("project does not have completed upstream artifacts")
+        _, attempt = await asyncio.to_thread(
+            self.projects.get_attempt, project_id, run_id
+        )
+        if attempt.get("rawStatus") != "completed" or not attempt.get(
+            "ldrResearchId"
+        ):
+            raise ProjectConflict("completed upstream artifacts are unavailable")
+        await self._sync_completed(
+            project_id,
+            run_id,
+            attempt["ldrResearchId"],
+            surface_upstream_errors=True,
+            force=True,
+        )
+        return await asyncio.to_thread(self.projects.get, project_id)
+
+    async def tick(self) -> None:
+        try:
+            session = await asyncio.to_thread(self.ldr.session_status)
+        except LdrUnavailable:
+            return
+        if session["status"] != "ready":
+            return
+        for project, attempt in await asyncio.to_thread(
+            self.projects.active_literature
+        ):
+            await self._reconcile_attempt(project, attempt)
+
+    async def _reconcile_attempt(
+        self, project: dict[str, Any], attempt: dict[str, Any]
+    ) -> None:
+        project_id = project["projectId"]
+        run_id = attempt["runId"]
+        ldr_id = attempt.get("ldrResearchId")
+        if not ldr_id:
+            try:
+                ldr_id = await asyncio.to_thread(
+                    self.ldr.find_research_by_run_id, run_id
+                )
+            except (LdrSessionExpired, LdrUnavailable):
+                return
+            if not ldr_id:
+                attempts = int(attempt.get("reconcileAttempts", 0)) + 1
+                fields: dict[str, Any] = {"reconcileAttempts": attempts}
+                if attempts >= MAX_RECONCILE_ATTEMPTS:
+                    fields.update(
+                        {
+                            "phase": "terminal",
+                            "outcome": "infrastructure_error",
+                            "rawStatus": attempt.get("rawStatus"),
+                            "terminalAt": utc_now(),
+                            "errorType": "missing_upstream_run",
+                            "errorMessage": "LDR did not expose an accepted research run",
+                        }
+                    )
+                await asyncio.to_thread(
+                    self.projects.update_attempt, project_id, run_id, fields
+                )
+                return
+            _, attempt = await asyncio.to_thread(
+                self.projects.update_attempt,
+                project_id,
+                run_id,
+                {"ldrResearchId": ldr_id, "reconcileAttempts": 0},
+            )
+
+        if attempt.get("cancelRequestedAt") and not attempt.get("cancelAppliedAt"):
+            try:
+                await asyncio.to_thread(self.ldr.terminate, ldr_id)
+            except (LdrSessionExpired, LdrUnavailable):
+                return
+            _, attempt = await asyncio.to_thread(
+                self.projects.update_attempt,
+                project_id,
+                run_id,
+                {"cancelAppliedAt": utc_now()},
+            )
+
+        try:
+            upstream = await asyncio.to_thread(self.ldr.research_status, ldr_id)
+        except (LdrSessionExpired, LdrUnavailable):
+            return
+        except LdrProtocolError:
+            await self._record_status_failure(project_id, attempt)
+            return
+        raw = upstream.get("status")
+        if not isinstance(raw, str):
+            await self._record_status_failure(project_id, attempt)
+            return
+        raw = raw.casefold()
+        fields = {
+            "rawStatus": raw,
+            "statusFailures": 0,
+            "progress": normalize_progress(upstream.get("progress")),
+            "latestLog": upstream.get("log_entry")
+            if isinstance(upstream.get("log_entry"), dict)
+            else None,
+        }
+        if raw == "queued":
+            fields.update({"phase": "queued", "outcome": None})
+        elif raw == "in_progress":
+            fields.update(
+                {
+                    "phase": "running",
+                    "outcome": None,
+                    "startedAt": attempt.get("startedAt") or utc_now(),
+                }
+            )
+        elif raw == "completed":
+            fields.update(
+                {"phase": "terminal", "outcome": "completed", "terminalAt": utc_now()}
+            )
+        elif raw == "suspended":
+            fields.update(
+                {"phase": "terminal", "outcome": "cancelled", "terminalAt": utc_now()}
+            )
+        elif raw in {"failed", "error"}:
+            outcome = (
+                "cancelled"
+                if attempt.get("cancelRequestedAt") and attempt.get("cancelAppliedAt")
+                else "failed"
+            )
+            error_info = upstream.get("metadata", {}).get("error_info", {})
+            fields.update(
+                {
+                    "phase": "terminal",
+                    "outcome": outcome,
+                    "terminalAt": utc_now(),
+                    "errorType": error_info.get("type")
+                    if isinstance(error_info, dict)
+                    else "upstream_error",
+                    "errorMessage": error_info.get("message")
+                    if isinstance(error_info, dict)
+                    else "LDR research failed",
+                }
+            )
+        else:
+            await asyncio.to_thread(
+                self.projects.update_attempt,
+                project_id,
+                run_id,
+                {"rawStatus": raw},
+            )
+            await self._record_status_failure(project_id, attempt)
+            return
+        project, updated_attempt = await asyncio.to_thread(
+            self.projects.update_attempt, project_id, run_id, fields
+        )
+        if raw == "completed":
+            await self._sync_completed(
+                project_id,
+                run_id,
+                str(updated_attempt["ldrResearchId"]),
+            )
+
+    async def _sync_completed(
+        self,
+        project_id: str,
+        run_id: str,
+        ldr_research_id: str,
+        *,
+        surface_upstream_errors: bool = False,
+        force: bool = False,
+    ) -> None:
+        async with self._sync_lock:
+            project, attempt = await asyncio.to_thread(
+                self.projects.get_attempt, project_id, run_id
+            )
+            if attempt.get("integrityStatus") == "verified" and not force:
+                return
+            try:
+                report = await asyncio.to_thread(self.ldr.report, ldr_research_id)
+                quarto = await asyncio.to_thread(
+                    self.ldr.export, ldr_research_id, "quarto"
+                )
+                ris = await asyncio.to_thread(self.ldr.export, ldr_research_id, "ris")
+                directory = await asyncio.to_thread(
+                    self.projects.run_directory, project_id, run_id
+                )
+                synced_at = utc_now()
+                receipt_attempt = dict(attempt)
+                receipt_attempt.update(
+                    {
+                        "outcome": "completed",
+                        "integrityStatus": "verified",
+                        "syncedAt": synced_at,
+                        "errorType": None,
+                        "errorMessage": None,
+                    }
+                )
+                manifest = await asyncio.to_thread(
+                    self.artifacts.persist,
+                    run_directory=directory,
+                    project=project,
+                    attempt=receipt_attempt,
+                    report=report,
+                    quarto_zip=quarto,
+                    ris=ris,
+                )
+            except (
+                LdrSessionExpired,
+                LdrUnavailable,
+                LdrProtocolError,
+                LiteratureArtifactError,
+            ) as exc:
+                error_message = (
+                    "The upstream review completed, but its result package failed "
+                    "integrity validation or synchronization"
+                )
+                if isinstance(exc, LiteratureArtifactError):
+                    error_message = f"{error_message}: {exc}"
+                await asyncio.to_thread(
+                    self.projects.update_attempt,
+                    project_id,
+                    run_id,
+                    {
+                        "outcome": "infrastructure_error",
+                        "integrityStatus": "failed",
+                        "errorType": "artifact_sync_failed",
+                        "errorMessage": error_message,
+                    },
+                )
+                if surface_upstream_errors and isinstance(
+                    exc, (LdrSessionExpired, LdrUnavailable)
+                ):
+                    raise
+                return
+            await asyncio.to_thread(
+                self.projects.update_attempt,
+                project_id,
+                run_id,
+                {
+                    "outcome": "completed",
+                    "integrityStatus": "verified",
+                    "syncedAt": synced_at,
+                    "artifacts": manifest,
+                    "errorType": None,
+                    "errorMessage": None,
+                },
+            )
+
+    async def _record_status_failure(
+        self, project_id: str, attempt: dict[str, Any]
+    ) -> None:
+        failures = int(attempt.get("statusFailures", 0)) + 1
+        fields: dict[str, Any] = {"statusFailures": failures}
+        if failures >= MAX_STATUS_FAILURES:
+            fields.update(
+                {
+                    "phase": "terminal",
+                    "outcome": "infrastructure_error",
+                    "terminalAt": utc_now(),
+                    "errorType": "invalid_upstream_status",
+                    "errorMessage": "LDR returned an unknown or malformed status",
+                }
+            )
+        await asyncio.to_thread(
+            self.projects.update_attempt,
+            project_id,
+            attempt["runId"],
+            fields,
+        )
+
+    async def _require_exact_collection_scope(
+        self, collection_id: str | None
+    ) -> None:
+        collections = await asyncio.to_thread(self.ldr.collections)
+        exposed_collection_ids = {
+            str(item.get("id"))
+            for item in collections
+            if item.get("is_public") is True
+            and item.get("agent_enabled") is True
+            and item.get("id")
+        }
+        if collection_id is None:
+            if exposed_collection_ids:
+                raise ProjectConflict(
+                    "public research-agent collections must match the selected project collection"
+                )
+            return
+        collection = next(
+            (item for item in collections if item.get("id") == collection_id), None
+        )
+        if collection is None:
+            raise ProjectConflict("LDR collection was not found")
+        document_count = int(collection.get("document_count") or 0)
+        indexed_count = int(collection.get("indexed_document_count") or 0)
+        if (
+            document_count <= 0
+            or indexed_count < document_count
+            or collection.get("is_public") is not True
+            or collection.get("agent_enabled") is not True
+        ):
+            raise ProjectConflict(
+                "collection must be fully indexed, public, and enabled for the research agent"
+            )
+        if exposed_collection_ids != {collection_id}:
+            raise ProjectConflict(
+                "public research-agent collections must match the selected project collection"
+            )
+
+
+def attempt_time(project: dict[str, Any], run_id: str, field: str) -> str:
+    for attempt in project["literature"]["attempts"]:
+        if attempt["runId"] == run_id:
+            return attempt.get(field) or utc_now()
+    return utc_now()
+
+
+def normalize_progress(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return max(0, min(int(value), 100))
+    return 0

--- a/extensions/ai-research/control/ai_research_control/mlflow_sink.py
+++ b/extensions/ai-research/control/ai_research_control/mlflow_sink.py
@@ -4,15 +4,17 @@ import hashlib
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import requests
-from mlflow import MlflowClient
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
 from opentelemetry.proto.trace.v1.trace_pb2 import Span, Status
 
 from .evidence import finalize_mlflow, verify_receipt
+
+if TYPE_CHECKING:
+    from mlflow import MlflowClient
 
 
 class MlflowSinkError(RuntimeError):
@@ -21,6 +23,8 @@ class MlflowSinkError(RuntimeError):
 
 class MlflowSink:
     def __init__(self, tracking_uri: str, experiment_name: str) -> None:
+        from mlflow import MlflowClient
+
         if not tracking_uri.startswith("http://ai-research-tracking:"):
             raise MlflowSinkError("tracking URI must target the private module service")
         self.tracking_uri = tracking_uri.rstrip("/")

--- a/extensions/ai-research/control/ai_research_control/model_relay.py
+++ b/extensions/ai-research/control/ai_research_control/model_relay.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import (
+    HTTPRedirectHandler,
+    ProxyHandler,
+    Request as UrlRequest,
+    build_opener,
+)
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+
+MAX_REQUEST_BYTES = 1024 * 1024
+MAX_RESPONSE_BYTES = 64 * 1024 * 1024
+CHUNK_BYTES = 64 * 1024
+ALLOWED_TARGET_HOSTS = {"host.docker.internal", "127.0.0.1", "localhost"}
+BRIDGE_PREFIX = "/api/ai-research/v1"
+
+
+class NoRedirect(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class RelaySettings:
+    target: str
+    timeout_seconds: float
+
+    @classmethod
+    def from_env(cls) -> "RelaySettings":
+        return cls(
+            target=validate_target(
+                os.getenv(
+                    "AI_RESEARCH_MODEL_RELAY_TARGET_URL",
+                    "http://host.docker.internal:8000/api/ai-research/v1",
+                )
+            ),
+            timeout_seconds=max(
+                5.0,
+                min(
+                    float(os.getenv("AI_RESEARCH_MODEL_RELAY_TIMEOUT_SECONDS", "180")),
+                    600.0,
+                ),
+            ),
+        )
+
+
+def validate_target(value: str) -> str:
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in ALLOWED_TARGET_HOSTS
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path.rstrip("/") != BRIDGE_PREFIX
+    ):
+        raise ValueError("relay target must be the local AI Research v1 bridge")
+    try:
+        if parsed.port is None:
+            raise ValueError
+    except ValueError as exc:
+        raise ValueError("relay target must include a valid port") from exc
+    return f"http://{parsed.hostname}:{parsed.port}{BRIDGE_PREFIX}"
+
+
+def create_app(settings: RelaySettings | None = None) -> FastAPI:
+    relay = settings or RelaySettings.from_env()
+    app = FastAPI(
+        title="ModelMirror AI Research Model Relay",
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
+    )
+
+    @app.middleware("http")
+    async def security_headers(request: Request, call_next):
+        response = await call_next(request)
+        response.headers["Cache-Control"] = "no-store"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "no-referrer"
+        response.headers["Permissions-Policy"] = (
+            "camera=(), microphone=(), geolocation=(), payment=()"
+        )
+        return response
+
+    @app.get("/healthz", include_in_schema=False)
+    async def healthz() -> dict[str, str]:
+        return {"status": "alive"}
+
+    @app.get(f"{BRIDGE_PREFIX}/models", include_in_schema=False)
+    async def models(request: Request):
+        return await forward(request, relay, suffix="/models", body=b"")
+
+    @app.post(f"{BRIDGE_PREFIX}/chat/completions", include_in_schema=False)
+    async def chat_completions(request: Request):
+        content_type = request.headers.get("content-type", "")
+        if content_type.split(";", 1)[0].strip().casefold() != "application/json":
+            raise HTTPException(status_code=415, detail="application/json is required")
+        body = await read_bounded_body(request)
+        return await forward(request, relay, suffix="/chat/completions", body=body)
+
+    return app
+
+
+async def read_bounded_body(request: Request) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > MAX_REQUEST_BYTES:
+            raise HTTPException(status_code=413, detail="relay request exceeded size limit")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def forward(
+    request: Request,
+    settings: RelaySettings,
+    *,
+    suffix: str,
+    body: bytes,
+):
+    if request.url.query:
+        raise HTTPException(status_code=400, detail="relay query parameters are forbidden")
+    authorization = request.headers.get("authorization", "")
+    scheme, separator, credential = authorization.partition(" ")
+    if (
+        not separator
+        or scheme.casefold() != "bearer"
+        or not credential
+        or len(authorization) > 4096
+    ):
+        raise HTTPException(status_code=401, detail="relay requires a bearer credential")
+    headers = {
+        "Authorization": authorization,
+        "Accept": request.headers.get("accept", "application/json"),
+    }
+    if body:
+        headers["Content-Type"] = "application/json"
+        headers["Content-Length"] = str(len(body))
+    upstream_request = UrlRequest(
+        settings.target + suffix,
+        data=body or None,
+        headers=headers,
+        method=request.method,
+    )
+    try:
+        upstream = await asyncio.to_thread(
+            open_upstream, upstream_request, settings.timeout_seconds
+        )
+    except URLError as exc:
+        raise HTTPException(status_code=503, detail="fixed model bridge unavailable") from exc
+    status = int(getattr(upstream, "status", upstream.getcode()))
+    if 300 <= status < 400:
+        upstream.close()
+        raise HTTPException(status_code=502, detail="fixed model bridge redirected")
+    content_type = upstream.headers.get("Content-Type", "application/json")
+    media_type = content_type.split(";", 1)[0].strip().casefold()
+    if media_type not in {"application/json", "text/event-stream"}:
+        upstream.close()
+        raise HTTPException(status_code=502, detail="fixed model bridge content type rejected")
+    response_headers = {"Cache-Control": "no-store"}
+    route_run_id = upstream.headers.get("X-ModelMirror-Route-Run-Id")
+    if route_run_id and len(route_run_id) <= 256:
+        response_headers["X-ModelMirror-Route-Run-Id"] = route_run_id
+    if media_type == "text/event-stream":
+        response_headers["X-Accel-Buffering"] = "no"
+    return StreamingResponse(
+        bounded_response(upstream),
+        status_code=status,
+        media_type=media_type,
+        headers=response_headers,
+    )
+
+
+def open_upstream(request: UrlRequest, timeout_seconds: float):
+    opener = build_opener(ProxyHandler({}), NoRedirect())
+    try:
+        return opener.open(request, timeout=timeout_seconds)
+    except HTTPError as exc:
+        return exc
+
+
+def bounded_response(upstream) -> Iterator[bytes]:
+    total = 0
+    try:
+        while True:
+            chunk = upstream.read(CHUNK_BYTES)
+            if not chunk:
+                return
+            total += len(chunk)
+            if total > MAX_RESPONSE_BYTES:
+                raise RuntimeError("relay response exceeded size limit")
+            yield chunk
+    finally:
+        upstream.close()
+
+
+app = create_app()

--- a/extensions/ai-research/control/ai_research_control/models.py
+++ b/extensions/ai-research/control/ai_research_control/models.py
@@ -103,6 +103,56 @@ class SystemView(BaseModel):
     status: Literal["ready", "degraded", "not_ready"]
     checks: list[SystemCheckView]
     checked_at: str = Field(alias="checkedAt")
+    literature_capability: dict[str, object] = Field(
+        default_factory=dict, alias="literatureCapability"
+    )
+
+
+class FixtureCapabilityClaimView(BaseModel):
+    enabled: Literal[True] = True
+    claim_level: Literal["harness_only"] = Field(
+        default="harness_only", alias="claimLevel"
+    )
+    pack_status: Literal["fixture_only"] = Field(
+        default="fixture_only", alias="packStatus"
+    )
+
+
+class LiteratureCapabilityClaimView(BaseModel):
+    enabled: Literal[True] = True
+    scientific_claim: Literal["none"] = Field(
+        default="none", alias="scientificClaim"
+    )
+    acceptance_state: Literal["pending_live_acceptance"] = Field(
+        default="pending_live_acceptance", alias="acceptanceState"
+    )
+    workflow_source: Literal["local_deep_research"] = Field(
+        default="local_deep_research", alias="workflowSource"
+    )
+
+
+class CapabilityClaimsView(BaseModel):
+    fixture_execution: FixtureCapabilityClaimView = Field(
+        default_factory=FixtureCapabilityClaimView, alias="fixtureExecution"
+    )
+    literature_research: LiteratureCapabilityClaimView = Field(
+        default_factory=LiteratureCapabilityClaimView, alias="literatureResearch"
+    )
+
+
+class ModuleInfoView(BaseModel):
+    module_id: str = Field(alias="moduleId")
+    module_version: str = Field(alias="moduleVersion")
+    api_version: str = Field(alias="apiVersion")
+    worker_protocol_version: int = Field(alias="workerProtocolVersion")
+    fixtures: list[CaseId]
+    runtimes: dict[str, str]
+    capabilities: dict[str, bool]
+    capability_claims: CapabilityClaimsView = Field(
+        default_factory=CapabilityClaimsView, alias="capabilityClaims"
+    )
+    links: dict[str, str]
+    limitations: list[str]
 
 
 class ArtifactView(BaseModel):

--- a/extensions/ai-research/control/ai_research_control/project_models.py
+++ b/extensions/ai-research/control/ai_research_control/project_models.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+LiteraturePhase = Literal["not_started", "queued", "running", "terminal"]
+LiteratureOutcome = Literal[
+    "completed", "cancelled", "failed", "infrastructure_error"
+]
+IntegrityStatus = Literal["pending", "verified", "failed"]
+
+
+class FrozenRequestModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class ProjectCreateRequest(FrozenRequestModel):
+    title: str = Field(min_length=1, max_length=120)
+    research_question: str = Field(
+        alias="researchQuestion", min_length=1, max_length=5000
+    )
+    idempotency_key: str = Field(
+        alias="idempotencyKey",
+        min_length=8,
+        max_length=128,
+        pattern=r"^[A-Za-z0-9._:-]+$",
+    )
+
+    @field_validator("title", "research_question")
+    @classmethod
+    def strip_required_text(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("value must contain non-whitespace characters")
+        return value
+
+
+class ProjectUpdateRequest(FrozenRequestModel):
+    title: str | None = Field(default=None, min_length=1, max_length=120)
+    research_question: str | None = Field(
+        default=None, alias="researchQuestion", min_length=1, max_length=5000
+    )
+
+    @field_validator("title", "research_question")
+    @classmethod
+    def strip_optional_text(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        value = value.strip()
+        if not value:
+            raise ValueError("value must contain non-whitespace characters")
+        return value
+
+    @model_validator(mode="after")
+    def require_change(self) -> "ProjectUpdateRequest":
+        if self.title is None and self.research_question is None:
+            raise ValueError("at least one editable field is required")
+        return self
+
+
+class LiteratureRunCreateRequest(FrozenRequestModel):
+    idempotency_key: str = Field(
+        alias="idempotencyKey",
+        min_length=8,
+        max_length=128,
+        pattern=r"^[A-Za-z0-9._:-]+$",
+    )
+    collection_id: str | None = Field(
+        default=None,
+        alias="collectionId",
+        min_length=1,
+        max_length=128,
+        pattern=r"^[A-Za-z0-9_-]+$",
+    )
+
+
+class LiteratureUnlockRequest(FrozenRequestModel):
+    username: str = Field(
+        min_length=3, max_length=64, pattern=r"^[A-Za-z0-9_-]+$"
+    )
+    password: str = Field(min_length=1, max_length=1024)
+
+
+class LiteratureSessionView(BaseModel):
+    status: Literal["locked", "ready", "expired"]
+    username: str | None
+
+
+class LiteratureAttemptView(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    run_id: str = Field(alias="runId")
+    ldr_research_id: str | None = Field(alias="ldrResearchId")
+    phase: LiteraturePhase
+    outcome: LiteratureOutcome | None
+    raw_status: str | None = Field(alias="rawStatus")
+    cancel_requested_at: str | None = Field(alias="cancelRequestedAt")
+    cancel_applied_at: str | None = Field(alias="cancelAppliedAt")
+    started_at: str | None = Field(alias="startedAt")
+    terminal_at: str | None = Field(alias="terminalAt")
+    synced_at: str | None = Field(alias="syncedAt")
+    error_type: str | None = Field(alias="errorType")
+    error_message: str | None = Field(alias="errorMessage")
+    integrity_status: IntegrityStatus = Field(alias="integrityStatus")
+    created_at: str = Field(alias="createdAt")
+    progress: int = Field(ge=0, le=100)
+    latest_log: dict[str, object] | None = Field(alias="latestLog")
+
+
+class ProjectView(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    schema_version: Literal[1] = Field(alias="schemaVersion")
+    project_id: str = Field(alias="projectId", pattern=r"^rp_[0-9a-f]{32}$")
+    title: str
+    research_question: str = Field(alias="researchQuestion")
+    domain: Literal["ai_agent"]
+    current_stage: Literal["literature"] = Field(alias="currentStage")
+    stages: dict[str, Literal["active", "not_available"]]
+    literature_phase: LiteraturePhase = Field(alias="literaturePhase")
+    literature_outcome: LiteratureOutcome | None = Field(alias="literatureOutcome")
+    active_run_id: str | None = Field(alias="activeRunId")
+    completed_run_id: str | None = Field(alias="completedRunId")
+    collection_id: str | None = Field(alias="collectionId")
+    profile_id: str = Field(alias="profileId")
+    model_id: str | None = Field(alias="modelId")
+    attempts: list[LiteratureAttemptView]
+    created_at: str = Field(alias="createdAt")
+    updated_at: str = Field(alias="updatedAt")
+
+
+class ProjectListResponse(BaseModel):
+    items: list[ProjectView]
+    next_cursor: str | None = Field(alias="nextCursor")

--- a/extensions/ai-research/control/ai_research_control/project_store.py
+++ b/extensions/ai-research/control/ai_research_control/project_store.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import tempfile
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import yaml
+
+
+PROJECT_ID_RE = re.compile(r"^rp_[0-9a-f]{32}$")
+RUN_ID_RE = re.compile(r"^lr_[0-9a-f]{32}$")
+MAX_MANIFEST_BYTES = 512 * 1024
+MAX_ATTEMPTS = 10
+
+
+class ProjectConflict(RuntimeError):
+    pass
+
+
+class ProjectIntegrityError(RuntimeError):
+    pass
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _hash_key(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+class ProjectStore:
+    def __init__(self, root: Path, *, source_lock_sha256: str) -> None:
+        self.root = root
+        self.source_lock_sha256 = source_lock_sha256
+        self._lock = threading.RLock()
+
+    def prepare(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        if self.root.is_symlink():
+            raise ProjectIntegrityError("projects root must not be a symlink")
+
+    def create(
+        self, *, title: str, research_question: str, idempotency_key: str
+    ) -> tuple[dict[str, Any], bool]:
+        with self._lock:
+            return self._create(
+                title=title,
+                research_question=research_question,
+                idempotency_key=idempotency_key,
+            )
+
+    def _create(
+        self, *, title: str, research_question: str, idempotency_key: str
+    ) -> tuple[dict[str, Any], bool]:
+        key_hash = _hash_key(idempotency_key)
+        for project in self._all():
+            if project["control"]["createIdempotencyHash"] == key_hash:
+                if (
+                    project["title"] != title
+                    or project["researchQuestion"] != research_question
+                ):
+                    raise ProjectConflict("idempotency key already used with other input")
+                return project, False
+
+        project_id = f"rp_{uuid4().hex}"
+        now = utc_now()
+        project = {
+            "schemaVersion": 1,
+            "projectId": project_id,
+            "title": title,
+            "researchQuestion": research_question,
+            "domain": "ai_agent",
+            "currentStage": "literature",
+            "stages": {
+                "literature": "active",
+                "hypothesis_protocol": "not_available",
+                "research_workspace": "not_available",
+                "evaluation": "not_available",
+                "analysis_report": "not_available",
+            },
+            "createdAt": now,
+            "updatedAt": now,
+            "control": {
+                "createIdempotencyHash": key_hash,
+                "sourceLockSha256": self.source_lock_sha256,
+            },
+            "literature": {
+                "profileId": "v0.1-literature-default",
+                "phase": "not_started",
+                "outcome": None,
+                "activeRunId": None,
+                "completedRunId": None,
+                "collectionId": None,
+                "modelId": None,
+                "attempts": [],
+            },
+        }
+        directory = self._project_dir(project_id, must_exist=False)
+        directory.mkdir(mode=0o700)
+        self._write(project)
+        return project, True
+
+    def get(self, project_id: str) -> dict[str, Any]:
+        with self._lock:
+            return self._read(self._manifest(project_id))
+
+    def list(
+        self,
+        *,
+        after_project_id: str | None,
+        limit: int,
+        query: str | None = None,
+        phase: str | None = None,
+        outcome: str | None = None,
+    ) -> list[dict[str, Any]]:
+        with self._lock:
+            return self._list(
+                after_project_id=after_project_id,
+                limit=limit,
+                query=query,
+                phase=phase,
+                outcome=outcome,
+            )
+
+    def _list(
+        self,
+        *,
+        after_project_id: str | None,
+        limit: int,
+        query: str | None = None,
+        phase: str | None = None,
+        outcome: str | None = None,
+    ) -> list[dict[str, Any]]:
+        projects = self._all()
+        projects.sort(key=lambda item: (item["createdAt"], item["projectId"]), reverse=True)
+        if query:
+            needle = query.casefold()
+            projects = [
+                item
+                for item in projects
+                if needle
+                in " ".join(
+                    (item["projectId"], item["title"], item["researchQuestion"])
+                ).casefold()
+            ]
+        if phase:
+            projects = [item for item in projects if item["literature"]["phase"] == phase]
+        if outcome:
+            projects = [
+                item for item in projects if item["literature"]["outcome"] == outcome
+            ]
+        if after_project_id:
+            positions = [
+                index
+                for index, item in enumerate(projects)
+                if item["projectId"] == after_project_id
+            ]
+            if not positions:
+                raise KeyError(after_project_id)
+            projects = projects[positions[0] + 1 :]
+        return projects[: max(1, min(limit, 101))]
+
+    def update(
+        self,
+        project_id: str,
+        *,
+        title: str | None,
+        research_question: str | None,
+    ) -> dict[str, Any]:
+        with self._lock:
+            project = self.get(project_id)
+            if project["literature"]["attempts"]:
+                raise ProjectConflict("project is immutable after literature starts")
+            if title is not None:
+                project["title"] = title
+            if research_question is not None:
+                project["researchQuestion"] = research_question
+            project["updatedAt"] = utc_now()
+            self._write(project)
+            return project
+
+    def bind_collection(self, project_id: str, collection_id: str | None) -> dict[str, Any]:
+        with self._lock:
+            project = self.get(project_id)
+            if project["literature"]["phase"] in {"queued", "running"}:
+                raise ProjectConflict("cannot change collection during an active run")
+            project["literature"]["collectionId"] = collection_id
+            project["updatedAt"] = utc_now()
+            self._write(project)
+            return project
+
+    def begin_attempt(
+        self,
+        project_id: str,
+        *,
+        idempotency_key: str,
+        model_id: str,
+        collection_id: str | None,
+    ) -> tuple[dict[str, Any], dict[str, Any], bool]:
+        with self._lock:
+            return self._begin_attempt(
+                project_id,
+                idempotency_key=idempotency_key,
+                model_id=model_id,
+                collection_id=collection_id,
+            )
+
+    def _begin_attempt(
+        self,
+        project_id: str,
+        *,
+        idempotency_key: str,
+        model_id: str,
+        collection_id: str | None,
+    ) -> tuple[dict[str, Any], dict[str, Any], bool]:
+        project = self.get(project_id)
+        literature = project["literature"]
+        key_hash = _hash_key(idempotency_key)
+        expected_search_engine = "openalex"
+        for attempt in literature["attempts"]:
+            if attempt["idempotencyHash"] == key_hash:
+                if (
+                    attempt.get("modelId") != model_id
+                    or attempt.get("searchEngine") != expected_search_engine
+                    or attempt.get(
+                        "collectionId", literature.get("collectionId")
+                    )
+                    != collection_id
+                ):
+                    raise ProjectConflict(
+                        "idempotency key already used with other literature input"
+                    )
+                return project, attempt, False
+        if literature["completedRunId"]:
+            raise ProjectConflict("project already has a completed literature review")
+        if literature["phase"] in {"queued", "running"}:
+            raise ProjectConflict("project already has an active literature run")
+        if len(literature["attempts"]) >= MAX_ATTEMPTS:
+            raise ProjectConflict("project reached the literature attempt limit")
+
+        run_id = f"lr_{uuid4().hex}"
+        now = utc_now()
+        attempt = {
+            "runId": run_id,
+            "idempotencyHash": key_hash,
+            "ldrResearchId": None,
+            "phase": "queued",
+            "outcome": None,
+            "rawStatus": None,
+            "cancelRequestedAt": None,
+            "cancelAppliedAt": None,
+            "createdAt": now,
+            "startedAt": None,
+            "terminalAt": None,
+            "syncedAt": None,
+            "errorType": None,
+            "errorMessage": None,
+            "integrityStatus": "pending",
+            "reconcileAttempts": 0,
+            "statusFailures": 0,
+            "progress": 0,
+            "latestLog": None,
+            "profileId": "v0.1-literature-default",
+            "modelId": model_id,
+            "searchEngine": expected_search_engine,
+            "collectionId": collection_id,
+            "strategy": "langgraph-agent",
+            "egress": "public_only",
+            "maxResults": 15,
+            "iterations": 2,
+            "questionsPerIteration": 3,
+            "artifacts": {},
+        }
+        literature["attempts"].append(attempt)
+        literature.update(
+            {
+                "phase": "queued",
+                "outcome": None,
+                "activeRunId": run_id,
+                "collectionId": collection_id,
+                "modelId": model_id,
+            }
+        )
+        project["updatedAt"] = now
+        self.run_directory(project_id, run_id, must_exist=False).mkdir(parents=True)
+        self._write(project)
+        return project, attempt, True
+
+    def update_attempt(
+        self, project_id: str, run_id: str, fields: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        with self._lock:
+            project = self.get(project_id)
+            attempt = self._attempt(project, run_id)
+            allowed = {
+                "ldrResearchId",
+                "phase",
+                "outcome",
+                "rawStatus",
+                "cancelRequestedAt",
+                "cancelAppliedAt",
+                "startedAt",
+                "terminalAt",
+                "syncedAt",
+                "errorType",
+                "errorMessage",
+                "integrityStatus",
+                "artifacts",
+                "reconcileAttempts",
+                "statusFailures",
+                "progress",
+                "latestLog",
+            }
+            unknown = set(fields) - allowed
+            if unknown:
+                raise ValueError(f"unsupported attempt fields: {sorted(unknown)}")
+            attempt.update(fields)
+            literature = project["literature"]
+            literature["phase"] = attempt["phase"]
+            literature["outcome"] = attempt["outcome"]
+            if attempt["phase"] == "terminal":
+                literature["activeRunId"] = None
+                if (
+                    attempt["outcome"] == "completed"
+                    and attempt.get("integrityStatus") == "verified"
+                ):
+                    literature["completedRunId"] = run_id
+                elif literature.get("completedRunId") == run_id:
+                    literature["completedRunId"] = None
+            project["updatedAt"] = utc_now()
+            self._write(project)
+            return project, attempt
+
+    def get_attempt(
+        self, project_id: str, run_id: str
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        with self._lock:
+            project = self.get(project_id)
+            return project, self._attempt(project, run_id)
+
+    def active_literature(self) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+        with self._lock:
+            active: list[tuple[dict[str, Any], dict[str, Any]]] = []
+            for project in self._all():
+                for attempt in project["literature"]["attempts"]:
+                    if attempt["phase"] in {"queued", "running"}:
+                        active.append((project, attempt))
+            active.sort(key=lambda item: item[1]["createdAt"])
+            return active
+
+    def run_directory(self, project_id: str, run_id: str, *, must_exist: bool = True) -> Path:
+        if not RUN_ID_RE.fullmatch(run_id):
+            raise KeyError(run_id)
+        project_directory = self._project_dir(project_id)
+        literature_directory = project_directory / "literature"
+        runs_directory = literature_directory / "runs"
+        directory = runs_directory / run_id
+        for candidate in (literature_directory, runs_directory, directory):
+            if candidate.is_symlink():
+                raise ProjectIntegrityError("literature path must not be a symlink")
+            if candidate.exists() and not candidate.is_dir():
+                raise ProjectIntegrityError("literature path must be a directory")
+        if must_exist and not directory.is_dir():
+            raise KeyError(run_id)
+        return directory
+
+    def _all(self) -> list[dict[str, Any]]:
+        self.prepare()
+        projects: list[dict[str, Any]] = []
+        for child in self.root.iterdir():
+            if child.is_symlink():
+                raise ProjectIntegrityError("project directory must not be a symlink")
+            if child.is_dir() and PROJECT_ID_RE.fullmatch(child.name):
+                projects.append(self._read(child / "research.yaml"))
+        return projects
+
+    def _project_dir(self, project_id: str, *, must_exist: bool = True) -> Path:
+        if not PROJECT_ID_RE.fullmatch(project_id):
+            raise KeyError(project_id)
+        directory = self.root / project_id
+        if must_exist and (not directory.is_dir() or directory.is_symlink()):
+            raise KeyError(project_id)
+        return directory
+
+    def _manifest(self, project_id: str) -> Path:
+        return self._project_dir(project_id) / "research.yaml"
+
+    def _write(self, project: dict[str, Any]) -> None:
+        path = self._project_dir(project["projectId"]) / "research.yaml"
+        content = yaml.safe_dump(
+            project, allow_unicode=True, sort_keys=False, width=100
+        ).encode("utf-8")
+        if len(content) > MAX_MANIFEST_BYTES:
+            raise ProjectIntegrityError("research manifest exceeds size limit")
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=".research-", suffix=".yaml.tmp", dir=path.parent
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, path)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+
+    def _read(self, path: Path) -> dict[str, Any]:
+        if not path.is_file() or path.is_symlink():
+            raise KeyError(path.parent.name)
+        if path.stat().st_size > MAX_MANIFEST_BYTES:
+            raise ProjectIntegrityError("research manifest exceeds size limit")
+        value = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict) or value.get("schemaVersion") != 1:
+            raise ProjectIntegrityError("unsupported research manifest")
+        if value.get("projectId") != path.parent.name:
+            raise ProjectIntegrityError("project id does not match directory")
+        return value
+
+    @staticmethod
+    def _attempt(project: dict[str, Any], run_id: str) -> dict[str, Any]:
+        for attempt in project["literature"]["attempts"]:
+            if attempt["runId"] == run_id:
+                return attempt
+        raise KeyError(run_id)

--- a/extensions/ai-research/control/ai_research_control/service.py
+++ b/extensions/ai-research/control/ai_research_control/service.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-from urllib.request import Request, urlopen
+from urllib.request import ProxyHandler, Request, build_opener
 
 from .config import Settings
 from .evidence import (
@@ -15,6 +16,10 @@ from .evidence import (
     verify_persisted_receipt,
 )
 from .mlflow_sink import MlflowSink
+from .ldr_client import LdrClient, LdrError, LdrProtocolError, LdrUnavailable
+from .literature_artifacts import LiteratureArtifactStore
+from .literature_runtime import LiteratureRuntime
+from .project_store import ProjectConflict, ProjectStore
 from .store import IdempotencyConflict, RunStore
 from .worker_client import WorkerBusy, WorkerClient, WorkerClientError
 
@@ -30,6 +35,25 @@ class ResearchService:
         self.store = RunStore(settings.control_db)
         self.worker = WorkerClient(settings.worker_socket)
         self.mlflow = MlflowSink(settings.mlflow_uri, settings.mlflow_experiment)
+        self.projects = ProjectStore(
+            settings.resolved_projects_root,
+            source_lock_sha256=hashlib.sha256(
+                settings.source_lock.read_bytes()
+            ).hexdigest(),
+        )
+        self.projects.prepare()
+        self.literature_artifacts = LiteratureArtifactStore(
+            settings.resolved_projects_root
+        )
+        self.ldr = LdrClient(settings.ldr_uri)
+        self.literature = LiteratureRuntime(
+            projects=self.projects,
+            artifacts=self.literature_artifacts,
+            ldr=self.ldr,
+            model_id=settings.literature_model_id,
+            bridge_url=settings.model_bridge_url,
+        )
+        self._literature_poll_due = 0.0
         self._stop = asyncio.Event()
         self._loop_task: asyncio.Task[None] | None = None
 
@@ -82,17 +106,202 @@ class ResearchService:
             status = "degraded"
         else:
             status = "ready"
+        literature = await self.literature_capability()
         return {
             "status": status,
             "checks": checks,
             "checkedAt": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "literatureCapability": literature,
         }
+
+    async def literature_capability(self) -> dict[str, Any]:
+        model_configured = bool(
+            self.settings.literature_model_id
+            and self.settings.model_bridge_url
+            and self.settings.model_bridge_token
+        )
+        bridge_status = "not_ready"
+        if model_configured:
+            try:
+                await asyncio.to_thread(self._probe_model_bridge)
+                bridge_status = "ready"
+            except Exception:
+                bridge_status = "not_ready"
+        try:
+            await asyncio.to_thread(self.ldr.probe)
+            service_status = "ready"
+            session = await asyncio.to_thread(self.ldr.session_status)
+        except (LdrUnavailable, LdrProtocolError):
+            service_status = "not_ready"
+            session = {"status": "locked", "username": None}
+        return {
+            "status": (
+                "ready"
+                if service_status == "ready" and bridge_status == "ready"
+                else "not_ready"
+            ),
+            "serviceStatus": service_status,
+            "sessionStatus": session["status"],
+            "profileStatus": bridge_status,
+            "modelBridgeStatus": bridge_status,
+            "username": session["username"],
+            "scientificClaim": "none",
+        }
+
+    async def literature_session(self) -> dict[str, str | None]:
+        return await asyncio.to_thread(self.ldr.session_status)
+
+    async def unlock_literature(
+        self, *, username: str, password: str
+    ) -> dict[str, str | None]:
+        if not (
+            self.settings.literature_model_id
+            and self.settings.model_bridge_url
+            and self.settings.model_bridge_token
+        ):
+            raise NotReady("fixed literature model bridge is not configured")
+        try:
+            await asyncio.to_thread(self._probe_model_bridge)
+        except Exception as exc:
+            raise NotReady("fixed literature model bridge is not ready") from exc
+        value = await asyncio.to_thread(self.ldr.unlock, username, password)
+        try:
+            await asyncio.to_thread(
+                self.ldr.configure_fixed_profile,
+                model_id=self.settings.literature_model_id,
+                bridge_url=self.settings.model_bridge_url,
+                bridge_token=self.settings.model_bridge_token,
+            )
+        except LdrError:
+            await asyncio.to_thread(self.ldr.clear)
+            raise
+        return value
+
+    async def clear_literature_session(self) -> dict[str, str | None]:
+        await asyncio.to_thread(self.ldr.clear)
+        return {"status": "locked", "username": None}
+
+    async def start_literature(
+        self,
+        project_id: str,
+        *,
+        idempotency_key: str,
+        collection_id: str | None,
+    ) -> tuple[dict[str, Any], bool]:
+        if not self.settings.literature_model_id:
+            raise NotReady("fixed literature model is not configured")
+        return await self.literature.start_run(
+            project_id,
+            idempotency_key=idempotency_key,
+            collection_id=collection_id,
+        )
+
+    async def cancel_literature(self, project_id: str) -> dict[str, Any]:
+        return await self.literature.cancel(project_id)
+
+    async def sync_literature(self, project_id: str) -> dict[str, Any]:
+        return await self.literature.sync(project_id)
+
+    async def literature_sources(self, project_id: str) -> dict[str, Any]:
+        project, attempt, directory = await asyncio.to_thread(
+            self._completed_literature, project_id
+        )
+        sources = await asyncio.to_thread(self.literature_artifacts.sources, directory)
+        return {
+            "projectId": project_id,
+            "literatureRunId": attempt["runId"],
+            "integrityStatus": "verified",
+            "sources": sources,
+        }
+
+    async def literature_review(self, project_id: str) -> dict[str, Any]:
+        _, attempt, directory = await asyncio.to_thread(
+            self._completed_literature, project_id
+        )
+        markdown = await asyncio.to_thread(self.literature_artifacts.review, directory)
+        return {
+            "projectId": project_id,
+            "literatureRunId": attempt["runId"],
+            "integrityStatus": "verified",
+            "markdown": markdown,
+        }
+
+    async def literature_artifact(
+        self, project_id: str, name: str
+    ) -> tuple[bytes, str]:
+        _, _, directory = await asyncio.to_thread(
+            self._completed_literature, project_id
+        )
+        return await asyncio.to_thread(
+            self.literature_artifacts.read_artifact, directory, name
+        )
+
+    async def literature_collections(self) -> dict[str, Any]:
+        items = await asyncio.to_thread(self.ldr.collections)
+        return {"collections": items}
+
+    async def index_literature_collection(
+        self, collection_id: str
+    ) -> dict[str, Any]:
+        events = await asyncio.to_thread(self.ldr.index_collection, collection_id)
+        terminal = events[-1]
+        if terminal.get("type") == "error":
+            raise ProjectConflict("LDR failed to index the selected collection")
+        return {
+            "collectionId": collection_id,
+            "status": "completed",
+            "eventCount": len(events),
+            "terminalType": terminal.get("type"),
+        }
+
+    async def literature_zotero_status(self) -> dict[str, Any]:
+        config = await asyncio.to_thread(self.ldr.zotero_config)
+        status = await asyncio.to_thread(self.ldr.zotero_status)
+        return {"config": config, "status": status}
+
+    async def sync_literature_zotero(self) -> dict[str, Any]:
+        return await asyncio.to_thread(self.ldr.zotero_sync)
+
+    def _completed_literature(
+        self, project_id: str
+    ) -> tuple[dict[str, Any], dict[str, Any], Path]:
+        project = self.projects.get(project_id)
+        run_id = project["literature"].get("completedRunId")
+        if not run_id:
+            raise ProjectConflict("project does not have a completed literature review")
+        _, attempt = self.projects.get_attempt(project_id, run_id)
+        if attempt.get("integrityStatus") != "verified":
+            raise ProjectConflict("literature result package is not verified")
+        directory = self.projects.run_directory(project_id, run_id)
+        return project, attempt, directory
 
     def _probe_inspect_view(self) -> None:
         request = Request(self.settings.inspect_view_uri + "/", method="GET")
-        with urlopen(request, timeout=2.0) as response:
+        with build_opener(ProxyHandler({})).open(request, timeout=2.0) as response:
             if response.status < 200 or response.status >= 400:
                 raise RuntimeError("Inspect View returned an unhealthy status")
+
+    def _probe_model_bridge(self) -> None:
+        request = Request(
+            self.settings.model_bridge_url + "/models",
+            method="GET",
+            headers={
+                "Authorization": f"Bearer {self.settings.model_bridge_token}",
+                "Accept": "application/json",
+            },
+        )
+        with build_opener(ProxyHandler({})).open(request, timeout=5.0) as response:
+            if response.status != 200:
+                raise RuntimeError("AI Research model bridge is unavailable")
+            content = response.read(1024 * 1024 + 1)
+        if len(content) > 1024 * 1024:
+            raise RuntimeError("AI Research model list exceeded size limit")
+        value = json.loads(content)
+        models = value.get("data") if isinstance(value, dict) else None
+        if not isinstance(models, list) or [
+            item.get("id") for item in models if isinstance(item, dict)
+        ] != [self.settings.literature_model_id]:
+            raise RuntimeError("fixed literature model is not eligible")
 
     async def evidence(self, run_id: str) -> dict[str, Any]:
         record = await asyncio.to_thread(self.store.evidence, run_id)
@@ -228,6 +437,10 @@ class ResearchService:
                         )
 
         await self._sync_outbox()
+        now = asyncio.get_running_loop().time()
+        if now >= self._literature_poll_due:
+            self._literature_poll_due = now + 2.0
+            await self.literature.tick()
 
     async def _ensure_receipt(
         self, run: dict[str, Any], worker_result: dict[str, Any]

--- a/extensions/ai-research/control/requirements.in
+++ b/extensions/ai-research/control/requirements.in
@@ -1,3 +1,5 @@
 fastapi==0.141.1
 mlflow==3.15.1
+pyyaml==6.0.3
+requests==2.34.2
 uvicorn==0.52.4

--- a/extensions/ai-research/module-boundary.json
+++ b/extensions/ai-research/module-boundary.json
@@ -1,14 +1,19 @@
 {
   "schemaVersion": 1,
   "moduleId": "modelmirror.ai-research",
-  "moduleVersion": "0.2.0-ar1",
-  "baseCommit": "174baf6a5289520b53578dc29cab82fd4c1d1e9e",
+  "moduleVersion": "0.3.0-v0.1",
+  "baseCommit": "11d35c1d84c0a18a05779a37d60cb59ef7a25867",
   "claimLevel": "harness_only",
   "packStatus": "fixture_only",
-  "parentIntegration": "none",
+  "parentIntegration": "restricted-model-bridge",
   "allowedParentFiles": [
     ".dockerignore",
-    ".github/workflows/ai-research.yml"
+    ".github/workflows/ai-research.yml",
+    "server/main.py",
+    "server/model_router/ai_research_bridge.py",
+    "server/model_router/chat_stable.py",
+    "server/tests/test_ai_research_bridge.py",
+    "server/tests/test_provider_chat_stable_service.py"
   ],
   "forbiddenParentRoots": [
     "client",
@@ -26,19 +31,25 @@
   ],
   "services": [
     "ai-research-control",
+    "ai-research-console-gateway",
     "ai-research-tracking",
     "ai-research-worker",
-    "ai-research-inspect-view"
+    "ai-research-inspect-view",
+    "ai-research-model-relay",
+    "ai-research-ldr-assets",
+    "ai-research-ldr"
   ],
   "publicBindings": [
     "127.0.0.1:8790",
     "127.0.0.1:8791",
+    "127.0.0.1:8792",
     "127.0.0.1:8793"
   ],
   "workerProtocolVersion": 1,
   "apiVersion": "v1",
   "allowedExecutionModes": [
-    "fixture"
+    "fixture",
+    "literature"
   ],
   "allowedFixtures": [
     "success",

--- a/extensions/ai-research/scripts/acceptance.py
+++ b/extensions/ai-research/scripts/acceptance.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import json
+import os
 import time
 import urllib.error
 import urllib.parse
@@ -12,9 +13,33 @@ from pathlib import Path
 from typing import Any
 
 
-CONTROL = "http://127.0.0.1:8790"
-TRACKING = "http://127.0.0.1:8791"
-INSPECT_VIEW = "http://127.0.0.1:8793"
+def loopback_url(environment_name: str, port_environment_name: str, default_port: int) -> str:
+    default = f"http://127.0.0.1:{os.getenv(port_environment_name, str(default_port))}"
+    value = os.getenv(environment_name, default).rstrip("/")
+    parsed = urllib.parse.urlsplit(value)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise RuntimeError(f"{environment_name} must be an HTTP loopback origin")
+    try:
+        if parsed.port is None:
+            raise RuntimeError(f"{environment_name} must include an explicit port")
+    except ValueError as exc:
+        raise RuntimeError(f"{environment_name} has an invalid port") from exc
+    return value
+
+
+CONTROL = loopback_url("AI_RESEARCH_ACCEPTANCE_CONTROL_URL", "AI_RESEARCH_CONTROL_PORT", 8790)
+TRACKING = loopback_url("AI_RESEARCH_ACCEPTANCE_TRACKING_URL", "AI_RESEARCH_MLFLOW_PORT", 8791)
+INSPECT_VIEW = loopback_url(
+    "AI_RESEARCH_ACCEPTANCE_INSPECT_VIEW_URL", "AI_RESEARCH_INSPECT_VIEW_PORT", 8793
+)
 
 
 class AcceptanceFailure(RuntimeError):
@@ -185,11 +210,19 @@ def write_state(path: Path, value: dict[str, Any]) -> None:
 def initial(state_path: Path) -> None:
     wait_ready()
     status, module = request("GET", f"{CONTROL}/api/v1/module")
+    capability_claims = module.get("capabilityClaims", {})
+    fixture_claim = capability_claims.get("fixtureExecution", {})
+    literature_claim = capability_claims.get("literatureResearch", {})
     if (
         status != 200
-        or module.get("moduleVersion") != "0.2.0-ar1"
-        or module.get("claimLevel") != "harness_only"
-        or module.get("packStatus") != "fixture_only"
+        or module.get("moduleVersion") != "0.3.0-v0.1"
+        or "claimLevel" in module
+        or "packStatus" in module
+        or fixture_claim.get("claimLevel") != "harness_only"
+        or fixture_claim.get("packStatus") != "fixture_only"
+        or literature_claim.get("scientificClaim") != "none"
+        or literature_claim.get("acceptanceState") != "pending_live_acceptance"
+        or literature_claim.get("workflowSource") != "local_deep_research"
         or module.get("capabilities", {}).get("modelEvaluation") is not False
     ):
         raise AcceptanceFailure(f"module claims are invalid: {status} {module}")

--- a/extensions/ai-research/scripts/init_ldr_assets.py
+++ b/extensions/ai-research/scripts/init_ldr_assets.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Callable
+
+
+MODEL_REPOSITORY = "sentence-transformers/all-MiniLM-L6-v2"
+MODEL_REVISION = "1110a243fdf4706b3f48f1d95db1a4f5529b4d41"
+MANIFEST_NAME = "modelmirror-asset-manifest.json"
+MAX_FILES = 10_000
+MAX_TOTAL_BYTES = 2 * 1024 * 1024 * 1024
+
+
+class AssetIntegrityError(RuntimeError):
+    pass
+
+
+def initialize(
+    root: Path,
+    *,
+    downloader: Callable[..., object],
+) -> dict[str, object]:
+    root.mkdir(parents=True, exist_ok=True)
+    if root.is_symlink():
+        raise AssetIntegrityError("model asset root must not be a symlink")
+    manifest_path = root / MANIFEST_NAME
+    if manifest_path.exists():
+        return verify(root)
+    downloader(
+        repo_id=MODEL_REPOSITORY,
+        revision=MODEL_REVISION,
+        local_dir=str(root),
+        local_dir_use_symlinks=False,
+    )
+    files = inventory(root)
+    manifest = {
+        "schemaVersion": 1,
+        "repository": MODEL_REPOSITORY,
+        "revision": MODEL_REVISION,
+        "files": files,
+    }
+    atomic_write(manifest_path, canonical_json(manifest))
+    for directory in sorted(
+        (path for path in root.rglob("*") if path.is_dir()),
+        key=lambda value: len(value.parts),
+        reverse=True,
+    ):
+        directory.chmod(0o755)
+    for path in root.rglob("*"):
+        if path.is_file():
+            path.chmod(0o444)
+    root.chmod(0o755)
+    return verify(root)
+
+
+def verify(root: Path) -> dict[str, object]:
+    manifest_path = root / MANIFEST_NAME
+    if not manifest_path.is_file() or manifest_path.is_symlink():
+        raise AssetIntegrityError("model asset manifest is unavailable")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        raise AssetIntegrityError("model asset manifest is malformed") from exc
+    if (
+        not isinstance(manifest, dict)
+        or manifest.get("schemaVersion") != 1
+        or manifest.get("repository") != MODEL_REPOSITORY
+        or manifest.get("revision") != MODEL_REVISION
+        or not isinstance(manifest.get("files"), dict)
+    ):
+        raise AssetIntegrityError("model asset manifest does not match the source lock")
+    if inventory(root) != manifest["files"]:
+        raise AssetIntegrityError("model asset integrity verification failed")
+    return manifest
+
+
+def inventory(root: Path) -> dict[str, dict[str, object]]:
+    result: dict[str, dict[str, object]] = {}
+    total = 0
+    for path in sorted(root.rglob("*")):
+        if path.name == MANIFEST_NAME:
+            continue
+        if path.is_symlink():
+            raise AssetIntegrityError("model assets must not contain symlinks")
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root).as_posix()
+        size = path.stat().st_size
+        total += size
+        if len(result) >= MAX_FILES or total > MAX_TOTAL_BYTES:
+            raise AssetIntegrityError("model assets exceed the fixed inventory limit")
+        result[relative] = {"sizeBytes": size, "sha256": digest(path)}
+    if not result:
+        raise AssetIntegrityError("model asset snapshot is empty")
+    return result
+
+
+def digest(path: Path) -> str:
+    value = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            value.update(chunk)
+    return value.hexdigest()
+
+
+def atomic_write(path: Path, content: bytes) -> None:
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}-", suffix=".tmp", dir=path.parent
+    )
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def canonical_json(value: object) -> bytes:
+    return (
+        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    ).encode("utf-8")
+
+
+def ensure_models_link(link: Path, target: Path) -> None:
+    if not link.is_absolute() or not target.is_absolute():
+        raise AssetIntegrityError("model link and target must be absolute")
+    if not target.is_dir() or target.is_symlink():
+        raise AssetIntegrityError("model link target must be a real directory")
+    target_resolved = target.resolve()
+    if link.is_symlink():
+        if link.resolve() != target_resolved:
+            raise AssetIntegrityError("model link points to an unexpected target")
+        return
+    if link.exists():
+        if not link.is_dir() or any(link.iterdir()):
+            raise AssetIntegrityError("model link path is not an empty directory")
+        link.rmdir()
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(target, target_is_directory=True)
+    if not link.is_symlink() or link.resolve() != target_resolved:
+        raise AssetIntegrityError("model link integrity verification failed")
+
+
+def main() -> None:
+    from huggingface_hub import snapshot_download
+
+    root = Path(
+        os.environ.get(
+            "AI_RESEARCH_LDR_MODEL_ROOT",
+            "/model-assets/sentence-transformers/all-MiniLM-L6-v2",
+        )
+    )
+    manifest = initialize(root, downloader=snapshot_download)
+    ensure_models_link(
+        Path(os.environ.get("AI_RESEARCH_LDR_MODEL_LINK", "/data/models")),
+        root.parents[1],
+    )
+    print(
+        json.dumps(
+            {
+                "status": "verified",
+                "repository": manifest["repository"],
+                "revision": manifest["revision"],
+                "fileCount": len(manifest["files"]),
+            },
+            separators=(",", ":"),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/extensions/ai-research/scripts/literature_acceptance.py
+++ b/extensions/ai-research/scripts/literature_acceptance.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+def loopback_control_url() -> str:
+    default = f"http://127.0.0.1:{os.getenv('AI_RESEARCH_CONTROL_PORT', '8790')}"
+    value = os.getenv("AI_RESEARCH_ACCEPTANCE_CONTROL_URL", default).rstrip("/")
+    parsed = urllib.parse.urlsplit(value)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise RuntimeError("AI_RESEARCH_ACCEPTANCE_CONTROL_URL must be an HTTP loopback origin")
+    try:
+        if parsed.port is None:
+            raise RuntimeError("AI_RESEARCH_ACCEPTANCE_CONTROL_URL must include an explicit port")
+    except ValueError as exc:
+        raise RuntimeError("AI_RESEARCH_ACCEPTANCE_CONTROL_URL has an invalid port") from exc
+    return value
+
+
+CONTROL = loopback_control_url()
+ARTIFACTS = {
+    "literature-review.md",
+    "upstream-quarto.zip",
+    "literature-review.qmd",
+    "references.bib",
+    "references.ris",
+    "sources.json",
+    "literature-receipt.json",
+    "artifact-manifest.json",
+}
+
+
+class AcceptanceFailure(RuntimeError):
+    pass
+
+
+def request(method: str, path: str, payload: dict[str, Any] | None = None) -> tuple[int, Any, dict[str, str]]:
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    value = urllib.request.Request(CONTROL + path, data=body, headers=headers, method=method)
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    try:
+        with opener.open(value, timeout=30) as response:
+            raw = response.read(128 * 1024 * 1024 + 1)
+            if len(raw) > 128 * 1024 * 1024:
+                raise AcceptanceFailure(f"oversized response from {path}")
+            content_type = response.headers.get_content_type()
+            attachment = response.headers.get("Content-Disposition", "").lower().startswith("attachment;")
+            decoded: Any = (
+                json.loads(raw)
+                if raw and content_type == "application/json" and not attachment
+                else raw
+            )
+            return response.status, decoded, dict(response.headers)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read(1024 * 1024 + 1)
+        try:
+            decoded = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            decoded = raw.decode("utf-8", errors="replace")
+        return exc.code, decoded, dict(exc.headers)
+
+
+def expect(status: int, body: Any, allowed: set[int], operation: str) -> dict[str, Any]:
+    if status not in allowed or not isinstance(body, dict):
+        raise AcceptanceFailure(f"{operation} failed: HTTP {status} {body}")
+    return body
+
+
+def unlock() -> str:
+    username = os.environ.get("AI_RESEARCH_ACCEPTANCE_LDR_USERNAME", "")
+    password = os.environ.get("AI_RESEARCH_ACCEPTANCE_LDR_PASSWORD", "")
+    if not username or not password:
+        raise AcceptanceFailure("live acceptance requires LDR username and password environment inputs")
+    status, body, _ = request(
+        "POST",
+        "/api/v1/literature/session/unlock",
+        {"username": username, "password": password},
+    )
+    session = expect(status, body, {200}, "unlocking LDR")
+    if session.get("status") != "ready" or session.get("username") != username:
+        raise AcceptanceFailure("LDR did not return the unlocked account identity")
+    return username
+
+
+def prepare_collection() -> str:
+    collection_id = os.environ.get("AI_RESEARCH_ACCEPTANCE_COLLECTION_ID", "")
+    if not collection_id:
+        raise AcceptanceFailure("live acceptance requires an explicitly approved Zotero/LDR collection id")
+    status, body, _ = request("GET", "/api/v1/literature/zotero/status")
+    zotero = expect(status, body, {200}, "reading Zotero status")
+    config = zotero.get("config")
+    if not isinstance(config, dict) or not (config.get("configured") or config.get("has_api_key")):
+        raise AcceptanceFailure("Zotero must be configured by the user in LDR before acceptance")
+    status, body, _ = request("POST", "/api/v1/literature/zotero/sync")
+    expect(status, body, {200}, "synchronizing Zotero")
+    encoded = urllib.parse.quote(collection_id, safe="")
+    status, body, _ = request("POST", f"/api/v1/literature/library/collections/{encoded}/index")
+    indexed = expect(status, body, {200}, "indexing the approved collection")
+    if indexed.get("status") != "completed":
+        raise AcceptanceFailure("LDR collection indexing did not complete")
+    status, body, _ = request("GET", "/api/v1/literature/library/collections")
+    collections = expect(status, body, {200}, "reading LDR collections").get("collections")
+    selected = next((item for item in collections or [] if isinstance(item, dict) and item.get("id") == collection_id), None)
+    if not selected:
+        raise AcceptanceFailure("the approved collection was not returned by LDR")
+    if not (
+        selected.get("is_public") is True
+        and selected.get("agent_enabled") is True
+        and int(selected.get("indexed_document_count") or 0) > 0
+    ):
+        raise AcceptanceFailure("the approved collection did not pass index and egress gates")
+    return collection_id
+
+
+def wait_for_terminal(project_id: str, timeout: float = 1800.0) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    last: Any = None
+    encoded = urllib.parse.quote(project_id, safe="")
+    while time.monotonic() < deadline:
+        status, body, _ = request("GET", f"/api/v1/projects/{encoded}")
+        last = (status, body)
+        if status == 200 and isinstance(body, dict) and body.get("literaturePhase") == "terminal":
+            return body
+        time.sleep(3)
+    raise AcceptanceFailure(f"literature run did not become terminal: {last}")
+
+
+def verify_outputs(project_id: str) -> dict[str, str]:
+    encoded = urllib.parse.quote(project_id, safe="")
+    status, body, _ = request("GET", f"/api/v1/projects/{encoded}/sources")
+    sources = expect(status, body, {200}, "reading sources")
+    if sources.get("integrityStatus") != "verified" or not sources.get("sources"):
+        raise AcceptanceFailure("verified literature sources are missing")
+    status, body, _ = request("GET", f"/api/v1/projects/{encoded}/review")
+    review = expect(status, body, {200}, "reading literature review")
+    if review.get("integrityStatus") != "verified" or not str(review.get("markdown") or "").strip():
+        raise AcceptanceFailure("verified literature review is missing")
+    digests: dict[str, str] = {}
+    for name in sorted(ARTIFACTS):
+        status, content, headers = request(
+            "GET", f"/api/v1/projects/{encoded}/artifacts/{urllib.parse.quote(name, safe='')}"
+        )
+        if status != 200 or not isinstance(content, bytes) or not content:
+            raise AcceptanceFailure(f"artifact download failed: {name}")
+        digest = hashlib.sha256(content).hexdigest()
+        if headers.get("X-Content-SHA256") != digest:
+            raise AcceptanceFailure(f"artifact response hash disagreed: {name}")
+        digests[name] = digest
+    return digests
+
+
+def initial(state_path: Path) -> None:
+    username = unlock()
+    collection_id = prepare_collection()
+    suffix = uuid.uuid4().hex
+    status, body, _ = request(
+        "POST",
+        "/api/v1/projects",
+        {
+            "title": os.environ.get("AI_RESEARCH_ACCEPTANCE_TITLE", "Agent 评测可复现性文献研究"),
+            "researchQuestion": os.environ.get(
+                "AI_RESEARCH_ACCEPTANCE_QUESTION",
+                "公开文献中，哪些方法用于提高大语言模型 Agent 评测的可复现性？",
+            ),
+            "idempotencyKey": f"acceptance:project:{suffix}",
+        },
+    )
+    project = expect(status, body, {200, 201}, "creating research project")
+    project_id = str(project.get("projectId") or "")
+    status, body, _ = request(
+        "POST",
+        f"/api/v1/projects/{urllib.parse.quote(project_id, safe='')}/literature/runs",
+        {"idempotencyKey": f"acceptance:literature:{suffix}", "collectionId": collection_id},
+    )
+    expect(status, body, {200, 201}, "starting literature research")
+    terminal = wait_for_terminal(project_id)
+    if terminal.get("literatureOutcome") != "completed":
+        raise AcceptanceFailure(f"literature research did not complete: {terminal}")
+    digests = verify_outputs(project_id)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "projectId": project_id,
+                "collectionId": collection_id,
+                "username": username,
+                "artifactSha256": digests,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def recovery(state_path: Path) -> None:
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    unlock()
+    project_id = str(state["projectId"])
+    terminal = wait_for_terminal(project_id, timeout=60)
+    if terminal.get("literatureOutcome") != "completed" or terminal.get("collectionId") != state["collectionId"]:
+        raise AcceptanceFailure("project state did not recover after restart")
+    if verify_outputs(project_id) != state["artifactSha256"]:
+        raise AcceptanceFailure("artifact hashes changed after restart")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("phase", choices=("initial", "recovery"))
+    parser.add_argument("--state", type=Path, required=True)
+    args = parser.parse_args()
+    if args.phase == "initial":
+        initial(args.state)
+    else:
+        recovery(args.state)
+    print(f"literature acceptance {args.phase} passed")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (AcceptanceFailure, OSError, ValueError, KeyError, json.JSONDecodeError) as exc:
+        print(f"literature acceptance failed: {exc}", file=os.sys.stderr)
+        raise SystemExit(1)

--- a/extensions/ai-research/scripts/validate_boundary.py
+++ b/extensions/ai-research/scripts/validate_boundary.py
@@ -14,6 +14,43 @@ from pathlib import Path
 
 MODULE_ROOT = Path(__file__).resolve().parent.parent
 REPO_ROOT = MODULE_ROOT.parents[1]
+LDR_IMAGE = (
+    "localdeepresearch/local-deep-research:1.10.6@"
+    "sha256:b2c634291de8fb8d0662ab81a0b82ec17ab807109d20d57386042c5bdcd472e5"
+)
+LDR_SBOM_FACTS = {
+    "sbomUrl": (
+        "https://github.com/LearningCircuit/local-deep-research/releases/download/"
+        "v1.10.6/sbom-container-amd64.spdx.json"
+    ),
+    "sbomSha256": "6f9c0e6f762763d2b34207a7638b65bedd37d818bd86e538483b21cb091c6315",
+    "sbomSizeBytes": 5245009,
+    "packageCount": 438,
+    "packageEcosystems": {
+        "pypi": 282,
+        "deb": 134,
+        "npm": 5,
+        "generic": 2,
+        "oci": 1,
+        "unclassified": 14,
+    },
+    "declaredGplOrLgplCount": 100,
+    "declaredUnknownCount": 60,
+    "declaredKnownConcludedNoAssertionCount": 378,
+    "declaredUnknownConcludedKnownCount": 22,
+    "effectiveUnknownCount": 38,
+    "concludedNoAssertionCount": 416,
+    "declaredAgplCount": 0,
+    "declaredCopyleftByEcosystem": {"deb": 98, "pypi": 2},
+}
+LDR_DISTRIBUTION_POLICY = {
+    "externalPull": "allowed",
+    "internallyHostedUse": "allowed_with_notice",
+    "mirror": "blocked",
+    "offlineBundle": "blocked",
+    "modifiedImage": "blocked",
+    "representAsMitOnly": "forbidden",
+}
 
 
 class BoundaryFailure(RuntimeError):
@@ -26,6 +63,11 @@ def is_ui_generated(path: Path) -> bool:
         ("ui", "node_modules"),
         ("ui", "dist"),
     }
+
+
+def is_local_generated(path: Path) -> bool:
+    relative = path.relative_to(MODULE_ROOT).parts
+    return bool(relative) and relative[0] in {".venv", "runtime"}
 
 
 def git(*args: str) -> list[str]:
@@ -80,7 +122,7 @@ def validate_paths(base: str, boundary: dict) -> None:
     if illegal:
         raise BoundaryFailure(f"files outside the approved boundary changed: {illegal}")
     for path in MODULE_ROOT.rglob("*"):
-        if is_ui_generated(path):
+        if is_ui_generated(path) or is_local_generated(path):
             continue
         mode = path.lstat().st_mode
         if stat.S_ISLNK(mode):
@@ -131,6 +173,7 @@ def validate_runtime_references(boundary: dict) -> None:
             or "tests" in path.parts
             or "scripts" in path.parts
             or is_ui_generated(path)
+            or is_local_generated(path)
         ):
             continue
         if path.suffix not in runtime_suffixes and path.name not in runtime_names:
@@ -168,12 +211,185 @@ def validate_parent_controls() -> None:
         raise BoundaryFailure("path-filtered module workflow is missing")
 
 
+def _service_block(compose: str, name: str) -> str:
+    marker = f"  {name}:\n"
+    start = compose.find(marker)
+    if start < 0:
+        raise BoundaryFailure(f"required Compose service is missing: {name}")
+    content_start = start + len(marker)
+    next_service = re.search(r"(?m)^  [a-z0-9][a-z0-9_-]*:\n", compose[content_start:])
+    end = content_start + next_service.start() if next_service else len(compose)
+    return compose[start:end]
+
+
+def validate_ldr_distribution_mode(
+    source_lock: dict,
+    distribution_mode: str,
+    *,
+    compose_text: str | None = None,
+    dockerfile_texts: dict[str, str] | None = None,
+    packaged_paths: list[str] | None = None,
+) -> None:
+    if distribution_mode == "redistributable-bundle":
+        raise BoundaryFailure(
+            "LDR redistributable-bundle is blocked until package obligations and "
+            "the 37 effective unknown licenses are disposed"
+        )
+    if distribution_mode != "external-pull":
+        raise BoundaryFailure(f"unsupported distribution mode: {distribution_mode}")
+
+    audit = source_lock.get("licenseAudit", {})
+    image_audit = audit.get("localDeepResearchImage", {})
+    if audit.get("status") != "passed_for_external_pull":
+        raise BoundaryFailure("license audit is not approved for external-pull mode")
+    if image_audit.get("integrationMode") != "external_pull_only":
+        raise BoundaryFailure("LDR integration must remain external_pull_only")
+    if image_audit.get("allowedImage") != LDR_IMAGE:
+        raise BoundaryFailure("LDR allowed image is not the audited public digest")
+    if image_audit.get("distributionPolicy") != LDR_DISTRIBUTION_POLICY:
+        raise BoundaryFailure("LDR distribution policy drifted")
+    for key, expected in LDR_SBOM_FACTS.items():
+        if image_audit.get(key) != expected:
+            raise BoundaryFailure(f"LDR SBOM fact drifted: {key}")
+
+    upstreams = [
+        item for item in source_lock.get("upstreams", [])
+        if item.get("name") == "Local Deep Research"
+    ]
+    if len(upstreams) != 1 or upstreams[0].get("image") != LDR_IMAGE:
+        raise BoundaryFailure("LDR upstream image lock is missing or ambiguous")
+    if upstreams[0].get("integration") != "pull-upstream-image-by-digest":
+        raise BoundaryFailure("LDR upstream integration is not a digest pull")
+
+    compose = compose_text
+    if compose is None:
+        compose = (MODULE_ROOT / "compose.yml").read_text(encoding="utf-8")
+    for service in ("ai-research-ldr-assets", "ai-research-ldr"):
+        block = _service_block(compose, service)
+        if f"    image: {LDR_IMAGE}\n" not in block:
+            raise BoundaryFailure(f"{service} must use the audited public LDR digest")
+        if re.search(r"(?m)^    build:", block):
+            raise BoundaryFailure(f"{service} must not build or modify the LDR image")
+        if re.search(r"(?m)^    pull_policy:\s*never\s*$", block):
+            raise BoundaryFailure(f"{service} must not require an offline-only image")
+    if compose.count(f"image: {LDR_IMAGE}") != 2:
+        raise BoundaryFailure("the audited LDR image must appear in exactly two services")
+    ldr_image_lines = [
+        line.strip() for line in compose.splitlines()
+        if line.lstrip().startswith("image:") and "local-deep-research" in line.lower()
+    ]
+    if ldr_image_lines != [f"image: {LDR_IMAGE}", f"image: {LDR_IMAGE}"]:
+        raise BoundaryFailure("an unapproved or private LDR image reference is present")
+
+    if dockerfile_texts is None:
+        dockerfile_texts = {
+            str(path.relative_to(MODULE_ROOT)): path.read_text(encoding="utf-8")
+            for path in MODULE_ROOT.rglob("Dockerfile")
+            if not is_local_generated(path) and not is_ui_generated(path)
+        }
+    for name, content in dockerfile_texts.items():
+        if re.search(r"(?im)^\s*(?:FROM|COPY)\b.*localdeepresearch", content):
+            raise BoundaryFailure(f"LDR image reuse in Dockerfile is forbidden: {name}")
+
+    if packaged_paths is None:
+        packaged_paths = [
+            str(path.relative_to(MODULE_ROOT)).replace("\\", "/")
+            for path in MODULE_ROOT.rglob("*")
+            if path.is_file() and not is_local_generated(path) and not is_ui_generated(path)
+        ]
+    forbidden_archives = [
+        path for path in packaged_paths
+        if Path(path).suffix.lower() in {".oci", ".tar", ".tgz"}
+        and ("ldr" in path.lower() or "local-deep-research" in path.lower())
+    ]
+    if forbidden_archives:
+        raise BoundaryFailure(f"bundled LDR image archive is forbidden: {forbidden_archives}")
+
+    notice = (MODULE_ROOT / "THIRD_PARTY_NOTICES.md").read_text(encoding="utf-8")
+    disposition = (MODULE_ROOT / "LDR_LICENSE_DISPOSITION.md").read_text(encoding="utf-8")
+    if "not represented as MIT-only" not in notice or "external_pull_only" not in disposition:
+        raise BoundaryFailure("LDR aggregate-image notice or disposition is missing")
+
+
 def validate_runtime_privacy_defaults() -> None:
     compose = (MODULE_ROOT / "compose.yml").read_text(encoding="utf-8")
+    control_dockerfile = (MODULE_ROOT / "control" / "Dockerfile").read_text(
+        encoding="utf-8"
+    )
+    if "/data/projects" not in control_dockerfile or "chown -R 65532:65532 /data" not in control_dockerfile:
+        raise BoundaryFailure(
+            "control image must initialize the projects volume for the non-root runtime"
+        )
+
+    def service_block(name: str) -> str:
+        service_marker = f"  {name}:\n"
+        marker_start = compose.find("\n" + service_marker)
+        if marker_start < 0:
+            raise BoundaryFailure(f"required Compose service is missing: {name}")
+        start = marker_start + 1
+        content_start = start + len(service_marker)
+        next_block = re.search(
+            r"(?m)^  [a-z0-9][a-z0-9_-]*:\n",
+            compose[content_start:],
+        )
+        end = (
+            content_start + next_block.start()
+            if next_block is not None
+            else len(compose)
+        )
+        return compose[start:end]
+
     if compose.count('MLFLOW_DISABLE_TELEMETRY: "true"') != 2:
         raise BoundaryFailure(
             "MLflow telemetry must be disabled in both control and tracking services"
         )
+    relay_contract = {
+        "AI_RESEARCH_MODEL_BRIDGE_URL: ${AI_RESEARCH_MODEL_BRIDGE_URL:-http://ai-research-model-relay:8090/api/ai-research/v1}",
+        "AI_RESEARCH_MODEL_RELAY_TARGET_URL: ${AI_RESEARCH_MODEL_RELAY_TARGET_URL:-http://host.docker.internal:8000/api/ai-research/v1}",
+        "subnet: ${AI_RESEARCH_TRACKING_SUBNET:-10.254.76.0/28}",
+        "subnet: ${AI_RESEARCH_INSPECT_VIEW_SUBNET:-10.254.76.16/28}",
+        "subnet: ${AI_RESEARCH_LITERATURE_CONTROL_SUBNET:-10.254.76.32/28}",
+        "subnet: ${AI_RESEARCH_LITERATURE_EGRESS_SUBNET:-10.254.76.48/28}",
+        "subnet: ${AI_RESEARCH_MODEL_BRIDGE_EGRESS_SUBNET:-10.254.76.64/28}",
+        "subnet: ${AI_RESEARCH_LOCAL_GATEWAY_SUBNET:-10.254.76.80/28}",
+        "ai_research_control.model_relay:app",
+        "ai_research_control.console_gateway",
+        "AI_RESEARCH_CONSOLE_GATEWAY_CONTROL_URL: http://ai-research-control:8080",
+        "AI_RESEARCH_CONSOLE_GATEWAY_TRACKING_URL: http://ai-research-tracking:5000",
+        "AI_RESEARCH_CONSOLE_GATEWAY_INSPECT_URL: http://ai-research-inspect-view:7575",
+        "AI_RESEARCH_CONSOLE_GATEWAY_INSPECT_PUBLIC_PORT: ${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}",
+        "127.0.0.1:${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}",
+        "localhost:${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}",
+    }
+    missing = sorted(value for value in relay_contract if value not in compose)
+    if missing:
+        raise BoundaryFailure(f"fixed model relay contract drifted: {missing}")
+    control_service = service_block("ai-research-control")
+    gateway_service = service_block("ai-research-console-gateway")
+    relay_block = service_block("ai-research-model-relay")
+    tracking_service = service_block("ai-research-tracking")
+    inspect_service = service_block("ai-research-inspect-view")
+    if "host.docker.internal" in control_service or "model_bridge_egress" in control_service:
+        raise BoundaryFailure("control must not have direct model-bridge or generic egress")
+    if "host.docker.internal:host-gateway" not in relay_block:
+        raise BoundaryFailure("only the fixed model relay may reach the host bridge")
+    if compose.count("host.docker.internal:host-gateway") != 1:
+        raise BoundaryFailure("host bridge mapping must exist only on the fixed model relay")
+    if any("\n    ports:" in block for block in (control_service, tracking_service, inspect_service)):
+        raise BoundaryFailure("internal UI services must not publish host ports directly")
+    required_gateway_bindings = {
+        '127.0.0.1:${AI_RESEARCH_CONTROL_PORT:-8790}:8080',
+        '127.0.0.1:${AI_RESEARCH_MLFLOW_PORT:-8791}:8091',
+        '127.0.0.1:${AI_RESEARCH_INSPECT_VIEW_PORT:-8793}:8093',
+    }
+    if any(binding not in gateway_service for binding in required_gateway_bindings):
+        raise BoundaryFailure("local UI bindings must terminate on the fixed gateway")
+    if compose.count("- local_gateway_ingress") != 1 or "- local_gateway_ingress" not in gateway_service:
+        raise BoundaryFailure("only the fixed console gateway may join the ingress network")
+    for network in ("tracking_internal", "inspect_view_internal", "literature_control_internal"):
+        marker = f"  {network}:\n    internal: true"
+        if marker not in compose:
+            raise BoundaryFailure(f"control network is not internal: {network}")
 
 
 def validate_no_secrets(boundary: dict) -> None:
@@ -184,7 +400,9 @@ def validate_no_secrets(boundary: dict) -> None:
         re.compile(r"AIza" + r"[A-Za-z0-9_-]{30,}"),
     ]
     candidates = [
-        path for path in MODULE_ROOT.rglob("*") if path.is_file() and not is_ui_generated(path)
+        path
+        for path in MODULE_ROOT.rglob("*")
+        if path.is_file() and not is_ui_generated(path) and not is_local_generated(path)
     ]
     candidates.extend(REPO_ROOT / relative for relative in boundary["allowedParentFiles"])
     for path in candidates:
@@ -200,7 +418,11 @@ def validate_no_secrets(boundary: dict) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base", default="origin/main")
-    parser.add_argument("--allow-pending-license", action="store_true")
+    parser.add_argument(
+        "--distribution-mode",
+        required=True,
+        choices=("external-pull", "redistributable-bundle"),
+    )
     args = parser.parse_args()
     boundary = json.loads((MODULE_ROOT / "module-boundary.json").read_text(encoding="utf-8"))
     source_lock = json.loads((MODULE_ROOT / "source-lock.json").read_text(encoding="utf-8"))
@@ -211,10 +433,9 @@ def main() -> int:
     validate_runtime_references(boundary)
     validate_metric_names()
     validate_parent_controls()
+    validate_ldr_distribution_mode(source_lock, args.distribution_mode)
     validate_runtime_privacy_defaults()
     validate_no_secrets(boundary)
-    if source_lock["licenseAudit"]["status"] != "passed" and not args.allow_pending_license:
-        raise BoundaryFailure("runtime license audit is not passed")
     print("AI Research boundary validation passed")
     return 0
 

--- a/extensions/ai-research/scripts/verify.ps1
+++ b/extensions/ai-research/scripts/verify.ps1
@@ -1,7 +1,10 @@
 param(
     [string]$Base = "origin/main",
     [ValidateSet("Quick", "Full")]
-    [string]$Mode = "Full"
+    [string]$Mode = "Full",
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("ExternalPull", "RedistributableBundle")]
+    [string]$DistributionMode
 )
 
 $ErrorActionPreference = "Stop"
@@ -20,7 +23,13 @@ if (-not $pythonFile) {
         $pythonPrefix = @("-3.12")
     }
 }
-$compose = @("compose", "-f", "compose.yml", "--profile", "ai-research")
+$composeProject = if ($env:AI_RESEARCH_COMPOSE_PROJECT) {
+    $env:AI_RESEARCH_COMPOSE_PROJECT
+} else {
+    "modelmirror-ai-research"
+}
+$compose = @("compose", "-p", $composeProject, "-f", "compose.yml", "--profile", "ai-research")
+$literatureCompose = @("compose", "-p", $composeProject, "-f", "compose.yml", "--profile", "literature")
 $runtime = Join-Path $moduleRoot "runtime"
 $diagnostics = Join-Path $runtime "diagnostics"
 $sbom = Join-Path $runtime "sbom"
@@ -69,6 +78,14 @@ function Extract-ImageFile([string]$Image, [string]$ContainerPath, [string]$Dest
     }
 }
 
+function Get-ComposeServiceId([string[]]$ComposeArguments, [string]$Service) {
+    $containerId = & docker @ComposeArguments ps -q $Service
+    if ($LASTEXITCODE -ne 0 -or -not $containerId) {
+        throw "running Compose service is missing: $Service"
+    }
+    return $containerId.Trim()
+}
+
 function Build-ClientProof([string]$GitRef, [string]$Context, [string]$Image) {
     $archive = Join-Path $Context "client.tar"
     Invoke-Checked "git" @(
@@ -87,24 +104,35 @@ function Build-ClientProof([string]$GitRef, [string]$Context, [string]$Image) {
 
 Push-Location $moduleRoot
 try {
-    Invoke-Python @("scripts/validate_boundary.py", "--base", $Base)
+    $distributionModeValue = if ($DistributionMode -eq "ExternalPull") {
+        "external-pull"
+    } else {
+        "redistributable-bundle"
+    }
+    $boundaryArgs = @(
+        "scripts/validate_boundary.py",
+        "--base", $Base,
+        "--distribution-mode", $distributionModeValue
+    )
+    Invoke-Python $boundaryArgs
     Invoke-Checked "docker" ($compose + @("config", "--quiet"))
+    Invoke-Checked "docker" ($literatureCompose + @("config", "--quiet"))
 
-    Invoke-Checked "docker" @("build", "--target", "test", "-f", "control/Dockerfile", "-t", "modelmirror-ai-research-control-test:ar1", ".")
-    Invoke-Checked "docker" @("run", "--rm", "modelmirror-ai-research-control-test:ar1")
-    Invoke-Checked "docker" @("build", "--target", "test", "-f", "worker/Dockerfile", "-t", "modelmirror-ai-research-worker-test:ar1", ".")
-    Invoke-Checked "docker" @("run", "--rm", "modelmirror-ai-research-worker-test:ar1")
+    Invoke-Checked "docker" @("build", "--target", "test", "-f", "control/Dockerfile", "-t", "modelmirror-ai-research-control-test:v0.1", ".")
+    Invoke-Checked "docker" @("run", "--rm", "modelmirror-ai-research-control-test:v0.1")
+    Invoke-Checked "docker" @("build", "--target", "test", "-f", "worker/Dockerfile", "-t", "modelmirror-ai-research-worker-test:v0.1", ".")
+    Invoke-Checked "docker" @("run", "--rm", "modelmirror-ai-research-worker-test:v0.1")
 
     if ($Mode -eq "Quick") { return }
 
-    Invoke-Checked "docker" @("build", "--sbom=true", "--provenance=true", "--target", "runtime", "-f", "control/Dockerfile", "-t", "modelmirror-ai-research-control:ar1", ".")
-    Invoke-Checked "docker" @("build", "--sbom=true", "--provenance=true", "--target", "runtime", "-f", "worker/Dockerfile", "-t", "modelmirror-ai-research-worker:ar1", ".")
+    Invoke-Checked "docker" @("build", "--sbom=true", "--provenance=true", "--target", "runtime", "-f", "control/Dockerfile", "-t", "modelmirror-ai-research-control:v0.1", ".")
+    Invoke-Checked "docker" @("build", "--sbom=true", "--provenance=true", "--target", "runtime", "-f", "worker/Dockerfile", "-t", "modelmirror-ai-research-worker:v0.1", ".")
     $controlInventoryPath = Join-Path $sbom "control-runtime-inventory.json"
     $workerInventoryPath = Join-Path $sbom "worker-runtime-inventory.json"
     $uiInventoryPath = Join-Path $sbom "ui-build-inventory.json"
-    Extract-ImageFile "modelmirror-ai-research-control:ar1" "/usr/share/doc/modelmirror-ai-research/runtime-inventory.json" $controlInventoryPath
-    Extract-ImageFile "modelmirror-ai-research-control:ar1" "/usr/share/doc/modelmirror-ai-research/ui-build-inventory.json" $uiInventoryPath
-    Extract-ImageFile "modelmirror-ai-research-worker:ar1" "/usr/share/doc/modelmirror-ai-research/runtime-inventory.json" $workerInventoryPath
+    Extract-ImageFile "modelmirror-ai-research-control:v0.1" "/usr/share/doc/modelmirror-ai-research/runtime-inventory.json" $controlInventoryPath
+    Extract-ImageFile "modelmirror-ai-research-control:v0.1" "/usr/share/doc/modelmirror-ai-research/ui-build-inventory.json" $uiInventoryPath
+    Extract-ImageFile "modelmirror-ai-research-worker:v0.1" "/usr/share/doc/modelmirror-ai-research/runtime-inventory.json" $workerInventoryPath
     $sourceLock = Get-Content -Raw -Encoding utf8 source-lock.json | ConvertFrom-Json
     $controlInventoryHash = (Get-FileHash -Algorithm SHA256 $controlInventoryPath).Hash.ToLowerInvariant()
     $workerInventoryHash = (Get-FileHash -Algorithm SHA256 $workerInventoryPath).Hash.ToLowerInvariant()
@@ -119,8 +147,8 @@ try {
         throw "UI build inventory hash disagrees with source-lock"
     }
     $imageEvidence = @(
-        (Measure-Image "modelmirror-ai-research-control:ar1" "control"),
-        (Measure-Image "modelmirror-ai-research-worker:ar1" "worker")
+        (Measure-Image "modelmirror-ai-research-control:v0.1" "control"),
+        (Measure-Image "modelmirror-ai-research-worker:v0.1" "worker")
     )
     Set-Content -LiteralPath (Join-Path $diagnostics "image-identities.txt") -Value $imageEvidence -Encoding utf8
 
@@ -155,6 +183,18 @@ try {
         Invoke-Python @("scripts/acceptance.py", "recovery", "--state", $state)
     }
 
+    if ($env:AI_RESEARCH_LIVE_ACCEPTANCE -eq "1") {
+        Invoke-Checked "docker" ($literatureCompose + @("up", "-d", "ai-research-model-relay", "ai-research-ldr"))
+        $literatureState = Join-Path $runtime "literature-acceptance-state.json"
+        Invoke-Python @("scripts/literature_acceptance.py", "initial", "--state", $literatureState)
+        for ($round = 1; $round -le 2; $round++) {
+            Invoke-Checked "docker" ($literatureCompose + @("restart", "ai-research-control", "ai-research-ldr"))
+            Invoke-Python @("scripts/literature_acceptance.py", "recovery", "--state", $literatureState)
+        }
+    } else {
+        Write-Warning "Live model/OpenAlex/Zotero journey was not run; V0.1 real acceptance remains open"
+    }
+
     $runIds = @((Get-Content -Raw -Encoding utf8 $state | ConvertFrom-Json).runs)
     $runIds += (Get-Content -Raw -Encoding utf8 $outboxState | ConvertFrom-Json).runId
     $runIds += (Get-Content -Raw -Encoding utf8 $workerRestartState | ConvertFrom-Json).runId
@@ -174,6 +214,7 @@ checks = [
     ("dns", lambda: socket.getaddrinfo("example.com", 443)),
     ("tcp", lambda: socket.create_connection(("1.1.1.1", 443), timeout=1)),
     ("http", lambda: urllib.request.urlopen("http://example.com", timeout=1)),
+    ("host", lambda: socket.getaddrinfo("host.docker.internal", 8000)),
 ]
 for name, check in checks:
     try:
@@ -186,12 +227,19 @@ if unexpected:
 '@
     & docker @compose exec -T ai-research-worker python -c $networkAttack
     if ($LASTEXITCODE -ne 0) { throw "worker network isolation attack failed" }
+    & docker @compose exec -T ai-research-control python -c $networkAttack
+    if ($LASTEXITCODE -ne 0) { throw "control network isolation attack failed" }
 
+    $environmentServices = @("ai-research-control", "ai-research-console-gateway", "ai-research-tracking", "ai-research-worker", "ai-research-inspect-view")
+    if ($env:AI_RESEARCH_LIVE_ACCEPTANCE -eq "1") {
+        $environmentServices += @("ai-research-model-relay", "ai-research-ldr")
+    }
     $containerEnv = @(
-        (& docker inspect modelmirror-ai-research-ai-research-control-1 --format "{{json .Config.Env}}"),
-        (& docker inspect modelmirror-ai-research-ai-research-tracking-1 --format "{{json .Config.Env}}"),
-        (& docker inspect modelmirror-ai-research-ai-research-worker-1 --format "{{json .Config.Env}}"),
-        (& docker inspect modelmirror-ai-research-ai-research-inspect-view-1 --format "{{json .Config.Env}}")
+        foreach ($service in $environmentServices) {
+            $containerId = Get-ComposeServiceId $literatureCompose $service
+            & docker inspect $containerId --format "{{json .Config.Env}}"
+            if ($LASTEXITCODE -ne 0) { throw "failed to inspect Compose service: $service" }
+        }
     ) -join "`n"
     if ($containerEnv -match "OPENROUTER_API_KEY|LLM_GATEWAY_KEY|DIFY_API_KEY|PROVIDER.*(KEY|TOKEN|SECRET)|sk-(or-v1-)?[A-Za-z0-9_-]{32,}|gh[pousr]_[A-Za-z0-9]{30,}|BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY") {
         throw "provider credential names were exposed to module containers"
@@ -213,17 +261,17 @@ if unexpected:
         Build-ClientProof `
             $sourceLock.modelMirrorBaseCommit `
             $clientBaselineContext `
-            "modelmirror-ai-research-client-proof:ar1-baseline"
+            "modelmirror-ai-research-client-proof:v0.1-baseline"
         Build-ClientProof `
             "HEAD" `
             $clientCurrentContext `
-            "modelmirror-ai-research-client-proof:ar1"
+            "modelmirror-ai-research-client-proof:v0.1"
         Extract-ImageFile `
-            "modelmirror-ai-research-client-proof:ar1-baseline" `
+            "modelmirror-ai-research-client-proof:v0.1-baseline" `
             "/proof/dist/." `
             $clientBaselineProof
         Extract-ImageFile `
-            "modelmirror-ai-research-client-proof:ar1" `
+            "modelmirror-ai-research-client-proof:v0.1" `
             "/proof/dist/." `
             $clientCurrentProof
         Invoke-Python @(
@@ -239,6 +287,6 @@ if unexpected:
         }
     }
 } finally {
-    & docker @compose down
+    & docker @literatureCompose down
     Pop-Location
 }

--- a/extensions/ai-research/scripts/verify.sh
+++ b/extensions/ai-research/scripts/verify.sh
@@ -3,9 +3,16 @@ set -euo pipefail
 
 BASE="${1:-origin/main}"
 MODE="${2:-full}"
+DISTRIBUTION_MODE="${3:?usage: verify.sh [base] [quick|full] [external-pull|redistributable-bundle]}"
+if [[ "$DISTRIBUTION_MODE" != "external-pull" && "$DISTRIBUTION_MODE" != "redistributable-bundle" ]]; then
+  echo "invalid distribution mode: $DISTRIBUTION_MODE" >&2
+  exit 2
+fi
 MODULE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 REPO_ROOT="$(cd "$MODULE_ROOT/../.." && pwd)"
-COMPOSE=(docker compose -f compose.yml --profile ai-research)
+COMPOSE_PROJECT="${AI_RESEARCH_COMPOSE_PROJECT:-modelmirror-ai-research}"
+COMPOSE=(docker compose -p "$COMPOSE_PROJECT" -f compose.yml --profile ai-research)
+LITERATURE_COMPOSE=(docker compose -p "$COMPOSE_PROJECT" -f compose.yml --profile literature)
 CLIENT_BASELINE_PROOF_DIR=""
 CLIENT_CURRENT_PROOF_DIR=""
 CLIENT_PROOF_CONTAINER=""
@@ -30,32 +37,34 @@ cleanup() {
   if [[ "$CLIENT_CURRENT_CONTEXT" == "$MODULE_ROOT"/runtime/client-current-context.* ]]; then
     rm -rf -- "$CLIENT_CURRENT_CONTEXT"
   fi
-  "${COMPOSE[@]}" down >/dev/null 2>&1 || true
+  "${LITERATURE_COMPOSE[@]}" down >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
-python scripts/validate_boundary.py --base "$BASE"
+BOUNDARY_ARGS=(scripts/validate_boundary.py --base "$BASE" --distribution-mode "$DISTRIBUTION_MODE")
+python "${BOUNDARY_ARGS[@]}"
 "${COMPOSE[@]}" config --quiet
-docker build --target test -f control/Dockerfile -t modelmirror-ai-research-control-test:ar1 .
-docker run --rm modelmirror-ai-research-control-test:ar1
-docker build --target test -f worker/Dockerfile -t modelmirror-ai-research-worker-test:ar1 .
-docker run --rm modelmirror-ai-research-worker-test:ar1
+"${LITERATURE_COMPOSE[@]}" config --quiet
+docker build --target test -f control/Dockerfile -t modelmirror-ai-research-control-test:v0.1 .
+docker run --rm modelmirror-ai-research-control-test:v0.1
+docker build --target test -f worker/Dockerfile -t modelmirror-ai-research-worker-test:v0.1 .
+docker run --rm modelmirror-ai-research-worker-test:v0.1
 
 if [[ "$MODE" == "quick" ]]; then
   exit 0
 fi
 
 docker build --sbom=true --provenance=true --target runtime -f control/Dockerfile \
-  -t modelmirror-ai-research-control:ar1 .
+  -t modelmirror-ai-research-control:v0.1 .
 docker build --sbom=true --provenance=true --target runtime -f worker/Dockerfile \
-  -t modelmirror-ai-research-worker:ar1 .
-docker run --rm modelmirror-ai-research-control:ar1 \
+  -t modelmirror-ai-research-worker:v0.1 .
+docker run --rm modelmirror-ai-research-control:v0.1 \
   cat //usr/share/doc/modelmirror-ai-research/runtime-inventory.json \
   > runtime/sbom/control-runtime-inventory.json
-docker run --rm modelmirror-ai-research-control:ar1 \
+docker run --rm modelmirror-ai-research-control:v0.1 \
   cat //usr/share/doc/modelmirror-ai-research/ui-build-inventory.json \
   > runtime/sbom/ui-build-inventory.json
-docker run --rm modelmirror-ai-research-worker:ar1 \
+docker run --rm modelmirror-ai-research-worker:v0.1 \
   cat //usr/share/doc/modelmirror-ai-research/runtime-inventory.json \
   > runtime/sbom/worker-runtime-inventory.json
 CONTROL_EXPECTED=$(python -c "import json; print(json.load(open('source-lock.json'))['licenseAudit']['control']['inventorySha256'])")
@@ -73,8 +82,8 @@ measure_image() {
   rm -f "$tar_path" "${tar_path}.gz"
 }
 {
-  measure_image modelmirror-ai-research-control:ar1 control
-  measure_image modelmirror-ai-research-worker:ar1 worker
+  measure_image modelmirror-ai-research-control:v0.1 control
+  measure_image modelmirror-ai-research-worker:v0.1 worker
 } > runtime/diagnostics/image-identities.txt
 
 "${COMPOSE[@]}" up -d
@@ -103,6 +112,16 @@ for _ in 1 2; do
   "${COMPOSE[@]}" restart ai-research-control ai-research-tracking
   python scripts/acceptance.py recovery --state runtime/acceptance-state.json
 done
+if [[ "${AI_RESEARCH_LIVE_ACCEPTANCE:-}" == "1" ]]; then
+  "${LITERATURE_COMPOSE[@]}" up -d ai-research-model-relay ai-research-ldr
+  python scripts/literature_acceptance.py initial --state runtime/literature-acceptance-state.json
+  for _ in 1 2; do
+    "${LITERATURE_COMPOSE[@]}" restart ai-research-control ai-research-ldr
+    python scripts/literature_acceptance.py recovery --state runtime/literature-acceptance-state.json
+  done
+else
+  echo "warning: live model/OpenAlex/Zotero journey was not run; V0.1 real acceptance remains open" >&2
+fi
 mapfile -t RUN_IDS < <(python -c \
   "import json; a=json.load(open('runtime/acceptance-state.json')); o=json.load(open('runtime/outbox-state.json')); w=json.load(open('runtime/worker-restart-state.json')); print(*a['runs'],o['runId'],w['runId'],sep='\\n')" \
   | tr -d '\r')
@@ -122,6 +141,28 @@ checks = [
     ("dns", lambda: socket.getaddrinfo("example.com", 443)),
     ("tcp", lambda: socket.create_connection(("1.1.1.1", 443), timeout=1)),
     ("http", lambda: urllib.request.urlopen("http://example.com", timeout=1)),
+    ("host", lambda: socket.getaddrinfo("host.docker.internal", 8000)),
+]
+for name, check in checks:
+    try:
+        check()
+    except OSError:
+        continue
+    unexpected.append(name)
+if unexpected:
+    raise SystemExit("network unexpectedly available: " + ",".join(unexpected))
+'
+"${COMPOSE[@]}" exec -T ai-research-control python -c \
+  '
+import socket
+import urllib.request
+
+unexpected = []
+checks = [
+    ("dns", lambda: socket.getaddrinfo("example.com", 443)),
+    ("tcp", lambda: socket.create_connection(("1.1.1.1", 443), timeout=1)),
+    ("http", lambda: urllib.request.urlopen("http://example.com", timeout=1)),
+    ("host", lambda: socket.getaddrinfo("host.docker.internal", 8000)),
 ]
 for name, check in checks:
     try:
@@ -133,12 +174,25 @@ if unexpected:
     raise SystemExit("network unexpectedly available: " + ",".join(unexpected))
 '
 
-CONTAINER_ENV=$(docker inspect \
-  modelmirror-ai-research-ai-research-control-1 \
-  modelmirror-ai-research-ai-research-tracking-1 \
-  modelmirror-ai-research-ai-research-worker-1 --format '{{json .Config.Env}}')
-CONTAINER_ENV+=$(docker inspect \
-  modelmirror-ai-research-ai-research-inspect-view-1 --format '{{json .Config.Env}}')
+ENVIRONMENT_SERVICES=(
+  ai-research-control
+  ai-research-console-gateway
+  ai-research-tracking
+  ai-research-worker
+  ai-research-inspect-view
+)
+if [[ "${AI_RESEARCH_LIVE_ACCEPTANCE:-}" == "1" ]]; then
+  ENVIRONMENT_SERVICES+=(ai-research-model-relay ai-research-ldr)
+fi
+CONTAINER_ENV=""
+for service in "${ENVIRONMENT_SERVICES[@]}"; do
+  container_id=$("${LITERATURE_COMPOSE[@]}" ps -q "$service")
+  if [[ -z "$container_id" ]]; then
+    echo "running Compose service is missing: $service" >&2
+    exit 1
+  fi
+  CONTAINER_ENV+=$(docker inspect "$container_id" --format '{{json .Config.Env}}')$'\n'
+done
 if grep -E 'OPENROUTER_API_KEY|LLM_GATEWAY_KEY|DIFY_API_KEY|PROVIDER.*(KEY|TOKEN|SECRET)|sk-(or-v1-)?[A-Za-z0-9_-]{32,}|gh[pousr]_[A-Za-z0-9]{30,}|BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY' <<<"$CONTAINER_ENV"; then
   echo "provider credential names were exposed to module containers" >&2
   exit 1
@@ -179,16 +233,16 @@ esac
 build_client_proof \
   "$LOCKED_BASE" \
   "$CLIENT_BASELINE_CONTEXT" \
-  modelmirror-ai-research-client-proof:ar1-baseline
+  modelmirror-ai-research-client-proof:v0.1-baseline
 build_client_proof \
   HEAD \
   "$CLIENT_CURRENT_CONTEXT" \
-  modelmirror-ai-research-client-proof:ar1
+  modelmirror-ai-research-client-proof:v0.1
 extract_client_proof \
-  modelmirror-ai-research-client-proof:ar1-baseline \
+  modelmirror-ai-research-client-proof:v0.1-baseline \
   "$CLIENT_BASELINE_PROOF_DIR"
 extract_client_proof \
-  modelmirror-ai-research-client-proof:ar1 \
+  modelmirror-ai-research-client-proof:v0.1 \
   "$CLIENT_CURRENT_PROOF_DIR"
 python scripts/zero_footprint.py \
   --baseline-client-dist "$CLIENT_BASELINE_PROOF_DIR" \

--- a/extensions/ai-research/scripts/zero_footprint.py
+++ b/extensions/ai-research/scripts/zero_footprint.py
@@ -78,9 +78,28 @@ def main() -> int:
     if volumes != baseline["defaultVolumes"]:
         failures.append(f"default Compose volumes changed: {volumes}")
 
-    forbidden_diff = command(
-        "git", "diff", "--name-only", locked_base, "--", "client", "server", "docker-compose.yml"
-    ).strip()
+    allowed_server = {
+        "server/main.py",
+        "server/model_router/ai_research_bridge.py",
+        "server/model_router/chat_stable.py",
+        "server/tests/test_ai_research_bridge.py",
+        "server/tests/test_provider_chat_stable_service.py",
+    }
+    core_diff = {
+        item.strip().replace("\\", "/")
+        for item in command(
+            "git",
+            "diff",
+            "--name-only",
+            locked_base,
+            "--",
+            "client",
+            "server",
+            "docker-compose.yml",
+        ).splitlines()
+        if item.strip()
+    }
+    forbidden_diff = sorted(core_diff - allowed_server)
     if forbidden_diff:
         failures.append(f"forbidden core diff exists: {forbidden_diff}")
     if failures:

--- a/extensions/ai-research/source-lock.json
+++ b/extensions/ai-research/source-lock.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-24",
-  "modelMirrorBaseCommit": "174baf6a5289520b53578dc29cab82fd4c1d1e9e",
+  "generatedAt": "2026-08-28",
+  "modelMirrorBaseCommit": "11d35c1d84c0a18a05779a37d60cb59ef7a25867",
   "claimLevel": "harness_only",
   "packStatus": "fixture_only",
   "runtimes": {
@@ -13,7 +13,11 @@
     "node": "22.23.2",
     "npm": "10.9.8",
     "react": "19.2.7",
-    "vite": "7.3.5"
+    "vite": "7.3.5",
+    "reactMarkdown": "10.1.0",
+    "remarkGfm": "4.0.1",
+    "localDeepResearch": "1.10.6",
+    "sentenceTransformersModelRevision": "1110a243fdf4706b3f48f1d95db1a4f5529b4d41"
   },
   "baseImage": {
     "reference": "python@sha256:401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461",
@@ -26,18 +30,18 @@
   "coreBaseline": {
     "clientDistGate": {
       "mode": "same_runner_base_vs_head",
-      "baseCommit": "174baf6a5289520b53578dc29cab82fd4c1d1e9e"
+      "baseCommit": "11d35c1d84c0a18a05779a37d60cb59ef7a25867"
     },
     "clientDistReference": {
-      "fileCount": 26,
-      "totalBytes": 17611866,
-      "aggregateSha256": "f7eec2e2477f00b62d7ea80050ed75298c8623b5b941c901696104fa8549670e"
+      "fileCount": 38,
+      "totalBytes": 18880491,
+      "aggregateSha256": "f2ffc492aa1a06299c173293eda9338383e17535029f14959a2b8a46793a13ce"
     },
     "trackedFiles": {
-      "docker-compose.yml": "c41af89b65dde80b6925d63c7b44f435fdf9984f8460d7b3d1351ab2a62019d1",
+      "docker-compose.yml": "6e4eeda28a07d8a1432d0230e65ac9fff65069229bf11ef20f5cfe4d6ea1a599",
       "server/requirements.txt": "2bdcee334343bfbeed372d9173ae684d0df839c209d293b780987cfc687a92a4",
-      "server/Dockerfile": "d192d823e21cd51c3a67bc35285130ab77ed22a64a0a8a0cd0083c2875927e63",
-      "client/package.json": "21ea8333343d09df2bb081e9caa05fe9e080d9c8509e71bea7fd12ae33c23ced",
+      "server/Dockerfile": "a84a7dca3063646dee999e4c2685518eda3bdb640d7026c8dd6c878a69db4560",
+      "client/package.json": "e1a089a9661e71140315bd931993c3fa047dd73d5eb4cef58bd1fc87ad292b7e",
       "client/package-lock.json": "0769346386c572ab84f1be52a4882315d98896d76f7e77d21223c359c7dde476"
     },
     "defaultServices": [
@@ -97,6 +101,22 @@
       "tag": "v3.15.1",
       "commit": "9a1c0d9a9827acd23c7a215f0999e4b0f97e9870",
       "license": "Apache-2.0"
+    },
+    {
+      "name": "Local Deep Research",
+      "repository": "https://github.com/LearningCircuit/local-deep-research",
+      "tag": "v1.10.6",
+      "commit": "641308272b2143df89c7a946051d2f05ca29b3c1",
+      "projectLicense": "MIT",
+      "image": "localdeepresearch/local-deep-research:1.10.6@sha256:b2c634291de8fb8d0662ab81a0b82ec17ab807109d20d57386042c5bdcd472e5",
+      "integration": "pull-upstream-image-by-digest"
+    },
+    {
+      "name": "sentence-transformers/all-MiniLM-L6-v2",
+      "repository": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
+      "revision": "1110a243fdf4706b3f48f1d95db1a4f5529b4d41",
+      "license": "Apache-2.0",
+      "integration": "one-shot-pinned-asset-initializer"
     }
   ],
   "lockedFiles": {
@@ -117,8 +137,8 @@
       "sha256": "c6095d8c3647eafc5287ed73cf976540c5d0de9b1da8810f12198bd779ed47ae"
     },
     "control/Dockerfile": {
-      "sizeBytes": 3181,
-      "sha256": "06f307490ad2c24e0621ef943e4df756eb414da2e5fe3f2100bc348911c7b866"
+      "sizeBytes": 3410,
+      "sha256": "5f2cd526aee9e769d7bfd7b475806cc68562554daf0afcaeed0a28e2b22f6223"
     },
     "worker/Dockerfile": {
       "sizeBytes": 1736,
@@ -129,17 +149,25 @@
       "sha256": "ca8ad9be55ddc67a3ef2a563e38abf354fc40b930c28d08824ee6868c6f4c34d"
     },
     "ui/package.json": {
-      "sizeBytes": 848,
-      "sha256": "96c426a30006a7bb3bfe1fe933a847277ff701373de86fbc2d36f216139a5424"
+      "sizeBytes": 908,
+      "sha256": "fd08a3d44333566d00fa27f8297ae6b2e5d64689d7b865ce21cf6c37900c8980"
     },
     "ui/package-lock.json": {
-      "sizeBytes": 136849,
-      "sha256": "32ef64bd8937c5aa8b975aabb94853596b1afe33599c09f1fb61002ff31c01f5"
+      "sizeBytes": 193529,
+      "sha256": "2af2a6fce0ebb773ef28cbbda579b4ababf14165bb82998ce60c9c93aba79a66"
+    },
+    "scripts/init_ldr_assets.py": {
+      "sizeBytes": 5854,
+      "sha256": "da33fbc665c144afd24c7eec7eed77edda3167906a9fa5be8144bd4595902416"
+    },
+    "compose.yml": {
+      "sizeBytes": 13165,
+      "sha256": "6c2c4a5f71b347e528755fb1326a559288bc2ae68867ce4d73f457e420bea6d9"
     }
   },
   "licenseAudit": {
-    "status": "passed",
-    "policy": "no unknown or denied runtime licenses",
+    "status": "passed_for_external_pull",
+    "policy": "module-owned runtimes must have no unknown or denied licenses; the unmodified upstream LDR image may only be pulled by exact public digest and must not be mirrored, bundled, modified, or represented as MIT-only",
     "policySha256": "b5842c43da0a044133de3eaadde94de73e8363c57c9e51f98f8a67d444df48d8",
     "inventory": "runtime/sbom",
     "control": {
@@ -151,8 +179,45 @@
       "inventorySha256": "7272d758ce92230ed35bf9a4030a9458a8e84cee061ce5507dae5e3fe452b08e"
     },
     "ui": {
-      "packageCount": 275,
-      "inventorySha256": "4eb07c393d3ae648abe6ca1175b11995cbf357b84a4f2c30b2b3bdd49dfe69fb"
+      "packageCount": 371,
+      "inventorySha256": "922b3e84ceb0ed19cc225d787b0e28891bf2362e213c0203c999ac93218582d0"
+    },
+    "localDeepResearchImage": {
+      "sbomUrl": "https://github.com/LearningCircuit/local-deep-research/releases/download/v1.10.6/sbom-container-amd64.spdx.json",
+      "sbomSha256": "6f9c0e6f762763d2b34207a7638b65bedd37d818bd86e538483b21cb091c6315",
+      "sbomSizeBytes": 5245009,
+      "packageCount": 438,
+      "packageEcosystems": {
+        "pypi": 282,
+        "deb": 134,
+        "npm": 5,
+        "generic": 2,
+        "oci": 1,
+        "unclassified": 14
+      },
+      "declaredGplOrLgplCount": 100,
+      "declaredUnknownCount": 60,
+      "declaredKnownConcludedNoAssertionCount": 378,
+      "declaredUnknownConcludedKnownCount": 22,
+      "effectiveUnknownCount": 38,
+      "concludedNoAssertionCount": 416,
+      "declaredAgplCount": 0,
+      "declaredCopyleftByEcosystem": {
+        "deb": 98,
+        "pypi": 2
+      },
+      "integrationMode": "external_pull_only",
+      "distributionPolicy": {
+        "externalPull": "allowed",
+        "internallyHostedUse": "allowed_with_notice",
+        "mirror": "blocked",
+        "offlineBundle": "blocked",
+        "modifiedImage": "blocked",
+        "representAsMitOnly": "forbidden"
+      },
+      "allowedImage": "localdeepresearch/local-deep-research:1.10.6@sha256:b2c634291de8fb8d0662ab81a0b82ec17ab807109d20d57386042c5bdcd472e5",
+      "redistributionCandidate": false,
+      "redistributionGate": "Complete package-level obligations and effective-unknown disposition before enabling any mirror, offline bundle, modified image, or ModelMirror-hosted image distribution."
     }
   }
 }

--- a/extensions/ai-research/tests/control/test_api.py
+++ b/extensions/ai-research/tests/control/test_api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+from pathlib import Path
 from typing import Any
 
 from fastapi.testclient import TestClient
@@ -131,9 +133,35 @@ class FakeService:
 
 def test_frozen_http_contract(monkeypatch) -> None:
     monkeypatch.setattr(app_module, "ResearchService", FakeService)
+    module_root = Path(__file__).resolve().parents[2]
+    monkeypatch.setattr(
+        app_module,
+        "settings",
+        replace(
+            app_module.settings,
+            module_boundary=module_root / "module-boundary.json",
+            source_lock=module_root / "source-lock.json",
+        ),
+    )
     with TestClient(app_module.app) as client:
         assert client.get("/healthz").json() == {"status": "alive"}
         assert client.get("/readyz").status_code == 200
+        module = client.get("/api/v1/module")
+        assert module.status_code == 200
+        claims = module.json()["capabilityClaims"]
+        assert claims["fixtureExecution"] == {
+            "enabled": True,
+            "claimLevel": "harness_only",
+            "packStatus": "fixture_only",
+        }
+        assert claims["literatureResearch"] == {
+            "enabled": True,
+            "scientificClaim": "none",
+            "acceptanceState": "pending_live_acceptance",
+            "workflowSource": "local_deep_research",
+        }
+        assert "claimLevel" not in module.json()
+        assert "packStatus" not in module.json()
         payload = {
             "fixtureId": "inspect-smoke-v1",
             "caseId": "success",

--- a/extensions/ai-research/tests/control/test_console_gateway.py
+++ b/extensions/ai-research/tests/control/test_console_gateway.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import io
+from email.message import Message
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ai_research_control import console_gateway
+
+
+class FakeUpstream:
+    def __init__(
+        self,
+        body: bytes,
+        *,
+        status: int = 200,
+        content_type: str = "application/json",
+        content_length: int | None = None,
+    ) -> None:
+        self.status = status
+        self._body = io.BytesIO(body)
+        self.closed = False
+        self.headers = Message()
+        self.headers["Content-Type"] = content_type
+        self.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+        self.headers["Set-Cookie"] = "forbidden=1"
+        if content_length is not None:
+            self.headers["Content-Length"] = str(content_length)
+
+    def getcode(self) -> int:
+        return self.status
+
+    def read(self, size: int) -> bytes:
+        return self._body.read(size)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def settings(*, expose_health: bool = True) -> console_gateway.GatewaySettings:
+    return console_gateway.GatewaySettings(
+        target="http://ai-research-control:8080",
+        timeout_seconds=5.0,
+        expose_health=expose_health,
+    )
+
+
+def test_gateway_forwards_fixed_path_query_body_and_minimal_headers(monkeypatch) -> None:
+    captured = {}
+    upstream = FakeUpstream(b'{"projectId":"rp_fixed"}')
+
+    def open_upstream(request, timeout):
+        captured.update(
+            url=request.full_url,
+            method=request.method,
+            body=request.data,
+            cookie=request.headers.get("Cookie"),
+            authorization=request.headers.get("Authorization"),
+            content_type=request.get_header("Content-type"),
+            timeout=timeout,
+        )
+        return upstream
+
+    monkeypatch.setattr(console_gateway, "open_upstream", open_upstream)
+    with TestClient(console_gateway.create_gateway_app(settings())) as client:
+        response = client.post(
+            "/api/v1/projects?source=console",
+            headers={
+                "Authorization": "Bearer must-not-forward",
+                "Cookie": "private=1",
+            },
+            json={"title": "Agent research"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"projectId": "rp_fixed"}
+    assert response.headers["cache-control"] == "public, max-age=31536000, immutable"
+    assert "set-cookie" not in response.headers
+    assert upstream.closed is True
+    assert captured["url"] == (
+        "http://ai-research-control:8080/api/v1/projects?source=console"
+    )
+    assert captured["method"] == "POST"
+    assert captured["body"] == b'{"title":"Agent research"}'
+    assert captured["cookie"] is None
+    assert captured["authorization"] is None
+    assert captured["content_type"] == "application/json"
+    assert captured["timeout"] == 5.0
+
+
+def test_gateway_streams_assets_and_artifacts_and_closes(monkeypatch) -> None:
+    upstream = FakeUpstream(b"PK\x03\x04artifact", content_type="application/zip")
+    upstream.headers["Content-Disposition"] = 'attachment; filename="result.zip"'
+    upstream.headers["X-Artifact-Sha256"] = "a" * 64
+    upstream.headers["X-Content-Sha256"] = "b" * 64
+    monkeypatch.setattr(
+        console_gateway,
+        "open_upstream",
+        lambda request, timeout: upstream,
+    )
+    with TestClient(console_gateway.create_gateway_app(settings())) as client:
+        response = client.get("/api/v1/projects/rp_fixed/artifacts/upstream-quarto.zip")
+
+    assert response.status_code == 200
+    assert response.content == b"PK\x03\x04artifact"
+    assert response.headers["content-disposition"] == 'attachment; filename="result.zip"'
+    assert response.headers["x-artifact-sha256"] == "a" * 64
+    assert response.headers["x-content-sha256"] == "b" * 64
+    assert upstream.closed is True
+
+
+def test_gateway_health_is_local_and_unsupported_methods_are_rejected(monkeypatch) -> None:
+    monkeypatch.setattr(
+        console_gateway,
+        "open_upstream",
+        lambda request, timeout: pytest.fail("health must not reach upstream"),
+    )
+    with TestClient(console_gateway.create_gateway_app(settings())) as client:
+        health = client.get("/gateway-healthz")
+        options = client.options("/api/v1/projects")
+
+    assert health.status_code == 200
+    assert health.json() == {"status": "alive"}
+    assert options.status_code == 405
+
+
+def test_inspect_gateway_forwards_only_allowlisted_loopback_host(monkeypatch) -> None:
+    captured = {}
+
+    def open_upstream(request, timeout):
+        captured["host"] = request.get_header("Host")
+        captured["origin"] = request.get_header("Origin")
+        return FakeUpstream(b'{"files":[]}')
+
+    monkeypatch.setattr(console_gateway, "open_upstream", open_upstream)
+    inspect_settings = console_gateway.GatewaySettings(
+        target="http://ai-research-inspect-view:7575",
+        timeout_seconds=5.0,
+        allowed_host_headers=("127.0.0.1:8893", "localhost:8893"),
+    )
+    with TestClient(console_gateway.create_gateway_app(inspect_settings)) as client:
+        accepted = client.get(
+            "/api/log-files",
+            headers={
+                "Host": "127.0.0.1:8893",
+                "Origin": "http://127.0.0.1:8893",
+            },
+        )
+        rejected = client.get(
+            "/api/log-files",
+            headers={
+                "Host": "attacker.example",
+                "Origin": "http://attacker.example",
+            },
+        )
+
+    assert accepted.status_code == 200
+    assert captured == {
+        "host": "127.0.0.1:8893",
+        "origin": "http://127.0.0.1:8893",
+    }
+    assert rejected.status_code == 400
+
+
+def test_gateway_rejects_unsafe_targets_bodies_redirects_and_large_responses(
+    monkeypatch,
+) -> None:
+    for value in (
+        "https://ai-research-control:8080",
+        "http://example.com:8080",
+        "http://ai-research-control:8081",
+        "http://user:secret@ai-research-control:8080",
+        "http://ai-research-control:8080/api",
+    ):
+        with pytest.raises(ValueError):
+            console_gateway.validate_target(
+                value,
+                expected_host="ai-research-control",
+                expected_port=8080,
+            )
+
+    redirect = FakeUpstream(b"", status=302)
+    monkeypatch.setattr(
+        console_gateway,
+        "open_upstream",
+        lambda request, timeout: redirect,
+    )
+    with TestClient(
+        console_gateway.create_gateway_app(settings()),
+        raise_server_exceptions=False,
+    ) as client:
+        body_rejected = client.request(
+            "GET",
+            "/api/v1/projects",
+            content=b"not-allowed",
+        )
+        oversized = client.post(
+            "/api/v1/projects",
+            content=b"x" * (console_gateway.MAX_REQUEST_BYTES + 1),
+        )
+        redirected = client.get("/")
+
+    assert body_rejected.status_code == 400
+    assert oversized.status_code == 413
+    assert redirected.status_code == 502
+    assert redirect.closed is True
+
+    too_large = FakeUpstream(
+        b"",
+        content_length=console_gateway.MAX_RESPONSE_BYTES + 1,
+    )
+    monkeypatch.setattr(
+        console_gateway,
+        "open_upstream",
+        lambda request, timeout: too_large,
+    )
+    with TestClient(console_gateway.create_gateway_app(settings())) as client:
+        response = client.get("/artifact.zip")
+    assert response.status_code == 502
+    assert too_large.closed is True
+
+
+def test_gateway_disables_environment_proxy_and_redirects(monkeypatch) -> None:
+    captured = {}
+
+    class Opener:
+        def open(self, request, timeout):
+            captured["timeout"] = timeout
+            return FakeUpstream(b"{}")
+
+    def build(*handlers):
+        captured["handlers"] = handlers
+        return Opener()
+
+    monkeypatch.setattr(console_gateway, "build_opener", build)
+    request = console_gateway.UrlRequest("http://ai-research-control:8080/healthz")
+    response = console_gateway.open_upstream(request, 5.0)
+
+    assert captured["timeout"] == 5.0
+    assert any(
+        isinstance(item, console_gateway.ProxyHandler) and item.proxies == {}
+        for item in captured["handlers"]
+    )
+    assert any(isinstance(item, console_gateway.NoRedirect) for item in captured["handlers"])
+    response.close()

--- a/extensions/ai-research/tests/control/test_ldr_assets.py
+++ b/extensions/ai-research/tests/control/test_ldr_assets.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "init_ldr_assets.py"
+SPEC = importlib.util.spec_from_file_location("init_ldr_assets", SCRIPT)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(module)
+
+
+def test_fixed_revision_download_is_inventoried_and_reused(tmp_path: Path) -> None:
+    calls: list[dict[str, object]] = []
+
+    def download(**kwargs: object) -> None:
+        calls.append(kwargs)
+        root = Path(str(kwargs["local_dir"]))
+        (root / "config.json").write_text("{}", encoding="utf-8")
+        (root / "model.safetensors").write_bytes(b"fixed-model-bytes")
+
+    root = tmp_path / "model"
+    first = module.initialize(root, downloader=download)
+    second = module.initialize(
+        root,
+        downloader=lambda **_: (_ for _ in ()).throw(
+            AssertionError("verified assets must not redownload")
+        ),
+    )
+    assert first == second
+    assert calls == [
+        {
+            "repo_id": module.MODEL_REPOSITORY,
+            "revision": module.MODEL_REVISION,
+            "local_dir": str(root),
+            "local_dir_use_symlinks": False,
+        }
+    ]
+
+
+def test_single_byte_tamper_and_symlink_fail_closed(tmp_path: Path) -> None:
+    root = tmp_path / "model"
+
+    def download(**kwargs: object) -> None:
+        Path(str(kwargs["local_dir"]), "model.safetensors").write_bytes(b"model")
+
+    module.initialize(root, downloader=download)
+    (root / "model.safetensors").chmod(0o644)
+    (root / "model.safetensors").write_bytes(b"modeL")
+    with pytest.raises(module.AssetIntegrityError, match="integrity"):
+        module.verify(root)
+
+    symlink_root = tmp_path / "symlink-model"
+    symlink_root.mkdir()
+    try:
+        (symlink_root / "link").symlink_to(root / "model.safetensors")
+    except OSError:
+        pytest.skip("symlinks are unavailable on this Windows host")
+    with pytest.raises(module.AssetIntegrityError, match="symlink"):
+        module.inventory(symlink_root)
+
+
+def test_models_link_replaces_only_an_empty_directory_and_is_idempotent(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "model-assets"
+    target.mkdir()
+    link = tmp_path / "data" / "models"
+    link.mkdir(parents=True)
+
+    try:
+        module.ensure_models_link(link, target)
+    except OSError:
+        pytest.skip("directory symlinks are unavailable on this Windows host")
+    module.ensure_models_link(link, target)
+
+    assert link.is_symlink()
+    assert link.resolve() == target.resolve()
+
+    link.unlink()
+    link.mkdir()
+    (link / "unexpected").write_text("preserve", encoding="utf-8")
+    with pytest.raises(module.AssetIntegrityError, match="not an empty"):
+        module.ensure_models_link(link, target)

--- a/extensions/ai-research/tests/control/test_ldr_client.py
+++ b/extensions/ai-research/tests/control/test_ldr_client.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import requests
+
+from ai_research_control.ldr_client import (
+    AGENT_TOOL_KEYS,
+    ENABLED_ACADEMIC_TOOLS,
+    LdrAuthenticationError,
+    LdrClient,
+    LdrProtocolError,
+    LdrSessionExpired,
+)
+
+
+LDR_V1_10_5_ENGINE_KEYS = {
+    "arxiv",
+    "brave",
+    "ddg",
+    "elasticsearch",
+    "exa",
+    "github",
+    "google_pse",
+    "guardian",
+    "gutenberg",
+    "mojeek",
+    "nasa_ads",
+    "openalex",
+    "openlibrary",
+    "paperless",
+    "pubchem",
+    "pubmed",
+    "scaleserp",
+    "searxng",
+    "semantic_scholar",
+    "serpapi",
+    "serper",
+    "sofya",
+    "stackexchange",
+    "tavily",
+    "tinyfish",
+    "wayback",
+    "wikinews",
+    "wikipedia",
+    "zenodo",
+}
+
+
+class Response:
+    def __init__(
+        self,
+        status: int,
+        *,
+        value: object | None = None,
+        text: str = "",
+        lines: list[str] | None = None,
+    ) -> None:
+        self.status_code = status
+        self._value = value
+        self._content = text.encode("utf-8") if value is None else json.dumps(value).encode()
+        self.headers = {"content-length": str(len(self._content))}
+        self._lines = lines or []
+
+    @property
+    def content(self) -> bytes:
+        return self._content
+
+    @property
+    def text(self) -> str:
+        return self._content.decode("utf-8")
+
+    def json(self) -> object:
+        if self._value is None:
+            raise ValueError
+        return self._value
+
+    def iter_lines(self, *, decode_unicode: bool) -> list[str]:
+        assert decode_unicode is True
+        return self._lines
+
+
+class ScriptedSession:
+    def __init__(self, responses: list[Response]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.trust_env = True
+
+    def close(self) -> None:
+        return None
+
+    def _next(self, method: str, url: str, **kwargs: Any) -> Response:
+        self.calls.append((method, url, kwargs))
+        return self.responses.pop(0)
+
+    def get(self, url: str, **kwargs: Any) -> Response:
+        return self._next("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> Response:
+        return self._next("POST", url, **kwargs)
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Response:
+        return self._next(method, url, **kwargs)
+
+
+def unlocked_client(script: list[Response]) -> tuple[LdrClient, ScriptedSession]:
+    session = ScriptedSession(
+        [
+            Response(200, text='<input value="login-csrf" name="csrf_token">'),
+            Response(302),
+            Response(200, value={"authenticated": True, "username": "researcher"}),
+            Response(200, value={"csrf_token": "api-csrf"}),
+            *script,
+        ]
+    )
+    client = LdrClient(
+        "http://ai-research-ldr:5000",
+        session=session,  # type: ignore[arg-type]
+        session_factory=lambda: session,  # type: ignore[return-value]
+    )
+    client.unlock("researcher", "correct horse battery staple")
+    return client, session
+
+
+def test_unlock_and_fixed_profile_use_real_csrf_contract() -> None:
+    first = ScriptedSession([])
+    active = ScriptedSession(
+        [
+            Response(200, text='<input value="login-csrf" name="csrf_token">'),
+            Response(302),
+            Response(200, value={"authenticated": True, "username": "researcher"}),
+            Response(200, value={"csrf_token": "api-csrf"}),
+            Response(200, value={"csrf_token": "fresh-api-csrf"}),
+            Response(200, value={"status": "success"}),
+        ]
+    )
+    client = LdrClient(
+        "http://ai-research-ldr:5000",
+        session=first,  # type: ignore[arg-type]
+        session_factory=lambda: active,  # type: ignore[return-value]
+    )
+
+    assert client.unlock("researcher", "not-stored-after-call") == {
+        "status": "ready",
+        "username": "researcher",
+    }
+    client.configure_fixed_profile(
+        model_id="fixed/model",
+        bridge_url="http://host.docker.internal:8000/api/ai-research/v1",
+        bridge_token="bridge-only-token",
+    )
+
+    method, url, kwargs = active.calls[-1]
+    assert (method, url) == (
+        "POST",
+        "http://ai-research-ldr:5000/settings/save_all_settings",
+    )
+    assert kwargs["headers"]["X-CSRF-Token"] == "fresh-api-csrf"
+    profile = kwargs["json"]
+    assert profile["search.tool"] == "openalex"
+    assert profile["search.search_strategy"] == "langgraph-agent"
+    assert (
+        profile[
+            "search.engine.web.openalex.default_params.enable_llm_relevance_filter"
+        ]
+        is False
+    )
+    assert profile["policy.egress_scope"] == "public_only"
+    assert profile["langgraph_agent.max_iterations"] == 10
+    assert profile["langgraph_agent.max_sub_iterations"] == 3
+    assert profile["langgraph_agent.include_sub_research"] is False
+    assert profile["langgraph_agent.max_subagent_workers"] == 1
+    assert profile["embeddings.require_local"] is True
+    assert profile["local_search_embedding_model"] == (
+        "/data/models/sentence-transformers/all-MiniLM-L6-v2"
+    )
+    enabled = {
+        key.split(".")[-2]
+        for key, value in profile.items()
+        if key.endswith(".agent_enabled") and value is True
+    }
+    configured = {
+        key.split(".")[-2]
+        for key in profile
+        if key.endswith(".agent_enabled")
+    }
+    assert set(AGENT_TOOL_KEYS) == LDR_V1_10_5_ENGINE_KEYS
+    assert configured == LDR_V1_10_5_ENGINE_KEYS
+    assert enabled == ENABLED_ACADEMIC_TOOLS
+    assert "not-stored-after-call" not in repr(client.__dict__)
+
+
+def test_start_is_fixed_and_response_loss_can_reconcile_by_metadata() -> None:
+    run_id = "lr_" + "a" * 32
+    client, session = unlocked_client(
+        [
+            Response(200, value={"csrf_token": "fresh-api-csrf"}),
+            Response(200, value={"status": "success", "research_id": "ldr-1"}),
+            Response(
+                200,
+                value={
+                    "status": "success",
+                    "items": [
+                        {
+                            "id": "ldr-1",
+                            "metadata": {"modelmirror_literature_run_id": run_id},
+                        }
+                    ],
+                },
+            ),
+        ]
+    )
+    research_id, raw_status = client.start_research(
+        question="Agent 评测如何确保可复现？",
+        control_run_id=run_id,
+        model_id="fixed/model",
+        bridge_url="http://host.docker.internal:8000/api/ai-research/v1",
+        collection_id="8f76dc23-8f1f-4c19-bca5-f055920a37c7",
+    )
+    assert research_id == "ldr-1"
+    assert raw_status == "success"
+    payload = session.calls[-1][2]["json"]
+    assert payload["search_engine"] == "openalex"
+    assert payload["strategy"] == "langgraph-agent"
+    assert payload["max_results"] == 15
+    assert payload["iterations"] == 2
+    assert payload["questions_per_iteration"] == 3
+    assert set(payload) >= {"metadata", "policy_egress_scope"}
+    assert payload["metadata"]["modelmirror_collection_id"] == (
+        "8f76dc23-8f1f-4c19-bca5-f055920a37c7"
+    )
+    assert client.find_research_by_run_id(run_id) == "ldr-1"
+
+
+def test_export_refreshes_csrf_after_a_long_running_research() -> None:
+    client, session = unlocked_client(
+        [
+            Response(200, value={"csrf_token": "rotated-api-csrf"}),
+            Response(200, text="quarto-zip"),
+        ]
+    )
+
+    assert client.export("ldr-1", "quarto") == b"quarto-zip"
+    refresh_method, refresh_url, _ = session.calls[-2]
+    export_method, export_url, export_kwargs = session.calls[-1]
+    assert (refresh_method, refresh_url) == (
+        "GET",
+        "http://ai-research-ldr:5000/auth/csrf-token",
+    )
+    assert (export_method, export_url) == (
+        "POST",
+        "http://ai-research-ldr:5000/api/v1/research/ldr-1/export/quarto",
+    )
+    assert export_kwargs["headers"]["X-CSRF-Token"] == "rotated-api-csrf"
+
+
+def test_failed_login_and_expired_session_fail_closed() -> None:
+    rejected = ScriptedSession(
+        [
+            Response(200, text='<input name="csrf_token" value="token">'),
+            Response(401),
+        ]
+    )
+    client = LdrClient(
+        "http://ai-research-ldr:5000",
+        session=ScriptedSession([]),  # type: ignore[arg-type]
+        session_factory=lambda: rejected,  # type: ignore[return-value]
+    )
+    with pytest.raises(LdrAuthenticationError):
+        client.unlock("researcher", "wrong-password")
+
+    expired, _ = unlocked_client([Response(401, value={"error": "expired"})])
+    with pytest.raises(LdrSessionExpired):
+        expired.collections()
+    assert expired.username is None
+
+
+def test_index_requires_terminal_sse_event() -> None:
+    client, _ = unlocked_client(
+        [Response(200, lines=['data: {"type":"progress"}'])]
+    )
+    with pytest.raises(LdrProtocolError, match="terminal"):
+        client.index_collection("collection-1")
+
+
+def test_unsafe_research_ids_never_enter_ldr_paths() -> None:
+    client, session = unlocked_client([])
+    with pytest.raises(LdrProtocolError, match="research id"):
+        client.research_status("../settings")
+    with pytest.raises(LdrProtocolError, match="research id"):
+        client.export("id?format=secret", "quarto")
+    assert all("../settings" not in url for _, url, _ in session.calls)

--- a/extensions/ai-research/tests/control/test_ldr_license_policy.py
+++ b/extensions/ai-research/tests/control/test_ldr_license_policy.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+MODULE_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = MODULE_ROOT / "scripts" / "validate_boundary.py"
+SPEC = importlib.util.spec_from_file_location("validate_boundary", SCRIPT)
+assert SPEC and SPEC.loader
+boundary = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(boundary)
+
+
+def source_lock() -> dict:
+    return json.loads((MODULE_ROOT / "source-lock.json").read_text(encoding="utf-8"))
+
+
+def compose_text() -> str:
+    return (MODULE_ROOT / "compose.yml").read_text(encoding="utf-8")
+
+
+def validate(lock: dict | None = None, compose: str | None = None) -> None:
+    boundary.validate_ldr_distribution_mode(
+        lock or source_lock(),
+        "external-pull",
+        compose_text=compose or compose_text(),
+        dockerfile_texts={"control/Dockerfile": "FROM python@sha256:fixed"},
+        packaged_paths=["README.md", "LDR_LICENSE_DISPOSITION.md"],
+    )
+
+
+def test_external_pull_policy_accepts_only_the_audited_upstream_digest() -> None:
+    validate()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("effectiveUnknownCount", 36),
+        ("concludedNoAssertionCount", 60),
+        ("declaredAgplCount", 1),
+        ("sbomSha256", "0" * 64),
+    ],
+)
+def test_sbom_facts_cannot_be_softened(field: str, value: object) -> None:
+    lock = source_lock()
+    lock["licenseAudit"]["localDeepResearchImage"][field] = value
+    with pytest.raises(boundary.BoundaryFailure, match="SBOM fact drifted"):
+        validate(lock=lock)
+
+
+def test_build_private_image_and_dockerfile_reuse_are_rejected() -> None:
+    compose = compose_text().replace(
+        "  ai-research-ldr:\n    profiles:",
+        "  ai-research-ldr:\n    build: .\n    profiles:",
+        1,
+    )
+    with pytest.raises(boundary.BoundaryFailure, match="must not build"):
+        validate(compose=compose)
+
+    private = compose_text().replace(boundary.LDR_IMAGE, "registry.example/ldr:1.10.6", 1)
+    with pytest.raises(boundary.BoundaryFailure, match="audited public LDR digest"):
+        validate(compose=private)
+
+    with pytest.raises(boundary.BoundaryFailure, match="Dockerfile"):
+        boundary.validate_ldr_distribution_mode(
+            source_lock(),
+            "external-pull",
+            compose_text=compose_text(),
+            dockerfile_texts={"Dockerfile": f"FROM {boundary.LDR_IMAGE}"},
+            packaged_paths=[],
+        )
+
+
+def test_offline_archive_and_redistributable_bundle_fail_closed() -> None:
+    with pytest.raises(boundary.BoundaryFailure, match="archive"):
+        boundary.validate_ldr_distribution_mode(
+            source_lock(),
+            "external-pull",
+            compose_text=compose_text(),
+            dockerfile_texts={},
+            packaged_paths=["vendor/local-deep-research-image.tar"],
+        )
+    with pytest.raises(boundary.BoundaryFailure, match="redistributable-bundle is blocked"):
+        boundary.validate_ldr_distribution_mode(
+            source_lock(),
+            "redistributable-bundle",
+            compose_text=compose_text(),
+            dockerfile_texts={},
+            packaged_paths=[],
+        )
+
+
+def test_distribution_policy_cannot_be_broadened() -> None:
+    lock = copy.deepcopy(source_lock())
+    lock["licenseAudit"]["localDeepResearchImage"]["distributionPolicy"]["mirror"] = "allowed"
+    with pytest.raises(boundary.BoundaryFailure, match="distribution policy drifted"):
+        validate(lock=lock)

--- a/extensions/ai-research/tests/control/test_literature_acceptance.py
+++ b/extensions/ai-research/tests/control/test_literature_acceptance.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[2] / "scripts" / "literature_acceptance.py"
+SPEC = importlib.util.spec_from_file_location("literature_acceptance", SCRIPT)
+assert SPEC and SPEC.loader
+literature_acceptance = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(literature_acceptance)
+
+FIXTURE_SCRIPT = Path(__file__).parents[2] / "scripts" / "acceptance.py"
+FIXTURE_SPEC = importlib.util.spec_from_file_location("fixture_acceptance", FIXTURE_SCRIPT)
+assert FIXTURE_SPEC and FIXTURE_SPEC.loader
+fixture_acceptance = importlib.util.module_from_spec(FIXTURE_SPEC)
+FIXTURE_SPEC.loader.exec_module(fixture_acceptance)
+
+
+def test_collection_acceptance_requires_explicit_upstream_egress_gates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AI_RESEARCH_ACCEPTANCE_COLLECTION_ID", "pilot")
+
+    def fake_request(method: str, path: str, payload=None):
+        if path.endswith("/zotero/status"):
+            return 200, {"config": {"configured": True}}, {}
+        if path.endswith("/zotero/sync"):
+            return 200, {"success": True}, {}
+        if path.endswith("/pilot/index"):
+            return 200, {"status": "completed"}, {}
+        return 200, {
+            "collections": [
+                {
+                    "id": "pilot",
+                    "is_public": False,
+                    "agent_enabled": True,
+                    "indexed_document_count": 3,
+                }
+            ]
+        }, {}
+
+    monkeypatch.setattr(literature_acceptance, "request", fake_request)
+    with pytest.raises(literature_acceptance.AcceptanceFailure, match="egress gates"):
+        literature_acceptance.prepare_collection()
+
+
+def test_output_acceptance_recomputes_every_artifact_hash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    content = b"verified artifact"
+    digest = hashlib.sha256(content).hexdigest()
+
+    def fake_request(method: str, path: str, payload=None):
+        if path.endswith("/sources"):
+            return 200, {"integrityStatus": "verified", "sources": [{"url": "https://openalex.org/W1"}]}, {}
+        if path.endswith("/review"):
+            return 200, {"integrityStatus": "verified", "markdown": "# Review"}, {}
+        return 200, content, {"X-Content-SHA256": digest}
+
+    monkeypatch.setattr(literature_acceptance, "request", fake_request)
+    hashes = literature_acceptance.verify_outputs("rp_" + "a" * 32)
+    assert set(hashes) == literature_acceptance.ARTIFACTS
+    assert set(hashes.values()) == {digest}
+
+
+def test_acceptance_control_url_uses_custom_loopback_port_and_rejects_remote(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AI_RESEARCH_ACCEPTANCE_CONTROL_URL", raising=False)
+    monkeypatch.setenv("AI_RESEARCH_CONTROL_PORT", "8890")
+    assert literature_acceptance.loopback_control_url() == "http://127.0.0.1:8890"
+
+    monkeypatch.setenv("AI_RESEARCH_ACCEPTANCE_CONTROL_URL", "https://example.com:8890")
+    with pytest.raises(RuntimeError, match="HTTP loopback"):
+        literature_acceptance.loopback_control_url()
+
+
+def test_fixture_acceptance_origin_is_loopback_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AI_RESEARCH_CONTROL_PORT", "8890")
+    assert fixture_acceptance.loopback_url(
+        "AI_RESEARCH_ACCEPTANCE_CONTROL_URL", "AI_RESEARCH_CONTROL_PORT", 8790
+    ) == "http://127.0.0.1:8890"
+
+    monkeypatch.setenv("AI_RESEARCH_ACCEPTANCE_CONTROL_URL", "http://127.0.0.1:8890/path")
+    with pytest.raises(RuntimeError, match="HTTP loopback"):
+        fixture_acceptance.loopback_url(
+            "AI_RESEARCH_ACCEPTANCE_CONTROL_URL", "AI_RESEARCH_CONTROL_PORT", 8790
+        )

--- a/extensions/ai-research/tests/control/test_literature_artifacts.py
+++ b/extensions/ai-research/tests/control/test_literature_artifacts.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from ai_research_control.literature_artifacts import (
+    LiteratureArtifactError,
+    LiteratureArtifactStore,
+)
+from ai_research_control.project_store import ProjectStore
+
+
+def quarto_zip(
+    qmd: str = "---\nbibliography: references.bib\n---\nEvidence [@source1].\n",
+    bib: str = "@article{source1, title={Evidence}}\n",
+    *,
+    extra: tuple[str, str] | None = None,
+) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("report.qmd", qmd)
+        archive.writestr("references.bib", bib)
+        if extra:
+            archive.writestr(extra[0], extra[1])
+    return buffer.getvalue()
+
+
+def setup(tmp_path: Path):
+    projects = ProjectStore(tmp_path / "projects", source_lock_sha256="a" * 64)
+    projects.prepare()
+    project, _ = projects.create(
+        title="Agent 评测",
+        research_question="Agent 评测如何确保可复现？",
+        idempotency_key="project:artifacts:001",
+    )
+    project, attempt, _ = projects.begin_attempt(
+        project["projectId"],
+        idempotency_key="literature:artifacts:001",
+        model_id="fixed/model",
+        collection_id=None,
+    )
+    directory = projects.run_directory(project["projectId"], attempt["runId"])
+    return LiteratureArtifactStore(tmp_path / "projects"), project, attempt, directory
+
+
+def test_persist_verify_read_and_detect_single_byte_tamper(tmp_path: Path) -> None:
+    store, project, attempt, directory = setup(tmp_path)
+    manifest = store.persist(
+        run_directory=directory,
+        project=project,
+        attempt=attempt,
+        report={
+            "content": "# Review\n\nEvidence [1].",
+            "sources": [
+                {"url": "https://openalex.org/W1", "title": "Evidence", "index": 1}
+            ],
+        },
+        quarto_zip=quarto_zip(),
+        ris=b"TY  - JOUR\nTI  - Evidence\nER  -\n",
+    )
+    assert set(manifest) >= {"literature-review.md", "references.bib", "sources.json"}
+    assert store.review(directory).startswith("# Review")
+    assert store.sources(directory)[0]["url"] == "https://openalex.org/W1"
+    receipt = json.loads(
+        store.read_artifact(directory, "literature-receipt.json")[0]
+    )
+    assert receipt["scientificClaim"] == "none"
+    assert receipt["ldrVersion"] == "1.10.6"
+    assert receipt["ldrCommit"] == "641308272b2143df89c7a946051d2f05ca29b3c1"
+    assert receipt["rawStatus"] is None
+    assert receipt["outputs"]["references.bib"]["sha256"] == manifest[
+        "references.bib"
+    ]["sha256"]
+    assert "literature-receipt.json" not in receipt["outputs"]
+
+    report_path = directory / "literature-review.md"
+    report_path.write_bytes(report_path.read_bytes() + b"x")
+    with pytest.raises(LiteratureArtifactError, match="integrity"):
+        store.verify(directory)
+
+
+def test_bibtex_entry_type_inside_fenced_code_is_not_a_citation(tmp_path: Path) -> None:
+    store, project, attempt, directory = setup(tmp_path)
+    archive = quarto_zip(
+        qmd=(
+            "---\nbibliography: references.bib\n---\n"
+            "Evidence [@ref1].\n\n"
+            "```bibtex\n@misc{ref1,\n  title = {Evidence}\n}\n```\n"
+        ),
+        bib="@misc{ref1, title={Evidence}}\n",
+    )
+
+    manifest = store.persist(
+        run_directory=directory,
+        project=project,
+        attempt=attempt,
+        report={
+            "content": "Review",
+            "sources": [{"url": "https://openalex.org/W1"}],
+        },
+        quarto_zip=archive,
+        ris=b"TY  - JOUR\nER  -\n",
+    )
+
+    assert "references.bib" in manifest
+
+
+@pytest.mark.parametrize(
+    "archive",
+    [
+        quarto_zip(extra=("../escape", "x")),
+        quarto_zip(qmd="Cites [@missing]."),
+        quarto_zip(extra=("second.qmd", "duplicate")),
+    ],
+)
+def test_quarto_traversal_missing_citation_and_duplicate_qmd_fail_closed(
+    tmp_path: Path, archive: bytes
+) -> None:
+    store, project, attempt, directory = setup(tmp_path)
+    with pytest.raises(LiteratureArtifactError):
+        store.persist(
+            run_directory=directory,
+            project=project,
+            attempt=attempt,
+            report={
+                "content": "Review",
+                "sources": [{"url": "https://openalex.org/W1"}],
+            },
+            quarto_zip=archive,
+            ris=b"TY  - JOUR\nER  -\n",
+        )
+
+
+def test_quarto_duplicate_non_document_filename_fails_closed(tmp_path: Path) -> None:
+    buffer = io.BytesIO()
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr("report.qmd", "Evidence [@source1].")
+            archive.writestr("references.bib", "@article{source1, title={Evidence}}")
+            archive.writestr("notes.txt", "first")
+            archive.writestr("notes.txt", "second")
+    store, project, attempt, directory = setup(tmp_path)
+    with pytest.raises(LiteratureArtifactError, match="duplicate filename"):
+        store.persist(
+            run_directory=directory,
+            project=project,
+            attempt=attempt,
+            report={
+                "content": "Review",
+                "sources": [{"url": "https://openalex.org/W1"}],
+            },
+            quarto_zip=buffer.getvalue(),
+            ris=b"TY  - JOUR\nER  -\n",
+        )
+
+
+def test_non_public_https_and_empty_sources_fail_closed(tmp_path: Path) -> None:
+    store, project, attempt, directory = setup(tmp_path)
+    for sources in (
+        [],
+        [{"url": "http://example.test/paper"}],
+        [{"url": "https://127.0.0.1/private"}],
+        [{"url": "https://10.0.0.8/private"}],
+        [{"url": "https://papers.local/private"}],
+    ):
+        with pytest.raises(LiteratureArtifactError):
+            store.persist(
+                run_directory=directory,
+                project=project,
+                attempt=attempt,
+                report={"content": "Review", "sources": sources},
+                quarto_zip=quarto_zip(),
+                ris=b"TY  - JOUR\nER  -\n",
+            )
+
+
+def test_arxiv_http_source_is_upgraded_without_losing_upstream_fact(
+    tmp_path: Path,
+) -> None:
+    store, project, attempt, directory = setup(tmp_path)
+    store.persist(
+        run_directory=directory,
+        project=project,
+        attempt=attempt,
+        report={
+            "content": "Review",
+            "sources": [{"url": "http://arxiv.org/abs/2606.29932v4"}],
+        },
+        quarto_zip=quarto_zip(),
+        ris=b"TY  - JOUR\nER  -\n",
+    )
+
+    source = store.sources(directory)[0]
+    assert source["url"] == "https://arxiv.org/abs/2606.29932v4"
+    assert source["upstreamUrl"] == "http://arxiv.org/abs/2606.29932v4"
+
+
+@pytest.mark.parametrize(
+    "failure_marker",
+    [
+        "Error: Error code: 503 - provider unavailable",
+        "Research collected 103 sources but synthesis failed: Error code: 503",
+        "Error: Final answer synthesis failed due to LLM timeout.",
+    ],
+)
+def test_upstream_generation_error_placeholder_fails_closed(
+    tmp_path: Path, failure_marker: str
+) -> None:
+    store, project, attempt, directory = setup(tmp_path)
+    with pytest.raises(
+        LiteratureArtifactError, match="contains upstream generation errors"
+    ):
+        store.persist(
+            run_directory=directory,
+            project=project,
+            attempt=attempt,
+            report={
+                "content": (
+                    "# Review\n\n"
+                    "## Reproducibility\n\n"
+                    f"{failure_marker}"
+                ),
+                "sources": [{"url": "https://openalex.org/W1"}],
+            },
+            quarto_zip=quarto_zip(),
+            ris=b"TY  - JOUR\nER  -\n",
+        )
+
+
+def test_unregistered_artifact_is_not_downloadable(tmp_path: Path) -> None:
+    store, project, attempt, directory = setup(tmp_path)
+    store.persist(
+        run_directory=directory,
+        project=project,
+        attempt=attempt,
+        report={
+            "content": "Review",
+            "sources": [{"url": "https://openalex.org/W1"}],
+        },
+        quarto_zip=quarto_zip(),
+        ris=b"TY  - JOUR\nER  -\n",
+    )
+    (directory / "secret.txt").write_text("not registered", encoding="utf-8")
+    with pytest.raises(KeyError):
+        store.read_artifact(directory, "secret.txt")
+
+
+def test_symbolic_run_directory_is_rejected(tmp_path: Path) -> None:
+    store, project, attempt, directory = setup(tmp_path)
+    store.persist(
+        run_directory=directory,
+        project=project,
+        attempt=attempt,
+        report={
+            "content": "Review",
+            "sources": [{"url": "https://openalex.org/W1"}],
+        },
+        quarto_zip=quarto_zip(),
+        ris=b"TY  - JOUR\nER  -\n",
+    )
+    alias = directory.parent / ("lr_" + "b" * 32)
+    try:
+        alias.symlink_to(directory, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink creation is not available")
+
+    with pytest.raises(LiteratureArtifactError, match="symbolic"):
+        store.read_artifact(alias, "sources.json")
+
+
+def test_download_rechecks_content_after_manifest_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, project, attempt, directory = setup(tmp_path)
+    store.persist(
+        run_directory=directory,
+        project=project,
+        attempt=attempt,
+        report={
+            "content": "Review",
+            "sources": [{"url": "https://openalex.org/W1"}],
+        },
+        quarto_zip=quarto_zip(),
+        ris=b"TY  - JOUR\nER  -\n",
+    )
+    original_verify = store.verify
+
+    def verify_then_tamper(run_directory: Path):
+        manifest = original_verify(run_directory)
+        (directory / "sources.json").write_bytes(b"[]\n")
+        return manifest
+
+    monkeypatch.setattr(store, "verify", verify_then_tamper)
+    with pytest.raises(LiteratureArtifactError, match="integrity"):
+        store.read_artifact(directory, "sources.json")

--- a/extensions/ai-research/tests/control/test_literature_run_api.py
+++ b/extensions/ai-research/tests/control/test_literature_run_api.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+import ai_research_control.app as app_module
+from ai_research_control.ldr_client import LdrSessionExpired
+from ai_research_control.project_store import ProjectConflict
+
+
+def project() -> dict[str, Any]:
+    return {
+        "schemaVersion": 1,
+        "projectId": "rp_" + "a" * 32,
+        "title": "Agent 评测",
+        "researchQuestion": "Agent 评测如何确保可复现？",
+        "domain": "ai_agent",
+        "currentStage": "literature",
+        "stages": {
+            "literature": "active",
+            "hypothesis_protocol": "not_available",
+            "research_workspace": "not_available",
+            "evaluation": "not_available",
+            "analysis_report": "not_available",
+        },
+        "createdAt": "2026-08-24T00:00:00Z",
+        "updatedAt": "2026-08-24T00:00:00Z",
+        "literature": {
+            "profileId": "v0.1-literature-default",
+            "phase": "running",
+            "outcome": None,
+            "activeRunId": "lr_" + "b" * 32,
+            "completedRunId": None,
+            "collectionId": None,
+            "modelId": "fixed/model",
+            "attempts": [
+                {
+                    "runId": "lr_" + "b" * 32,
+                    "ldrResearchId": "ldr-1",
+                    "phase": "running",
+                    "outcome": None,
+                    "rawStatus": "in_progress",
+                    "cancelRequestedAt": None,
+                    "cancelAppliedAt": None,
+                    "createdAt": "2026-08-24T00:00:00Z",
+                    "startedAt": "2026-08-24T00:00:01Z",
+                    "terminalAt": None,
+                    "syncedAt": None,
+                    "errorType": None,
+                    "errorMessage": None,
+                    "integrityStatus": "pending",
+                    "progress": 35,
+                    "latestLog": {"message": "Searching OpenAlex"},
+                }
+            ],
+        },
+    }
+
+
+class LiteratureApiService:
+    mode = "ready"
+
+    def __init__(self, settings: object) -> None:
+        return None
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def start_literature(
+        self,
+        project_id: str,
+        *,
+        idempotency_key: str,
+        collection_id: str | None,
+    ) -> tuple[dict[str, Any], bool]:
+        if self.mode == "locked":
+            raise LdrSessionExpired("LDR session is not unlocked")
+        if self.mode == "busy":
+            raise ProjectConflict("another literature research is active")
+        return deepcopy(project()), True
+
+    async def cancel_literature(self, project_id: str) -> dict[str, Any]:
+        value = deepcopy(project())
+        value["literature"]["attempts"][0]["cancelRequestedAt"] = (
+            "2026-08-24T00:00:02Z"
+        )
+        return value
+
+    async def sync_literature(self, project_id: str) -> dict[str, Any]:
+        value = deepcopy(project())
+        value["literature"]["phase"] = "terminal"
+        value["literature"]["outcome"] = "completed"
+        value["literature"]["activeRunId"] = None
+        value["literature"]["completedRunId"] = "lr_" + "b" * 32
+        attempt = value["literature"]["attempts"][0]
+        attempt.update(
+            {
+                "phase": "terminal",
+                "outcome": "completed",
+                "rawStatus": "completed",
+                "terminalAt": "2026-08-24T00:00:03Z",
+                "syncedAt": "2026-08-24T00:00:04Z",
+                "integrityStatus": "verified",
+            }
+        )
+        return value
+
+    async def literature_sources(self, project_id: str) -> dict[str, Any]:
+        return {
+            "projectId": project_id,
+            "literatureRunId": "lr_" + "b" * 32,
+            "integrityStatus": "verified",
+            "sources": [{"url": "https://openalex.org/W1", "title": "Evidence"}],
+        }
+
+    async def literature_review(self, project_id: str) -> dict[str, Any]:
+        return {
+            "projectId": project_id,
+            "literatureRunId": "lr_" + "b" * 32,
+            "integrityStatus": "verified",
+            "markdown": "# Review",
+        }
+
+    async def literature_artifact(
+        self, project_id: str, name: str
+    ) -> tuple[bytes, str]:
+        if name != "references.bib":
+            raise KeyError(name)
+        return b"@article{source1}\n", "a" * 64
+
+    async def literature_collections(self) -> dict[str, Any]:
+        return {"collections": [{"id": "collection-1", "is_public": False}]}
+
+    async def index_literature_collection(self, collection_id: str) -> dict[str, Any]:
+        return {
+            "collectionId": collection_id,
+            "status": "completed",
+            "eventCount": 2,
+            "terminalType": "complete",
+        }
+
+    async def literature_zotero_status(self) -> dict[str, Any]:
+        return {
+            "config": {"success": True, "configured": True, "has_api_key": True},
+            "status": {"success": True, "collections": []},
+        }
+
+    async def sync_literature_zotero(self) -> dict[str, Any]:
+        return {"success": True, "message": "sync started"}
+
+    class Projects:
+        @staticmethod
+        def get(project_id: str) -> dict[str, Any]:
+            if project_id != "rp_" + "a" * 32:
+                raise KeyError(project_id)
+            return deepcopy(project())
+
+    projects = Projects()
+
+
+def test_literature_start_status_cancel_contract(monkeypatch) -> None:
+    monkeypatch.setattr(app_module, "ResearchService", LiteratureApiService)
+    project_id = "rp_" + "a" * 32
+    with TestClient(app_module.app) as api:
+        started = api.post(
+            f"/api/v1/projects/{project_id}/literature/runs",
+            json={"idempotencyKey": "literature:http:001"},
+        )
+        assert started.status_code == 201
+        attempt = started.json()["attempts"][0]
+        assert attempt["rawStatus"] == "in_progress"
+        assert attempt["progress"] == 35
+        assert attempt["latestLog"]["message"] == "Searching OpenAlex"
+        assert api.get(f"/api/v1/projects/{project_id}/literature").status_code == 200
+        cancelled = api.post(f"/api/v1/projects/{project_id}/literature/cancel")
+        assert cancelled.json()["attempts"][0]["cancelRequestedAt"]
+
+
+def test_literature_start_surface_maps_lock_conflict_and_unknown_fields(monkeypatch) -> None:
+    monkeypatch.setattr(app_module, "ResearchService", LiteratureApiService)
+    project_id = "rp_" + "a" * 32
+    with TestClient(app_module.app) as api:
+        service = api.app.state.research
+        service.mode = "locked"
+        assert api.post(
+            f"/api/v1/projects/{project_id}/literature/runs",
+            json={"idempotencyKey": "literature:http:002"},
+        ).status_code == 423
+        service.mode = "busy"
+        assert api.post(
+            f"/api/v1/projects/{project_id}/literature/runs",
+            json={"idempotencyKey": "literature:http:003"},
+        ).status_code == 409
+        assert api.post(
+            f"/api/v1/projects/{project_id}/literature/runs",
+            json={"idempotencyKey": "literature:http:004", "model": "arbitrary"},
+        ).status_code == 422
+
+
+def test_literature_results_library_and_safe_download_contract(monkeypatch) -> None:
+    monkeypatch.setattr(app_module, "ResearchService", LiteratureApiService)
+    project_id = "rp_" + "a" * 32
+    with TestClient(app_module.app) as api:
+        synced = api.post(f"/api/v1/projects/{project_id}/literature/sync")
+        assert synced.status_code == 200
+        assert synced.json()["attempts"][0]["integrityStatus"] == "verified"
+        sources = api.get(f"/api/v1/projects/{project_id}/sources")
+        assert sources.json()["sources"][0]["url"].startswith("https://")
+        assert api.get(f"/api/v1/projects/{project_id}/review").json()[
+            "markdown"
+        ] == "# Review"
+        artifact = api.get(
+            f"/api/v1/projects/{project_id}/artifacts/references.bib"
+        )
+        assert artifact.status_code == 200
+        assert artifact.headers["x-content-sha256"] == "a" * 64
+        assert artifact.headers["cache-control"] == "no-store"
+        assert api.get(
+            f"/api/v1/projects/{project_id}/artifacts/../../secret"
+        ).status_code in {404, 422}
+
+        assert api.get("/api/v1/literature/library/collections").status_code == 200
+        assert api.post(
+            "/api/v1/literature/library/collections/collection-1/index"
+        ).json()["terminalType"] == "complete"
+        assert api.post(
+            "/api/v1/literature/library/collections/../index"
+        ).status_code in {404, 422}
+        zotero = api.get("/api/v1/literature/zotero/status").json()
+        assert zotero["config"]["has_api_key"] is True
+        assert "secret-zotero-key" not in str(zotero)
+        assert api.post("/api/v1/literature/zotero/sync").status_code == 200

--- a/extensions/ai-research/tests/control/test_literature_runtime.py
+++ b/extensions/ai-research/tests/control/test_literature_runtime.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ai_research_control.literature_runtime import LiteratureRuntime
+from ai_research_control.literature_artifacts import LiteratureArtifactStore
+from ai_research_control.project_store import ProjectConflict, ProjectStore
+
+
+class FakeLdr:
+    def __init__(self) -> None:
+        self.start_result = ("ldr-1", "success")
+        self.found: str | None = None
+        self.statuses: list[dict[str, Any]] = []
+        self.terminate_count = 0
+        self.report_value: dict[str, Any] = {
+            "content": "# Review\n\nEvidence [1].",
+            "sources": [{"url": "https://openalex.org/W1", "title": "Evidence"}],
+        }
+        self.collection_values: list[dict[str, Any]] = [
+            {
+                "id": "private",
+                "document_count": 2,
+                "indexed_document_count": 2,
+                "is_public": False,
+                "agent_enabled": True,
+            }
+        ]
+
+    def session_status(self) -> dict[str, str | None]:
+        return {"status": "ready", "username": "researcher"}
+
+    def collections(self) -> list[dict[str, Any]]:
+        return self.collection_values
+
+    def start_research(self, **_: object) -> tuple[str, str]:
+        return self.start_result
+
+    def find_research_by_run_id(self, run_id: str) -> str | None:
+        return self.found
+
+    def research_status(self, research_id: str) -> dict[str, Any]:
+        return self.statuses.pop(0)
+
+    def terminate(self, research_id: str) -> dict[str, Any]:
+        self.terminate_count += 1
+        return {"status": "success"}
+
+    def report(self, research_id: str) -> dict[str, Any]:
+        return self.report_value
+
+    def export(self, research_id: str, export_format: str) -> bytes:
+        if export_format == "ris":
+            return b"TY  - JOUR\nTI  - Evidence\nER  -\n"
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr(
+                "review.qmd",
+                "---\nbibliography: references.bib\n---\nEvidence [@source1].\n",
+            )
+            archive.writestr(
+                "references.bib", "@article{source1, title={Evidence}}\n"
+            )
+        return buffer.getvalue()
+
+
+def setup(tmp_path: Path) -> tuple[ProjectStore, FakeLdr, LiteratureRuntime, str]:
+    projects = ProjectStore(tmp_path / "projects", source_lock_sha256="a" * 64)
+    projects.prepare()
+    project, _ = projects.create(
+        title="Agent 评测",
+        research_question="Agent 评测如何确保可复现？",
+        idempotency_key="project:runtime:001",
+    )
+    ldr = FakeLdr()
+    runtime = LiteratureRuntime(
+        projects=projects,
+        artifacts=LiteratureArtifactStore(tmp_path / "projects"),
+        ldr=ldr,  # type: ignore[arg-type]
+        model_id="fixed/model",
+        bridge_url="http://host.docker.internal:8000/api/ai-research/v1",
+    )
+    return projects, ldr, runtime, project["projectId"]
+
+
+def test_start_progress_and_complete_preserve_upstream_status(tmp_path: Path) -> None:
+    projects, ldr, runtime, project_id = setup(tmp_path)
+    project, created = asyncio.run(
+        runtime.start_run(
+            project_id,
+            idempotency_key="literature:runtime:001",
+            collection_id=None,
+        )
+    )
+    assert created is True
+    assert project["literature"]["phase"] == "running"
+    ldr.statuses = [
+        {"status": "in_progress", "progress": 42},
+        {"status": "completed", "progress": 100},
+    ]
+    asyncio.run(runtime.tick())
+    assert projects.get(project_id)["literature"]["attempts"][0]["progress"] == 42
+    asyncio.run(runtime.tick())
+    restored = projects.get(project_id)
+    assert restored["literature"]["outcome"] == "completed"
+    assert restored["literature"]["attempts"][0]["rawStatus"] == "completed"
+    attempt = restored["literature"]["attempts"][0]
+    assert attempt["integrityStatus"] == "verified"
+    assert attempt["syncedAt"]
+    assert "references.bib" in attempt["artifacts"]
+
+
+def test_completed_with_bad_artifact_preserves_raw_fact_and_can_resync(
+    tmp_path: Path,
+) -> None:
+    projects, ldr, runtime, project_id = setup(tmp_path)
+    asyncio.run(
+        runtime.start_run(
+            project_id,
+            idempotency_key="literature:runtime:bad-artifact",
+            collection_id=None,
+        )
+    )
+    ldr.report_value = {"content": "Review", "sources": []}
+    ldr.statuses = [{"status": "completed", "progress": 100}]
+    asyncio.run(runtime.tick())
+    attempt = projects.get(project_id)["literature"]["attempts"][0]
+    assert attempt["rawStatus"] == "completed"
+    assert attempt["outcome"] == "infrastructure_error"
+    assert attempt["integrityStatus"] == "failed"
+    assert attempt["errorType"] == "artifact_sync_failed"
+    assert projects.get(project_id)["literature"]["completedRunId"] is None
+    assert attempt["errorMessage"].endswith(
+        ": LDR report did not provide sources"
+    )
+
+    ldr.report_value = {
+        "content": "Review",
+        "sources": [{"url": "https://openalex.org/W1"}],
+    }
+    asyncio.run(runtime.sync(project_id))
+    attempt = projects.get(project_id)["literature"]["attempts"][0]
+    assert attempt["outcome"] == "completed"
+    assert attempt["integrityStatus"] == "verified"
+    assert attempt["errorType"] is None
+    assert projects.get(project_id)["literature"]["completedRunId"] == attempt["runId"]
+    receipt = json.loads(
+        (
+            projects.run_directory(project_id, attempt["runId"])
+            / "literature-receipt.json"
+        ).read_text("utf-8")
+    )
+    assert receipt["rawStatus"] == "completed"
+    assert receipt["outcome"] == "completed"
+    assert receipt["syncedAt"] == attempt["syncedAt"]
+
+
+def test_response_loss_reconciles_without_starting_a_second_research(tmp_path: Path) -> None:
+    projects, ldr, runtime, project_id = setup(tmp_path)
+    project, _ = asyncio.run(
+        runtime.start_run(
+            project_id,
+            idempotency_key="literature:runtime:002",
+            collection_id=None,
+        )
+    )
+    run_id = project["literature"]["activeRunId"]
+    projects.update_attempt(project_id, run_id, {"ldrResearchId": None, "phase": "queued"})
+    ldr.found = "ldr-reconciled"
+    ldr.statuses = [{"status": "in_progress", "progress": 1}]
+    asyncio.run(runtime.tick())
+    attempt = projects.get(project_id)["literature"]["attempts"][0]
+    assert attempt["ldrResearchId"] == "ldr-reconciled"
+    assert attempt["phase"] == "running"
+
+
+def test_cancel_applied_plus_upstream_error_normalizes_without_erasing_error(
+    tmp_path: Path,
+) -> None:
+    projects, ldr, runtime, project_id = setup(tmp_path)
+    asyncio.run(
+        runtime.start_run(
+            project_id,
+            idempotency_key="literature:runtime:003",
+            collection_id=None,
+        )
+    )
+    asyncio.run(runtime.cancel(project_id))
+    ldr.statuses = [
+        {
+            "status": "error",
+            "metadata": {
+                "error_info": {"type": "terminated", "message": "TerminateTaskError"}
+            },
+        }
+    ]
+    asyncio.run(runtime.tick())
+    attempt = projects.get(project_id)["literature"]["attempts"][0]
+    assert attempt["cancelRequestedAt"]
+    assert attempt["cancelAppliedAt"]
+    assert attempt["rawStatus"] == "error"
+    assert attempt["outcome"] == "cancelled"
+    assert attempt["errorMessage"] == "TerminateTaskError"
+
+
+def test_cancel_requested_without_visible_upstream_does_not_claim_cancellation(
+    tmp_path: Path,
+) -> None:
+    projects, ldr, runtime, project_id = setup(tmp_path)
+    project, _ = asyncio.run(
+        runtime.start_run(
+            project_id,
+            idempotency_key="literature:runtime:cancel-before-visible",
+            collection_id=None,
+        )
+    )
+    run_id = project["literature"]["activeRunId"]
+    projects.update_attempt(
+        project_id,
+        run_id,
+        {"ldrResearchId": None, "phase": "queued", "rawStatus": None},
+    )
+
+    asyncio.run(runtime.cancel(project_id))
+    for _ in range(6):
+        asyncio.run(runtime.tick())
+
+    attempt = projects.get(project_id)["literature"]["attempts"][0]
+    assert attempt["phase"] == "terminal"
+    assert attempt["outcome"] == "infrastructure_error"
+    assert attempt["cancelRequestedAt"]
+    assert attempt["cancelAppliedAt"] is None
+    assert attempt["rawStatus"] is None
+    assert attempt["errorType"] == "missing_upstream_run"
+
+
+def test_global_active_limit_and_private_collection_fail_closed(tmp_path: Path) -> None:
+    projects, _, runtime, project_id = setup(tmp_path)
+    asyncio.run(
+        runtime.start_run(
+            project_id,
+            idempotency_key="literature:runtime:004",
+            collection_id=None,
+        )
+    )
+    second, _ = projects.create(
+        title="第二个项目",
+        research_question="另一个问题",
+        idempotency_key="project:runtime:002",
+    )
+    with pytest.raises(ProjectConflict, match="another"):
+        asyncio.run(
+            runtime.start_run(
+                second["projectId"],
+                idempotency_key="literature:runtime:005",
+                collection_id=None,
+            )
+        )
+
+    projects.update_attempt(
+        project_id,
+        projects.get(project_id)["literature"]["activeRunId"],
+        {"phase": "terminal", "outcome": "failed"},
+    )
+    with pytest.raises(ProjectConflict, match="fully indexed"):
+        asyncio.run(
+            runtime.start_run(
+                second["projectId"],
+                idempotency_key="literature:runtime:006",
+                collection_id="private",
+            )
+        )
+
+
+def test_collection_tool_surface_must_exactly_match_project_selection(
+    tmp_path: Path,
+) -> None:
+    _, ldr, runtime, project_id = setup(tmp_path)
+    ldr.collection_values.extend(
+        [
+            {
+                "id": "eligible",
+                "document_count": 2,
+                "indexed_document_count": 2,
+                "is_public": True,
+                "agent_enabled": True,
+            },
+            {
+                "id": "other-public",
+                "document_count": 1,
+                "indexed_document_count": 0,
+                "is_public": True,
+                "agent_enabled": True,
+            },
+        ]
+    )
+
+    with pytest.raises(ProjectConflict, match="match the selected"):
+        asyncio.run(
+            runtime.start_run(
+                project_id,
+                idempotency_key="literature:runtime:scope:001",
+                collection_id="eligible",
+            )
+        )
+
+    ldr.collection_values = [
+        item for item in ldr.collection_values if item["id"] != "other-public"
+    ]
+    project, created = asyncio.run(
+        runtime.start_run(
+            project_id,
+            idempotency_key="literature:runtime:scope:002",
+            collection_id="eligible",
+        )
+    )
+    assert created is True
+    assert project["literature"]["collectionId"] == "eligible"

--- a/extensions/ai-research/tests/control/test_literature_session_api.py
+++ b/extensions/ai-research/tests/control/test_literature_session_api.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import ai_research_control.app as app_module
+from ai_research_control.ldr_client import LdrAuthenticationError
+from ai_research_control.service import NotReady
+
+
+class SessionService:
+    configured = True
+
+    def __init__(self, settings: object) -> None:
+        self.state = {"status": "locked", "username": None}
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def literature_session(self) -> dict[str, str | None]:
+        return self.state
+
+    async def unlock_literature(
+        self, *, username: str, password: str
+    ) -> dict[str, str | None]:
+        if not self.configured:
+            raise NotReady("fixed literature model bridge is not configured")
+        if password != "correct-password":
+            raise LdrAuthenticationError("LDR credentials were rejected")
+        self.state = {"status": "ready", "username": username}
+        return self.state
+
+    async def clear_literature_session(self) -> dict[str, str | None]:
+        self.state = {"status": "locked", "username": None}
+        return self.state
+
+
+def test_unlock_status_and_clear_are_no_store(monkeypatch) -> None:
+    monkeypatch.setattr(app_module, "ResearchService", SessionService)
+    with TestClient(app_module.app) as api:
+        locked = api.get("/api/v1/literature/session")
+        assert locked.json() == {"status": "locked", "username": None}
+        assert locked.headers["cache-control"] == "no-store"
+
+        unlocked = api.post(
+            "/api/v1/literature/session/unlock",
+            json={"username": "researcher", "password": "correct-password"},
+        )
+        assert unlocked.status_code == 200
+        assert unlocked.json() == {"status": "ready", "username": "researcher"}
+        assert unlocked.headers["cache-control"] == "no-store"
+
+        cleared = api.delete("/api/v1/literature/session")
+        assert cleared.json() == {"status": "locked", "username": None}
+        assert cleared.headers["cache-control"] == "no-store"
+
+
+def test_unlock_rejects_bad_input_credentials_and_missing_bridge(monkeypatch) -> None:
+    monkeypatch.setattr(app_module, "ResearchService", SessionService)
+    with TestClient(app_module.app) as api:
+        assert api.post(
+            "/api/v1/literature/session/unlock",
+            json={"username": "../bad", "password": "correct-password"},
+        ).status_code == 422
+        assert api.post(
+            "/api/v1/literature/session/unlock",
+            json={"username": "researcher", "password": "wrong"},
+        ).status_code == 423
+        api.app.state.research.configured = False
+        assert api.post(
+            "/api/v1/literature/session/unlock",
+            json={"username": "researcher", "password": "correct-password"},
+        ).status_code == 503

--- a/extensions/ai-research/tests/control/test_model_relay.py
+++ b/extensions/ai-research/tests/control/test_model_relay.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import io
+from email.message import Message
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ai_research_control.config import _model_bridge_url
+from ai_research_control import model_relay
+
+
+class FakeUpstream:
+    def __init__(
+        self,
+        body: bytes,
+        *,
+        status: int = 200,
+        content_type: str = "application/json",
+    ) -> None:
+        self.status = status
+        self._body = io.BytesIO(body)
+        self.closed = False
+        self.headers = Message()
+        self.headers["Content-Type"] = content_type
+        self.headers["X-ModelMirror-Route-Run-Id"] = "chatrun_relay"
+
+    def getcode(self) -> int:
+        return self.status
+
+    def read(self, size: int) -> bytes:
+        return self._body.read(size)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def settings() -> model_relay.RelaySettings:
+    return model_relay.RelaySettings(
+        target="http://127.0.0.1:8000/api/ai-research/v1",
+        timeout_seconds=5.0,
+    )
+
+
+def test_relay_forwards_only_fixed_models_path_and_minimal_headers(monkeypatch) -> None:
+    captured = {}
+    upstream = FakeUpstream(b'{"data":[{"id":"fixed"}]}')
+
+    def open_upstream(request, timeout):
+        captured["url"] = request.full_url
+        captured["method"] = request.method
+        captured["authorization"] = request.headers["Authorization"]
+        captured["cookie"] = request.headers.get("Cookie")
+        captured["timeout"] = timeout
+        return upstream
+
+    monkeypatch.setattr(model_relay, "open_upstream", open_upstream)
+    with TestClient(model_relay.create_app(settings())) as client:
+        response = client.get(
+            "/api/ai-research/v1/models",
+            headers={"Authorization": "Bearer relay-secret", "Cookie": "private=1"},
+        )
+        rejected = client.get(
+            "/api/ai-research/v1/models?target=http://example.com",
+            headers={"Authorization": "Bearer relay-secret"},
+        )
+        missing = client.get(
+            "/api/ai-research/v1/arbitrary",
+            headers={"Authorization": "Bearer relay-secret"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"data": [{"id": "fixed"}]}
+    assert response.headers["x-modelmirror-route-run-id"] == "chatrun_relay"
+    assert upstream.closed is True
+    assert captured == {
+        "url": "http://127.0.0.1:8000/api/ai-research/v1/models",
+        "method": "GET",
+        "authorization": "Bearer relay-secret",
+        "cookie": None,
+        "timeout": 5.0,
+    }
+    assert rejected.status_code == 400
+    assert missing.status_code == 404
+
+
+def test_relay_streams_chat_and_closes_upstream(monkeypatch) -> None:
+    upstream = FakeUpstream(
+        b'data: {"choices":[]}\n\ndata: [DONE]\n\n',
+        content_type="text/event-stream; charset=utf-8",
+    )
+    monkeypatch.setattr(model_relay, "open_upstream", lambda request, timeout: upstream)
+    with TestClient(model_relay.create_app(settings())) as client:
+        response = client.post(
+            "/api/ai-research/v1/chat/completions",
+            headers={"Authorization": "Bearer relay-secret"},
+            json={"model": "fixed", "messages": [{"role": "user", "content": "hi"}], "stream": True},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert response.content.endswith(b"data: [DONE]\n\n")
+    assert upstream.closed is True
+
+
+def test_relay_rejects_unsafe_target_content_and_oversized_request(monkeypatch) -> None:
+    for value in (
+        "https://host.docker.internal:8000/api/ai-research/v1",
+        "http://example.com:8000/api/ai-research/v1",
+        "http://127.0.0.1:8000/api/chat",
+        "http://user:secret@127.0.0.1:8000/api/ai-research/v1",
+    ):
+        with pytest.raises(ValueError):
+            model_relay.validate_target(value)
+
+    monkeypatch.setattr(
+        model_relay,
+        "open_upstream",
+        lambda request, timeout: FakeUpstream(b"secret", content_type="text/html"),
+    )
+    with TestClient(model_relay.create_app(settings()), raise_server_exceptions=False) as client:
+        content_rejected = client.get(
+            "/api/ai-research/v1/models",
+            headers={"Authorization": "Bearer relay-secret"},
+        )
+        oversized = client.post(
+            "/api/ai-research/v1/chat/completions",
+            headers={
+                "Authorization": "Bearer relay-secret",
+                "Content-Type": "application/json",
+            },
+            content=b"x" * (model_relay.MAX_REQUEST_BYTES + 1),
+        )
+
+    assert content_rejected.status_code == 502
+    assert "secret" not in content_rejected.text
+    assert oversized.status_code == 413
+
+
+def test_control_configuration_requires_the_internal_relay() -> None:
+    assert _model_bridge_url(
+        "http://ai-research-model-relay:8090/api/ai-research/v1"
+    ) == "http://ai-research-model-relay:8090/api/ai-research/v1"
+    with pytest.raises(ValueError, match="internal model relay"):
+        _model_bridge_url(
+            "http://host.docker.internal:8000/api/ai-research/v1"
+        )
+
+
+def test_open_upstream_disables_environment_proxy_and_redirects(monkeypatch) -> None:
+    captured = {}
+
+    class Opener:
+        def open(self, request, timeout):
+            captured["timeout"] = timeout
+            return FakeUpstream(b"{}")
+
+    def build(*handlers):
+        captured["handlers"] = handlers
+        return Opener()
+
+    monkeypatch.setattr(model_relay, "build_opener", build)
+    request = model_relay.UrlRequest("http://127.0.0.1:8000/api/ai-research/v1/models")
+    response = model_relay.open_upstream(request, 5.0)
+
+    assert captured["timeout"] == 5.0
+    assert any(isinstance(item, model_relay.ProxyHandler) and item.proxies == {} for item in captured["handlers"])
+    assert any(isinstance(item, model_relay.NoRedirect) for item in captured["handlers"])
+    response.close()

--- a/extensions/ai-research/tests/control/test_project_api.py
+++ b/extensions/ai-research/tests/control/test_project_api.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import ai_research_control.app as app_module
+from ai_research_control.project_store import ProjectStore
+
+
+class ProjectApiService:
+    root: Path
+
+    def __init__(self, settings: object) -> None:
+        self.projects = ProjectStore(self.root, source_lock_sha256="a" * 64)
+        self.projects.prepare()
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+
+def client(monkeypatch, tmp_path: Path) -> TestClient:
+    ProjectApiService.root = tmp_path / "projects"
+    monkeypatch.setattr(app_module, "ResearchService", ProjectApiService)
+    return TestClient(app_module.app)
+
+
+def test_project_http_journey_is_idempotent_and_recovers(monkeypatch, tmp_path: Path) -> None:
+    payload = {
+        "title": "  Agent 评测的可复现性  ",
+        "researchQuestion": "  公开研究中报告了哪些复现缺口？  ",
+        "idempotencyKey": "project:create:http-001",
+    }
+    with client(monkeypatch, tmp_path) as api:
+        created = api.post("/api/v1/projects", json=payload)
+        assert created.status_code == 201
+        project = created.json()
+        assert project["title"] == "Agent 评测的可复现性"
+        assert project["literaturePhase"] == "not_started"
+
+        repeated = api.post("/api/v1/projects", json=payload)
+        assert repeated.status_code == 200
+        assert repeated.json()["projectId"] == project["projectId"]
+
+        edited = api.patch(
+            f"/api/v1/projects/{project['projectId']}",
+            json={"title": "Agent 评测复现性"},
+        )
+        assert edited.status_code == 200
+        assert edited.json()["title"] == "Agent 评测复现性"
+
+    with client(monkeypatch, tmp_path) as restarted:
+        restored = restarted.get(f"/api/v1/projects/{project['projectId']}")
+        assert restored.status_code == 200
+        assert restored.json()["researchQuestion"] == "公开研究中报告了哪些复现缺口？"
+        listing = restarted.get("/api/v1/projects?q=复现&literaturePhase=not_started")
+        assert [item["projectId"] for item in listing.json()["items"]] == [
+            project["projectId"]
+        ]
+
+
+def test_project_http_surface_fails_closed(monkeypatch, tmp_path: Path) -> None:
+    with client(monkeypatch, tmp_path) as api:
+        valid = {
+            "title": "A",
+            "researchQuestion": "B",
+            "idempotencyKey": "project:create:http-002",
+        }
+        assert api.post("/api/v1/projects", json=valid).status_code == 201
+        assert api.post("/api/v1/projects", json={**valid, "path": "../x"}).status_code == 422
+        assert api.post(
+            "/api/v1/projects", json={**valid, "title": "另一个标题"}
+        ).status_code == 409
+        assert api.post(
+            "/api/v1/projects",
+            json={**valid, "idempotencyKey": "project:create:http-003", "title": "   "},
+        ).status_code == 422
+        assert api.patch("/api/v1/projects/rp_" + "0" * 32, json={}).status_code == 422
+        assert api.get("/api/v1/projects?literaturePhase=unknown").status_code == 422
+        assert api.get("/api/v1/projects?cursor=rp_" + "f" * 32).status_code == 422

--- a/extensions/ai-research/tests/control/test_project_store.py
+++ b/extensions/ai-research/tests/control/test_project_store.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from ai_research_control.project_store import (
+    ProjectConflict,
+    ProjectIntegrityError,
+    ProjectStore,
+)
+
+
+def store(tmp_path: Path) -> ProjectStore:
+    value = ProjectStore(tmp_path / "projects", source_lock_sha256="a" * 64)
+    value.prepare()
+    return value
+
+
+def test_project_create_is_idempotent_and_persists_yaml(tmp_path: Path) -> None:
+    projects = store(tmp_path)
+    first, created = projects.create(
+        title="Agent 评测复现性",
+        research_question="当前 Agent 评测的复现性缺口是什么？",
+        idempotency_key="project:create:001",
+    )
+    repeated, repeated_created = projects.create(
+        title=first["title"],
+        research_question=first["researchQuestion"],
+        idempotency_key="project:create:001",
+    )
+
+    assert created is True
+    assert repeated_created is False
+    assert repeated["projectId"] == first["projectId"]
+    assert projects.get(first["projectId"])["literature"]["phase"] == "not_started"
+    assert (tmp_path / "projects" / first["projectId"] / "research.yaml").is_file()
+
+
+def test_idempotency_conflict_and_edit_freeze(tmp_path: Path) -> None:
+    projects = store(tmp_path)
+    project, _ = projects.create(
+        title="A", research_question="研究问题 A", idempotency_key="project:create:002"
+    )
+    with pytest.raises(ProjectConflict):
+        projects.create(
+            title="B", research_question="研究问题 B", idempotency_key="project:create:002"
+        )
+
+    updated = projects.update(
+        project["projectId"], title="新标题", research_question=None
+    )
+    assert updated["title"] == "新标题"
+    projects.begin_attempt(
+        project["projectId"],
+        idempotency_key="literature:start:001",
+        model_id="fixed/model",
+        collection_id=None,
+    )
+    with pytest.raises(ProjectConflict):
+        projects.update(project["projectId"], title="不可修改", research_question=None)
+
+
+def test_concurrent_create_with_same_key_produces_one_project(tmp_path: Path) -> None:
+    projects = store(tmp_path)
+
+    def create() -> tuple[str, bool]:
+        project, created = projects.create(
+            title="并发幂等",
+            research_question="同一请求并发到达时会发生什么？",
+            idempotency_key="project:create:concurrent",
+        )
+        return project["projectId"], created
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(lambda _: create(), range(16)))
+
+    assert len({project_id for project_id, _ in results}) == 1
+    assert sum(1 for _, created in results if created) == 1
+    assert len(projects.list(after_project_id=None, limit=100)) == 1
+
+
+def test_attempt_lifecycle_preserves_raw_status_and_completed_result(tmp_path: Path) -> None:
+    projects = store(tmp_path)
+    project, _ = projects.create(
+        title="A", research_question="研究问题", idempotency_key="project:create:003"
+    )
+    project, attempt, created = projects.begin_attempt(
+        project["projectId"],
+        idempotency_key="literature:start:002",
+        model_id="fixed/model",
+        collection_id="1",
+    )
+    assert created is True
+    assert attempt["searchEngine"] == "openalex"
+    assert attempt["collectionId"] == "1"
+    assert attempt["strategy"] == "langgraph-agent"
+    _, repeated, repeated_created = projects.begin_attempt(
+        project["projectId"],
+        idempotency_key="literature:start:002",
+        model_id="fixed/model",
+        collection_id="1",
+    )
+    assert repeated_created is False
+    assert repeated["runId"] == attempt["runId"]
+    with pytest.raises(ProjectConflict, match="other literature input"):
+        projects.begin_attempt(
+            project["projectId"],
+            idempotency_key="literature:start:002",
+            model_id="fixed/model",
+            collection_id="2",
+        )
+
+    final, final_attempt = projects.update_attempt(
+        project["projectId"],
+        attempt["runId"],
+        {
+            "phase": "terminal",
+            "outcome": "completed",
+            "rawStatus": "completed",
+            "terminalAt": "2026-08-24T00:00:00Z",
+        },
+    )
+    assert final["literature"]["completedRunId"] is None
+    assert final_attempt["rawStatus"] == "completed"
+    final, _ = projects.update_attempt(
+        project["projectId"],
+        attempt["runId"],
+        {"integrityStatus": "verified"},
+    )
+    assert final["literature"]["completedRunId"] == attempt["runId"]
+    with pytest.raises(ProjectConflict):
+        projects.begin_attempt(
+            project["projectId"],
+            idempotency_key="literature:start:003",
+            model_id="fixed/model",
+            collection_id=None,
+        )
+
+
+def test_symlink_project_and_unsafe_ids_fail_closed(tmp_path: Path) -> None:
+    projects = store(tmp_path)
+    with pytest.raises(KeyError):
+        projects.get("../outside")
+
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "projects" / ("rp_" + "b" * 32)
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink creation is not available")
+    with pytest.raises(ProjectIntegrityError):
+        projects.list(after_project_id=None, limit=10)
+
+
+def test_symlink_literature_directory_fails_closed(tmp_path: Path) -> None:
+    projects = store(tmp_path)
+    project, _ = projects.create(
+        title="A", research_question="研究问题", idempotency_key="project:create:symlink"
+    )
+    target = tmp_path / "outside-literature"
+    target.mkdir()
+    link = tmp_path / "projects" / project["projectId"] / "literature"
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink creation is not available")
+
+    with pytest.raises(ProjectIntegrityError, match="symlink"):
+        projects.run_directory(
+            project["projectId"], "lr_" + "c" * 32, must_exist=False
+        )

--- a/extensions/ai-research/tests/control/test_service.py
+++ b/extensions/ai-research/tests/control/test_service.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from types import SimpleNamespace
 
+from ai_research_control.ldr_client import LdrProtocolError
 from ai_research_control.service import ResearchService
 
 
@@ -34,3 +37,127 @@ def test_cancel_race_does_not_send_terminal_run_to_worker() -> None:
     assert result["phase"] == "terminal"
     assert result["outcome"] == "success"
     assert result["cancel_requested"] is False
+
+
+class BridgeResponse:
+    status = 200
+
+    def __init__(self, value: dict[str, object]) -> None:
+        self.content = json.dumps(value).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def read(self, limit: int) -> bytes:
+        return self.content[:limit]
+
+
+def test_model_bridge_probe_is_exact_and_uses_no_proxy(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class Opener:
+        def open(self, request, timeout: float):
+            captured["url"] = request.full_url
+            captured["authorization"] = request.headers["Authorization"]
+            captured["timeout"] = timeout
+            return BridgeResponse(
+                {"data": [{"id": "provider/fixed", "object": "model"}]}
+            )
+
+    def opener(proxy):
+        captured["proxies"] = proxy.proxies
+        return Opener()
+
+    monkeypatch.setattr("ai_research_control.service.build_opener", opener)
+    service = object.__new__(ResearchService)
+    service.settings = SimpleNamespace(
+        model_bridge_url="http://host.docker.internal:8000/api/ai-research/v1",
+        model_bridge_token="bridge-secret",
+        literature_model_id="provider/fixed",
+    )
+    service._probe_model_bridge()
+
+    assert captured == {
+        "proxies": {},
+        "url": "http://host.docker.internal:8000/api/ai-research/v1/models",
+        "authorization": "Bearer bridge-secret",
+        "timeout": 5.0,
+    }
+
+
+def test_model_bridge_probe_rejects_another_or_multiple_models(monkeypatch) -> None:
+    class Opener:
+        def open(self, request, timeout: float):
+            return BridgeResponse(
+                {"data": [{"id": "provider/fixed"}, {"id": "provider/other"}]}
+            )
+
+    monkeypatch.setattr(
+        "ai_research_control.service.build_opener", lambda proxy: Opener()
+    )
+    service = object.__new__(ResearchService)
+    service.settings = SimpleNamespace(
+        model_bridge_url="http://host.docker.internal:8000/api/ai-research/v1",
+        model_bridge_token="bridge-secret",
+        literature_model_id="provider/fixed",
+    )
+    try:
+        service._probe_model_bridge()
+    except RuntimeError as exc:
+        assert "not eligible" in str(exc)
+    else:
+        raise AssertionError("multiple models must fail closed")
+
+
+def test_literature_capability_degrades_on_malformed_ldr_session() -> None:
+    class MalformedLdr:
+        def probe(self):
+            return True
+
+        def session_status(self):
+            raise LdrProtocolError("malformed session")
+
+    service = object.__new__(ResearchService)
+    service.settings = SimpleNamespace(
+        model_bridge_url="http://host.docker.internal:8000/api/ai-research/v1",
+        model_bridge_token="bridge-secret",
+        literature_model_id="provider/fixed",
+    )
+    service.ldr = MalformedLdr()
+    service._probe_model_bridge = lambda: None
+
+    result = asyncio.run(service.literature_capability())
+
+    assert result["status"] == "not_ready"
+    assert result["serviceStatus"] == "not_ready"
+    assert result["sessionStatus"] == "locked"
+
+
+def test_literature_capability_fails_closed_when_model_qualification_is_lost() -> None:
+    class ReadyLdr:
+        def probe(self):
+            return True
+
+        def session_status(self):
+            return {"status": "ready", "username": "researcher"}
+
+    service = object.__new__(ResearchService)
+    service.settings = SimpleNamespace(
+        model_bridge_url="http://host.docker.internal:8000/api/ai-research/v1",
+        model_bridge_token="bridge-secret",
+        literature_model_id="provider/fixed",
+    )
+    service.ldr = ReadyLdr()
+    service._probe_model_bridge = lambda: (_ for _ in ()).throw(
+        RuntimeError("provider qualification is not ready")
+    )
+
+    result = asyncio.run(service.literature_capability())
+
+    assert result["status"] == "not_ready"
+    assert result["serviceStatus"] == "ready"
+    assert result["sessionStatus"] == "ready"
+    assert result["modelBridgeStatus"] == "not_ready"

--- a/extensions/ai-research/ui/package-lock.json
+++ b/extensions/ai-research/ui/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "@modelmirror/ai-research-console",
-  "version": "0.2.0-ar1",
+  "version": "0.3.0-v0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelmirror/ai-research-console",
-      "version": "0.2.0-ar1",
+      "version": "0.3.0-v0.1",
       "dependencies": {
         "lucide-react": "1.27.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-router-dom": "6.30.4"
+        "react-markdown": "10.1.0",
+        "react-router-dom": "6.30.4",
+        "remark-gfm": "4.0.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "7.0.0",
@@ -1684,6 +1686,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1695,14 +1706,45 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1717,6 +1759,18 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -1962,6 +2016,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.18",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.18.tgz",
@@ -2076,6 +2140,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2084,6 +2158,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -2122,6 +2236,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -2179,7 +2303,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -2215,7 +2338,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2236,14 +2358,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/didyoumean": {
@@ -2357,6 +2504,28 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2376,6 +2545,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -2505,6 +2680,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -2518,6 +2733,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2526,6 +2751,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-binary-path": {
@@ -2557,6 +2812,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2580,6 +2845,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2588,6 +2863,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -2711,6 +2998,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2751,6 +3048,286 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -2767,6 +3344,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -2796,7 +3936,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -2883,6 +4022,31 @@
       "engines": {
         "node": ">=12.20.0"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.1",
@@ -3120,6 +4284,16 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3179,6 +4353,33 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -3254,6 +4455,72 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-from-string": {
@@ -3415,6 +4682,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3429,6 +4706,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -3440,6 +4731,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -3680,6 +4989,26 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -3709,6 +5038,93 @@
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -3748,6 +5164,34 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vite": {
       "version": "7.3.5",
@@ -4046,6 +5490,16 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/extensions/ai-research/ui/package.json
+++ b/extensions/ai-research/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelmirror/ai-research-console",
-  "version": "0.2.0-ar1",
+  "version": "0.3.0-v0.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -12,7 +12,9 @@
     "lucide-react": "1.27.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "react-router-dom": "6.30.4"
+    "react-markdown": "10.1.0",
+    "react-router-dom": "6.30.4",
+    "remark-gfm": "4.0.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "7.0.0",

--- a/extensions/ai-research/ui/src/App.test.tsx
+++ b/extensions/ai-research/ui/src/App.test.tsx
@@ -14,6 +14,30 @@ const system = {
     { id: "inspectView", status: "ready", required: false },
   ],
   checkedAt: "2026-08-24T00:00:00Z",
+  literatureCapability: {
+    status: "ready",
+    serviceStatus: "ready",
+    sessionStatus: "locked",
+    profileStatus: "ready",
+    modelBridgeStatus: "ready",
+    username: null,
+    scientificClaim: "none",
+  },
+};
+const moduleInfo = {
+  moduleId: "modelmirror-ai-research",
+  moduleVersion: "0.3.0-v0.1",
+  apiVersion: "v1",
+  workerProtocolVersion: 1,
+  fixtures: ["success", "task_error", "long_running_cancel"],
+  runtimes: { localDeepResearch: "1.10.6" },
+  capabilities: { fixtureExecution: true, literatureResearch: true },
+  capabilityClaims: {
+    fixtureExecution: { enabled: true, claimLevel: "harness_only", packStatus: "fixture_only" },
+    literatureResearch: { enabled: true, scientificClaim: "none", acceptanceState: "pending_live_acceptance", workflowSource: "local_deep_research" },
+  },
+  links: { mlflow: "http://127.0.0.1:8791", inspectView: "http://127.0.0.1:8793", localDeepResearch: "http://127.0.0.1:8792" },
+  limitations: ["literature workflow only; scientificClaim=none"],
 };
 const createBodies: string[] = [];
 
@@ -28,7 +52,9 @@ beforeEach(() => {
         headers: { "Content-Type": "application/json" },
       });
     }
-    const body = path.includes("/system")
+    const body = path.includes("/api/v1/module")
+      ? moduleInfo
+      : path.includes("/system")
       ? system
       : path.includes("/summary")
         ? { total: 0, phases: { queued: 0, running: 0, terminal: 0 }, outcomes: { success: 0, task_error: 0, cancelled: 0, infrastructure_error: 0 }, evidenceStates: { pending: 0, synced: 0, failed: 0 }, updatedAt: null }
@@ -42,11 +68,21 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-test("overview states the fixture-only product boundary", async () => {
+test("overview presents the real literature path without a scientific claim", async () => {
   render(<MemoryRouter initialEntries={["/"]}><App /></MemoryRouter>);
-  expect(screen.getByRole("heading", { name: "科研执行控制台" })).toBeInTheDocument();
-  expect(screen.getByText(/不调用模型，不产生科研结论/)).toBeInTheDocument();
-  await waitFor(() => expect(screen.getByText("创建工程夹具")).toBeInTheDocument());
+  expect(screen.getByRole("heading", { name: "继续你的文献研究" })).toBeInTheDocument();
+  expect(screen.getByText(/scientificClaim=none/)).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: "创建研究项目" })).toBeInTheDocument();
+  await waitFor(() => expect(screen.getByText("工程夹具与证据框架")).toBeInTheDocument());
+});
+
+test("system separates fixture claims from pending literature acceptance", async () => {
+  render(<MemoryRouter initialEntries={["/system"]}><App /></MemoryRouter>);
+  expect(await screen.findByText("harness_only")).toBeInTheDocument();
+  expect(screen.getByText("fixture_only")).toBeInTheDocument();
+  expect(screen.getByText("Local Deep Research", { selector: "dd" })).toBeInTheDocument();
+  expect(screen.getByText("功能已实现，真实环境验收待完成")).toBeInTheDocument();
+  expect(screen.getByText("none，结果需人工复核")).toBeInTheDocument();
 });
 
 test("illegal run filter is presented as all", async () => {
@@ -132,8 +168,13 @@ test("mobile navigation closes on Escape and returns focus to its toggle", async
   render(<MemoryRouter initialEntries={["/runs"]}><App /></MemoryRouter>);
   const open = screen.getByRole("button", { name: "打开导航" });
 
-  await user.click(open);
-  const runLink = screen.getByRole("link", { name: "运行" });
+  open.focus();
+  await user.keyboard("{Enter}");
+  expect(screen.getByRole("button", { name: "关闭导航" })).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
+  const runLink = screen.getByRole("link", { name: "工程夹具" });
   runLink.focus();
   await user.keyboard("{Escape}");
 
@@ -144,7 +185,7 @@ test("mobile navigation closes on Escape and returns focus to its toggle", async
 
 test("a failed create retry reuses the same idempotency key", async () => {
   const user = userEvent.setup();
-  render(<MemoryRouter initialEntries={["/"]}><App /></MemoryRouter>);
+  render(<MemoryRouter initialEntries={["/runs"]}><App /></MemoryRouter>);
   const create = screen.getByRole("button", { name: "创建并查看" });
   await waitFor(() => expect(create).toBeEnabled());
   await user.click(create);

--- a/extensions/ai-research/ui/src/App.tsx
+++ b/extensions/ai-research/ui/src/App.tsx
@@ -3,6 +3,11 @@ import { Route, Routes } from "react-router-dom";
 import { PageHeader } from "./components/Page";
 import { Shell } from "./components/Shell";
 import { OverviewPage } from "./pages/OverviewPage";
+import { ProjectDetailPage } from "./pages/ProjectDetailPage";
+import { ProjectNewPage } from "./pages/ProjectNewPage";
+import { ProjectReviewPage } from "./pages/ProjectReviewPage";
+import { ProjectSourcesPage } from "./pages/ProjectSourcesPage";
+import { ProjectsPage } from "./pages/ProjectsPage";
 import { RunDetailPage } from "./pages/RunDetailPage";
 import { RunEventsPage } from "./pages/RunEventsPage";
 import { RunEvidencePage } from "./pages/RunEvidencePage";
@@ -18,6 +23,11 @@ export function App() {
     <Routes>
       <Route element={<Shell />}>
         <Route index element={<OverviewPage />} />
+        <Route path="projects" element={<ProjectsPage />} />
+        <Route path="projects/new" element={<ProjectNewPage />} />
+        <Route path="projects/:projectId" element={<ProjectDetailPage />} />
+        <Route path="projects/:projectId/sources" element={<ProjectSourcesPage />} />
+        <Route path="projects/:projectId/review" element={<ProjectReviewPage />} />
         <Route path="runs" element={<RunsPage />} />
         <Route path="runs/:runId" element={<RunDetailPage />} />
         <Route path="runs/:runId/events" element={<RunEventsPage />} />

--- a/extensions/ai-research/ui/src/api.ts
+++ b/extensions/ai-research/ui/src/api.ts
@@ -7,6 +7,13 @@ import type {
   RunList,
   RunSummary,
   SystemStatus,
+  CollectionList,
+  LiteratureSession,
+  ProjectList,
+  ProjectReview,
+  ProjectSources,
+  ResearchProject,
+  ZoteroStatus,
 } from "./types";
 
 export class ApiError extends Error {
@@ -72,4 +79,76 @@ export const api = {
     ),
   evidence: (runId: string, signal?: AbortSignal) =>
     request<Evidence>(`/api/v1/runs/${encodeURIComponent(runId)}/evidence`, { signal }),
+  projects: (params = new URLSearchParams(), signal?: AbortSignal) => {
+    const query = params.toString();
+    return request<ProjectList>(`/api/v1/projects${query ? `?${query}` : ""}`, { signal });
+  },
+  project: (projectId: string, signal?: AbortSignal) =>
+    request<ResearchProject>(`/api/v1/projects/${encodeURIComponent(projectId)}`, { signal }),
+  createProject: (
+    title: string,
+    researchQuestion: string,
+    idempotencyKey: string,
+    signal?: AbortSignal,
+  ) =>
+    request<ResearchProject>("/api/v1/projects", {
+      method: "POST",
+      signal,
+      body: JSON.stringify({ title, researchQuestion, idempotencyKey }),
+    }),
+  literatureSession: (signal?: AbortSignal) =>
+    request<LiteratureSession>("/api/v1/literature/session", { signal }),
+  unlockLiterature: (username: string, password: string, signal?: AbortSignal) =>
+    request<LiteratureSession>("/api/v1/literature/session/unlock", {
+      method: "POST",
+      signal,
+      body: JSON.stringify({ username, password }),
+    }),
+  clearLiteratureSession: (signal?: AbortSignal) =>
+    request<LiteratureSession>("/api/v1/literature/session", {
+      method: "DELETE",
+      signal,
+    }),
+  startLiterature: (
+    projectId: string,
+    idempotencyKey: string,
+    collectionId?: string,
+    signal?: AbortSignal,
+  ) =>
+    request<ResearchProject>(
+      `/api/v1/projects/${encodeURIComponent(projectId)}/literature/runs`,
+      {
+        method: "POST",
+        signal,
+        body: JSON.stringify({ idempotencyKey, ...(collectionId ? { collectionId } : {}) }),
+      },
+    ),
+  cancelLiterature: (projectId: string, signal?: AbortSignal) =>
+    request<ResearchProject>(
+      `/api/v1/projects/${encodeURIComponent(projectId)}/literature/cancel`,
+      { method: "POST", signal },
+    ),
+  syncLiterature: (projectId: string, signal?: AbortSignal) =>
+    request<ResearchProject>(
+      `/api/v1/projects/${encodeURIComponent(projectId)}/literature/sync`,
+      { method: "POST", signal },
+    ),
+  sources: (projectId: string, signal?: AbortSignal) =>
+    request<ProjectSources>(`/api/v1/projects/${encodeURIComponent(projectId)}/sources`, { signal }),
+  review: (projectId: string, signal?: AbortSignal) =>
+    request<ProjectReview>(`/api/v1/projects/${encodeURIComponent(projectId)}/review`, { signal }),
+  collections: (signal?: AbortSignal) =>
+    request<CollectionList>("/api/v1/literature/library/collections", { signal }),
+  indexCollection: (collectionId: string, signal?: AbortSignal) =>
+    request<{ collectionId: string; status: "completed"; eventCount: number; terminalType: string }>(
+      `/api/v1/literature/library/collections/${encodeURIComponent(collectionId)}/index`,
+      { method: "POST", signal },
+    ),
+  zoteroStatus: (signal?: AbortSignal) =>
+    request<ZoteroStatus>("/api/v1/literature/zotero/status", { signal }),
+  syncZotero: (signal?: AbortSignal) =>
+    request<{ success?: boolean; message?: string }>("/api/v1/literature/zotero/sync", {
+      method: "POST",
+      signal,
+    }),
 };

--- a/extensions/ai-research/ui/src/components/Page.tsx
+++ b/extensions/ai-research/ui/src/components/Page.tsx
@@ -35,7 +35,7 @@ export function FixtureNotice() {
 
 export function ErrorNotice({ message, onRetry }: { message: string; onRetry?: () => void }) {
   return (
-    <div className="mt-4 flex items-start justify-between gap-4 border-l-2 border-[var(--red)] bg-[#291719] px-4 py-3 text-sm text-[#ffc2c2]" role="alert">
+    <div className="mt-4 flex items-start justify-between gap-4 rounded-md border border-[#704044] bg-[#291719] px-4 py-3 text-sm text-[#ffc2c2]" role="alert">
       <span className="flex items-start gap-2">
         <AlertCircle aria-hidden="true" className="mt-0.5 shrink-0" size={16} />
         {message}

--- a/extensions/ai-research/ui/src/components/Shell.tsx
+++ b/extensions/ai-research/ui/src/components/Shell.tsx
@@ -1,10 +1,11 @@
-import { Activity, Beaker, ListTree, Menu, ServerCog, X } from "lucide-react";
+import { Activity, Beaker, FolderKanban, ListTree, Menu, ServerCog, X } from "lucide-react";
 import { useRef, useState } from "react";
 import { NavLink, Outlet } from "react-router-dom";
 
 const links = [
   { to: "/", label: "总览", icon: Activity, end: true },
-  { to: "/runs", label: "运行", icon: ListTree, end: false },
+  { to: "/projects", label: "研究项目", icon: FolderKanban, end: false },
+  { to: "/runs", label: "工程夹具", icon: ListTree, end: false },
   { to: "/system", label: "系统", icon: ServerCog, end: false },
 ];
 
@@ -27,7 +28,7 @@ export function Shell() {
             </span>
             <span className="min-w-0">
               <span className="block truncate text-sm font-semibold text-white">模镜科研</span>
-              <span className="block text-[10px] uppercase tracking-[0.12em] text-[var(--muted)]">
+              <span className="block text-[10px] tracking-[0.04em] text-[var(--muted)]">
                 Research Console
               </span>
             </span>
@@ -67,8 +68,8 @@ export function Shell() {
         </nav>
 
         <div className={`${open ? "block" : "hidden"} mt-auto border-t border-[var(--border)] p-4 text-xs leading-5 text-[var(--muted)] md:block`}>
-          <span className="block font-semibold text-[#bdc7cd]">0.2.0-ar1</span>
-          fixture_only · harness_only
+          <span className="block font-semibold text-[#bdc7cd]">0.3.0-v0.1</span>
+          Literature · scientificClaim none
         </div>
       </aside>
       <main className="main-column" id="main-content">

--- a/extensions/ai-research/ui/src/pages/OverviewPage.tsx
+++ b/extensions/ai-research/ui/src/pages/OverviewPage.tsx
@@ -1,115 +1,81 @@
-import { ArrowRight, Play, RefreshCw } from "lucide-react";
-import { FormEvent, useCallback, useRef, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { ArrowRight, BookOpen, FolderPlus, Library, Wrench } from "lucide-react";
+import { useCallback } from "react";
+import { Link } from "react-router-dom";
 
-import { ApiError, api } from "../api";
-import { ErrorNotice, FixtureNotice, LoadingRows, PageHeader } from "../components/Page";
-import { RunTable } from "../components/RunTable";
+import { api } from "../api";
+import { ErrorNotice, LoadingRows, PageHeader } from "../components/Page";
+import { formatTime } from "../components/RunTable";
 import { Status } from "../components/Status";
 import { usePolling } from "../hooks/usePolling";
-import type { CaseId } from "../types";
+import type { LiteratureOutcome, LiteraturePhase } from "../types";
 
-const cases: { id: CaseId; label: string; description: string }[] = [
-  { id: "success", label: "成功夹具", description: "验证正常执行、日志与证据同步。" },
-  { id: "task_error", label: "任务错误夹具", description: "验证退出码与 Inspect 原始终态分离。" },
-  { id: "long_running_cancel", label: "长运行取消夹具", description: "验证取消意图、受理事实与终态保留。" },
-];
+function projectStatus(phase: LiteraturePhase, outcome: LiteratureOutcome | null) {
+  if (phase === "queued" || phase === "running") return { value: "running", label: "研究中" };
+  if (outcome === "completed") return { value: "success", label: "综述已完成" };
+  if (outcome === "cancelled") return { value: "cancelled", label: "已取消" };
+  if (outcome) return { value: "failed", label: "需要处理" };
+  return { value: "pending", label: "待开始" };
+}
 
 export function OverviewPage() {
-  const navigate = useNavigate();
-  const [caseId, setCaseId] = useState<CaseId>("success");
-  const [submitting, setSubmitting] = useState(false);
-  const [createError, setCreateError] = useState<string | null>(null);
-  const idempotencyKey = useRef<string | null>(null);
   const system = usePolling(useCallback((signal: AbortSignal) => api.system(signal), []), 10_000);
-  const summary = usePolling(useCallback((signal: AbortSignal) => api.summary(signal), []), 5_000);
-  const recent = usePolling(
-    useCallback((signal: AbortSignal) => api.runs(new URLSearchParams({ limit: "5" }), signal), []),
+  const projects = usePolling(
+    useCallback((signal: AbortSignal) => api.projects(new URLSearchParams({ limit: "5" }), signal), []),
     5_000,
   );
-  const creationBlocked = !system.data || system.data.status === "not_ready";
-
-  const submit = async (event: FormEvent) => {
-    event.preventDefault();
-    if (submitting || creationBlocked) return;
-    setSubmitting(true);
-    setCreateError(null);
-    idempotencyKey.current ??= `console:${crypto.randomUUID()}`;
-    try {
-      const run = await api.createRun(caseId, idempotencyKey.current);
-      idempotencyKey.current = null;
-      navigate(`/runs/${run.runId}`);
-    } catch (caught) {
-      setCreateError(caught instanceof ApiError ? caught.message : "创建请求未完成，请使用同一请求重试。 ");
-    } finally {
-      setSubmitting(false);
-    }
-  };
+  const literature = system.data?.literatureCapability;
 
   return (
     <div className="page">
-      <PageHeader eyebrow="AI Research / AR1" title="科研执行控制台" description="从受控夹具创建到 Inspect 原始终态、证据完整性与 MLflow 记录，集中查看工程闭环。" />
-      <FixtureNotice />
+      <PageHeader
+        eyebrow="AI / Agent Research"
+        title="继续你的文献研究"
+        description="以 Research Project 为主线，复用 Local Deep Research 完成公开论文检索、来源复核、资料库关联与可验证成果导出。"
+        actions={<Link className="button button-primary" to="/projects/new"><FolderPlus size={16} />创建研究项目</Link>}
+      />
+      <div className="notice" role="note">本轮形成真实文献研究与来源包；报告需人工复核，scientificClaim=none。工程夹具保留为独立验证工具。</div>
 
-      <section className="section" aria-labelledby="dependency-title">
+      <section className="section" aria-labelledby="capability-title">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h2 className="section-title" id="dependency-title">依赖状态</h2>
-          <Status value={system.data?.status ?? "not_ready"} />
+          <div><h2 className="section-title" id="capability-title">文献能力</h2><p className="mt-2 text-sm text-[var(--muted)]">固定模型桥、OpenAlex 主检索、LDR Library 与 Zotero。</p></div>
+          <Status value={literature?.status ?? "not_ready"} label={literature?.status === "ready" ? "可启动研究" : "需要配置"} />
         </div>
         {system.loading ? <LoadingRows count={1} /> : null}
         {system.error ? <ErrorNotice message={system.error.message} onRetry={system.refresh} /> : null}
-        {system.data ? (
-          <ul className="mt-4 grid gap-px bg-[var(--border)] sm:grid-cols-2 lg:grid-cols-4">
-            {system.data.checks.map((check) => (
-              <li className="flex items-center justify-between gap-3 bg-[var(--surface)] px-3 py-3" key={check.id}>
-                <span className="text-sm text-[#c8d0d5]">{check.id}</span>
-                <Status value={check.status} label={check.required ? undefined : `${check.status === "ready" ? "就绪" : "离线"} · 可选`} />
-              </li>
-            ))}
-          </ul>
+        {literature ? (
+          <dl className="definition-grid mt-4">
+            <div className="definition-row"><dt>Local Deep Research</dt><dd><Status value={literature.serviceStatus} /></dd></div>
+            <div className="definition-row"><dt>模型桥</dt><dd><Status value={literature.modelBridgeStatus ?? "not_ready"} /></dd></div>
+            <div className="definition-row"><dt>账户会话</dt><dd><Status value={literature.sessionStatus === "ready" ? "ready" : "pending"} label={literature.sessionStatus === "ready" ? `已解锁 · ${literature.username ?? "本地账户"}` : "进入项目后解锁"} /></dd></div>
+            <div className="definition-row"><dt>研究配置</dt><dd>OpenAlex · langgraph-agent · 2 轮</dd></div>
+          </dl>
         ) : null}
       </section>
 
-      <section className="section" aria-labelledby="summary-title">
-        <h2 className="section-title" id="summary-title">运行摘要</h2>
-        {summary.data ? (
-          <dl className="mt-4 grid gap-px bg-[var(--border)] sm:grid-cols-4">
-            <div className="bg-[var(--surface)] p-4"><dt className="text-xs text-[var(--muted)]">全部</dt><dd className="mt-1 text-xl font-semibold">{summary.data.total}</dd></div>
-            <div className="bg-[var(--surface)] p-4"><dt className="text-xs text-[var(--muted)]">运行中</dt><dd className="mt-1 text-xl font-semibold">{summary.data.phases.running}</dd></div>
-            <div className="bg-[var(--surface)] p-4"><dt className="text-xs text-[var(--muted)]">成功</dt><dd className="mt-1 text-xl font-semibold">{summary.data.outcomes.success}</dd></div>
-            <div className="bg-[var(--surface)] p-4"><dt className="text-xs text-[var(--muted)]">证据待处理</dt><dd className="mt-1 text-xl font-semibold">{summary.data.evidenceStates.pending + summary.data.evidenceStates.failed}</dd></div>
-          </dl>
-        ) : summary.error ? <ErrorNotice message={summary.error.message} onRetry={summary.refresh} /> : <LoadingRows count={1} />}
+      <section className="section" aria-labelledby="journey-title">
+        <h2 className="section-title" id="journey-title">V0.1 科研主线</h2>
+        <ol className="journey-line">
+          <li><FolderPlus size={16} /><span><strong>定义项目</strong><small>AI / Agent 研究问题</small></span></li>
+          <li><BookOpen size={16} /><span><strong>运行文献研究</strong><small>公开学术来源与固定模型</small></span></li>
+          <li><Library size={16} /><span><strong>关联资料库</strong><small>Zotero 与本地索引门禁</small></span></li>
+          <li><ArrowRight size={16} /><span><strong>复核并导出</strong><small>综述、引用、来源和 manifest</small></span></li>
+        </ol>
       </section>
 
-      <section className="section" aria-labelledby="create-title">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <h2 className="section-title" id="create-title">创建工程夹具</h2>
-          {creationBlocked ? <span className="text-xs text-[var(--amber)]">必需依赖未就绪，当前禁止创建</span> : null}
-        </div>
-        <form className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end" onSubmit={submit}>
-          <label className="field-label">
-            夹具场景
-            <select className="field" value={caseId} onChange={(event) => { setCaseId(event.target.value as CaseId); idempotencyKey.current = null; }}>
-              {cases.map((item) => <option key={item.id} value={item.id}>{item.label} — {item.description}</option>)}
-            </select>
-          </label>
-          <button className="button button-primary" type="submit" disabled={submitting || creationBlocked}>
-            {submitting ? <RefreshCw aria-hidden="true" className="animate-spin" size={16} /> : <Play aria-hidden="true" size={16} />}
-            {submitting ? "正在创建" : "创建并查看"}
-          </button>
-        </form>
-        {createError ? <ErrorNotice message={createError} /> : null}
+      <section className="section" aria-labelledby="recent-projects-title">
+        <div className="flex items-center justify-between gap-3"><h2 className="section-title" id="recent-projects-title">最近项目</h2><Link className="inline-flex items-center gap-1 text-xs font-semibold text-[var(--cyan)] hover:underline" to="/projects">全部项目 <ArrowRight size={14} /></Link></div>
+        {projects.loading ? <LoadingRows count={4} /> : null}
+        {projects.error ? <ErrorNotice message={projects.error.message} onRetry={projects.refresh} /> : null}
+        {projects.data?.items.length === 0 ? <div className="empty-state"><p className="font-semibold text-white">还没有研究项目</p><p>创建一个明确的 AI/Agent 研究问题，项目创建本身不会调用模型。</p><Link className="button button-primary mt-3" to="/projects/new"><FolderPlus size={15} />创建第一个项目</Link></div> : null}
+        {projects.data?.items.length ? <ul className="project-list mt-4">{projects.data.items.map((project) => { const state = projectStatus(project.literaturePhase, project.literatureOutcome); return <li key={project.projectId}><Link className="project-row" to={`/projects/${project.projectId}`}><span className="min-w-0"><span className="block truncate font-semibold text-[#edf2f4]">{project.title}</span><span className="mt-1 block line-clamp-2 text-sm leading-6 text-[var(--muted)]">{project.researchQuestion}</span><span className="mt-2 block text-xs text-[#7f8a93]">更新于 {formatTime(project.updatedAt)}</span></span><span className="flex shrink-0 items-center gap-3"><Status value={state.value} label={state.label} /><ArrowRight size={16} /></span></Link></li>; })}</ul> : null}
       </section>
 
-      <section className="section" aria-labelledby="recent-title">
-        <div className="flex items-center justify-between gap-3">
-          <h2 className="section-title" id="recent-title">最近运行</h2>
-          <Link className="inline-flex items-center gap-1 text-xs font-semibold text-[var(--cyan)] hover:underline" to="/runs">全部运行 <ArrowRight aria-hidden="true" size={14} /></Link>
-        </div>
-        {recent.data ? <RunTable runs={recent.data.items} /> : recent.error ? <ErrorNotice message={recent.error.message} onRetry={recent.refresh} /> : <LoadingRows />}
+      <section className="section compact-callout" aria-labelledby="fixture-link-title">
+        <Wrench aria-hidden="true" size={18} />
+        <div><h2 className="section-title" id="fixture-link-title">工程夹具与证据框架</h2><p className="mt-1 text-sm text-[var(--muted)]">AR1 的 success、task_error、cancel 夹具仍可独立运行，不混入真实研究项目。</p></div>
+        <Link className="button" to="/runs">打开工程夹具 <ArrowRight size={14} /></Link>
       </section>
-      <p className="sr-only" aria-live="polite">{system.refreshing || recent.refreshing ? "状态正在更新" : "状态已更新"}</p>
+      <p className="sr-only" aria-live="polite">{system.refreshing || projects.refreshing ? "状态正在更新" : "状态已更新"}</p>
     </div>
   );
 }

--- a/extensions/ai-research/ui/src/pages/ProjectDetailPage.tsx
+++ b/extensions/ai-research/ui/src/pages/ProjectDetailPage.tsx
@@ -1,0 +1,125 @@
+import { BookOpen, ExternalLink, KeyRound, Library, LoaderCircle, RefreshCw, Square } from "lucide-react";
+import { FormEvent, useCallback, useRef, useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+
+import { ApiError, api } from "../api";
+import { ErrorNotice, LoadingRows, PageHeader } from "../components/Page";
+import { formatTime } from "../components/RunTable";
+import { Status } from "../components/Status";
+import { usePolling } from "../hooks/usePolling";
+
+const stageLabels: Record<string, string> = {
+  literature: "文献研究",
+  hypothesis_protocol: "假设与协议",
+  research_workspace: "研究工作区",
+  evaluation: "评测执行",
+  analysis_report: "分析与报告",
+};
+
+const literatureLabels: Record<string, string> = {
+  not_started: "尚未开始",
+  queued: "排队中",
+  running: "研究中",
+  terminal: "已终止",
+  completed: "综述已完成",
+  cancelled: "已取消",
+  failed: "研究失败",
+  infrastructure_error: "基础设施错误",
+};
+
+export function ProjectDetailPage() {
+  const { projectId = "" } = useParams();
+  const [searchParams] = useSearchParams();
+  const selectedCollection = (searchParams.get("collectionId") ?? "").trim().slice(0, 200) || undefined;
+  const project = usePolling(useCallback((signal: AbortSignal) => api.project(projectId, signal), [projectId]), 2_000, Boolean(projectId), (value) => ["queued", "running"].includes(value.literaturePhase));
+  const session = usePolling(useCallback((signal: AbortSignal) => api.literatureSession(signal), []), 10_000);
+  const system = usePolling(useCallback((signal: AbortSignal) => api.system(signal), []), 10_000);
+  const module = usePolling(useCallback((signal: AbortSignal) => api.module(signal), []), 60_000);
+  const [action, setAction] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmCancel, setConfirmCancel] = useState(false);
+  const runKey = useRef<string | null>(null);
+
+  const unlock = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formElement = event.currentTarget;
+    const form = new FormData(formElement);
+    setAction("unlock"); setError(null);
+    try {
+      await api.unlockLiterature(String(form.get("username") ?? ""), String(form.get("password") ?? ""));
+      formElement.reset(); session.refresh(); project.refresh();
+    } catch (caught) { setError(caught instanceof ApiError ? caught.message : "账户解锁失败。 "); }
+    finally { setAction(null); }
+  };
+  const run = async () => {
+    setAction("run"); setError(null); runKey.current ??= `literature:${crypto.randomUUID()}`;
+    try { await api.startLiterature(projectId, runKey.current, selectedCollection ?? project.data?.collectionId ?? undefined); runKey.current = null; project.refresh(); }
+    catch (caught) { setError(caught instanceof ApiError ? caught.message : "研究启动请求未完成。 "); }
+    finally { setAction(null); }
+  };
+  const cancel = async () => { setAction("cancel"); setError(null); try { await api.cancelLiterature(projectId); setConfirmCancel(false); project.refresh(); } catch (caught) { setError(caught instanceof ApiError ? caught.message : "取消请求未完成。 "); } finally { setAction(null); } };
+  const sync = async () => { setAction("sync"); setError(null); try { await api.syncLiterature(projectId); project.refresh(); } catch (caught) { setError(caught instanceof ApiError ? caught.message : "成果同步未完成。 "); } finally { setAction(null); } };
+
+  if (project.loading) return <div className="page"><LoadingRows count={6} /></div>;
+  if (project.error || !project.data) return <div className="page"><PageHeader eyebrow="Research Project" title="无法读取项目" description="项目不存在，或项目文件未通过完整性检查。" /><ErrorNotice message={project.error?.message ?? "项目不可用"} onRetry={project.refresh} /></div>;
+  const value = project.data;
+  const attempt = value.attempts.at(-1);
+  const active = value.literaturePhase === "queued" || value.literaturePhase === "running";
+  const completedAttempt = value.completedRunId
+    ? value.attempts.find((candidate) => candidate.runId === value.completedRunId)
+    : undefined;
+  const formallyCompleted = completedAttempt?.integrityStatus === "verified";
+  const canSyncArtifacts =
+    attempt?.rawStatus === "completed" &&
+    attempt.integrityStatus === "failed" &&
+    Boolean(attempt.ldrResearchId);
+  const literatureReady = system.data?.literatureCapability?.status === "ready";
+  const readinessMessage = system.loading
+    ? "正在检查固定模型执行资格。"
+    : system.error
+      ? "无法验证固定模型执行资格，已停止启动新研究。"
+      : !literatureReady
+        ? "固定模型执行资格未就绪，恢复 Provider 资格后再重试。"
+        : null;
+  const statusLabel = active
+    ? literatureLabels[value.literaturePhase]
+    : formallyCompleted
+      ? literatureLabels.completed
+      : attempt?.integrityStatus === "failed"
+        ? "成果不完整"
+        : literatureLabels[value.literatureOutcome ?? value.literaturePhase];
+
+  return (
+    <div className="page">
+      <PageHeader eyebrow="AI / Agent Research" title={value.title} description={value.researchQuestion} actions={<Status value={active ? "running" : formallyCompleted ? "success" : value.literatureOutcome ? "failed" : "pending"} label={statusLabel} />} />
+      <div className="notice" role="note">本轮复用 Local Deep Research 形成真实文献研究与来源包；结果需人工复核，不构成科研结论。</div>
+
+      <ol className="stage-track" aria-label="科研阶段">
+        {Object.entries(value.stages).map(([id, state], index) => <li className={state === "active" ? "stage-active" : "stage-disabled"} key={id}><span>{index + 1}</span><div><strong>{stageLabels[id] ?? id}</strong><small>{state === "active" ? "当前开放" : "后续轮次"}</small></div></li>)}
+      </ol>
+
+      <section className="section" aria-labelledby="literature-control-title">
+        <div className="flex flex-wrap items-center justify-between gap-3"><div><h2 className="section-title" id="literature-control-title">文献研究</h2><p className="mt-2 text-sm text-[var(--muted)]">固定模型、OpenAlex 主检索、2 轮研究，不向项目暴露调参。</p></div><div className="flex flex-wrap gap-2"><Link className="button" to={`/projects/${projectId}/sources`}><Library size={16} />来源与资料库</Link><Link className="button" to={`/projects/${projectId}/review`}><BookOpen size={16} />查看综述</Link></div></div>
+        {attempt ? <dl className="definition-grid mt-4"><div className="definition-row"><dt>上游状态</dt><dd>{attempt.rawStatus ?? "等待对账"}</dd></div><div className="definition-row"><dt>进度</dt><dd>{attempt.progress}%</dd></div><div className="definition-row"><dt>成果完整性</dt><dd>{attempt.integrityStatus}</dd></div><div className="definition-row"><dt>开始时间</dt><dd>{formatTime(attempt.startedAt ?? attempt.createdAt)}</dd></div></dl> : null}
+        {attempt?.latestLog ? <pre className="code-block mt-4">{JSON.stringify(attempt.latestLog, null, 2)}</pre> : null}
+        {attempt?.integrityStatus === "failed" ? (
+          <div className="mt-4">
+            <ErrorNotice message="上游研究已结束，但报告、来源或引用成果包未通过完整性校验。可先重新同步；如果仍失败，请在 Local Deep Research 检查本次导出。" />
+            {attempt.errorMessage ? <details className="mt-2 text-xs leading-5 text-[var(--muted)]"><summary className="cursor-pointer text-[#c7d1d6]">查看技术原因</summary><p className="mt-2 break-words">{attempt.errorMessage}</p></details> : null}
+          </div>
+        ) : null}
+        {error ? <ErrorNotice message={error} /> : null}
+        <div className="mt-4 flex flex-wrap gap-2">
+          {!active && !formallyCompleted && session.data?.status === "ready" ? <button className="button button-primary" type="button" disabled={Boolean(action) || !literatureReady} onClick={run}>{action === "run" ? <LoaderCircle className="animate-spin" size={16} /> : <BookOpen size={16} />}{action === "run" ? "正在启动" : attempt ? "重试文献研究" : "开始文献研究"}</button> : null}
+          {active && !confirmCancel ? <button className="button button-danger" type="button" disabled={Boolean(action)} onClick={() => setConfirmCancel(true)}><Square size={14} />请求取消</button> : null}
+          {canSyncArtifacts ? <button className="button" type="button" disabled={Boolean(action)} onClick={sync}><RefreshCw size={15} />重新同步成果</button> : null}
+        </div>
+        {!active && !formallyCompleted && session.data?.status === "ready" && readinessMessage ? <p className="mt-3 text-sm text-[var(--amber)]" role="status" aria-live="polite">{readinessMessage}</p> : null}
+        {(selectedCollection ?? value.collectionId) && !active && !formallyCompleted ? <p className="mt-3 text-sm text-[#a6d8c0]">下一次研究会将已通过门禁的集合 <code>{selectedCollection ?? value.collectionId}</code> 提供给研究 Agent；OpenAlex 仍为主检索。Control 会在启动前重新验证其索引、Agent 可用性和 egress 状态。</p> : null}
+        {active && confirmCancel ? <div className="confirmation-row" role="group" aria-label="确认取消文献研究"><p>取消会向 Local Deep Research 发送终止请求，并保留原始终态与取消事实。</p><div className="flex shrink-0 gap-2"><button className="button" type="button" onClick={() => setConfirmCancel(false)}>继续运行</button><button className="button button-danger" type="button" disabled={Boolean(action)} onClick={cancel}>{action === "cancel" ? "正在取消" : "确认取消"}</button></div></div> : null}
+      </section>
+
+      {session.data?.status !== "ready" ? <section className="section" aria-labelledby="unlock-title"><div className="flex flex-wrap items-start justify-between gap-3"><div><h2 className="section-title" id="unlock-title">解锁 Local Deep Research</h2><p className="mt-2 max-w-2xl text-sm leading-6 text-[var(--muted)]">密码和会话只保留在 Control 内存。Control 重启后需要重新解锁，项目与成果不会删除。</p></div>{module.data ? <a className="button" href={`${module.data.links.localDeepResearch}/auth/register`} target="_blank" rel="noopener noreferrer">注册或管理 LDR <ExternalLink size={14} /></a> : null}</div><form className="mt-4 grid gap-3 md:grid-cols-[1fr_1fr_auto] md:items-end" onSubmit={unlock}><label className="field-label">LDR 用户名<input className="field" name="username" required minLength={3} maxLength={64} autoComplete="username" /></label><label className="field-label">LDR 密码<input className="field" name="password" required type="password" autoComplete="current-password" /></label><button className="button button-primary" type="submit" disabled={Boolean(action)}><KeyRound size={16} />{action === "unlock" ? "正在解锁" : "解锁账户"}</button></form></section> : <p className="section flex items-center gap-2 text-sm text-[#a6d8c0]"><KeyRound size={15} />已解锁为 {session.data.username}，可启动或恢复研究。</p>}
+    </div>
+  );
+}

--- a/extensions/ai-research/ui/src/pages/ProjectNewPage.tsx
+++ b/extensions/ai-research/ui/src/pages/ProjectNewPage.tsx
@@ -1,0 +1,52 @@
+import { ArrowLeft, FolderPlus, LoaderCircle } from "lucide-react";
+import { FormEvent, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+import { ApiError, api } from "../api";
+import { ErrorNotice, PageHeader } from "../components/Page";
+
+export function ProjectNewPage() {
+  const navigate = useNavigate();
+  const idempotencyKey = useRef<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (submitting) return;
+    const form = new FormData(event.currentTarget);
+    const title = String(form.get("title") ?? "").trim();
+    const researchQuestion = String(form.get("researchQuestion") ?? "").trim();
+    setSubmitting(true);
+    setError(null);
+    idempotencyKey.current ??= `project:${crypto.randomUUID()}`;
+    try {
+      const project = await api.createProject(title, researchQuestion, idempotencyKey.current);
+      idempotencyKey.current = null;
+      navigate(`/projects/${project.projectId}`);
+    } catch (caught) {
+      setError(caught instanceof ApiError ? caught.message : "创建请求未完成，请使用当前表单重试。 ");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="page page-narrow">
+      <PageHeader eyebrow="New Research Project" title="创建研究项目" description="先定义一个明确的 AI/Agent 研究问题。本轮仅开放文献研究阶段，项目创建不会自动调用模型。" />
+      <form className="section grid gap-5" onSubmit={submit} onChange={() => { idempotencyKey.current = null; }}>
+        <label className="field-label">项目标题<input className="field" name="title" required maxLength={120} placeholder="例如：Agent 评测可复现性研究" /></label>
+        <label className="field-label">研究问题<textarea className="field min-h-44 resize-y" name="researchQuestion" required maxLength={5000} placeholder="明确对象、范围与希望从文献中回答的问题。" /></label>
+        <div className="constraint-panel">
+          <p className="font-semibold text-[#dbe4e7]">固定研究配置</p>
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-[var(--muted)]"><li>领域固定为 AI / Agent</li><li>主检索使用 OpenAlex，学术工具限 OpenAlex、arXiv、Semantic Scholar</li><li>结果保留上游原文，scientificClaim=none</li></ul>
+        </div>
+        {error ? <ErrorNotice message={error} /> : null}
+        <div className="flex flex-wrap justify-end gap-2 border-t border-[var(--border)] pt-4">
+          <Link className="button" to="/projects"><ArrowLeft size={16} />返回项目</Link>
+          <button className="button button-primary" type="submit" disabled={submitting}>{submitting ? <LoaderCircle className="animate-spin" size={16} /> : <FolderPlus size={16} />}{submitting ? "正在创建" : "创建项目"}</button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/extensions/ai-research/ui/src/pages/ProjectPages.test.tsx
+++ b/extensions/ai-research/ui/src/pages/ProjectPages.test.tsx
@@ -1,0 +1,182 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, expect, test, vi } from "vitest";
+
+import { App } from "../App";
+
+const projectId = "rp_0123456789abcdef0123456789abcdef";
+const project = {
+  schemaVersion: 1,
+  projectId,
+  title: "Agent 评测综述",
+  researchQuestion: "如何提高 Agent 评测的可复现性？",
+  domain: "ai_agent",
+  currentStage: "literature",
+  stages: { literature: "active", hypothesis_protocol: "not_available" },
+  literaturePhase: "terminal",
+  literatureOutcome: "completed",
+  activeRunId: null,
+  completedRunId: "lr_01",
+  collectionId: null,
+  profileId: "v0.1-literature-default",
+  modelId: "fixed-model",
+  attempts: [],
+  createdAt: "2026-08-25T00:00:00Z",
+  updatedAt: "2026-08-25T00:01:00Z",
+};
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+test("sources page separates cited sources from eligible local collections", async () => {
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const path = String(input);
+    let body: unknown = project;
+    if (path.endsWith("/sources")) body = { projectId, literatureRunId: "lr_01", integrityStatus: "verified", sources: [{ index: 1, title: "A reproducibility paper", url: "https://openalex.org/W1" }] };
+    else if (path.endsWith("/literature/session")) body = { status: "ready", username: "researcher" };
+    else if (path.endsWith("/library/collections")) body = { collections: [{ id: "collection-1", name: "Zotero Pilot", is_public: true, agent_enabled: true, document_count: 4, indexed_document_count: 4 }] };
+    else if (path.endsWith("/zotero/status")) body = { config: { configured: true, has_api_key: true }, status: { success: true } };
+    return new Response(JSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } });
+  }));
+
+  render(<MemoryRouter initialEntries={[`/projects/${projectId}/sources`]}><App /></MemoryRouter>);
+
+  const source = await screen.findByRole(
+    "link",
+    { name: /A reproducibility paper/ },
+    { timeout: 3_000 },
+  );
+  expect(source).toHaveAttribute("href", "https://openalex.org/W1");
+  expect(source).toHaveAttribute("rel", "noopener noreferrer");
+  expect(await screen.findByText("可用于综述")).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: "用于下一次研究" })).toHaveAttribute("href", `/projects/${projectId}?collectionId=collection-1`);
+});
+
+test("review renders verified markdown without raw images or non-HTTPS links", async () => {
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const path = String(input);
+    const body = path.endsWith("/review")
+      ? { projectId, literatureRunId: "lr_01", integrityStatus: "verified", markdown: "## 研究缺口\n[可信来源](https://example.org/paper) [不安全来源](http://127.0.0.1/private) ![远程像素](https://example.org/pixel.png)" }
+      : project;
+    return new Response(JSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } });
+  }));
+
+  const { container } = render(<MemoryRouter initialEntries={[`/projects/${projectId}/review`]}><App /></MemoryRouter>);
+
+  const safeLink = await screen.findByRole("link", { name: /可信来源/ });
+  expect(safeLink).toHaveAttribute("href", "https://example.org/paper");
+  expect(screen.queryByRole("link", { name: "不安全来源" })).not.toBeInTheDocument();
+  await waitFor(() => expect(container.querySelector(".markdown-body img")).toBeNull());
+  expect(screen.getByText(/上游报告包含研究缺口章节/)).toBeInTheDocument();
+  expect(screen.getAllByRole("link", { name: /Markdown 综述|Quarto 文稿|BibTeX 引用|RIS 引用|来源清单|完整性 manifest|研究 receipt|上游 Quarto ZIP/ })).toHaveLength(8);
+});
+
+test("project detail keeps an upstream completion retryable when artifacts failed integrity", async () => {
+  const failedProject = {
+    ...project,
+    completedRunId: null,
+    attempts: [{
+      runId: "lr_failed",
+      ldrResearchId: "ldr_failed",
+      phase: "terminal",
+      outcome: "completed",
+      rawStatus: "completed",
+      integrityStatus: "failed",
+      errorType: "artifact_sync_failed",
+      errorMessage: "LDR report did not provide sources",
+      createdAt: "2026-08-25T00:00:00Z",
+      startedAt: "2026-08-25T00:00:01Z",
+      progress: 100,
+      latestLog: null,
+    }],
+  };
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const path = String(input);
+    const body = path.endsWith("/literature/session")
+      ? { status: "ready", username: "researcher" }
+      : path.endsWith("/system")
+        ? { status: "ready", checks: [], checkedAt: "2026-08-25T00:00:00Z", literatureCapability: { status: "ready", serviceStatus: "ready", sessionStatus: "ready", profileStatus: "ready", modelBridgeStatus: "ready", username: "researcher", scientificClaim: "none" } }
+      : path.endsWith("/module")
+        ? { links: { localDeepResearch: "http://127.0.0.1:8792" } }
+        : failedProject;
+    return new Response(JSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } });
+  }));
+
+  render(<MemoryRouter initialEntries={[`/projects/${projectId}`]}><App /></MemoryRouter>);
+
+  expect(await screen.findByText("成果不完整")).toBeInTheDocument();
+  expect(screen.queryByText("综述已完成")).not.toBeInTheDocument();
+  expect(screen.getByText(/报告、来源或引用成果包未通过完整性校验/)).toBeInTheDocument();
+  expect(screen.getByText("查看技术原因")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "重试文献研究" })).toBeEnabled();
+  expect(screen.getByRole("button", { name: "重新同步成果" })).toBeEnabled();
+});
+
+test("project detail blocks retry when fixed model execution is not ready", async () => {
+  const failedProject = {
+    ...project,
+    completedRunId: null,
+    attempts: [{
+      runId: "lr_failed",
+      ldrResearchId: "ldr_failed",
+      phase: "terminal",
+      outcome: "completed",
+      rawStatus: "completed",
+      integrityStatus: "failed",
+      errorType: "artifact_sync_failed",
+      errorMessage: "citation package is incomplete",
+      createdAt: "2026-08-25T00:00:00Z",
+      progress: 100,
+      latestLog: null,
+    }],
+  };
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const path = String(input);
+    const body = path.endsWith("/literature/session")
+      ? { status: "ready", username: "researcher" }
+      : path.endsWith("/system")
+        ? { status: "ready", checks: [], checkedAt: "2026-08-25T00:00:00Z", literatureCapability: { status: "not_ready", serviceStatus: "ready", sessionStatus: "ready", profileStatus: "not_ready", modelBridgeStatus: "not_ready", username: "researcher", scientificClaim: "none" } }
+        : path.endsWith("/module")
+          ? { links: { localDeepResearch: "http://127.0.0.1:8792" } }
+          : failedProject;
+    return new Response(JSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } });
+  }));
+
+  render(<MemoryRouter initialEntries={[`/projects/${projectId}`]}><App /></MemoryRouter>);
+
+  expect(await screen.findByText(/固定模型执行资格未就绪/)).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "重试文献研究" })).toBeDisabled();
+  expect(screen.getByRole("button", { name: "重新同步成果" })).toBeEnabled();
+});
+
+test("project list reports integrity failure instead of a stale completed outcome", async () => {
+  const staleCompletedProject = {
+    ...project,
+    completedRunId: "lr_failed",
+    attempts: [{
+      runId: "lr_failed",
+      ldrResearchId: "ldr_failed",
+      phase: "terminal",
+      outcome: "completed",
+      rawStatus: "completed",
+      integrityStatus: "failed",
+      errorType: "artifact_sync_failed",
+      errorMessage: "citation package is incomplete",
+      createdAt: "2026-08-25T00:00:00Z",
+      progress: 100,
+      latestLog: null,
+    }],
+  };
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(
+    JSON.stringify({ items: [staleCompletedProject], nextCursor: null }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  )));
+
+  render(<MemoryRouter initialEntries={["/projects"]}><App /></MemoryRouter>);
+
+  expect(await screen.findByText("成果不完整")).toBeInTheDocument();
+  expect(screen.queryByText("completed")).not.toBeInTheDocument();
+  expect(screen.getByRole("option", { name: "综述已完成" })).toBeInTheDocument();
+});

--- a/extensions/ai-research/ui/src/pages/ProjectReviewPage.tsx
+++ b/extensions/ai-research/ui/src/pages/ProjectReviewPage.tsx
@@ -1,0 +1,92 @@
+import { ArrowLeft, Download, ExternalLink, FileArchive, ShieldCheck } from "lucide-react";
+import { useCallback } from "react";
+import ReactMarkdown from "react-markdown";
+import { Link, useParams } from "react-router-dom";
+import remarkGfm from "remark-gfm";
+
+import { api } from "../api";
+import { ErrorNotice, LoadingRows, PageHeader } from "../components/Page";
+import { Status } from "../components/Status";
+import { usePolling } from "../hooks/usePolling";
+
+const artifacts = [
+  ["literature-review.md", "Markdown 综述"],
+  ["literature-review.qmd", "Quarto 文稿"],
+  ["references.bib", "BibTeX 引用"],
+  ["references.ris", "RIS 引用"],
+  ["sources.json", "来源清单"],
+  ["artifact-manifest.json", "完整性 manifest"],
+  ["literature-receipt.json", "研究 receipt"],
+  ["upstream-quarto.zip", "上游 Quarto ZIP"],
+] as const;
+
+function safeHttps(value: string | undefined) {
+  if (!value) return undefined;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" ? parsed.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function ProjectReviewPage() {
+  const { projectId = "" } = useParams();
+  const project = usePolling(
+    useCallback((signal: AbortSignal) => api.project(projectId, signal), [projectId]),
+    10_000,
+    Boolean(projectId),
+  );
+  const hasResult = Boolean(project.data?.completedRunId);
+  const review = usePolling(
+    useCallback((signal: AbortSignal) => api.review(projectId, signal), [projectId]),
+    30_000,
+    hasResult,
+  );
+  const hasGapSection = /(^|\n)#{1,6}\s+.*(?:research\s+gaps?|研究缺口|研究空白)/im.test(review.data?.markdown ?? "");
+
+  if (project.loading) return <div className="page"><LoadingRows count={6} /></div>;
+  if (project.error || !project.data) return <div className="page"><PageHeader eyebrow="文献综述" title="无法读取项目" description="项目不存在，或项目文件未通过完整性检查。" /><ErrorNotice message={project.error?.message ?? "项目不可用"} onRetry={project.refresh} /></div>;
+
+  return (
+    <div className="page review-page">
+      <PageHeader
+        eyebrow="文献综述"
+        title={project.data.title}
+        description="原样呈现 Local Deep Research 的 Markdown 报告，并提供经过哈希验证的引用与导出包。"
+        actions={<Link className="button" to={`/projects/${projectId}`}><ArrowLeft size={15} />返回项目</Link>}
+      />
+      <div className="notice" role="note">该报告由上游研究流程生成，需人工核对来源与论证，不构成模镜的科研结论。</div>
+
+      <div className="review-split">
+        <article className="section review-document" aria-labelledby="review-document-title">
+          <div className="flex items-center justify-between gap-3"><h2 className="section-title" id="review-document-title">综述正文</h2>{review.data ? <Status value={review.data.integrityStatus} /> : null}</div>
+          {!hasResult ? <div className="empty-state"><p className="font-semibold text-white">尚无正式综述</p><p>完成并同步一次文献研究后，报告将在这里显示。</p></div> : null}
+          {hasResult && review.loading ? <LoadingRows count={8} /> : null}
+          {review.error ? <ErrorNotice message={review.error.message} onRetry={review.refresh} /> : null}
+          {review.data ? (
+            <div className="markdown-body">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                urlTransform={(url) => safeHttps(url) ?? ""}
+                components={{
+                  a: ({ href, children }) => {
+                    const safe = safeHttps(href);
+                    return safe ? <a href={safe} target="_blank" rel="noopener noreferrer">{children}<ExternalLink aria-hidden="true" size={12} /></a> : <span>{children}</span>;
+                  },
+                  img: () => null,
+                }}
+              >{review.data.markdown}</ReactMarkdown>
+            </div>
+          ) : null}
+        </article>
+
+        <aside className="section review-assets" aria-labelledby="artifact-package-title">
+          <div className="flex items-start justify-between gap-3"><div><h2 className="section-title" id="artifact-package-title">成果包</h2><p className="mt-2 text-sm leading-6 text-[var(--muted)]">下载前由 Control 再次核验文件名、路径、大小与 SHA-256。</p></div><FileArchive aria-hidden="true" className="text-[var(--cyan)]" size={19} /></div>
+          {review.data ? <ul className="artifact-list">{artifacts.map(([name, label]) => <li key={name}><a href={`/api/v1/projects/${encodeURIComponent(projectId)}/artifacts/${encodeURIComponent(name)}`} download><span><strong>{label}</strong><small>{name}</small></span><Download aria-hidden="true" size={15} /></a></li>)}</ul> : <p className="mt-4 text-sm text-[var(--muted)]">成果同步完成后开放下载。</p>}
+          <div className="constraint-panel mt-5"><p className="flex items-center gap-2 font-semibold text-[#dbe4e7]"><ShieldCheck size={15} />研究缺口</p><p className="mt-2 text-sm leading-6 text-[var(--muted)]">{hasGapSection ? "上游报告包含研究缺口章节，请结合来源人工复核。" : "上游报告未提供独立研究缺口章节；模镜不会自行补写。下一次可在研究问题中明确要求分析研究缺口。"}</p></div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/extensions/ai-research/ui/src/pages/ProjectSourcesPage.tsx
+++ b/extensions/ai-research/ui/src/pages/ProjectSourcesPage.tsx
@@ -1,0 +1,140 @@
+import { ArrowLeft, Database, ExternalLink, Library, RefreshCw, SearchCheck } from "lucide-react";
+import { useCallback, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { ApiError, api } from "../api";
+import { ErrorNotice, LoadingRows, PageHeader } from "../components/Page";
+import { Status } from "../components/Status";
+import { usePolling } from "../hooks/usePolling";
+import type { LibraryCollection } from "../types";
+
+function collectionName(collection: LibraryCollection) {
+  return collection.name?.trim() || `集合 ${collection.id}`;
+}
+
+function isEligible(collection: LibraryCollection) {
+  const indexed = (collection.indexed_document_count ?? 0) > 0;
+  return indexed && collection.is_public === true && collection.agent_enabled === true;
+}
+
+export function ProjectSourcesPage() {
+  const { projectId = "" } = useParams();
+  const [action, setAction] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const project = usePolling(
+    useCallback((signal: AbortSignal) => api.project(projectId, signal), [projectId]),
+    5_000,
+    Boolean(projectId),
+  );
+  const session = usePolling(useCallback((signal: AbortSignal) => api.literatureSession(signal), []), 10_000);
+  const unlocked = session.data?.status === "ready";
+  const hasResult = Boolean(project.data?.completedRunId);
+  const sources = usePolling(
+    useCallback((signal: AbortSignal) => api.sources(projectId, signal), [projectId]),
+    10_000,
+    hasResult,
+  );
+  const collections = usePolling(
+    useCallback((signal: AbortSignal) => api.collections(signal), []),
+    10_000,
+    unlocked,
+  );
+  const zotero = usePolling(
+    useCallback((signal: AbortSignal) => api.zoteroStatus(signal), []),
+    10_000,
+    unlocked,
+  );
+
+  const runAction = async (id: string, work: () => Promise<unknown>) => {
+    setAction(id);
+    setActionError(null);
+    try {
+      await work();
+      collections.refresh();
+      zotero.refresh();
+    } catch (caught) {
+      setActionError(caught instanceof ApiError ? caught.message : "资料库操作未完成。");
+    } finally {
+      setAction(null);
+    }
+  };
+
+  if (project.loading) return <div className="page"><LoadingRows count={6} /></div>;
+  if (project.error || !project.data) return <div className="page"><PageHeader eyebrow="来源与资料库" title="无法读取项目" description="项目不存在，或项目文件未通过完整性检查。" /><ErrorNotice message={project.error?.message ?? "项目不可用"} onRetry={project.refresh} /></div>;
+
+  return (
+    <div className="page">
+      <PageHeader
+        eyebrow="来源与资料库"
+        title={project.data.title}
+        description="左侧复核本次研究实际引用的公开来源；右侧管理 LDR Library 与 Zotero，同步和索引都由上游能力完成。"
+        actions={<Link className="button" to={`/projects/${projectId}`}><ArrowLeft size={15} />返回项目</Link>}
+      />
+      <div className="notice" role="note">集合只有在已建立索引、标记为公开且允许 Agent 使用时，才可主动选入下一次综述。模镜不会改变集合隐私设置。</div>
+
+      <div className="research-split">
+        <section className="section research-pane" aria-labelledby="source-list-title">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="section-title" id="source-list-title">本次研究来源</h2>
+            {sources.data ? <Status value={sources.data.integrityStatus} /> : null}
+          </div>
+          {!hasResult ? <div className="empty-state"><p className="font-semibold text-white">尚无正式来源包</p><p>完成一次文献研究后，来源将在这里按上游顺序展示。</p></div> : null}
+          {hasResult && sources.loading ? <LoadingRows count={5} /> : null}
+          {sources.error ? <ErrorNotice message={sources.error.message} onRetry={sources.refresh} /> : null}
+          {sources.data?.sources.length === 0 ? <div className="empty-state"><p className="font-semibold text-white">成果包没有来源</p><p>该结果不能作为完整文献成果使用，请返回项目检查同步错误。</p></div> : null}
+          {sources.data?.sources.length ? (
+            <ol className="source-list">
+              {sources.data.sources.map((source, index) => (
+                <li key={`${source.url}:${index}`}>
+                  <span className="source-index">{source.index ?? index + 1}</span>
+                  <a href={source.url} target="_blank" rel="noopener noreferrer">
+                    <strong>{source.title || "未命名来源"}</strong>
+                    <span>{source.url}</span>
+                    <ExternalLink aria-hidden="true" size={14} />
+                  </a>
+                </li>
+              ))}
+            </ol>
+          ) : null}
+        </section>
+
+        <aside className="section research-pane" aria-labelledby="library-title">
+          <div className="flex items-start justify-between gap-3">
+            <div><h2 className="section-title" id="library-title">LDR Library</h2><p className="mt-2 text-sm leading-6 text-[var(--muted)]">Zotero 密钥只在 LDR 中配置，Research Console 只读取非敏感状态。</p></div>
+            <Library aria-hidden="true" className="text-[var(--cyan)]" size={19} />
+          </div>
+          {!unlocked ? <div className="empty-state"><p className="font-semibold text-white">需要先解锁 LDR</p><p>返回项目输入本地 LDR 账户，之后才能读取集合和 Zotero 状态。</p><Link className="button mt-3" to={`/projects/${projectId}`}>返回解锁</Link></div> : null}
+          {unlocked && zotero.loading ? <LoadingRows count={1} /> : null}
+          {zotero.error ? <ErrorNotice message={zotero.error.message} onRetry={zotero.refresh} /> : null}
+          {zotero.data ? (
+            <div className="library-status">
+              <div><Database size={15} /><span>Zotero</span><Status value={zotero.data.config.configured || zotero.data.config.has_api_key ? "ready" : "not_ready"} label={zotero.data.config.configured || zotero.data.config.has_api_key ? "已配置" : "未配置"} /></div>
+              <button className="button" type="button" disabled={Boolean(action)} onClick={() => runAction("zotero", () => api.syncZotero())}><RefreshCw className={action === "zotero" ? "animate-spin" : ""} size={14} />同步 Zotero</button>
+            </div>
+          ) : null}
+          {actionError ? <ErrorNotice message={actionError} /> : null}
+          {unlocked && collections.loading ? <LoadingRows count={4} /> : null}
+          {collections.error ? <ErrorNotice message={collections.error.message} onRetry={collections.refresh} /> : null}
+          {collections.data?.collections.length === 0 ? <div className="empty-state"><p className="font-semibold text-white">资料库暂无集合</p><p>请在 LDR 中同步 Zotero 或创建集合。</p></div> : null}
+          {collections.data?.collections.length ? (
+            <ul className="collection-list">
+              {collections.data.collections.map((collection) => {
+                const eligible = isEligible(collection);
+                const selected = project.data?.collectionId === collection.id;
+                return (
+                  <li key={collection.id}>
+                    <div className="flex items-start justify-between gap-3"><div className="min-w-0"><strong>{collectionName(collection)}</strong><p>{collection.indexed_document_count ?? 0} / {collection.document_count ?? 0} 篇已索引</p></div><Status value={eligible ? "ready" : "pending"} label={eligible ? "可用于综述" : "未通过使用门禁"} /></div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <button className="button" type="button" disabled={Boolean(action)} onClick={() => runAction(`index:${collection.id}`, () => api.indexCollection(collection.id))}><SearchCheck size={14} />{action === `index:${collection.id}` ? "正在索引" : "建立索引"}</button>
+                      {eligible ? <Link className={`button ${selected ? "button-primary" : ""}`} to={`/projects/${projectId}?collectionId=${encodeURIComponent(collection.id)}`}>{selected ? "当前项目集合" : "用于下一次研究"}</Link> : null}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/extensions/ai-research/ui/src/pages/ProjectsPage.tsx
+++ b/extensions/ai-research/ui/src/pages/ProjectsPage.tsx
@@ -1,0 +1,147 @@
+import { ArrowRight, FolderPlus, Search } from "lucide-react";
+import { FormEvent, useCallback, useMemo } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+
+import { api } from "../api";
+import { ErrorNotice, LoadingRows, PageHeader } from "../components/Page";
+import { formatTime } from "../components/RunTable";
+import { Status } from "../components/Status";
+import { usePolling } from "../hooks/usePolling";
+import type { LiteratureOutcome, LiteraturePhase, ResearchProject } from "../types";
+
+const phases: LiteraturePhase[] = ["not_started", "queued", "running", "terminal"];
+const outcomes: LiteratureOutcome[] = ["completed", "cancelled", "failed", "infrastructure_error"];
+
+function phaseLabel(value: LiteraturePhase) {
+  return { not_started: "未开始", queued: "排队中", running: "研究中", terminal: "已终止" }[value];
+}
+
+function outcomeLabel(value: LiteratureOutcome) {
+  return {
+    completed: "综述已完成",
+    cancelled: "已取消",
+    failed: "需要处理",
+    infrastructure_error: "系统异常",
+  }[value];
+}
+
+function projectStatus(project: ResearchProject) {
+  if (project.literaturePhase === "running" || project.literaturePhase === "queued") {
+    return { value: "running" as const, label: phaseLabel(project.literaturePhase) };
+  }
+  const completedAttempt = project.completedRunId
+    ? project.attempts.find((attempt) => attempt.runId === project.completedRunId)
+    : undefined;
+  if (completedAttempt?.integrityStatus === "verified") {
+    return { value: "success" as const, label: "综述已完成" };
+  }
+  const latestAttempt = project.attempts.at(-1);
+  if (latestAttempt?.integrityStatus === "failed") {
+    return { value: "failed" as const, label: "成果不完整" };
+  }
+  if (project.literatureOutcome === "cancelled") {
+    return { value: "cancelled" as const, label: "已取消" };
+  }
+  if (project.literatureOutcome) {
+    return { value: "failed" as const, label: outcomeLabel(project.literatureOutcome) };
+  }
+  return { value: "pending" as const, label: phaseLabel(project.literaturePhase) };
+}
+
+export function ProjectsPage() {
+  const [params, setParams] = useSearchParams();
+  const query = (params.get("q") ?? "").slice(0, 100);
+  const phase = phases.includes(params.get("literaturePhase") as LiteraturePhase)
+    ? (params.get("literaturePhase") as LiteraturePhase)
+    : "";
+  const outcome = outcomes.includes(params.get("literatureOutcome") as LiteratureOutcome)
+    ? (params.get("literatureOutcome") as LiteratureOutcome)
+    : "";
+  const requestParams = useMemo(() => {
+    const value = new URLSearchParams({ limit: "50" });
+    if (query) value.set("q", query);
+    if (phase) value.set("literaturePhase", phase);
+    if (outcome) value.set("literatureOutcome", outcome);
+    return value;
+  }, [outcome, phase, query]);
+  const projects = usePolling(
+    useCallback((signal: AbortSignal) => api.projects(requestParams, signal), [requestParams]),
+    5_000,
+  );
+
+  const update = (name: string, value: string) => {
+    const next = new URLSearchParams(params);
+    if (value) next.set(name, value);
+    else next.delete(name);
+    next.delete("cursor");
+    setParams(next, { replace: true });
+  };
+  const search = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    update("q", String(data.get("q") ?? "").slice(0, 100).trim());
+  };
+
+  return (
+    <div className="page">
+      <PageHeader
+        eyebrow="Research Projects"
+        title="研究项目"
+        description="每个项目保存研究问题、文献运行、来源和完整性状态，关闭页面或重启 Control 后仍可恢复。"
+        actions={<Link className="button button-primary" to="/projects/new"><FolderPlus size={16} />创建项目</Link>}
+      />
+      <div className="notice" role="note">本轮复用 Local Deep Research 形成真实文献研究与来源包；结果需人工复核，不构成科研结论。</div>
+
+      <section className="section" aria-labelledby="project-filter-title">
+        <h2 className="section-title" id="project-filter-title">筛选项目</h2>
+        <div className="mt-4 grid gap-3 md:grid-cols-[minmax(220px,1fr)_180px_210px]">
+          <form className="flex gap-2" onSubmit={search}>
+            <label className="sr-only" htmlFor="project-search">搜索项目</label>
+            <input className="field" id="project-search" name="q" maxLength={100} defaultValue={query} placeholder="标题、问题或项目 ID" />
+            <button className="button" type="submit" aria-label="搜索项目"><Search size={16} /></button>
+          </form>
+          <select className="field" aria-label="文献阶段" value={phase} onChange={(event) => update("literaturePhase", event.target.value)}>
+            <option value="">全部阶段</option>
+            {phases.map((item) => <option key={item} value={item}>{phaseLabel(item)}</option>)}
+          </select>
+          <select className="field" aria-label="文献结果" value={outcome} onChange={(event) => update("literatureOutcome", event.target.value)}>
+            <option value="">全部结果</option>
+            {outcomes.map((item) => <option key={item} value={item}>{outcomeLabel(item)}</option>)}
+          </select>
+        </div>
+      </section>
+
+      <section className="section" aria-labelledby="project-list-title">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="section-title" id="project-list-title">项目列表</h2>
+          <span className="text-xs text-[var(--muted)]" aria-live="polite">{projects.data ? `${projects.data.items.length} 个结果` : "正在读取"}</span>
+        </div>
+        {projects.loading ? <LoadingRows count={4} /> : null}
+        {projects.error ? <ErrorNotice message={projects.error.message} onRetry={projects.refresh} /> : null}
+        {projects.data?.items.length === 0 ? (
+          <div className="empty-state"><p className="font-semibold text-white">没有匹配的研究项目</p><p>调整筛选，或创建一个 AI/Agent 研究问题。</p></div>
+        ) : null}
+        {projects.data?.items.length ? (
+          <ul className="project-list mt-4">
+            {projects.data.items.map((project) => {
+              const status = projectStatus(project);
+              return <li key={project.projectId}>
+                <Link className="project-row" to={`/projects/${project.projectId}`}>
+                  <span className="min-w-0">
+                    <span className="block truncate font-semibold text-[#edf2f4]">{project.title}</span>
+                    <span className="mt-1 block line-clamp-2 text-sm leading-6 text-[var(--muted)]">{project.researchQuestion}</span>
+                    <span className="mt-2 block text-xs text-[#7f8a93]">更新于 {formatTime(project.updatedAt)}</span>
+                  </span>
+                  <span className="flex shrink-0 items-center gap-3">
+                    <Status value={status.value} label={status.label} />
+                    <ArrowRight aria-hidden="true" size={16} />
+                  </span>
+                </Link>
+              </li>;
+            })}
+          </ul>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/extensions/ai-research/ui/src/pages/RunsPage.tsx
+++ b/extensions/ai-research/ui/src/pages/RunsPage.tsx
@@ -1,10 +1,11 @@
-import { RotateCcw, Search } from "lucide-react";
-import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { Play, RotateCcw, Search } from "lucide-react";
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { api } from "../api";
-import { ErrorNotice, LoadingRows, PageHeader } from "../components/Page";
+import { ErrorNotice, FixtureNotice, LoadingRows, PageHeader } from "../components/Page";
 import { RunTable } from "../components/RunTable";
+import { Status } from "../components/Status";
 import { usePolling } from "../hooks/usePolling";
 import type { CaseId, EvidenceState, Outcome, Phase } from "../types";
 
@@ -13,6 +14,11 @@ const cases = new Set<CaseId>(["success", "task_error", "long_running_cancel"]);
 const phases = new Set<Phase>(["queued", "running", "terminal"]);
 const outcomes = new Set<Outcome>(["success", "task_error", "cancelled", "infrastructure_error"]);
 const evidence = new Set<EvidenceState>(["pending", "synced", "failed"]);
+const fixtureCases: { id: CaseId; label: string }[] = [
+  { id: "success", label: "成功执行" },
+  { id: "task_error", label: "任务错误" },
+  { id: "long_running_cancel", label: "长运行取消" },
+];
 
 function legal<T extends string>(value: string | null, values: Set<T>): T | "" {
   return value && values.has(value as T) ? (value as T) : "";
@@ -21,6 +27,11 @@ function legal<T extends string>(value: string | null, values: Set<T>): T | "" {
 export function RunsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  const [createCase, setCreateCase] = useState<CaseId>("success");
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const createKey = useRef<string | null>(null);
+  const system = usePolling(useCallback((signal: AbortSignal) => api.system(signal), []), 10_000);
   const q = (searchParams.get("q") ?? "").slice(0, 100);
   const [draft, setDraft] = useState(q);
   useEffect(() => setDraft(q), [q]);
@@ -63,9 +74,35 @@ export function RunsPage() {
     setSearchParams(next);
   };
 
+  const createFixture = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (creating || system.data?.status === "not_ready") return;
+    setCreating(true);
+    setCreateError(null);
+    createKey.current ??= `console:${crypto.randomUUID()}`;
+    try {
+      const created = await api.createRun(createCase, createKey.current);
+      createKey.current = null;
+      navigate(`/runs/${created.runId}`);
+    } catch (caught) {
+      setCreateError(caught instanceof Error ? caught.message : "创建请求未完成，请使用当前场景重试。");
+    } finally {
+      setCreating(false);
+    }
+  };
+
   return (
     <div className="page">
       <PageHeader eyebrow="Runs" title="运行记录" description="按夹具、生命周期、结果和证据状态组合筛选；所有筛选轴按 AND 生效。" />
+      <FixtureNotice />
+      <section className="section" aria-labelledby="create-fixture-title">
+        <div className="flex flex-wrap items-center justify-between gap-3"><div><h2 className="section-title" id="create-fixture-title">创建工程夹具</h2><p className="mt-2 text-sm text-[var(--muted)]">仅验证 Inspect 执行、取消与证据链，不调用模型。</p></div>{system.data ? <Status value={system.data.status} /> : null}</div>
+        <form className="mt-4 flex flex-wrap items-end gap-3" onSubmit={createFixture}>
+          <label className="field-label min-w-[240px] flex-1">夹具场景<select className="field" value={createCase} onChange={(event) => { setCreateCase(event.target.value as CaseId); createKey.current = null; }}>{fixtureCases.map((item) => <option key={item.id} value={item.id}>{item.label} · {item.id}</option>)}</select></label>
+          <button className="button button-primary" type="submit" disabled={creating || !system.data || system.data.status === "not_ready"}><Play size={15} />{creating ? "正在创建" : "创建并查看"}</button>
+        </form>
+        {createError ? <ErrorNotice message={createError} /> : null}
+      </section>
       <section className="section" aria-label="运行筛选">
         <form className="grid gap-3 lg:grid-cols-[minmax(180px,1.5fr)_repeat(4,minmax(130px,1fr))_auto] lg:items-end" onSubmit={submitSearch}>
           <label className="field-label">搜索

--- a/extensions/ai-research/ui/src/pages/SystemPage.tsx
+++ b/extensions/ai-research/ui/src/pages/SystemPage.tsx
@@ -17,18 +17,27 @@ const names: Record<string, string> = {
 export function SystemPage() {
   const system = usePolling(useCallback((signal: AbortSignal) => api.system(signal), []), 10_000);
   const module = usePolling(useCallback((signal: AbortSignal) => api.module(signal), []), 60_000);
+  const fixtureClaim = module.data?.capabilityClaims.fixtureExecution;
+  const literatureClaim = module.data?.capabilityClaims.literatureResearch;
   return (
     <div className="page">
-      <PageHeader eyebrow="System" title="系统与运行时" description="区分必需依赖和可选只读视图；可选服务离线只会降级，不阻止创建夹具。" actions={<button className="button" type="button" onClick={() => { system.refresh(); module.refresh(); }}><RefreshCw aria-hidden="true" size={14} />刷新</button>} />
+      <PageHeader eyebrow="系统" title="能力与运行时" description="夹具执行和真实文献研究使用独立门禁；LDR 锁定不会破坏 AR1 历史与证据浏览。" actions={<button className="button" type="button" onClick={() => { system.refresh(); module.refresh(); }}><RefreshCw aria-hidden="true" size={14} />刷新</button>} />
       <FixtureNotice />
       <section className="section" aria-labelledby="health-title">
-        <div className="flex items-center justify-between gap-3"><h2 className="section-title" id="health-title">依赖检查</h2><Status value={system.data?.status ?? "not_ready"} /></div>
+        <div className="flex items-center justify-between gap-3"><div><h2 className="section-title" id="health-title">工程夹具能力</h2><p className="mt-2 text-sm text-[var(--muted)]">Control Ledger、Worker 与 Tracking 共同决定创建门禁。</p></div><Status value={system.data?.status ?? "not_ready"} /></div>
         {system.data ? (
           <ul className="mt-4 divide-y divide-[var(--border)] border-y border-[var(--border)]">
             {system.data.checks.map((check) => <li className="flex items-center justify-between gap-3 py-3" key={check.id}><div><p className="text-sm font-semibold text-[#dde4e8]">{names[check.id] ?? check.id}</p><p className="mt-1 text-xs text-[var(--muted)]">{check.required ? "必需 · 影响创建门禁" : "可选 · 离线仅降级"}</p></div><Status value={check.status} /></li>)}
           </ul>
         ) : system.error ? <ErrorNotice message={system.error.message} onRetry={system.refresh} /> : <LoadingRows count={4} />}
         {system.data ? <p className="mt-3 text-xs text-[var(--muted)]">检查时间 {formatTime(system.data.checkedAt)}</p> : null}
+        {fixtureClaim ? <dl className="definition-grid mt-3"><div className="definition-row"><dt>夹具声明等级</dt><dd>{fixtureClaim.claimLevel}</dd></div><div className="definition-row"><dt>内容状态</dt><dd>{fixtureClaim.packStatus}</dd></div></dl> : null}
+      </section>
+
+      <section className="section" aria-labelledby="literature-health-title">
+        <div className="flex items-center justify-between gap-3"><div><h2 className="section-title" id="literature-health-title">文献研究能力</h2><p className="mt-2 text-sm text-[var(--muted)]">Local Deep Research、固定 profile、受限模型桥与内存会话。</p></div><Status value={system.data?.literatureCapability?.status ?? "not_ready"} /></div>
+        {system.data?.literatureCapability ? <dl className="definition-grid mt-3"><div className="definition-row"><dt>LDR 服务</dt><dd><Status value={system.data.literatureCapability.serviceStatus} /></dd></div><div className="definition-row"><dt>固定 profile</dt><dd><Status value={system.data.literatureCapability.profileStatus} /></dd></div><div className="definition-row"><dt>模型桥</dt><dd><Status value={system.data.literatureCapability.modelBridgeStatus ?? "not_ready"} /></dd></div><div className="definition-row"><dt>账户会话</dt><dd><Status value={system.data.literatureCapability.sessionStatus === "ready" ? "ready" : "pending"} label={system.data.literatureCapability.sessionStatus === "ready" ? `已解锁 · ${system.data.literatureCapability.username ?? "本地账户"}` : system.data.literatureCapability.sessionStatus} /></dd></div><div className="definition-row"><dt>工作流来源</dt><dd>{literatureClaim?.workflowSource === "local_deep_research" ? "Local Deep Research" : "待确认"}</dd></div><div className="definition-row"><dt>科学声明</dt><dd>{system.data.literatureCapability.scientificClaim}，结果需人工复核</dd></div></dl> : <p className="mt-4 text-sm text-[var(--muted)]">当前 Control 尚未返回 V0.1 文献能力状态。</p>}
+        {literatureClaim ? <div className="constraint-panel mt-4 flex flex-wrap items-center gap-3"><Status value="pending" label="功能已实现，真实环境验收待完成" /><p className="m-0 text-xs leading-5 text-[var(--muted)]">该状态描述产品验收进度，不代表科学有效性验证。</p></div> : null}
       </section>
 
       <section className="section" aria-labelledby="runtime-title">
@@ -38,7 +47,7 @@ export function SystemPage() {
 
       <section className="section" aria-labelledby="boundary-title">
         <h2 className="section-title" id="boundary-title">模块边界</h2>
-        {module.data ? <><dl className="definition-grid mt-3"><div className="definition-row"><dt>模块版本</dt><dd>{module.data.moduleVersion}</dd></div><div className="definition-row"><dt>控制协议</dt><dd>{module.data.apiVersion}</dd></div><div className="definition-row"><dt>Worker 协议</dt><dd>{module.data.workerProtocolVersion}</dd></div><div className="definition-row"><dt>声明级别</dt><dd>{module.data.claimLevel} · {module.data.packStatus}</dd></div></dl><ul className="mt-4 list-inside list-disc space-y-2 text-sm text-[var(--muted)]">{module.data.limitations.map((item) => <li key={item}>{item}</li>)}</ul><p className="mt-4 border-l-2 border-[#826b36] pl-3 text-xs leading-5 text-[#c8b98f]">MLflow 是本机上游开发界面，可修改其自身记录；Control Ledger 与 canonical receipt 才是本模块的权威事实。</p><div className="mt-4 flex flex-wrap gap-2"><a className="button" href={module.data.links.inspectView} target="_blank" rel="noopener noreferrer">Inspect View <ExternalLink aria-hidden="true" size={14} /></a><a className="button" href={module.data.links.mlflow} target="_blank" rel="noopener noreferrer">打开 MLflow 开发界面 <ExternalLink aria-hidden="true" size={14} /></a></div></> : null}
+        {module.data ? <><dl className="definition-grid mt-3"><div className="definition-row"><dt>模块版本</dt><dd>{module.data.moduleVersion}</dd></div><div className="definition-row"><dt>控制协议</dt><dd>{module.data.apiVersion}</dd></div><div className="definition-row"><dt>Worker 协议</dt><dd>{module.data.workerProtocolVersion}</dd></div></dl><ul className="mt-4 list-inside list-disc space-y-2 text-sm text-[var(--muted)]">{module.data.limitations.map((item) => <li key={item}>{item}</li>)}</ul><p className="constraint-panel mt-4 text-xs leading-5 text-[#c8b98f]">MLflow 是本机上游开发界面，可修改其自身记录；Control Ledger 与 canonical receipt 才是夹具能力的权威事实。文献成果另以项目目录中的 manifest 和 receipt 为准。</p><div className="mt-4 flex flex-wrap gap-2"><a className="button" href={module.data.links.localDeepResearch} target="_blank" rel="noopener noreferrer">Local Deep Research <ExternalLink aria-hidden="true" size={14} /></a><a className="button" href={module.data.links.inspectView} target="_blank" rel="noopener noreferrer">Inspect View <ExternalLink aria-hidden="true" size={14} /></a><a className="button" href={module.data.links.mlflow} target="_blank" rel="noopener noreferrer">打开 MLflow 开发界面 <ExternalLink aria-hidden="true" size={14} /></a></div></> : null}
       </section>
     </div>
   );

--- a/extensions/ai-research/ui/src/styles.css
+++ b/extensions/ai-research/ui/src/styles.css
@@ -35,9 +35,7 @@ body {
   min-width: 320px;
   min-height: 100vh;
   margin: 0;
-  background:
-    radial-gradient(circle at 80% -20%, rgb(34 89 91 / 18%), transparent 34rem),
-    #090b0e;
+  background: #090b0e;
 }
 
 button,
@@ -46,10 +44,18 @@ select {
   font: inherit;
 }
 
+textarea {
+  font: inherit;
+}
+
 button,
 a,
 input,
 select {
+  outline: none;
+}
+
+textarea {
   outline: none;
 }
 
@@ -89,18 +95,21 @@ a {
   padding: 32px clamp(20px, 4vw, 56px) 64px;
 }
 
+.page-narrow {
+  width: min(900px, 100%);
+}
+
 .eyebrow {
   color: var(--cyan);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  font-size: 0.78rem;
+  font-weight: 650;
+  letter-spacing: 0.01em;
 }
 
 .page-title {
   margin: 7px 0 8px;
   color: #f7f9fa;
-  font-size: clamp(1.55rem, 3vw, 2.15rem);
+  font-size: 2rem;
   font-weight: 650;
   letter-spacing: -0.035em;
 }
@@ -199,7 +208,8 @@ a {
   align-items: flex-start;
   gap: 10px;
   margin-top: 20px;
-  border-left: 2px solid var(--cyan);
+  border: 1px solid #275153;
+  border-radius: 6px;
   padding: 11px 14px;
   color: #c7d1d6;
   background: rgb(20 52 53 / 38%);
@@ -224,8 +234,7 @@ a {
   color: #8e99a3;
   font-size: 0.72rem;
   font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .data-table tbody tr:hover {
@@ -279,15 +288,343 @@ a {
 .skeleton {
   height: 42px;
   border-radius: 4px;
-  background: linear-gradient(90deg, #11161a 25%, #1a2025 50%, #11161a 75%);
-  background-size: 200% 100%;
-  animation: loading 1.4s infinite linear;
+  background: #192026;
+  animation: loading 1.2s infinite ease-in-out alternate;
 }
 
 @keyframes loading {
   to {
-    background-position-x: -200%;
+    opacity: 0.48;
   }
+}
+
+.empty-state {
+  margin-top: 16px;
+  border: 1px dashed var(--border-strong);
+  padding: 22px;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.65;
+  text-align: center;
+}
+
+.project-list,
+.source-list,
+.collection-list,
+.artifact-list {
+  margin-bottom: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.project-list > li,
+.collection-list > li,
+.artifact-list > li {
+  border-bottom: 1px solid var(--border);
+}
+
+.project-list > li:first-child,
+.collection-list > li:first-child,
+.artifact-list > li:first-child {
+  border-top: 1px solid var(--border);
+}
+
+.project-row {
+  display: flex;
+  min-height: 92px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 14px 4px;
+  text-decoration: none;
+}
+
+.project-row:hover {
+  color: var(--cyan);
+  background: rgb(255 255 255 / 2%);
+}
+
+.constraint-panel {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 14px;
+  background: #10151a;
+}
+
+.journey-line {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  margin: 16px 0 0;
+  padding: 0;
+  background: var(--border);
+  list-style: none;
+}
+
+.journey-line li {
+  display: flex;
+  gap: 10px;
+  padding: 15px;
+  color: var(--cyan);
+  background: var(--surface);
+}
+
+.journey-line strong,
+.journey-line small {
+  display: block;
+}
+
+.journey-line strong {
+  color: #e7edef;
+  font-size: 0.82rem;
+}
+
+.journey-line small {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 0.7rem;
+  line-height: 1.4;
+}
+
+.compact-callout {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+}
+
+.stage-track {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1px;
+  margin: 26px 0 0;
+  padding: 0;
+  background: var(--border);
+  list-style: none;
+}
+
+.stage-track li {
+  display: flex;
+  min-width: 0;
+  gap: 9px;
+  padding: 12px;
+  background: var(--surface);
+}
+
+.stage-track li > span {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  place-items: center;
+  border: 1px solid var(--border-strong);
+  border-radius: 50%;
+  font-size: 0.72rem;
+}
+
+.stage-track strong,
+.stage-track small {
+  display: block;
+}
+
+.stage-track strong {
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.stage-track small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.68rem;
+}
+
+.stage-active {
+  color: #c7f4f1;
+}
+
+.stage-active > span {
+  border-color: #4db4b2 !important;
+  background: var(--cyan-soft);
+}
+
+.stage-disabled {
+  color: #737d85;
+}
+
+.confirmation-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 14px;
+  border: 1px solid #714044;
+  border-radius: 6px;
+  padding: 12px 14px;
+  color: #efb4b4;
+  background: #211416;
+  font-size: 0.84rem;
+}
+
+.research-split,
+.review-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+  gap: 34px;
+}
+
+.research-pane,
+.review-document,
+.review-assets {
+  min-width: 0;
+}
+
+.source-list {
+  margin-top: 16px;
+}
+
+.source-list li {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  gap: 10px;
+  border-bottom: 1px solid var(--border);
+  padding: 13px 0;
+}
+
+.source-index {
+  color: #71808a;
+  font-family: "Cascadia Code", Consolas, monospace;
+  font-size: 0.74rem;
+}
+
+.source-list a {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 4px 10px;
+  color: #e7edef;
+  text-decoration: none;
+}
+
+.source-list a strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.source-list a span {
+  grid-column: 1 / -1;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 0.72rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-list a:hover strong {
+  color: var(--cyan);
+}
+
+.library-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
+  border-block: 1px solid var(--border);
+  padding: 12px 0;
+}
+
+.library-status > div {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.collection-list {
+  margin-top: 18px;
+}
+
+.collection-list > li {
+  padding: 14px 0;
+}
+
+.collection-list strong,
+.collection-list p {
+  overflow-wrap: anywhere;
+}
+
+.collection-list p {
+  margin: 5px 0 0;
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+
+.review-split {
+  grid-template-columns: minmax(0, 1fr) 300px;
+}
+
+.markdown-body {
+  margin-top: 18px;
+  color: #d9e0e3;
+  font-size: 0.94rem;
+  line-height: 1.8;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4 {
+  margin: 1.7em 0 0.65em;
+  color: #f1f5f6;
+  line-height: 1.35;
+}
+
+.markdown-body h1 { font-size: 1.55rem; }
+.markdown-body h2 { border-bottom: 1px solid var(--border); padding-bottom: 8px; font-size: 1.25rem; }
+.markdown-body h3 { font-size: 1.08rem; }
+.markdown-body p,
+.markdown-body ul,
+.markdown-body ol,
+.markdown-body blockquote { margin: 0.9em 0; }
+.markdown-body ul,
+.markdown-body ol { padding-left: 1.4em; }
+.markdown-body blockquote { border-left: 2px solid var(--border-strong); padding-left: 14px; color: var(--muted); }
+.markdown-body code { border: 1px solid var(--border); border-radius: 3px; padding: 1px 4px; background: #090c0f; font-size: 0.86em; }
+.markdown-body pre { overflow: auto; border: 1px solid var(--border); padding: 14px; background: #080a0c; }
+.markdown-body pre code { border: 0; padding: 0; background: transparent; }
+.markdown-body a { display: inline-flex; align-items: baseline; gap: 3px; color: var(--cyan); text-decoration: underline; text-underline-offset: 3px; }
+.markdown-body table { display: block; width: 100%; overflow-x: auto; border-collapse: collapse; }
+.markdown-body th,
+.markdown-body td { border: 1px solid var(--border); padding: 8px 10px; text-align: left; }
+
+.artifact-list {
+  margin-top: 16px;
+}
+
+.artifact-list a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 11px 2px;
+  text-decoration: none;
+}
+
+.artifact-list a:hover {
+  color: var(--cyan);
+}
+
+.artifact-list strong,
+.artifact-list small {
+  display: block;
+}
+
+.artifact-list strong {
+  font-size: 0.82rem;
+}
+
+.artifact-list small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.7rem;
 }
 
 @media (max-width: 760px) {
@@ -328,6 +665,45 @@ a {
 
   .definition-grid {
     grid-template-columns: 1fr;
+  }
+
+  .page-title {
+    font-size: 1.65rem;
+  }
+
+  .project-row,
+  .confirmation-row,
+  .library-status {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .project-row > span:last-child {
+    justify-content: space-between;
+  }
+
+  .stage-track,
+  .journey-line,
+  .research-split,
+  .review-split {
+    grid-template-columns: 1fr;
+  }
+
+  .stage-track {
+    gap: 0;
+    background: transparent;
+  }
+
+  .stage-track li {
+    border-bottom: 1px solid var(--border);
+  }
+
+  .compact-callout {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .compact-callout .button {
+    grid-column: 1 / -1;
   }
 }
 

--- a/extensions/ai-research/ui/src/types.ts
+++ b/extensions/ai-research/ui/src/types.ts
@@ -3,6 +3,9 @@ export type Phase = "queued" | "running" | "terminal";
 export type Outcome = "success" | "task_error" | "cancelled" | "infrastructure_error";
 export type EvidenceState = "pending" | "synced" | "failed";
 export type Readiness = "ready" | "not_ready";
+export type LiteraturePhase = "not_started" | "queued" | "running" | "terminal";
+export type LiteratureOutcome = "completed" | "cancelled" | "failed" | "infrastructure_error";
+export type IntegrityStatus = "pending" | "verified" | "failed";
 
 export interface Run {
   runId: string;
@@ -65,6 +68,15 @@ export interface SystemStatus {
   status: "ready" | "degraded" | "not_ready";
   checks: SystemCheck[];
   checkedAt: string;
+  literatureCapability?: {
+    status: Readiness;
+    serviceStatus: Readiness;
+    sessionStatus: "locked" | "ready" | "expired";
+    profileStatus: Readiness;
+    modelBridgeStatus?: Readiness;
+    username: string | null;
+    scientificClaim: "none";
+  };
 }
 
 export interface ModuleInfo {
@@ -72,12 +84,23 @@ export interface ModuleInfo {
   moduleVersion: string;
   apiVersion: string;
   workerProtocolVersion: number;
-  claimLevel: "harness_only";
-  packStatus: "fixture_only";
   fixtures: CaseId[];
   runtimes: Record<string, string>;
   capabilities: Record<string, boolean>;
-  links: { mlflow: string; inspectView: string };
+  capabilityClaims: {
+    fixtureExecution: {
+      enabled: true;
+      claimLevel: "harness_only";
+      packStatus: "fixture_only";
+    };
+    literatureResearch: {
+      enabled: true;
+      scientificClaim: "none";
+      acceptanceState: "pending_live_acceptance";
+      workflowSource: "local_deep_research";
+    };
+  };
+  links: { mlflow: string; inspectView: string; localDeepResearch: string };
   limitations: string[];
 }
 
@@ -98,4 +121,104 @@ export interface Evidence {
   artifacts: EvidenceArtifact[];
   mlflow: Record<string, string | null>;
   outbox: Record<string, unknown> | null;
+}
+
+export interface LiteratureAttempt {
+  runId: string;
+  ldrResearchId: string | null;
+  phase: LiteraturePhase;
+  outcome: LiteratureOutcome | null;
+  rawStatus: string | null;
+  cancelRequestedAt: string | null;
+  cancelAppliedAt: string | null;
+  startedAt: string | null;
+  terminalAt: string | null;
+  syncedAt: string | null;
+  errorType: string | null;
+  errorMessage: string | null;
+  integrityStatus: IntegrityStatus;
+  createdAt: string;
+  progress: number;
+  latestLog: Record<string, unknown> | null;
+}
+
+export interface ResearchProject {
+  schemaVersion: 1;
+  projectId: string;
+  title: string;
+  researchQuestion: string;
+  domain: "ai_agent";
+  currentStage: "literature";
+  stages: Record<string, "active" | "not_available">;
+  literaturePhase: LiteraturePhase;
+  literatureOutcome: LiteratureOutcome | null;
+  activeRunId: string | null;
+  completedRunId: string | null;
+  collectionId: string | null;
+  profileId: string;
+  modelId: string | null;
+  attempts: LiteratureAttempt[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectList {
+  items: ResearchProject[];
+  nextCursor: string | null;
+}
+
+export interface LiteratureSession {
+  status: "locked" | "ready" | "expired";
+  username: string | null;
+}
+
+export interface LiteratureSource {
+  url: string;
+  title: string;
+  index: number | null;
+}
+
+export interface ProjectSources {
+  projectId: string;
+  literatureRunId: string;
+  integrityStatus: "verified";
+  sources: LiteratureSource[];
+}
+
+export interface ProjectReview {
+  projectId: string;
+  literatureRunId: string;
+  integrityStatus: "verified";
+  markdown: string;
+}
+
+export interface LibraryCollection {
+  id: string;
+  name?: string;
+  description?: string | null;
+  is_public?: boolean;
+  agent_enabled?: boolean;
+  document_count?: number;
+  indexed_document_count?: number;
+  embedding_model?: string | null;
+}
+
+export interface CollectionList {
+  collections: LibraryCollection[];
+}
+
+export interface ZoteroStatus {
+  config: {
+    success?: boolean;
+    enabled?: boolean;
+    configured?: boolean;
+    has_api_key?: boolean;
+    library_type?: string;
+    library_id?: string;
+  };
+  status: {
+    success?: boolean;
+    collections?: unknown[];
+    progress?: unknown;
+  };
 }

--- a/server/main.py
+++ b/server/main.py
@@ -1419,12 +1419,16 @@ try:
         start_provider_batch_recovery,
         stop_provider_batch_recovery,
     )
+    from server.model_router.ai_research_bridge import (
+        router as ai_research_bridge_router,
+    )
 except ModuleNotFoundError:
     from model_router.api import (
         get_catalog_coordinator,
         start_provider_batch_recovery,
         stop_provider_batch_recovery,
     )
+    from model_router.ai_research_bridge import router as ai_research_bridge_router
 
 try:
     from server.model_router.expert_team_gateway import (
@@ -1736,6 +1740,7 @@ app.include_router(benchmarks_router)
 app.include_router(xpert_evolutions_router)
 app.include_router(model_router_router)
 app.include_router(model_catalog_router)
+app.include_router(ai_research_bridge_router)
 app.include_router(omniroute_router)
 app.include_router(multimodal_router)
 app.include_router(coding_router)

--- a/server/model_router/ai_research_bridge.py
+++ b/server/model_router/ai_research_bridge.py
@@ -1,0 +1,697 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Annotated, Any, Literal
+
+import httpx
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from .api import get_model_router_service
+from .chat_canary import ProviderChatCanaryStreamEvidence
+from .chat_stable import ProviderChatStableDispatch, ProviderChatStableService
+from .service import ModelRouterService, RouterServiceError
+
+
+MAX_MESSAGES = 128
+MAX_TOTAL_MESSAGE_CHARS = 128_000
+MAX_MESSAGE_CHARS = MAX_TOTAL_MESSAGE_CHARS
+MAX_TOOLS = 32
+MAX_TOOL_DESCRIPTION_CHARS = 2_048
+MAX_TOOL_ARGUMENT_CHARS = 65_536
+MAX_TOOL_SCHEMA_BYTES = 65_536
+MAX_TOTAL_TOOL_SCHEMA_BYTES = 256_000
+MAX_REQUEST_BYTES = 1024 * 1024
+MAX_RESPONSE_BYTES = 64 * 1024 * 1024
+TOOL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+class BridgeResponseError(ValueError):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class TextMessage(StrictModel):
+    role: Literal["system", "user"]
+    content: str = Field(min_length=1, max_length=MAX_MESSAGE_CHARS)
+
+    @field_validator("content")
+    @classmethod
+    def require_text(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("message content must contain text")
+        return value
+
+
+class ToolCallFunction(StrictModel):
+    name: str = Field(min_length=1, max_length=64)
+    arguments: str = Field(max_length=MAX_TOOL_ARGUMENT_CHARS)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        if not TOOL_NAME_PATTERN.fullmatch(value):
+            raise ValueError("tool name contains unsupported characters")
+        return value
+
+
+class ToolCall(StrictModel):
+    id: str = Field(min_length=1, max_length=128)
+    type: Literal["function"]
+    function: ToolCallFunction
+
+
+class AssistantMessage(StrictModel):
+    role: Literal["assistant"]
+    content: str | None = Field(default=None, max_length=MAX_MESSAGE_CHARS)
+    tool_calls: list[ToolCall] = Field(default_factory=list, max_length=MAX_TOOLS)
+
+    @model_validator(mode="after")
+    def require_content_or_tool_call(self) -> "AssistantMessage":
+        if not (self.content or "").strip() and not self.tool_calls:
+            raise ValueError("assistant message requires text or tool_calls")
+        return self
+
+
+class ToolMessage(StrictModel):
+    role: Literal["tool"]
+    content: str = Field(max_length=MAX_MESSAGE_CHARS)
+    tool_call_id: str = Field(min_length=1, max_length=128)
+
+
+ChatMessage = Annotated[
+    TextMessage | AssistantMessage | ToolMessage,
+    Field(discriminator="role"),
+]
+
+
+class FunctionDefinition(StrictModel):
+    name: str = Field(min_length=1, max_length=64)
+    description: str | None = Field(default=None, max_length=MAX_TOOL_DESCRIPTION_CHARS)
+    parameters: dict[str, Any]
+    strict: bool | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        if not TOOL_NAME_PATTERN.fullmatch(value):
+            raise ValueError("tool name contains unsupported characters")
+        return value
+
+    @field_validator("parameters")
+    @classmethod
+    def validate_parameters(cls, value: dict[str, Any]) -> dict[str, Any]:
+        if value.get("type") != "object":
+            raise ValueError("tool parameters must be an object JSON schema")
+        if _json_size(value) > MAX_TOOL_SCHEMA_BYTES:
+            raise ValueError("tool parameter schema exceeds the size limit")
+        if _json_depth(value) > 16:
+            raise ValueError("tool parameter schema exceeds the depth limit")
+        return value
+
+
+class FunctionTool(StrictModel):
+    type: Literal["function"]
+    function: FunctionDefinition
+
+
+class NamedToolChoiceFunction(StrictModel):
+    name: str = Field(min_length=1, max_length=64)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        if not TOOL_NAME_PATTERN.fullmatch(value):
+            raise ValueError("tool name contains unsupported characters")
+        return value
+
+
+class NamedToolChoice(StrictModel):
+    type: Literal["function"]
+    function: NamedToolChoiceFunction
+
+
+ToolChoice = Literal["none", "auto", "required"] | NamedToolChoice
+
+
+@dataclass(slots=True)
+class _BridgeStreamEvidence(ProviderChatCanaryStreamEvidence):
+    tool_call_observed: bool = False
+
+    def _consume_event(self, event: str) -> None:
+        ProviderChatCanaryStreamEvidence._consume_event(self, event)
+        data_lines = [
+            line[5:].lstrip()
+            for line in event.split("\n")
+            if line.startswith("data:")
+        ]
+        if not data_lines or data_lines == ["[DONE]"]:
+            return
+        try:
+            payload = json.loads("\n".join(data_lines))
+        except (json.JSONDecodeError, TypeError):
+            return
+        if not isinstance(payload, dict):
+            return
+        for choice in payload.get("choices") or []:
+            if not isinstance(choice, dict):
+                continue
+            for container_name in ("delta", "message"):
+                container = choice.get(container_name)
+                if isinstance(container, dict) and isinstance(
+                    container.get("tool_calls"), list
+                ):
+                    self.tool_call_observed = self.tool_call_observed or bool(
+                        container["tool_calls"]
+                    )
+
+    def finish_for_bridge(
+        self, *, transport_completed: bool, allow_tool_calls: bool
+    ) -> tuple[str, str, str | None]:
+        status_value, result_class, error_code, _, _ = (
+            ProviderChatCanaryStreamEvidence.finish(
+                self, transport_completed=transport_completed
+            )
+        )
+        if (
+            allow_tool_calls
+            and self.tool_call_observed
+            and self.terminal_observed
+            and not self.invalid
+            and error_code == "provider_chat_empty_stream"
+        ):
+            return "succeeded", "success", None
+        return status_value, result_class, error_code
+
+
+class StreamOptions(StrictModel):
+    include_usage: bool = Field(default=False, alias="include_usage")
+
+
+class ChatCompletionRequest(StrictModel):
+    model: str = Field(min_length=1, max_length=256)
+    messages: list[ChatMessage] = Field(min_length=1, max_length=MAX_MESSAGES)
+    temperature: float | None = Field(default=None, ge=0, le=2)
+    max_tokens: int | None = Field(default=None, ge=1, le=32_768)
+    max_completion_tokens: int | None = Field(default=None, ge=1, le=32_768)
+    top_p: float | None = Field(default=None, gt=0, le=1)
+    stop: str | list[str] | None = None
+    stream: bool = False
+    stream_options: StreamOptions | None = None
+    tools: list[FunctionTool] | None = Field(
+        default=None, min_length=1, max_length=MAX_TOOLS
+    )
+    tool_choice: ToolChoice | None = None
+    parallel_tool_calls: bool | None = None
+
+    @field_validator("stop")
+    @classmethod
+    def validate_stop(cls, value: str | list[str] | None):
+        if value is None:
+            return value
+        items = [value] if isinstance(value, str) else value
+        if not items or len(items) > 4:
+            raise ValueError("stop must contain between one and four strings")
+        if any(not isinstance(item, str) or not item or len(item) > 100 for item in items):
+            raise ValueError("stop values must be non-empty strings of at most 100 chars")
+        return value
+
+    @model_validator(mode="after")
+    def validate_shape(self) -> "ChatCompletionRequest":
+        message_chars = 0
+        declared_tools = {
+            tool.function.name for tool in (self.tools or [])
+        }
+        if len(declared_tools) != len(self.tools or []):
+            raise ValueError("tool names must be unique")
+        if sum(_json_size(tool.function.parameters) for tool in (self.tools or [])) > MAX_TOTAL_TOOL_SCHEMA_BYTES:
+            raise ValueError("tool parameter schemas exceed the total size limit")
+        pending_calls: dict[str, str] = {}
+        seen_call_ids: set[str] = set()
+        for message in self.messages:
+            content = getattr(message, "content", None)
+            if isinstance(content, str):
+                message_chars += len(content)
+            if isinstance(message, AssistantMessage):
+                for call in message.tool_calls:
+                    if call.id in seen_call_ids:
+                        raise ValueError("tool call ids must be unique")
+                    if call.function.name not in declared_tools:
+                        raise ValueError("assistant tool call is not declared")
+                    seen_call_ids.add(call.id)
+                    pending_calls[call.id] = call.function.name
+                    message_chars += len(call.function.arguments)
+            elif isinstance(message, ToolMessage):
+                if message.tool_call_id not in pending_calls:
+                    raise ValueError("tool message does not match a pending tool call")
+                pending_calls.pop(message.tool_call_id)
+        if pending_calls:
+            raise ValueError("each assistant tool call requires a tool response")
+        if message_chars > MAX_TOTAL_MESSAGE_CHARS:
+            raise ValueError("messages exceed the total text limit")
+        if self.stream_options is not None and not self.stream:
+            raise ValueError("stream_options requires stream=true")
+        if self.max_tokens is not None and self.max_completion_tokens is not None:
+            raise ValueError(
+                "max_tokens and max_completion_tokens cannot both be provided"
+            )
+        if not self.tools and (
+            self.tool_choice is not None or self.parallel_tool_calls is not None
+        ):
+            raise ValueError("tool options require tools")
+        if isinstance(self.tool_choice, NamedToolChoice):
+            if self.tool_choice.function.name not in declared_tools:
+                raise ValueError("tool_choice must name a declared tool")
+        if _json_size(self.model_dump(by_alias=True, exclude_none=True)) > MAX_REQUEST_BYTES:
+            raise ValueError("request exceeds the bridge size limit")
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class BridgeSettings:
+    enabled: bool
+    token: str
+    model_id: str
+
+    @classmethod
+    def from_env(cls) -> "BridgeSettings":
+        enabled = os.getenv("AI_RESEARCH_S2S_ENABLED", "false").strip().casefold()
+        return cls(
+            enabled=enabled in {"1", "true", "yes", "on"},
+            token=os.getenv("AI_RESEARCH_S2S_TOKEN", ""),
+            model_id=os.getenv("AI_RESEARCH_LITERATURE_MODEL_ID", "").strip(),
+        )
+
+
+router = APIRouter(prefix="/api/ai-research/v1", tags=["ai-research-s2s"])
+
+
+def require_bridge(
+    authorization: Annotated[str | None, Header()] = None,
+) -> BridgeSettings:
+    settings = BridgeSettings.from_env()
+    if not settings.enabled or not settings.token or not settings.model_id:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="AI Research model bridge is not configured",
+        )
+    scheme, separator, credential = (authorization or "").partition(" ")
+    if (
+        not separator
+        or scheme.casefold() != "bearer"
+        or not credential
+        or not secrets.compare_digest(credential, settings.token)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid AI Research service credential",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return settings
+
+
+def stable_service(
+    router_service: ModelRouterService = Depends(get_model_router_service),
+) -> ProviderChatStableService:
+    return ProviderChatStableService(router_service)
+
+
+@router.get("/models")
+async def models(
+    settings: BridgeSettings = Depends(require_bridge),
+    stable: ProviderChatStableService = Depends(stable_service),
+) -> dict[str, Any]:
+    ready, reason = stable.readiness(settings.model_id, "chat_tools")
+    if not ready:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=reason or "fixed model control is not ready",
+        )
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": settings.model_id,
+                "object": "model",
+                "created": 0,
+                "owned_by": "modelmirror-control-plane",
+            }
+        ],
+    }
+
+
+@router.post("/chat/completions")
+async def chat_completions(
+    payload: ChatCompletionRequest,
+    settings: BridgeSettings = Depends(require_bridge),
+    stable: ProviderChatStableService = Depends(stable_service),
+):
+    if payload.model != settings.model_id:
+        raise HTTPException(status_code=422, detail="model is not enabled for AI Research")
+    capability = "chat_tools" if payload.tools else "chat_text"
+    try:
+        preflight = await stable.begin(settings.model_id, capability)
+    except RouterServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503, detail="AI Research model preflight failed"
+        ) from exc
+    if not preflight.intercepted or preflight.dispatch is None:
+        raise HTTPException(
+            status_code=503,
+            detail=preflight.error_code or "fixed model control is not ready",
+        )
+
+    upstream_payload = payload.model_dump(by_alias=True, exclude_none=True)
+    completion_limit = upstream_payload.pop("max_completion_tokens", None)
+    if completion_limit is not None:
+        upstream_payload["max_tokens"] = completion_limit
+    dispatch = preflight.dispatch
+    client = httpx.AsyncClient(**stable.transport.client_kwargs())
+    started = time.perf_counter()
+    try:
+        request = stable.transport.build_authorized_stream_request(
+            client,
+            dispatch.target,
+            dispatch.authorized,
+            upstream_payload,
+            headers={
+                "Accept": "text/event-stream" if payload.stream else "application/json"
+            },
+        )
+        stable.mark_dispatched(dispatch)
+        response = await stable.transport.send_authorized_stream(client, request)
+    except RouterServiceError as exc:
+        await client.aclose()
+        raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        stable.complete(
+            dispatch,
+            status="failed",
+            result_class="transient_failure",
+            error_code="ai_research_bridge_transport_failed",
+            e2e_ms=_elapsed_ms(started),
+        )
+        await client.aclose()
+        raise HTTPException(status_code=503, detail="fixed model transport failed") from exc
+    except Exception as exc:
+        try:
+            stable.complete(
+                dispatch,
+                status="failed",
+                result_class="transient_failure",
+                error_code="ai_research_bridge_dispatch_failed",
+                e2e_ms=_elapsed_ms(started),
+            )
+        except Exception:
+            pass
+        await client.aclose()
+        raise HTTPException(
+            status_code=503, detail="fixed model dispatch failed"
+        ) from exc
+
+    if response.status_code < 200 or response.status_code >= 300:
+        try:
+            await _read_bounded(response)
+        except (httpx.HTTPError, ValueError):
+            pass
+        finally:
+            await response.aclose()
+            await client.aclose()
+        result_class, code, hard_failure = stable.classify_http_failure(
+            response.status_code
+        )
+        stable.complete(
+            dispatch,
+            status="failed",
+            result_class=result_class,
+            error_code=code,
+            hard_failure=hard_failure,
+            e2e_ms=_elapsed_ms(started),
+        )
+        return JSONResponse(
+            status_code=503 if response.status_code >= 500 else 502,
+            content={"error": {"message": "fixed model request failed", "code": code}},
+            headers={"Cache-Control": "no-store"},
+        )
+
+    if payload.stream:
+        return StreamingResponse(
+            _stream_response(
+                stable=stable,
+                dispatch=dispatch,
+                response=response,
+                client=client,
+                requested_model=settings.model_id,
+                started=started,
+                allow_tool_calls=bool(payload.tools),
+            ),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-store",
+                "X-Accel-Buffering": "no",
+                "X-ModelMirror-Route-Run-Id": dispatch.run_id,
+            },
+        )
+
+    try:
+        content = await _read_bounded(response)
+        value = json.loads(content)
+        _validate_completion_response(
+            value,
+            requested_model=settings.model_id,
+            allowed_tool_names={
+                tool.function.name for tool in (payload.tools or [])
+            },
+        )
+        usage = value.get("usage") if isinstance(value.get("usage"), dict) else {}
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        _reject_invalid_response(
+            stable, dispatch, "ai_research_bridge_invalid_json", started, exc
+        )
+    except BridgeResponseError as exc:
+        _reject_invalid_response(stable, dispatch, exc.code, started, exc)
+    except ValueError as exc:
+        _reject_invalid_response(
+            stable,
+            dispatch,
+            "ai_research_bridge_response_limit_exceeded",
+            started,
+            exc,
+        )
+    except (httpx.HTTPError, OSError) as exc:
+        stable.complete(
+            dispatch,
+            status="failed",
+            result_class="transient_failure",
+            error_code="ai_research_bridge_response_read_failed",
+            e2e_ms=_elapsed_ms(started),
+        )
+        raise HTTPException(status_code=503, detail="fixed model response failed") from exc
+    finally:
+        await response.aclose()
+        await client.aclose()
+    stable.complete(
+        dispatch,
+        status="succeeded",
+        result_class="success",
+        actual_model=settings.model_id,
+        e2e_ms=_elapsed_ms(started),
+        prompt_tokens=_integer(usage.get("prompt_tokens")),
+        completion_tokens=_integer(usage.get("completion_tokens")),
+        total_tokens=_integer(usage.get("total_tokens")),
+    )
+    return JSONResponse(
+        content=value,
+        headers={
+            "Cache-Control": "no-store",
+            "X-ModelMirror-Route-Run-Id": dispatch.run_id,
+        },
+    )
+
+
+async def _stream_response(
+    *,
+    stable: ProviderChatStableService,
+    dispatch: ProviderChatStableDispatch,
+    response: httpx.Response,
+    client: httpx.AsyncClient,
+    requested_model: str,
+    started: float,
+    allow_tool_calls: bool,
+):
+    evidence = _BridgeStreamEvidence(started_at=started)
+    total = 0
+    finalized = False
+    try:
+        async for chunk in response.aiter_text():
+            encoded_size = len(chunk.encode("utf-8"))
+            total += encoded_size
+            if total > MAX_RESPONSE_BYTES:
+                raise ValueError("stream exceeded bridge response limit")
+            evidence.feed(chunk)
+            yield chunk
+        status_value, result_class, error_code = evidence.finish_for_bridge(
+            transport_completed=True,
+            allow_tool_calls=allow_tool_calls,
+        )
+        if evidence.actual_model not in {None, requested_model}:
+            status_value = "failed"
+            result_class = "hard_failure"
+            error_code = "ai_research_bridge_model_mismatch"
+        stable.complete(
+            dispatch,
+            status=status_value,
+            result_class=result_class,
+            error_code=error_code,
+            actual_model=evidence.actual_model or requested_model,
+            hard_failure=result_class == "hard_failure",
+            ttft_ms=evidence.ttft_ms,
+            e2e_ms=_elapsed_ms(started),
+            prompt_tokens=evidence.prompt_tokens,
+            completion_tokens=evidence.completion_tokens,
+            total_tokens=evidence.total_tokens,
+        )
+        finalized = True
+        if status_value != "succeeded":
+            raise RuntimeError(error_code or "ai_research_bridge_invalid_stream")
+    except asyncio.CancelledError:
+        stable.complete(
+            dispatch,
+            status="cancelled",
+            result_class="client_cancelled",
+            error_code="provider_chat_client_cancelled",
+            client_cancelled=True,
+            e2e_ms=_elapsed_ms(started),
+        )
+        finalized = True
+        raise
+    except Exception:
+        if not finalized:
+            stable.complete(
+                dispatch,
+                status="failed",
+                result_class="transient_failure",
+                error_code="ai_research_bridge_stream_failed",
+                e2e_ms=_elapsed_ms(started),
+            )
+            finalized = True
+        raise
+    finally:
+        await response.aclose()
+        await client.aclose()
+
+
+async def _read_bounded(response: httpx.Response) -> bytes:
+    total = 0
+    chunks: list[bytes] = []
+    async for chunk in response.aiter_bytes():
+        total += len(chunk)
+        if total > MAX_RESPONSE_BYTES:
+            raise ValueError("response exceeded bridge limit")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _validate_completion_response(
+    value: object,
+    *,
+    requested_model: str,
+    allowed_tool_names: set[str],
+) -> None:
+    if not isinstance(value, dict):
+        raise BridgeResponseError("ai_research_bridge_invalid_envelope")
+    actual_model = value.get("model")
+    if actual_model is not None and actual_model != requested_model:
+        raise BridgeResponseError("ai_research_bridge_model_mismatch")
+    choices = value.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise BridgeResponseError("ai_research_bridge_missing_choices")
+    valid_choice = False
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        message = choice.get("message")
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and content:
+            valid_choice = True
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list) or not tool_calls:
+            continue
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict) or tool_call.get("type") != "function":
+                raise BridgeResponseError("ai_research_bridge_invalid_tool_call")
+            function = tool_call.get("function")
+            if (
+                not isinstance(tool_call.get("id"), str)
+                or not tool_call["id"]
+                or not isinstance(function, dict)
+                or function.get("name") not in allowed_tool_names
+                or not isinstance(function.get("arguments"), str)
+            ):
+                raise BridgeResponseError("ai_research_bridge_invalid_tool_call")
+        valid_choice = True
+    if not valid_choice:
+        raise BridgeResponseError("ai_research_bridge_empty_completion")
+
+
+def _reject_invalid_response(
+    stable: ProviderChatStableService,
+    dispatch: ProviderChatStableDispatch,
+    error_code: str,
+    started: float,
+    exc: Exception,
+) -> None:
+    stable.complete(
+        dispatch,
+        status="failed",
+        result_class="hard_failure",
+        error_code=error_code,
+        hard_failure=True,
+        e2e_ms=_elapsed_ms(started),
+    )
+    raise HTTPException(
+        status_code=502, detail="fixed model returned an invalid response"
+    ) from exc
+
+
+def _json_size(value: object) -> int:
+    return len(
+        json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    )
+
+
+def _json_depth(value: object) -> int:
+    if isinstance(value, dict):
+        return 1 + max((_json_depth(item) for item in value.values()), default=0)
+    if isinstance(value, list):
+        return 1 + max((_json_depth(item) for item in value), default=0)
+    return 0
+
+
+def _integer(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _elapsed_ms(started: float) -> float:
+    return max(0.0, (time.perf_counter() - started) * 1000)

--- a/server/model_router/chat_stable.py
+++ b/server/model_router/chat_stable.py
@@ -43,6 +43,49 @@ class ProviderChatStableService:
         self.control = ProviderChatControlService(router_service)
         self.transport = ProviderChatTransport(router_service.egress_policy)
 
+    def readiness(
+        self,
+        model_id: str,
+        capability: ProviderChatCapability = "chat_text",
+    ) -> tuple[bool, str | None]:
+        """Inspect the current managed route without creating a run receipt."""
+
+        if not self.control.feature_enabled():
+            return False, "provider_chat_control_feature_disabled"
+        policy = self.control.get_policy()
+        clean_model = str(model_id or "").strip()
+        if (
+            policy.effective_mode == "legacy"
+            or clean_model not in policy.stable_model_ids
+        ):
+            return False, "provider_chat_no_qualified_route"
+        runtime_allowed, runtime_error = self.control.required_runtime_allowed(policy)
+        if not runtime_allowed:
+            return False, runtime_error or "provider_chat_required_gate_degraded"
+        route = next(
+            (item for item in policy.routes if item.capability == capability),
+            None,
+        )
+        route_ids = list(route.connection_ids if route else [])
+        if policy.effective_mode == "newapi_required_default":
+            route_ids = route_ids[:1]
+        qualifications = {
+            item.connection_id: item
+            for item in policy.qualifications
+            if item.capability == capability and item.model_id == clean_model
+        }
+        failures: list[str] = []
+        for connection_id in route_ids:
+            qualification = qualifications.get(connection_id)
+            if qualification is not None and qualification.valid:
+                return True, None
+            failures.append(
+                qualification.reason_code
+                if qualification is not None
+                else "provider_chat_qualification_missing"
+            )
+        return False, failures[-1] if failures else "provider_chat_no_qualified_route"
+
     async def begin(
         self,
         model_id: str,

--- a/server/tests/test_ai_research_bridge.py
+++ b/server/tests/test_ai_research_bridge.py
@@ -1,0 +1,616 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from server.model_router.ai_research_bridge import router, stable_service
+
+
+MODEL_ID = "provider/fixed-research-model"
+TOKEN = "test-ai-research-service-token"
+
+
+@dataclass
+class FakeDispatch:
+    run_id: str = "chatrun_test"
+    target: object = None
+    authorized: object = None
+
+
+class FakeTransport:
+    def __init__(self, handler) -> None:
+        self.handler = handler
+
+    def client_kwargs(self) -> dict[str, object]:
+        return {
+            "transport": httpx.MockTransport(self.handler),
+            "trust_env": False,
+            "follow_redirects": False,
+        }
+
+    def build_authorized_stream_request(
+        self,
+        client: httpx.AsyncClient,
+        target: object,
+        authorized: object,
+        payload: dict[str, Any],
+        *,
+        headers: dict[str, str],
+    ) -> httpx.Request:
+        return client.build_request(
+            "POST", "https://provider.example/v1/chat/completions", json=payload, headers=headers
+        )
+
+    async def send_authorized_stream(
+        self, client: httpx.AsyncClient, request: httpx.Request
+    ) -> httpx.Response:
+        return await client.send(request, stream=True)
+
+
+class FakeStable:
+    def __init__(self, handler) -> None:
+        self.transport = FakeTransport(handler)
+        self.completed: list[dict[str, Any]] = []
+        self.dispatched = 0
+        self.capabilities: list[str] = []
+        self.ready = True
+        self.readiness_reason: str | None = None
+        self.readiness_calls: list[tuple[str, str]] = []
+
+    def readiness(self, model_id: str, capability: str):
+        assert model_id == MODEL_ID
+        self.readiness_calls.append((model_id, capability))
+        return self.ready, self.readiness_reason
+
+    async def begin(self, model_id: str, capability: str):
+        assert model_id == MODEL_ID
+        self.capabilities.append(capability)
+        return SimpleNamespace(
+            intercepted=True,
+            dispatch=FakeDispatch(),
+            error_code=None,
+        )
+
+    def mark_dispatched(self, dispatch: FakeDispatch) -> None:
+        self.dispatched += 1
+
+    def complete(self, dispatch: FakeDispatch, **fields: Any) -> None:
+        self.completed.append(fields)
+
+    @staticmethod
+    def classify_http_failure(status_code: int) -> tuple[str, str, bool]:
+        return "transient_failure", f"provider_chat_http_{status_code}", False
+
+
+def app_for(stable: FakeStable) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[stable_service] = lambda: stable
+    return app
+
+
+def enable(monkeypatch) -> None:
+    monkeypatch.setenv("AI_RESEARCH_S2S_ENABLED", "true")
+    monkeypatch.setenv("AI_RESEARCH_S2S_TOKEN", TOKEN)
+    monkeypatch.setenv("AI_RESEARCH_LITERATURE_MODEL_ID", MODEL_ID)
+
+
+def headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {TOKEN}"}
+
+
+def valid_payload(*, stream: bool = False) -> dict[str, Any]:
+    return {
+        "model": MODEL_ID,
+        "messages": [
+            {"role": "system", "content": "Write a literature synthesis."},
+            {"role": "user", "content": "What makes agent evaluation reproducible?"},
+        ],
+        "temperature": 0.2,
+        "max_tokens": 512,
+        "stream": stream,
+        **({"stream_options": {"include_usage": True}} if stream else {}),
+    }
+
+
+def tool_payload(*, stream: bool = False) -> dict[str, Any]:
+    payload = valid_payload(stream=stream)
+    payload["tools"] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search_openalex",
+                "description": "Search public academic metadata.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        }
+    ]
+    payload["tool_choice"] = "auto"
+    payload["parallel_tool_calls"] = False
+    return payload
+
+
+def test_disabled_wrong_token_and_models_fail_closed(monkeypatch) -> None:
+    stable = FakeStable(lambda request: httpx.Response(500))
+    api = TestClient(app_for(stable))
+    assert api.get("/api/ai-research/v1/models").status_code == 503
+
+    enable(monkeypatch)
+    assert api.get(
+        "/api/ai-research/v1/models", headers={"Authorization": "Bearer wrong"}
+    ).status_code == 401
+    models = api.get("/api/ai-research/v1/models", headers=headers())
+    assert models.status_code == 200
+    assert [item["id"] for item in models.json()["data"]] == [MODEL_ID]
+    assert stable.readiness_calls == [(MODEL_ID, "chat_tools")]
+
+    stable.ready = False
+    stable.readiness_reason = "provider_chat_hard_failure_recertification_required"
+    not_ready = api.get("/api/ai-research/v1/models", headers=headers())
+    assert not_ready.status_code == 503
+    assert not_ready.json()["detail"] == (
+        "provider_chat_hard_failure_recertification_required"
+    )
+
+
+def test_rejects_wrong_model_multimodal_and_unknown_fields(monkeypatch) -> None:
+    enable(monkeypatch)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    with TestClient(app_for(stable)) as api:
+        wrong = valid_payload()
+        wrong["model"] = "provider/other"
+        assert api.post(
+            "/api/ai-research/v1/chat/completions", json=wrong, headers=headers()
+        ).status_code == 422
+        for field, value in (
+            ("response_format", {"type": "json_object"}),
+            ("user", "caller-selected-user"),
+        ):
+            invalid = valid_payload()
+            invalid[field] = value
+            assert api.post(
+                "/api/ai-research/v1/chat/completions",
+                json=invalid,
+                headers=headers(),
+            ).status_code == 422
+        multimodal = valid_payload()
+        multimodal["messages"][1]["content"] = [
+            {"type": "image_url", "image_url": {"url": "https://example.test/x"}}
+        ]
+        assert api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=multimodal,
+            headers=headers(),
+        ).status_code == 422
+    assert stable.dispatched == 0
+
+
+def test_tool_request_uses_qualified_tools_route_and_preserves_contract(monkeypatch) -> None:
+    enable(monkeypatch)
+
+    def upstream(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["tools"][0]["function"]["name"] == "search_openalex"
+        assert body["tool_choice"] == "auto"
+        assert body["parallel_tool_calls"] is False
+        return httpx.Response(
+            200,
+            json={
+                "model": MODEL_ID,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_openalex",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "search_openalex",
+                                        "arguments": '{"query":"AgentBench"}',
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+            },
+        )
+
+    stable = FakeStable(upstream)
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=tool_payload(),
+            headers=headers(),
+        )
+    assert response.status_code == 200
+    assert stable.capabilities == ["chat_tools"]
+    assert stable.completed[0]["status"] == "succeeded"
+
+
+def test_tool_followup_requires_declared_matched_calls(monkeypatch) -> None:
+    enable(monkeypatch)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    valid = tool_payload()
+    valid["messages"].extend(
+        [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_openalex",
+                        "type": "function",
+                        "function": {
+                            "name": "search_openalex",
+                            "arguments": '{"query":"AgentBench"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_openalex",
+                "content": "One public result",
+            },
+        ]
+    )
+    invalid_cases = []
+    undeclared = tool_payload()
+    undeclared["messages"].append(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_bad",
+                    "type": "function",
+                    "function": {"name": "shell", "arguments": "{}"},
+                }
+            ],
+        }
+    )
+    invalid_cases.append(undeclared)
+    orphan = tool_payload()
+    orphan["messages"].append(
+        {"role": "tool", "tool_call_id": "call_missing", "content": "x"}
+    )
+    invalid_cases.append(orphan)
+    bad_schema = tool_payload()
+    bad_schema["tools"][0]["function"]["parameters"] = {"type": "string"}
+    invalid_cases.append(bad_schema)
+
+    def upstream(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "model": MODEL_ID,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "Synthesis"},
+                    }
+                ],
+            },
+        )
+
+    stable.transport.handler = upstream
+    with TestClient(app_for(stable)) as api:
+        accepted = api.post(
+            "/api/ai-research/v1/chat/completions", json=valid, headers=headers()
+        )
+        assert accepted.status_code == 200
+        for invalid in invalid_cases:
+            assert api.post(
+                "/api/ai-research/v1/chat/completions",
+                json=invalid,
+                headers=headers(),
+            ).status_code == 422
+    assert stable.dispatched == 1
+
+
+def test_streaming_tool_call_is_a_valid_terminal(monkeypatch) -> None:
+    enable(monkeypatch)
+    events = (
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{"tool_calls":[{{"index":0,"id":"call_openalex","type":"function","function":{{"name":"search_openalex","arguments":"{{\\"query\\":\\"AgentBench\\"}}"}}}}]}},"finish_reason":null}}]}}\n\n'
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{}},"finish_reason":"tool_calls"}}]}}\n\n'
+        "data: [DONE]\n\n"
+    )
+    stable = FakeStable(
+        lambda request: httpx.Response(
+            200,
+            content=events.encode("utf-8"),
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=tool_payload(stream=True),
+            headers=headers(),
+        )
+    assert response.status_code == 200
+    assert response.text.endswith("data: [DONE]\n\n")
+    assert stable.capabilities == ["chat_tools"]
+    assert stable.completed[0]["status"] == "succeeded"
+
+
+def test_completion_token_alias_is_bounded_normalized_and_exclusive(monkeypatch) -> None:
+    enable(monkeypatch)
+
+    def upstream(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["max_tokens"] == 30_000
+        assert "max_completion_tokens" not in body
+        return httpx.Response(
+            200,
+            json={
+                "model": MODEL_ID,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "Review"},
+                    }
+                ],
+            },
+        )
+
+    stable = FakeStable(upstream)
+    with TestClient(app_for(stable)) as api:
+        alias_payload = valid_payload()
+        alias_payload.pop("max_tokens")
+        alias_payload["max_completion_tokens"] = 30_000
+        assert api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=alias_payload,
+            headers=headers(),
+        ).status_code == 200
+
+        both_payload = valid_payload()
+        both_payload["max_completion_tokens"] = 512
+        assert api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=both_payload,
+            headers=headers(),
+        ).status_code == 422
+
+        oversized_payload = valid_payload()
+        oversized_payload.pop("max_tokens")
+        oversized_payload["max_completion_tokens"] = 32_769
+        assert api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=oversized_payload,
+            headers=headers(),
+        ).status_code == 422
+    assert stable.dispatched == 1
+
+
+def test_non_streaming_request_uses_fixed_control_and_records_usage(monkeypatch) -> None:
+    enable(monkeypatch)
+
+    def upstream(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["model"] == MODEL_ID
+        assert set(body) <= {
+            "model",
+            "messages",
+            "temperature",
+            "max_tokens",
+            "top_p",
+            "stop",
+            "stream",
+            "stream_options",
+        }
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "model": MODEL_ID,
+                "choices": [
+                    {"index": 0, "message": {"role": "assistant", "content": "Review"}}
+                ],
+                "usage": {
+                    "prompt_tokens": 11,
+                    "completion_tokens": 2,
+                    "total_tokens": 13,
+                },
+            },
+        )
+
+    stable = FakeStable(upstream)
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=valid_payload(),
+            headers=headers(),
+        )
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "Review"
+    assert response.headers["cache-control"] == "no-store"
+    assert stable.dispatched == 1
+    assert stable.completed[0]["status"] == "succeeded"
+    assert stable.completed[0]["total_tokens"] == 13
+
+
+def test_non_streaming_response_with_other_model_fails_closed(monkeypatch) -> None:
+    enable(monkeypatch)
+    stable = FakeStable(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "model": "provider/unexpected-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "wrong route"},
+                    }
+                ],
+            },
+        )
+    )
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=valid_payload(),
+            headers=headers(),
+        )
+    assert response.status_code == 502
+    assert "wrong route" not in response.text
+    assert stable.completed[0]["status"] == "failed"
+    assert stable.completed[0]["result_class"] == "hard_failure"
+    assert stable.completed[0]["error_code"] == "ai_research_bridge_model_mismatch"
+
+
+def test_non_streaming_invalid_responses_store_only_contract_category(monkeypatch) -> None:
+    enable(monkeypatch)
+    cases = (
+        (b"not-json", "ai_research_bridge_invalid_json"),
+        (
+            json.dumps({"model": MODEL_ID, "choices": []}).encode("utf-8"),
+            "ai_research_bridge_missing_choices",
+        ),
+        (
+            json.dumps(
+                {
+                    "model": MODEL_ID,
+                    "choices": [{"message": {"role": "assistant", "content": ""}}],
+                }
+            ).encode("utf-8"),
+            "ai_research_bridge_empty_completion",
+        ),
+    )
+    for content, expected_code in cases:
+        stable = FakeStable(lambda request, value=content: httpx.Response(200, content=value))
+        with TestClient(app_for(stable)) as api:
+            response = api.post(
+                "/api/ai-research/v1/chat/completions",
+                json=valid_payload(),
+                headers=headers(),
+            )
+        assert response.status_code == 502
+        assert response.json()["detail"] == "fixed model returned an invalid response"
+        assert stable.completed[0]["error_code"] == expected_code
+
+
+def test_rejects_total_text_over_bridge_limit_before_dispatch(monkeypatch) -> None:
+    enable(monkeypatch)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    payload = valid_payload()
+    payload["messages"] = [
+        {"role": "user", "content": "x" * 32_768} for _ in range(4)
+    ]
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=payload,
+            headers=headers(),
+        )
+    assert response.status_code == 422
+    assert stable.dispatched == 0
+
+
+def test_accepts_single_ldr_synthesis_message_over_legacy_limit(monkeypatch) -> None:
+    enable(monkeypatch)
+    stable = FakeStable(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-ldr-synthesis",
+                "object": "chat.completion",
+                "model": MODEL_ID,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "Review"},
+                    }
+                ],
+            },
+        )
+    )
+    payload = valid_payload()
+    payload["messages"] = [{"role": "user", "content": "x" * 32_769}]
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=payload,
+            headers=headers(),
+        )
+    assert response.status_code == 200
+    assert stable.dispatched == 1
+
+
+def test_streaming_request_preserves_sse_and_records_terminal(monkeypatch) -> None:
+    enable(monkeypatch)
+    events = (
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{"content":"Review"}},"finish_reason":null}}]}}\n\n'
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{}},"finish_reason":"stop"}}],"usage":{{"prompt_tokens":11,"completion_tokens":2,"total_tokens":13}}}}\n\n'
+        "data: [DONE]\n\n"
+    )
+    stable = FakeStable(
+        lambda request: httpx.Response(
+            200, content=events.encode("utf-8"), headers={"content-type": "text/event-stream"}
+        )
+    )
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=valid_payload(stream=True),
+            headers=headers(),
+        )
+    assert response.status_code == 200
+    assert response.text.endswith("data: [DONE]\n\n")
+    assert response.headers["x-modelmirror-route-run-id"] == "chatrun_test"
+    assert stable.completed[0]["status"] == "succeeded"
+    assert stable.completed[0]["total_tokens"] == 13
+
+
+def test_upstream_failure_is_sanitized_and_finalized(monkeypatch) -> None:
+    enable(monkeypatch)
+    stable = FakeStable(
+        lambda request: httpx.Response(
+            500, json={"error": "provider-secret-should-not-pass-through"}
+        )
+    )
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=valid_payload(),
+            headers=headers(),
+        )
+    assert response.status_code == 503
+    assert "provider-secret" not in response.text
+    assert stable.completed[0]["status"] == "failed"
+
+
+def test_unexpected_dispatch_failure_is_sanitized_and_finalized(monkeypatch) -> None:
+    enable(monkeypatch)
+
+    def fail_before_response(request: httpx.Request) -> httpx.Response:
+        raise RuntimeError("provider-secret-in-unexpected-error")
+
+    stable = FakeStable(fail_before_response)
+    with TestClient(app_for(stable), raise_server_exceptions=False) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=valid_payload(),
+            headers=headers(),
+        )
+    assert response.status_code == 503
+    assert "provider-secret" not in response.text
+    assert stable.completed[0]["status"] == "failed"
+    assert stable.completed[0]["error_code"] == "ai_research_bridge_dispatch_failed"

--- a/server/tests/test_provider_chat_stable_service.py
+++ b/server/tests/test_provider_chat_stable_service.py
@@ -201,6 +201,30 @@ def _activate_required_for_test(repository: SQLiteRouterRepository) -> None:
             )
 
 
+def test_readiness_checks_current_qualification_without_creating_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    receipt_count = len(repository.list_chat_control_receipts("local"))
+
+    assert service.readiness(MODEL_ID, "chat_text") == (True, None)
+    assert len(repository.list_chat_control_receipts("local")) == receipt_count
+
+    for connection_id in (newapi_id, backup_id):
+        repository.save_test_result(
+            "local",
+            connection_id,
+            health="offline",
+            model_count=1,
+            checked_at="2026-08-21T01:00:00+00:00",
+        )
+    ready, reason = service.readiness(MODEL_ID, "chat_text")
+
+    assert ready is False
+    assert reason == "provider_connection_not_online"
+    assert len(repository.list_chat_control_receipts("local")) == receipt_count
+
+
 @pytest.mark.asyncio
 async def test_preferred_selects_backup_only_after_primary_preflight_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## 交付内容

- 新增独立可选的 ModelMirror AI Research V0.1 文献工作台：Research Project、Local Deep Research 会话与运行、来源/综述/成果包、Zotero/Library 状态与索引入口。
- 新增默认关闭、固定模型、文本限定的 AI Research S2S 模型桥，复用既有 Provider 稳定路由与控制面，不向扩展暴露 Provider key。
- 保留 AR1 fixture/MLflow/Inspect 证据能力；LDR 仅按固定 digest 外部拉取，不重打包为模镜镜像。
- 不修改主站 client、根 Compose、默认安装或主数据库 schema；scientificClaim 仍为 none。

## 真实验收证据

- 项目：`rp_24f3daa9623d4fcb9983773bb6543829`
- 文献运行：`lr_960ddb42633742b2812a9d6b4639a0c2`
- 上游 LDR 研究：`a82f3fa1-7d22-4c4a-b63f-0c80d47a2e09`
- 终态：completed；成果完整性：verified。
- 248 个唯一 HTTPS 来源、248 个 BibTeX 条目、248 个引用键，缺失引用键为 0。
- Markdown、QMD、BibTeX、RIS、sources、receipt、manifest 等 8 个下载端点均验证了 200、附件头、no-store、长度及 SHA-256。
- 已完成人工浏览器验收：项目恢复、LDR 解锁、Zotero 同步/集合索引、综述与来源页。

## 验证

- `verify.ps1 -Base origin/main -Mode Quick -DistributionMode ExternalPull`：通过。
  - UI license audit：371 个锁定包。
  - Control：90 passed。
  - Worker：14 passed。
- `test_ai_research_bridge.py + test_provider_chat_stable_service.py`：22 passed。
- 最新 `origin/main` 客户端独立构建：通过；38 个文件，18,880,491 bytes，聚合 SHA-256 `f2ffc492aa1a06299c173293eda9338383e17535029f14959a2b8a46793a13ce`。
- 最终范围：68 个授权文件；工作树干净；base `11d35c1d84c0a18a05779a37d60cb59ef7a25867`；无 diff whitespace 错误。

### 未绿的全量后端检查

全量 `server/tests/` 未取得 exit 0。使用只读源码挂载运行时，主线的 MCP、AgentTable、RAG lexical store 依次在测试收集阶段尝试创建 SQLite/WAL，最终均为 88 个 `sqlite3.OperationalError: unable to open database file` 收集错误；未进入测试断言。该环境/夹具问题未通过修改产品代码规避，受影响的 22 项后端测试已独立通过。

## 已知限制

- LDR 官方镜像包含 GPL/LGPL/未知声明的传递组件；本 PR 仅 external-pull，不宣称整个镜像为 MIT，也不作为可再分发候选。
- 主线客户端构建报告既有 5 个 npm audit 项（1 low、2 moderate、2 high）。
- V0.1 没有整次研究的 token/cost 总上限；`max_results=15` 是单次搜索限制，真实运行可聚合更多来源。
- LDR 生成报告必须人工复核，不构成科研结论；暂无多租户、计费或商业化能力。

## 回退

关闭 AI Research S2S 环境开关并停止模块 `literature` profile；移除 V0.1 扩展/API 接入即可。默认保留 projects、LDR models/data 与既有 AR1 证据卷，删除数据需另行授权。