### PR TITLE
fix: 收尾 RAG P0 执行身份与验收门禁

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -74,6 +74,7 @@ COPY evolutions ./evolutions
 COPY workflow_deployments.py .
 COPY workflow_forms.py .
 COPY workflow_rss.py .
+COPY workflow_email.py .
 COPY workflow_native ./workflow_native
 COPY world ./world
 COPY xpert_runtime ./xpert_runtime

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -7090,6 +7090,21 @@ class RagService:
             resolved_effective["dimension"] = stored_dimension
             resolved["dimension"] = stored_dimension
             resolved["effective"] = resolved_effective
+            if (
+                stored_access_mode == "legacy"
+                and str(resolved_effective.get("provider") or "")
+                == EMBEDDING_PROVIDER_OPENAI_COMPATIBLE
+            ):
+                base = self.embedder.api_base or "https://api.openai.com/v1"
+                identity = self._embedding_space_identity(
+                    provider_kind=EMBEDDING_PROVIDER_OPENAI_COMPATIBLE,
+                    endpoint=f"{base.rstrip('/')}/embeddings",
+                    model_id=str(resolved_effective.get("model") or ""),
+                    vector_dimension=stored_dimension,
+                )
+                resolved["embedding_space_fingerprint"] = str(
+                    identity["fingerprint"]
+                )
         return resolved
 
     async def _embed_query(

--- a/server/tests/test_rag_retrieval_v2.py
+++ b/server/tests/test_rag_retrieval_v2.py
@@ -14,6 +14,7 @@ from server.rag.lexical_store import LexicalChunk, SqliteLexicalStore, tokenize_
 from server.rag.pipeline_executor import KnowledgePipelineExecutor
 from server.rag.rag_service import RagService
 from server.rag.rag_service import PipelineDraftValidationError
+from server.rag.rag_service import RagRetrievalUnavailableError
 from server.rag.reranker import RerankDocument, RerankItem, RerankOutcome, RerankService
 from server.rag.retrieval import RetrievalCandidate, RetrievalConfig, fuse_rankings
 from server.rag.splitter import ParentChildTextSplitter, TextSplitter
@@ -340,6 +341,28 @@ async def test_real_embedding_version_records_actual_dimension_and_fails_closed(
     assert version["embedding_profile"]["effective"]["dimension"] == 3
     assert version["embedding_profile"]["dimension"] == 3
     evidence_before = service.pipeline_version_evidence(version["version_id"])
+
+    result = await service.query_pipeline_version(
+        version["version_id"],
+        "REAL-VECTOR-IDENTITY",
+        retrieval={"mode": "vector"},
+        generate_answer=False,
+    )
+    assert result["sources"]
+    assert result["retrieval"]["embedding_dimension"] == 3
+
+    embedder.api_base = "https://different-embedding.test/v1"
+    with pytest.raises(
+        RagRetrievalUnavailableError,
+        match="embedding identity does not match",
+    ):
+        await service.query_pipeline_version(
+            version["version_id"],
+            "REAL-VECTOR-IDENTITY",
+            retrieval={"mode": "vector"},
+            generate_answer=False,
+        )
+    embedder.api_base = "https://embedding.test/v1"
 
     embedder.api_key = ""
     evidence_after = service.pipeline_version_evidence(version["version_id"])

--- a/server/tests/test_rag_vision.py
+++ b/server/tests/test_rag_vision.py
@@ -236,6 +236,8 @@ async def test_scanned_pdf_job_honors_visual_failure_policy(
     failure_policy: str,
     expected_status: str,
 ) -> None:
+    monkeypatch.delenv("LLM_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("LLM_GATEWAY_KEY", raising=False)
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     calls = 0
 

--- a/server/tests/test_workflow_email.py
+++ b/server/tests/test_workflow_email.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import httpx
@@ -58,6 +59,12 @@ except ModuleNotFoundError:
 
 CREDENTIAL_ID = "cred_" + "a" * 32
 EMAIL_CREDENTIAL_VALUE = '{"username":"user@example.test","password":"app-pass"}'
+
+
+def test_server_image_packages_workflow_email_module() -> None:
+    dockerfile = Path(__file__).resolve().parents[1] / "Dockerfile"
+
+    assert "COPY workflow_email.py ." in dockerfile.read_text(encoding="utf-8")
 
 
 def email_entry_data() -> dict:


### PR DESCRIPTION
## 摘要

- 使用当前 endpoint、固化模型和 Provider 实际维度重算 legacy embedding 查询指纹；同身份可查询，endpoint 漂移和凭据缺失继续 fail-closed。
- 补齐 workflow_email.py 的服务镜像打包并增加回归检查。
- 隔离扫描 PDF 视觉失败策略测试的 Provider 环境，不修改生产 failover 语义。

## 验证

- P0 定向合同：196 passed。
- RAG / Knowledge / Benchmark：437 passed。
- 全量后端：5203 passed，29 skipped。
- 隔离候选镜像 running/healthy。
- 严格 fake Provider 链路：1 次模型探测、2 次 embedding、1 次 LLM rerank；0 鉴权失败、0 意外路由。
- git diff --check 与敏感信息扫描通过。
- 未调用真实 Provider，未修改活动索引或共享数据。

## 已知外部基线

最新 main@6a278837 的 Backend quality、Frontend quality、Windows Project Host 和 readiness 均成功；AI Research 的 zero-footprint 检查因其 provenance 仍固定到旧 main 而在 main 自身失败。该基线问题不纳入本 RAG PR。

## 回滚

按顺序撤销本 PR 的两个独立提交；无索引、Gold 或持久化数据回滚。