### PR TITLE
refactor: 建立 Meta Planner Graph IR V3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,7 +315,7 @@ workflow-native 是实验线。经典工作流是 `/workflow` 默认入口。任
 python -m pytest server/tests/test_meta_agent.py -q
 ```
 
-### 8.1 EvoAgentX Meta Planner V2 护栏
+### 8.1 EvoAgentX Meta Planner Graph IR V3 护栏
 
 Meta Planner V2 只生成候选 Xpert，并使用 Authoring Proposal 作为唯一持久化来源：
 
@@ -323,8 +323,11 @@ Meta Planner V2 只生成候选 Xpert，并使用 Authoring Proposal 作为唯�
   和当前资源 Store；禁止在 Planner 内维护第二份可生成节点或资源 ID 清单。
 - Snapshot 只能暴露 `server/meta_agent/node_adapters.py` 中存在版本化编译适配器的
   节点；Registry 的展示开关不等于 Planner 可编译能力。
-- Planner 编译输出必须使用 Typed IR V2，显式声明 typed ports、控制边、绑定目标和
-  唯一最终输出。任务与 `workflow_agent` 不得强制一一对应，编译器不得猜测 sink。
+- Planner 新生成结果必须单写 Graph IR V3，显式声明 typed ports、变量来源、控制边、
+  绑定目标和唯一最终输出。Typed IR V2 只允许无损双读；来源歧义必须 fail-closed。
+- 模型只可输出 Graph Intent；资源版本、Handle、执行效果、安全属性和 compiler
+  checksum 必须由服务端依据 NodeContract、Capability Snapshot 和资源 Store解析。
+- Graph IR data 边不得写入 Native Workflow 拓扑或改变 classic runner 调度。
 - Snapshot 只包含安全元数据和规范化 hash，不得包含凭据、完整 Tool Schema、知识正文、
   Plugin/Skill 文件、工具输出或本地物理路径。
 - Sandbox、Browser、Client Tools、Automation、Authoring 等高风险能力默认不授权；
@@ -351,7 +354,8 @@ npm.cmd run build
 - 所有 `NativeNodeKind` 必须在 `NodeContractRegistry` 中唯一登记；未知或缺失契约必须 fail-closed。
 - `contract_status=complete` 不等于 Planner、Evaluator、Evolution 或 App 可用。入口许可必须由契约显式声明。
 - Capability Snapshot 只允许完整契约、真实 Adapter、Adapter 版本和 compiler checksum 一致的节点；当前范围仍严格为既有七类。
-- NodeContract 版本与 Typed IR 版本独立。V3 Snapshot 必须继续声明 `ir_version=2`，直到独立 IR 升级轮次完成。
+- NodeContract 版本与 Planner IR 版本独立。Capability Snapshot V4 声明
+  `ir_version=3` 与 `supported_ir_versions=[2,3]`，但仍只开放既有七类能力。
 - `checksum` 覆盖完整契约，`compiler_checksum` 仅覆盖编译关键事实；标题、图标和分类不得使 Adapter 失效。
 - 前端 fallback 只能保存展示信息，不得伪造 Planner 状态、端口、安全策略或 checksum。
 - 发布、Evaluator、App 和 Evolution 的静态节点策略必须查询 `NodePolicyService`；资源、Toolset、循环和中间件领域检查不得被删除。

--- a/client/src/components/meta/MetaPlannerV2.tsx
+++ b/client/src/components/meta/MetaPlannerV2.tsx
@@ -43,6 +43,8 @@ interface MetaPlannerScope extends Record<ScopeKey, string[]> {
 
 interface CapabilitySnapshot {
   version: string;
+  ir_version: 2 | 3;
+  supported_ir_versions: Array<2 | 3>;
   snapshot_hash: string;
   generated_at: number;
   nodes: CapabilityItem[];
@@ -106,6 +108,15 @@ interface MetaPlannerResponse {
   repair_used: boolean;
   capability_snapshot_version: string;
   capability_snapshot_hash: string;
+  ir_version: 2 | 3;
+  graph_ir: Record<string, unknown> | null;
+  graph_ir_checksum: string;
+  compatibility: {
+    source_version: 2 | 3;
+    upgraded: boolean;
+    lossy: boolean;
+    warnings: string[];
+  };
   run_id?: string | null;
   provider_route_receipts?: ProviderRouteReceipt | null;
 }

--- a/docs/EVOAGENTX_ALIGNMENT.md
+++ b/docs/EVOAGENTX_ALIGNMENT.md
@@ -22,9 +22,9 @@ EvoAgentX 的唯一复用基线是：
 ## V3/V4 当前路线
 
 Meta Planner 后续方向已经锁定为 **V3 十轮 + V4 轮次待定**，唯一规范见
-[META_PLANNER_V3_V4_ROADMAP.md](./META_PLANNER_V3_V4_ROADMAP.md)。当前实现仍是
-Capability Snapshot V3 与 Typed IR V2，不能把完整 NodeContract、画布可见节点或
-Runner 已支持节点误报为 Planner 已支持。
+[META_PLANNER_V3_V4_ROADMAP.md](./META_PLANNER_V3_V4_ROADMAP.md)。首轮 Graph IR V3
+已经交付为单写格式，Capability Snapshot 升级为 V4，旧 Typed IR V2 继续双读兼容。
+当前仍不能把完整 NodeContract、画布可见节点或 Runner 已支持节点误报为 Planner 已支持。
 
 V3 先建立 Graph IR V3 和 Headless Authoring，再依次开放纯节点、控制流、只读资源、
 视觉、受控写入和经审计的长运行能力；节点语义稳定后才增强 EvoAgentX 规划质量，
@@ -75,7 +75,7 @@ Client Tools、Automation、Plugin 和 Prompt。Meta Planner V2 已补齐候选�
 
 | 能力域 | ModelMirror 当前状态 | 审计判定 | 目标产物 |
 | --- | --- | --- | --- |
-| Workflow generation | V2 已生成当前 Agent DAG 与五类绑定边 | `adapt` | Meta Planner V2 已交付 |
+| Workflow generation | Graph IR V3 已表达 Agent DAG、类型化 data 边与五类绑定 | `adapt` | V3 首轮已交付，节点开放继续分轮 |
 | Agent generation | V2 已覆盖当前 Agent 配置、资源与 middleware | `adapt` | 候选 Xpert 草稿已交付 |
 | Task planning | V2 已生成 1–8 个带依赖与契约的任务 | `adapt` | 结构化规划已交付 |
 | Evaluator | 已支持只读安全的固定版本/Proposal 快照评测 | `adapt` | Evaluator 已交付 |

--- a/docs/META_AGENT.md
+++ b/docs/META_AGENT.md
@@ -9,7 +9,7 @@
 已经可以从实时 Registry 编译 `workflow_agent`、资源绑定、中间件和发布预检所需配置；
 旧生成器仍保留用于兼容经典工作流导入与既有 AgentTask/Handoff 操作。
 
-当前实现仍是 **Capability Snapshot V3 + Typed IR V2**。后续升级已经锁定为
+当前实现是 **Capability Snapshot V4 + Graph IR V3 单写、Typed IR V2 双读**。后续升级已经锁定为
 “V3 十轮 + V4 轮次待定”，唯一方向文档是
 [META_PLANNER_V3_V4_ROADMAP.md](./META_PLANNER_V3_V4_ROADMAP.md)。V3 先补齐
 Graph IR、无头编排、节点 Adapter、效果语义和评测，再逐类开放真实节点；V4 只有在
@@ -136,24 +136,40 @@ EvoAgentX 的来源与已交付历史见
 
 ### NodeContract V3 能力门禁
 
-Meta Planner 的节点事实统一来自 `NodeContractRegistry`。Capability Snapshot V3
+Meta Planner 的节点事实统一来自 `NodeContractRegistry`。Capability Snapshot V4
 只暴露满足以下全部条件的节点：契约状态完整、Planner 显式启用、编译模式真实存在、
 Adapter 版本一致，并且契约与 Adapter 的 compiler checksum 匹配。UI Registry 中出现
 节点不等于 Planner 可以生成该节点。
 
 当前开放范围仍严格保持为 `input`、`output`、`workflow_agent`、
 `external_xpert`、`knowledge_base`、`toolset_resource` 和 `plugin_resource`。
-NodeContract V3 与 Typed IR 独立演进，本轮 Capability Snapshot 升级为 V3，
-`ir_version` 仍为 2。旧 V2 Snapshot 保持可读，详见
+NodeContract V3 与 Planner IR 独立演进。Capability Snapshot 当前为 V4，
+`ir_version=3` 且声明 `supported_ir_versions=[2,3]`。旧 V2 Snapshot 保持可读，详见
 [NODE_CONTRACT_V3.md](./NODE_CONTRACT_V3.md)。
 
-### Typed IR V2 编译边界
+### Graph IR V3 编译边界
 
-能力编译阶段现在输出 `MetaPlannerTypedBlueprintV2`，显式声明节点引用、任务覆盖、
+候选生成现在由模型输出 `GraphIntentV3`，服务端再依据 NodeContract、Capability
+Snapshot 和资源 Store 解析为 `ResolvedGraphIRV3`。模型不能指定资源版本、Handle、
+执行效果或安全属性。Resolved IR 显式区分 `control/data/binding/metadata` 四类边；
+data 边只表达类型化变量来源，不进入 classic runner 的拓扑或调度。
+
+外部 Xpert、Toolset、Plugin 和 Prompt Profile 在解析时固定发布版本；知识库保持
+活动版本指针语义并记录观察版本。Graph checksum 排除布局和时间戳，编译产物另有
+独立 checksum。新 Proposal 保存完整安全 IR 和两个 checksum；人工编辑候选后 IR
+标记为 `stale`，审批仍以实际 Workflow 为权威。
+
+旧 `MetaPlannerTypedBlueprintV2` 继续可读，但只有变量来源能够唯一恢复时才升级为
+V3；歧义来源返回结构化 `lossy_conversion`，不得猜测。生成入口已经单写 V3，模型
+调用预算仍为任务规划、能力编译和最多一次修复。
+
+### Typed IR V2 兼容边界
+
+旧候选可继续读取 `MetaPlannerTypedBlueprintV2`，其中显式声明节点引用、任务覆盖、
 类型化输入/输出变量、控制边、资源/中间件目标和唯一最终输出。任务和 Agent 不再
 强制一一对应：一个 Agent 可以覆盖多个任务，一个任务也可以由多个节点共同完成。
 
-Capability Snapshot V3 只暴露当前存在且与 NodeContract 校验一致的编译能力。首轮可执行 IR 节点只有
+Capability Snapshot V4 只暴露当前存在且与 NodeContract 校验一致的编译能力。首轮可执行 IR 节点只有
 `workflow_agent`；`input/output` 由编译器管理，外部 Xpert、知识库、Toolset 和
 Plugin 通过绑定记录编译。JSON、Agent Table、知识检索和视觉理解尚无 Planner
 适配器，因此不会进入授权快照，也不会被模型生成。

--- a/docs/NODE_CONTRACT_V3.md
+++ b/docs/NODE_CONTRACT_V3.md
@@ -55,8 +55,8 @@ The first complete-contract group is:
 
 | Group | Node kinds | Planner state |
 | --- | --- | --- |
-| Compiler managed | `input`, `output` | enabled in IR V2 |
-| Adapter | `workflow_agent` | enabled in IR V2 |
+| Compiler managed | `input`, `output` | enabled in Graph IR V3 |
+| Adapter | `workflow_agent` | enabled in Graph IR V3 |
 | Resource bindings | `external_xpert`, `knowledge_base`, `toolset_resource`, `plugin_resource` | binding only |
 | Pure-data targets | `json_serialize`, `json_deserialize` | unsupported |
 | Read targets | `knowledge_retrieval`, `data_table_query`, `vision_understanding` | unsupported |
@@ -65,7 +65,8 @@ The first complete-contract group is:
 
 All other nodes have compatibility contracts and remain executable through the
 existing classic validator and runner. Capability Snapshot still exposes only
-the existing seven node kinds. Typed IR remains version 2.
+the existing seven node kinds. Graph IR V3 is the write format; Typed IR V2 is
+read-only compatibility input.
 
 JSON nodes retain their current inline-error behavior until the separate pure
 node round. Agent Table Query remains disabled in Evaluator. Vision remains
@@ -103,8 +104,8 @@ Planner claims. If the server response is absent, incomplete, or has a checksum
 shape other than V3, contract-dependent operations stay disabled while the
 classic palette may continue to render.
 
-Meta Planner Capability Snapshot version is V3 while `ir_version` remains 2.
-Persisted V2 snapshots without contract metadata remain readable. Contract
+Meta Planner Capability Snapshot version is V4 with `ir_version=3` and
+`supported_ir_versions=[2,3]`. Persisted V2 snapshots without contract metadata remain readable. Contract
 drift is a warning for an existing proposal; missing or invalid resources still
 block approval.
 

--- a/docs/XPERT_RUNTIME.md
+++ b/docs/XPERT_RUNTIME.md
@@ -348,6 +348,11 @@ Compatibility contracts preserve classic runner behavior and default Planner
 to disabled. See `docs/NODE_CONTRACT_V3.md` for the checksum and migration
 contract.
 
+Meta Planner 候选使用 Graph IR V3：模型只输出 Graph Intent，服务端依据本契约和资源
+Store 解析执行效果、端口、Handle 与固定版本。语义 data 边不会进入 classic runner
+调度；新 Proposal 保存安全 IR、Graph checksum 和编译产物 checksum，人工编辑后将
+IR 标记为 stale。Typed IR V2 仅作为无损双读兼容输入。
+
 ## Versioned MCP And API Toolset Runtime
 
 `ToolsetStore` persists editable MCP, OpenAPI, OData, and builtin Provider Toolset definitions plus immutable published versions. A version fixes the transport, API, or Provider profile, credential references, enabled tools, aliases, default arguments, JSON Schema hashes, tool semantics, prefix, and release metadata. Xpert publication resolves `latest` to a concrete Toolset version; later discovery, import, or draft edits cannot expand an already published Xpert.

--- a/server/meta_agent/NOTICE.md
+++ b/server/meta_agent/NOTICE.md
@@ -10,7 +10,7 @@ Audited upstream source:
 - Commit: `aad19b912f640161ea07e8904d9237cd34fde5f1`
 - License: MIT, Copyright (c) 2025 EvoAgentX
 
-Meta Planner V2 adapts the layered concepts found in these audited upstream
+Meta Planner Graph IR V3 continues to adapt the layered concepts found in these audited upstream
 files:
 
 - `evoagentx/workflow/task_planning.py`
@@ -53,10 +53,11 @@ implementation uses its own Pydantic contracts, Workflow Node Registry,
 Runtime Middleware Registry, AuthoringProposalStore, XpertStore, workflow
 validator, and publish preflight.
 
-NodeContract V3 independently applies the audited parameter-schema and layered
-validation concepts to ModelMirror's own node, entrypoint-policy, and compiler
-adapter contracts. No EvoAgentX schema or runtime object is copied. Typed IR
-remains a ModelMirror contract and EvoAgentX is not used to execute workflows.
+NodeContract V3 and Graph IR V3 independently apply the audited parameter-schema and layered
+validation concepts to ModelMirror's own node, entrypoint-policy, compiler
+adapter, intent, and resolved-graph contracts. No EvoAgentX schema or runtime
+object is copied. Graph IR remains a ModelMirror contract and EvoAgentX is not
+used to execute workflows.
 
 No EvoAgentX source file is copied into this package and EvoAgentX is not a
 runtime dependency. Provider, RAG, storage, HITL, memory, tool, workflow, and

--- a/server/meta_agent/__init__.py
+++ b/server/meta_agent/__init__.py
@@ -8,6 +8,7 @@ from .planner import (
     parse_meta_agent_plan,
 )
 from .schemas import (
+    GraphIntentV3,
     MetaAgentGenerateRequest,
     MetaAgentGenerateResponse,
     MetaAgentPlan,
@@ -15,6 +16,7 @@ from .schemas import (
     MetaPlannerGenerateResponse,
     MetaPlannerPreviewResponse,
     MetaPlannerScope,
+    ResolvedGraphIRV3,
     ProviderRouteCallReceipt,
     ProviderRouteReceiptSummary,
 )
@@ -30,10 +32,12 @@ __all__ = [
     "MetaAgentGenerateRequest",
     "MetaAgentGenerateResponse",
     "MetaAgentPlan",
+    "GraphIntentV3",
     "MetaPlannerGenerateRequest",
     "MetaPlannerGenerateResponse",
     "MetaPlannerPreviewResponse",
     "MetaPlannerScope",
+    "ResolvedGraphIRV3",
     "MetaPlannerV2Service",
     "ManagedMetaAgentGateway",
     "ManagedMetaAgentRoutingError",

--- a/server/meta_agent/capabilities.py
+++ b/server/meta_agent/capabilities.py
@@ -109,6 +109,7 @@ def build_capability_snapshot(
                         "contract_version": compiler["contract_version"],
                         "contract_checksum": compiler["contract_checksum"],
                         "compiler_checksum": compiler["compiler_checksum"],
+                        "adapter_checksum": compiler["adapter_checksum"],
                         "default_data": dict(planner.get("default_data") or {}),
                         "config_constraints": dict(
                             planner.get("config_constraints") or {}
@@ -147,6 +148,7 @@ def build_capability_snapshot(
                         "contract_version": compiler["contract_version"],
                         "contract_checksum": compiler["contract_checksum"],
                         "compiler_checksum": compiler["compiler_checksum"],
+                        "adapter_checksum": compiler["adapter_checksum"],
                         "default_data": dict(planner.get("default_data") or {}),
                         "config_constraints": dict(
                             planner.get("config_constraints") or {}
@@ -313,8 +315,9 @@ def build_capability_snapshot(
         agent_ids=[item["id"] for item in expert_summaries],
     )
     payload = {
-        "version": "evoagentx-meta-planner-capabilities-v3",
-        "ir_version": 2,
+        "version": "evoagentx-meta-planner-capabilities-v4",
+        "ir_version": 3,
+        "supported_ir_versions": [2, 3],
         "contract_version": int(node_payload.get("contract_version") or 0),
         "contract_checksum": str(node_payload.get("contract_checksum") or ""),
         "node_registry_version": workflow_registry.version,

--- a/server/meta_agent/graph_ir_v3.py
+++ b/server/meta_agent/graph_ir_v3.py
@@ -1,0 +1,953 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections import defaultdict, deque
+from typing import Any
+
+try:
+    from server.workflow_native.node_contracts import (
+        NODE_CONTRACT_VERSION,
+        WorkflowValueSchema,
+        canonical_checksum,
+        workflow_node_contract_registry,
+    )
+except ModuleNotFoundError:
+    from workflow_native.node_contracts import (
+        NODE_CONTRACT_VERSION,
+        WorkflowValueSchema,
+        canonical_checksum,
+        workflow_node_contract_registry,
+    )
+
+from .schemas import (
+    GraphIntentControlEdgeV3,
+    GraphIntentFinalOutputV3,
+    GraphIntentInputBindingV3,
+    GraphIntentNodeV3,
+    GraphIntentOutputBindingV3,
+    GraphIntentV3,
+    MetaPlannerCapabilitySnapshot,
+    MetaPlannerIRCompatibility,
+    MetaPlannerIRControlEdge,
+    MetaPlannerIRFinalOutput,
+    MetaPlannerIRInputBinding,
+    MetaPlannerIRMiddlewareBinding,
+    MetaPlannerIRNode,
+    MetaPlannerIROutputBinding,
+    MetaPlannerIRResourceBinding,
+    MetaPlannerTypedBlueprintV2,
+    ResolvedGraphEdgeV3,
+    ResolvedGraphEndpointV3,
+    ResolvedGraphIRV3,
+    ResolvedGraphNodeV3,
+    ResolvedGraphPortV3,
+    ResolvedPromptProfileV3,
+)
+
+
+GRAPH_IR_VERSION = 3
+SUPPORTED_GRAPH_IR_VERSIONS = (2, 3)
+
+
+def _safe_identifier(value: str, fallback: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_]", "_", str(value or "").strip())
+    normalized = re.sub(r"_+", "_", normalized).strip("_")
+    if not normalized or normalized[0].isdigit():
+        normalized = f"{fallback}_{normalized}" if normalized else fallback
+    return normalized[:120]
+
+
+def _stable_ref(prefix: str, *parts: str) -> str:
+    payload = "\x1f".join(str(item) for item in parts)
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}_{digest}"
+
+
+def graph_ir_checksum(graph_ir: ResolvedGraphIRV3 | dict[str, Any]) -> str:
+    payload = (
+        graph_ir.model_dump(mode="json")
+        if isinstance(graph_ir, ResolvedGraphIRV3)
+        else dict(graph_ir)
+    )
+    payload.pop("graph_checksum", None)
+    return canonical_checksum(payload)
+
+
+def workflow_semantic_checksum(candidate: dict[str, Any]) -> str:
+    workflow = dict(candidate.get("draft", {}).get("workflow") or {})
+    payload = {
+        "id": workflow.get("id"),
+        "version": workflow.get("version"),
+        "nodes": sorted(
+            [
+                {
+                    "id": node.get("id"),
+                    "type": node.get("type"),
+                    "data": node.get("data") or {},
+                }
+                for node in workflow.get("nodes") or []
+            ],
+            key=lambda item: str(item["id"]),
+        ),
+        "edges": sorted(
+            [
+                {
+                    key: edge.get(key)
+                    for key in (
+                        "id",
+                        "source",
+                        "target",
+                        "sourceHandle",
+                        "targetHandle",
+                    )
+                    if edge.get(key) is not None
+                }
+                for edge in workflow.get("edges") or []
+            ],
+            key=lambda item: str(item["id"]),
+        ),
+        "prompt_profiles": candidate.get("draft", {}).get("prompt_profiles") or [],
+    }
+    return canonical_checksum(payload)
+
+
+def _value_schema(value_type: str) -> WorkflowValueSchema:
+    normalized = value_type if value_type in {
+        "any",
+        "null",
+        "string",
+        "number",
+        "boolean",
+        "object",
+        "array",
+    } else "any"
+    return WorkflowValueSchema(type=normalized)
+
+
+def _control_graph(
+    refs: list[str],
+    edges: list[GraphIntentControlEdgeV3],
+) -> tuple[dict[str, set[str]], dict[str, set[str]], list[str], list[str]]:
+    children = {ref: set() for ref in refs}
+    parents = {ref: set() for ref in refs}
+    indegree = {ref: 0 for ref in refs}
+    for edge in edges:
+        if edge.source_ref not in children or edge.target_ref not in children:
+            continue
+        if edge.target_ref not in children[edge.source_ref]:
+            children[edge.source_ref].add(edge.target_ref)
+            parents[edge.target_ref].add(edge.source_ref)
+            indegree[edge.target_ref] += 1
+    queue = deque(sorted(ref for ref, count in indegree.items() if count == 0))
+    order: list[str] = []
+    while queue:
+        current = queue.popleft()
+        order.append(current)
+        for child in sorted(children[current]):
+            indegree[child] -= 1
+            if indegree[child] == 0:
+                queue.append(child)
+    sinks = sorted(ref for ref in refs if not children[ref])
+    return children, parents, order, sinks
+
+
+def _ancestors(
+    refs: list[str], parents: dict[str, set[str]], order: list[str]
+) -> dict[str, set[str]]:
+    result = {ref: set() for ref in refs}
+    for ref in order:
+        for parent in parents[ref]:
+            result[ref].add(parent)
+            result[ref].update(result[parent])
+    return result
+
+
+def v2_to_graph_intent(
+    blueprint: MetaPlannerTypedBlueprintV2,
+) -> tuple[GraphIntentV3 | None, MetaPlannerIRCompatibility]:
+    refs = [node.ref for node in blueprint.nodes]
+    _, parents, order, _ = _control_graph(
+        refs,
+        [
+            GraphIntentControlEdgeV3(
+                source_ref=edge.source_ref,
+                target_ref=edge.target_ref,
+            )
+            for edge in blueprint.control_edges
+        ],
+    )
+    ancestors = _ancestors(refs, parents, order)
+    producers: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+    for node in blueprint.nodes:
+        for output in node.outputs:
+            producers[output.variable].append(
+                (node.ref, output.port, output.value_type)
+            )
+    external = {
+        "user_input": ("input", "user_input", "string"),
+        "conversation_history": ("input", "conversation_history", "array"),
+    }
+    warnings: list[str] = []
+    converted_nodes: list[GraphIntentNodeV3] = []
+    for node in blueprint.nodes:
+        converted_inputs: list[GraphIntentInputBindingV3] = []
+        for binding in node.inputs:
+            candidates = producers.get(binding.variable, [])
+            if binding.variable in external:
+                source_ref, source_port, source_type = external[binding.variable]
+            elif len(candidates) == 1 and candidates[0][0] in ancestors.get(node.ref, set()):
+                source_ref, source_port, source_type = candidates[0]
+            else:
+                reason = "ambiguous" if len(candidates) > 1 else "unreachable"
+                warnings.append(
+                    "lossy_conversion: input variable "
+                    f"{binding.variable} for {node.ref} has {reason} provenance."
+                )
+                continue
+            converted_inputs.append(
+                GraphIntentInputBindingV3(
+                    port="task",
+                    variable=binding.variable,
+                    source_ref=source_ref,
+                    source_port=source_port,
+                    value_schema=_value_schema(binding.value_type or source_type),
+                )
+            )
+        converted_nodes.append(
+            GraphIntentNodeV3(
+                ref=node.ref,
+                kind=node.kind,
+                title=node.title,
+                description=node.description,
+                task_ids=node.task_ids,
+                inputs=converted_inputs,
+                outputs=[
+                    GraphIntentOutputBindingV3(
+                        port=item.port,
+                        variable=item.variable,
+                        value_schema=_value_schema(item.value_type),
+                    )
+                    for item in node.outputs
+                ],
+                config=node.config,
+            )
+        )
+    compatibility = MetaPlannerIRCompatibility(
+        source_version=2,
+        upgraded=not warnings,
+        lossy=bool(warnings),
+        warnings=warnings,
+    )
+    if warnings:
+        return None, compatibility
+    return (
+        GraphIntentV3(
+            name=blueprint.name,
+            description=blueprint.description,
+            tags=blueprint.tags,
+            starters=blueprint.starters,
+            nodes=converted_nodes,
+            control_edges=[
+                GraphIntentControlEdgeV3(
+                    source_ref=edge.source_ref,
+                    target_ref=edge.target_ref,
+                )
+                for edge in blueprint.control_edges
+            ],
+            resources=blueprint.resources,
+            middleware=blueprint.middleware,
+            prompt_profile_ids=blueprint.prompt_profile_ids,
+            final_output=GraphIntentFinalOutputV3(
+                node_ref=blueprint.final_output.node_ref,
+                variable=blueprint.final_output.variable,
+            ),
+        ),
+        compatibility,
+    )
+
+
+def graph_intent_to_v2(intent: GraphIntentV3) -> MetaPlannerTypedBlueprintV2:
+    return MetaPlannerTypedBlueprintV2(
+        name=intent.name,
+        description=intent.description,
+        tags=intent.tags,
+        starters=intent.starters,
+        nodes=[
+            MetaPlannerIRNode(
+                ref=node.ref,
+                kind=node.kind,
+                title=node.title,
+                description=node.description,
+                task_ids=node.task_ids,
+                inputs=[
+                    MetaPlannerIRInputBinding(
+                        port=f"{item.port}_{index + 1}",
+                        variable=item.variable,
+                        value_type=item.value_schema.type,
+                    )
+                    for index, item in enumerate(node.inputs)
+                ],
+                outputs=[
+                    MetaPlannerIROutputBinding(
+                        port=item.port,
+                        variable=item.variable,
+                        value_type=item.value_schema.type,
+                    )
+                    for item in node.outputs
+                ],
+                config=node.config,
+            )
+            for node in intent.nodes
+        ],
+        control_edges=[
+            MetaPlannerIRControlEdge(
+                source_ref=edge.source_ref,
+                target_ref=edge.target_ref,
+            )
+            for edge in intent.control_edges
+        ],
+        resources=intent.resources,
+        middleware=intent.middleware,
+        prompt_profile_ids=intent.prompt_profile_ids,
+        final_output=MetaPlannerIRFinalOutput(
+            node_ref=intent.final_output.node_ref,
+            variable=intent.final_output.variable,
+        ),
+    )
+
+
+def _schemas_compatible(
+    source: WorkflowValueSchema, target: WorkflowValueSchema
+) -> bool:
+    if source.type == "any" or target.type == "any":
+        return True
+    if source.type == target.type:
+        return True
+    return source.type == "integer" and target.type == "number"
+
+
+def _resolved_node(
+    *,
+    ref: str,
+    node_id: str,
+    kind: str,
+    role: str,
+    title: str,
+    description: str = "",
+    task_ids: list[str] | None = None,
+    config: dict[str, Any] | None = None,
+) -> ResolvedGraphNodeV3:
+    contract = workflow_node_contract_registry.require(kind)
+    return ResolvedGraphNodeV3(
+        ref=ref,
+        node_id=node_id,
+        kind=kind,
+        role=role,
+        title=title,
+        description=description,
+        task_ids=list(task_ids or []),
+        config=dict(config or {}),
+        ports=[ResolvedGraphPortV3.model_validate(port.model_dump(mode="json")) for port in contract.ports],
+        contract_version=NODE_CONTRACT_VERSION,
+        contract_checksum=contract.checksum,
+        compiler_checksum=contract.compiler_checksum,
+        execution=contract.execution.model_dump(mode="json"),
+        resource_contracts=[item.model_dump(mode="json") for item in contract.resources],
+    )
+
+
+def resolve_graph_intent(
+    intent: GraphIntentV3,
+    snapshot: MetaPlannerCapabilitySnapshot,
+    *,
+    default_agent_model_id: str | None = None,
+) -> ResolvedGraphIRV3:
+    refs = [node.ref for node in intent.nodes]
+    if len(refs) != len(set(refs)):
+        raise ValueError("Graph IR node refs must be unique.")
+    known_refs = set(refs)
+    edge_keys: set[tuple[str, str]] = set()
+    for edge in intent.control_edges:
+        if edge.source_ref not in known_refs or edge.target_ref not in known_refs:
+            raise ValueError("Graph IR control edge references an unknown node.")
+        key = (edge.source_ref, edge.target_ref)
+        if edge.source_ref == edge.target_ref or key in edge_keys:
+            raise ValueError("Graph IR control edges must be unique and non-reflexive.")
+        edge_keys.add(key)
+    _, parents, order, sinks = _control_graph(refs, intent.control_edges)
+    if len(order) != len(refs):
+        raise ValueError("Graph IR control edges must form an acyclic graph.")
+    if len(sinks) != 1 or sinks[0] != intent.final_output.node_ref:
+        raise ValueError("Graph IR requires one terminal matching final_output.")
+    ancestors = _ancestors(refs, parents, order)
+
+    nodes: list[ResolvedGraphNodeV3] = [
+        _resolved_node(
+            ref="input",
+            node_id="input",
+            kind="input",
+            role="input",
+            title="Conversation input",
+            config={
+                "variableName": "user_input",
+                "historyVariable": "conversation_history",
+            },
+        )
+    ]
+    resolved_by_ref = {"input": nodes[0]}
+    declared_outputs: dict[tuple[str, str], tuple[str, WorkflowValueSchema]] = {
+        ("input", "user_input"): (
+            "user_input",
+            WorkflowValueSchema(type="string"),
+        ),
+        ("input", "conversation_history"): (
+            "conversation_history",
+            WorkflowValueSchema(
+                type="array", items=WorkflowValueSchema(type="object")
+            ),
+        ),
+    }
+    producer_by_variable: dict[str, str] = {
+        "user_input": "input",
+        "conversation_history": "input",
+    }
+    for node in intent.nodes:
+        resolved_config = dict(node.config)
+        if (
+            node.kind == "workflow_agent"
+            and not resolved_config.get("model_id")
+            and default_agent_model_id
+        ):
+            resolved_config["model_id"] = default_agent_model_id
+        resolved = _resolved_node(
+            ref=node.ref,
+            node_id=f"node_{_safe_identifier(node.ref, 'node')}",
+            kind=node.kind,
+            role="executable",
+            title=node.title,
+            description=node.description,
+            task_ids=node.task_ids,
+            config=resolved_config,
+        )
+        contract_outputs = {
+            port.name: port for port in resolved.ports if port.direction == "output"
+        }
+        for output in node.outputs:
+            contract_port = contract_outputs.get(output.port)
+            if contract_port is None:
+                raise ValueError(
+                    f"Node {node.ref} declares unknown output port {output.port}."
+                )
+            if not _schemas_compatible(output.value_schema, contract_port.value_schema):
+                raise ValueError(
+                    f"Node {node.ref} output {output.port} has an incompatible type."
+                )
+            key = (node.ref, output.port)
+            if key in declared_outputs:
+                raise ValueError(f"Node {node.ref} output port {output.port} is duplicated.")
+            previous_producer = producer_by_variable.get(output.variable)
+            if previous_producer is not None:
+                raise ValueError(
+                    f"Variable {output.variable} is produced by multiple nodes."
+                )
+            producer_by_variable[output.variable] = node.ref
+            declared_outputs[key] = (output.variable, output.value_schema)
+        nodes.append(resolved)
+        resolved_by_ref[node.ref] = resolved
+
+    edges: list[ResolvedGraphEdgeV3] = []
+    roots = sorted(ref for ref in refs if not parents[ref])
+    for target_ref in roots:
+        edges.append(
+            ResolvedGraphEdgeV3(
+                ref=_stable_ref("control", "input", target_ref),
+                mode="control",
+                source=ResolvedGraphEndpointV3(node_ref="input", node_id="input"),
+                target=ResolvedGraphEndpointV3(
+                    node_ref=target_ref,
+                    node_id=resolved_by_ref[target_ref].node_id,
+                ),
+                outcome="success",
+                join="all",
+            )
+        )
+    for edge in intent.control_edges:
+        edges.append(
+            ResolvedGraphEdgeV3(
+                ref=_stable_ref("control", edge.source_ref, edge.target_ref),
+                mode="control",
+                source=ResolvedGraphEndpointV3(
+                    node_ref=edge.source_ref,
+                    node_id=resolved_by_ref[edge.source_ref].node_id,
+                ),
+                target=ResolvedGraphEndpointV3(
+                    node_ref=edge.target_ref,
+                    node_id=resolved_by_ref[edge.target_ref].node_id,
+                ),
+                outcome=edge.outcome,
+                join=edge.join,
+            )
+        )
+
+    for node in intent.nodes:
+        target_ports = {
+            port.name: port
+            for port in resolved_by_ref[node.ref].ports
+            if port.direction == "input"
+        }
+        counts: dict[str, int] = defaultdict(int)
+        for binding in node.inputs:
+            target_port = target_ports.get(binding.port)
+            if target_port is None:
+                raise ValueError(
+                    f"Node {node.ref} declares unknown input port {binding.port}."
+                )
+            counts[binding.port] += 1
+            if counts[binding.port] > 1 and target_port.cardinality != "many":
+                raise ValueError(
+                    f"Node {node.ref} input port {binding.port} exceeds cardinality."
+                )
+            source = declared_outputs.get((binding.source_ref, binding.source_port))
+            if source is None:
+                raise ValueError(
+                    f"Node {node.ref} input {binding.variable} has an unknown source port."
+                )
+            source_variable, source_schema = source
+            if source_variable != binding.variable:
+                raise ValueError(
+                    f"Node {node.ref} input variable does not match its source output."
+                )
+            if binding.source_ref != "input" and binding.source_ref not in ancestors[node.ref]:
+                raise ValueError(
+                    f"Node {node.ref} input {binding.variable} is not control-reachable."
+                )
+            if not _schemas_compatible(source_schema, binding.value_schema):
+                raise ValueError(
+                    f"Node {node.ref} input {binding.variable} has an incompatible type."
+                )
+            if not _schemas_compatible(binding.value_schema, target_port.value_schema):
+                raise ValueError(
+                    f"Node {node.ref} input port {binding.port} rejects its value type."
+                )
+            edges.append(
+                ResolvedGraphEdgeV3(
+                    ref=_stable_ref(
+                        "data",
+                        binding.source_ref,
+                        binding.source_port,
+                        node.ref,
+                        binding.port,
+                        binding.variable,
+                    ),
+                    mode="data",
+                    source=ResolvedGraphEndpointV3(
+                        node_ref=binding.source_ref,
+                        node_id=resolved_by_ref[binding.source_ref].node_id,
+                        port=binding.source_port,
+                    ),
+                    target=ResolvedGraphEndpointV3(
+                        node_ref=node.ref,
+                        node_id=resolved_by_ref[node.ref].node_id,
+                        port=binding.port,
+                    ),
+                    variable=binding.variable,
+                    value_schema=binding.value_schema,
+                )
+            )
+        missing_required = sorted(
+            port.name
+            for port in target_ports.values()
+            if port.required and not counts[port.name]
+        )
+        if missing_required:
+            raise ValueError(
+                f"Node {node.ref} is missing required input ports: "
+                + ", ".join(missing_required)
+            )
+
+    resources = {
+        "external_xpert": {item["id"]: item for item in snapshot.external_xperts},
+        "knowledge_base": {item["id"]: item for item in snapshot.knowledge_bases},
+        "toolset_resource": {item["id"]: item for item in snapshot.toolsets},
+        "plugin_resource": {item["id"]: item for item in snapshot.plugins},
+    }
+    for binding in intent.resources:
+        if binding.target_ref not in resolved_by_ref:
+            raise ValueError(f"Resource {binding.resource_id} targets an unknown node.")
+        resource = resources[binding.kind].get(binding.resource_id)
+        if resource is None:
+            raise ValueError(f"Resource {binding.resource_id} is unavailable.")
+        ref = _stable_ref("resource", binding.kind, binding.resource_id, binding.target_ref)
+        contract = workflow_node_contract_registry.require(binding.kind)
+        config: dict[str, Any] = {
+            "resource_id": binding.resource_id,
+            "version_policy": "active" if binding.kind == "knowledge_base" else "pinned",
+        }
+        if binding.kind == "knowledge_base":
+            config["observed_active_version_id"] = (resource.get("metadata") or {}).get(
+                "active_version_id"
+            )
+            config["top_k"] = binding.top_k
+            config["score_threshold"] = binding.score_threshold
+        else:
+            version = resource.get("published_version")
+            if not version:
+                raise ValueError(f"Resource {binding.resource_id} has no published version.")
+            config["pinned_version"] = int(version)
+        config["resource_checksum"] = canonical_checksum(resource)
+        resolved_resource = _resolved_node(
+            ref=ref,
+            node_id=ref,
+            kind=binding.kind,
+            role="resource",
+            title=str(resource.get("name") or binding.kind),
+            description=binding.description or str(resource.get("description") or ""),
+            config=config,
+        )
+        nodes.append(resolved_resource)
+        resolved_by_ref[ref] = resolved_resource
+        source_handle = contract.edge.allowed_source_handles[0]
+        target_handle = contract.edge.allowed_target_handles[0]
+        edges.append(
+            ResolvedGraphEdgeV3(
+                ref=_stable_ref("binding", ref, binding.target_ref),
+                mode="binding",
+                source=ResolvedGraphEndpointV3(
+                    node_ref=ref, node_id=ref, handle=source_handle
+                ),
+                target=ResolvedGraphEndpointV3(
+                    node_ref=binding.target_ref,
+                    node_id=resolved_by_ref[binding.target_ref].node_id,
+                    handle=target_handle,
+                ),
+            )
+        )
+
+    middleware_lookup = {item["id"]: item for item in snapshot.middleware}
+    seen_middleware: set[tuple[str, str]] = set()
+    for binding in sorted(
+        intent.middleware,
+        key=lambda item: (item.priority, item.middleware_id, item.target_ref),
+    ):
+        key = (binding.target_ref, binding.middleware_id)
+        if key in seen_middleware:
+            raise ValueError("Graph IR cannot bind duplicate middleware.")
+        seen_middleware.add(key)
+        middleware = middleware_lookup.get(binding.middleware_id)
+        if middleware is None or binding.target_ref not in resolved_by_ref:
+            raise ValueError(f"Middleware {binding.middleware_id} is unavailable.")
+        defaults = dict(middleware.get("default_config") or {})
+        defaults.update(binding.config)
+        ref = _stable_ref("middleware", binding.middleware_id, binding.target_ref)
+        resolved_middleware = _resolved_node(
+            ref=ref,
+            node_id=ref,
+            kind="runtime_middleware",
+            role="metadata",
+            title=str(middleware.get("title") or binding.middleware_id),
+            description=str(middleware.get("description") or ""),
+            config={
+                "middleware_id": binding.middleware_id,
+                "priority": binding.priority,
+                "config": defaults,
+                "config_version": middleware.get("config_version"),
+                "definition_checksum": canonical_checksum(middleware),
+            },
+        )
+        nodes.append(resolved_middleware)
+        resolved_by_ref[ref] = resolved_middleware
+        edges.append(
+            ResolvedGraphEdgeV3(
+                ref=_stable_ref("metadata", ref, binding.target_ref),
+                mode="metadata",
+                source=ResolvedGraphEndpointV3(
+                    node_ref=ref,
+                    node_id=ref,
+                    handle="middleware-binding",
+                ),
+                target=ResolvedGraphEndpointV3(
+                    node_ref=binding.target_ref,
+                    node_id=resolved_by_ref[binding.target_ref].node_id,
+                    handle="middleware",
+                ),
+            )
+        )
+
+    final_source = declared_outputs.get(
+        (intent.final_output.node_ref, intent.final_output.port)
+    )
+    if final_source is None or final_source[0] != intent.final_output.variable:
+        raise ValueError("Graph IR final output does not match its source port.")
+    output_node = _resolved_node(
+        ref="output",
+        node_id="output",
+        kind="output",
+        role="output",
+        title="Final answer",
+        config={
+            "outputVariable": intent.final_output.variable,
+            "template": f"{{{{{intent.final_output.variable}}}}}",
+        },
+    )
+    nodes.append(output_node)
+    resolved_by_ref["output"] = output_node
+    edges.append(
+        ResolvedGraphEdgeV3(
+            ref=_stable_ref("control", intent.final_output.node_ref, "output"),
+            mode="control",
+            source=ResolvedGraphEndpointV3(
+                node_ref=intent.final_output.node_ref,
+                node_id=resolved_by_ref[intent.final_output.node_ref].node_id,
+            ),
+            target=ResolvedGraphEndpointV3(node_ref="output", node_id="output"),
+            outcome="success",
+            join="all",
+        )
+    )
+    edges.append(
+        ResolvedGraphEdgeV3(
+            ref=_stable_ref(
+                "data",
+                intent.final_output.node_ref,
+                intent.final_output.port,
+                "output",
+                "result",
+                intent.final_output.variable,
+            ),
+            mode="data",
+            source=ResolvedGraphEndpointV3(
+                node_ref=intent.final_output.node_ref,
+                node_id=resolved_by_ref[intent.final_output.node_ref].node_id,
+                port=intent.final_output.port,
+            ),
+            target=ResolvedGraphEndpointV3(
+                node_ref="output", node_id="output", port="result"
+            ),
+            variable=intent.final_output.variable,
+            value_schema=final_source[1],
+        )
+    )
+
+    prompt_lookup = {item["id"]: item for item in snapshot.prompt_profiles}
+    prompt_profiles: list[ResolvedPromptProfileV3] = []
+    for profile_id in dict.fromkeys(intent.prompt_profile_ids):
+        resource = prompt_lookup.get(profile_id)
+        if resource is None or not resource.get("published_version"):
+            raise ValueError(f"Prompt Profile {profile_id} is unavailable.")
+        prompt_profiles.append(
+            ResolvedPromptProfileV3(
+                profile_id=profile_id,
+                pinned_version=int(resource["published_version"]),
+                checksum=canonical_checksum(resource),
+            )
+        )
+
+    graph = ResolvedGraphIRV3(
+        name=intent.name,
+        description=intent.description,
+        tags=list(dict.fromkeys(intent.tags)),
+        starters=list(dict.fromkeys(intent.starters)),
+        nodes=sorted(nodes, key=lambda item: item.ref),
+        edges=sorted(edges, key=lambda item: item.ref),
+        prompt_profiles=prompt_profiles,
+        final_output=intent.final_output,
+        contract_version=NODE_CONTRACT_VERSION,
+        capability_snapshot_version=snapshot.version,
+        capability_snapshot_hash=snapshot.snapshot_hash,
+    )
+    return graph.model_copy(update={"graph_checksum": graph_ir_checksum(graph)})
+
+
+def annotate_candidate_with_graph_ir(
+    candidate: dict[str, Any],
+    intent: GraphIntentV3,
+    graph_ir: ResolvedGraphIRV3,
+) -> None:
+    workflow = candidate.get("draft", {}).get("workflow") or {}
+    resolved_by_id = {node.node_id: node for node in graph_ir.nodes}
+    intent_by_ref = {node.ref: node for node in intent.nodes}
+    for node in workflow.get("nodes") or []:
+        resolved = resolved_by_id.get(str(node.get("id") or ""))
+        if resolved is None:
+            continue
+        data = node.setdefault("data", {})
+        data["plannerIRVersion"] = GRAPH_IR_VERSION
+        data["plannerRef"] = resolved.ref
+        data["plannerContractVersion"] = resolved.contract_version
+        data["plannerCompilerChecksum"] = resolved.compiler_checksum
+        source = intent_by_ref.get(resolved.ref)
+        if source is not None:
+            data["plannerInputsV3"] = [
+                item.model_dump(mode="json") for item in source.inputs
+            ]
+            data["plannerOutputsV3"] = [
+                item.model_dump(mode="json") for item in source.outputs
+            ]
+
+
+def decompile_candidate_to_graph_intent(
+    candidate: dict[str, Any],
+) -> GraphIntentV3:
+    from .node_adapters import decompile_planner_node_v3
+
+    try:
+        from server.workflow_native.schemas import NativeWorkflowNode
+    except ModuleNotFoundError:
+        from workflow_native.schemas import NativeWorkflowNode
+
+    draft = candidate.get("draft") or {}
+    workflow = draft.get("workflow") or {}
+    raw_nodes = list(workflow.get("nodes") or [])
+    node_by_id = {str(node.get("id") or ""): node for node in raw_nodes}
+    ref_by_id: dict[str, str] = {}
+    business_nodes: list[GraphIntentNodeV3] = []
+    for raw_node in raw_nodes:
+        data = raw_node.get("data") or {}
+        kind = str(data.get("kind") or raw_node.get("type") or "")
+        if kind != "workflow_agent":
+            continue
+        restored = decompile_planner_node_v3(
+            NativeWorkflowNode.model_validate(raw_node)
+        )
+        node_id = str(raw_node.get("id") or "")
+        ref_by_id[node_id] = restored.ref
+        business_nodes.append(restored)
+
+    control_edges: list[GraphIntentControlEdgeV3] = []
+    resources: list[MetaPlannerIRResourceBinding] = []
+    middleware: list[MetaPlannerIRMiddlewareBinding] = []
+    for raw_edge in workflow.get("edges") or []:
+        source_id = str(raw_edge.get("source") or "")
+        target_id = str(raw_edge.get("target") or "")
+        source_ref = ref_by_id.get(source_id)
+        target_ref = ref_by_id.get(target_id)
+        source_handle = str(raw_edge.get("sourceHandle") or "")
+        target_handle = str(raw_edge.get("targetHandle") or "")
+        if source_ref and target_ref and not source_handle and not target_handle:
+            control_edges.append(
+                GraphIntentControlEdgeV3(
+                    source_ref=source_ref,
+                    target_ref=target_ref,
+                )
+            )
+            continue
+        if not target_ref:
+            continue
+        source_node = node_by_id.get(source_id) or {}
+        source_data = source_node.get("data") or {}
+        source_kind = str(source_data.get("kind") or source_node.get("type") or "")
+        if target_handle == "middleware" and source_kind == "runtime_middleware":
+            middleware.append(
+                MetaPlannerIRMiddlewareBinding(
+                    target_ref=target_ref,
+                    middleware_id=str(source_data.get("runtimeMiddlewareId") or ""),
+                    priority=int(source_data.get("middlewarePriority") or 100),
+                    config=dict(source_data.get("runtimeMiddlewareConfig") or {}),
+                )
+            )
+            continue
+        if source_kind not in {
+            "external_xpert",
+            "knowledge_base",
+            "toolset_resource",
+            "plugin_resource",
+        }:
+            continue
+        id_fields = {
+            "external_xpert": "xpertId",
+            "knowledge_base": "knowledgeBaseId",
+            "toolset_resource": "toolsetId",
+            "plugin_resource": "pluginId",
+        }
+        resources.append(
+            MetaPlannerIRResourceBinding(
+                target_ref=target_ref,
+                kind=source_kind,
+                resource_id=str(source_data.get(id_fields[source_kind]) or ""),
+                tool_name=str(source_data.get("toolName") or ""),
+                description=str(source_data.get("description") or ""),
+                top_k=int(source_data.get("topK") or 5),
+                score_threshold=float(source_data.get("scoreThreshold") or 0),
+            )
+        )
+
+    output_node = next(
+        (
+            node
+            for node in raw_nodes
+            if str((node.get("data") or {}).get("kind") or node.get("type"))
+            == "output"
+        ),
+        None,
+    )
+    if output_node is None:
+        raise ValueError("Compiled candidate has no output node.")
+    output_data = output_node.get("data") or {}
+    output_variable = str(output_data.get("outputVariable") or "")
+    terminal_edge = next(
+        (
+            edge
+            for edge in workflow.get("edges") or []
+            if str(edge.get("target") or "") == str(output_node.get("id") or "")
+            and not edge.get("sourceHandle")
+            and not edge.get("targetHandle")
+        ),
+        None,
+    )
+    terminal_ref = ref_by_id.get(str((terminal_edge or {}).get("source") or ""))
+    if not terminal_ref or not output_variable:
+        raise ValueError("Compiled candidate final output metadata is incomplete.")
+    prompt_ids = [
+        str(item.get("profile_id") or "")
+        for item in draft.get("prompt_profiles") or []
+        if item.get("enabled", True) and item.get("profile_id")
+    ]
+    return GraphIntentV3(
+        name=str(candidate.get("name") or workflow.get("title") or "Xpert"),
+        description=str(candidate.get("description") or ""),
+        tags=list(candidate.get("tags") or []),
+        starters=list(candidate.get("starters") or []),
+        nodes=sorted(business_nodes, key=lambda item: item.ref),
+        control_edges=sorted(
+            control_edges, key=lambda item: (item.source_ref, item.target_ref)
+        ),
+        resources=resources,
+        middleware=middleware,
+        prompt_profile_ids=prompt_ids,
+        final_output=GraphIntentFinalOutputV3(
+            node_ref=terminal_ref,
+            variable=output_variable,
+        ),
+    )
+
+
+def resolved_behavior_projection(graph_ir: ResolvedGraphIRV3) -> dict[str, Any]:
+    return {
+        "nodes": [
+            {
+                "ref": node.ref,
+                "kind": node.kind,
+                "role": node.role,
+                "config": node.config,
+            }
+            for node in graph_ir.nodes
+        ],
+        "edges": [
+            {
+                "mode": edge.mode,
+                "source": edge.source.node_ref,
+                "target": edge.target.node_ref,
+                "source_handle": edge.source.handle,
+                "target_handle": edge.target.handle,
+                "variable": edge.variable,
+            }
+            for edge in graph_ir.edges
+            if edge.mode != "data"
+        ],
+        "final_output": graph_ir.final_output.model_dump(mode="json"),
+        "prompt_profiles": [
+            item.model_dump(mode="json") for item in graph_ir.prompt_profiles
+        ],
+    }

--- a/server/meta_agent/graph_ir_v3.py
+++ b/server/meta_agent/graph_ir_v3.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import re
 from collections import defaultdict, deque
+from copy import deepcopy
 from typing import Any
 
 try:
@@ -50,6 +51,19 @@ from .schemas import (
 GRAPH_IR_VERSION = 3
 SUPPORTED_GRAPH_IR_VERSIONS = (2, 3)
 
+_TEMPLATE_PATTERN = re.compile(r"\{\{\s*(.*?)\s*\}\}", re.DOTALL)
+_SENSITIVE_CONFIG_KEY = re.compile(
+    r"(?:^|[_-])(?:authorization|cookie|credential|password|passwd|secret|"
+    r"api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key)"
+    r"(?:$|[_-])",
+    re.IGNORECASE,
+)
+_SENSITIVE_CONFIG_VALUE = re.compile(
+    r"(?:Bearer\s+\S+|sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{12,}|"
+    r"-----BEGIN\s+(?:RSA\s+)?PRIVATE\s+KEY-----)",
+    re.IGNORECASE,
+)
+
 
 def _safe_identifier(value: str, fallback: str) -> str:
     normalized = re.sub(r"[^A-Za-z0-9_]", "_", str(value or "").strip())
@@ -65,13 +79,110 @@ def _stable_ref(prefix: str, *parts: str) -> str:
     return f"{prefix}_{digest}"
 
 
+def _template_variables(template: str) -> set[str]:
+    moustache: set[str] = set()
+    for match in _TEMPLATE_PATTERN.finditer(template):
+        expression = match.group(1).strip()
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", expression):
+            raise ValueError("Template contains an unsupported template expression.")
+        moustache.add(expression)
+    return moustache
+
+
+def _contains_sensitive_config(value: Any) -> bool:
+    if isinstance(value, dict):
+        return any(
+            _SENSITIVE_CONFIG_KEY.search(str(key))
+            or _contains_sensitive_config(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, list):
+        return any(_contains_sensitive_config(item) for item in value)
+    return isinstance(value, str) and bool(_SENSITIVE_CONFIG_VALUE.search(value))
+
+
+def resolve_middleware_config(
+    middleware: dict[str, Any], supplied: dict[str, Any]
+) -> dict[str, Any]:
+    fields = {
+        str(field.get("name") or ""): field
+        for field in middleware.get("fields") or []
+        if isinstance(field, dict) and field.get("name")
+    }
+    unknown = sorted(set(supplied) - set(fields))
+    if unknown:
+        raise ValueError(
+            "Middleware config fields are not declared: " + ", ".join(unknown)
+        )
+    if _contains_sensitive_config(supplied):
+        raise ValueError("Middleware config contains credential material.")
+    resolved = dict(middleware.get("default_config") or {})
+    resolved.update(supplied)
+    for name, field in fields.items():
+        if field.get("required") and name not in resolved:
+            raise ValueError(f"Middleware config field {name} is required.")
+        if name not in resolved:
+            continue
+        value = resolved[name]
+        field_type = str(field.get("type") or "")
+        valid = (
+            (
+                field_type in {"text", "textarea", "select"}
+                and isinstance(value, str)
+            )
+            or (field_type == "boolean" and isinstance(value, bool))
+            or (
+                field_type == "number"
+                and isinstance(value, (int, float))
+                and not isinstance(value, bool)
+            )
+            or field_type == "json"
+        )
+        if not valid:
+            raise ValueError(
+                f"Middleware config field {name} does not match type {field_type}."
+            )
+        options = field.get("options")
+        if options and value not in options:
+            raise ValueError(
+                f"Middleware config field {name} has an invalid option."
+            )
+        if field_type == "number":
+            minimum = field.get("min_value")
+            maximum = field.get("max_value")
+            if minimum is not None and value < minimum:
+                raise ValueError(
+                    f"Middleware config field {name} is below its minimum."
+                )
+            if maximum is not None and value > maximum:
+                raise ValueError(
+                    f"Middleware config field {name} exceeds its maximum."
+                )
+    return resolved
+
+
 def graph_ir_checksum(graph_ir: ResolvedGraphIRV3 | dict[str, Any]) -> str:
     payload = (
         graph_ir.model_dump(mode="json")
         if isinstance(graph_ir, ResolvedGraphIRV3)
-        else dict(graph_ir)
+        else deepcopy(graph_ir)
     )
     payload.pop("graph_checksum", None)
+    payload["tags"] = sorted(set(payload.get("tags") or []))
+    payload["starters"] = sorted(set(payload.get("starters") or []))
+    payload["nodes"] = sorted(
+        payload.get("nodes") or [], key=lambda item: str(item.get("ref") or "")
+    )
+    payload["edges"] = sorted(
+        payload.get("edges") or [], key=lambda item: str(item.get("ref") or "")
+    )
+    payload["prompt_profiles"] = sorted(
+        payload.get("prompt_profiles") or [],
+        key=lambda item: (
+            str(item.get("profile_id") or ""),
+            int(item.get("pinned_version") or 0),
+        ),
+    )
     return canonical_checksum(payload)
 
 
@@ -108,7 +219,13 @@ def workflow_semantic_checksum(candidate: dict[str, Any]) -> str:
             ],
             key=lambda item: str(item["id"]),
         ),
-        "prompt_profiles": candidate.get("draft", {}).get("prompt_profiles") or [],
+        "prompt_profiles": sorted(
+            candidate.get("draft", {}).get("prompt_profiles") or [],
+            key=lambda item: (
+                str(item.get("profile_id") or ""),
+                int(item.get("pinned_version") or 0),
+            ),
+        ),
     }
     return canonical_checksum(payload)
 
@@ -190,6 +307,14 @@ def v2_to_graph_intent(
         "conversation_history": ("input", "conversation_history", "array"),
     }
     warnings: list[str] = []
+    reserved_collisions = sorted(set(producers) & set(external))
+    if reserved_collisions:
+        warnings.append(
+            "lossy_conversion: node outputs collide with reserved external "
+            "variables: "
+            + ", ".join(reserved_collisions)
+            + "."
+        )
     converted_nodes: list[GraphIntentNodeV3] = []
     for node in blueprint.nodes:
         converted_inputs: list[GraphIntentInputBindingV3] = []
@@ -321,11 +446,52 @@ def graph_intent_to_v2(intent: GraphIntentV3) -> MetaPlannerTypedBlueprintV2:
 def _schemas_compatible(
     source: WorkflowValueSchema, target: WorkflowValueSchema
 ) -> bool:
-    if source.type == "any" or target.type == "any":
+    def variants(schema: WorkflowValueSchema) -> list[WorkflowValueSchema]:
+        resolved = (
+            list(schema.any_of)
+            if schema.any_of
+            else [schema.model_copy(update={"nullable": False, "any_of": ()})]
+        )
+        if schema.nullable:
+            resolved.append(WorkflowValueSchema(type="null"))
+        return resolved
+
+    if source.any_of or source.nullable or target.any_of or target.nullable:
+        return all(
+            any(_schemas_compatible(item, accepted) for accepted in variants(target))
+            for item in variants(source)
+        )
+
+    if target.type == "any":
         return True
-    if source.type == target.type:
+    if source.type == "any":
+        return False
+    if source.type == "null" or target.type == "null":
+        return source.type == target.type
+    if source.type == "integer" and target.type == "number":
         return True
-    return source.type == "integer" and target.type == "number"
+    if source.type != target.type:
+        return False
+    if source.type == "array":
+        if target.items is None:
+            return True
+        if source.items is None:
+            return False
+        return _schemas_compatible(source.items, target.items)
+    if source.type == "object":
+        source_required = set(source.required)
+        target_required = set(target.required)
+        if not target_required.issubset(source_required):
+            return False
+        for name, target_property in target.properties.items():
+            source_property = source.properties.get(name)
+            if source_property is None:
+                if name in target_required:
+                    return False
+                continue
+            if not _schemas_compatible(source_property, target_property):
+                return False
+    return True
 
 
 def _resolved_node(
@@ -367,6 +533,56 @@ def resolve_graph_intent(
     refs = [node.ref for node in intent.nodes]
     if len(refs) != len(set(refs)):
         raise ValueError("Graph IR node refs must be unique.")
+    compiled_ids = [f"node_{_safe_identifier(ref, 'node')}" for ref in refs]
+    if len(compiled_ids) != len(set(compiled_ids)):
+        raise ValueError(
+            "Graph IR node refs collide after identifier normalization."
+        )
+    snapshot_nodes = {
+        str(item.get("kind") or ""): item for item in snapshot.nodes
+    }
+    available_models = {
+        str(item.get("id") or "")
+        for item in snapshot.models
+        if item.get("safe") is True and item.get("id")
+    }
+    if default_agent_model_id:
+        available_models.add(default_agent_model_id)
+    try:
+        from .node_adapters import (
+            get_planner_node_adapter,
+            planner_capability_metadata,
+        )
+    except ImportError:  # pragma: no cover - package fallback
+        from meta_agent.node_adapters import (  # type: ignore
+            get_planner_node_adapter,
+            planner_capability_metadata,
+        )
+    for node in intent.nodes:
+        projection = snapshot_nodes.get(node.kind)
+        current = planner_capability_metadata(node.kind)
+        planner = dict((projection or {}).get("planner") or {})
+        if (
+            projection is None
+            or current is None
+            or current.get("support") != "full"
+            or not planner.get("compilable")
+            or any(
+                planner.get(field) != current.get(field)
+                for field in (
+                    "ir_version",
+                    "contract_version",
+                    "contract_checksum",
+                    "compiler_checksum",
+                    "adapter_checksum",
+                )
+            )
+        ):
+            raise ValueError(
+                f"Node kind {node.kind} is not an authoritative Planner capability."
+            )
+        if get_planner_node_adapter(node.kind) is None:
+            raise ValueError(f"Node kind {node.kind} has no Planner adapter.")
     known_refs = set(refs)
     edge_keys: set[tuple[str, str]] = set()
     for edge in intent.control_edges:
@@ -421,6 +637,28 @@ def resolve_graph_intent(
             and default_agent_model_id
         ):
             resolved_config["model_id"] = default_agent_model_id
+        adapter = get_planner_node_adapter(node.kind)
+        assert adapter is not None
+        resolved_config = adapter.config_model.model_validate(
+            resolved_config
+        ).model_dump(mode="json")
+        model_id = str(resolved_config.get("model_id") or "")
+        if model_id and model_id not in available_models:
+            raise ValueError(
+                f"Agent model {model_id} is unavailable in the Capability Snapshot."
+            )
+        declared_inputs = {binding.variable for binding in node.inputs}
+        referenced: set[str] = set()
+        for field in ("role_prompt", "task_input"):
+            referenced.update(
+                _template_variables(str(resolved_config.get(field) or ""))
+            )
+        missing_bindings = sorted(referenced - declared_inputs)
+        if missing_bindings:
+            raise ValueError(
+                f"Node {node.ref} template variables need explicit data bindings: "
+                + ", ".join(missing_bindings)
+            )
         resolved = _resolved_node(
             ref=node.ref,
             node_id=f"node_{_safe_identifier(node.ref, 'node')}",
@@ -573,9 +811,20 @@ def resolve_graph_intent(
         "toolset_resource": {item["id"]: item for item in snapshot.toolsets},
         "plugin_resource": {item["id"]: item for item in snapshot.plugins},
     }
+    seen_resources: set[tuple[str, str, str]] = set()
+    seen_external_tools: set[tuple[str, str]] = set()
     for binding in intent.resources:
-        if binding.target_ref not in resolved_by_ref:
+        target = resolved_by_ref.get(binding.target_ref)
+        if target is None:
             raise ValueError(f"Resource {binding.resource_id} targets an unknown node.")
+        if target.kind != "workflow_agent" or target.role != "executable":
+            raise ValueError(
+                f"Resource {binding.resource_id} must target a workflow_agent."
+            )
+        resource_key = (binding.kind, binding.resource_id, binding.target_ref)
+        if resource_key in seen_resources:
+            raise ValueError("Graph IR cannot bind a duplicate resource.")
+        seen_resources.add(resource_key)
         resource = resources[binding.kind].get(binding.resource_id)
         if resource is None:
             raise ValueError(f"Resource {binding.resource_id} is unavailable.")
@@ -595,7 +844,28 @@ def resolve_graph_intent(
             version = resource.get("published_version")
             if not version:
                 raise ValueError(f"Resource {binding.resource_id} has no published version.")
-            config["pinned_version"] = int(version)
+            expected_version = intent._pinned_resource_versions.get(
+                (binding.kind, binding.resource_id)
+            )
+            if expected_version is not None and int(version) != expected_version:
+                raise ValueError(
+                    f"Resource {binding.resource_id} drifted from pinned version "
+                    f"{expected_version} to {version}."
+                )
+            config["pinned_version"] = expected_version or int(version)
+        if binding.kind == "external_xpert":
+            tool_name = _safe_identifier(
+                binding.tool_name or f"xpert_{binding.resource_id[:12]}",
+                "external_xpert",
+            )
+            tool_key = (binding.target_ref, tool_name)
+            if tool_key in seen_external_tools:
+                raise ValueError(
+                    f"External Xpert tool name {tool_name} is duplicated for "
+                    f"node {binding.target_ref}."
+                )
+            seen_external_tools.add(tool_key)
+            config["tool_name"] = tool_name
         config["resource_checksum"] = canonical_checksum(resource)
         resolved_resource = _resolved_node(
             ref=ref,
@@ -636,10 +906,14 @@ def resolve_graph_intent(
             raise ValueError("Graph IR cannot bind duplicate middleware.")
         seen_middleware.add(key)
         middleware = middleware_lookup.get(binding.middleware_id)
-        if middleware is None or binding.target_ref not in resolved_by_ref:
+        target = resolved_by_ref.get(binding.target_ref)
+        if middleware is None or target is None:
             raise ValueError(f"Middleware {binding.middleware_id} is unavailable.")
-        defaults = dict(middleware.get("default_config") or {})
-        defaults.update(binding.config)
+        if target.kind != "workflow_agent" or target.role != "executable":
+            raise ValueError(
+                f"Middleware {binding.middleware_id} must target a workflow_agent."
+            )
+        defaults = resolve_middleware_config(middleware, binding.config)
         ref = _stable_ref("middleware", binding.middleware_id, binding.target_ref)
         resolved_middleware = _resolved_node(
             ref=ref,
@@ -732,14 +1006,23 @@ def resolve_graph_intent(
 
     prompt_lookup = {item["id"]: item for item in snapshot.prompt_profiles}
     prompt_profiles: list[ResolvedPromptProfileV3] = []
+    if len(intent.prompt_profile_ids) != len(set(intent.prompt_profile_ids)):
+        raise ValueError("Graph IR cannot bind duplicate Prompt Profiles.")
     for profile_id in dict.fromkeys(intent.prompt_profile_ids):
         resource = prompt_lookup.get(profile_id)
         if resource is None or not resource.get("published_version"):
             raise ValueError(f"Prompt Profile {profile_id} is unavailable.")
+        version = int(resource["published_version"])
+        expected_version = intent._pinned_prompt_profile_versions.get(profile_id)
+        if expected_version is not None and version != expected_version:
+            raise ValueError(
+                f"Prompt Profile {profile_id} drifted from pinned version "
+                f"{expected_version} to {version}."
+            )
         prompt_profiles.append(
             ResolvedPromptProfileV3(
                 profile_id=profile_id,
-                pinned_version=int(resource["published_version"]),
+                pinned_version=expected_version or version,
                 checksum=canonical_checksum(resource),
             )
         )
@@ -817,6 +1100,7 @@ def decompile_candidate_to_graph_intent(
 
     control_edges: list[GraphIntentControlEdgeV3] = []
     resources: list[MetaPlannerIRResourceBinding] = []
+    pinned_resource_versions: dict[tuple[str, str], int] = {}
     middleware: list[MetaPlannerIRMiddlewareBinding] = []
     for raw_edge in workflow.get("edges") or []:
         source_id = str(raw_edge.get("source") or "")
@@ -861,11 +1145,26 @@ def decompile_candidate_to_graph_intent(
             "toolset_resource": "toolsetId",
             "plugin_resource": "pluginId",
         }
+        resource_id = str(source_data.get(id_fields[source_kind]) or "")
+        if source_kind != "knowledge_base":
+            try:
+                pinned_version = int(source_data.get("pinnedVersion"))
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"Compiled {source_kind} resource has no pinned version."
+                ) from None
+            pin_key = (source_kind, resource_id)
+            previous_pin = pinned_resource_versions.get(pin_key)
+            if previous_pin is not None and previous_pin != pinned_version:
+                raise ValueError(
+                    "Compiled resource carries conflicting pinned versions."
+                )
+            pinned_resource_versions[pin_key] = pinned_version
         resources.append(
             MetaPlannerIRResourceBinding(
                 target_ref=target_ref,
                 kind=source_kind,
-                resource_id=str(source_data.get(id_fields[source_kind]) or ""),
+                resource_id=resource_id,
                 tool_name=str(source_data.get("toolName") or ""),
                 description=str(source_data.get("description") or ""),
                 top_k=int(source_data.get("topK") or 5),
@@ -899,12 +1198,25 @@ def decompile_candidate_to_graph_intent(
     terminal_ref = ref_by_id.get(str((terminal_edge or {}).get("source") or ""))
     if not terminal_ref or not output_variable:
         raise ValueError("Compiled candidate final output metadata is incomplete.")
-    prompt_ids = [
-        str(item.get("profile_id") or "")
+    prompt_items = [
+        item
         for item in draft.get("prompt_profiles") or []
         if item.get("enabled", True) and item.get("profile_id")
     ]
-    return GraphIntentV3(
+    prompt_ids = [
+        str(item.get("profile_id") or "")
+        for item in prompt_items
+    ]
+    pinned_prompt_versions: dict[str, int] = {}
+    for item in prompt_items:
+        profile_id = str(item.get("profile_id") or "")
+        try:
+            pinned_prompt_versions[profile_id] = int(item.get("pinned_version"))
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"Compiled Prompt Profile {profile_id} has no pinned version."
+            ) from None
+    intent = GraphIntentV3(
         name=str(candidate.get("name") or workflow.get("title") or "Xpert"),
         description=str(candidate.get("description") or ""),
         tags=list(candidate.get("tags") or []),
@@ -921,6 +1233,9 @@ def decompile_candidate_to_graph_intent(
             variable=output_variable,
         ),
     )
+    intent._pinned_resource_versions = pinned_resource_versions
+    intent._pinned_prompt_profile_versions = pinned_prompt_versions
+    return intent
 
 
 def resolved_behavior_projection(graph_ir: ResolvedGraphIRV3) -> dict[str, Any]:

--- a/server/meta_agent/meta_planner_v2.py
+++ b/server/meta_agent/meta_planner_v2.py
@@ -40,11 +40,14 @@ from .graph_ir_v3 import (
     GRAPH_IR_VERSION,
     annotate_candidate_with_graph_ir,
     graph_intent_to_v2,
+    resolve_middleware_config,
     resolve_graph_intent,
     v2_to_graph_intent,
     workflow_semantic_checksum,
 )
 from .node_adapters import (
+    META_PLANNER_BINDING_KINDS,
+    META_PLANNER_COMPILER_MANAGED_KINDS,
     META_PLANNER_COMPILABLE_NODE_KINDS,
     META_PLANNER_IR_VERSION,
     PlannerNodeCompileContext,
@@ -89,6 +92,8 @@ explicit dependencies, an input contract, and one output contract.
 BLUEPRINT_SYSTEM_PROMPT = """\
 You are the capability-compilation stage of ModelMirror Meta Planner Graph IR V3.
 Return one strict JSON object only. Do not include markdown or hidden reasoning.
+Return GraphIntentV3 with ir_version=3. The nodes array contains executable nodes
+only; compiler-managed input/output and resource-binding nodes are never emitted.
 Use only IDs and middleware listed in the authorized capability snapshot.
 Compile the task DAG into explicit typed IR nodes, control edges, resource bindings,
 middleware bindings, and one explicit final output. A node may cover multiple tasks
@@ -101,7 +106,9 @@ Never invent credentials, tools, resource IDs, node kinds, versions, or private 
 
 
 REPAIR_SYSTEM_PROMPT = """\
-You repair a ModelMirror Meta Planner blueprint. Return one strict JSON object only.
+You repair a ModelMirror Meta Planner GraphIntentV3. Return one strict JSON object
+only with ir_version=3. Never return legacy V2 IR. The nodes array contains only
+executable nodes; input/output and resource nodes are compiler-managed.
 Make the smallest changes required by the structured validation issues. Do not add
 capabilities outside the supplied authorized snapshot. This is the only repair pass.
 Return the complete blueprint and obey every supplied typed_ir_constraint.
@@ -193,6 +200,167 @@ def _typed_ir_prompt_constraints(
             "workflow_agent config accepts only workflow_agent_config_allowed_fields; agent_id belongs to the task plan and must not appear in node.config.",
             "Return a complete typed blueprint, not a patch or partial fragment.",
         ],
+    }
+
+
+def _graph_intent_prompt_contract(
+    request: MetaPlannerGenerateRequest,
+    snapshot: MetaPlannerCapabilitySnapshot,
+) -> dict[str, Any]:
+    allowed_kinds = set(request.scope.allowed_node_kinds)
+    executable_kinds = sorted(
+        kind
+        for kind in allowed_kinds
+        if get_planner_node_adapter(kind) is not None
+    )
+    compiler_managed_kinds = sorted(
+        allowed_kinds & set(META_PLANNER_COMPILER_MANAGED_KINDS)
+    )
+    binding_kinds = sorted(allowed_kinds & set(META_PLANNER_BINDING_KINDS))
+    snapshot_kinds = {
+        str(item.get("kind") or "")
+        for item in snapshot.nodes
+        if isinstance(item, dict)
+    }
+
+    return {
+        "required_ir_version": GRAPH_IR_VERSION,
+        "node_roles": {
+            "executable_node_kinds": executable_kinds,
+            "compiler_managed_node_kinds": compiler_managed_kinds,
+            "resource_binding_kinds": binding_kinds,
+        },
+        "workflow_agent": {
+            "config_schema": MetaPlannerWorkflowAgentConfig.model_json_schema(),
+            "config_field_names": list(MetaPlannerWorkflowAgentConfig.model_fields),
+            "input_port": {
+                "name": "task",
+                "cardinality": "many",
+                "root_source_ref": "input",
+                "root_source_port": "user_input",
+                "root_variable": "user_input",
+            },
+            "output_port": {
+                "name": "result",
+                "type": "string",
+                "cardinality": "one",
+            },
+        },
+        "authorized": {
+            "middleware_ids": list(request.scope.middleware_ids),
+            "prompt_profile_ids": list(request.scope.prompt_profile_ids),
+            "external_xpert_ids": list(request.scope.external_xpert_ids),
+            "knowledge_base_ids": list(request.scope.knowledge_base_ids),
+            "toolset_ids": list(request.scope.toolset_ids),
+            "plugin_ids": list(request.scope.plugin_ids),
+        },
+        "rules": [
+            "Set ir_version to 3; never return a V2 blueprint.",
+            "nodes may contain only executable_node_kinds.",
+            "Never put compiler_managed_node_kinds or resource_binding_kinds in nodes.",
+            "Represent resources only in resources and target a workflow_agent ref.",
+            "Use snake_case workflow_agent config fields exactly as config_field_names; never emit outputVariable, taskInput, rolePrompt, or agent_id in config.",
+            "Every workflow_agent declares exactly one string output on port result with a unique variable.",
+            "Every root workflow_agent binds user_input from source_ref input and source_port user_input to input port task.",
+            "Every dependency input binds the exact ancestor result variable from source_port result to input port task.",
+            "Every {{variable}} used in role_prompt or task_input has a matching explicit input binding.",
+            "Control edges represent every cross-node task dependency and form one acyclic graph with one terminal node.",
+            "final_output references the terminal workflow_agent result port and its exact output variable.",
+            "middleware may contain only authorized middleware_ids; when that list is empty, middleware must be empty.",
+        ],
+        "snapshot_node_kinds": sorted(snapshot_kinds & allowed_kinds),
+    }
+
+
+def _planner_prompt_snapshot(
+    request: MetaPlannerGenerateRequest,
+    snapshot: MetaPlannerCapabilitySnapshot,
+) -> dict[str, Any]:
+    def authorized(items: list[dict[str, Any]], ids: list[str]) -> list[dict[str, Any]]:
+        allowed = set(ids)
+        return [item for item in items if str(item.get("id") or "") in allowed]
+
+    return {
+        "version": snapshot.version,
+        "snapshot_hash": snapshot.snapshot_hash,
+        "graph_intent_contract": _graph_intent_prompt_contract(request, snapshot),
+        "resources": {
+            "external_xperts": authorized(
+                snapshot.external_xperts, request.scope.external_xpert_ids
+            ),
+            "knowledge_bases": authorized(
+                snapshot.knowledge_bases, request.scope.knowledge_base_ids
+            ),
+            "toolsets": authorized(snapshot.toolsets, request.scope.toolset_ids),
+            "plugins": authorized(snapshot.plugins, request.scope.plugin_ids),
+            "prompt_profiles": authorized(
+                snapshot.prompt_profiles, request.scope.prompt_profile_ids
+            ),
+        },
+        "middleware": authorized(snapshot.middleware, request.scope.middleware_ids),
+        "models": [
+            item
+            for item in snapshot.models
+            if item.get("safe") is True and item.get("id")
+        ],
+        "agents": authorized(snapshot.agents, request.scope.agent_ids),
+    }
+
+
+def _canonical_graph_intent_example(
+    request: MetaPlannerGenerateRequest,
+    plan: MetaPlannerTaskPlan,
+) -> dict[str, Any]:
+    """Give the model one compact, structurally valid V3 shape to adapt."""
+
+    task_ids = [task.task_id for task in plan.tasks]
+    return {
+        "ir_version": GRAPH_IR_VERSION,
+        "name": "Replace with the candidate Xpert name",
+        "description": "Replace with a concise candidate description",
+        "tags": [],
+        "starters": [],
+        "nodes": [
+            {
+                "ref": "xpert_agent",
+                "kind": "workflow_agent",
+                "title": "Replace with the workflow agent title",
+                "description": "Replace with the workflow agent responsibility",
+                "task_ids": task_ids,
+                "inputs": [
+                    {
+                        "port": "task",
+                        "variable": "user_input",
+                        "source_ref": "input",
+                        "source_port": "user_input",
+                        "value_schema": {"type": "string"},
+                    }
+                ],
+                "outputs": [
+                    {
+                        "port": "result",
+                        "variable": "final_result",
+                        "value_schema": {"type": "string"},
+                    }
+                ],
+                "config": {
+                    "role_prompt": "Replace with instructions covering task_ids.",
+                    "task_input": "{{user_input}}",
+                    "model_id": request.default_agent_model_id,
+                    "source_agent_id": None,
+                    "method_skill_ids": [],
+                },
+            }
+        ],
+        "control_edges": [],
+        "resources": [],
+        "middleware": [],
+        "prompt_profile_ids": [],
+        "final_output": {
+            "node_ref": "xpert_agent",
+            "port": "result",
+            "variable": "final_result",
+        },
     }
 
 
@@ -317,6 +485,12 @@ def legacy_blueprint_to_typed_ir(
     if len(task_order) != len(plan.tasks):
         raise ValueError("Legacy blueprint task plan contains a dependency cycle.")
 
+    task_ancestors: dict[str, set[str]] = {task_id: set() for task_id in task_order}
+    for task_id in task_order:
+        for dependency in task_by_id[task_id].depends_on:
+            task_ancestors[task_id].add(dependency)
+            task_ancestors[task_id].update(task_ancestors[dependency])
+
     outputs: dict[str, str] = {}
     node_refs: dict[str, str] = {}
     nodes: list[MetaPlannerIRNode] = []
@@ -329,7 +503,11 @@ def legacy_blueprint_to_typed_ir(
         outputs[task.task_id] = output_variable
         task_input = agent.task_input.strip()
         input_bindings: list[MetaPlannerIRInputBinding] = []
-        if not task.depends_on:
+        references_user_input = any(
+            re.search(r"\{\{\s*user_input\s*\}\}", template)
+            for template in (agent.role_prompt, task_input)
+        )
+        if not task.depends_on or references_user_input:
             input_bindings.append(
                 MetaPlannerIRInputBinding(
                     port="request", variable="user_input", value_type="string"
@@ -355,6 +533,44 @@ def legacy_blueprint_to_typed_ir(
                     f"\n\nDependency {dependency}:\n"
                     f"{{{{{dependency_variable}}}}}"
                 )
+        referenced_variables = {
+            match.group(1)
+            for template in (agent.role_prompt, task_input)
+            for match in re.finditer(
+                r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}",
+                template,
+            )
+        }
+        bound_variables = {binding.variable for binding in input_bindings}
+        if (
+            "conversation_history" in referenced_variables
+            and "conversation_history" not in bound_variables
+        ):
+            input_bindings.append(
+                MetaPlannerIRInputBinding(
+                    port="history",
+                    variable="conversation_history",
+                    value_type="array",
+                )
+            )
+            bound_variables.add("conversation_history")
+        ancestor_outputs = {
+            outputs[ancestor]: ancestor
+            for ancestor in task_ancestors[task.task_id]
+            if ancestor in outputs
+        }
+        for variable in sorted(referenced_variables - bound_variables):
+            producer_task = ancestor_outputs.get(variable)
+            if producer_task is None:
+                continue
+            input_bindings.append(
+                MetaPlannerIRInputBinding(
+                    port=f"context_{producer_task}",
+                    variable=variable,
+                    value_type="string",
+                )
+            )
+            bound_variables.add(variable)
         nodes.append(
             MetaPlannerIRNode(
                 ref=node_ref,
@@ -504,6 +720,12 @@ def validate_blueprint_authorization(
     task_nodes: dict[str, list[MetaPlannerIRNode]] = defaultdict(list)
     known_agents = {item["id"] for item in snapshot.agents}
     authorized_agents = set(request.scope.agent_ids)
+    available_models = {
+        str(item.get("id") or "")
+        for item in snapshot.models
+        if item.get("safe") is True and item.get("id")
+    }
+    available_models.add(request.default_agent_model_id)
     parsed_configs: dict[str, MetaPlannerWorkflowAgentConfig] = {}
     for node in typed.nodes:
         if node.kind not in request.scope.allowed_node_kinds:
@@ -525,6 +747,24 @@ def validate_blueprint_authorization(
                 f"Node {node.ref} config is invalid: {_safe_exception_message(exc)}"
             )
             continue
+        if isinstance(blueprint, GraphIntentV3):
+            graph_node = next(
+                item for item in blueprint.nodes if item.ref == node.ref
+            )
+            declared_inputs = {item.variable for item in graph_node.inputs}
+            referenced = {
+                match.group(1)
+                for template in (config.role_prompt, config.task_input)
+                for match in re.finditer(
+                    r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}",
+                    template,
+                )
+            }
+            for variable in sorted(referenced - declared_inputs):
+                issues.append(
+                    f"Node {node.ref} template variable {variable} needs an "
+                    "explicit data binding."
+                )
         if len(node.outputs) != 1 or node.outputs[0].port != "result":
             issues.append(
                 f"Node {node.ref} must expose exactly one result output port."
@@ -559,6 +799,10 @@ def validate_blueprint_authorization(
                     f"Node {node.ref} must keep method Skills for task {task_id}."
                 )
         source_agent_id = config.source_agent_id
+        if config.model_id and config.model_id not in available_models:
+            issues.append(
+                f"Agent model {config.model_id} is no longer available."
+            )
         if source_agent_id and source_agent_id not in authorized_agents:
             issues.append(f"Expert {source_agent_id} is not authorized.")
         if source_agent_id and source_agent_id not in known_agents:
@@ -720,6 +964,15 @@ def validate_blueprint_authorization(
             issues.append(
                 f"Middleware {binding.middleware_id} is no longer available."
             )
+        else:
+            try:
+                resolve_middleware_config(
+                    middleware_lookup[binding.middleware_id], binding.config
+                )
+            except ValueError as exc:
+                issues.append(
+                    f"Middleware {binding.middleware_id} config is invalid: {exc}"
+                )
         key = (binding.target_ref, binding.middleware_id)
         if key in seen_middleware:
             issues.append(
@@ -1893,17 +2146,22 @@ class MetaPlannerV2Service:
         try:
             payload = _json_payload(raw_blueprint)
             if payload.get("ir_version") == 2:
-                legacy = MetaPlannerTypedBlueprintV2.model_validate(payload)
-                blueprint, compatibility = v2_to_graph_intent(legacy)
-                if blueprint is None:
-                    return (
-                        None,
-                        {},
-                        {"valid": False, "issues": compatibility.warnings},
-                        compatibility.warnings,
-                        None,
-                        compatibility,
-                    )
+                issue = (
+                    "Legacy V2 IR is read-only compatibility input and is not "
+                    "valid for a new V3 generation. Return GraphIntentV3 with "
+                    "ir_version=3."
+                )
+                return (
+                    None,
+                    {},
+                    {"valid": False, "issues": [issue]},
+                    [issue],
+                    None,
+                    MetaPlannerIRCompatibility(
+                        source_version=2,
+                        warnings=[issue],
+                    ),
+                )
             else:
                 blueprint = GraphIntentV3.model_validate(payload)
             issues = validate_blueprint_authorization(
@@ -2003,6 +2261,7 @@ class MetaPlannerV2Service:
         snapshot: MetaPlannerCapabilitySnapshot,
         target: XpertDefinition | None,
     ) -> str:
+        prompt_snapshot = _planner_prompt_snapshot(request, snapshot)
         target_summary = None
         if target is not None:
             target_summary = {
@@ -2018,9 +2277,15 @@ class MetaPlannerV2Service:
                 "task_plan": plan.model_dump(mode="json"),
                 "default_agent_model_id": request.default_agent_model_id,
                 "authorized_scope": request.scope.model_dump(mode="json"),
-                "capability_snapshot": snapshot.model_dump(mode="json"),
+                "capability_snapshot": prompt_snapshot,
+                "graph_intent_contract": prompt_snapshot[
+                    "graph_intent_contract"
+                ],
                 "target_xpert": target_summary,
                 "required_schema": GraphIntentV3.model_json_schema(),
+                "canonical_minimal_example": _canonical_graph_intent_example(
+                    request, plan
+                ),
                 "typed_ir_constraints": _typed_ir_prompt_constraints(request, plan),
                 "rules": [
                     "Use only executable node kinds marked compilable in the snapshot.",
@@ -2033,6 +2298,7 @@ class MetaPlannerV2Service:
                     "Resource and middleware bindings target workflow_agent node refs.",
                     "Reference dependency outputs in task_input using {{variable}}.",
                     "Do not include credentials, hidden reasoning, or raw private data.",
+                    "When uncertain, preserve the exact shape of canonical_minimal_example and adapt its content; never change it to V2.",
                 ],
             },
             ensure_ascii=False,
@@ -2046,6 +2312,8 @@ class MetaPlannerV2Service:
         raw_blueprint: str,
         issues: list[str],
     ) -> str:
+        prompt_snapshot = _planner_prompt_snapshot(request, snapshot)
+        resources = prompt_snapshot["resources"]
         return json.dumps(
             {
                 "goal": request.goal,
@@ -2053,17 +2321,20 @@ class MetaPlannerV2Service:
                 "default_agent_model_id": request.default_agent_model_id,
                 "authorized_scope": request.scope.model_dump(mode="json"),
                 "capability_snapshot_hash": snapshot.snapshot_hash,
+                "capability_snapshot": prompt_snapshot,
+                "graph_intent_contract": prompt_snapshot[
+                    "graph_intent_contract"
+                ],
                 "available_resources": {
-                    "external_xperts": snapshot.external_xperts,
-                    "knowledge_bases": snapshot.knowledge_bases,
-                    "toolsets": snapshot.toolsets,
-                    "plugins": snapshot.plugins,
-                    "prompt_profiles": snapshot.prompt_profiles,
-                    "middleware": snapshot.middleware,
+                    **resources,
+                    "middleware": prompt_snapshot["middleware"],
                 },
                 "invalid_blueprint": raw_blueprint[:30_000],
                 "validation_issues": issues[:30],
                 "required_schema": GraphIntentV3.model_json_schema(),
+                "canonical_minimal_example": _canonical_graph_intent_example(
+                    request, plan
+                ),
                 "typed_ir_constraints": _typed_ir_prompt_constraints(request, plan),
             },
             ensure_ascii=False,

--- a/server/meta_agent/meta_planner_v2.py
+++ b/server/meta_agent/meta_planner_v2.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import json
 import re
 import time
@@ -37,6 +36,14 @@ except ModuleNotFoundError:
     from xperts.models import XpertDefinition, XpertDraft
 
 from .capabilities import assert_scope_is_authorized
+from .graph_ir_v3 import (
+    GRAPH_IR_VERSION,
+    annotate_candidate_with_graph_ir,
+    graph_intent_to_v2,
+    resolve_graph_intent,
+    v2_to_graph_intent,
+    workflow_semantic_checksum,
+)
 from .node_adapters import (
     META_PLANNER_COMPILABLE_NODE_KINDS,
     META_PLANNER_IR_VERSION,
@@ -50,6 +57,7 @@ from .schemas import (
     MetaPlannerCapabilitySnapshot,
     MetaPlannerGenerateRequest,
     MetaPlannerGenerateResponse,
+    GraphIntentV3,
     MetaPlannerIRControlEdge,
     MetaPlannerIRFinalOutput,
     MetaPlannerIRInputBinding,
@@ -58,6 +66,8 @@ from .schemas import (
     MetaPlannerIROutputBinding,
     MetaPlannerIRResourceBinding,
     MetaPlannerPreviewResponse,
+    MetaPlannerIRCompatibility,
+    ResolvedGraphIRV3,
     MetaPlannerTaskPlan,
     MetaPlannerTypedBlueprintV2,
     MetaPlannerWorkflowAgentConfig,
@@ -69,7 +79,7 @@ PreflightCallback = Callable[[XpertDefinition], Any]
 
 
 TASK_PLAN_SYSTEM_PROMPT = """\
-You are the task-planning stage of ModelMirror Meta Planner V2.
+You are the task-planning stage of ModelMirror Meta Planner Graph IR V3.
 Return one strict JSON object only. Do not include markdown or hidden reasoning.
 Create a bounded task DAG. Every task must have a stable lowercase task_id,
 explicit dependencies, an input contract, and one output contract.
@@ -77,12 +87,14 @@ explicit dependencies, an input contract, and one output contract.
 
 
 BLUEPRINT_SYSTEM_PROMPT = """\
-You are the capability-compilation stage of ModelMirror Meta Planner V2.
+You are the capability-compilation stage of ModelMirror Meta Planner Graph IR V3.
 Return one strict JSON object only. Do not include markdown or hidden reasoning.
 Use only IDs and middleware listed in the authorized capability snapshot.
 Compile the task DAG into explicit typed IR nodes, control edges, resource bindings,
 middleware bindings, and one explicit final output. A node may cover multiple tasks
 and a task may require multiple nodes. Bindings must target a workflow_agent node ref.
+Every node input must identify its source node and source port. Use the workflow_agent
+task port for each task input; that port accepts multiple typed variables.
 Respect the supplied typed_ir_constraints, including its workflow-agent node limit.
 Never invent credentials, tools, resource IDs, node kinds, versions, or private content.
 """
@@ -411,11 +423,26 @@ def legacy_blueprint_to_typed_ir(
 
 def _typed_blueprint(
     plan: MetaPlannerTaskPlan,
-    blueprint: MetaPlannerBlueprint | MetaPlannerTypedBlueprintV2,
+    blueprint: MetaPlannerBlueprint | MetaPlannerTypedBlueprintV2 | GraphIntentV3,
 ) -> MetaPlannerTypedBlueprintV2:
+    if isinstance(blueprint, GraphIntentV3):
+        return graph_intent_to_v2(blueprint)
     if isinstance(blueprint, MetaPlannerTypedBlueprintV2):
         return blueprint
     return legacy_blueprint_to_typed_ir(plan, blueprint)
+
+
+def _graph_intent(
+    plan: MetaPlannerTaskPlan,
+    blueprint: MetaPlannerBlueprint | MetaPlannerTypedBlueprintV2 | GraphIntentV3,
+) -> tuple[GraphIntentV3, MetaPlannerIRCompatibility]:
+    if isinstance(blueprint, GraphIntentV3):
+        return blueprint, MetaPlannerIRCompatibility(source_version=3)
+    typed = _typed_blueprint(plan, blueprint)
+    intent, compatibility = v2_to_graph_intent(typed)
+    if intent is None:
+        raise ValueError("; ".join(compatibility.warnings))
+    return intent, compatibility
 
 
 def _typed_graph(
@@ -447,7 +474,7 @@ def _typed_graph(
 def validate_blueprint_authorization(
     request: MetaPlannerGenerateRequest,
     plan: MetaPlannerTaskPlan,
-    blueprint: MetaPlannerBlueprint | MetaPlannerTypedBlueprintV2,
+    blueprint: MetaPlannerBlueprint | MetaPlannerTypedBlueprintV2 | GraphIntentV3,
     snapshot: MetaPlannerCapabilitySnapshot,
 ) -> list[str]:
     issues = validate_task_plan(
@@ -1067,11 +1094,17 @@ def compile_xpert_candidate(
     *,
     request: MetaPlannerGenerateRequest,
     plan: MetaPlannerTaskPlan,
-    blueprint: MetaPlannerBlueprint | MetaPlannerTypedBlueprintV2,
+    blueprint: MetaPlannerBlueprint | MetaPlannerTypedBlueprintV2 | GraphIntentV3,
     snapshot: MetaPlannerCapabilitySnapshot,
     target: XpertDefinition | None,
 ) -> dict[str, Any]:
-    typed = _typed_blueprint(plan, blueprint)
+    intent, _ = _graph_intent(plan, blueprint)
+    resolved_graph = resolve_graph_intent(
+        intent,
+        snapshot,
+        default_agent_model_id=request.default_agent_model_id,
+    )
+    typed = graph_intent_to_v2(intent)
     task_by_id = {task.task_id: task for task in plan.tasks}
     node_by_ref = {node.ref: node for node in typed.nodes}
     resource_lookup = _resource_lookup(snapshot)
@@ -1106,6 +1139,28 @@ def compile_xpert_candidate(
     }
     resources_by_ref: dict[str, list[MetaPlannerIRResourceBinding]] = defaultdict(list)
     middleware_by_ref: dict[str, list[MetaPlannerIRMiddlewareBinding]] = defaultdict(list)
+    resolved_nodes_by_ref = {node.ref: node for node in resolved_graph.nodes}
+    resolved_resource_ids: dict[tuple[str, str, str], str] = {}
+    resolved_middleware_ids: dict[tuple[str, str], str] = {}
+    for graph_edge in resolved_graph.edges:
+        source_node = resolved_nodes_by_ref.get(graph_edge.source.node_ref)
+        if source_node is None:
+            continue
+        if graph_edge.mode == "binding":
+            resolved_resource_ids[
+                (
+                    source_node.kind,
+                    str(source_node.config.get("resource_id") or ""),
+                    graph_edge.target.node_ref,
+                )
+            ] = source_node.node_id
+        elif graph_edge.mode == "metadata":
+            resolved_middleware_ids[
+                (
+                    str(source_node.config.get("middleware_id") or ""),
+                    graph_edge.target.node_ref,
+                )
+            ] = source_node.node_id
     for binding in typed.resources:
         resources_by_ref[binding.target_ref].append(binding)
     for binding in typed.middleware:
@@ -1176,7 +1231,9 @@ def compile_xpert_candidate(
     for index, binding in enumerate(typed.resources):
         target_node_id = compiled_node_ids[binding.target_ref]
         resource = resource_lookup[binding.kind][binding.resource_id]
-        node_id = f"resource_{index + 1}_{binding.kind}"
+        node_id = resolved_resource_ids[
+            (binding.kind, binding.resource_id, binding.target_ref)
+        ]
         published_version = resource.get("published_version")
         if binding.kind == "external_xpert":
             data = {
@@ -1263,10 +1320,9 @@ def compile_xpert_candidate(
         middleware = middleware_lookup[binding.middleware_id]
         defaults = dict(middleware.get("default_config") or {})
         defaults.update(binding.config)
-        node_id = (
-            f"middleware_{index + 1}_"
-            f"{_safe_identifier(binding.middleware_id, 'mw')}"
-        )
+        node_id = resolved_middleware_ids[
+            (binding.middleware_id, binding.target_ref)
+        ]
         target_position = next(
             node.position for node in nodes if node.id == target_node_id
         )
@@ -1326,16 +1382,10 @@ def compile_xpert_candidate(
         )
     )
 
-    canonical_ir = json.dumps(
-        typed.model_dump(mode="json"),
-        ensure_ascii=True,
-        sort_keys=True,
-        separators=(",", ":"),
-    )
     workflow = NativeWorkflowDefinition(
-        id=f"meta_{hashlib.sha256(canonical_ir.encode('utf-8')).hexdigest()[:12]}",
+        id=f"meta_{resolved_graph.graph_checksum[:12]}",
         title=typed.name,
-        version="evoagentx-meta-planner-v2",
+        version="evoagentx-meta-planner-graph-ir-v3",
         source="workflow-native",
         nodes=nodes,
         edges=edges,
@@ -1361,13 +1411,15 @@ def compile_xpert_candidate(
         draft_payload["agent_config"] = base_draft.agent_config
         draft_payload["features"] = base_draft.features
     draft = XpertDraft(**draft_payload)
-    return {
+    candidate = {
         "name": typed.name,
         "description": typed.description,
         "tags": list(dict.fromkeys(typed.tags)),
         "starters": list(dict.fromkeys(typed.starters)),
         "draft": draft.model_dump(mode="json"),
     }
+    annotate_candidate_with_graph_ir(candidate, intent, resolved_graph)
+    return candidate
 
 
 def _candidate_xpert(
@@ -1552,7 +1604,14 @@ class MetaPlannerV2Service:
         )
         repair_used = False
         warnings: list[str] = []
-        blueprint, candidate, validation, issues = self._compile_and_validate(
+        (
+            blueprint,
+            candidate,
+            validation,
+            issues,
+            graph_ir,
+            compatibility,
+        ) = self._compile_and_validate(
             request=request,
             plan=plan,
             raw_blueprint=raw_blueprint,
@@ -1574,7 +1633,14 @@ class MetaPlannerV2Service:
                 0,
                 8_192,
             )
-            blueprint, candidate, validation, issues = self._compile_and_validate(
+            (
+                blueprint,
+                candidate,
+                validation,
+                issues,
+                graph_ir,
+                compatibility,
+            ) = self._compile_and_validate(
                 request=request,
                 plan=plan,
                 raw_blueprint=repaired_raw,
@@ -1586,7 +1652,7 @@ class MetaPlannerV2Service:
                     "The single repair pass did not produce an approvable candidate."
                 )
                 if not candidate:
-                    candidate = self._fallback_candidate(
+                    candidate, graph_ir, compatibility = self._fallback_candidate(
                         request=request,
                         plan=plan,
                         snapshot=snapshot,
@@ -1621,8 +1687,18 @@ class MetaPlannerV2Service:
                 ]
 
         report = {
-            "planner_version": "evoagentx-meta-planner-v2",
-            "typed_ir_version": META_PLANNER_IR_VERSION,
+            "planner_version": "evoagentx-meta-planner-graph-ir-v3",
+            "typed_ir_version": GRAPH_IR_VERSION,
+            "ir_version": GRAPH_IR_VERSION,
+            "graph_ir": (
+                graph_ir.model_dump(mode="json") if graph_ir is not None else None
+            ),
+            "graph_ir_checksum": (
+                graph_ir.graph_checksum if graph_ir is not None else ""
+            ),
+            "graph_ir_status": "current" if graph_ir is not None else "unavailable",
+            "compiled_workflow_checksum": workflow_semantic_checksum(candidate),
+            "compatibility": compatibility.model_dump(mode="json"),
             "goal": request.goal,
             "mode": request.mode,
             "plan": plan.model_dump(mode="json"),
@@ -1678,6 +1754,8 @@ class MetaPlannerV2Service:
             warnings=warnings,
             repair_used=repair_used,
             snapshot=snapshot,
+            graph_ir=graph_ir,
+            compatibility=compatibility,
         )
 
     def preview(
@@ -1686,7 +1764,7 @@ class MetaPlannerV2Service:
         snapshot: MetaPlannerCapabilitySnapshot,
         *,
         plan: MetaPlannerTaskPlan,
-        blueprint: MetaPlannerBlueprint | MetaPlannerTypedBlueprintV2,
+        blueprint: MetaPlannerBlueprint | MetaPlannerTypedBlueprintV2 | GraphIntentV3,
         target: XpertDefinition | None = None,
         warnings: list[str] | None = None,
         repair_used: bool = False,
@@ -1717,6 +1795,12 @@ class MetaPlannerV2Service:
         issues = list(dict.fromkeys([*plan_issues, *blueprint_issues]))
         if issues:
             raise ValueError("; ".join(issues))
+        intent, compatibility = _graph_intent(plan, blueprint)
+        graph_ir = resolve_graph_intent(
+            intent,
+            snapshot,
+            default_agent_model_id=request.default_agent_model_id,
+        )
         candidate = compile_xpert_candidate(
             request=request,
             plan=plan,
@@ -1737,6 +1821,10 @@ class MetaPlannerV2Service:
             repair_used=repair_used,
             capability_snapshot_version=snapshot.version,
             capability_snapshot_hash=snapshot.snapshot_hash,
+            ir_version=GRAPH_IR_VERSION,
+            graph_ir=graph_ir.model_dump(mode="json"),
+            graph_ir_checksum=graph_ir.graph_checksum,
+            compatibility=compatibility,
         )
 
     @staticmethod
@@ -1746,7 +1834,7 @@ class MetaPlannerV2Service:
         plan: MetaPlannerTaskPlan,
         snapshot: MetaPlannerCapabilitySnapshot,
         target: XpertDefinition | None,
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], ResolvedGraphIRV3, MetaPlannerIRCompatibility]:
         blueprint = MetaPlannerBlueprint(
             name=(target.name if target is not None else "Unresolved Xpert candidate"),
             description="Meta Planner repair failed. Review validation issues.",
@@ -1765,6 +1853,12 @@ class MetaPlannerV2Service:
                 for task in plan.tasks
             ],
         )
+        intent, compatibility = _graph_intent(plan, blueprint)
+        graph_ir = resolve_graph_intent(
+            intent,
+            snapshot,
+            default_agent_model_id=request.default_agent_model_id,
+        )
         candidate = compile_xpert_candidate(
             request=request,
             plan=plan,
@@ -1777,7 +1871,7 @@ class MetaPlannerV2Service:
             if node.get("type") == "workflow_agent":
                 node["data"]["modelId"] = ""
                 break
-        return candidate
+        return candidate, graph_ir, compatibility
 
     def _compile_and_validate(
         self,
@@ -1788,20 +1882,47 @@ class MetaPlannerV2Service:
         snapshot: MetaPlannerCapabilitySnapshot,
         target: XpertDefinition | None,
     ) -> tuple[
-        MetaPlannerTypedBlueprintV2 | None,
+        GraphIntentV3 | None,
         dict[str, Any],
         dict[str, Any],
         list[str],
+        ResolvedGraphIRV3 | None,
+        MetaPlannerIRCompatibility,
     ]:
+        compatibility = MetaPlannerIRCompatibility(source_version=3)
         try:
-            blueprint = MetaPlannerTypedBlueprintV2.model_validate(
-                _json_payload(raw_blueprint)
-            )
+            payload = _json_payload(raw_blueprint)
+            if payload.get("ir_version") == 2:
+                legacy = MetaPlannerTypedBlueprintV2.model_validate(payload)
+                blueprint, compatibility = v2_to_graph_intent(legacy)
+                if blueprint is None:
+                    return (
+                        None,
+                        {},
+                        {"valid": False, "issues": compatibility.warnings},
+                        compatibility.warnings,
+                        None,
+                        compatibility,
+                    )
+            else:
+                blueprint = GraphIntentV3.model_validate(payload)
             issues = validate_blueprint_authorization(
                 request, plan, blueprint, snapshot
             )
             if issues:
-                return blueprint, {}, {"valid": False, "issues": issues}, issues
+                return (
+                    blueprint,
+                    {},
+                    {"valid": False, "issues": issues},
+                    issues,
+                    None,
+                    compatibility,
+                )
+            graph_ir = resolve_graph_intent(
+                blueprint,
+                snapshot,
+                default_agent_model_id=request.default_agent_model_id,
+            )
             candidate = compile_xpert_candidate(
                 request=request,
                 plan=plan,
@@ -1818,10 +1939,24 @@ class MetaPlannerV2Service:
                 str(issue.get("message") or issue)
                 for issue in validation.get("issues", [])
             ]
-            return blueprint, candidate, validation, errors
+            return (
+                blueprint,
+                candidate,
+                validation,
+                errors,
+                graph_ir,
+                compatibility,
+            )
         except Exception as exc:
             message = _safe_exception_message(exc)
-            return None, {}, {"valid": False, "issues": [message]}, [message]
+            return (
+                None,
+                {},
+                {"valid": False, "issues": [message]},
+                [message],
+                None,
+                compatibility,
+            )
 
     @staticmethod
     def _plan_prompt(request: MetaPlannerGenerateRequest) -> str:
@@ -1885,12 +2020,14 @@ class MetaPlannerV2Service:
                 "authorized_scope": request.scope.model_dump(mode="json"),
                 "capability_snapshot": snapshot.model_dump(mode="json"),
                 "target_xpert": target_summary,
-                "required_schema": MetaPlannerTypedBlueprintV2.model_json_schema(),
+                "required_schema": GraphIntentV3.model_json_schema(),
                 "typed_ir_constraints": _typed_ir_prompt_constraints(request, plan),
                 "rules": [
                     "Use only executable node kinds marked compilable in the snapshot.",
                     "A workflow_agent may cover multiple task_ids and a task may use multiple nodes.",
                     "Declare every control edge, typed input/output binding, and the final output explicitly.",
+                    "Every input binding must identify source_ref and source_port.",
+                    "Use target port task for every workflow_agent input; the port accepts many variables.",
                     "Do not emit input, output, or resource nodes inside nodes; the compiler creates them from bindings.",
                     "Use resource and middleware IDs only from authorized_scope.",
                     "Resource and middleware bindings target workflow_agent node refs.",
@@ -1926,7 +2063,7 @@ class MetaPlannerV2Service:
                 },
                 "invalid_blueprint": raw_blueprint[:30_000],
                 "validation_issues": issues[:30],
-                "required_schema": MetaPlannerTypedBlueprintV2.model_json_schema(),
+                "required_schema": GraphIntentV3.model_json_schema(),
                 "typed_ir_constraints": _typed_ir_prompt_constraints(request, plan),
             },
             ensure_ascii=False,
@@ -1943,6 +2080,8 @@ class MetaPlannerV2Service:
         warnings: list[str],
         repair_used: bool,
         snapshot: MetaPlannerCapabilitySnapshot,
+        graph_ir: ResolvedGraphIRV3 | None,
+        compatibility: MetaPlannerIRCompatibility,
     ) -> MetaPlannerGenerateResponse:
         return MetaPlannerGenerateResponse(
             proposal_id=proposal.proposal_id,
@@ -1957,4 +2096,12 @@ class MetaPlannerV2Service:
             repair_used=repair_used,
             capability_snapshot_version=snapshot.version,
             capability_snapshot_hash=snapshot.snapshot_hash,
+            ir_version=GRAPH_IR_VERSION,
+            graph_ir=(
+                graph_ir.model_dump(mode="json") if graph_ir is not None else None
+            ),
+            graph_ir_checksum=(
+                graph_ir.graph_checksum if graph_ir is not None else ""
+            ),
+            compatibility=compatibility,
         )

--- a/server/meta_agent/node_adapters.py
+++ b/server/meta_agent/node_adapters.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 from pydantic import BaseModel
 
 from .schemas import (
+    GraphIntentNodeV3,
     MetaPlannerIRNode,
     MetaPlannerWorkflowAgentConfig,
 )
@@ -26,7 +27,7 @@ except ModuleNotFoundError:
     from workflow_native.schemas import NativeWorkflowNode, WorkflowPosition
 
 
-META_PLANNER_IR_VERSION = 2
+META_PLANNER_IR_VERSION = 3
 META_PLANNER_ADAPTER_VERSION = "node-contract-v3"
 META_PLANNER_COMPILER_MANAGED_KINDS = frozenset({"input", "output"})
 META_PLANNER_BINDING_KINDS = frozenset(
@@ -59,6 +60,7 @@ class PlannerNodeAdapter:
         NativeWorkflowNode,
     ]
     decompile_node: Callable[[NativeWorkflowNode], MetaPlannerIRNode]
+    decompile_node_v3: Callable[[NativeWorkflowNode], GraphIntentNodeV3]
     contract_version: int = NODE_CONTRACT_VERSION
 
     def validate_config(self, node: MetaPlannerIRNode) -> BaseModel:
@@ -67,6 +69,19 @@ class PlannerNodeAdapter:
     @property
     def config_schema_checksum(self) -> str:
         return canonical_checksum(self.config_model.model_json_schema())
+
+    @property
+    def adapter_checksum(self) -> str:
+        contract = workflow_node_contract_registry.require(self.kind)
+        return canonical_checksum(
+            {
+                "kind": self.kind,
+                "ir_version": META_PLANNER_IR_VERSION,
+                "adapter_version": META_PLANNER_ADAPTER_VERSION,
+                "config_schema_checksum": self.config_schema_checksum,
+                "compiler_checksum": contract.compiler_checksum,
+            }
+        )
 
 
 def _compile_workflow_agent(
@@ -163,12 +178,36 @@ def _decompile_workflow_agent(node: NativeWorkflowNode) -> MetaPlannerIRNode:
     )
 
 
+def _decompile_workflow_agent_v3(node: NativeWorkflowNode) -> GraphIntentNodeV3:
+    legacy = _decompile_workflow_agent(node)
+    data = node.data if isinstance(node.data, dict) else {}
+    if int(data.get("plannerIRVersion") or 0) != META_PLANNER_IR_VERSION:
+        raise ValueError("Workflow Agent does not carry Graph IR V3 metadata.")
+    inputs = data.get("plannerInputsV3")
+    outputs = data.get("plannerOutputsV3")
+    if not isinstance(inputs, list) or not isinstance(outputs, list):
+        raise ValueError("Workflow Agent is missing Graph IR V3 port metadata.")
+    return GraphIntentNodeV3.model_validate(
+        {
+            "ref": legacy.ref,
+            "kind": legacy.kind,
+            "title": legacy.title,
+            "description": legacy.description,
+            "task_ids": legacy.task_ids,
+            "inputs": inputs,
+            "outputs": outputs,
+            "config": legacy.config,
+        }
+    )
+
+
 PLANNER_NODE_ADAPTERS: dict[str, PlannerNodeAdapter] = {
     "workflow_agent": PlannerNodeAdapter(
         kind="workflow_agent",
         config_model=MetaPlannerWorkflowAgentConfig,
         compile_node=_compile_workflow_agent,
         decompile_node=_decompile_workflow_agent,
+        decompile_node_v3=_decompile_workflow_agent_v3,
     )
 }
 
@@ -190,6 +229,14 @@ def decompile_planner_node(node: NativeWorkflowNode) -> MetaPlannerIRNode:
     if adapter is None:
         raise ValueError(f"Node kind {kind} has no compiler adapter.")
     return adapter.decompile_node(node)
+
+
+def decompile_planner_node_v3(node: NativeWorkflowNode) -> GraphIntentNodeV3:
+    kind = str((node.data or {}).get("kind") or node.type or "")
+    adapter = get_planner_node_adapter(kind)
+    if adapter is None:
+        raise ValueError(f"Node kind {kind} has no compiler adapter.")
+    return adapter.decompile_node_v3(node)
 
 
 def planner_capability_metadata(kind: str) -> dict[str, Any] | None:
@@ -215,6 +262,21 @@ def planner_capability_metadata(kind: str) -> dict[str, Any] | None:
         if adapter.config_schema_checksum != contract_schema_checksum:
             return None
         support = "full"
+    adapter = get_planner_node_adapter(kind)
+    adapter_checksum = (
+        adapter.adapter_checksum
+        if adapter is not None
+        else canonical_checksum(
+            {
+                "kind": kind,
+                "ir_version": META_PLANNER_IR_VERSION,
+                "adapter_version": META_PLANNER_ADAPTER_VERSION,
+                "support": support,
+                "compiler_checksum": contract.compiler_checksum,
+                "config_schema_checksum": "compiler-managed",
+            }
+        )
+    )
     return {
         "compilable": True,
         "support": support,
@@ -223,4 +285,5 @@ def planner_capability_metadata(kind: str) -> dict[str, Any] | None:
         "contract_version": NODE_CONTRACT_VERSION,
         "contract_checksum": contract.checksum,
         "compiler_checksum": contract.compiler_checksum,
+        "adapter_checksum": adapter_checksum,
     }

--- a/server/meta_agent/schemas.py
+++ b/server/meta_agent/schemas.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import re
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    field_validator,
+    model_validator,
+)
 
 try:
     from server.workflow_native.node_contracts import (
@@ -354,6 +361,15 @@ class GraphIntentFinalOutputV3(BaseModel):
 
 class GraphIntentV3(BaseModel):
     model_config = ConfigDict(extra="forbid")
+
+    # Trusted decompilation constraints are deliberately absent from the JSON
+    # schema, so model output cannot forge immutable resource versions.
+    _pinned_resource_versions: dict[tuple[str, str], int] = PrivateAttr(
+        default_factory=dict
+    )
+    _pinned_prompt_profile_versions: dict[str, int] = PrivateAttr(
+        default_factory=dict
+    )
 
     ir_version: Literal[3] = 3
     name: str = Field(min_length=1, max_length=120)

--- a/server/meta_agent/schemas.py
+++ b/server/meta_agent/schemas.py
@@ -3,12 +3,18 @@ from __future__ import annotations
 import re
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 try:
-    from server.workflow_native.node_contracts import WorkflowAgentPlannerConfig
+    from server.workflow_native.node_contracts import (
+        WorkflowAgentPlannerConfig,
+        WorkflowValueSchema,
+    )
 except ModuleNotFoundError:
-    from workflow_native.node_contracts import WorkflowAgentPlannerConfig
+    from workflow_native.node_contracts import (
+        WorkflowAgentPlannerConfig,
+        WorkflowValueSchema,
+    )
 
 
 class MetaAgentGenerateRequest(BaseModel):
@@ -164,7 +170,7 @@ class MetaPlannerResourceBinding(BaseModel):
     tool_name: str = Field(default="", max_length=120)
     description: str = Field(default="", max_length=1_000)
     top_k: int = Field(default=5, ge=1, le=50)
-    score_threshold: float = Field(default=0, ge=0, le=1)
+    score_threshold: float = Field(default=0.0, ge=0, le=1)
 
 
 class MetaPlannerMiddlewareBinding(BaseModel):
@@ -241,6 +247,8 @@ class MetaPlannerIRControlEdge(BaseModel):
 
 
 class MetaPlannerIRResourceBinding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     target_ref: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,63}$")
     kind: Literal[
         "external_xpert",
@@ -252,10 +260,12 @@ class MetaPlannerIRResourceBinding(BaseModel):
     tool_name: str = Field(default="", max_length=120)
     description: str = Field(default="", max_length=1_000)
     top_k: int = Field(default=5, ge=1, le=50)
-    score_threshold: float = Field(default=0, ge=0, le=1)
+    score_threshold: float = Field(default=0.0, ge=0, le=1)
 
 
 class MetaPlannerIRMiddlewareBinding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     target_ref: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,63}$")
     middleware_id: str = Field(min_length=1, max_length=160)
     priority: int = Field(default=100, ge=0, le=10_000)
@@ -290,9 +300,163 @@ class MetaPlannerTypedBlueprintV2(BaseModel):
     final_output: MetaPlannerIRFinalOutput
 
 
+class GraphIntentInputBindingV3(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    port: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_-]{0,63}$")
+    variable: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
+    source_ref: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,63}$")
+    source_port: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_-]{0,63}$")
+    value_schema: WorkflowValueSchema = Field(default_factory=WorkflowValueSchema)
+
+
+class GraphIntentOutputBindingV3(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    port: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_-]{0,63}$")
+    variable: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
+    value_schema: WorkflowValueSchema = Field(default_factory=WorkflowValueSchema)
+
+
+class GraphIntentNodeV3(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ref: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,63}$")
+    kind: str = Field(min_length=1, max_length=80)
+    title: str = Field(min_length=1, max_length=120)
+    description: str = Field(default="", max_length=2_000)
+    task_ids: list[str] = Field(min_length=1, max_length=8)
+    inputs: list[GraphIntentInputBindingV3] = Field(
+        default_factory=list, max_length=16
+    )
+    outputs: list[GraphIntentOutputBindingV3] = Field(
+        default_factory=list, max_length=16
+    )
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class GraphIntentControlEdgeV3(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_ref: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,63}$")
+    target_ref: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,63}$")
+    outcome: Literal["success"] = "success"
+    join: Literal["all"] = "all"
+
+
+class GraphIntentFinalOutputV3(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    node_ref: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,63}$")
+    port: str = Field(default="result", pattern=r"^[A-Za-z_][A-Za-z0-9_-]{0,63}$")
+    variable: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
+
+
+class GraphIntentV3(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ir_version: Literal[3] = 3
+    name: str = Field(min_length=1, max_length=120)
+    description: str = Field(default="", max_length=2_000)
+    tags: list[str] = Field(default_factory=list, max_length=20)
+    starters: list[str] = Field(default_factory=list, max_length=8)
+    nodes: list[GraphIntentNodeV3] = Field(min_length=1, max_length=24)
+    control_edges: list[GraphIntentControlEdgeV3] = Field(
+        default_factory=list, max_length=40
+    )
+    resources: list[MetaPlannerIRResourceBinding] = Field(
+        default_factory=list, max_length=40
+    )
+    middleware: list[MetaPlannerIRMiddlewareBinding] = Field(
+        default_factory=list, max_length=40
+    )
+    prompt_profile_ids: list[str] = Field(default_factory=list, max_length=20)
+    final_output: GraphIntentFinalOutputV3
+
+
+class ResolvedGraphPortV3(BaseModel):
+    name: str
+    direction: Literal["input", "output"]
+    value_schema: WorkflowValueSchema
+    required: bool = False
+    cardinality: Literal["one", "many"] = "one"
+    binding: Literal["variable", "literal", "resource", "none"] = "variable"
+
+
+class ResolvedGraphNodeV3(BaseModel):
+    ref: str
+    node_id: str
+    kind: str
+    role: Literal["input", "output", "executable", "resource", "metadata"]
+    title: str
+    description: str = ""
+    task_ids: list[str] = Field(default_factory=list)
+    config: dict[str, Any] = Field(default_factory=dict)
+    ports: list[ResolvedGraphPortV3] = Field(default_factory=list)
+    contract_version: int
+    contract_checksum: str
+    compiler_checksum: str
+    execution: dict[str, Any] = Field(default_factory=dict)
+    resource_contracts: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class ResolvedGraphEndpointV3(BaseModel):
+    node_ref: str
+    node_id: str
+    port: str | None = None
+    handle: str | None = None
+
+
+class ResolvedGraphEdgeV3(BaseModel):
+    ref: str
+    mode: Literal["control", "data", "binding", "metadata"]
+    source: ResolvedGraphEndpointV3
+    target: ResolvedGraphEndpointV3
+    variable: str | None = None
+    value_schema: WorkflowValueSchema | None = None
+    outcome: Literal["success"] | None = None
+    join: Literal["all"] | None = None
+
+
+class ResolvedPromptProfileV3(BaseModel):
+    profile_id: str
+    pinned_version: int
+    checksum: str = ""
+
+
+class ResolvedGraphIRV3(BaseModel):
+    ir_version: Literal[3] = 3
+    name: str
+    description: str = ""
+    tags: list[str] = Field(default_factory=list)
+    starters: list[str] = Field(default_factory=list)
+    nodes: list[ResolvedGraphNodeV3]
+    edges: list[ResolvedGraphEdgeV3]
+    prompt_profiles: list[ResolvedPromptProfileV3] = Field(default_factory=list)
+    final_output: GraphIntentFinalOutputV3
+    default_outcome: Literal["success"] = "success"
+    join_policy: Literal["all"] = "all"
+    terminal_count: Literal[1] = 1
+    compensation: dict[str, Any] = Field(
+        default_factory=lambda: {"enabled": False}
+    )
+    contract_version: int
+    capability_snapshot_version: str
+    capability_snapshot_hash: str
+    graph_checksum: str = ""
+
+
+class MetaPlannerIRCompatibility(BaseModel):
+    source_version: Literal[2, 3]
+    upgraded: bool = False
+    lossy: bool = False
+    warnings: list[str] = Field(default_factory=list)
+
+
 class MetaPlannerCapabilitySnapshot(BaseModel):
     version: str
-    ir_version: Literal[2] = 2
+    ir_version: Literal[2, 3] = 2
+    supported_ir_versions: list[Literal[2, 3]] = Field(default_factory=lambda: [2])
     # Persisted V2 proposals did not carry NodeContract metadata. Keep them
     # readable; newly built snapshots always set the V3 values explicitly.
     contract_version: int = 2
@@ -320,6 +484,12 @@ class MetaPlannerPreviewResponse(BaseModel):
     repair_used: bool = False
     capability_snapshot_version: str
     capability_snapshot_hash: str
+    ir_version: Literal[2, 3] = 3
+    graph_ir: dict[str, Any] | None = None
+    graph_ir_checksum: str = ""
+    compatibility: MetaPlannerIRCompatibility = Field(
+        default_factory=lambda: MetaPlannerIRCompatibility(source_version=3)
+    )
 
 
 class MetaPlannerGenerateResponse(BaseModel):
@@ -335,5 +505,11 @@ class MetaPlannerGenerateResponse(BaseModel):
     repair_used: bool = False
     capability_snapshot_version: str
     capability_snapshot_hash: str
+    ir_version: Literal[2, 3] = 3
+    graph_ir: dict[str, Any] | None = None
+    graph_ir_checksum: str = ""
+    compatibility: MetaPlannerIRCompatibility = Field(
+        default_factory=lambda: MetaPlannerIRCompatibility(source_version=3)
+    )
     run_id: str | None = None
     provider_route_receipts: ProviderRouteReceiptSummary | None = None

--- a/server/tests/test_meta_agent_managed_endpoints.py
+++ b/server/tests/test_meta_agent_managed_endpoints.py
@@ -8,6 +8,7 @@ import pytest_asyncio
 
 from server import main as main_module
 from server.main import app
+from server.meta_agent.graph_ir_v3 import v2_to_graph_intent
 from server.meta_agent.schemas import (
     MetaPlannerIRFinalOutput,
     MetaPlannerIRInputBinding,
@@ -126,7 +127,7 @@ def _planner_outputs() -> list[str]:
             )
         ],
     )
-    blueprint = MetaPlannerTypedBlueprintV2(
+    legacy_blueprint = MetaPlannerTypedBlueprintV2(
         name="Managed Meta Agent",
         description="A bounded managed candidate.",
         nodes=[
@@ -153,6 +154,9 @@ def _planner_outputs() -> list[str]:
         ],
         final_output=MetaPlannerIRFinalOutput(node_ref="writer", variable="answer"),
     )
+    blueprint, compatibility = v2_to_graph_intent(legacy_blueprint)
+    assert blueprint is not None
+    assert compatibility.lossy is False
     return [
         plan.model_dump_json(),
         json.dumps({"name": "invalid"}),

--- a/server/tests/test_meta_planner_v2.py
+++ b/server/tests/test_meta_planner_v2.py
@@ -128,6 +128,7 @@ def test_blueprint_and_repair_prompts_expose_typed_ir_agent_constraints():
 
     for prompt in (blueprint_prompt, repair_prompt):
         constraints = prompt["typed_ir_constraints"]
+        graph_contract = prompt["graph_intent_contract"]
         assert constraints["max_workflow_agent_nodes"] == request.max_agents
         assert constraints["required_task_ids"] == [
             task.task_id for task in plan.tasks
@@ -155,7 +156,44 @@ def test_blueprint_and_repair_prompts_expose_typed_ir_agent_constraints():
             "group compatible task_ids" in rule
             for rule in constraints["rules"]
         )
+        assert graph_contract["required_ir_version"] == 3
+        assert graph_contract["node_roles"] == {
+            "executable_node_kinds": ["workflow_agent"],
+            "compiler_managed_node_kinds": ["input", "output"],
+            "resource_binding_kinds": [
+                "external_xpert",
+                "knowledge_base",
+                "plugin_resource",
+                "toolset_resource",
+            ],
+        }
+        assert graph_contract["workflow_agent"]["config_field_names"] == list(
+            MetaPlannerWorkflowAgentConfig.model_fields
+        )
+        assert graph_contract["workflow_agent"]["input_port"] == {
+            "name": "task",
+            "cardinality": "many",
+            "root_source_ref": "input",
+            "root_source_port": "user_input",
+            "root_variable": "user_input",
+        }
+        assert any(
+            "never emit outputVariable" in rule
+            for rule in graph_contract["rules"]
+        )
+        assert (
+            prompt["capability_snapshot"]["graph_intent_contract"]
+            == graph_contract
+        )
         assert prompt["default_agent_model_id"] == request.default_agent_model_id
+        example = GraphIntentV3.model_validate(prompt["canonical_minimal_example"])
+        assert example.ir_version == 3
+        assert [node.kind for node in example.nodes] == ["workflow_agent"]
+        assert example.nodes[0].task_ids == [task.task_id for task in plan.tasks]
+        assert example.nodes[0].inputs[0].port == "task"
+        assert example.nodes[0].inputs[0].source_ref == "input"
+        assert example.nodes[0].inputs[0].value_schema.type == "string"
+        assert example.nodes[0].config["model_id"] == request.default_agent_model_id
 
     assert repair_prompt["validation_issues"] == [
         "Typed IR exceeds max_agents=3."
@@ -712,7 +750,7 @@ async def test_generation_persists_proposal_and_uses_at_most_one_repair(
     assert graph_intent is not None
     outputs = [
         _plan().model_dump_json(),
-        json.dumps({"name": "invalid"}, ensure_ascii=False),
+        _typed_blueprint().model_dump_json(),
         graph_intent.model_dump_json(),
     ]
     calls = []
@@ -858,7 +896,9 @@ async def test_update_revision_drift_uses_final_proposal_validation(
         return original_validate(proposal_id, revision=revision)
 
     authoring.validate = validate_after_revision_drift  # type: ignore[method-assign]
-    outputs = [_plan().model_dump_json(), _typed_blueprint().model_dump_json()]
+    graph_intent, _ = v2_to_graph_intent(_typed_blueprint())
+    assert graph_intent is not None
+    outputs = [_plan().model_dump_json(), graph_intent.model_dump_json()]
 
     async def complete(model_id, system_prompt, user_prompt, temperature, max_tokens):
         return outputs.pop(0)
@@ -875,8 +915,8 @@ async def test_update_revision_drift_uses_final_proposal_validation(
     response = await service.generate(request, _snapshot(), target=target)
 
     proposal = proposal_store.require(response.proposal_id)
-    assert response.compatibility.source_version == 2
-    assert response.compatibility.upgraded is True
+    assert response.compatibility.source_version == 3
+    assert response.compatibility.upgraded is False
     assert proposal.validation["valid"] is False
     assert response.validation["valid"] is False
     authoring_stage = next(

--- a/server/tests/test_meta_planner_v2.py
+++ b/server/tests/test_meta_planner_v2.py
@@ -6,9 +6,16 @@ from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 from server.main import app
 from server.meta_agent.capabilities import build_capability_snapshot
+from server.meta_agent.graph_ir_v3 import (
+    decompile_candidate_to_graph_intent,
+    resolve_graph_intent,
+    v2_to_graph_intent,
+    workflow_semantic_checksum,
+)
 from server.meta_agent.meta_planner_v2 import (
     MetaPlannerV2Service,
     compile_xpert_candidate,
@@ -16,6 +23,7 @@ from server.meta_agent.meta_planner_v2 import (
     validate_task_plan,
 )
 from server.meta_agent.schemas import (
+    GraphIntentV3,
     MetaPlannerAgentBlueprint,
     MetaPlannerBlueprint,
     MetaPlannerGenerateRequest,
@@ -432,8 +440,9 @@ def test_capability_api_returns_stable_safe_contract():
     response = client.get("/api/meta-agent/capabilities")
     assert response.status_code == 200
     payload = response.json()
-    assert payload["version"] == "evoagentx-meta-planner-capabilities-v3"
-    assert payload["ir_version"] == 2
+    assert payload["version"] == "evoagentx-meta-planner-capabilities-v4"
+    assert payload["ir_version"] == 3
+    assert payload["supported_ir_versions"] == [2, 3]
     assert payload["contract_version"] == 3
     assert len(payload["contract_checksum"]) == 64
     assert payload["snapshot_hash"]
@@ -456,7 +465,8 @@ def test_capability_snapshot_only_exposes_compilable_node_kinds():
         "plugin_resource",
     }
     assert all(item["planner"]["compilable"] for item in snapshot.nodes)
-    assert all(item["planner"]["ir_version"] == 2 for item in snapshot.nodes)
+    assert all(item["planner"]["ir_version"] == 3 for item in snapshot.nodes)
+    assert all(len(item["planner"]["adapter_checksum"]) == 64 for item in snapshot.nodes)
     assert all(item["contract"]["contract_status"] == "complete" for item in snapshot.nodes)
     assert all(
         item["planner"]["contract_checksum"] == item["contract"]["checksum"]
@@ -499,6 +509,96 @@ def test_compiler_creates_control_and_five_binding_edge_shapes():
             "enabled": True,
         }
     ]
+
+
+def test_v3_graph_ir_keeps_data_edges_out_of_native_topology_and_round_trips():
+    snapshot = _snapshot()
+    request = _request()
+    plan = _plan()
+    intent, compatibility = v2_to_graph_intent(_typed_blueprint())
+
+    assert intent is not None
+    assert compatibility.upgraded is True
+    assert compatibility.lossy is False
+    graph = resolve_graph_intent(
+        intent, snapshot, default_agent_model_id=request.default_agent_model_id
+    )
+    assert {edge.mode for edge in graph.edges} == {
+        "control",
+        "data",
+        "binding",
+        "metadata",
+    }
+    assert graph.graph_checksum
+    assert next(
+        node for node in graph.nodes if node.kind == "toolset_resource"
+    ).config["pinned_version"] == 2
+    assert next(
+        node for node in graph.nodes if node.kind == "knowledge_base"
+    ).config["observed_active_version_id"] == "version-3"
+
+    candidate = compile_xpert_candidate(
+        request=request,
+        plan=plan,
+        blueprint=intent,
+        snapshot=snapshot,
+        target=None,
+    )
+    native_edges = candidate["draft"]["workflow"]["edges"]
+    assert all("variable" not in edge for edge in native_edges)
+    assert len(native_edges) == len(
+        [edge for edge in graph.edges if edge.mode in {"control", "binding", "metadata"}]
+    )
+
+    restored_intent = decompile_candidate_to_graph_intent(candidate)
+    restored_graph = resolve_graph_intent(
+        restored_intent,
+        snapshot,
+        default_agent_model_id=request.default_agent_model_id,
+    )
+    restored_candidate = compile_xpert_candidate(
+        request=request,
+        plan=plan,
+        blueprint=restored_intent,
+        snapshot=snapshot,
+        target=None,
+    )
+    assert restored_graph.graph_checksum == graph.graph_checksum
+    assert workflow_semantic_checksum(restored_candidate) == workflow_semantic_checksum(
+        candidate
+    )
+
+
+def test_v2_upgrade_rejects_ambiguous_variable_provenance():
+    blueprint = _typed_blueprint().model_copy(deep=True)
+    duplicate = blueprint.nodes[0].model_copy(deep=True)
+    duplicate.ref = "duplicate_researcher"
+    blueprint.nodes.append(duplicate)
+
+    intent, compatibility = v2_to_graph_intent(blueprint)
+
+    assert intent is None
+    assert compatibility.lossy is True
+    assert any("lossy_conversion" in warning for warning in compatibility.warnings)
+
+
+def test_v3_intent_rejects_forged_versions_and_unknown_ports():
+    intent, _ = v2_to_graph_intent(_typed_blueprint())
+    assert intent is not None
+    forged = intent.model_dump(mode="json")
+    forged["resources"][0]["pinned_version"] = 99
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        GraphIntentV3.model_validate(forged)
+
+    invalid_port = intent.model_copy(deep=True)
+    invalid_port.nodes[1].inputs[0].port = "invented_port"
+    with pytest.raises(ValueError, match="unknown input port"):
+        resolve_graph_intent(
+            invalid_port,
+            _snapshot(),
+            default_agent_model_id=_request().default_agent_model_id,
+        )
 
 
 def test_typed_ir_allows_one_agent_to_cover_multiple_tasks():
@@ -608,10 +708,12 @@ async def test_generation_persists_proposal_and_uses_at_most_one_repair(
         skill_store,
         xpert_preflight=preflight,
     )
+    graph_intent, _ = v2_to_graph_intent(_typed_blueprint())
+    assert graph_intent is not None
     outputs = [
         _plan().model_dump_json(),
         json.dumps({"name": "invalid"}, ensure_ascii=False),
-        _typed_blueprint().model_dump_json(),
+        graph_intent.model_dump_json(),
     ]
     calls = []
 
@@ -639,6 +741,14 @@ async def test_generation_persists_proposal_and_uses_at_most_one_repair(
     assert proposal.source_type == "meta_planner"
     assert proposal.status == "pending"
     assert proposal.validation["valid"] is True
+    report = proposal.payload["meta_planner_report"]
+    assert response.ir_version == 3
+    assert response.graph_ir_checksum == report["graph_ir_checksum"]
+    assert report["graph_ir_status"] == "current"
+    assert report["graph_ir"]["ir_version"] == 3
+    assert report["compatibility"]["source_version"] == 3
+    assert report["compatibility"]["upgraded"] is False
+    assert len(report["compiled_workflow_checksum"]) == 64
     assert xpert_store.list_xperts() == []
 
     approved = authoring.approve(
@@ -709,6 +819,8 @@ async def test_failed_repair_persists_unapprovable_candidate_until_human_edit(
         revision=proposal.revision,
         payload=edited_payload,
     )
+    assert edited.payload["meta_planner_report"]["graph_ir_status"] == "stale"
+    assert edited.payload["meta_planner_report"]["human_modified"] is True
     validated = authoring.validate(
         edited.proposal_id,
         revision=edited.revision,
@@ -763,6 +875,8 @@ async def test_update_revision_drift_uses_final_proposal_validation(
     response = await service.generate(request, _snapshot(), target=target)
 
     proposal = proposal_store.require(response.proposal_id)
+    assert response.compatibility.source_version == 2
+    assert response.compatibility.upgraded is True
     assert proposal.validation["valid"] is False
     assert response.validation["valid"] is False
     authoring_stage = next(

--- a/server/tests/test_meta_planner_v3_falsification.py
+++ b/server/tests/test_meta_planner_v3_falsification.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from server.meta_agent.graph_ir_v3 import (
+    _schemas_compatible,
+    decompile_candidate_to_graph_intent,
+    resolve_graph_intent,
+    v2_to_graph_intent,
+    workflow_semantic_checksum,
+)
+from server.meta_agent.meta_planner_v2 import (
+    MetaPlannerV2Service,
+    compile_xpert_candidate,
+    legacy_blueprint_to_typed_ir,
+    validate_blueprint_authorization,
+)
+from server.meta_agent.schemas import (
+    GraphIntentFinalOutputV3,
+    GraphIntentInputBindingV3,
+    GraphIntentNodeV3,
+    GraphIntentOutputBindingV3,
+    GraphIntentV3,
+    MetaPlannerIRInputBinding,
+    MetaPlannerIROutputBinding,
+    MetaPlannerIRResourceBinding,
+)
+from server.tests.test_meta_planner_v2 import (
+    _blueprint,
+    _plan,
+    _request,
+    _snapshot,
+    _typed_blueprint,
+)
+from server.workflow_native.node_contracts import WorkflowValueSchema
+
+
+def _intent() -> GraphIntentV3:
+    intent, compatibility = v2_to_graph_intent(_typed_blueprint())
+    assert intent is not None and not compatibility.lossy
+    return intent
+
+
+def test_attack_model_prompt_exposes_only_authorized_v3_node_roles_and_resources():
+    request = _request().model_copy(deep=True)
+    request.scope.toolset_ids = []
+    request.scope.middleware_ids = []
+    snapshot = _snapshot()
+
+    blueprint_prompt = json.loads(
+        MetaPlannerV2Service._blueprint_prompt(request, _plan(), snapshot, None)
+    )
+    repair_prompt = json.loads(
+        MetaPlannerV2Service._repair_prompt(
+            request,
+            _plan(),
+            snapshot,
+            '{"ir_version":2}',
+            ["Legacy V2 IR is not valid for a new V3 generation."],
+        )
+    )
+
+    for prompt in (blueprint_prompt, repair_prompt):
+        contract = prompt["graph_intent_contract"]
+        example = GraphIntentV3.model_validate(prompt["canonical_minimal_example"])
+        assert contract["required_ir_version"] == 3
+        assert example.ir_version == 3
+        assert [node.kind for node in example.nodes] == ["workflow_agent"]
+        assert contract["node_roles"]["executable_node_kinds"] == [
+            "workflow_agent"
+        ]
+        assert contract["node_roles"]["compiler_managed_node_kinds"] == [
+            "input",
+            "output",
+        ]
+        assert prompt["capability_snapshot"]["resources"]["toolsets"] == []
+        assert prompt["capability_snapshot"]["middleware"] == []
+        assert any(
+            "never return a V2" in rule for rule in contract["rules"]
+        )
+
+
+def test_attack_resolver_rejects_node_not_exposed_by_capability_snapshot():
+    intent = GraphIntentV3(
+        name="Unsupported node attack",
+        nodes=[
+            GraphIntentNodeV3(
+                ref="serializer",
+                kind="json_serialize",
+                title="Serializer",
+                task_ids=["research"],
+                inputs=[
+                    GraphIntentInputBindingV3(
+                        port="value",
+                        variable="user_input",
+                        source_ref="input",
+                        source_port="user_input",
+                        value_schema=WorkflowValueSchema(type="string"),
+                    )
+                ],
+                outputs=[
+                    GraphIntentOutputBindingV3(
+                        port="json",
+                        variable="serialized",
+                        value_schema=WorkflowValueSchema(type="string"),
+                    )
+                ],
+                config={
+                    "inputVariable": "user_input",
+                    "outputVariable": "serialized",
+                    "format": "compact",
+                },
+            )
+        ],
+        final_output=GraphIntentFinalOutputV3(
+            node_ref="serializer", port="json", variable="serialized"
+        ),
+    )
+
+    with pytest.raises(ValueError, match="capability snapshot|Planner"):
+        resolve_graph_intent(intent, _snapshot())
+
+
+def test_attack_resolver_rejects_resource_binding_to_compiler_input():
+    intent = _intent().model_copy(deep=True)
+    intent.resources[0].target_ref = "input"
+
+    with pytest.raises(ValueError, match="workflow_agent"):
+        resolve_graph_intent(intent, _snapshot())
+
+
+def test_attack_resolver_rejects_duplicate_resource_binding():
+    intent = _intent().model_copy(deep=True)
+    intent.resources.append(intent.resources[1].model_copy(deep=True))
+
+    with pytest.raises(ValueError, match="duplicate resource"):
+        resolve_graph_intent(intent, _snapshot())
+
+
+def test_attack_normalized_node_id_collision_is_rejected_by_resolver():
+    intent = _intent().model_copy(deep=True)
+    duplicate = intent.nodes[0].model_copy(deep=True)
+    duplicate.ref = "researcher-x"
+    duplicate.outputs[0].variable = "secondary_research_output"
+    intent.nodes[0].ref = "researcher_x"
+    intent.nodes.append(duplicate)
+    intent.control_edges = [
+        intent.control_edges[0].model_copy(
+            update={"source_ref": "researcher_x", "target_ref": "writer"}
+        ),
+        intent.control_edges[0].model_copy(
+            update={"source_ref": "researcher-x", "target_ref": "writer"}
+        ),
+    ]
+    for binding in intent.resources:
+        if binding.target_ref == "researcher":
+            binding.target_ref = "researcher_x"
+    intent.nodes[1].inputs = [
+        item.model_copy(update={"source_ref": "researcher_x"})
+        for item in intent.nodes[1].inputs
+    ]
+
+    with pytest.raises(ValueError, match="normalization"):
+        resolve_graph_intent(intent, _snapshot())
+
+
+def test_attack_external_tool_name_is_part_of_resolved_semantics():
+    first = _intent().model_copy(deep=True)
+    second = _intent().model_copy(deep=True)
+    first.resources[0].tool_name = "research_primary"
+    second.resources[0].tool_name = "research_secondary"
+
+    first_graph = resolve_graph_intent(first, _snapshot())
+    second_graph = resolve_graph_intent(second, _snapshot())
+    first_resource = next(
+        node for node in first_graph.nodes if node.kind == "external_xpert"
+    )
+
+    assert first_resource.config["tool_name"] == "research_primary"
+    assert first_graph.graph_checksum != second_graph.graph_checksum
+
+
+def test_attack_v2_external_name_collision_fails_closed():
+    blueprint = _typed_blueprint().model_copy(deep=True)
+    blueprint.nodes[0].outputs = [
+        MetaPlannerIROutputBinding(
+            port="result", variable="user_input", value_type="string"
+        )
+    ]
+    blueprint.nodes[1].inputs = [
+        MetaPlannerIRInputBinding(
+            port="evidence", variable="user_input", value_type="string"
+        )
+    ]
+    blueprint.nodes[1].config["task_input"] = "{{user_input}}"
+    blueprint.final_output.variable = "agent_output"
+
+    intent, compatibility = v2_to_graph_intent(blueprint)
+
+    assert intent is None and compatibility.lossy
+    assert any(
+        "reserved external variables" in item
+        for item in compatibility.warnings
+    )
+
+
+def test_attack_legacy_downstream_user_input_gets_explicit_v3_data_edge():
+    blueprint = _blueprint().model_copy(deep=True)
+    blueprint.agents[1].task_input = "{{user_input}} {{research_output}}"
+    typed = legacy_blueprint_to_typed_ir(_plan(), blueprint)
+
+    intent, compatibility = v2_to_graph_intent(typed)
+
+    assert intent is not None and not compatibility.lossy
+    writer = next(node for node in intent.nodes if node.ref == "agent_deliver")
+    assert any(
+        item.variable == "user_input"
+        and item.source_ref == "input"
+        and item.source_port == "user_input"
+        for item in writer.inputs
+    )
+
+
+def test_attack_template_variables_must_have_explicit_data_bindings():
+    intent = _intent().model_copy(deep=True)
+    writer = next(node for node in intent.nodes if node.ref == "writer")
+    writer.config["task_input"] = "{{research_output}} {{user_input}}"
+
+    issues = validate_blueprint_authorization(
+        _request(), _plan(), intent, _snapshot()
+    )
+
+    assert any("explicit" in issue and "user_input" in issue for issue in issues)
+
+
+def test_attack_complex_template_expression_is_rejected_not_silently_ignored():
+    intent = _intent().model_copy(deep=True)
+    writer = next(node for node in intent.nodes if node.ref == "writer")
+    writer.config["task_input"] = "{{research_output.value}}"
+
+    with pytest.raises(ValueError, match="unsupported template expression"):
+        resolve_graph_intent(intent, _snapshot())
+
+
+def test_attack_json_example_braces_are_not_misclassified_as_variables():
+    intent = _intent().model_copy(deep=True)
+    writer = next(node for node in intent.nodes if node.ref == "writer")
+    writer.config["role_prompt"] = (
+        'Return JSON shaped like {"answer": "..."} from {{research_output}}.'
+    )
+
+    graph = resolve_graph_intent(intent, _snapshot())
+
+    resolved_writer = next(node for node in graph.nodes if node.ref == "writer")
+    assert '{"answer": "..."}' in resolved_writer.config["role_prompt"]
+
+
+def test_attack_unknown_middleware_config_is_rejected_before_persistence():
+    intent = _intent().model_copy(deep=True)
+    intent.middleware[0].config["api_key"] = "sk-adversarial-placeholder"
+
+    issues = validate_blueprint_authorization(
+        _request(), _plan(), intent, _snapshot()
+    )
+
+    assert any("api_key" in issue and "not declared" in issue for issue in issues)
+
+
+def test_attack_permutations_do_not_change_graph_checksum():
+    baseline = _intent()
+    permuted = baseline.model_copy(deep=True)
+    permuted.nodes = list(reversed(permuted.nodes))
+    permuted.resources = list(reversed(permuted.resources))
+    permuted.middleware = list(reversed(permuted.middleware))
+
+    first = resolve_graph_intent(baseline, _snapshot())
+    second = resolve_graph_intent(permuted, _snapshot())
+
+    assert first.graph_checksum == second.graph_checksum
+
+
+def test_attack_decompile_does_not_silently_repin_immutable_resource():
+    snapshot = _snapshot()
+    request = _request()
+    plan = _plan()
+    intent = _intent()
+    candidate = compile_xpert_candidate(
+        request=request,
+        plan=plan,
+        blueprint=intent,
+        snapshot=snapshot,
+        target=None,
+    )
+    restored = decompile_candidate_to_graph_intent(candidate)
+    newer_snapshot = snapshot.model_copy(deep=True)
+    newer_snapshot.toolsets[0]["published_version"] = 3
+
+    resolve_graph_intent(restored, snapshot)
+    with pytest.raises(ValueError, match="drifted from pinned version 2 to 3"):
+        resolve_graph_intent(restored, newer_snapshot)
+
+
+def test_attack_nested_value_schema_mismatch_is_not_hidden_by_outer_type():
+    source = WorkflowValueSchema(
+        type="array",
+        items=WorkflowValueSchema(
+            type="object",
+            properties={"answer": WorkflowValueSchema(type="string")},
+            required=("answer",),
+        ),
+    )
+    target = WorkflowValueSchema(
+        type="array",
+        items=WorkflowValueSchema(
+            type="object",
+            properties={"score": WorkflowValueSchema(type="number")},
+            required=("score",),
+        ),
+    )
+
+    assert not _schemas_compatible(source, target)
+
+
+def test_attack_nullable_source_cannot_flow_into_non_nullable_target():
+    assert not _schemas_compatible(
+        WorkflowValueSchema(type="string", nullable=True),
+        WorkflowValueSchema(type="string", nullable=False),
+    )
+    assert _schemas_compatible(
+        WorkflowValueSchema(type="string", nullable=True),
+        WorkflowValueSchema(type="string", nullable=True),
+    )
+    assert _schemas_compatible(
+        WorkflowValueSchema(type="integer"),
+        WorkflowValueSchema(type="number"),
+    )
+
+
+def test_attack_display_order_does_not_change_semantic_checksums():
+    first = _intent().model_copy(deep=True)
+    first.tags = ["review", "research"]
+    first.starters = ["Review this", "Research this"]
+    first.prompt_profile_ids = ["prompt-review", "prompt-secondary"]
+    second = first.model_copy(deep=True)
+    second.tags.reverse()
+    second.starters.reverse()
+    second.prompt_profile_ids.reverse()
+
+    snapshot = _snapshot()
+    second_profile = dict(snapshot.prompt_profiles[0])
+    second_profile["id"] = "prompt-secondary"
+    second_profile["name"] = "Secondary prompt"
+    snapshot.prompt_profiles.append(second_profile)
+
+    first_graph = resolve_graph_intent(first, snapshot)
+    second_graph = resolve_graph_intent(second, snapshot)
+    assert first_graph.graph_checksum == second_graph.graph_checksum
+
+    candidate = compile_xpert_candidate(
+        request=_request(),
+        plan=_plan(),
+        blueprint=first,
+        snapshot=snapshot,
+        target=None,
+    )
+    extra_profile = dict(candidate["draft"]["prompt_profiles"][0])
+    extra_profile["profile_id"] = "prompt-third"
+    candidate["draft"]["prompt_profiles"].append(extra_profile)
+    reordered = {
+        **candidate,
+        "draft": {
+            **candidate["draft"],
+            "prompt_profiles": list(
+                reversed(candidate["draft"]["prompt_profiles"])
+            ),
+        },
+    }
+    assert workflow_semantic_checksum(candidate) == workflow_semantic_checksum(
+        reordered
+    )
+
+
+def test_attack_snapshot_adapter_checksum_tampering_fails_closed():
+    snapshot = _snapshot().model_copy(deep=True)
+    workflow_agent = next(
+        item for item in snapshot.nodes if item["kind"] == "workflow_agent"
+    )
+    workflow_agent["planner"]["adapter_checksum"] = "0" * 64
+
+    with pytest.raises(ValueError, match="authoritative Planner capability"):
+        resolve_graph_intent(_intent(), snapshot)
+
+
+def test_attack_allowed_middleware_field_cannot_smuggle_a_secret_value():
+    intent = _intent().model_copy(deep=True)
+    synthetic_secret = "sk-" + "adversarial-secret-value-123456"
+    intent.middleware[0].config["system_prompt"] = synthetic_secret
+
+    issues = validate_blueprint_authorization(
+        _request(), _plan(), intent, _snapshot()
+    )
+
+    assert any("credential material" in issue for issue in issues)
+
+
+def test_attack_allowed_middleware_field_rejects_embedded_secret_value():
+    intent = _intent().model_copy(deep=True)
+    synthetic_secret = "sk-" + "adversarial-secret-value-123456"
+    intent.middleware[0].config["system_prompt"] = (
+        f"Use this credential {synthetic_secret} for requests."
+    )
+
+    issues = validate_blueprint_authorization(
+        _request(), _plan(), intent, _snapshot()
+    )
+
+    assert any("credential material" in issue for issue in issues)
+
+
+def test_attack_explicit_private_default_model_is_scoped_to_this_request():
+    graph = resolve_graph_intent(
+        _intent(),
+        _snapshot(),
+        default_agent_model_id="private-gateway/model",
+    )
+
+    agent_models = {
+        node.config.get("model_id")
+        for node in graph.nodes
+        if node.kind == "workflow_agent"
+    }
+    assert agent_models == {"private-gateway/model"}
+
+
+def test_attack_unavailable_node_model_is_rejected_by_authorization():
+    intent = _intent().model_copy(deep=True)
+    intent.nodes[0].config["model_id"] = "model/forged"
+
+    issues = validate_blueprint_authorization(
+        _request(), _plan(), intent, _snapshot()
+    )
+
+    assert any("model/forged" in issue and "available" in issue for issue in issues)
+
+
+def test_attack_decompile_does_not_silently_repin_prompt_profile():
+    snapshot = _snapshot()
+    candidate = compile_xpert_candidate(
+        request=_request(),
+        plan=_plan(),
+        blueprint=_intent(),
+        snapshot=snapshot,
+        target=None,
+    )
+    restored = decompile_candidate_to_graph_intent(candidate)
+    newer_snapshot = snapshot.model_copy(deep=True)
+    newer_snapshot.prompt_profiles[0]["published_version"] = 3
+
+    with pytest.raises(ValueError, match="drifted from pinned version 2 to 3"):
+        resolve_graph_intent(restored, newer_snapshot)
+
+
+def test_attack_trusted_decompile_pins_are_not_model_forgeable_fields():
+    candidate = compile_xpert_candidate(
+        request=_request(),
+        plan=_plan(),
+        blueprint=_intent(),
+        snapshot=_snapshot(),
+        target=None,
+    )
+    restored = decompile_candidate_to_graph_intent(candidate)
+    dumped = restored.model_dump(mode="json")
+    schema = GraphIntentV3.model_json_schema()
+
+    assert restored._pinned_resource_versions
+    assert restored._pinned_prompt_profile_versions
+    assert "_pinned_resource_versions" not in dumped
+    assert "_pinned_prompt_profile_versions" not in dumped
+    assert "_pinned_resource_versions" not in schema.get("properties", {})
+    assert "_pinned_prompt_profile_versions" not in schema.get("properties", {})

--- a/server/workflow_native/node_contracts.py
+++ b/server/workflow_native/node_contracts.py
@@ -186,7 +186,7 @@ class NodePlannerContract(BaseModel):
     enabled: bool = False
     support: NodePlannerSupport = "unsupported"
     compilation_mode: NodePlannerCompilationMode = "none"
-    ir_version: int = 2
+    ir_version: int = 3
     adapter_version: str = ""
     default_data: dict[str, Any] = Field(default_factory=dict)
     config_constraints: dict[str, Any] = Field(default_factory=dict)
@@ -2796,7 +2796,11 @@ def _complete_contracts() -> dict[str, NodeContract]:
         ),
         ports=(
             NodePortContract(
-                name="task", direction="input", value_schema=string_value, required=True
+                name="task",
+                direction="input",
+                value_schema=string_value,
+                required=True,
+                cardinality="many",
             ),
             NodePortContract(
                 name="result", direction="output", value_schema=string_value

--- a/server/xpert_runtime/authoring_store.py
+++ b/server/xpert_runtime/authoring_store.py
@@ -338,6 +338,8 @@ class AuthoringProposalStore:
                     report = next_payload.get("meta_planner_report")
                     if isinstance(report, dict):
                         report["human_modified"] = True
+                        if report.get("graph_ir") is not None:
+                            report["graph_ir_status"] = "stale"
                 item.payload = next_payload
                 item.payload_digest = self._payload_digest(next_payload)
                 item.content_digest = self._skill_content_digest(


### PR DESCRIPTION
## Summary
- add server-authoritative Graph Intent V3 and Resolved Graph IR V3 with stable checksums, typed ports, and control/data/binding/metadata edges
- switch new Meta Planner generation to strict V3 single-write while retaining lossless V2 dual-read compatibility
- fail closed on forged capabilities, normalized ID collisions, implicit template inputs, unsafe middleware config, model drift, and immutable resource repinning
- pin immutable resources, preserve knowledge active-version semantics, persist safe IR evidence, and mark it stale after human edits
- keep the planner capability boundary at the existing seven node kinds and leave the classic runner, Workflow SSE, and approval flow unchanged

## Validation
- real DeepSeek smoke: native V3 candidate was valid without repair; approval created only an unpublished Xpert draft; legacy V2 Proposal survived restart and remained readable
- 48 passed: Meta Planner, managed endpoint, and Graph IR V3 falsification tests on the rebased branch
- 24 passed: dedicated adversarial/falsification suite
- fresh backend Docker image build passed; Python `py_compile` passed
- frontend production build passed: 3165 modules transformed
- `git diff origin/main...HEAD --check` passed; secret/local-path scan passed
- one-shot full server run: 5223 passed, 29 skipped, 7 PDF worker startup timeouts after prolonged process accumulation
- full isolated rerun of both affected files passed: 63 passed (`test_file_asset_validation.py` and `test_rag_vision.py`)

## Risk and rollback
- no data migration, Workflow SSE change, runtime protocol change, or new Planner node exposure
- the seven one-shot failures were isolated to pre-existing PDF subprocess timeout behavior and passed in a clean container; they are not hidden as a green full-suite run
- rollback is the two commits in this PR; existing V2 proposals and published Xperts remain readable