### PR TITLE
feature: R8B 统一图片、Vision 与原生 PDF Provider 控制面

### DIFF
--- a/client/src/components/settings/ProviderWorkloadControlSettings.test.tsx
+++ b/client/src/components/settings/ProviderWorkloadControlSettings.test.tsx
@@ -77,7 +77,7 @@ describe("ProviderWorkloadControlSettings", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<ProviderWorkloadControlSettings csrfToken="csrf-value" view="certifications" />);
-    await screen.findByText("R6 / R7 资格与 R8 Adapter 基础");
+    await screen.findByText("R6 / R7 资格与 R8 多模态认证");
     fireEvent.change(screen.getByLabelText("执行形态"), {
       target: { value: "chat_json_object" },
     });
@@ -109,6 +109,53 @@ describe("ProviderWorkloadControlSettings", () => {
       model_id: "openai/gpt-test",
       acknowledge_billed_call: true,
     });
+  });
+
+  it("opens R8B image certification while later multimodal shapes remain blocked", async () => {
+    const multimodalConnection = {
+      ...connection,
+      scopes: ["chat", "image", "audio"],
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/router/connections") return jsonResponse([multimodalConnection]);
+      if (url === "/api/router/certifications/workloads" && !init) {
+        return jsonResponse({ certifications: [] });
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ProviderWorkloadControlSettings csrfToken="csrf-value" view="certifications" />);
+    await screen.findByText("R6 / R7 资格与 R8 多模态认证");
+    fireEvent.change(screen.getByLabelText("执行形态"), {
+      target: { value: "chat_image_stream" },
+    });
+    fireEvent.change(screen.getByLabelText("精确模型 ID"), {
+      target: { value: "openai/gpt-4o-mini" },
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", {
+      name: "运行资格认证",
+    })).toBeEnabled());
+    expect(screen.getByLabelText("Adapter Contract")).toHaveValue(
+      "openrouter_chat_multimodal_v1",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "运行资格认证" }));
+    expect(screen.getByRole("dialog")).toHaveTextContent("最多一个 Provider POST");
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("/certifications/workloads"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "取消" }));
+
+    fireEvent.change(screen.getByLabelText("执行形态"), {
+      target: { value: "audio_transcription" },
+    });
+    await waitFor(() => expect(screen.getByRole("button", {
+      name: "运行资格认证",
+    })).toBeDisabled());
+    expect(screen.getByText(/该多模态形态目前仅建立 Adapter/)).toBeVisible();
   });
 
   it("saves exact bindings with optimistic revision while an unintegrated entry stays blocked", async () => {

--- a/client/src/components/settings/ProviderWorkloadControlSettings.tsx
+++ b/client/src/components/settings/ProviderWorkloadControlSettings.tsx
@@ -268,6 +268,13 @@ const MULTIMODAL_SHAPES = new Set<ExecutionShape>([
   "realtime_voice_session",
 ]);
 
+const R8B_CERTIFICATION_SHAPES = new Set<ExecutionShape>([
+  "chat_image_stream",
+  "chat_document_stream",
+  "vision_json_unary",
+  "image_generation",
+]);
+
 const ADAPTER_OPTIONS: Record<AdapterContract, {
   label: string;
   shapes: ExecutionShape[];
@@ -778,11 +785,14 @@ export default function ProviderWorkloadControlSettings({
 
   if (view === "certifications") {
     const fusionSelected = certificationShape === "fusion_native";
-    const multimodalFoundationOnly = MULTIMODAL_SHAPES.has(certificationShape);
+    const multimodalSelected = MULTIMODAL_SHAPES.has(certificationShape);
+    const multimodalFoundationOnly = multimodalSelected
+      && !R8B_CERTIFICATION_SHAPES.has(certificationShape);
     const canConfirm = Boolean(
       connectionId &&
       certificationModel.trim() &&
       (!fusionSelected || (candidateModels.trim() && judgeModel.trim())) &&
+      (!multimodalSelected || certificationAdapter) &&
       !multimodalFoundationOnly,
     );
     return (
@@ -790,7 +800,7 @@ export default function ProviderWorkloadControlSettings({
         <div className="flex flex-wrap items-start justify-between gap-3 border-b border-white/10 bg-violet-300/[0.04] px-5 py-5">
           <div>
             <p className="text-sm font-semibold text-violet-100">Managed Workload 资格</p>
-            <h2 className="mt-2 text-xl font-semibold text-white">R6 / R7 资格与 R8 Adapter 基础</h2>
+            <h2 className="mt-2 text-xl font-semibold text-white">R6 / R7 资格与 R8 多模态认证</h2>
             <p className="mt-2 max-w-[78ch] text-sm leading-6 text-slate-300">
               仅发送固定合成输入，自动刷新完整目录，并对精确连接、模型和执行形态留存脱敏资格。Embedding、Rerank 与 Batch 不会因此自动接管数据面。
             </p>
@@ -818,7 +828,7 @@ export default function ProviderWorkloadControlSettings({
               精确模型 ID
               <input className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-white" onChange={(event) => setCertificationModel(event.target.value)} placeholder={fusionSelected ? "openrouter/fusion" : "provider/model"} value={certificationModel} />
             </label>
-            {multimodalFoundationOnly ? <label className="block text-sm text-slate-300">
+            {multimodalSelected ? <label className="block text-sm text-slate-300">
               Adapter Contract
               <select className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-white" onChange={(event) => setCertificationAdapter(event.target.value as AdapterContract)} value={certificationAdapter ?? ""}>
                 {adaptersForShape(certificationShape).map(([contract, spec]) => <option key={contract} value={contract}>{spec.label}</option>)}
@@ -835,7 +845,7 @@ export default function ProviderWorkloadControlSettings({
                 <option value="llm_json">LLM JSON Adapter</option>
               </select>
             </label> : null}
-            {multimodalFoundationOnly ? <p className="rounded-lg border border-amber-300/20 bg-amber-300/[0.06] p-3 text-xs leading-5 text-amber-100">R8A 仅建立 Adapter、Binding 和状态基础，不会发送付费认证。对应数据面批次接入后才开放此按钮。</p> : null}
+            {multimodalFoundationOnly ? <p className="rounded-lg border border-amber-300/20 bg-amber-300/[0.06] p-3 text-xs leading-5 text-amber-100">该多模态形态目前仅建立 Adapter、Binding 和状态基础，不会发送付费认证；对应数据面批次接入后才开放此按钮。</p> : null}
             <button className="inline-flex items-center gap-2 rounded-full bg-violet-200 px-4 py-2 text-sm font-semibold text-ink-950 disabled:cursor-not-allowed disabled:opacity-40" disabled={!canConfirm || busy} onClick={() => setConfirmCertification(true)} type="button">
               <ShieldCheck className="h-4 w-4" />运行资格认证
             </button>

--- a/client/src/content/help-center/articles/recover-unavailable-feature.md
+++ b/client/src/content/help-center/articles/recover-unavailable-feature.md
@@ -42,7 +42,9 @@
 
 ### 为什么设置里能选择多模态 Adapter，却不能运行认证或激活？
 
-R8A 只建立图片、文档、语音、视频和 Realtime 的控制面基础。管理员可以为连接添加明确的 `document`、`image` 或 `video` scope，并查看各入口要求的 Adapter；这不代表数据面已经接入。对应的 R8B—R8F 尚未完成时，认证按钮和 Managed 激活会保持阻断，也不会产生付费调用。不要通过修改请求或打开 Feature Flag 绕过该门禁。
+R8A 建立了图片、文档、语音、视频和 Realtime 的控制面基础；R8B 已接入图片 Chat、原生 PDF Chat、RAG/Workflow/Xpert Vision 和图片生成。管理员仍需为连接添加明确的 `chat`、`document` 或 `image` scope，刷新目录，完成精确模型、执行形态和 Adapter 的真实认证，再到“路由与实验”激活对应入口。认证通过不等于已生产启用，Feature Flag 默认关闭。
+
+STT/TTS、Chat Audio、音频生成、视频和 Realtime 仍等待 R8C—R8F；这些入口的认证按钮和 Managed 激活会继续阻断且不会产生付费调用。图片与原生 PDF、工具或其他未按同一形态认证的组合请求也会在发送前阻断。不要通过修改请求或打开 Feature Flag 绕过门禁。
 
 ### RAG Formal 显示“引用已失效”或“不可重放”怎么办？
 

--- a/client/src/pages/XpertChatPage.file-assets.test.ts
+++ b/client/src/pages/XpertChatPage.file-assets.test.ts
@@ -38,6 +38,51 @@ describe("latestXpertProviderReceipt", () => {
     expect(latestXpertProviderReceipt([])).toBeNull();
     expect(latestXpertProviderReceipt([{ event: "workflow_end" }])).toBeNull();
   });
+
+  it("deduplicates progressive receipts and combines vision with the Xpert call", () => {
+    const visionReceipt = {
+      contract_version: "modelmirror-provider-multimodal-routing-v1" as const,
+      entry_id: "xpert_vision" as const,
+      routing_mode: "managed_required" as const,
+      run_reference: "vision-run-1",
+      status: "passed" as const,
+      call_count: 1,
+      reason_codes: [],
+      calls: [{
+        call_sequence: 1,
+        model_id: "provider/vision-model",
+        status: "passed" as const,
+        total_tokens: 20,
+      }],
+    };
+    const xpertReceipt = {
+      contract_version: "modelmirror-provider-workload-routing-v1" as const,
+      entry_id: "xpert" as const,
+      routing_mode: "managed_required" as const,
+      run_reference: "xpert-run-1",
+      status: "passed" as const,
+      call_count: 1,
+      reason_codes: [],
+      calls: [{
+        call_sequence: 1,
+        model_id: "provider/text-model",
+        status: "passed" as const,
+        total_tokens: 10,
+      }],
+    };
+
+    const combined = latestXpertProviderReceipt([
+      { event: "node_end", provider_route_receipts: visionReceipt },
+      { event: "node_end", provider_route_receipts: visionReceipt },
+      { event: "workflow_end", provider_route_receipts: xpertReceipt },
+    ]);
+
+    expect(combined).toMatchObject({ status: "passed", call_count: 2 });
+    expect(combined?.calls).toEqual([
+      expect.objectContaining({ call_sequence: 1, model_id: "provider/vision-model" }),
+      expect.objectContaining({ call_sequence: 2, model_id: "provider/text-model" }),
+    ]);
+  });
 });
 
 afterEach(() => {

--- a/client/src/pages/XpertChatPage.tsx
+++ b/client/src/pages/XpertChatPage.tsx
@@ -98,12 +98,76 @@ interface XpertRunEvent {
 export function latestXpertProviderReceipt(
   events: XpertRunEvent[],
 ): ProviderRouteReceipt | null {
-  for (let index = events.length - 1; index >= 0; index -= 1) {
-    if (events[index]?.provider_route_receipts) {
-      return events[index].provider_route_receipts ?? null;
-    }
+  const receiptsByRun = new Map<string, ProviderRouteReceipt>();
+  events.forEach((event) => {
+    const receipt = event.provider_route_receipts;
+    if (!receipt) return;
+    receiptsByRun.set(`${receipt.entry_id}:${receipt.run_reference}`, receipt);
+  });
+  const receipts = [...receiptsByRun.values()];
+  if (!receipts.length) return null;
+  if (receipts.length === 1) return receipts[0] ?? null;
+
+  const statuses = new Set(receipts.map((receipt) => receipt.status));
+  const status: ProviderRouteReceipt["status"] = statuses.has("uncertain")
+    ? "uncertain"
+    : statuses.has("failed")
+      ? "failed"
+      : statuses.has("cancelled")
+        ? "cancelled"
+        : statuses.has("running")
+          ? "running"
+          : "passed";
+  const calls = receipts.flatMap((receipt) => receipt.calls).map((call, index) => ({
+    ...call,
+    call_sequence: index + 1,
+  }));
+  return {
+    contract_version: "modelmirror-provider-workload-routing-v1",
+    entry_id: "xpert",
+    routing_mode: "managed_required",
+    run_reference: `xpert-composed-${receipts.length}`,
+    status,
+    call_count: receipts.reduce((total, receipt) => total + receipt.call_count, 0),
+    reason_codes: [...new Set(receipts.flatMap((receipt) => receipt.reason_codes))],
+    calls,
+  };
+}
+
+function xpertProviderReceiptEvents(
+  events: XpertRunEvent[],
+): XpertRunEvent[] {
+  return events.filter((event) => event.provider_route_receipts);
+}
+
+function appendXpertProviderReceiptEvent(
+  events: XpertRunEvent[],
+  event: XpertRunEvent,
+): XpertRunEvent[] {
+  if (!event.provider_route_receipts) return events;
+  return [...events, event];
+}
+
+function resetXpertProviderReceipts(
+  receiptEventsRef: { current: XpertRunEvent[] },
+  setProviderReceipt: (receipt: ProviderRouteReceipt | null) => void,
+) {
+  receiptEventsRef.current = [];
+  setProviderReceipt(null);
+}
+
+function recordXpertProviderReceipt(
+  receiptEventsRef: { current: XpertRunEvent[] },
+  event: XpertRunEvent,
+  setProviderReceipt: (receipt: ProviderRouteReceipt | null) => void,
+) {
+  receiptEventsRef.current = appendXpertProviderReceiptEvent(
+    receiptEventsRef.current,
+    event,
+  );
+  if (event.provider_route_receipts) {
+    setProviderReceipt(latestXpertProviderReceipt(receiptEventsRef.current));
   }
-  return null;
 }
 
 export function selectedXpertFilesAfterConversationRestore(
@@ -353,6 +417,7 @@ export default function XpertChatPage() {
   const [input, setInput] = useState("");
   const [events, setEvents] = useState<XpertRunEvent[]>([]);
   const [providerReceipt, setProviderReceipt] = useState<ProviderRouteReceipt | null>(null);
+  const providerReceiptEventsRef = useRef<XpertRunEvent[]>([]);
   const [runId, setRunId] = useState("");
   const [taskId, setTaskId] = useState("");
   const [trace, setTrace] = useState<TraceBundle | null>(null);
@@ -554,7 +619,7 @@ export default function XpertChatPage() {
     setFileOutputs([]);
     setSelectedFileIds([]);
     setEvents([]);
-    setProviderReceipt(null);
+    resetXpertProviderReceipts(providerReceiptEventsRef, setProviderReceipt);
     setContextLoading(true);
     setError("");
     try {
@@ -605,6 +670,7 @@ export default function XpertChatPage() {
               conversationIdRef.current,
             )) {
               setEvents(restored);
+              providerReceiptEventsRef.current = xpertProviderReceiptEvents(restoredEvents);
               setProviderReceipt(latestXpertProviderReceipt(restoredEvents));
             }
           }
@@ -1060,7 +1126,7 @@ export default function XpertChatPage() {
     setInput("");
     setSelectedFileIds(nextSelectedFileIds);
     setEvents([]);
-    setProviderReceipt(null);
+    resetXpertProviderReceipts(providerReceiptEventsRef, setProviderReceipt);
     setTrace(null);
     setRunId("");
     setTaskId("");
@@ -1100,9 +1166,7 @@ export default function XpertChatPage() {
           if (!raw) continue;
           const event = JSON.parse(raw) as XpertRunEvent;
           setEvents((current) => [...current.slice(-79), event]);
-          if (event.provider_route_receipts) {
-            setProviderReceipt(event.provider_route_receipts);
-          }
+          recordXpertProviderReceipt(providerReceiptEventsRef, event, setProviderReceipt);
           if (event.run_id) {
             nextRunId = event.run_id;
             setRunId(event.run_id);
@@ -1185,7 +1249,7 @@ export default function XpertChatPage() {
       let finalSuggestions: string[] = [];
       let finalConversationTitle = "";
       setEvents([]);
-      setProviderReceipt(null);
+      resetXpertProviderReceipts(providerReceiptEventsRef, setProviderReceipt);
 
       const processBlock = (block: string) => {
         for (const line of block.split(/\r?\n/)) {
@@ -1194,9 +1258,7 @@ export default function XpertChatPage() {
           if (!raw) continue;
           const event = JSON.parse(raw) as XpertRunEvent;
           setEvents((current) => [...current.slice(-79), event]);
-          if (event.provider_route_receipts) {
-            setProviderReceipt(event.provider_route_receipts);
-          }
+          recordXpertProviderReceipt(providerReceiptEventsRef, event, setProviderReceipt);
           if (event.run_id) {
             nextRunId = event.run_id;
             setRunId(event.run_id);

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -525,7 +525,10 @@ export interface ProviderRouteReceipt {
     | "workflow_interactive_agent"
     | "workflow_deployment_agent"
     | "xpert"
-    | "xpert_app";
+    | "xpert_app"
+    | "workflow_interactive_vision"
+    | "workflow_deployment_vision"
+    | "xpert_vision";
   routing_mode: "managed_required";
   run_reference: string;
   status: "running" | "passed" | "failed" | "uncertain" | "cancelled";

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -163,6 +163,11 @@ STT/TTS、Chat Audio、音频生成、视频分析/生成和 Realtime SDP 保持
 精确 `entry + shape + model + connection + adapter` Binding、资格状态和脱敏 Receipt。
 所有 R8 开关默认关闭，R8A 不发起真实资格调用，现有 Chat SSE 与专用多模态路径不变。
 
+Round 8B 在该外壳内接入图片 Chat、原生 PDF Chat、RAG/Workflow/Xpert Vision 和图片生成。
+每个入口只调用一个精确 Managed Connection；图片、PDF、严格 JSON 和 Images 仍保留独立执行
+协议。图片与原生 PDF等未认证混合形态会在派发前阻断，派发后错误不触发第二 Provider或 legacy。
+STT/TTS、Chat Audio、音频生成、视频与 Realtime 继续等待 R8C—R8F，全部 Feature Flag 仍默认关闭。
+
 Round 5A 在控制面增加 `modelmirror-provider-chat-routing-v1`：`chat_text`、
 `chat_tools` 与 `chat_file_output` 各自具有独立认证、稳定模型资格和有序 Managed
 Provider 路由。SQLite v15 保存租户隔离的策略、资格、Gate 纪元以及不含用户正文的

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -315,10 +315,18 @@ MODEL_CONTROL_VIDEO_GENERATION_ENABLED=false
 MODEL_CONTROL_REALTIME_VOICE_ENABLED=false
 ```
 
-R8A 只迁移 Router SQLite 至 v18，并展示 scope、Adapter、Binding 与资格框架；不得把打开环境变量
-解释为数据面已接入。R8B—R8F 合并并完成对应真实验收前，Settings 会阻止多模态资格付费调用和
-Policy 激活。部署前使用 SQLite Backup API 备份 Router 数据库；回滚代码时保留 v18 表和新增的
-可空任务证据列，旧代码会忽略它们。不得删除现有媒体任务、Provider 凭据或 newAPI 数据。
+R8A 迁移 Router SQLite 至 v18，并展示 scope、Adapter、Binding 与资格框架。R8B 已接入图片 Chat、
+原生 PDF Chat、RAG/Workflow/Xpert Vision 与图片生成的数据面；只有对应连接完成精确 shape/Adapter
+资格后才能激活。STT/TTS、Chat Audio、音频生成、视频与 Realtime 在 R8C—R8F 合并并完成真实
+验收前仍会阻止付费认证和 Policy 激活。不得把打开环境变量解释为资格已通过或生产切换已批准。
+
+Managed 图片生成请求必须携带 1—200 字符的 `Idempotency-Key`。OpenAI-compatible Images
+连接使用 `/v1/images/generations`、标准 `size` 和 `response_format=b64_json`；若所选高级参数不在
+该 Adapter 合同内，请改用已认证 Adapter或移除参数，不要靠失败后切换 Provider 探测。
+
+部署前使用 SQLite Backup API 备份 Router 数据库；回滚时关闭受影响 R8B Flag 并显式停用 Policy，
+保留 v18 表、资格、Receipt 和新增的可空任务证据列。不得删除现有媒体任务、Provider 凭据或
+newAPI 数据。
 
 规则：
 

--- a/docs/MODEL_PROVIDER_CONTROL_PLANE.md
+++ b/docs/MODEL_PROVIDER_CONTROL_PLANE.md
@@ -323,6 +323,20 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
 - v18 对现有音频、视频与 Realtime 任务只增加可空的 Workload/Adapter/派发证据字段；旧记录
   视为 legacy，不重写、不联网回填。已派发但结果不确定的会话重启后保持 `uncertain`，不得重放。
 
+## 图片、Vision 与原生 PDF 数据面（Round 8B）
+
+- R8B 将 `chat_image`、`chat_document_native`、`rag_vision`、Workflow 交互/部署 Vision、
+  `xpert_vision` 和 `image_generation` 接入 R8A 的精确 Binding 与 Receipt；其余多模态入口仍未接管。
+- Chat 图片和原生 PDF 继续使用原 `/api/chat` SSE；Vision 继续返回严格 JSON；图片生成继续使用
+  `/api/multimodal/image/generations` 完整响应。统一控制面不合并这些协议。
+- 同一调用只使用一个已批准 IP和一个 Provider POST。请求派发后，HTTP 错误、超时、断流或
+  uncertain 均不切换连接、模型、Adapter 或 legacy；混合图片与原生 PDF等未认证组合在 POST 前阻断。
+- `openrouter_images_v1` 使用 OpenRouter `/images`；`openai_compatible_images_generations_v1`
+  使用 `/images/generations`，并将 UI 的 `resolution` 映射为标准 `size`，强制请求 Base64 输出。
+- 图片生成在 Managed 模式要求 `Idempotency-Key`；稳定运行引用只保存 Key 哈希。图片、PDF、
+  Prompt、Vision 结果、生成正文和完整错误体不进入 Router SQLite 或 Receipt。
+- 所有 R8B Feature Flag 仍默认关闭。PR 合并不等于生产启用、真实认证或 Provider 默认切换。
+
 ## 回退
 
 关闭管理面或回退路由不得删除 Provider SQLite、newAPI 数据目录、旧主密钥或迁移
@@ -330,8 +344,9 @@ python -m server.model_router.migrate_credentials --storage-dir <path>
 将 `MODEL_CONTROL_CHAT_ENABLED=false` 保持 R5 数据面关闭。关闭各入口对应的
 `MODEL_CONTROL_*_ENABLED` 可保持 R6 数据面为 legacy。代码回退保留 v15/v16 表和
 脱敏证据；关闭 R7 对应 Feature Flag 可恢复 RAG/Skill/Batch 的 legacy 路径，并保留 v17 表、
-资格、Batch 映射与 Receipt。关闭全部 R8 Flag 可保持多模态数据面为 legacy；回退 R8A 时保留
-v18 表、Adapter、资格会话与新增任务证据列。非终态 Batch 应继续通过本地任务 ID只读轮询，
+资格、Batch 映射与 Receipt。关闭对应 R8B Flag 可恢复图片、PDF 和 Vision 的 legacy 路径；
+关闭全部 R8 Flag 可保持其余多模态数据面为 legacy。回退 R8A/R8B 时保留 v18 表、Adapter、
+资格会话与新增任务证据列。非终态 Batch 应继续通过本地任务 ID只读轮询，
 不得清理或重发。
 只需将策略 `auto_enabled=false` 即可停止新增 Auto 证据而不改变 Auto 调度。
 旧版本可忽略新表继续运行。部署回退通过恢复上一版本

--- a/docs/help-center/evidence/provider-multimodal-r8b.md
+++ b/docs/help-center/evidence/provider-multimodal-r8b.md
@@ -1,0 +1,74 @@
+# R8B 图片、Vision 与原生 PDF 独立预览证据
+
+- 基线：`origin/main@be056e994d99fca2dcc158bd42cc71e8ebfc3db7`。
+- 分支：`codex/provider-multimodal-image-r8b`。
+- 独立预览：前端 `http://127.0.0.1:15152`，后端
+  `http://127.0.0.1:18152`；Router 数据位于独立的 R8B 预览目录，未复用 R8A
+  或主工作区的可写数据。
+- 已验证前后端均返回 HTTP 200，Settings 未配对状态正常，Marble 仍位于 Provider
+  控制面之外。
+- 公开状态投影确认 R8B 七个入口的部署开关已开启，但 Policy 默认为 `legacy`，因此
+  未认证、未绑定时不会产生 Provider 请求；R8C 及后续入口保持关闭。
+- 容器启动日志未出现 R8B 路由、迁移或凭据错误。
+
+## 自动验证
+
+- R8B 专项与原生 PDF `/api/chat` 数据面测试：12 passed，其中固定合成 PNG
+  必须通过真实解码校验。
+- 受影响后端套件：最终修复后 67 passed；原始 `be056e99` 实现基线的全量后端：
+  5,072 passed、29 skipped、25 failed。JUnit 结果保存在独立验收目录，未依赖终端
+  缓冲区判断终态。
+- 干净 `be056e99` 基线 Worktree 使用相同镜像与相同定向命令，精确复现全部新增
+  候选失败；因此 R8B 新增失败为 0。25 项由 14 个缺少 Agency Worker 构建产物、
+  3 个 Expert Team Worker 依赖失败、3 个容器内 TypeScript 模块加载失败，以及 4 个
+  基线文件资产旧断言、1 个受预览镜像 R8 Feature Flag 环境影响的基线断言组成。
+- 前端全量：123 个测试文件、768 tests 与 1 个 Node header test 通过；production
+  build 通过。原始增量 `typecheck` 因 Worktree 共用 `node_modules/.tmp` 的
+  `tsbuildinfo` 被 Windows 拒绝写入而两次阻断；app 与 Vite 配置分别使用
+  `--incremental false` 执行同等严格 TypeScript 检查，均以退出码 0 通过。
+- Xpert Vision Receipt 投影修复后，Workflow Vision 定向测试 7 passed；Chat、文件、
+  RAG 与 R8B 受影响后端集合 67 passed。成功和失败事件均只投影一个脱敏 Receipt
+  对象，多页调用重新编号，前端按入口与运行引用去除渐进重复后再合并调用数。
+- Core、独立 newAPI 与 Overlay Compose 配置均通过。
+- `git diff --check` 通过；生产文件与文档未发现凭据或预览密钥。
+- 发布前已 rebase 到 `origin/main@b143cde199feaf3a6304b8680739246b087100b3`。
+  最新主线交叉验证为：后端受影响套件 67 passed、前端 Receipt/Settings 定向
+  25 passed、app 与 Vite 配置 TypeScript 严格检查均退出码 0；Vite 7.3.5 使用
+  `--configLoader runner` 在独立临时目录完成 3,165 modules 的 production build。
+  rebase 后未重复运行全量后端或前端全量测试，原始全量结果不冒充最新主线全量结果。
+
+## 真实 Provider 证据与待验收项
+
+- 管理员配对、R8B Adapter 选择、付费确认门禁与失败证据持久化已在独立预览确认。
+- 首次 `chat_image_stream` 真实认证只产生一个 OpenRouter Chat POST，上游返回 HTTP
+  400，记录为 `provider_workload_http_error`；无重试、第二连接或 legacy 回退。
+- 证伪检查发现仓库内固定 1×1 PNG 的 IDAT CRC 无效。已替换为可解码的 2×2 PNG、
+  增加回归测试并重建预览。
+- 修复后的 `chat_image_stream` 重测只产生一个 OpenRouter Chat POST并返回 HTTP 200；
+  资格为 `passed`，实际模型与请求的 `openai/gpt-4o-mini` 一致。上游报告
+  `8511` 个输入 token、`3` 个输出 token，共 `8514`；这是一条调用的 usage，不是重复调用。
+- SQLite 保留首次失败和修复后通过两条脱敏资格记录；认证表没有 Prompt、消息、图片、
+  模型正文、完整响应或 Key 字段。
+- `chat_image`、`chat_document_native`、`workflow_interactive_vision`、
+  `workflow_deployment_vision`、RAG Vision 与 `image_generation` 的真实资格和用户入口
+  Smoke 已逐项完成；每个受控逻辑调用均对应一个 Provider POST，未观察到第二连接、
+  第二 IP 或 legacy 回退。
+- Published Xpert Smoke 使用公开测试图片，运行 ID
+  `53069871-cb29-4780-904d-0fa736d34a4c`、任务 ID
+  `a1abefbddf4a475fb81614c3617253b9`。SQLite 只记录两条脱敏、已确认调用：
+  `xpert_vision/vision_json_unary` 一次（25,657 tokens）与 `xpert/chat_text` 一次
+  （586 tokens）；两者实际模型均与精确绑定一致，无重复和远程回退。
+- 严格审计发现成功 Vision Receipt 原先只写入 SQLite 和节点变量，未进入成功
+  `node_end`，导致 Xpert 页面最终只显示后续文本调用一次。现已修复成功/失败事件投影
+  及前端多阶段合并，并由 Mock 回归证明显示口径为两次且不会重复计算渐进 Receipt。
+- 修复后在同一预览构建完成新的真实浏览器闭环，页面运行 ID 为
+  `2e2f7f7e-3444-4f30-8f56-4686cd31faa1`：用户侧正确显示调用 1 与调用 2，最终状态
+  `completed`。SQLite 同期只新增 `xpert_vision/vision_json_unary` 一次
+  （25,635 tokens）和 `xpert/chat_text` 一次（507 tokens）；两条记录均为
+  `dispatched=1`、`confirmed`、`passed`，请求与实际模型均为
+  `openai/gpt-4o-mini`，无第二连接、远程回退或重复 POST。
+- Smoke 期间仅有一个伴随的 `/api/files/outputs` 只读请求返回 503；已确认预览器明确
+  关闭 `FILE_OUTPUT_ASSETS_ENABLED` 与 `CHAT_FILE_OUTPUT_TOOL_ENABLED`，该请求不在
+  R8B Vision 数据面内，也未影响回答、Receipt 或运行完成状态。
+- 本证据仅证明 R8B 已验收的 operation/Adapter；不声称 newAPI 多模态默认切换或 R8C
+  及后续能力已经通过。任何新增付费 POST 均需逐次授权。

--- a/docs/task-cards/provider-multimodal-r8b.md
+++ b/docs/task-cards/provider-multimodal-r8b.md
@@ -1,0 +1,40 @@
+# 任务卡：R8B 图片、Vision 与原生 PDF Provider 控制面
+
+## 范围
+
+- 实施基线：`origin/main@be056e994d99fca2dcc158bd42cc71e8ebfc3db7`，已包含 R8A。
+- 接管 `chat_image`、`chat_document_native`、`rag_vision`、Workflow 交互/部署 Vision、
+  `xpert_vision` 和 `image_generation`。
+- 只统一精确 Binding、Adapter、资格、出口、单次派发和 Receipt；Chat SSE、Vision JSON、
+  原生 PDF 与 Images 响应继续使用各自协议。
+- 不接管 STT/TTS、Chat Audio、音频生成、视频或 Realtime，不改变 Catalog 与提示词选择器口径。
+
+## 安全边界
+
+- 所有 R8B Feature Flag 默认关闭；Policy 为 `legacy` 时原路径保持不变。
+- `managed_required` 只接受当前模型、连接指纹、scope、资格和 Adapter 完全匹配的 Binding。
+- 一个逻辑调用最多派发一个 POST；派发后不得切换第二 IP、连接、模型、Adapter 或 legacy。
+- 图片与原生 PDF、工具或其他未经同形态认证的组合请求在 POST 前失败关闭。
+- OpenAI-compatible Images Adapter 固定使用 `/images/generations`、`size` 与
+  `response_format=b64_json`；未验证的高级参数不静默透传。
+- 控制面不保存图片、PDF、Prompt、Vision 结果、生成图片或完整上游错误体。
+
+## 验收
+
+- 固定 PNG、有效单页 PDF 和低尺寸图片生成资格各自独立；资格不能跨 shape 继承。
+- Chat 图片、原生 PDF、RAG/Workflow/Xpert Vision 和图片生成的 Receipt 与实际目标一致。
+- HTTP 错误、超时、断流、取消和响应超限均不重放；确定失败与 uncertain 可区分。
+- Managed 图片生成要求 `Idempotency-Key`；重复键在任何第二次 POST 前阻断。
+- R8A、R5—R7、多模态 legacy、Chat 文件与 SSE 回归通过，并完成严格证伪测试。
+- 独立预览、真实资格和各用户入口 Smoke 分别验收；付费调用逐次授权。
+
+## 回滚
+
+关闭对应 R8B Feature Flag 并重启即可恢复 legacy。保留 v18 表、资格和脱敏 Receipt；
+不得删除 Router SQLite、Provider 凭据、媒体任务或 newAPI 数据。
+
+## Help Center Impact
+
+- 影响用户体验：是。Settings 会把 R8B 七个入口显示为“数据面已接入”，其余 R8 入口仍保持阻断。
+- 正式文章：`client/src/content/help-center/articles/recover-unavailable-feature.md`。
+- 独立预览证据：`docs/help-center/evidence/provider-multimodal-r8b.md`。

--- a/server/file_assets/api.py
+++ b/server/file_assets/api.py
@@ -67,9 +67,11 @@ try:
         get_model_router_service,
     )
     from server.model_router.chat_control import ProviderChatControlService
+    from server.model_router.workload_control import ProviderWorkloadControlService
 except ModuleNotFoundError:
     from model_router.api import get_catalog_coordinator, get_model_router_service
     from model_router.chat_control import ProviderChatControlService
+    from model_router.workload_control import ProviderWorkloadControlService
 
 
 MIB = 1024 * 1024
@@ -392,6 +394,21 @@ def delete_file_output(
 
 
 async def _verified_native_pdf(model_id: str) -> bool:
+    if ProviderWorkloadControlService.feature_enabled("chat_document_native"):
+        try:
+            managed_status = ProviderWorkloadControlService(
+                get_model_router_service()
+            ).public_status(
+                "chat_document_native",
+                model_id,
+                "chat_document_stream",
+            )
+        except Exception:
+            # Once the managed data plane is enabled, its projection is the
+            # authority and must fail closed instead of borrowing legacy state.
+            return False
+        if managed_status.status != "legacy":
+            return managed_status.available
     if not _active_chat_url_is_openrouter():
         return False
     try:

--- a/server/main.py
+++ b/server/main.py
@@ -1460,6 +1460,11 @@ try:
         ManagedWorkflowNodeRun,
         ManagedWorkflowRoutingError,
     )
+    from server.model_router.multimodal_gateway import (
+        ManagedMultimodalChatDispatch,
+        ManagedMultimodalError,
+        ManagedMultimodalGateway,
+    )
 except ModuleNotFoundError:
     from model_router.expert_team_gateway import (
         ManagedExpertTeamGateway,
@@ -1475,6 +1480,11 @@ except ModuleNotFoundError:
         ManagedWorkflowAgentRun,
         ManagedWorkflowNodeRun,
         ManagedWorkflowRoutingError,
+    )
+    from model_router.multimodal_gateway import (
+        ManagedMultimodalChatDispatch,
+        ManagedMultimodalError,
+        ManagedMultimodalGateway,
     )
 
 try:
@@ -1512,12 +1522,14 @@ except ModuleNotFoundError:
 try:
     from server.xpert_runtime.workflow_vision import (
         WorkflowVisionError,
+        compose_workflow_vision_receipt,
         execute_workflow_vision,
         resolve_workflow_vision_asset,
     )
 except ModuleNotFoundError:
     from xpert_runtime.workflow_vision import (
         WorkflowVisionError,
+        compose_workflow_vision_receipt,
         execute_workflow_vision,
         resolve_workflow_vision_asset,
     )
@@ -3492,6 +3504,17 @@ async def model_supports_image_input(model_id: str) -> bool:
         and profile.interaction_status == "ready"
         for profile in catalog.profiles
     )
+
+
+async def workflow_vision_model_available(entry_id: str, model_id: str) -> bool:
+    """Project the selected control-plane mode without crossing fallback boundaries."""
+
+    routing_mode = workflow_vision_service.managed_routing_mode(entry_id)
+    if routing_mode == "managed_required":
+        return workflow_vision_service.managed_model_available(entry_id, model_id)
+    if routing_mode == "degraded_required":
+        return False
+    return await model_supports_image_input(model_id)
 
 
 async def validate_multimodal_content(
@@ -6609,11 +6632,19 @@ class WorkflowKnowledgeFatalError(RuntimeError):
 class WorkflowVisionFatalError(RuntimeError):
     """Stable, content-free fatal error for vision_understanding nodes."""
 
-    def __init__(self, node_id: str, error_code: str, safe_message: str) -> None:
+    def __init__(
+        self,
+        node_id: str,
+        error_code: str,
+        safe_message: str,
+        *,
+        provider_route_receipts: list[dict[str, Any]] | None = None,
+    ) -> None:
         super().__init__(safe_message)
         self.node_id = node_id
         self.error_code = error_code
         self.safe_message = safe_message
+        self.provider_route_receipts = list(provider_route_receipts or [])
 
 
 def _legacy_path_identity(path: Path) -> tuple[int, int, int, int]:
@@ -17698,6 +17729,13 @@ async def _run_workflow_response(
 
                 elif kind == "vision_understanding":
                     try:
+                        managed_vision_entry_id = (
+                            "workflow_deployment_vision"
+                            if trusted_source_kind == "workflow_deployment"
+                            else "xpert_vision"
+                            if trusted_source_kind in {"xpert_chat", "xpert_app"}
+                            else "workflow_interactive_vision"
+                        )
                         output_variable = str(
                             node.data.get("outputVariable") or "vision_result"
                         ).strip()
@@ -17729,7 +17767,10 @@ async def _run_workflow_response(
                                 "workflow_vision_model_required",
                                 "Select an image-input model before running this node.",
                             )
-                        if not await model_supports_image_input(model_id):
+                        if not await workflow_vision_model_available(
+                            managed_vision_entry_id,
+                            model_id,
+                        ):
                             raise WorkflowVisionFatalError(
                                 node.id,
                                 "workflow_vision_model_unavailable",
@@ -17764,8 +17805,15 @@ async def _run_workflow_response(
                                 or "continue_on_error"
                             ),
                             service=workflow_vision_service,
+                            managed_entry_id=managed_vision_entry_id,
+                            parent_run_reference=(
+                                f"{workflow_run.run_id}:{node.id}:vision"
+                            ),
                         )
                         variables[output_variable] = result_payload
+                        node_provider_receipt = compose_workflow_vision_receipt(
+                            result.provider_route_receipts
+                        )
                         await run_registry.record_checkpoint(
                             workflow_run.run_id,
                             event_type="workflow.vision.completed",
@@ -17806,6 +17854,9 @@ async def _run_workflow_response(
                             node.id,
                             exc.error_code,
                             exc.message,
+                            provider_route_receipts=(
+                                exc.provider_route_receipts
+                            ),
                         ) from None
                     except Exception as exc:
                         logger.warning(
@@ -23950,6 +24001,19 @@ async def _run_workflow_response(
             )
         except WorkflowVisionFatalError as exc:
             failure_error = f"{exc.error_code}: {exc.safe_message}"
+            failure_receipt = compose_workflow_vision_receipt(
+                exc.provider_route_receipts
+            )
+            failure_event = {
+                "event": "error",
+                "task_id": task_id,
+                "run_id": workflow_run.run_id,
+                "node_id": exc.node_id,
+                "code": exc.error_code,
+                "message": exc.safe_message,
+            }
+            if failure_receipt is not None:
+                failure_event["provider_route_receipts"] = failure_receipt
             logger.warning(
                 "Workflow vision node failed workflow=%s node=%s code=%s",
                 payload.workflow.id,
@@ -23982,30 +24046,14 @@ async def _run_workflow_response(
                 workflow_execution_store.fail(task_id, error=failure_error)
                 workflow_execution_store.append_event(
                     task_id,
-                    {
-                        "event": "error",
-                        "task_id": task_id,
-                        "run_id": workflow_run.run_id,
-                        "node_id": exc.node_id,
-                        "code": exc.error_code,
-                        "message": exc.safe_message,
-                    },
+                    failure_event,
                 )
             except Exception:
                 logger.warning(
                     "Failed to persist workflow vision failure",
                     exc_info=True,
                 )
-            yield sse_payload(
-                {
-                    "event": "error",
-                    "task_id": task_id,
-                    "run_id": workflow_run.run_id,
-                    "node_id": exc.node_id,
-                    "code": exc.error_code,
-                    "message": exc.safe_message,
-                }
-            )
+            yield sse_payload(failure_event)
         except WorkflowDocumentFatalError as exc:
             failure_error = f"{exc.error_code}: {exc.safe_message}"
             logger.warning(
@@ -29450,6 +29498,15 @@ async def chat(payload: ChatRequest, request: Request):
     direct_file_requested = any(
         message_has_file(message.content) for message in payload.messages
     )
+    direct_image_requested = any(
+        message_has_image(message.content) for message in payload.messages
+    )
+    native_document_requested = any(
+        isinstance(part, InputFileContentPart) and part.handling == "native"
+        for message in payload.messages
+        if isinstance(message.content, list)
+        for part in message.content
+    )
     resolved_chat_files: tuple[ResolvedChatFile, ...] = ()
     resolved_output_images: dict[str, str] = {}
     resolved_output_attachments: dict[str, tuple[str, bytes]] = {}
@@ -29509,6 +29566,102 @@ async def chat(payload: ChatRequest, request: Request):
             )
             for message in payload.messages
         )
+    )
+    managed_multimodal_gateway = ManagedMultimodalGateway.for_router(
+        get_model_router_service()
+    )
+    image_control_mode = (
+        managed_multimodal_gateway.routing_mode("chat_image")
+        if direct_image_requested and payload.gateway == "default"
+        else "legacy"
+    )
+    document_control_mode = (
+        managed_multimodal_gateway.routing_mode("chat_document_native")
+        if native_document_requested and payload.gateway == "default"
+        else "legacy"
+    )
+    managed_multimodal_entry = (
+        "chat_document_native"
+        if native_document_requested
+        else "chat_image"
+        if direct_image_requested
+        else None
+    )
+    managed_multimodal_shape = (
+        "chat_document_stream"
+        if native_document_requested
+        else "chat_image_stream"
+        if direct_image_requested
+        else None
+    )
+    managed_multimodal_mode = (
+        document_control_mode
+        if native_document_requested
+        else image_control_mode
+        if direct_image_requested
+        else "legacy"
+    )
+    managed_multimodal_request_supported = bool(
+        managed_multimodal_entry is not None
+        and payload.tool_mode == "none"
+        and payload.output_mode == "none"
+        and payload.response_audio is None
+        and payload.skill_application is None
+        and payload.routing is None
+        and not direct_audio_requested
+        and not direct_video_requested
+    )
+    if (
+        direct_image_requested
+        and native_document_requested
+        and (image_control_mode != "legacy" or document_control_mode != "legacy")
+    ):
+        reason_code = "provider_multimodal_mixed_shape_unsupported"
+        blocked_entry = (
+            "chat_image"
+            if image_control_mode != "legacy"
+            else "chat_document_native"
+        )
+        return JSONResponse(
+            status_code=422,
+            content={
+                "error": "图片与原生 PDF 不能在同一次 Managed 多模态调用中混合发送。",
+                "code": reason_code,
+                "route_receipt": managed_multimodal_gateway.blocked_receipt(
+                    blocked_entry, reason_code
+                ),
+            },
+        )
+    if managed_multimodal_mode == "degraded_required":
+        reason_code = "provider_workload_policy_not_active"
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": "多模态 Managed Provider 策略已降级，调用已在发送前阻断。",
+                "code": reason_code,
+                "route_receipt": managed_multimodal_gateway.blocked_receipt(
+                    managed_multimodal_entry, reason_code  # type: ignore[arg-type]
+                ),
+            },
+        )
+    if (
+        managed_multimodal_mode == "managed_required"
+        and not managed_multimodal_request_supported
+    ):
+        reason_code = "provider_multimodal_request_shape_unsupported"
+        return JSONResponse(
+            status_code=422,
+            content={
+                "error": "该组合请求未通过当前多模态 Adapter 认证，调用已在发送前阻断。",
+                "code": reason_code,
+                "route_receipt": managed_multimodal_gateway.blocked_receipt(
+                    managed_multimodal_entry, reason_code  # type: ignore[arg-type]
+                ),
+            },
+        )
+    use_managed_multimodal_chat = bool(
+        managed_multimodal_mode == "managed_required"
+        and managed_multimodal_request_supported
     )
     chat_canary_session_id = (
         payload.routing.session_id
@@ -29631,6 +29784,7 @@ async def chat(payload: ChatRequest, request: Request):
         and not native_audio_requested
         and not direct_video_requested
         and not stable_chat_shape_requested
+        and not use_managed_multimodal_chat
     ):
         return JSONResponse(
             status_code=500,
@@ -29870,7 +30024,11 @@ async def chat(payload: ChatRequest, request: Request):
         await validate_multimodal_content(
             payload.model_id,
             payload.messages,
-            trust_gateway_catalog=use_omniroute or use_native_router,
+            trust_gateway_catalog=(
+                use_omniroute
+                or use_native_router
+                or use_managed_multimodal_chat
+            ),
         )
         validate_content(payload.messages)
         if payload.skill_application is not None:
@@ -29900,7 +30058,9 @@ async def chat(payload: ChatRequest, request: Request):
             )
             native_pdf_verified = False
             if native_requested:
-                if not is_openrouter_contract_url(url):
+                if use_managed_multimodal_chat:
+                    native_pdf_verified = True
+                elif not is_openrouter_contract_url(url):
                     raise HTTPException(
                         status_code=422,
                         detail=(
@@ -29908,9 +30068,10 @@ async def chat(payload: ChatRequest, request: Request):
                             "请改选“提取内容后发送”，或切换到 OpenRouter 连接。"
                         ),
                     )
-                native_pdf_verified = await model_supports_native_pdf_input(
-                    payload.model_id
-                )
+                if not use_managed_multimodal_chat:
+                    native_pdf_verified = await model_supports_native_pdf_input(
+                        payload.model_id
+                    )
                 if not native_pdf_verified:
                     raise HTTPException(
                         status_code=422,
@@ -29956,6 +30117,27 @@ async def chat(payload: ChatRequest, request: Request):
             status_code=500,
             content={"error": "后端校验请求时出错，请查看服务日志。"},
         )
+
+    managed_multimodal_dispatch: ManagedMultimodalChatDispatch | None = None
+    if use_managed_multimodal_chat:
+        try:
+            managed_multimodal_dispatch = (
+                await managed_multimodal_gateway.prepare_chat_dispatch(
+                    managed_multimodal_entry,  # type: ignore[arg-type]
+                    execution_shape=managed_multimodal_shape,  # type: ignore[arg-type]
+                    requested_model=payload.model_id,
+                    parent_run_reference=f"chat:{runtime_task_id}",
+                )
+            )
+        except ManagedMultimodalError as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={
+                    "error": str(exc),
+                    "code": exc.code,
+                    "route_receipt": exc.receipt,
+                },
+            )
 
     stable_chat_preflight = None
     stable_chat_dispatch = None
@@ -30015,6 +30197,7 @@ async def chat(payload: ChatRequest, request: Request):
         and not use_native_router
         and not native_audio_requested
         and not direct_video_requested
+        and not use_managed_multimodal_chat
     ):
         return JSONResponse(
             status_code=500,
@@ -31355,6 +31538,14 @@ async def chat(payload: ChatRequest, request: Request):
                 for target in native_plan.targets
             )
         )
+        if use_managed_multimodal_chat:
+            if managed_multimodal_dispatch is None:
+                raise RuntimeError("provider_multimodal_chat_dispatch_missing")
+            return await managed_multimodal_dispatch.send(
+                client,
+                request_payload,
+                headers=llm_gateway_headers(""),
+            )
         if use_stable_chat:
             if stable_chat_dispatch is None:
                 raise RuntimeError("provider_chat_stable_dispatch_missing")
@@ -31838,6 +32029,30 @@ async def chat(payload: ChatRequest, request: Request):
             e2e_ms=e2e_ms,
         )
 
+    def finalize_managed_multimodal_chat(
+        *,
+        status: str,
+        result_class: str,
+        error_code: str | None = None,
+        actual_model: str | None = None,
+        ttft_ms: float | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+    ) -> dict[str, Any] | None:
+        if not use_managed_multimodal_chat or managed_multimodal_dispatch is None:
+            return None
+        return managed_multimodal_dispatch.complete(
+            status=status,  # type: ignore[arg-type]
+            result_class=result_class,
+            error_code=error_code,
+            actual_model=actual_model or actual_model_id,
+            ttft_ms=ttft_ms,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+        )
+
     try:
         response = await send_initial_response()
     except RouterServiceError as exc:
@@ -31854,6 +32069,13 @@ async def chat(payload: ChatRequest, request: Request):
                 requested_model=payload.model_id,
                 reason_codes=[exc.code],
             )
+        managed_multimodal_receipt = finalize_managed_multimodal_chat(
+            status="failed",
+            result_class="control_plane_error",
+            error_code=exc.code,
+        )
+        if managed_multimodal_receipt is not None:
+            error_content["route_receipt"] = managed_multimodal_receipt
         return JSONResponse(status_code=exc.status_code, content=error_content)
     except httpx.TimeoutException:
         finalize_auto_failure("transient_failure", "provider_chat_timeout")
@@ -31862,6 +32084,11 @@ async def chat(payload: ChatRequest, request: Request):
         )
         stable_receipt = finalize_stable_chat_failure(
             "transient_failure", "provider_chat_timeout"
+        )
+        managed_multimodal_receipt = finalize_managed_multimodal_chat(
+            status="uncertain",
+            result_class="transport_error",
+            error_code="provider_workload_timeout",
         )
         if use_chat_canary:
             logger.warning(
@@ -31890,6 +32117,11 @@ async def chat(payload: ChatRequest, request: Request):
             timeout_content.update(
                 code="provider_chat_timeout", route_receipt=stable_receipt
             )
+        if managed_multimodal_receipt is not None:
+            timeout_content.update(
+                code="provider_workload_timeout",
+                route_receipt=managed_multimodal_receipt,
+            )
         return JSONResponse(status_code=504, content=timeout_content)
     except httpx.HTTPError as exc:
         finalize_auto_failure(
@@ -31900,6 +32132,11 @@ async def chat(payload: ChatRequest, request: Request):
         )
         stable_receipt = finalize_stable_chat_failure(
             "transient_failure", "provider_chat_transport_error"
+        )
+        managed_multimodal_receipt = finalize_managed_multimodal_chat(
+            status="uncertain",
+            result_class="transport_error",
+            error_code="provider_workload_transport_error",
         )
         if use_chat_canary:
             logger.warning(
@@ -31941,6 +32178,11 @@ async def chat(payload: ChatRequest, request: Request):
                 code="provider_chat_transport_error",
                 route_receipt=stable_receipt,
             )
+        if managed_multimodal_receipt is not None:
+            transport_content.update(
+                code="provider_workload_transport_error",
+                route_receipt=managed_multimodal_receipt,
+            )
         return JSONResponse(status_code=502, content=transport_content)
     except Exception:
         finalize_auto_failure(
@@ -31953,6 +32195,11 @@ async def chat(payload: ChatRequest, request: Request):
             "uncertain",
             "provider_chat_unexpected_error",
             status="uncertain",
+        )
+        managed_multimodal_receipt = finalize_managed_multimodal_chat(
+            status="uncertain",
+            result_class="unexpected_error",
+            error_code="provider_workload_dispatch_uncertain",
         )
         if use_stable_chat:
             logger.warning(
@@ -31980,6 +32227,11 @@ async def chat(payload: ChatRequest, request: Request):
                 code="provider_chat_unexpected_error",
                 route_receipt=stable_receipt,
             )
+        if managed_multimodal_receipt is not None:
+            unexpected_content.update(
+                code="provider_workload_dispatch_uncertain",
+                route_receipt=managed_multimodal_receipt,
+            )
         return JSONResponse(status_code=500, content=unexpected_content)
 
     if response.status_code >= 400:
@@ -32006,6 +32258,8 @@ async def chat(payload: ChatRequest, request: Request):
             )
         stable_http_receipt = None
         stable_http_error_code = None
+        managed_multimodal_http_receipt = None
+        managed_multimodal_http_error_code = None
         if use_chat_canary:
             result_class, canary_error_code = (
                 chat_canary_service.classify_http_failure(response.status_code)
@@ -32042,6 +32296,31 @@ async def chat(payload: ChatRequest, request: Request):
                 actual_model_id,
                 stable_http_error_code,
             )
+        elif use_managed_multimodal_chat:
+            managed_multimodal_http_error_code = {
+                401: "provider_workload_http_401",
+                403: "provider_workload_http_403",
+                404: "provider_workload_http_404",
+                429: "provider_workload_http_429",
+            }.get(
+                response.status_code,
+                "provider_workload_http_5xx"
+                if response.status_code >= 500
+                else "provider_workload_http_error",
+            )
+            managed_multimodal_http_receipt = finalize_managed_multimodal_chat(
+                status="failed",
+                result_class="provider_error",
+                error_code=managed_multimodal_http_error_code,
+            )
+            message = "多模态 Managed Provider 请求失败；本次请求未重放到其他目标。"
+            data = None
+            logger.warning(
+                "Managed multimodal Chat failed status=%s model=%s code=%s",
+                response.status_code,
+                actual_model_id,
+                managed_multimodal_http_error_code,
+            )
         elif direct_file_requested:
             message, file_error_code = chat_file_upstream_error(
                 response.status_code
@@ -32065,7 +32344,12 @@ async def chat(payload: ChatRequest, request: Request):
                 response.status_code,
                 actual_model_id,
             )
-        elif not direct_file_requested and not use_chat_canary and not use_stable_chat:
+        elif (
+            not direct_file_requested
+            and not use_chat_canary
+            and not use_stable_chat
+            and not use_managed_multimodal_chat
+        ):
             logger.warning(
                 "OpenRouter error status=%s model=%s message=%s body=%s",
                 response.status_code,
@@ -32079,6 +32363,7 @@ async def chat(payload: ChatRequest, request: Request):
             and not use_native_router
             and not use_chat_canary
             and not use_stable_chat
+            and not use_managed_multimodal_chat
             and not native_audio_requested
             and should_fallback_gateway_to_openrouter(
             response.status_code,
@@ -32175,6 +32460,7 @@ async def chat(payload: ChatRequest, request: Request):
             and not use_native_router
             and not use_chat_canary
             and not use_stable_chat
+            and not use_managed_multimodal_chat
             and not native_audio_requested
             and response.status_code >= 400
             and should_fallback_model(
@@ -32303,6 +32589,11 @@ async def chat(payload: ChatRequest, request: Request):
                     code=stable_http_error_code,
                     route_receipt=stable_http_receipt,
                 )
+            if managed_multimodal_http_receipt is not None:
+                error_content.update(
+                    code=managed_multimodal_http_error_code,
+                    route_receipt=managed_multimodal_http_receipt,
+                )
             return JSONResponse(
                 status_code=response.status_code,
                 content=error_content,
@@ -32327,6 +32618,11 @@ async def chat(payload: ChatRequest, request: Request):
             started_at=stable_chat_started_at or chat_request_started_at
         )
         if use_stable_chat
+        else None
+    )
+    managed_multimodal_stream_evidence = (
+        ProviderChatCanaryStreamEvidence(started_at=chat_request_started_at)
+        if use_managed_multimodal_chat
         else None
     )
     capture_chat_media = bool(
@@ -32862,11 +33158,14 @@ async def chat(payload: ChatRequest, request: Request):
         file_terminal_receipt: dict[str, Any] | None = None
         stable_file_summary: dict[str, object] | None = None
         stable_terminal_receipt: dict[str, object] | None = None
+        managed_multimodal_terminal_receipt: dict[str, Any] | None = None
         sidecar_ttft_ms: float | None = None
         chat_canary_transport_error: str | None = None
         chat_canary_client_cancelled = False
         stable_chat_transport_error: str | None = None
         stable_chat_client_cancelled = False
+        managed_multimodal_transport_error: str | None = None
+        managed_multimodal_client_cancelled = False
         try:
             if fallback_notice:
                 payload_json = json.dumps(
@@ -32894,6 +33193,8 @@ async def chat(payload: ChatRequest, request: Request):
                         chat_canary_stream_evidence.feed(line)
                     if stable_chat_stream_evidence is not None:
                         stable_chat_stream_evidence.feed(line)
+                    if managed_multimodal_stream_evidence is not None:
+                        managed_multimodal_stream_evidence.feed(line)
                     if use_omniroute:
                         update_stream_state(line, omniroute_stream_state)
                         if (
@@ -32913,13 +33214,13 @@ async def chat(payload: ChatRequest, request: Request):
                     if line.lstrip().startswith(":"):
                         continue
                     if (
-                        (use_omniroute or native_audio_requested or direct_file_requested or capture_chat_media or chat_canary_requested or use_stable_chat)
+                        (use_omniroute or native_audio_requested or direct_file_requested or capture_chat_media or chat_canary_requested or use_stable_chat or use_managed_multimodal_chat)
                         and line.strip() == "data: [DONE]"
                     ):
                         deferred_done = True
                         continue
                     if (
-                        (use_omniroute or native_audio_requested or direct_file_requested or capture_chat_media or chat_canary_requested or use_stable_chat)
+                        (use_omniroute or native_audio_requested or direct_file_requested or capture_chat_media or chat_canary_requested or use_stable_chat or use_managed_multimodal_chat)
                         and deferred_done
                         and not line.strip()
                     ):
@@ -32938,7 +33239,11 @@ async def chat(payload: ChatRequest, request: Request):
                     status="cancelled",
                     client_cancelled=True,
                 )
-            if not use_chat_canary and not use_stable_chat:
+            if (
+                not use_chat_canary
+                and not use_stable_chat
+                and not use_managed_multimodal_chat
+            ):
                 raise
             runtime_status = "error"
             runtime_error = "client cancelled"
@@ -32947,6 +33252,11 @@ async def chat(payload: ChatRequest, request: Request):
             if use_stable_chat:
                 stable_chat_transport_error = "provider_chat_client_cancelled"
                 stable_chat_client_cancelled = True
+            if use_managed_multimodal_chat:
+                managed_multimodal_transport_error = (
+                    "provider_chat_client_cancelled"
+                )
+                managed_multimodal_client_cancelled = True
         except httpx.HTTPError:
             runtime_status = "error"
             runtime_error = "stream interrupted"
@@ -32954,6 +33264,10 @@ async def chat(payload: ChatRequest, request: Request):
                 chat_canary_transport_error = "provider_chat_stream_interrupted"
             if use_stable_chat:
                 stable_chat_transport_error = "provider_chat_stream_interrupted"
+            if use_managed_multimodal_chat:
+                managed_multimodal_transport_error = (
+                    "provider_chat_stream_interrupted"
+                )
             if direct_file_requested:
                 logger.warning(
                     "File chat stream failed model=%s code=stream_interrupted",
@@ -32979,6 +33293,10 @@ async def chat(payload: ChatRequest, request: Request):
                 chat_canary_transport_error = "provider_chat_stream_interrupted"
             if use_stable_chat:
                 stable_chat_transport_error = "provider_chat_stream_interrupted"
+            if use_managed_multimodal_chat:
+                managed_multimodal_transport_error = (
+                    "provider_chat_stream_interrupted"
+                )
             if direct_file_requested:
                 logger.warning(
                     "File chat stream failed model=%s code=stream_proxy_failed",
@@ -33074,6 +33392,8 @@ async def chat(payload: ChatRequest, request: Request):
                     chat_canary_stream_evidence.feed(buffer)
                 if stable_chat_stream_evidence is not None:
                     stable_chat_stream_evidence.feed(buffer)
+                if managed_multimodal_stream_evidence is not None:
+                    managed_multimodal_stream_evidence.feed(buffer)
                 if use_omniroute:
                     update_stream_state(buffer, omniroute_stream_state)
                     if (
@@ -33093,7 +33413,7 @@ async def chat(payload: ChatRequest, request: Request):
                 if buffer.lstrip().startswith(":"):
                     pass
                 elif (
-                    (use_omniroute or native_audio_requested or direct_file_requested or capture_chat_media or chat_canary_requested or use_stable_chat)
+                    (use_omniroute or native_audio_requested or direct_file_requested or capture_chat_media or chat_canary_requested or use_stable_chat or use_managed_multimodal_chat)
                     and buffer.strip() == "data: [DONE]"
                 ):
                     deferred_done = True
@@ -33717,6 +34037,84 @@ async def chat(payload: ChatRequest, request: Request):
                 if not direct_file_requested:
                     yield route_receipt_sse(stable_terminal_receipt)
 
+            if (
+                use_managed_multimodal_chat
+                and managed_multimodal_stream_evidence is not None
+            ):
+                (
+                    managed_status,
+                    managed_result_class,
+                    managed_error_code,
+                    _managed_checks,
+                    _managed_warnings,
+                ) = managed_multimodal_stream_evidence.finish(
+                    transport_completed=stream_completed,
+                    transport_error_code=managed_multimodal_transport_error,
+                )
+                observed_model = (
+                    managed_multimodal_stream_evidence.actual_model
+                    or actual_model_id
+                )
+                if (
+                    managed_status == "succeeded"
+                    and managed_multimodal_stream_evidence.actual_model is not None
+                    and observed_model != payload.model_id
+                ):
+                    managed_status = "failed"
+                    managed_result_class = "hard_failure"
+                    managed_error_code = "provider_workload_model_mismatch"
+                storage_status = (
+                    "passed"
+                    if managed_status == "succeeded"
+                    else "cancelled"
+                    if managed_status == "cancelled"
+                    else "failed"
+                )
+                managed_multimodal_terminal_receipt = (
+                    finalize_managed_multimodal_chat(
+                        status=storage_status,
+                        result_class=managed_result_class,
+                        error_code=managed_error_code,
+                        actual_model=observed_model,
+                        ttft_ms=managed_multimodal_stream_evidence.ttft_ms,
+                        prompt_tokens=(
+                            managed_multimodal_stream_evidence.prompt_tokens
+                        ),
+                        completion_tokens=(
+                            managed_multimodal_stream_evidence.completion_tokens
+                        ),
+                        total_tokens=(
+                            managed_multimodal_stream_evidence.total_tokens
+                        ),
+                    )
+                )
+                if managed_status != "succeeded":
+                    runtime_status = "error"
+                    runtime_error = (
+                        managed_error_code
+                        or "provider_multimodal_stream_failed"
+                    )
+                    if managed_status != "cancelled":
+                        error_payload = {
+                            "error": {
+                                "message": (
+                                    "多模态 Managed Provider 响应未通过完整性检查；"
+                                    "本次请求未重放到其他目标。"
+                                ),
+                                "code": runtime_error,
+                            }
+                        }
+                        yield (
+                            f"data: {json.dumps(error_payload, ensure_ascii=False)}\n\n"
+                        ).encode("utf-8")
+                if (
+                    managed_multimodal_terminal_receipt is not None
+                    and not direct_file_requested
+                ):
+                    yield route_receipt_sse(
+                        managed_multimodal_terminal_receipt
+                    )
+
             if use_chat_canary and chat_canary_stream_evidence is not None:
                 (
                     canary_status,
@@ -33843,6 +34241,19 @@ async def chat(payload: ChatRequest, request: Request):
                         and stable_terminal_receipt is not None
                     ):
                         yield route_receipt_sse(stable_terminal_receipt)
+                elif use_managed_multimodal_chat:
+                    file_terminal_receipt = (
+                        managed_multimodal_terminal_receipt
+                        if runtime_status in {"completed", "output_limit"}
+                        else None
+                    )
+                    if (
+                        file_terminal_receipt is None
+                        and managed_multimodal_terminal_receipt is not None
+                    ):
+                        yield route_receipt_sse(
+                            managed_multimodal_terminal_receipt
+                        )
                 for event in chat_file_terminal_events(
                     file_terminal_receipt,
                     failure_error_emitted=runtime_status == "error",
@@ -33856,6 +34267,7 @@ async def chat(payload: ChatRequest, request: Request):
                 or captured_outputs
                 or chat_canary_requested
                 or use_stable_chat
+                or use_managed_multimodal_chat
             ):
                 yield b"data: [DONE]\n\n"
             if runtime_status in {"completed", "output_limit"}:

--- a/server/model_router/multimodal_control.py
+++ b/server/model_router/multimodal_control.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Literal
+from dataclasses import dataclass, field
+from typing import Literal, Mapping
 
+import httpx
+
+from .egress import AuthorizedProviderTarget, ProviderEgressPolicy
+from .provider_chat import ProviderChatEndpointResolver
 from .repository import RouterRepositoryError
 from .schemas import (
     MULTIMODAL_WORKLOAD_SHAPES,
@@ -14,6 +18,14 @@ from .service import ModelRouterService, RouterServiceError
 
 
 PROVIDER_MULTIMODAL_PROTOCOL_VERSION = "modelmirror-provider-multimodal-v1"
+R8B_EXECUTION_SHAPES: frozenset[ProviderWorkloadExecutionShape] = frozenset(
+    {
+        "chat_image_stream",
+        "chat_document_stream",
+        "vision_json_unary",
+        "image_generation",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,6 +35,87 @@ class MultimodalAdapterSpec:
     provider_kinds: frozenset[ConnectionKind]
     required_scopes: tuple[str, ...]
     certification_mode: Literal["sync", "async", "browser_assisted"]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderMultimodalTarget:
+    provider_kind: ConnectionKind
+    connection_id: str
+    adapter_contract: ProviderMultimodalAdapterContract
+    execution_shape: ProviderWorkloadExecutionShape
+    endpoint_url: str
+    _api_key: str = field(repr=False, compare=False)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        provider_kind: ConnectionKind,
+        connection_id: str,
+        base_url: str,
+        api_key: str,
+        adapter_contract: ProviderMultimodalAdapterContract,
+        execution_shape: ProviderWorkloadExecutionShape,
+    ) -> "ProviderMultimodalTarget":
+        multimodal_adapter_spec(adapter_contract, execution_shape)
+        api_base = ProviderChatEndpointResolver.resolve(base_url).base_url
+        if adapter_contract == "openrouter_images_v1":
+            endpoint_url = f"{api_base}/images"
+        elif adapter_contract == "openai_compatible_images_generations_v1":
+            endpoint_url = f"{api_base}/images/generations"
+        else:
+            endpoint_url = f"{api_base}/chat/completions"
+        return cls(
+            provider_kind=provider_kind,
+            connection_id=connection_id,
+            adapter_contract=adapter_contract,
+            execution_shape=execution_shape,
+            endpoint_url=endpoint_url,
+            _api_key=str(api_key or ""),
+        )
+
+    def authorization_headers(
+        self, extra: Mapping[str, str] | None = None
+    ) -> dict[str, str]:
+        headers = dict(extra or {})
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+
+class ProviderMultimodalTransport:
+    """One-address transport for a qualified multimodal Adapter endpoint."""
+
+    def __init__(self, egress_policy: ProviderEgressPolicy) -> None:
+        self.egress_policy = egress_policy
+
+    async def authorize(
+        self, target: ProviderMultimodalTarget
+    ) -> AuthorizedProviderTarget:
+        return await self.egress_policy.authorize(target.endpoint_url)
+
+    @staticmethod
+    def build_authorized_json_request(
+        client: httpx.AsyncClient,
+        target: ProviderMultimodalTarget,
+        authorized: AuthorizedProviderTarget,
+        payload: Mapping[str, object],
+        *,
+        headers: Mapping[str, str] | None = None,
+    ) -> httpx.Request:
+        return client.build_request(
+            "POST",
+            authorized.pinned_urls[0],
+            headers=authorized.request_headers(target.authorization_headers(headers)),
+            extensions=authorized.extensions,
+            json=dict(payload),
+        )
+
+    @staticmethod
+    async def send_authorized(
+        client: httpx.AsyncClient, request: httpx.Request
+    ) -> httpx.Response:
+        return await client.send(request, stream=True, follow_redirects=False)
 
 
 _OPENAI_COMPATIBLE_KINDS: frozenset[ConnectionKind] = frozenset(

--- a/server/model_router/multimodal_gateway.py
+++ b/server/model_router/multimodal_gateway.py
@@ -1,0 +1,606 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import uuid
+from collections.abc import Callable, Mapping
+from typing import Any, Literal, TypeVar
+
+import httpx
+
+from .service import ModelRouterService, RouterServiceError
+from .workflow_gateway import (
+    ManagedWorkflowGateway,
+    ManagedWorkflowNodeRun,
+    ManagedWorkflowRoutingError,
+    WorkflowProviderCallReceipt,
+)
+from .workload_control import (
+    PROVIDER_WORKLOAD_CONTRACT_VERSION,
+    ProviderWorkloadCallService,
+    ProviderWorkloadPreparedCall,
+)
+
+
+R8BEntryId = Literal[
+    "chat_image",
+    "chat_document_native",
+    "rag_vision",
+    "workflow_interactive_vision",
+    "workflow_deployment_vision",
+    "xpert_vision",
+    "image_generation",
+]
+R8BRoutingMode = Literal["legacy", "managed_required", "degraded_required"]
+_T = TypeVar("_T")
+_MAX_IMAGE_RESPONSE_BYTES = 32 * 1024 * 1024
+
+
+class ManagedMultimodalError(RuntimeError):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        status_code: int = 409,
+        receipt: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+        self.receipt = receipt
+
+
+class ManagedMultimodalGateway:
+    """R8 managed Adapter boundary over the qualified workload call service."""
+
+    def __init__(
+        self,
+        call_service: ProviderWorkloadCallService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self.call_service = call_service
+        self._workflow_gateway = ManagedWorkflowGateway(
+            call_service,
+            client_factory=client_factory,
+        )
+        self._client_factory = client_factory
+
+    @classmethod
+    def for_router(
+        cls,
+        router_service: ModelRouterService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> "ManagedMultimodalGateway":
+        return cls(
+            ProviderWorkloadCallService(router_service),
+            client_factory=client_factory,
+        )
+
+    def routing_mode(self, entry_id: R8BEntryId) -> R8BRoutingMode:
+        control = self.call_service.control
+        if not control.feature_enabled(entry_id):
+            return "legacy"
+        policy = control.get_policy(entry_id)
+        if policy.configured_status == "legacy":
+            return "legacy"
+        if policy.effective_status == "managed_required":
+            return "managed_required"
+        return "degraded_required"
+
+    def exact_model_id(
+        self,
+        entry_id: R8BEntryId,
+        execution_shape: str,
+        *,
+        requested_model: str,
+    ) -> str:
+        policy = self.call_service.control.get_policy(entry_id)
+        if policy.effective_status != "managed_required":
+            raise self._blocked(entry_id, "provider_workload_policy_not_active")
+        matches = [
+            item.model_id
+            for item in policy.bindings
+            if item.execution_shape == execution_shape
+            and item.model_id == requested_model
+            and item.valid
+        ]
+        if len(matches) != 1:
+            raise self._blocked(entry_id, "provider_workload_binding_missing")
+        return matches[0]
+
+    def start_run(
+        self,
+        entry_id: R8BEntryId,
+        *,
+        parent_run_reference: str,
+        stable: bool,
+    ) -> "ManagedMultimodalRun":
+        if self.routing_mode(entry_id) != "managed_required":
+            raise self._blocked(entry_id, "provider_workload_policy_not_active")
+        parent = parent_run_reference.strip() or f"multimodal:{entry_id}:{uuid.uuid4().hex}"
+        try:
+            run_id = (
+                self.call_service.start_stable_run(
+                    entry_id, parent_run_reference=parent
+                )
+                if stable
+                else self.call_service.start_run(
+                    entry_id, parent_run_reference=parent
+                )
+            )
+        except RouterServiceError as exc:
+            raise ManagedMultimodalError(
+                exc.code,
+                "多模态 Managed Provider 运行在派发前被阻断。",
+                status_code=exc.status_code,
+                receipt=self.blocked_receipt(entry_id, exc.code),
+            ) from exc
+        delegate = ManagedWorkflowNodeRun(
+            self._workflow_gateway,
+            entry_id,  # type: ignore[arg-type]
+            run_id,
+        )
+        return ManagedMultimodalRun(self, entry_id, delegate)
+
+    async def prepare_chat_dispatch(
+        self,
+        entry_id: Literal["chat_image", "chat_document_native"],
+        *,
+        execution_shape: Literal["chat_image_stream", "chat_document_stream"],
+        requested_model: str,
+        parent_run_reference: str,
+    ) -> "ManagedMultimodalChatDispatch":
+        model_id = self.exact_model_id(
+            entry_id,
+            execution_shape,
+            requested_model=requested_model,
+        )
+        run = self.start_run(
+            entry_id,
+            parent_run_reference=parent_run_reference,
+            stable=True,
+        )
+        try:
+            prepared = await self.call_service.prepare_call(
+                run_id=run._delegate.run_id,  # noqa: SLF001 - same gateway boundary
+                entry_id=entry_id,
+                execution_shape=execution_shape,
+                model_id=model_id,
+                logical_call_key="chat",
+                call_sequence=1,
+            )
+        except RouterServiceError as exc:
+            receipt = run.finish_failure(exc.code)
+            raise ManagedMultimodalError(
+                exc.code,
+                "多模态 Chat 在 Provider 派发前被阻断。",
+                status_code=exc.status_code,
+                receipt=receipt,
+            ) from exc
+        return ManagedMultimodalChatDispatch(run, prepared)
+
+    @staticmethod
+    def blocked_receipt(entry_id: R8BEntryId, reason_code: str) -> dict[str, Any]:
+        return {
+            "contract_version": PROVIDER_WORKLOAD_CONTRACT_VERSION,
+            "entry_id": entry_id,
+            "routing_mode": "managed_required",
+            "run_reference": "blocked_before_dispatch",
+            "status": "failed",
+            "call_count": 0,
+            "reason_codes": [reason_code],
+            "calls": [],
+        }
+
+    def _blocked(self, entry_id: R8BEntryId, code: str) -> ManagedMultimodalError:
+        return ManagedMultimodalError(
+            code,
+            "多模态入口缺少当前精确模型的合格 Managed Binding。",
+            receipt=self.blocked_receipt(entry_id, code),
+        )
+
+
+class ManagedMultimodalRun:
+    def __init__(
+        self,
+        gateway: ManagedMultimodalGateway,
+        entry_id: R8BEntryId,
+        delegate: ManagedWorkflowNodeRun,
+    ) -> None:
+        self.gateway = gateway
+        self.entry_id = entry_id
+        self._delegate = delegate
+
+    async def complete_vision_json(
+        self,
+        *,
+        logical_call_key: str,
+        call_sequence: int,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        max_tokens: int = 1024,
+    ) -> dict[str, Any]:
+        try:
+            text = await self._delegate.complete_json_object_for_shape(
+                logical_call_key=logical_call_key,
+                call_sequence=call_sequence,
+                execution_shape="vision_json_unary",
+                model_id=model_id,
+                messages=messages,
+                temperature=0,
+                max_tokens=max_tokens,
+            )
+            parsed = json.loads(text)
+            if not isinstance(parsed, dict):
+                raise ValueError("provider_multimodal_vision_json_invalid")
+            return parsed
+        except (ManagedWorkflowRoutingError, json.JSONDecodeError, ValueError) as exc:
+            if isinstance(exc, ManagedWorkflowRoutingError):
+                code = exc.code
+                status_code = exc.status_code
+            else:
+                code = "provider_multimodal_vision_json_invalid"
+                status_code = 502
+            raise ManagedMultimodalError(
+                code,
+                "视觉 Provider 未返回有效的结构化结果，系统未重试或切换目标。",
+                status_code=status_code,
+                receipt=self._delegate.receipt_summary(),
+            ) from exc
+
+    async def complete_image_generation(
+        self,
+        *,
+        logical_call_key: str,
+        model_id: str,
+        payload: Mapping[str, object],
+        parse_response: Callable[[httpx.Response], _T],
+    ) -> tuple[_T, dict[str, Any]]:
+        prepared: ProviderWorkloadPreparedCall | None = None
+        dispatched = False
+        response_received = False
+        response_complete = False
+        started = time.perf_counter()
+        try:
+            prepared = await self.gateway.call_service.prepare_call(
+                run_id=self._delegate.run_id,
+                entry_id=self.entry_id,
+                execution_shape="image_generation",
+                model_id=model_id,
+                logical_call_key=logical_call_key,
+                call_sequence=1,
+            )
+            target = prepared.multimodal_target
+            if target is None:
+                raise RouterServiceError(
+                    "provider_multimodal_target_missing",
+                    "图片生成缺少已授权的 Adapter 目标。",
+                    status_code=409,
+                )
+            request_payload = self._image_request_payload(target, payload)
+            request_payload["model"] = model_id
+            async with self._client() as client:
+                request = self.gateway.call_service.multimodal_transport.build_authorized_json_request(
+                    client,
+                    target,
+                    prepared.authorized_target,
+                    request_payload,
+                )
+                self.gateway.call_service.mark_dispatched(prepared)
+                dispatched = True
+                response = await self.gateway.call_service.multimodal_transport.send_authorized(
+                    client, request
+                )
+                response_received = True
+                try:
+                    self._validate_status(response.status_code)
+                    await self._read_bounded(response)
+                    response_complete = True
+                    result = parse_response(response)
+                finally:
+                    await response.aclose()
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            actual_model = str(getattr(result, "actual_model", model_id) or model_id)
+            usage = getattr(result, "usage", None)
+            self.gateway.call_service.complete_call(
+                prepared,
+                status="passed",
+                result_class="success",
+                actual_model=actual_model,
+                ttft_ms=elapsed_ms,
+                e2e_ms=elapsed_ms,
+                prompt_tokens=getattr(usage, "input_tokens", None),
+                completion_tokens=getattr(usage, "output_tokens", None),
+                total_tokens=getattr(usage, "total_tokens", None),
+            )
+            self._delegate.calls.append(
+                WorkflowProviderCallReceipt(
+                    call_sequence=1,
+                    model_id=model_id,
+                    actual_model=actual_model,
+                    dispatched=True,
+                    status="passed",
+                    prompt_tokens=getattr(usage, "input_tokens", None),
+                    completion_tokens=getattr(usage, "output_tokens", None),
+                    total_tokens=getattr(usage, "total_tokens", None),
+                )
+            )
+            self._delegate.finish("passed")
+            return result, self._delegate.receipt_summary()
+        except asyncio.CancelledError:
+            self._record_failure(
+                prepared, model_id, dispatched, "cancelled", "client_cancelled",
+                "provider_workload_call_cancelled",
+            )
+            raise
+        except ManagedMultimodalError as exc:
+            status = "failed" if response_received or not dispatched else "uncertain"
+            self._record_failure(
+                prepared,
+                model_id,
+                dispatched,
+                status,
+                "provider_error"
+                if response_received
+                else "transport_error"
+                if dispatched
+                else "preflight_failure",
+                exc.code,
+            )
+            raise ManagedMultimodalError(
+                exc.code,
+                str(exc),
+                status_code=exc.status_code,
+                receipt=self._delegate.receipt_summary(),
+            ) from exc
+        except Exception as exc:
+            status = "failed" if response_received or not dispatched else "uncertain"
+            code = self._error_code(exc, dispatched=dispatched, complete=response_complete)
+            self._record_failure(
+                prepared,
+                model_id,
+                dispatched,
+                status,
+                "provider_error" if response_complete else "transport_error",
+                code,
+            )
+            raise ManagedMultimodalError(
+                code,
+                "图片生成 Managed Provider 调用失败，系统未重试或切换目标。",
+                status_code=getattr(exc, "status_code", 502),
+                receipt=self._delegate.receipt_summary(),
+            ) from exc
+
+    def finish_success(self) -> dict[str, Any]:
+        self._delegate.finish("passed")
+        return self._delegate.receipt_summary()
+
+    def finish_failure(self, reason_code: str) -> dict[str, Any]:
+        status = (
+            "uncertain"
+            if any(call.status == "uncertain" for call in self._delegate.calls)
+            else "failed"
+        )
+        self._delegate.finish(status, reason_code=reason_code)
+        return self._delegate.receipt_summary()
+
+    def receipt_summary(self) -> dict[str, Any]:
+        return self._delegate.receipt_summary()
+
+    def _client(self) -> httpx.AsyncClient:
+        if self.gateway._client_factory is not None:
+            return self.gateway._client_factory()
+        return httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=15, read=180, write=30, pool=10),
+            follow_redirects=False,
+            trust_env=False,
+            transport=httpx.AsyncHTTPTransport(retries=0),
+        )
+
+    @staticmethod
+    async def _read_bounded(response: httpx.Response) -> None:
+        total = 0
+        chunks: list[bytes] = []
+        async for chunk in response.aiter_bytes():
+            total += len(chunk)
+            if total > _MAX_IMAGE_RESPONSE_BYTES:
+                raise ManagedMultimodalError(
+                    "provider_multimodal_response_too_large",
+                    "图片生成响应超过安全上限。",
+                    status_code=502,
+                )
+            chunks.append(chunk)
+        response._content = b"".join(chunks)  # noqa: SLF001 - preserve parsed response
+
+    @staticmethod
+    def _image_request_payload(
+        target: object,
+        payload: Mapping[str, object],
+    ) -> dict[str, object]:
+        request_payload = dict(payload)
+        if (
+            getattr(target, "adapter_contract", None)
+            != "openai_compatible_images_generations_v1"
+        ):
+            return request_payload
+        unsupported = sorted(
+            key
+            for key in ("aspect_ratio", "seed", "input_references")
+            if request_payload.get(key) is not None
+        )
+        if unsupported:
+            raise ManagedMultimodalError(
+                "provider_multimodal_adapter_parameter_unsupported",
+                "OpenAI-compatible 图片生成 Adapter 不支持本次高级参数。",
+                status_code=422,
+            )
+        resolution = request_payload.pop("resolution", None)
+        if resolution is not None:
+            request_payload["size"] = resolution
+        request_payload["response_format"] = "b64_json"
+        return request_payload
+
+    @staticmethod
+    def _validate_status(status_code: int) -> None:
+        if 200 <= status_code < 300:
+            return
+        code = {
+            401: "provider_workload_http_401",
+            403: "provider_workload_http_403",
+            404: "provider_workload_http_404",
+            429: "provider_workload_http_429",
+        }.get(
+            status_code,
+            "provider_workload_http_5xx"
+            if status_code >= 500
+            else "provider_workload_http_error",
+        )
+        raise ManagedMultimodalError(code, "图片生成 Provider 请求失败。", status_code=status_code)
+
+    @staticmethod
+    def _error_code(exc: Exception, *, dispatched: bool, complete: bool) -> str:
+        if isinstance(exc, ManagedMultimodalError):
+            return exc.code
+        if isinstance(exc, RouterServiceError):
+            return exc.code
+        if isinstance(exc, (httpx.TimeoutException, TimeoutError)):
+            return "provider_workload_timeout"
+        if isinstance(exc, httpx.HTTPError):
+            return "provider_workload_transport_error"
+        if dispatched and not complete:
+            return "provider_workload_dispatch_uncertain"
+        return "provider_multimodal_invalid_response" if complete else "provider_workload_preflight_failed"
+
+    def _record_failure(
+        self,
+        prepared: ProviderWorkloadPreparedCall | None,
+        model_id: str,
+        dispatched: bool,
+        status: str,
+        result_class: str,
+        code: str,
+    ) -> None:
+        if prepared is not None:
+            self.gateway.call_service.complete_call(
+                prepared,
+                status=status,
+                result_class=result_class,
+                error_code=code,
+            )
+        self._delegate.calls.append(
+            WorkflowProviderCallReceipt(
+                call_sequence=1,
+                model_id=model_id,
+                actual_model=None,
+                dispatched=dispatched,
+                status=status,  # type: ignore[arg-type]
+                error_code=code,
+            )
+        )
+        self._delegate.finish(
+            "uncertain" if status == "uncertain" else "failed",
+            reason_code=code,
+        )
+
+
+class ManagedMultimodalChatDispatch:
+    def __init__(
+        self,
+        run: ManagedMultimodalRun,
+        prepared: ProviderWorkloadPreparedCall,
+    ) -> None:
+        self.run = run
+        self.prepared = prepared
+        self.dispatched = False
+        self.completed = False
+        self.started_at: float | None = None
+
+    @property
+    def target_model(self) -> str:
+        return self.prepared.model_id
+
+    async def send(
+        self,
+        client: httpx.AsyncClient,
+        payload: Mapping[str, object],
+        *,
+        headers: Mapping[str, str] | None = None,
+    ) -> httpx.Response:
+        if self.dispatched:
+            raise ManagedMultimodalError(
+                "provider_multimodal_duplicate_post_blocked",
+                "同一多模态 Chat 逻辑调用不能重复派发。",
+                receipt=self.run.receipt_summary(),
+            )
+        target = self.prepared.multimodal_target
+        if target is None:
+            raise ManagedMultimodalError(
+                "provider_multimodal_target_missing",
+                "多模态 Chat 缺少已授权的 Adapter 目标。",
+                receipt=self.run.receipt_summary(),
+            )
+        request = self.run.gateway.call_service.multimodal_transport.build_authorized_json_request(
+            client,
+            target,
+            self.prepared.authorized_target,
+            payload,
+            headers=headers,
+        )
+        self.run.gateway.call_service.mark_dispatched(self.prepared)
+        self.dispatched = True
+        self.started_at = time.perf_counter()
+        return await self.run.gateway.call_service.multimodal_transport.send_authorized(
+            client, request
+        )
+
+    def complete(
+        self,
+        *,
+        status: Literal["passed", "failed", "uncertain", "cancelled"],
+        result_class: str,
+        error_code: str | None = None,
+        actual_model: str | None = None,
+        ttft_ms: float | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+    ) -> dict[str, Any]:
+        if self.completed:
+            return self.run.receipt_summary()
+        e2e_ms = (
+            (time.perf_counter() - self.started_at) * 1000
+            if self.started_at is not None
+            else None
+        )
+        self.run.gateway.call_service.complete_call(
+            self.prepared,
+            status=status,
+            result_class=result_class,
+            error_code=error_code,
+            actual_model=actual_model,
+            ttft_ms=ttft_ms,
+            e2e_ms=e2e_ms,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+        )
+        self.run._delegate.calls.append(  # noqa: SLF001 - receipt adapter
+            WorkflowProviderCallReceipt(
+                call_sequence=1,
+                model_id=self.prepared.model_id,
+                actual_model=actual_model,
+                dispatched=self.dispatched,
+                status=status,
+                error_code=error_code,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+            )
+        )
+        self.run._delegate.finish(status, reason_code=error_code)  # noqa: SLF001
+        self.completed = True
+        return self.run.receipt_summary()

--- a/server/model_router/workflow_gateway.py
+++ b/server/model_router/workflow_gateway.py
@@ -884,6 +884,33 @@ class ManagedWorkflowNodeRun:
             cancel_event=cancel_event,
         )
 
+    async def complete_json_object_for_shape(
+        self,
+        *,
+        logical_call_key: str,
+        call_sequence: int,
+        execution_shape: str,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        cancel_event: asyncio.Event | None = None,
+    ) -> str:
+        """Run a qualified JSON unary shape without weakening its exact Binding."""
+
+        return await self._complete_unary(
+            logical_call_key=logical_call_key,
+            call_sequence=call_sequence,
+            execution_shape=execution_shape,  # type: ignore[arg-type]
+            model_id=model_id,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            response_format={"type": "json_object"},
+            require_json_object=True,
+            cancel_event=cancel_event,
+        )
+
     async def _complete_unary(
         self,
         *,

--- a/server/model_router/workload_control.py
+++ b/server/model_router/workload_control.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import json
 import math
@@ -24,6 +25,9 @@ from .provider_operations import (
 )
 from .multimodal_control import (
     PROVIDER_MULTIMODAL_PROTOCOL_VERSION,
+    R8B_EXECUTION_SHAPES,
+    ProviderMultimodalTarget,
+    ProviderMultimodalTransport,
     validate_multimodal_adapter,
 )
 from .repository import RouterCredentialUnavailable, RouterRepositoryError
@@ -67,6 +71,52 @@ SYNTHETIC_RERANK_DOCUMENTS = (
     "This document is unrelated to provider routing.",
     "Managed bindings select one exact provider model.",
 )
+SYNTHETIC_VISION_PNG_DATA_URL = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEklEQVR4nGNkSPvPwMDAxAAGAA/nAWnOxjxZAAAAAElFTkSuQmCC"
+)
+
+
+def _build_synthetic_single_page_pdf() -> bytes:
+    content = b"BT /F1 12 Tf 20 100 Td (ModelMirror PDF certification) Tj ET"
+    objects = (
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] "
+            b"/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>"
+        ),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        b"<< /Length "
+        + str(len(content)).encode("ascii")
+        + b" >>\nstream\n"
+        + content
+        + b"\nendstream",
+    )
+    document = bytearray(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+    offsets = [0]
+    for index, body in enumerate(objects, start=1):
+        offsets.append(len(document))
+        document.extend(f"{index} 0 obj\n".encode("ascii"))
+        document.extend(body)
+        document.extend(b"\nendobj\n")
+    xref_offset = len(document)
+    document.extend(f"xref\n0 {len(objects) + 1}\n".encode("ascii"))
+    document.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        document.extend(f"{offset:010d} 00000 n \n".encode("ascii"))
+    document.extend(
+        (
+            f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+            f"startxref\n{xref_offset}\n%%EOF\n"
+        ).encode("ascii")
+    )
+    return bytes(document)
+
+
+SYNTHETIC_NATIVE_PDF_DATA_URL = "data:application/pdf;base64," + base64.b64encode(
+    _build_synthetic_single_page_pdf()
+).decode("ascii")
 MAX_WORKLOAD_UNARY_RESPONSE_BYTES = 1024 * 1024
 MAX_WORKLOAD_SSE_EVENT_BYTES = 256 * 1024
 MAX_WORKLOAD_STREAM_BYTES = 4 * 1024 * 1024
@@ -210,6 +260,13 @@ DATA_PLANE_INTEGRATED_ENTRIES: frozenset[ProviderWorkloadEntryId] = frozenset(
         "rag_rerank",
         "skill_rerank",
         "openrouter_batch",
+        "chat_image",
+        "chat_document_native",
+        "rag_vision",
+        "workflow_interactive_vision",
+        "workflow_deployment_vision",
+        "xpert_vision",
+        "image_generation",
     }
 )
 
@@ -290,6 +347,9 @@ class ProviderWorkloadCertificationService:
         self.operation_transport = ProviderOperationTransport(
             router_service.egress_policy
         )
+        self.multimodal_transport = ProviderMultimodalTransport(
+            router_service.egress_policy
+        )
         self._client_factory = client_factory or (
             lambda: httpx.AsyncClient(
                 **ProviderChatTransport.client_kwargs(certification=True)
@@ -366,7 +426,10 @@ class ProviderWorkloadCertificationService:
             payload.execution_shape,
             adapter_contract=payload.adapter_contract,
         )
-        if payload.execution_shape in MULTIMODAL_WORKLOAD_SHAPES:
+        if (
+            payload.execution_shape in MULTIMODAL_WORKLOAD_SHAPES
+            and payload.execution_shape not in R8B_EXECUTION_SHAPES
+        ):
             raise RouterServiceError(
                 "provider_multimodal_certification_not_integrated",
                 "该多模态认证将在对应 R8 数据面批次接入；R8A 不会发送付费调用。",
@@ -499,7 +562,16 @@ class ProviderWorkloadCertificationService:
             )
             async with asyncio.timeout(60):
                 async with self._client_factory() as client:
-                    if payload.execution_shape in {
+                    if payload.execution_shape in R8B_EXECUTION_SHAPES:
+                        await self._run_r8b_certification(
+                            client,
+                            connection,
+                            api_key,
+                            payload,
+                            evidence,
+                            started,
+                        )
+                    elif payload.execution_shape in {
                         "embedding_vectors",
                         "rerank_documents",
                         "openrouter_batch_chat",
@@ -865,6 +937,186 @@ class ProviderWorkloadCertificationService:
                 }
             )
         return request
+
+    async def _run_r8b_certification(
+        self,
+        client: httpx.AsyncClient,
+        connection: RouterConnection,
+        api_key: str,
+        payload: ProviderWorkloadCertificationRequest,
+        evidence: _CertificationEvidence,
+        started: float,
+    ) -> None:
+        if payload.adapter_contract is None:
+            raise _WorkloadCertificationFailure(
+                "provider_multimodal_adapter_required"
+            )
+        target = ProviderMultimodalTarget.create(
+            provider_kind=connection.kind,
+            connection_id=connection.id,
+            base_url=connection.base_url,
+            api_key=api_key,
+            adapter_contract=payload.adapter_contract,
+            execution_shape=payload.execution_shape,
+        )
+        request_payload = self._r8b_request_payload(payload)
+        authorized = await self.multimodal_transport.authorize(target)
+        request = self.multimodal_transport.build_authorized_json_request(
+            client,
+            target,
+            authorized,
+            request_payload,
+        )
+        response = await self.multimodal_transport.send_authorized(client, request)
+        try:
+            self._validate_status(response.status_code)
+            evidence.checks["http_ok"] = True
+            if payload.execution_shape in {
+                "chat_image_stream",
+                "chat_document_stream",
+            }:
+                await self._consume_fusion_stream(
+                    response,
+                    evidence,
+                    started,
+                    expected_model=payload.model_id,
+                )
+            elif payload.execution_shape == "vision_json_unary":
+                await self._consume_unary_response(
+                    response,
+                    evidence,
+                    started,
+                    requested_model=payload.model_id,
+                    execution_shape="chat_json_object",
+                )
+            else:
+                response_payload = await self._read_json_response(response)
+                self._validate_image_generation_response(
+                    response_payload,
+                    evidence,
+                    requested_model=payload.model_id,
+                )
+                evidence.ttft_ms = (time.perf_counter() - started) * 1000
+        finally:
+            await response.aclose()
+        evidence.checks["multimodal_adapter_verified"] = True
+
+    @staticmethod
+    def _r8b_request_payload(
+        payload: ProviderWorkloadCertificationRequest,
+    ) -> dict[str, object]:
+        if payload.execution_shape == "image_generation":
+            if payload.adapter_contract == "openrouter_images_v1":
+                return {
+                    "model": payload.model_id,
+                    "prompt": "A single blue square on a white background.",
+                    "n": 1,
+                    "quality": "low",
+                    "aspect_ratio": "1:1",
+                }
+            return {
+                "model": payload.model_id,
+                "prompt": "A single blue square on a white background.",
+                "n": 1,
+                "size": "256x256",
+                "response_format": "b64_json",
+            }
+        if payload.execution_shape == "chat_document_stream":
+            return {
+                "model": payload.model_id,
+                "stream": True,
+                "temperature": 0,
+                "max_tokens": 32,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Reply with OK."},
+                            {
+                                "type": "file",
+                                "file": {
+                                    "filename": "modelmirror-certification.pdf",
+                                    "file_data": SYNTHETIC_NATIVE_PDF_DATA_URL,
+                                },
+                            },
+                        ],
+                    }
+                ],
+                "plugins": [{"id": "file-parser", "pdf": {"engine": "native"}}],
+            }
+        request: dict[str, object] = {
+            "model": payload.model_id,
+            "stream": payload.execution_shape == "chat_image_stream",
+            "temperature": 0,
+            "max_tokens": 64,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "Reply with OK."
+                                if payload.execution_shape == "chat_image_stream"
+                                else 'Return exactly one JSON object: {"ok":true}'
+                            ),
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": SYNTHETIC_VISION_PNG_DATA_URL},
+                        },
+                    ],
+                }
+            ],
+        }
+        if payload.execution_shape == "vision_json_unary":
+            request["response_format"] = {"type": "json_object"}
+        return request
+
+    @staticmethod
+    def _validate_image_generation_response(
+        payload: Mapping[str, object],
+        evidence: _CertificationEvidence,
+        *,
+        requested_model: str,
+    ) -> None:
+        actual_model = payload.get("model")
+        if isinstance(actual_model, str) and actual_model:
+            evidence.actual_model = actual_model
+            if actual_model != requested_model:
+                raise _WorkloadCertificationFailure(
+                    "provider_workload_model_mismatch"
+                )
+            evidence.checks["actual_model_verified"] = True
+        else:
+            evidence.warning_codes.append("actual_model_missing")
+        data = payload.get("data")
+        if not isinstance(data, list) or len(data) != 1 or not isinstance(data[0], dict):
+            raise _WorkloadCertificationFailure(
+                "provider_multimodal_image_output_invalid"
+            )
+        encoded = data[0].get("b64_json")
+        if not isinstance(encoded, str) or not encoded:
+            raise _WorkloadCertificationFailure(
+                "provider_multimodal_image_output_invalid"
+            )
+        try:
+            image = base64.b64decode(encoded, validate=True)
+        except (ValueError, TypeError) as exc:
+            raise _WorkloadCertificationFailure(
+                "provider_multimodal_image_output_invalid"
+            ) from exc
+        if not (
+            image.startswith(b"\x89PNG\r\n\x1a\n")
+            or image.startswith(b"\xff\xd8\xff")
+            or (len(image) >= 12 and image[8:12] == b"WEBP")
+        ):
+            raise _WorkloadCertificationFailure(
+                "provider_multimodal_image_output_invalid"
+            )
+        evidence.checks["content_observed"] = True
+        evidence.checks["response_complete"] = True
+        ProviderWorkloadCertificationService._read_usage(payload, evidence)
 
     async def _run_operation_certification(
         self,
@@ -2706,6 +2958,7 @@ class ProviderWorkloadPreparedCall:
     policy_fingerprint: str
     target: ProviderChatTarget
     operation_target: ProviderOperationTarget | None
+    multimodal_target: ProviderMultimodalTarget | None
     rerank_access_mode: str | None
     adapter_contract: str | None
     protocol_version: str | None
@@ -2721,6 +2974,9 @@ class ProviderWorkloadCallService:
         self.control = ProviderWorkloadControlService(router_service)
         self.transport = ProviderChatTransport(router_service.egress_policy)
         self.operation_transport = ProviderOperationTransport(
+            router_service.egress_policy
+        )
+        self.multimodal_transport = ProviderMultimodalTransport(
             router_service.egress_policy
         )
 
@@ -2863,7 +3119,26 @@ class ProviderWorkloadCallService:
             connection_id=connection.id,
         )
         operation_target: ProviderOperationTarget | None = None
-        if execution_shape in {
+        multimodal_target: ProviderMultimodalTarget | None = None
+        if execution_shape in MULTIMODAL_WORKLOAD_SHAPES:
+            if binding.adapter_contract is None:
+                raise RouterServiceError(
+                    "provider_multimodal_adapter_required",
+                    "多模态调用缺少明确的 Adapter。",
+                    status_code=409,
+                )
+            multimodal_target = ProviderMultimodalTarget.create(
+                provider_kind=connection.kind,
+                connection_id=connection.id,
+                base_url=connection.base_url,
+                api_key=api_key,
+                adapter_contract=binding.adapter_contract,
+                execution_shape=execution_shape,
+            )
+            authorized = await self.multimodal_transport.authorize(
+                multimodal_target
+            )
+        elif execution_shape in {
             "embedding_vectors",
             "rerank_documents",
             "openrouter_batch_chat",
@@ -2919,6 +3194,7 @@ class ProviderWorkloadCallService:
             policy_fingerprint=policy.policy_fingerprint,
             target=target,
             operation_target=operation_target,
+            multimodal_target=multimodal_target,
             rerank_access_mode=binding.rerank_access_mode,
             adapter_contract=binding.adapter_contract,
             protocol_version=binding.protocol_version,

--- a/server/multimodal/api.py
+++ b/server/multimodal/api.py
@@ -12,6 +12,7 @@ from fastapi import (
     BackgroundTasks,
     File,
     Form,
+    Header,
     HTTPException,
     Response,
     UploadFile,
@@ -386,6 +387,7 @@ async def generate_image(
     background: str | None = Form(default=None),
     seed: int | None = Form(default=None),
     reference_images: list[UploadFile] | None = File(default=None),
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
 ) -> ImageGenerationResult:
     references = reference_images or []
     try:
@@ -416,6 +418,7 @@ async def generate_image(
                 image.content_type for image in references
             ],
             reference_contents=contents,
+            idempotency_key=idempotency_key,
         )
     except MultimodalServiceError as exc:
         raise _http_error(exc) from exc
@@ -941,7 +944,10 @@ def _provider_options(raw: str | None) -> dict[str, object] | None:
 
 
 def _http_error(exc: MultimodalServiceError) -> HTTPException:
+    detail = {"code": exc.code, "message": exc.message}
+    if exc.route_receipt is not None:
+        detail["route_receipt"] = exc.route_receipt
     return HTTPException(
         status_code=exc.status_code,
-        detail={"code": exc.code, "message": exc.message},
+        detail=detail,
     )

--- a/server/multimodal/image_generation.py
+++ b/server/multimodal/image_generation.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import base64
 import binascii
+import hashlib
 from collections.abc import Callable
 from io import BytesIO
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 from PIL import Image, UnidentifiedImageError
@@ -15,6 +16,9 @@ try:
     from server.model_router.egress import request_provider_url
 except ModuleNotFoundError:
     from model_router.egress import request_provider_url
+
+if TYPE_CHECKING:
+    from server.model_router.multimodal_gateway import ManagedMultimodalGateway
 
 from .image_catalog import ImageCatalogService, ImageModelProfile
 from .stt import MultimodalServiceError, OpenRouterTarget
@@ -67,6 +71,9 @@ class ImageGenerationResult(BaseModel):
     request_id: str
     images: list[ImageGenerationItem] = Field(default_factory=list)
     usage: ImageGenerationUsage
+    provider_route_receipts: list[dict[str, Any]] = Field(default_factory=list)
+    execution_mode: str = "legacy"
+    fallback_reason_codes: list[str] = Field(default_factory=list)
 
 
 class ImageGenerationService:
@@ -75,6 +82,7 @@ class ImageGenerationService:
         catalog_service: ImageCatalogService,
         *,
         client_factory: Callable[[], httpx.AsyncClient] | None = None,
+        managed_gateway: ManagedMultimodalGateway | None = None,
     ) -> None:
         self.catalog_service = catalog_service
         self.client_factory = client_factory or (
@@ -84,6 +92,7 @@ class ImageGenerationService:
                 trust_env=False,
             )
         )
+        self.managed_gateway = managed_gateway
 
     async def generate(
         self,
@@ -100,6 +109,7 @@ class ImageGenerationService:
         reference_filenames: list[str],
         reference_content_types: list[str | None],
         reference_contents: list[bytes],
+        idempotency_key: str | None = None,
     ) -> ImageGenerationResult:
         clean_model = model_id.strip()
         clean_prompt = prompt.strip()
@@ -153,6 +163,81 @@ class ImageGenerationService:
                 }
                 for data_url in references
             ]
+
+        try:
+            from server.model_router import get_model_router_service
+            from server.model_router.multimodal_gateway import (
+                ManagedMultimodalError,
+                ManagedMultimodalGateway,
+            )
+        except ModuleNotFoundError:
+            from model_router import get_model_router_service
+            from model_router.multimodal_gateway import (
+                ManagedMultimodalError,
+                ManagedMultimodalGateway,
+            )
+        gateway = self.managed_gateway or ManagedMultimodalGateway.for_router(
+            get_model_router_service()
+        )
+        mode = gateway.routing_mode("image_generation")
+        if mode == "degraded_required":
+            reason_code = "provider_workload_policy_not_active"
+            raise MultimodalServiceError(
+                reason_code,
+                "图片生成 Managed Provider 策略已降级，调用已在发送前阻断。",
+                status_code=409,
+                route_receipt=gateway.blocked_receipt(
+                    "image_generation", reason_code
+                ),
+            )
+        if mode == "managed_required":
+            clean_key = str(idempotency_key or "").strip()
+            if not clean_key or len(clean_key) > 200:
+                reason_code = "invalid_idempotency_key"
+                raise MultimodalServiceError(
+                    reason_code,
+                    "Managed 图片生成要求 1 至 200 个字符的 Idempotency-Key。",
+                    status_code=422,
+                    route_receipt=gateway.blocked_receipt(
+                        "image_generation", reason_code
+                    ),
+                )
+            try:
+                clean_model = gateway.exact_model_id(
+                    "image_generation",
+                    "image_generation",
+                    requested_model=clean_model,
+                )
+                run = gateway.start_run(
+                    "image_generation",
+                    parent_run_reference=(
+                        "image-generation:"
+                        + hashlib.sha256(clean_key.encode("utf-8")).hexdigest()
+                    ),
+                    stable=True,
+                )
+                result, receipt = await run.complete_image_generation(
+                    logical_call_key="generate",
+                    model_id=clean_model,
+                    payload=payload,
+                    parse_response=lambda response: self._result(
+                        clean_model, response
+                    ),
+                )
+                return result.model_copy(
+                    update={
+                        "provider": "managed",
+                        "provider_route_receipts": [receipt],
+                        "execution_mode": "managed",
+                    }
+                )
+            except ManagedMultimodalError as exc:
+                raise MultimodalServiceError(
+                    exc.code,
+                    "图片生成 Managed Provider 调用失败，系统未重试或切换目标。",
+                    status_code=exc.status_code,
+                    route_receipt=exc.receipt,
+                ) from exc
 
         target = self.catalog_service.resolve_target()
         response = await self._request(target, payload)

--- a/server/multimodal/stt.py
+++ b/server/multimodal/stt.py
@@ -97,11 +97,19 @@ def manual_verification_enabled(model_id: str) -> bool:
 
 
 class MultimodalServiceError(Exception):
-    def __init__(self, code: str, message: str, *, status_code: int) -> None:
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        status_code: int,
+        route_receipt: dict[str, Any] | None = None,
+    ) -> None:
         super().__init__(message)
         self.code = code
         self.message = message
         self.status_code = status_code
+        self.route_receipt = route_receipt
 
 
 @dataclass(frozen=True)

--- a/server/multimodal/vision_understanding.py
+++ b/server/multimodal/vision_understanding.py
@@ -8,10 +8,11 @@ import json
 import os
 import re
 import threading
+import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
@@ -21,6 +22,13 @@ try:
 except ModuleNotFoundError:
     from file_assets.contracts import FileInputKind, FilePurpose
     from file_assets.registry import get_file_format_registry
+
+if TYPE_CHECKING:
+    from server.model_router.multimodal_gateway import (
+        ManagedMultimodalGateway,
+        ManagedMultimodalRun,
+        R8BEntryId,
+    )
 
 
 SUPPORTED_IMAGE_EXTENSIONS = set(
@@ -109,6 +117,9 @@ class VisionSourceResult:
     blocks: list[VisionBlock]
     page_results: list[VisionPageResult]
     warnings: list[str] = field(default_factory=list)
+    provider_route_receipts: list[dict[str, Any]] = field(default_factory=list)
+    execution_mode: str = "legacy"
+    fallback_reason_codes: list[str] = field(default_factory=list)
 
     def payload(self, *, max_text: int | None = None) -> dict[str, Any]:
         return {
@@ -121,6 +132,9 @@ class VisionSourceResult:
             "block_count": len(self.blocks),
             "block_counts": _block_counts(self.blocks),
             "warnings": list(self.warnings),
+            "provider_route_receipts": list(self.provider_route_receipts),
+            "execution_mode": self.execution_mode,
+            "fallback_reason_codes": list(self.fallback_reason_codes),
             "blocks": [block.payload(max_text=max_text) for block in self.blocks],
             "pages": [item.payload(max_text=max_text) for item in self.page_results],
         }
@@ -135,10 +149,12 @@ class VisionUnderstandingService:
         request_override: Callable[[str, str, dict[str, Any]], Any] | None = None,
         max_concurrency: int = 2,
         before_request: Callable[[], Any] | None = None,
+        managed_gateway: ManagedMultimodalGateway | None = None,
     ) -> None:
         self._request_override = request_override
         self._semaphore = asyncio.Semaphore(max(1, min(max_concurrency, 8)))
         self._before_request = before_request
+        self._managed_gateway = managed_gateway
 
     def capabilities(self) -> dict[str, Any]:
         targets = self._targets()
@@ -169,6 +185,60 @@ class VisionUnderstandingService:
                 "attempts": 2,
             },
         }
+
+    def managed_model_available(
+        self,
+        entry_id: R8BEntryId,
+        model_id: str,
+        execution_shape: str = "vision_json_unary",
+    ) -> bool:
+        """Project exact managed readiness without borrowing legacy targets."""
+
+        try:
+            from server.model_router import get_model_router_service
+            from server.model_router.multimodal_gateway import (
+                ManagedMultimodalGateway,
+            )
+        except ModuleNotFoundError:
+            from model_router import get_model_router_service
+            from model_router.multimodal_gateway import (
+                ManagedMultimodalGateway,
+            )
+        try:
+            gateway = self._managed_gateway or ManagedMultimodalGateway.for_router(
+                get_model_router_service()
+            )
+            if gateway.routing_mode(entry_id) != "managed_required":
+                return False
+            gateway.exact_model_id(
+                entry_id,
+                execution_shape,
+                requested_model=model_id,
+            )
+            return True
+        except Exception:
+            return False
+
+    def managed_routing_mode(self, entry_id: R8BEntryId) -> str:
+        """Expose the effective managed state for safe preflight projection."""
+
+        try:
+            from server.model_router import get_model_router_service
+            from server.model_router.multimodal_gateway import (
+                ManagedMultimodalGateway,
+            )
+        except ModuleNotFoundError:
+            from model_router import get_model_router_service
+            from model_router.multimodal_gateway import (
+                ManagedMultimodalGateway,
+            )
+        try:
+            gateway = self._managed_gateway or ManagedMultimodalGateway.for_router(
+                get_model_router_service()
+            )
+            return gateway.routing_mode(entry_id)
+        except Exception:
+            return "degraded_required"
 
     def validate_image_bytes(self, content: bytes, filename: str) -> dict[str, Any]:
         extension = Path(filename).suffix.lower()
@@ -237,6 +307,8 @@ class VisionUnderstandingService:
         cache_get: Callable[[int], dict[str, Any] | None] | None = None,
         cache_set: Callable[[int, dict[str, Any]], None] | None = None,
         cancel_check: Callable[[], bool] | None = None,
+        managed_entry_id: R8BEntryId | None = None,
+        parent_run_reference: str | None = None,
     ) -> VisionSourceResult:
         return await self.analyze_bytes(
             path.read_bytes(),
@@ -246,6 +318,8 @@ class VisionUnderstandingService:
             cache_get=cache_get,
             cache_set=cache_set,
             cancel_check=cancel_check,
+            managed_entry_id=managed_entry_id,
+            parent_run_reference=parent_run_reference,
         )
 
     async def analyze_bytes(
@@ -258,6 +332,8 @@ class VisionUnderstandingService:
         cache_get: Callable[[int], dict[str, Any] | None] | None = None,
         cache_set: Callable[[int, dict[str, Any]], None] | None = None,
         cancel_check: Callable[[], bool] | None = None,
+        managed_entry_id: R8BEntryId | None = None,
+        parent_run_reference: str | None = None,
     ) -> VisionSourceResult:
         normalized = _normalize_config(config)
         model_id = normalized["vision_model_id"]
@@ -284,7 +360,54 @@ class VisionUnderstandingService:
                 f"Visual processing was limited to the first {max_pages} selected pages."
             )
 
-        async def process(plan: VisionPagePlan) -> VisionPageResult:
+        managed_run: ManagedMultimodalRun | None = None
+        execution_mode = "legacy"
+        if managed_entry_id is not None:
+            try:
+                from server.model_router import get_model_router_service
+                from server.model_router.multimodal_gateway import (
+                    ManagedMultimodalError,
+                    ManagedMultimodalGateway,
+                )
+            except ModuleNotFoundError:
+                from model_router import get_model_router_service
+                from model_router.multimodal_gateway import (
+                    ManagedMultimodalError,
+                    ManagedMultimodalGateway,
+                )
+            gateway = self._managed_gateway or ManagedMultimodalGateway.for_router(
+                get_model_router_service()
+            )
+            mode = gateway.routing_mode(managed_entry_id)
+            if mode == "degraded_required":
+                raise VisionProcessingError(
+                    "Managed Vision policy is degraded and failed closed."
+                )
+            if mode == "managed_required":
+                try:
+                    model_id = gateway.exact_model_id(
+                        managed_entry_id,
+                        "vision_json_unary",
+                        requested_model=model_id,
+                    )
+                    managed_run = gateway.start_run(
+                        managed_entry_id,
+                        parent_run_reference=(
+                            parent_run_reference
+                            or f"vision:{source_id}:{uuid.uuid4().hex}"
+                        ),
+                        stable=bool(parent_run_reference),
+                    )
+                    execution_mode = "managed"
+                except ManagedMultimodalError as exc:
+                    error = VisionProcessingError(str(exc))
+                    error.code = exc.code  # type: ignore[attr-defined]
+                    error.receipt = exc.receipt  # type: ignore[attr-defined]
+                    raise error from exc
+
+        async def process(
+            plan: VisionPagePlan, call_sequence: int
+        ) -> VisionPageResult:
             if cancel_check and cancel_check():
                 raise asyncio.CancelledError
             cached = cache_get(plan.page_number) if cache_get else None
@@ -306,6 +429,9 @@ class VisionUnderstandingService:
                         model_id=model_id,
                         image_bytes=rendered["content"],
                         mime_type=rendered["mime_type"],
+                        managed_run=managed_run,
+                        logical_call_key=f"page:{plan.page_number}",
+                        call_sequence=call_sequence,
                     )
                 blocks, warning = self._blocks_from_analysis(
                     data,
@@ -334,11 +460,22 @@ class VisionUnderstandingService:
                 cache_set(plan.page_number, result.payload(max_text=None))
             return result
 
-        page_results = list(await asyncio.gather(*(process(item) for item in selected)))
+        page_results = list(
+            await asyncio.gather(
+                *(process(item, index) for index, item in enumerate(selected, start=1))
+            )
+        )
         blocks = [block for result in page_results for block in result.blocks]
         failed = sum(1 for item in page_results if item.status == "failed")
         processed = sum(1 for item in page_results if item.status == "completed")
         warnings.extend(item.warning for item in page_results if item.warning)
+        receipts: list[dict[str, Any]] = []
+        if managed_run is not None:
+            receipts.append(
+                managed_run.finish_failure("provider_multimodal_page_failed")
+                if failed
+                else managed_run.finish_success()
+            )
         return VisionSourceResult(
             source_id=source_id,
             filename=filename,
@@ -349,6 +486,8 @@ class VisionUnderstandingService:
             blocks=blocks,
             page_results=page_results,
             warnings=[str(item) for item in warnings if item],
+            provider_route_receipts=receipts,
+            execution_mode=execution_mode,
         )
 
     async def _call_before_request(self) -> None:
@@ -470,6 +609,9 @@ class VisionUnderstandingService:
         model_id: str,
         image_bytes: bytes,
         mime_type: str,
+        managed_run: ManagedMultimodalRun | None = None,
+        logical_call_key: str = "vision",
+        call_sequence: int = 1,
     ) -> dict[str, Any]:
         encoded = base64.b64encode(image_bytes).decode("ascii")
         payload = {
@@ -504,6 +646,14 @@ class VisionUnderstandingService:
             "max_tokens": 4000,
             "stream": False,
         }
+        if managed_run is not None:
+            return await managed_run.complete_vision_json(
+                logical_call_key=logical_call_key,
+                call_sequence=call_sequence,
+                model_id=model_id,
+                messages=payload["messages"],
+                max_tokens=int(payload["max_tokens"]),
+            )
         errors: list[str] = []
         for attempt in range(2):
             for target_name, url, key in self._targets():

--- a/server/rag/api.py
+++ b/server/rag/api.py
@@ -634,6 +634,10 @@ class PipelineDocumentResultPayload(BaseModel):
     vision_block_count: int = 0
     vision_warnings: list[str] = Field(default_factory=list)
     vision_error: str | None = None
+    vision_execution_mode: Literal["managed", "legacy"] = "legacy"
+    vision_provider_route_receipts: list[dict[str, Any]] = Field(
+        default_factory=list
+    )
     execution_mode: Literal["managed", "legacy"] = "legacy"
     provider_route_receipts: dict[str, Any] | None = None
 

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -2215,6 +2215,17 @@ class RagService:
         vision_stage = stages["stage_image_understanding"]
         vision_config = dict(vision_stage.get("config") or {})
         vision_capabilities = self.vision_processor.capabilities()
+        managed_vision_available = self.vision_processor.managed_model_available(
+            "rag_vision",
+            str(vision_config.get("vision_model_id") or "").strip(),
+        )
+        vision_configured = bool(
+            vision_capabilities.get("image_decoder_ready")
+            and (
+                vision_capabilities.get("targets")
+                or managed_vision_available
+            )
+        )
         embedding_profile = dict(draft.get("embedding_profile") or {})
         embedding_effective = dict(embedding_profile.get("effective") or {})
         retrieval_mode = str(
@@ -2254,7 +2265,7 @@ class RagService:
         if bool(vision_config.get("enabled")):
             if not str(vision_config.get("vision_model_id") or "").strip():
                 warnings.append("Image understanding requires an explicit vision model.")
-            if not bool(vision_capabilities.get("configured")):
+            if not vision_configured:
                 warnings.append(
                     "Image understanding requires PDF/image rendering and a configured model gateway."
                 )
@@ -2288,9 +2299,7 @@ class RagService:
                     severity = "warning"
                     status = "blocked"
                     summary = "Visual sources are waiting for an enabled image understanding stage."
-                elif bool(vision_config.get("enabled")) and not bool(
-                    vision_capabilities.get("configured")
-                ):
+                elif bool(vision_config.get("enabled")) and not vision_configured:
                     severity = "warning"
                     status = "blocked"
                     summary = "The renderer or model gateway required by image understanding is unavailable."
@@ -2719,6 +2728,8 @@ class RagService:
                     "vision_block_count": 0,
                     "vision_warnings": [],
                     "vision_error": None,
+                    "vision_execution_mode": "legacy",
+                    "vision_provider_route_receipts": [],
                     "vision_artifact_key": (
                         self.pipeline_vision_dir
                         / job_id
@@ -2945,6 +2956,8 @@ class RagService:
                     "vision_block_count": 0,
                     "vision_warnings": [],
                     "vision_error": None,
+                    "vision_execution_mode": "legacy",
+                    "vision_provider_route_receipts": [],
                     "vision_artifact_key": (
                         self.pipeline_vision_dir / job_id / f"source_{index}.json"
                     ).relative_to(self.storage_dir).as_posix(),
@@ -3375,10 +3388,28 @@ class RagService:
                         "vision_failed_page_count": failed_pages,
                         "vision_block_count": len(payload.get("blocks") or []),
                         "vision_warnings": list(payload.get("warnings") or []),
+                        "vision_execution_mode": str(
+                            payload.get("execution_mode") or "legacy"
+                        ),
+                        "vision_provider_route_receipts": list(
+                            payload.get("provider_route_receipts") or []
+                        ),
                         "vision_error": (
                             f"{failed_pages} visual page(s) failed."
                             if failed_pages
                             else None
+                        ),
+                        **(
+                            {
+                                "execution_mode": "managed",
+                                "provider_route_receipts": list(
+                                    payload.get("provider_route_receipts") or []
+                                )[0],
+                            }
+                            if str(payload.get("execution_mode") or "")
+                            == "managed"
+                            and payload.get("provider_route_receipts")
+                            else {}
                         ),
                     },
                 )
@@ -3530,11 +3561,17 @@ class RagService:
                     "warnings": list(document.warnings),
                     "error": None,
                     "duration_ms": duration_ms,
-                    "execution_mode": generation.execution_mode,
-                    "provider_route_receipts": (
-                        generation.provider_route_receipts
-                    ),
                 }
+                if (
+                    generation.execution_mode == "managed"
+                    or generation.provider_route_receipts is not None
+                ):
+                    result_values.update(
+                        execution_mode=generation.execution_mode,
+                        provider_route_receipts=(
+                            generation.provider_route_receipts
+                        ),
+                    )
                 self._update_pipeline_document_result(
                     job_id,
                     source_id,
@@ -7785,7 +7822,13 @@ class RagService:
                             node_id=vision_node,
                         )
                     ], None
-                if not bool(capabilities.get("targets")):
+                managed_vision_available = (
+                    self.vision_processor.managed_model_available(
+                        "rag_vision",
+                        str(vision.get("vision_model_id") or "").strip(),
+                    )
+                )
+                if not bool(capabilities.get("targets")) and not managed_vision_available:
                     return [
                         GraphValidationIssue(
                             "vision_model_unavailable",
@@ -8238,6 +8281,8 @@ class RagService:
                 result.setdefault("vision_block_count", 0)
                 result.setdefault("vision_warnings", [])
                 result.setdefault("vision_error", None)
+                result.setdefault("vision_execution_mode", "legacy")
+                result.setdefault("vision_provider_route_receipts", [])
         return metadata
 
     def _write_metadata(self, metadata: dict[str, Any]) -> None:

--- a/server/rag/vision_processor.py
+++ b/server/rag/vision_processor.py
@@ -72,6 +72,9 @@ class VisionSourceResult:
     blocks: list[DocumentBlock]
     page_results: list[VisionPageResult]
     warnings: list[str] = field(default_factory=list)
+    provider_route_receipts: list[dict[str, Any]] = field(default_factory=list)
+    execution_mode: str = "legacy"
+    fallback_reason_codes: list[str] = field(default_factory=list)
 
     def payload(self, *, max_text: int | None = None) -> dict[str, Any]:
         return {
@@ -84,6 +87,9 @@ class VisionSourceResult:
             "block_count": len(self.blocks),
             "block_counts": _block_counts(self.blocks),
             "warnings": list(self.warnings),
+            "provider_route_receipts": list(self.provider_route_receipts),
+            "execution_mode": self.execution_mode,
+            "fallback_reason_codes": list(self.fallback_reason_codes),
             "blocks": [block.payload(max_text=max_text) for block in self.blocks],
             "pages": [item.payload(max_text=max_text) for item in self.page_results],
         }
@@ -126,6 +132,11 @@ class VisionUnderstandingService(GenericVisionUnderstandingService):
             cache_get=cache_get,
             cache_set=cache_set,
             cancel_check=cancel_check,
+            managed_entry_id="rag_vision",
+            parent_run_reference=(
+                str(config.get("provider_parent_run_reference") or "").strip()
+                or None
+            ),
         )
         return self._adapt_source_result(result)
 
@@ -190,6 +201,9 @@ class VisionUnderstandingService(GenericVisionUnderstandingService):
             blocks=[_to_document_block(block) for block in result.blocks],
             page_results=page_results,
             warnings=list(result.warnings),
+            provider_route_receipts=list(result.provider_route_receipts),
+            execution_mode=result.execution_mode,
+            fallback_reason_codes=list(result.fallback_reason_codes),
         )
 
 

--- a/server/tests/test_file_asset_chat.py
+++ b/server/tests/test_file_asset_chat.py
@@ -304,6 +304,72 @@ async def test_capabilities_only_expose_native_pdf_for_live_openrouter_model(
 
 
 @pytest.mark.asyncio
+async def test_capabilities_expose_native_pdf_from_managed_control_plane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CHAT_FILE_INPUT_ENABLED", "true")
+    monkeypatch.setenv("FILE_ASSET_STORE_MODE", "shadow")
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_DOCUMENT_ENABLED", "true")
+    monkeypatch.delenv("LLM_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("LLM_GATEWAY_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    class ManagedControl:
+        @staticmethod
+        def feature_enabled(entry_id: str) -> bool:
+            assert entry_id == "chat_document_native"
+            return True
+
+        def __init__(self, _router_service) -> None:
+            pass
+
+        def public_status(
+            self,
+            entry_id: str,
+            model_id: str,
+            execution_shape: str,
+        ):
+            assert (
+                entry_id,
+                model_id,
+                execution_shape,
+            ) == (
+                "chat_document_native",
+                "openai/gpt-file",
+                "chat_document_stream",
+            )
+            return SimpleNamespace(
+                status="managed_required",
+                available=True,
+            )
+
+    monkeypatch.setattr(
+        file_api,
+        "ProviderWorkloadControlService",
+        ManagedControl,
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.get(
+            "/api/files/capabilities",
+            params={"purpose": "chat", "model_id": "openai/gpt-file"},
+        )
+
+    assert response.status_code == 200
+    document = next(
+        item
+        for item in response.json()["capabilities"]
+        if item["input_kind"] == "document"
+    )
+    assert [item["handling"] for item in document["handling_options"]] == [
+        "extract",
+        "native",
+    ]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("gateway_url", "stale", "availability"),
     [

--- a/server/tests/test_provider_multimodal_r8b.py
+++ b/server/tests/test_provider_multimodal_r8b.py
@@ -1,0 +1,1046 @@
+from __future__ import annotations
+
+import base64
+import io
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from httpx import MockTransport, Request, Response
+from PIL import Image
+
+from server import main as main_module
+from server.file_assets.document_parser import ParsedDocument, ParsedSection
+from server.file_assets.service import ResolvedChatFile
+from server.main import app
+from server.model_router import configure_model_router, get_model_router_service
+from server.model_router.egress import ProviderEgressPolicy
+from server.model_router.multimodal_control import ProviderMultimodalTarget
+from server.model_router.multimodal_gateway import (
+    ManagedMultimodalError,
+    ManagedMultimodalGateway,
+)
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import (
+    ProviderWorkloadActivationRequest,
+    ProviderWorkloadBindingUpdate,
+    ProviderWorkloadCertificationRequest,
+    ProviderWorkloadPolicyUpdate,
+    RouterConnectionCreate,
+)
+from server.model_router.service import ModelRouterService
+from server.model_router.workload_control import (
+    ProviderWorkloadCertificationService,
+    ProviderWorkloadControlService,
+    SYNTHETIC_NATIVE_PDF_DATA_URL,
+    SYNTHETIC_VISION_PNG_DATA_URL,
+)
+from server.multimodal.image_catalog import (
+    ImageModelCatalogResponse,
+    ImageModelProfile,
+)
+from server.multimodal.api import _http_error
+from server.multimodal.image_generation import ImageGenerationService
+from server.multimodal.stt import MultimodalServiceError
+from server.multimodal.vision_understanding import VisionUnderstandingService
+
+
+def png_bytes() -> bytes:
+    output = io.BytesIO()
+    Image.new("RGB", (2, 2), color=(0, 0, 255)).save(output, format="PNG")
+    return output.getvalue()
+
+
+def test_synthetic_vision_png_is_decodable() -> None:
+    prefix = "data:image/png;base64,"
+    assert SYNTHETIC_VISION_PNG_DATA_URL.startswith(prefix)
+    payload = base64.b64decode(
+        SYNTHETIC_VISION_PNG_DATA_URL.removeprefix(prefix),
+        validate=True,
+    )
+    image = Image.open(io.BytesIO(payload))
+    assert image.format == "PNG"
+    assert image.size == (2, 2)
+    image.verify()
+
+
+class _ChatResponse(httpx.Response):
+    def __init__(
+        self,
+        request: object,
+        *,
+        status_code: int = 200,
+        actual_model: str = "provider/vision",
+    ) -> None:
+        content = (
+            (
+                f'data: {{"model":"{actual_model}","choices":'
+                '[{"delta":{"content":"OK"},"finish_reason":null}]}\n\n'
+                'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+                "data: [DONE]\n\n"
+            ).encode("utf-8")
+            if status_code < 400
+            else b'{"error":{"message":"redacted-upstream-body"}}'
+        )
+        super().__init__(
+            status_code,
+            headers={"content-type": "text/event-stream"},
+            content=content,
+            request=httpx.Request("POST", str(request.get("url", "https://provider.test"))),
+        )
+
+
+class _ChatClient:
+    def __init__(
+        self,
+        sent: list[dict[str, object]],
+        *,
+        status_code: int,
+        actual_model: str = "provider/vision",
+    ) -> None:
+        self.sent = sent
+        self.status_code = status_code
+        self.actual_model = actual_model
+
+    def build_request(self, method, url, **kwargs):
+        return {"method": method, "url": str(url), **kwargs}
+
+    async def send(self, request, *, stream, follow_redirects=False):
+        assert stream is True
+        assert follow_redirects is False
+        self.sent.append(request)
+        return _ChatResponse(
+            request,
+            status_code=self.status_code,
+            actual_model=self.actual_model,
+        )
+
+    async def aclose(self) -> None:
+        return None
+
+
+def router_service(
+    tmp_path: Path,
+    transport: MockTransport,
+    *,
+    kind: str = "openrouter",
+    scopes: list[str] | None = None,
+) -> tuple[ModelRouterService, object]:
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    connection = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="R8B Provider",
+            kind=kind,
+            base_url="https://provider.example/api/v1",
+            api_key="r8b-secret",
+            scopes=scopes or ["chat", "image"],
+        ),
+    )
+    return (
+        ModelRouterService(
+            repository,
+            client_factory=lambda: httpx.AsyncClient(
+                transport=transport,
+                follow_redirects=False,
+                trust_env=False,
+            ),
+            egress_policy=ProviderEgressPolicy(
+                resolver=lambda _host, _port: ["8.8.8.8"]
+            ),
+        ),
+        connection,
+    )
+
+
+def test_r8b_adapter_resolves_exact_endpoint_without_secret_in_repr() -> None:
+    openrouter = ProviderMultimodalTarget.create(
+        provider_kind="openrouter",
+        connection_id="conn-1",
+        base_url="https://openrouter.example/api/v1/chat/completions",
+        api_key="do-not-print",
+        adapter_contract="openrouter_images_v1",
+        execution_shape="image_generation",
+    )
+    compatible = ProviderMultimodalTarget.create(
+        provider_kind="newapi",
+        connection_id="conn-2",
+        base_url="https://newapi.example/v1",
+        api_key="also-secret",
+        adapter_contract="openai_compatible_images_generations_v1",
+        execution_shape="image_generation",
+    )
+
+    assert openrouter.endpoint_url == "https://openrouter.example/api/v1/images"
+    assert compatible.endpoint_url == "https://newapi.example/v1/images/generations"
+    assert "do-not-print" not in repr(openrouter)
+    assert "also-secret" not in repr(compatible)
+
+
+def test_native_pdf_certification_asset_is_a_single_page_xref_pdf() -> None:
+    document = base64.b64decode(SYNTHETIC_NATIVE_PDF_DATA_URL.split(",", 1)[1])
+    startxref = int(document.rsplit(b"startxref\n", 1)[1].splitlines()[0])
+
+    assert document.startswith(b"%PDF-1.4")
+    assert b"/Type /Pages /Count 1" in document
+    assert b"/Type /Page " in document
+    assert document[startxref:].startswith(b"xref\n")
+    assert document.endswith(b"%%EOF\n")
+
+
+@pytest.mark.asyncio
+async def test_chat_image_certification_and_runtime_each_send_one_post(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[Request] = []
+
+    def handler(request: Request) -> Response:
+        requests.append(request)
+        if request.method == "GET":
+            return Response(200, json={"data": [{"id": "provider/vision"}]})
+        body = json.loads(request.content)
+        assert body["model"] == "provider/vision"
+        assert body["messages"][0]["content"][1]["type"] == "image_url"
+        return Response(
+            200,
+            content=(
+                b'data: {"model":"provider/vision","choices":'
+                b'[{"delta":{"content":"OK"},"finish_reason":null}]}\n\n'
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+                b"data: [DONE]\n\n"
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    transport = MockTransport(handler)
+    service, connection = router_service(tmp_path, transport)
+    certification = await ProviderWorkloadCertificationService(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    ).run(
+        connection.id,
+        ProviderWorkloadCertificationRequest(
+            execution_shape="chat_image_stream",
+            model_id="provider/vision",
+            adapter_contract="openrouter_chat_multimodal_v1",
+            acknowledge_billed_call=True,
+        ),
+        idempotency_key="chat-image-cert",
+    )
+    assert certification.status == "passed"
+
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_IMAGE_ENABLED", "true")
+    control = ProviderWorkloadControlService(service)
+    saved = control.update_policy(
+        "chat_image",
+        ProviderWorkloadPolicyUpdate(
+            expected_revision=0,
+            bindings=[
+                ProviderWorkloadBindingUpdate(
+                    execution_shape="chat_image_stream",
+                    model_id="provider/vision",
+                    connection_id=connection.id,
+                    adapter_contract="openrouter_chat_multimodal_v1",
+                )
+            ],
+        ),
+    )
+    control.activate(
+        "chat_image",
+        ProviderWorkloadActivationRequest(
+            expected_revision=saved.revision,
+            no_open_p0_p1=True,
+            acknowledge_fail_closed=True,
+        ),
+    )
+    gateway = ManagedMultimodalGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    )
+    dispatch = await gateway.prepare_chat_dispatch(
+        "chat_image",
+        execution_shape="chat_image_stream",
+        requested_model="provider/vision",
+        parent_run_reference="chat:test-r8b",
+    )
+    async with httpx.AsyncClient(
+        transport=transport, follow_redirects=False, trust_env=False
+    ) as client:
+        response = await dispatch.send(
+            client,
+            {
+                "model": "provider/vision",
+                "stream": True,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "describe"},
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": "data:image/png;base64,"
+                                    + base64.b64encode(png_bytes()).decode("ascii")
+                                },
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+        await response.aread()
+        await response.aclose()
+        with pytest.raises(ManagedMultimodalError) as duplicate:
+            await dispatch.send(client, {"model": "provider/vision"})
+    assert duplicate.value.code == "provider_multimodal_duplicate_post_blocked"
+    receipt = dispatch.complete(
+        status="passed",
+        result_class="success",
+        actual_model="provider/vision",
+    )
+    assert receipt["call_count"] == 1
+    assert [item.method for item in requests].count("POST") == 2
+    assert "r8b-secret" not in json.dumps(receipt)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("upstream_status", [200, 500])
+async def test_api_chat_image_managed_path_is_exact_and_never_falls_back(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    upstream_status: int,
+) -> None:
+    encoded = base64.b64encode(png_bytes()).decode("ascii")
+
+    def certification_handler(request: Request) -> Response:
+        if request.method == "GET":
+            return Response(200, json={"data": [{"id": "provider/vision"}]})
+        return Response(
+            200,
+            content=(
+                b'data: {"model":"provider/vision","choices":'
+                b'[{"delta":{"content":"OK"},"finish_reason":null}]}\n\n'
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+                b"data: [DONE]\n\n"
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    transport = MockTransport(certification_handler)
+    service, connection = router_service(tmp_path, transport, scopes=["chat", "image"])
+    certification = await ProviderWorkloadCertificationService(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    ).run(
+        connection.id,
+        ProviderWorkloadCertificationRequest(
+            execution_shape="chat_image_stream",
+            model_id="provider/vision",
+            adapter_contract="openrouter_chat_multimodal_v1",
+            acknowledge_billed_call=True,
+        ),
+        idempotency_key=f"api-chat-image-{upstream_status}",
+    )
+    assert certification.status == "passed"
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_IMAGE_ENABLED", "true")
+    control = ProviderWorkloadControlService(service)
+    saved = control.update_policy(
+        "chat_image",
+        ProviderWorkloadPolicyUpdate(
+            expected_revision=0,
+            bindings=[
+                ProviderWorkloadBindingUpdate(
+                    execution_shape="chat_image_stream",
+                    model_id="provider/vision",
+                    connection_id=connection.id,
+                    adapter_contract="openrouter_chat_multimodal_v1",
+                )
+            ],
+        ),
+    )
+    control.activate(
+        "chat_image",
+        ProviderWorkloadActivationRequest(
+            expected_revision=saved.revision,
+            no_open_p0_p1=True,
+            acknowledge_fail_closed=True,
+        ),
+    )
+
+    original_service = get_model_router_service()
+    configure_model_router(service)
+    sent: list[dict[str, object]] = []
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("", ""),
+    )
+    payload = {
+        "model_id": "provider/vision",
+        "gateway": "default",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{encoded}"},
+                    },
+                ],
+            }
+        ],
+    }
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            monkeypatch.setattr(
+                main_module.httpx,
+                "AsyncClient",
+                lambda **_kwargs: _ChatClient(sent, status_code=upstream_status),
+            )
+            response = await client.post("/api/chat", json=payload)
+            unsupported_payload = json.loads(json.dumps(payload))
+            unsupported_payload["tool_mode"] = "mcp_tools"
+            unsupported_response = await client.post(
+                "/api/chat", json=unsupported_payload
+            )
+            mixed_payload = json.loads(json.dumps(payload))
+            mixed_payload["file_scope_id"] = "chat-session-r8b"
+            mixed_payload["messages"][0]["content"].append(
+                {
+                    "type": "input_file",
+                    "asset_id": "file_" + "1" * 32,
+                    "handling": "native",
+                    "confirmation_revision": 1,
+                }
+            )
+            mixed_response = await client.post("/api/chat", json=mixed_payload)
+    finally:
+        configure_model_router(original_service)
+
+    assert len(sent) == 1
+    assert "8.8.8.8" in str(sent[0]["url"])
+    assert sent[0]["headers"]["Host"] == "provider.example"
+    assert all(item.get("headers", {}).get("Authorization") != "Bearer legacy" for item in sent)
+    assert unsupported_response.status_code == 422
+    assert unsupported_response.json()["code"] == (
+        "provider_multimodal_request_shape_unsupported"
+    )
+    assert mixed_response.status_code == 422
+    assert mixed_response.json()["code"] == (
+        "provider_multimodal_mixed_shape_unsupported"
+    )
+    if upstream_status == 200:
+        assert response.status_code == 200
+        assert response.text.count("event: route_receipt") == 1
+        assert response.text.rstrip().endswith("data: [DONE]")
+    else:
+        assert response.status_code == 500
+        body = response.json()
+        assert body["code"] == "provider_workload_http_5xx"
+        assert body["route_receipt"]["call_count"] == 1
+        assert "redacted-upstream-body" not in response.text
+    stored = service.repository.list_workload_receipts("local")
+    assert len(stored["calls"]) == 1
+    assert stored["calls"][0]["dispatched"] == 1
+    assert "describe" not in json.dumps(stored)
+    assert "OK" not in json.dumps(stored)
+
+    restarted_repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    restarted = restarted_repository.list_workload_receipts("local")
+    assert len(restarted["calls"]) == 1
+    assert restarted["calls"][0]["status"] != "uncertain"
+
+
+@pytest.mark.asyncio
+async def test_image_generation_certification_uses_compatible_endpoint(
+    tmp_path: Path,
+) -> None:
+    requests: list[Request] = []
+    encoded = base64.b64encode(png_bytes()).decode("ascii")
+
+    def handler(request: Request) -> Response:
+        requests.append(request)
+        if request.method == "GET":
+            return Response(200, json={"data": [{"id": "provider/image"}]})
+        assert request.url.path == "/api/v1/images/generations"
+        return Response(
+            200,
+            json={
+                "model": "provider/image",
+                "data": [{"b64_json": encoded}],
+            },
+        )
+
+    transport = MockTransport(handler)
+    service, connection = router_service(
+        tmp_path,
+        transport,
+        kind="newapi",
+        scopes=["image"],
+    )
+    result = await ProviderWorkloadCertificationService(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    ).run(
+        connection.id,
+        ProviderWorkloadCertificationRequest(
+            execution_shape="image_generation",
+            model_id="provider/image",
+            adapter_contract="openai_compatible_images_generations_v1",
+            acknowledge_billed_call=True,
+        ),
+        idempotency_key="image-cert",
+    )
+    assert result.status == "passed"
+    assert [item.method for item in requests].count("POST") == 1
+
+
+@pytest.mark.asyncio
+async def test_openrouter_image_certification_uses_declared_parameters_only(
+    tmp_path: Path,
+) -> None:
+    requests: list[Request] = []
+    encoded = base64.b64encode(png_bytes()).decode("ascii")
+
+    def handler(request: Request) -> Response:
+        requests.append(request)
+        if request.method == "GET":
+            return Response(200, json={"data": [{"id": "provider/image"}]})
+        assert request.url.path == "/api/v1/images"
+        body = json.loads(request.content)
+        assert body == {
+            "model": "provider/image",
+            "prompt": "A single blue square on a white background.",
+            "n": 1,
+            "quality": "low",
+            "aspect_ratio": "1:1",
+        }
+        return Response(
+            200,
+            json={"data": [{"b64_json": encoded}]},
+        )
+
+    transport = MockTransport(handler)
+    service, connection = router_service(
+        tmp_path,
+        transport,
+        kind="openrouter",
+        scopes=["image"],
+    )
+    result = await ProviderWorkloadCertificationService(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    ).run(
+        connection.id,
+        ProviderWorkloadCertificationRequest(
+            execution_shape="image_generation",
+            model_id="provider/image",
+            adapter_contract="openrouter_images_v1",
+            acknowledge_billed_call=True,
+        ),
+        idempotency_key="openrouter-image-cert",
+    )
+    assert result.status == "passed"
+    assert [item.method for item in requests].count("POST") == 1
+
+
+@pytest.mark.asyncio
+async def test_native_pdf_certification_uses_distinct_adapter_and_one_post(
+    tmp_path: Path,
+) -> None:
+    requests: list[Request] = []
+
+    def handler(request: Request) -> Response:
+        requests.append(request)
+        if request.method == "GET":
+            return Response(200, json={"data": [{"id": "provider/pdf"}]})
+        body = json.loads(request.content)
+        assert body["plugins"] == [
+            {"id": "file-parser", "pdf": {"engine": "native"}}
+        ]
+        file_part = body["messages"][0]["content"][1]
+        assert file_part["type"] == "file"
+        assert file_part["file"]["file_data"] == SYNTHETIC_NATIVE_PDF_DATA_URL
+        return Response(
+            200,
+            content=(
+                b'data: {"model":"provider/pdf","choices":'
+                b'[{"delta":{"content":"OK"},"finish_reason":null}]}\n\n'
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+                b"data: [DONE]\n\n"
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    transport = MockTransport(handler)
+    service, connection = router_service(
+        tmp_path,
+        transport,
+        scopes=["chat", "document"],
+    )
+    result = await ProviderWorkloadCertificationService(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    ).run(
+        connection.id,
+        ProviderWorkloadCertificationRequest(
+            execution_shape="chat_document_stream",
+            model_id="provider/pdf",
+            adapter_contract="openrouter_chat_native_pdf_v1",
+            acknowledge_billed_call=True,
+        ),
+        idempotency_key="native-pdf-certification",
+    )
+
+    assert result.status == "passed"
+    assert [item.method for item in requests].count("POST") == 1
+
+
+@pytest.mark.asyncio
+async def test_api_chat_native_pdf_uses_exact_managed_adapter_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[Request] = []
+
+    def certification_handler(request: Request) -> Response:
+        requests.append(request)
+        if request.method == "GET":
+            return Response(200, json={"data": [{"id": "provider/pdf"}]})
+        return Response(
+            200,
+            content=(
+                b'data: {"model":"provider/pdf","choices":'
+                b'[{"delta":{"content":"OK"},"finish_reason":null}]}\n\n'
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+                b"data: [DONE]\n\n"
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    transport = MockTransport(certification_handler)
+    service, connection = router_service(
+        tmp_path,
+        transport,
+        scopes=["chat", "document"],
+    )
+    certification = await ProviderWorkloadCertificationService(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    ).run(
+        connection.id,
+        ProviderWorkloadCertificationRequest(
+            execution_shape="chat_document_stream",
+            model_id="provider/pdf",
+            adapter_contract="openrouter_chat_native_pdf_v1",
+            acknowledge_billed_call=True,
+        ),
+        idempotency_key="native-pdf-runtime-certification",
+    )
+    assert certification.status == "passed"
+
+    monkeypatch.setenv("MODEL_CONTROL_CHAT_DOCUMENT_ENABLED", "true")
+    control = ProviderWorkloadControlService(service)
+    saved = control.update_policy(
+        "chat_document_native",
+        ProviderWorkloadPolicyUpdate(
+            expected_revision=0,
+            bindings=[
+                ProviderWorkloadBindingUpdate(
+                    execution_shape="chat_document_stream",
+                    model_id="provider/pdf",
+                    connection_id=connection.id,
+                    adapter_contract="openrouter_chat_native_pdf_v1",
+                )
+            ],
+        ),
+    )
+    control.activate(
+        "chat_document_native",
+        ProviderWorkloadActivationRequest(
+            expected_revision=saved.revision,
+            no_open_p0_p1=True,
+            acknowledge_fail_closed=True,
+        ),
+    )
+
+    class NativeFileService:
+        def __init__(self) -> None:
+            self.resolved = (
+                ResolvedChatFile(
+                    asset_id="file_" + "1" * 32,
+                    scope_id="chat-session-r8b-pdf",
+                    display_name="synthetic.pdf",
+                    format_id="pdf",
+                    media_type="application/pdf",
+                    byte_size=16,
+                    handling="native",
+                    native_content=b"%PDF-R8B",
+                    parsed_document=ParsedDocument(
+                        format="pdf",
+                        title="synthetic.pdf",
+                        sections=(ParsedSection(text="fixed test", page=1),),
+                        extracted_chars=10,
+                    ),
+                ),
+            )
+
+        def resolve_chat_inputs(self, *_args, **kwargs):
+            assert kwargs["scope_id"] == "chat-session-r8b-pdf"
+            assert kwargs["native_pdf_verified"] is True
+            return self.resolved
+
+        def finalize_chat_inputs(self, _files, *, success: bool):
+            return success
+
+    original_service = get_model_router_service()
+    configure_model_router(service)
+    sent: list[dict[str, object]] = []
+    monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+    monkeypatch.setattr(
+        main_module,
+        "get_file_asset_service",
+        lambda: NativeFileService(),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("https://legacy-must-not-run.example/v1/chat/completions", "legacy"),
+    )
+    payload = {
+        "model_id": "provider/pdf",
+        "gateway": "default",
+        "file_scope_id": "chat-session-r8b-pdf",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "summarize"},
+                    {
+                        "type": "input_file",
+                        "asset_id": "file_" + "1" * 32,
+                        "handling": "native",
+                        "confirmation_revision": 1,
+                    },
+                ],
+            }
+        ],
+    }
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            monkeypatch.setattr(
+                main_module.httpx,
+                "AsyncClient",
+                lambda **_kwargs: _ChatClient(
+                    sent,
+                    status_code=200,
+                    actual_model="provider/pdf",
+                ),
+            )
+            response = await client.post("/api/chat", json=payload)
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 200
+    assert len(sent) == 1
+    assert "8.8.8.8" in str(sent[0]["url"])
+    assert "legacy-must-not-run" not in str(sent)
+    body = sent[0]["json"]
+    assert body["plugins"] == [
+        {"id": "file-parser", "pdf": {"engine": "native"}}
+    ]
+    file_part = body["messages"][0]["content"][1]
+    assert file_part["type"] == "file"
+    assert file_part["file"]["file_data"].startswith(
+        "data:application/pdf;base64,"
+    )
+    assert response.text.count("event: route_receipt") == 1
+    stored = service.repository.list_workload_receipts("local")
+    assert len(stored["calls"]) == 1
+    assert "summarize" not in json.dumps(stored)
+    assert "%PDF-R8B" not in json.dumps(stored)
+
+
+@pytest.mark.asyncio
+async def test_vision_managed_path_never_calls_legacy_override() -> None:
+    calls: list[str] = []
+
+    class FakeRun:
+        async def complete_vision_json(self, **_kwargs):
+            calls.append("managed")
+            return {
+                "ocr_text": "",
+                "visual_summary": "blue square",
+                "tables": [],
+                "charts": [],
+                "language": "en",
+                "warnings": [],
+            }
+
+        def finish_success(self):
+            return {"status": "passed", "call_count": 1, "calls": []}
+
+        def finish_failure(self, _reason):
+            return {"status": "failed", "call_count": 1, "calls": []}
+
+    class FakeGateway:
+        def routing_mode(self, _entry):
+            return "managed_required"
+
+        def blocked_receipt(self, entry_id, reason_code):
+            return {
+                "entry_id": entry_id,
+                "status": "failed",
+                "call_count": 0,
+                "reason_codes": [reason_code],
+                "calls": [],
+            }
+
+        def exact_model_id(self, _entry, _shape, *, requested_model):
+            return requested_model
+
+        def start_run(self, *_args, **_kwargs):
+            return FakeRun()
+
+    def legacy_override(*_args):
+        raise AssertionError("legacy target must not run")
+
+    service = VisionUnderstandingService(
+        request_override=legacy_override,
+        managed_gateway=FakeGateway(),  # type: ignore[arg-type]
+    )
+    result = await service.analyze_bytes(
+        png_bytes(),
+        filename="square.png",
+        source_id="source-1",
+        config={
+            "vision_model_id": "provider/vision",
+            "pdf_page_strategy": "auto",
+            "render_dpi": 144,
+            "max_pages": 10,
+            "max_image_edge": 1024,
+            "failure_policy": "continue_on_error",
+        },
+        managed_entry_id="rag_vision",
+    )
+    assert calls == ["managed"]
+    assert result.execution_mode == "managed"
+    assert result.provider_route_receipts[0]["call_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_managed_image_generation_requires_idempotency_and_returns_receipt() -> None:
+    encoded = base64.b64encode(png_bytes()).decode("ascii")
+
+    class FakeRun:
+        async def complete_image_generation(self, *, parse_response, **_kwargs):
+            result = parse_response(
+                httpx.Response(
+                    200,
+                    json={
+                        "id": "img-1",
+                        "model": "provider/image",
+                        "data": [{"b64_json": encoded}],
+                    },
+                )
+            )
+            return result, {"status": "passed", "call_count": 1, "calls": []}
+
+    class FakeGateway:
+        def routing_mode(self, _entry):
+            return "managed_required"
+
+        def blocked_receipt(self, entry_id, reason_code):
+            return {
+                "entry_id": entry_id,
+                "status": "failed",
+                "call_count": 0,
+                "reason_codes": [reason_code],
+                "calls": [],
+            }
+
+        def exact_model_id(self, _entry, _shape, *, requested_model):
+            return requested_model
+
+        def start_run(self, *_args, **_kwargs):
+            return FakeRun()
+
+    class FakeCatalog:
+        router_service = SimpleNamespace()
+
+        async def get_catalog(self):
+            return ImageModelCatalogResponse(
+                source="openrouter",
+                status="online",
+                stale=False,
+                synced_at=None,
+                profiles=[
+                    ImageModelProfile(
+                        model_id="provider/image",
+                        display_name="Image",
+                        operation="generate_image",
+                    )
+                ],
+            )
+
+    service = ImageGenerationService(
+        FakeCatalog(),  # type: ignore[arg-type]
+        managed_gateway=FakeGateway(),  # type: ignore[arg-type]
+    )
+    arguments = {
+        "model_id": "provider/image",
+        "prompt": "blue square",
+        "reference_filenames": [],
+        "reference_content_types": [],
+        "reference_contents": [],
+    }
+    with pytest.raises(MultimodalServiceError) as missing:
+        await service.generate(**arguments)
+    assert missing.value.code == "invalid_idempotency_key"
+    assert missing.value.route_receipt["call_count"] == 0
+    assert _http_error(missing.value).detail["route_receipt"]["call_count"] == 0
+
+    result = await service.generate(**arguments, idempotency_key="image-one")
+    assert result.execution_mode == "managed"
+    assert result.provider == "managed"
+    assert result.provider_route_receipts[0]["call_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_managed_image_http_failure_finishes_receipt_without_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[Request] = []
+    encoded = base64.b64encode(png_bytes()).decode("ascii")
+
+    def handler(request: Request) -> Response:
+        requests.append(request)
+        if request.method == "GET":
+            return Response(200, json={"data": [{"id": "provider/image"}]})
+        if [item.method for item in requests].count("POST") == 1:
+            return Response(200, json={"data": [{"b64_json": encoded}]})
+        body = json.loads(request.content)
+        assert body["size"] == "1024x1024"
+        assert body["response_format"] == "b64_json"
+        assert "resolution" not in body
+        return Response(500, json={"error": {"message": "do-not-persist"}})
+
+    transport = MockTransport(handler)
+    service, connection = router_service(
+        tmp_path,
+        transport,
+        kind="newapi",
+        scopes=["image"],
+    )
+    certification = await ProviderWorkloadCertificationService(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    ).run(
+        connection.id,
+        ProviderWorkloadCertificationRequest(
+            execution_shape="image_generation",
+            model_id="provider/image",
+            adapter_contract="openai_compatible_images_generations_v1",
+            acknowledge_billed_call=True,
+        ),
+        idempotency_key="image-failure-cert",
+    )
+    assert certification.status == "passed"
+
+    monkeypatch.setenv("MODEL_CONTROL_IMAGE_GENERATION_ENABLED", "true")
+    control = ProviderWorkloadControlService(service)
+    saved = control.update_policy(
+        "image_generation",
+        ProviderWorkloadPolicyUpdate(
+            expected_revision=0,
+            bindings=[
+                ProviderWorkloadBindingUpdate(
+                    execution_shape="image_generation",
+                    model_id="provider/image",
+                    connection_id=connection.id,
+                    adapter_contract="openai_compatible_images_generations_v1",
+                )
+            ],
+        ),
+    )
+    control.activate(
+        "image_generation",
+        ProviderWorkloadActivationRequest(
+            expected_revision=saved.revision,
+            no_open_p0_p1=True,
+            acknowledge_fail_closed=True,
+        ),
+    )
+    gateway = ManagedMultimodalGateway.for_router(
+        service,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=transport, follow_redirects=False, trust_env=False
+        ),
+    )
+    run = gateway.start_run(
+        "image_generation",
+        parent_run_reference="image:test-http-failure",
+        stable=True,
+    )
+
+    with pytest.raises(ManagedMultimodalError) as failure:
+        await run.complete_image_generation(
+            logical_call_key="image-http-failure",
+            model_id="provider/image",
+            payload={
+                "prompt": "fixed test prompt",
+                "resolution": "1024x1024",
+            },
+            parse_response=lambda response: response.json(),
+        )
+
+    assert failure.value.code == "provider_workload_http_5xx"
+    assert failure.value.receipt["status"] == "failed"
+    assert failure.value.receipt["call_count"] == 1
+    assert failure.value.receipt["calls"][0]["dispatched"] is True
+    assert [item.method for item in requests].count("POST") == 2
+    stored = service.repository.list_workload_receipts("local")
+    assert stored["calls"][-1]["status"] == "failed"
+    assert "do-not-persist" not in json.dumps(stored)
+
+    unsupported_run = gateway.start_run(
+        "image_generation",
+        parent_run_reference="image:test-unsupported-parameter",
+        stable=True,
+    )
+    with pytest.raises(ManagedMultimodalError) as unsupported:
+        await unsupported_run.complete_image_generation(
+            logical_call_key="image-unsupported-parameter",
+            model_id="provider/image",
+            payload={"prompt": "fixed test prompt", "aspect_ratio": "16:9"},
+            parse_response=lambda response: response.json(),
+        )
+    assert unsupported.value.code == "provider_multimodal_adapter_parameter_unsupported"
+    assert unsupported.value.receipt["calls"][0]["dispatched"] is False
+    assert [item.method for item in requests].count("POST") == 2

--- a/server/tests/test_provider_workload_control.py
+++ b/server/tests/test_provider_workload_control.py
@@ -401,7 +401,7 @@ def test_multimodal_adapter_is_exact_and_scope_is_not_inherited() -> None:
 
 
 @pytest.mark.asyncio
-async def test_r8a_multimodal_certification_fails_before_catalog_or_paid_post(
+async def test_future_multimodal_certification_fails_before_catalog_or_paid_post(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -409,16 +409,16 @@ async def test_r8a_multimodal_certification_fails_before_catalog_or_paid_post(
     connection = repository.create_connection(
         "local",
         RouterConnectionCreate(
-            name="OpenRouter image",
+            name="OpenRouter audio",
             kind="openrouter",
             base_url="https://openrouter.ai/api/v1",
             api_key="test-secret",
-            scopes=["chat", "image"],
+            scopes=["audio"],
         ),
     )
 
     async def forbidden_catalog_refresh(*_args, **_kwargs):
-        raise AssertionError("R8A must stop before catalog or network work")
+        raise AssertionError("Future R8 batches must stop before catalog or network work")
 
     monkeypatch.setattr(
         "server.model_router.workload_control.ProviderCatalogService.refresh_connection",
@@ -430,12 +430,12 @@ async def test_r8a_multimodal_certification_fails_before_catalog_or_paid_post(
         ).run(
             connection.id,
             ProviderWorkloadCertificationRequest(
-                model_id="provider/vision",
-                execution_shape="chat_image_stream",
-                adapter_contract="openrouter_chat_multimodal_v1",
+                model_id="provider/audio",
+                execution_shape="audio_transcription",
+                adapter_contract="openrouter_audio_transcription_json_v1",
                 acknowledge_billed_call=True,
             ),
-            idempotency_key="r8a-no-paid-call",
+            idempotency_key="future-r8-no-paid-call",
         )
     assert blocked.value.code == "provider_multimodal_certification_not_integrated"
     assert repository.list_workload_certifications("local") == []
@@ -2420,11 +2420,26 @@ async def test_workload_admin_api_is_session_and_csrf_protected_and_public_redac
         }
         assert len(r8_policies) == 18
         assert all(item["feature_enabled"] is False for item in r8_policies.values())
-        assert all(item["data_plane_integrated"] is False for item in r8_policies.values())
+        r8b_entries = {
+            "chat_image",
+            "chat_document_native",
+            "rag_vision",
+            "workflow_interactive_vision",
+            "workflow_deployment_vision",
+            "xpert_vision",
+            "image_generation",
+        }
         assert all(
-            "provider_workload_data_plane_not_integrated"
-            in item["blocking_reason_codes"]
-            for item in r8_policies.values()
+            item["data_plane_integrated"] is (entry_id in r8b_entries)
+            for entry_id, item in r8_policies.items()
+        )
+        assert all(
+            (
+                "provider_workload_data_plane_not_integrated"
+                in item["blocking_reason_codes"]
+            )
+            is (entry_id not in r8b_entries)
+            for entry_id, item in r8_policies.items()
         )
         assert policies.json()["contract_version"] == PROVIDER_WORKLOAD_CONTRACT_VERSION
 

--- a/server/tests/test_rag_vision.py
+++ b/server/tests/test_rag_vision.py
@@ -356,8 +356,81 @@ async def test_image_upload_requires_pipeline_and_mime_matches_extension(vision_
 
 
 @pytest.mark.asyncio
-async def test_visual_pipeline_builds_dual_index_and_returns_page_citation(vision_api) -> None:
+async def test_managed_rag_vision_does_not_require_legacy_gateway(
+    vision_api,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, service, _executor = vision_api
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("LLM_GATEWAY_KEY", raising=False)
+    monkeypatch.setattr(
+        service.vision_processor,
+        "managed_model_available",
+        lambda entry_id, model_id, execution_shape="vision_json_unary": (
+            entry_id == "rag_vision"
+            and model_id == "openai/gpt-4o-mini"
+            and execution_shape == "vision_json_unary"
+        ),
+    )
+    kb_id = (
+        await client.post(
+            "/api/rag/knowledge_bases",
+            json={"name": "managed visual"},
+        )
+    ).json()["id"]
+    document = await client.post(
+        f"/api/rag/knowledge_bases/{kb_id}/documents",
+        files={"file": ("managed.png", _png_bytes(), "image/png")},
+    )
+    assert document.status_code == 200
+    draft = service.update_pipeline_draft(
+        kb_id,
+        {
+            "stage_image_understanding": {
+                "config": {
+                    "enabled": True,
+                    "vision_model_id": "openai/gpt-4o-mini",
+                }
+            }
+        },
+    )
+
+    job = service.create_pipeline_job(
+        kb_id,
+        draft_version=draft["version"],
+        source_document_ids=[document.json()["id"]],
+    )
+
+    assert job["status"] == "queued"
+
+
+@pytest.mark.asyncio
+async def test_visual_pipeline_builds_dual_index_and_returns_page_citation(
+    vision_api,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client, service, executor = vision_api
+    original_analyze = service.vision_processor.analyze_source
+
+    async def managed_analyze(*args, **kwargs):
+        result = await original_analyze(*args, **kwargs)
+        result.execution_mode = "managed"
+        result.provider_route_receipts = [
+            {
+                "entry_id": "rag_vision",
+                "status": "passed",
+                "call_count": 1,
+                "calls": [],
+            }
+        ]
+        return result
+
+    monkeypatch.setattr(
+        service.vision_processor,
+        "analyze_source",
+        managed_analyze,
+    )
     kb_id = (await client.post("/api/rag/knowledge_bases", json={"name": "charts"})).json()["id"]
     document = await client.post(
         f"/api/rag/knowledge_bases/{kb_id}/documents",
@@ -395,6 +468,10 @@ async def test_visual_pipeline_builds_dual_index_and_returns_page_citation(visio
     assert result["vision_processed_page_count"] == 1
     assert result["vision_failed_page_count"] == 0
     assert result["vision_block_count"] == 4
+    assert result["vision_execution_mode"] == "managed"
+    assert result["vision_provider_route_receipts"][0]["entry_id"] == "rag_vision"
+    assert result["execution_mode"] == "managed"
+    assert result["provider_route_receipts"]["entry_id"] == "rag_vision"
 
     version = service.get_pipeline_version(completed["candidate_version_id"])
     assert version["vision_profile"]["vision_model_id"] == "openai/gpt-4.1-mini"

--- a/server/tests/test_workflow_vision_understanding.py
+++ b/server/tests/test_workflow_vision_understanding.py
@@ -12,6 +12,7 @@ from server import main as main_module
 from server.multimodal.vision_understanding import VisionUnderstandingService
 from server.xpert_runtime.workflow_vision import (
     WorkflowVisionError,
+    compose_workflow_vision_receipt,
     execute_workflow_vision,
     resolve_workflow_vision_asset,
 )
@@ -89,6 +90,256 @@ def _events(response: httpx.Response) -> list[dict]:
         for line in response.text.splitlines()
         if line.startswith("data:")
     ]
+
+
+@pytest.mark.asyncio
+async def test_workflow_vision_preflight_respects_managed_and_degraded_modes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_checks: list[str] = []
+
+    class StubVisionService:
+        mode = "managed_required"
+
+        def managed_routing_mode(self, entry_id: str) -> str:
+            assert entry_id == "workflow_interactive_vision"
+            return self.mode
+
+        def managed_model_available(self, entry_id: str, model_id: str) -> bool:
+            assert entry_id == "workflow_interactive_vision"
+            assert model_id == "test/vision-model"
+            return True
+
+    async def legacy_model_support(model_id: str) -> bool:
+        legacy_checks.append(model_id)
+        return True
+
+    service = StubVisionService()
+    monkeypatch.setattr(main_module, "workflow_vision_service", service)
+    monkeypatch.setattr(main_module, "model_supports_image_input", legacy_model_support)
+
+    assert await main_module.workflow_vision_model_available(
+        "workflow_interactive_vision",
+        "test/vision-model",
+    )
+    assert legacy_checks == []
+
+    service.mode = "degraded_required"
+    assert not await main_module.workflow_vision_model_available(
+        "workflow_interactive_vision",
+        "test/vision-model",
+    )
+    assert legacy_checks == []
+
+    service.mode = "legacy"
+    assert await main_module.workflow_vision_model_available(
+        "workflow_interactive_vision",
+        "test/vision-model",
+    )
+    assert legacy_checks == ["test/vision-model"]
+
+
+@pytest.mark.asyncio
+async def test_workflow_vision_success_projects_managed_receipt_to_node_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt = {
+        "contract_version": "modelmirror-provider-workload-routing-v1",
+        "entry_id": "workflow_interactive_vision",
+        "routing_mode": "managed_required",
+        "run_reference": "vision-run-1",
+        "status": "passed",
+        "call_count": 1,
+        "reason_codes": [],
+        "calls": [
+            {
+                "call_sequence": 1,
+                "model_id": "test/vision-model",
+                "actual_model": "test/vision-model",
+                "dispatched": True,
+                "status": "passed",
+                "total_tokens": 9,
+            }
+        ],
+    }
+
+    class StubFileService:
+        def resolve_workflow_visual_asset(self, asset_id: str, *, scope_id: str):
+            assert scope_id == "workflow:workflow-vision"
+            return SimpleNamespace(
+                asset_id=asset_id,
+                display_name="safe.png",
+                format_id="png",
+                byte_size=len(_png_bytes()),
+                content=_png_bytes(),
+            )
+
+    class StubVisionService:
+        def managed_routing_mode(self, entry_id: str) -> str:
+            assert entry_id == "workflow_interactive_vision"
+            return "managed_required"
+
+        def managed_model_available(self, entry_id: str, model_id: str) -> bool:
+            assert entry_id == "workflow_interactive_vision"
+            assert model_id == "test/vision-model"
+            return True
+
+    async def stub_execute_workflow_vision(**kwargs):
+        assert kwargs["managed_entry_id"] == "workflow_interactive_vision"
+        assert kwargs["parent_run_reference"].endswith(":vision:vision")
+        return (
+            {
+                "blocks": [],
+                "provider_route_receipts": [receipt],
+                "execution_mode": "managed",
+                "fallback_reason_codes": [],
+            },
+            SimpleNamespace(
+                selected_page_count=1,
+                processed_page_count=1,
+                failed_page_count=0,
+                provider_route_receipts=[receipt],
+            ),
+        )
+
+    monkeypatch.setattr(main_module, "get_file_asset_service", lambda: StubFileService())
+    monkeypatch.setattr(main_module, "workflow_vision_service", StubVisionService())
+    monkeypatch.setattr(
+        main_module,
+        "execute_workflow_vision",
+        stub_execute_workflow_vision,
+    )
+    transport = httpx.ASGITransport(app=main_module.app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/workflow/run",
+            json={
+                "workflow": _workflow(),
+                "inputs": {
+                    "user_input": "read the invoice",
+                    "selected_file_asset_id": "file_visual_1",
+                },
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    node_end = next(
+        item
+        for item in _events(response)
+        if item.get("event") == "node_end" and item.get("node_id") == "vision"
+    )
+    assert node_end["provider_route_receipts"] == receipt
+    assert "private prompt" not in response.text
+    assert "api_key" not in response.text
+
+
+def test_workflow_vision_receipt_composition_resequences_page_calls() -> None:
+    composed = compose_workflow_vision_receipt(
+        [
+            {
+                "entry_id": "xpert_vision",
+                "run_reference": "vision-run",
+                "status": "passed",
+                "call_count": 1,
+                "reason_codes": [],
+                "calls": [{"call_sequence": 1, "model_id": "model-a"}],
+            },
+            {
+                "entry_id": "xpert_vision",
+                "run_reference": "vision-run",
+                "status": "passed",
+                "call_count": 1,
+                "reason_codes": [],
+                "calls": [{"call_sequence": 1, "model_id": "model-a"}],
+            },
+        ]
+    )
+
+    assert composed is not None
+    assert composed["entry_id"] == "xpert_vision"
+    assert composed["call_count"] == 2
+    assert [call["call_sequence"] for call in composed["calls"]] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_workflow_vision_failure_projects_one_receipt_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed_receipt = {
+        "contract_version": "modelmirror-provider-workload-routing-v1",
+        "entry_id": "workflow_interactive_vision",
+        "routing_mode": "managed_required",
+        "run_reference": "vision-run-failed",
+        "status": "failed",
+        "call_count": 1,
+        "reason_codes": ["provider_workload_http_error"],
+        "calls": [
+            {
+                "call_sequence": 1,
+                "model_id": "test/vision-model",
+                "dispatched": True,
+                "status": "failed",
+                "error_code": "provider_workload_http_error",
+            }
+        ],
+    }
+
+    class StubFileService:
+        def resolve_workflow_visual_asset(self, asset_id: str, *, scope_id: str):
+            return SimpleNamespace(
+                asset_id=asset_id,
+                display_name="safe.png",
+                format_id="png",
+                byte_size=len(_png_bytes()),
+                content=_png_bytes(),
+            )
+
+    class StubVisionService:
+        def managed_routing_mode(self, _entry_id: str) -> str:
+            return "managed_required"
+
+        def managed_model_available(self, _entry_id: str, _model_id: str) -> bool:
+            return True
+
+    async def failed_execute_workflow_vision(**_kwargs):
+        raise WorkflowVisionError(
+            "workflow_vision_processing_failed",
+            "视觉理解未能处理所选附件。",
+            provider_route_receipts=[failed_receipt],
+        )
+
+    monkeypatch.setattr(main_module, "get_file_asset_service", lambda: StubFileService())
+    monkeypatch.setattr(main_module, "workflow_vision_service", StubVisionService())
+    monkeypatch.setattr(
+        main_module,
+        "execute_workflow_vision",
+        failed_execute_workflow_vision,
+    )
+    transport = httpx.ASGITransport(app=main_module.app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/workflow/run",
+            json={
+                "workflow": _workflow(),
+                "inputs": {
+                    "user_input": "read the invoice",
+                    "selected_file_asset_id": "file_visual_1",
+                },
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    error_event = next(
+        item for item in _events(response) if item.get("event") == "error"
+    )
+    assert error_event["provider_route_receipts"] == failed_receipt
+    assert not isinstance(error_event["provider_route_receipts"], list)
 
 
 @pytest.mark.asyncio
@@ -200,9 +451,15 @@ async def test_workflow_vision_failure_is_fail_closed_and_content_free() -> None
         async def analyze_bytes(self, *_args, **_kwargs):
             from server.multimodal.vision_understanding import VisionProcessingError
 
-            raise VisionProcessingError(
+            error = VisionProcessingError(
                 r"provider failed C:\private\source.png api_key=secret-value"
             )
+            error.receipt = {  # type: ignore[attr-defined]
+                "status": "failed",
+                "call_count": 0,
+                "reason_codes": ["provider_workload_policy_not_active"],
+            }
+            raise error
 
     with pytest.raises(WorkflowVisionError) as failure:
         await execute_workflow_vision(
@@ -223,3 +480,10 @@ async def test_workflow_vision_failure_is_fail_closed_and_content_free() -> None
     assert failure.value.error_code == "workflow_vision_processing_failed"
     assert "private" not in failure.value.message.lower()
     assert "secret-value" not in failure.value.message
+    assert failure.value.provider_route_receipts == [
+        {
+            "status": "failed",
+            "call_count": 0,
+            "reason_codes": ["provider_workload_policy_not_active"],
+        }
+    ]

--- a/server/xpert_runtime/workflow_vision.py
+++ b/server/xpert_runtime/workflow_vision.py
@@ -30,10 +30,17 @@ _PRIVATE_XPERT_RUN_TYPES = {"xpert"}
 class WorkflowVisionError(RuntimeError):
     """Safe workflow-facing visual execution error."""
 
-    def __init__(self, error_code: str, message: str) -> None:
+    def __init__(
+        self,
+        error_code: str,
+        message: str,
+        *,
+        provider_route_receipts: list[dict[str, Any]] | None = None,
+    ) -> None:
         super().__init__(message)
         self.error_code = error_code
         self.message = message
+        self.provider_route_receipts = list(provider_route_receipts or [])
 
 
 @dataclass(frozen=True, slots=True)
@@ -144,6 +151,8 @@ async def execute_workflow_vision(
     max_image_edge: int,
     failure_policy: Literal["continue_on_error", "strict"],
     service: VisionUnderstandingService,
+    managed_entry_id: str | None = None,
+    parent_run_reference: str | None = None,
 ) -> tuple[dict[str, Any], VisionSourceResult]:
     try:
         result = await service.analyze_bytes(
@@ -158,24 +167,101 @@ async def execute_workflow_vision(
                 "max_image_edge": max_image_edge,
                 "failure_policy": failure_policy,
             },
+            managed_entry_id=managed_entry_id,  # type: ignore[arg-type]
+            parent_run_reference=parent_run_reference,
         )
     except VisionProcessingError as exc:
         raise WorkflowVisionError(
             "workflow_vision_processing_failed",
             "视觉理解未能处理所选附件。",
+            provider_route_receipts=(
+                [exc.receipt]
+                if isinstance(getattr(exc, "receipt", None), dict)
+                else []
+            ),
         ) from exc
 
     if result.failed_page_count and failure_policy == "strict":
         raise WorkflowVisionError(
             "workflow_vision_strict_failure",
             "至少一个选中页面未能完成视觉理解。",
+            provider_route_receipts=result.provider_route_receipts,
         )
     if result.selected_page_count > 0 and result.processed_page_count == 0:
         raise WorkflowVisionError(
             "workflow_vision_all_pages_failed",
             "所有选中页面均未能完成视觉理解。",
+            provider_route_receipts=result.provider_route_receipts,
         )
     return _workflow_payload(asset, model_id, result), result
+
+
+def compose_workflow_vision_receipt(
+    receipts: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Compose page-level evidence for the workflow node without content data."""
+
+    safe_receipts = [dict(item) for item in receipts if isinstance(item, dict)]
+    if not safe_receipts:
+        return None
+    if len(safe_receipts) == 1:
+        return safe_receipts[0]
+
+    calls = [
+        dict(call)
+        for receipt in safe_receipts
+        for call in receipt.get("calls", [])
+        if isinstance(call, dict)
+    ]
+    for sequence, call in enumerate(calls, start=1):
+        call["call_sequence"] = sequence
+    reason_codes = list(
+        dict.fromkeys(
+            str(code)
+            for receipt in safe_receipts
+            for code in receipt.get("reason_codes", [])
+            if str(code)
+        )
+    )
+    statuses = {str(receipt.get("status") or "") for receipt in safe_receipts}
+    status = (
+        "uncertain"
+        if "uncertain" in statuses
+        else "failed"
+        if "failed" in statuses
+        else "cancelled"
+        if "cancelled" in statuses
+        else "running"
+        if "running" in statuses
+        else "passed"
+    )
+    entry_ids = list(
+        dict.fromkeys(
+            str(receipt.get("entry_id") or "")
+            for receipt in safe_receipts
+            if str(receipt.get("entry_id") or "")
+        )
+    )
+    run_references = list(
+        dict.fromkeys(
+            str(receipt.get("run_reference") or "")
+            for receipt in safe_receipts
+            if str(receipt.get("run_reference") or "")
+        )
+    )
+    return {
+        "contract_version": "modelmirror-provider-multimodal-routing-v1",
+        "entry_id": entry_ids[0] if len(entry_ids) == 1 else "multimodal",
+        "routing_mode": "managed_required",
+        "run_reference": run_references[0] if len(run_references) == 1 else "composed",
+        "status": status,
+        "call_count": sum(
+            max(0, int(receipt.get("call_count") or 0))
+            for receipt in safe_receipts
+        ),
+        "reason_codes": reason_codes,
+        "calls": calls,
+    }
 
 
 def _workflow_payload(
@@ -237,12 +323,16 @@ def _workflow_payload(
         "charts": [item for item in blocks if item["kind"] == "visual_chart"],
         "warnings": list(dict.fromkeys(value for value in warning_values if value)),
         "truncated": truncated,
+        "provider_route_receipts": list(result.provider_route_receipts),
+        "execution_mode": result.execution_mode,
+        "fallback_reason_codes": list(result.fallback_reason_codes),
     }
 
 
 __all__ = [
     "WorkflowVisionAsset",
     "WorkflowVisionError",
+    "compose_workflow_vision_receipt",
     "execute_workflow_vision",
     "resolve_workflow_vision_asset",
 ]


### PR DESCRIPTION
## 概要

- 将 Chat 图片、原生 PDF、RAG/Workflow/Xpert Vision 与图片生成接入精确 Managed Provider Binding、Adapter 资格和失败关闭语义。
- 复用统一出口授权、单 IP、零自动重试与脱敏 Receipt；Feature Flag 关闭时保留 legacy 行为。
- 补齐 Settings 的 R8B 资格与路由状态，并修复 Published Xpert 多阶段 Vision Receipt 只显示一次调用的问题。
- 更新架构、部署、控制面文档、任务卡和独立预览证据。

## 验证

- 最新基线：`origin/main@b143cde199feaf3a6304b8680739246b087100b3`。
- 后端受影响套件：`67 passed, 4 warnings`。
- 前端 Receipt/Settings 定向：`25 passed`。
- TypeScript：app 与 Vite 配置均使用 `--incremental false`，退出码 0。
- Production build：Vite 7.3.5 `--configLoader runner`，3,165 modules，构建通过。
- 原始实现基线全量后端：`5072 passed, 29 skipped, 25 failed`；25 项均在同 SHA 干净基线复现，本轮新增失败为 0。rebase 后未冒充执行过新的全量套件。
- `git diff --check` 与敏感信息扫描通过。

## 真实预览证据

- Chat 图片、原生 PDF、Workflow 交互/部署 Vision、RAG Vision、图片生成与 Published Xpert 已完成逐入口真实 Smoke。
- 修复后 Published Xpert 同构建闭环仅产生两次受控 POST：Vision 1 次、Xpert 文本 1 次；请求/实际模型一致，无第二连接、远程回退或重复调用。
- 页面正确聚合“调用 1 / 调用 2”，刷新后两条 Receipt 与 usage 仍保留。

## 已知边界与回滚

- 预览器关闭可选文件输出开关时，伴随的只读 `/api/files/outputs` 请求返回 503；不属于 R8B Vision 数据面，也不影响运行完成或 Receipt。
- 刷新 Xpert 会话后，历史 Receipt 保留，但旧运行状态/Run ID 展示会回到待运行口径；本 PR 不扩大范围修复该既有 UX 局限。
- 回滚时停用对应 Policy 或关闭 R8B Feature Flag 即恢复 legacy；保留 Router SQLite、资格、Receipt 与媒体数据。
- 本 PR 不启用 R8C 及后续能力，不改变默认 Provider，不执行部署或生产切换。
