### PR TITLE
fix: 修复 AI Research 比较基线门禁

### DIFF
--- a/.github/workflows/ai-research.yml
+++ b/.github/workflows/ai-research.yml
@@ -6,7 +6,6 @@ on:
       - "extensions/ai-research/**"
       - ".dockerignore"
       - ".github/workflows/ai-research.yml"
-      - "server/main.py"
       - "server/model_router/ai_research_bridge.py"
       - "server/model_router/chat_stable.py"
       - "server/tests/test_ai_research_bridge.py"
@@ -17,7 +16,6 @@ on:
       - "extensions/ai-research/**"
       - ".dockerignore"
       - ".github/workflows/ai-research.yml"
-      - "server/main.py"
       - "server/model_router/ai_research_bridge.py"
       - "server/model_router/chat_stable.py"
       - "server/tests/test_ai_research_bridge.py"
@@ -27,8 +25,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   verify:
@@ -41,6 +39,148 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Resolve comparison base and enforce trusted scope
+        id: comparison-base
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          case "$EVENT_NAME" in
+            pull_request) comparison_base="$PULL_REQUEST_BASE_SHA" ;;
+            push) comparison_base="$PUSH_BEFORE_SHA" ;;
+            *)
+              echo "unsupported workflow event: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+          if [[ -z "$comparison_base" || "$comparison_base" =~ ^0+$ ]]; then
+            echo "comparison base is missing or all-zero" >&2
+            exit 1
+          fi
+          comparison_base=$(git rev-parse --verify "${comparison_base}^{commit}")
+          if ! git merge-base --is-ancestor "$comparison_base" HEAD; then
+            echo "comparison base is not an ancestor of HEAD: $comparison_base" >&2
+            exit 1
+          fi
+          python3 -I -S - "$comparison_base" <<'PY'
+          import json
+          import re
+          import subprocess
+          import sys
+
+          base = sys.argv[1]
+          module_prefix = "extensions/ai-research/"
+          trust_files = {
+              "extensions/ai-research/source-lock.json",
+              "extensions/ai-research/module-boundary.json",
+          }
+
+          def git(*args: str) -> bytes:
+              return subprocess.run(
+                  ["git", *args], check=True, capture_output=True
+              ).stdout
+
+          try:
+              source_lock = json.loads(
+                  git("show", f"{base}:extensions/ai-research/source-lock.json")
+              )
+              boundary = json.loads(
+                  git("show", f"{base}:extensions/ai-research/module-boundary.json")
+              )
+          except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+              raise SystemExit("trusted AI Research configuration cannot be loaded from Base") from exc
+
+          if not isinstance(source_lock, dict) or not isinstance(boundary, dict):
+              raise SystemExit("trusted AI Research configuration must contain JSON objects")
+          locked = source_lock.get("modelMirrorBaseCommit")
+          if not isinstance(locked, str) or not re.fullmatch(r"[0-9a-f]{40}", locked):
+              raise SystemExit("trusted source-lock commit is invalid")
+          if boundary.get("baseCommit") != locked:
+              raise SystemExit("trusted module boundary and source lock disagree")
+          if subprocess.run(
+              ["git", "merge-base", "--is-ancestor", locked, base]
+          ).returncode != 0:
+              raise SystemExit("comparison Base diverged from the locked AI Research source")
+
+          allowed_value = boundary.get("allowedParentFiles")
+          if not isinstance(allowed_value, list) or not all(
+              isinstance(path, str) and path for path in allowed_value
+          ):
+              raise SystemExit("trusted allowedParentFiles is invalid")
+
+          def normalized_relative_paths(values: object, label: str) -> set[str]:
+              if not isinstance(values, (list, tuple, set)) or not all(
+                  isinstance(path, str) and path for path in values
+              ):
+                  raise SystemExit(f"trusted {label} is invalid")
+              normalized: set[str] = set()
+              for path in values:
+                  if "\\" in path:
+                      raise SystemExit(f"trusted {label} contains an unsafe path")
+                  candidate = path
+                  parts = candidate.split("/")
+                  if (
+                      candidate.startswith("/")
+                      or re.match(r"^[A-Za-z]:/", candidate)
+                      or any(part in {"", ".", ".."} for part in parts)
+                  ):
+                      raise SystemExit(f"trusted {label} contains an unsafe path")
+                  normalized.add(candidate)
+              return normalized
+
+          allowed_parent = normalized_relative_paths(
+              allowed_value, "allowedParentFiles"
+          )
+
+          core_baseline = source_lock.get("coreBaseline")
+          if not isinstance(core_baseline, dict):
+              raise SystemExit("trusted coreBaseline is invalid")
+          tracked = core_baseline.get("trackedFiles")
+          if not isinstance(tracked, dict) or not tracked or not all(
+              isinstance(path, str) and path for path in tracked
+          ):
+              raise SystemExit("trusted protected-file list is invalid")
+          protected = normalized_relative_paths(
+              list(tracked), "protected-file list"
+          )
+
+          changed_raw = git(
+              "diff",
+              "--name-only",
+              "-z",
+              "--no-renames",
+              "--diff-filter=ACDMRTUXB",
+              base,
+              "HEAD",
+              "--",
+          )
+          try:
+              changed = {
+                  path.decode("utf-8")
+                  for path in changed_raw.split(b"\0")
+                  if path
+              }
+          except UnicodeDecodeError as exc:
+              raise SystemExit("current-batch paths are not valid UTF-8") from exc
+          if any("\\" in path for path in changed):
+              raise SystemExit("current-batch paths contain an unsafe backslash")
+
+          changed_trust = sorted(changed & trust_files)
+          if changed_trust:
+              raise SystemExit(f"AI Research trust configuration changed: {changed_trust}")
+          forbidden = sorted(
+              path
+              for path in changed
+              if not path.startswith(module_prefix) and path not in allowed_parent
+          )
+          if forbidden:
+              raise SystemExit(f"forbidden current-batch paths changed: {forbidden}")
+          changed_protected = sorted(changed & protected)
+          if changed_protected:
+              raise SystemExit(f"protected core files changed: {changed_protected}")
+          PY
+          echo "comparison_base=$comparison_base" >> "$GITHUB_OUTPUT"
       - name: Set up Docker 29.7.2 with containerd image store
         uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1 # v5
         with:
@@ -61,7 +201,7 @@ jobs:
         run: python -m pytest server/tests/test_ai_research_bridge.py server/tests/test_provider_chat_stable_service.py -q
       - name: Verify V0.1 development candidate
         working-directory: extensions/ai-research
-        run: bash scripts/verify.sh origin/main full external-pull
+        run: bash scripts/verify.sh "${{ steps.comparison-base.outputs.comparison_base }}" full external-pull
       - name: Preserve module logs on failure
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/extensions/ai-research/scripts/validate_boundary.py
+++ b/extensions/ai-research/scripts/validate_boundary.py
@@ -79,12 +79,61 @@ def git(*args: str) -> list[str]:
         text=True,
         encoding="utf-8",
     )
-    return [line.strip().replace("\\", "/") for line in result.stdout.splitlines() if line.strip()]
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def git_paths(*args: str) -> list[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    try:
+        paths = [item.decode("utf-8") for item in result.stdout.split(b"\0") if item]
+    except UnicodeDecodeError as exc:
+        raise BoundaryFailure("Git paths are not valid UTF-8") from exc
+    if any("\\" in path for path in paths):
+        raise BoundaryFailure("Git paths contain an unsafe backslash")
+    return paths
 
 
 def changed_paths(base: str) -> set[str]:
-    paths = set(git("diff", "--name-only", "--diff-filter=ACMRTUXB", base))
-    paths.update(git("ls-files", "--others", "--exclude-standard"))
+    paths = set(
+        git_paths(
+            "diff",
+            "--name-only",
+            "-z",
+            "--no-renames",
+            "--diff-filter=ACDMRTUXB",
+            base,
+            "HEAD",
+            "--",
+        )
+    )
+    paths.update(
+        git_paths(
+            "diff",
+            "--name-only",
+            "-z",
+            "--no-renames",
+            "--diff-filter=ACDMRTUXB",
+            "--cached",
+            "HEAD",
+            "--",
+        )
+    )
+    paths.update(
+        git_paths(
+            "diff",
+            "--name-only",
+            "-z",
+            "--no-renames",
+            "--diff-filter=ACDMRTUXB",
+            "--",
+        )
+    )
+    paths.update(git_paths("ls-files", "-z", "--others", "--exclude-standard"))
     return paths
 
 
@@ -114,7 +163,14 @@ def sha256(path: Path) -> str:
 
 
 def validate_paths(base: str, boundary: dict) -> None:
-    allowed_parent = set(boundary["allowedParentFiles"])
+    allowed_value = boundary.get("allowedParentFiles")
+    if not isinstance(allowed_value, list) or not all(
+        isinstance(path, str) and path for path in allowed_value
+    ):
+        raise BoundaryFailure("allowedParentFiles must be a list of paths")
+    if any("\\" in path for path in allowed_value):
+        raise BoundaryFailure("allowedParentFiles contains an unsafe backslash")
+    allowed_parent = set(allowed_value)
     prefix = "extensions/ai-research/"
     illegal = sorted(
         path for path in changed_paths(base) if not path.startswith(prefix) and path not in allowed_parent

--- a/extensions/ai-research/scripts/verify.ps1
+++ b/extensions/ai-research/scripts/verify.ps1
@@ -1,5 +1,7 @@
 param(
-    [string]$Base = "origin/main",
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Base,
     [ValidateSet("Quick", "Full")]
     [string]$Mode = "Full",
     [Parameter(Mandatory = $true)]
@@ -10,19 +12,6 @@ param(
 $ErrorActionPreference = "Stop"
 $moduleRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $repoRoot = (Resolve-Path (Join-Path $moduleRoot "..\..")).Path
-$pythonFile = $env:AI_RESEARCH_PYTHON
-$pythonPrefix = @()
-if (-not $pythonFile) {
-    $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
-    if ($pythonCommand) {
-        $pythonFile = $pythonCommand.Source
-    } else {
-        $launcher = Get-Command py -ErrorAction SilentlyContinue
-        if (-not $launcher) { throw "Set AI_RESEARCH_PYTHON to a Python 3.12.13 executable" }
-        $pythonFile = $launcher.Source
-        $pythonPrefix = @("-3.12")
-    }
-}
 $composeProject = if ($env:AI_RESEARCH_COMPOSE_PROJECT) {
     $env:AI_RESEARCH_COMPOSE_PROJECT
 } else {
@@ -33,7 +22,6 @@ $literatureCompose = @("compose", "-p", $composeProject, "-f", "compose.yml", "-
 $runtime = Join-Path $moduleRoot "runtime"
 $diagnostics = Join-Path $runtime "diagnostics"
 $sbom = Join-Path $runtime "sbom"
-New-Item -ItemType Directory -Force -Path $diagnostics, $sbom | Out-Null
 
 function Invoke-Checked([string]$File, [string[]]$Arguments) {
     & $File @Arguments
@@ -102,6 +90,55 @@ function Build-ClientProof([string]$GitRef, [string]$Context, [string]$Image) {
     )
 }
 
+function Resolve-ComparisonBase([string]$RequestedBase) {
+    if ([string]::IsNullOrWhiteSpace($RequestedBase) -or $RequestedBase -match "^0+$") {
+        throw "comparison base is required and must not be all-zero"
+    }
+    $resolved = & git -C $repoRoot rev-parse --verify "${RequestedBase}^{commit}"
+    if ($LASTEXITCODE -ne 0 -or -not $resolved) {
+        throw "comparison base cannot be resolved: $RequestedBase"
+    }
+    $resolved = $resolved.Trim()
+    & git -C $repoRoot merge-base --is-ancestor $resolved HEAD
+    if ($LASTEXITCODE -ne 0) {
+        throw "comparison base is not an ancestor of HEAD: $resolved"
+    }
+    return $resolved
+}
+
+$comparisonBase = Resolve-ComparisonBase $Base
+$trustFiles = @(
+    "extensions/ai-research/source-lock.json",
+    "extensions/ai-research/module-boundary.json"
+)
+& git -C $repoRoot diff --quiet --no-ext-diff $comparisonBase HEAD -- @trustFiles
+if ($LASTEXITCODE -ne 0) {
+    throw "AI Research trust configuration changed in the candidate"
+}
+& git -C $repoRoot diff --quiet --no-ext-diff --cached HEAD -- @trustFiles
+if ($LASTEXITCODE -ne 0) {
+    throw "AI Research trust configuration changed in the workspace index"
+}
+& git -C $repoRoot diff --quiet --no-ext-diff -- @trustFiles
+if ($LASTEXITCODE -ne 0) {
+    throw "AI Research trust configuration changed in the workspace"
+}
+$pythonFile = $env:AI_RESEARCH_PYTHON
+$pythonPrefix = @()
+if (-not $pythonFile) {
+    $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+    if ($pythonCommand) {
+        $pythonFile = $pythonCommand.Source
+    } else {
+        $launcher = Get-Command py -ErrorAction SilentlyContinue
+        if (-not $launcher) { throw "Set AI_RESEARCH_PYTHON to a Python 3.12.13 executable" }
+        $pythonFile = $launcher.Source
+        $pythonPrefix = @("-3.12")
+    }
+}
+New-Item -ItemType Directory -Force -Path $diagnostics, $sbom | Out-Null
+$pytestBaseTemp = Join-Path $runtime ("pytest-" + [Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $pytestBaseTemp | Out-Null
 Push-Location $moduleRoot
 try {
     $distributionModeValue = if ($DistributionMode -eq "ExternalPull") {
@@ -111,10 +148,16 @@ try {
     }
     $boundaryArgs = @(
         "scripts/validate_boundary.py",
-        "--base", $Base,
+        "--base", $comparisonBase,
         "--distribution-mode", $distributionModeValue
     )
     Invoke-Python $boundaryArgs
+    Invoke-Python @(
+        "-m", "pytest",
+        "tests/control/test_boundary_base.py",
+        "tests/control/test_zero_footprint_base.py",
+        "-q", "-p", "no:cacheprovider", "--basetemp", $pytestBaseTemp
+    )
     Invoke-Checked "docker" ($compose + @("config", "--quiet"))
     Invoke-Checked "docker" ($literatureCompose + @("config", "--quiet"))
 
@@ -246,13 +289,17 @@ if unexpected:
     }
 
     $sourceLock = Get-Content -Raw -LiteralPath (Join-Path $moduleRoot "source-lock.json") | ConvertFrom-Json
+    $clientSourceProof = Join-Path $runtime ("client-source-proof-" + [Guid]::NewGuid().ToString("N"))
     $clientBaselineProof = Join-Path $runtime ("client-baseline-proof-" + [Guid]::NewGuid().ToString("N"))
     $clientCurrentProof = Join-Path $runtime ("client-current-proof-" + [Guid]::NewGuid().ToString("N"))
+    $clientSourceContext = Join-Path $runtime ("client-source-context-" + [Guid]::NewGuid().ToString("N"))
     $clientBaselineContext = Join-Path $runtime ("client-baseline-context-" + [Guid]::NewGuid().ToString("N"))
     $clientCurrentContext = Join-Path $runtime ("client-current-context-" + [Guid]::NewGuid().ToString("N"))
     $clientPaths = @(
+        $clientSourceProof,
         $clientBaselineProof,
         $clientCurrentProof,
+        $clientSourceContext,
         $clientBaselineContext,
         $clientCurrentContext
     )
@@ -260,12 +307,20 @@ if unexpected:
     try {
         Build-ClientProof `
             $sourceLock.modelMirrorBaseCommit `
+            $clientSourceContext `
+            "modelmirror-ai-research-client-proof:v0.1-source"
+        Build-ClientProof `
+            $comparisonBase `
             $clientBaselineContext `
             "modelmirror-ai-research-client-proof:v0.1-baseline"
         Build-ClientProof `
             "HEAD" `
             $clientCurrentContext `
             "modelmirror-ai-research-client-proof:v0.1"
+        Extract-ImageFile `
+            "modelmirror-ai-research-client-proof:v0.1-source" `
+            "/proof/dist/." `
+            $clientSourceProof
         Extract-ImageFile `
             "modelmirror-ai-research-client-proof:v0.1-baseline" `
             "/proof/dist/." `
@@ -276,6 +331,8 @@ if unexpected:
             $clientCurrentProof
         Invoke-Python @(
             "scripts/zero_footprint.py",
+            "--base", $comparisonBase,
+            "--source-client-dist", $clientSourceProof,
             "--baseline-client-dist", $clientBaselineProof,
             "--client-dist", $clientCurrentProof
         )
@@ -289,4 +346,7 @@ if unexpected:
 } finally {
     & docker @literatureCompose down
     Pop-Location
+    if (Test-Path -LiteralPath $pytestBaseTemp) {
+        Remove-Item -LiteralPath $pytestBaseTemp -Recurse -Force
+    }
 }

--- a/extensions/ai-research/scripts/verify.sh
+++ b/extensions/ai-research/scripts/verify.sh
@@ -1,11 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE="${1:-origin/main}"
+usage() {
+  echo "usage: verify.sh <base> [quick|full] <external-pull|redistributable-bundle>" >&2
+}
+
+BASE_INPUT="${1:-}"
 MODE="${2:-full}"
-DISTRIBUTION_MODE="${3:?usage: verify.sh [base] [quick|full] [external-pull|redistributable-bundle]}"
+DISTRIBUTION_MODE="${3:-}"
+if [[ -z "$BASE_INPUT" || "$BASE_INPUT" =~ ^0+$ ]]; then
+  echo "comparison base is required and must not be all-zero" >&2
+  usage
+  exit 2
+fi
+if [[ "$MODE" != "quick" && "$MODE" != "full" ]]; then
+  echo "invalid verification mode: $MODE" >&2
+  usage
+  exit 2
+fi
 if [[ "$DISTRIBUTION_MODE" != "external-pull" && "$DISTRIBUTION_MODE" != "redistributable-bundle" ]]; then
   echo "invalid distribution mode: $DISTRIBUTION_MODE" >&2
+  usage
   exit 2
 fi
 MODULE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -15,10 +30,40 @@ COMPOSE=(docker compose -p "$COMPOSE_PROJECT" -f compose.yml --profile ai-resear
 LITERATURE_COMPOSE=(docker compose -p "$COMPOSE_PROJECT" -f compose.yml --profile literature)
 CLIENT_BASELINE_PROOF_DIR=""
 CLIENT_CURRENT_PROOF_DIR=""
+CLIENT_SOURCE_PROOF_DIR=""
 CLIENT_PROOF_CONTAINER=""
 CLIENT_BASELINE_CONTEXT=""
 CLIENT_CURRENT_CONTEXT=""
+CLIENT_SOURCE_CONTEXT=""
+PYTEST_BASETEMP=""
 
+BASE=$(git -C "$REPO_ROOT" rev-parse --verify "${BASE_INPUT}^{commit}") || {
+  echo "comparison base cannot be resolved: $BASE_INPUT" >&2
+  exit 2
+}
+if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$BASE" HEAD; then
+  echo "comparison base is not an ancestor of HEAD: $BASE" >&2
+  exit 2
+fi
+TRUST_FILES=(
+  extensions/ai-research/source-lock.json
+  extensions/ai-research/module-boundary.json
+)
+if ! git -C "$REPO_ROOT" diff --quiet --no-ext-diff "$BASE" HEAD -- "${TRUST_FILES[@]}"; then
+  echo "AI Research trust configuration changed in the candidate" >&2
+  git -C "$REPO_ROOT" diff --name-only --no-ext-diff "$BASE" HEAD -- "${TRUST_FILES[@]}" >&2 || true
+  exit 2
+fi
+if ! git -C "$REPO_ROOT" diff --quiet --no-ext-diff --cached HEAD -- "${TRUST_FILES[@]}"; then
+  echo "AI Research trust configuration changed in the workspace index" >&2
+  git -C "$REPO_ROOT" diff --name-only --no-ext-diff --cached HEAD -- "${TRUST_FILES[@]}" >&2 || true
+  exit 2
+fi
+if ! git -C "$REPO_ROOT" diff --quiet --no-ext-diff -- "${TRUST_FILES[@]}"; then
+  echo "AI Research trust configuration changed in the workspace" >&2
+  git -C "$REPO_ROOT" diff --name-only --no-ext-diff -- "${TRUST_FILES[@]}" >&2 || true
+  exit 2
+fi
 cd "$MODULE_ROOT"
 mkdir -p runtime/diagnostics runtime/sbom
 cleanup() {
@@ -31,11 +76,20 @@ cleanup() {
   if [[ "$CLIENT_CURRENT_PROOF_DIR" == "$MODULE_ROOT"/runtime/client-current-proof.* ]]; then
     rm -rf -- "$CLIENT_CURRENT_PROOF_DIR"
   fi
+  if [[ "$CLIENT_SOURCE_PROOF_DIR" == "$MODULE_ROOT"/runtime/client-source-proof.* ]]; then
+    rm -rf -- "$CLIENT_SOURCE_PROOF_DIR"
+  fi
   if [[ "$CLIENT_BASELINE_CONTEXT" == "$MODULE_ROOT"/runtime/client-baseline-context.* ]]; then
     rm -rf -- "$CLIENT_BASELINE_CONTEXT"
   fi
   if [[ "$CLIENT_CURRENT_CONTEXT" == "$MODULE_ROOT"/runtime/client-current-context.* ]]; then
     rm -rf -- "$CLIENT_CURRENT_CONTEXT"
+  fi
+  if [[ "$CLIENT_SOURCE_CONTEXT" == "$MODULE_ROOT"/runtime/client-source-context.* ]]; then
+    rm -rf -- "$CLIENT_SOURCE_CONTEXT"
+  fi
+  if [[ "$PYTEST_BASETEMP" == "$MODULE_ROOT"/runtime/pytest.* ]]; then
+    rm -rf -- "$PYTEST_BASETEMP"
   fi
   "${LITERATURE_COMPOSE[@]}" down >/dev/null 2>&1 || true
 }
@@ -43,6 +97,11 @@ trap cleanup EXIT
 
 BOUNDARY_ARGS=(scripts/validate_boundary.py --base "$BASE" --distribution-mode "$DISTRIBUTION_MODE")
 python "${BOUNDARY_ARGS[@]}"
+PYTEST_BASETEMP=$(mktemp -d "$MODULE_ROOT/runtime/pytest.XXXXXX")
+python -m pytest \
+  tests/control/test_boundary_base.py \
+  tests/control/test_zero_footprint_base.py \
+  -q -p no:cacheprovider --basetemp "$PYTEST_BASETEMP"
 "${COMPOSE[@]}" config --quiet
 "${LITERATURE_COMPOSE[@]}" config --quiet
 docker build --target test -f control/Dockerfile -t modelmirror-ai-research-control-test:v0.1 .
@@ -222,8 +281,10 @@ extract_client_proof() {
 }
 
 LOCKED_BASE=$(python -c "import json; print(json.load(open('source-lock.json'))['modelMirrorBaseCommit'])")
+CLIENT_SOURCE_PROOF_DIR=$(mktemp -d "$MODULE_ROOT/runtime/client-source-proof.XXXXXX")
 CLIENT_BASELINE_PROOF_DIR=$(mktemp -d "$MODULE_ROOT/runtime/client-baseline-proof.XXXXXX")
 CLIENT_CURRENT_PROOF_DIR=$(mktemp -d "$MODULE_ROOT/runtime/client-current-proof.XXXXXX")
+CLIENT_SOURCE_CONTEXT=$(mktemp -d "$MODULE_ROOT/runtime/client-source-context.XXXXXX")
 CLIENT_BASELINE_CONTEXT=$(mktemp -d "$MODULE_ROOT/runtime/client-baseline-context.XXXXXX")
 CLIENT_CURRENT_CONTEXT=$(mktemp -d "$MODULE_ROOT/runtime/client-current-context.XXXXXX")
 CLIENT_PROOF_SOURCE="/proof/dist/."
@@ -232,6 +293,10 @@ case "$(uname -s)" in
 esac
 build_client_proof \
   "$LOCKED_BASE" \
+  "$CLIENT_SOURCE_CONTEXT" \
+  modelmirror-ai-research-client-proof:v0.1-source
+build_client_proof \
+  "$BASE" \
   "$CLIENT_BASELINE_CONTEXT" \
   modelmirror-ai-research-client-proof:v0.1-baseline
 build_client_proof \
@@ -239,20 +304,29 @@ build_client_proof \
   "$CLIENT_CURRENT_CONTEXT" \
   modelmirror-ai-research-client-proof:v0.1
 extract_client_proof \
+  modelmirror-ai-research-client-proof:v0.1-source \
+  "$CLIENT_SOURCE_PROOF_DIR"
+extract_client_proof \
   modelmirror-ai-research-client-proof:v0.1-baseline \
   "$CLIENT_BASELINE_PROOF_DIR"
 extract_client_proof \
   modelmirror-ai-research-client-proof:v0.1 \
   "$CLIENT_CURRENT_PROOF_DIR"
 python scripts/zero_footprint.py \
+  --base "$BASE" \
+  --source-client-dist "$CLIENT_SOURCE_PROOF_DIR" \
   --baseline-client-dist "$CLIENT_BASELINE_PROOF_DIR" \
   --client-dist "$CLIENT_CURRENT_PROOF_DIR"
 rm -rf -- \
+  "$CLIENT_SOURCE_PROOF_DIR" \
   "$CLIENT_BASELINE_PROOF_DIR" \
   "$CLIENT_CURRENT_PROOF_DIR" \
+  "$CLIENT_SOURCE_CONTEXT" \
   "$CLIENT_BASELINE_CONTEXT" \
   "$CLIENT_CURRENT_CONTEXT"
+CLIENT_SOURCE_PROOF_DIR=""
 CLIENT_BASELINE_PROOF_DIR=""
 CLIENT_CURRENT_PROOF_DIR=""
+CLIENT_SOURCE_CONTEXT=""
 CLIENT_BASELINE_CONTEXT=""
 CLIENT_CURRENT_CONTEXT=""

--- a/extensions/ai-research/scripts/zero_footprint.py
+++ b/extensions/ai-research/scripts/zero_footprint.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -10,6 +11,12 @@ from pathlib import Path
 
 MODULE_ROOT = Path(__file__).resolve().parent.parent
 REPO_ROOT = MODULE_ROOT.parents[1]
+MODULE_PREFIX = "extensions/ai-research/"
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+TRUST_FILES = (
+    "extensions/ai-research/source-lock.json",
+    "extensions/ai-research/module-boundary.json",
+)
 
 
 class BaselineFailure(RuntimeError):
@@ -20,9 +27,47 @@ def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def run(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        cwd=REPO_ROOT,
+        check=check,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+
 def command(*args: str) -> str:
+    return run(*args).stdout
+
+
+def git_paths(*args: str) -> set[str]:
     result = subprocess.run(
-        list(args), cwd=REPO_ROOT, check=True, capture_output=True, text=True, encoding="utf-8"
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    try:
+        paths = {item.decode("utf-8") for item in result.stdout.split(b"\0") if item}
+    except UnicodeDecodeError as exc:
+        raise BaselineFailure("Git paths are not valid UTF-8") from exc
+    if any("\\" in path for path in paths):
+        raise BaselineFailure("Git paths contain an unsafe backslash")
+    return paths
+
+
+def git_blob(commit: str, relative: str) -> bytes:
+    result = subprocess.run(
+        ["git", "show", f"{commit}:{relative}"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
     )
     return result.stdout
 
@@ -45,73 +90,216 @@ def client_dist(root: Path) -> dict[str, object]:
     }
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--client-dist", type=Path, default=REPO_ROOT / "client" / "dist")
-    parser.add_argument("--baseline-client-dist", type=Path)
-    args = parser.parse_args()
-    client_dist_root = args.client_dist.resolve()
-    source_lock = json.loads((MODULE_ROOT / "source-lock.json").read_text(encoding="utf-8"))
-    baseline = source_lock["coreBaseline"]
-    locked_base = source_lock["modelMirrorBaseCommit"]
-    failures: list[str] = []
-    for relative, expected in baseline["trackedFiles"].items():
-        actual = sha256(REPO_ROOT / relative)
+def resolve_commit(reference: str) -> str:
+    if not reference.strip() or set(reference.strip()) == {"0"}:
+        raise BaselineFailure("Git comparison base is missing or all-zero")
+    result = run("git", "rev-parse", "--verify", f"{reference}^{{commit}}", check=False)
+    commit = result.stdout.strip().lower()
+    if result.returncode != 0 or not COMMIT_RE.fullmatch(commit):
+        raise BaselineFailure(f"Git commit cannot be resolved: {reference}")
+    return commit
+
+
+def require_ancestor(ancestor: str, descendant: str, message: str) -> None:
+    result = run("git", "merge-base", "--is-ancestor", ancestor, descendant, check=False)
+    if result.returncode != 0:
+        raise BaselineFailure(message)
+
+
+def validate_lineage(locked_reference: str, requested_base: str) -> tuple[str, str, str]:
+    locked_commit = resolve_commit(locked_reference)
+    base_commit = resolve_commit(requested_base)
+    head_commit = resolve_commit("HEAD")
+    require_ancestor(
+        locked_commit,
+        base_commit,
+        f"requested base {base_commit} diverged from locked source {locked_commit}",
+    )
+    require_ancestor(
+        base_commit,
+        head_commit,
+        f"requested base {base_commit} is not an ancestor of HEAD {head_commit}",
+    )
+    return locked_commit, base_commit, head_commit
+
+
+def load_trusted_configuration(
+    base_commit: str,
+) -> tuple[dict[str, object], dict[str, object]]:
+    try:
+        source_lock = json.loads(git_blob(base_commit, TRUST_FILES[0]).decode("utf-8"))
+        boundary = json.loads(git_blob(base_commit, TRUST_FILES[1]).decode("utf-8"))
+    except (UnicodeDecodeError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        raise BaselineFailure("trusted configuration cannot be loaded from caller base") from exc
+    if not isinstance(source_lock, dict) or not isinstance(boundary, dict):
+        raise BaselineFailure("trusted configuration in caller base must be JSON objects")
+    return source_lock, boundary
+
+
+def validate_trust_files_unchanged(base_commit: str, head_commit: str) -> None:
+    for relative in TRUST_FILES:
+        try:
+            trusted = git_blob(base_commit, relative)
+            candidate = git_blob(head_commit, relative)
+            workspace = (REPO_ROOT / relative).read_bytes()
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise BaselineFailure(f"trusted configuration is missing: {relative}") from exc
+        if candidate != trusted or workspace != trusted:
+            raise BaselineFailure(f"trusted configuration changed in current batch: {relative}")
+
+
+def changed_paths(base_commit: str, head_commit: str) -> set[str]:
+    return git_paths(
+        "diff",
+        "--name-only",
+        "-z",
+        "--no-renames",
+        "--diff-filter=ACDMRTUXB",
+        base_commit,
+        head_commit,
+        "--",
+    )
+
+
+def validate_current_scope(
+    base_commit: str,
+    head_commit: str,
+    boundary: dict[str, object],
+) -> list[str]:
+    allowed_parent_value = boundary.get("allowedParentFiles")
+    if not isinstance(allowed_parent_value, list) or not all(
+        isinstance(path, str) and path for path in allowed_parent_value
+    ):
+        raise BaselineFailure("trusted module boundary has invalid allowedParentFiles")
+    if any("\\" in path for path in allowed_parent_value):
+        raise BaselineFailure("trusted allowedParentFiles contains an unsafe backslash")
+    allowed_parent = set(allowed_parent_value)
+    changed = changed_paths(base_commit, head_commit)
+    forbidden = sorted(
+        path
+        for path in changed
+        if not path.startswith(MODULE_PREFIX) and path not in allowed_parent
+    )
+    if forbidden:
+        raise BaselineFailure(f"forbidden current-batch paths changed: {forbidden}")
+    return sorted(changed)
+
+
+def validate_locked_source(
+    source_lock: dict[str, object],
+    locked_commit: str,
+    source_client_dist: dict[str, object],
+) -> None:
+    baseline = source_lock.get("coreBaseline")
+    if not isinstance(baseline, dict):
+        raise BaselineFailure("source-lock coreBaseline evidence is missing or invalid")
+    gate = baseline.get("clientDistGate")
+    if not isinstance(gate, dict) or gate.get("baseCommit") != locked_commit:
+        raise BaselineFailure("locked client proof commit drifted from source-lock provenance")
+
+    tracked_files = baseline.get("trackedFiles")
+    if not isinstance(tracked_files, dict) or not tracked_files:
+        raise BaselineFailure("source-lock core tracked file evidence is missing")
+    for relative, expected in tracked_files.items():
+        actual = sha256_bytes(git_blob(locked_commit, str(relative)))
         if actual != expected:
-            failures.append(f"core tracked file drifted: {relative}")
-    expected_client_dist = baseline["clientDistReference"]
-    if args.baseline_client_dist is not None:
-        expected_client_dist = client_dist(args.baseline_client_dist.resolve())
-    actual_client_dist = client_dist(client_dist_root)
-    if actual_client_dist != expected_client_dist:
-        failures.append(
-            "client dist hash/count/size changed: "
+            raise BaselineFailure(f"locked source hash drifted: {relative}")
+
+    expected_client_dist = baseline.get("clientDistReference")
+    if source_client_dist != expected_client_dist:
+        raise BaselineFailure(
+            "locked source client proof drifted: "
             f"expected={json.dumps(expected_client_dist, sort_keys=True)} "
-            f"actual={json.dumps(actual_client_dist, sort_keys=True)}"
+            f"actual={json.dumps(source_client_dist, sort_keys=True)}"
         )
 
-    services = sorted(command("docker", "compose", "config", "--services").splitlines())
-    if services != baseline["defaultServices"]:
-        failures.append(f"default Compose services changed: {services}")
-    compose_config = json.loads(command("docker", "compose", "config", "--format", "json"))
-    volumes = sorted((compose_config.get("volumes") or {}).keys())
-    if volumes != baseline["defaultVolumes"]:
-        failures.append(f"default Compose volumes changed: {volumes}")
 
-    allowed_server = {
-        "server/main.py",
-        "server/model_router/ai_research_bridge.py",
-        "server/model_router/chat_stable.py",
-        "server/tests/test_ai_research_bridge.py",
-        "server/tests/test_provider_chat_stable_service.py",
-    }
-    core_diff = {
-        item.strip().replace("\\", "/")
-        for item in command(
-            "git",
-            "diff",
-            "--name-only",
-            locked_base,
-            "--",
-            "client",
-            "server",
-            "docker-compose.yml",
-        ).splitlines()
-        if item.strip()
-    }
-    forbidden_diff = sorted(core_diff - allowed_server)
-    if forbidden_diff:
-        failures.append(f"forbidden core diff exists: {forbidden_diff}")
-    if failures:
-        raise BaselineFailure("; ".join(failures))
+def validate_protected_batch_files(
+    source_lock: dict[str, object], base_commit: str, head_commit: str
+) -> None:
+    baseline = source_lock.get("coreBaseline")
+    if not isinstance(baseline, dict):
+        raise BaselineFailure("source-lock coreBaseline evidence is missing or invalid")
+    protected = baseline.get("trackedFiles")
+    if not isinstance(protected, dict) or not protected:
+        raise BaselineFailure("source-lock protected core file list is missing")
+    for relative in protected:
+        before = git_blob(base_commit, str(relative))
+        after = git_blob(head_commit, str(relative))
+        if before != after:
+            raise BaselineFailure(f"protected core file changed in current batch: {relative}")
+
+
+def render_current_compose() -> tuple[list[str], list[str]]:
+    compose_config = json.loads(command("docker", "compose", "config", "--format", "json"))
+    if not isinstance(compose_config, dict):
+        raise BaselineFailure("current Compose rendering must be a JSON object")
+    services = sorted((compose_config.get("services") or {}).keys())
+    volumes = sorted((compose_config.get("volumes") or {}).keys())
+    if not services:
+        raise BaselineFailure("current Compose configuration has no services")
+    return services, volumes
+
+
+def validate_current_client_proof(
+    baseline_client_dist: dict[str, object], current_client_dist: dict[str, object]
+) -> None:
+    if baseline_client_dist != current_client_dist:
+        raise BaselineFailure(
+            "root client changed in current batch: "
+            f"base={json.dumps(baseline_client_dist, sort_keys=True)} "
+            f"head={json.dumps(current_client_dist, sort_keys=True)}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-client-dist", type=Path, required=True)
+    parser.add_argument("--baseline-client-dist", type=Path, required=True)
+    parser.add_argument("--client-dist", type=Path, required=True)
+    parser.add_argument("--base", required=True)
+    args = parser.parse_args(argv)
+
+    base_commit = resolve_commit(args.base)
+    head_commit = resolve_commit("HEAD")
+    source_lock, boundary = load_trusted_configuration(base_commit)
+    validate_trust_files_unchanged(base_commit, head_commit)
+    locked_reference = source_lock.get("modelMirrorBaseCommit")
+    if not isinstance(locked_reference, str) or not COMMIT_RE.fullmatch(
+        locked_reference.lower()
+    ):
+        raise BaselineFailure("source-lock modelMirrorBaseCommit is missing or invalid")
+    if boundary.get("baseCommit") != locked_reference:
+        raise BaselineFailure("module boundary and source lock disagree on locked source commit")
+
+    locked_commit, lineage_base, lineage_head = validate_lineage(
+        str(locked_reference), args.base
+    )
+    if lineage_base != base_commit or lineage_head != head_commit:
+        raise BaselineFailure("resolved Git identities changed during zero-footprint validation")
+    source_client_dist = client_dist(args.source_client_dist.resolve())
+    baseline_client_dist = client_dist(args.baseline_client_dist.resolve())
+    current_client_dist = client_dist(args.client_dist.resolve())
+
+    validate_locked_source(source_lock, locked_commit, source_client_dist)
+    current_paths = validate_current_scope(base_commit, head_commit, boundary)
+    validate_protected_batch_files(source_lock, base_commit, head_commit)
+    validate_current_client_proof(baseline_client_dist, current_client_dist)
+
+    services, volumes = render_current_compose()
     print(
         json.dumps(
             {
                 "status": "passed",
-                "baselineClientDist": expected_client_dist,
-                "clientDist": actual_client_dist,
-                "defaultServiceCount": len(services),
-                "defaultVolumeCount": len(volumes),
+                "lockedSourceCommit": locked_commit,
+                "baseCommit": base_commit,
+                "headCommit": head_commit,
+                "sourceClientDist": source_client_dist,
+                "baselineClientDist": baseline_client_dist,
+                "clientDist": current_client_dist,
+                "currentBatchPaths": current_paths,
+                "currentComposeServiceCount": len(services),
+                "currentComposeVolumeCount": len(volumes),
             },
             sort_keys=True,
         )

--- a/extensions/ai-research/tests/control/test_zero_footprint_base.py
+++ b/extensions/ai-research/tests/control/test_zero_footprint_base.py
@@ -1,0 +1,1236 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+MODULE_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = MODULE_ROOT / "scripts" / "zero_footprint.py"
+if not SCRIPT.is_file():
+    pytest.skip(
+        "repository-level zero-footprint tests run in the host preflight",
+        allow_module_level=True,
+    )
+SPEC = importlib.util.spec_from_file_location("zero_footprint_base", SCRIPT)
+assert SPEC and SPEC.loader
+zero_footprint = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(zero_footprint)
+
+BOUNDARY_SCRIPT = MODULE_ROOT / "scripts" / "validate_boundary.py"
+BOUNDARY_SPEC = importlib.util.spec_from_file_location(
+    "validate_boundary_delete_base", BOUNDARY_SCRIPT
+)
+assert BOUNDARY_SPEC and BOUNDARY_SPEC.loader
+validate_boundary = importlib.util.module_from_spec(BOUNDARY_SPEC)
+BOUNDARY_SPEC.loader.exec_module(validate_boundary)
+
+WORKFLOW_PATH = zero_footprint.REPO_ROOT / ".github/workflows/ai-research.yml"
+TRUST_PATHS = {
+    "extensions/ai-research/source-lock.json",
+    "extensions/ai-research/module-boundary.json",
+}
+DEFAULT_ALLOWED_PARENT = [
+    ".dockerignore",
+    ".github/workflows/ai-research.yml",
+    "server/main.py",
+    "server/model_router/ai_research_bridge.py",
+    "server/model_router/chat_stable.py",
+    "server/tests/test_ai_research_bridge.py",
+    "server/tests/test_provider_chat_stable_service.py",
+]
+PROTECTED_PATHS = [
+    "docker-compose.yml",
+    "server/requirements.txt",
+    "server/Dockerfile",
+    "client/package.json",
+    "client/package-lock.json",
+]
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=check,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+def _write(repo: Path, relative: str, value: str) -> None:
+    target = repo / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(value, encoding="utf-8")
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def _init_gate_repo(
+    tmp_path: Path, *, allowed_parent: list[str] | None = None
+) -> tuple[Path, str]:
+    repo = tmp_path / "gate-repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "gate@example.test")
+    _git(repo, "config", "user.name", "Gate Test")
+    _git(repo, "config", "core.autocrlf", "false")
+    _write(repo, "seed.txt", "locked source")
+    locked = _commit(repo, "locked")
+
+    source_lock = {
+        "modelMirrorBaseCommit": locked,
+        "coreBaseline": {
+            "trackedFiles": {path: "locked-hash" for path in PROTECTED_PATHS}
+        },
+    }
+    boundary = {
+        "baseCommit": locked,
+        "allowedParentFiles": allowed_parent or list(DEFAULT_ALLOWED_PARENT),
+    }
+    _write(
+        repo,
+        "extensions/ai-research/source-lock.json",
+        json.dumps(source_lock),
+    )
+    _write(
+        repo,
+        "extensions/ai-research/module-boundary.json",
+        json.dumps(boundary),
+    )
+    for path in PROTECTED_PATHS:
+        _write(repo, path, f"protected:{path}")
+    return repo, _commit(repo, "base")
+
+
+def _workflow_gate_script() -> str:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    marker = '          python3 -I -S - "$comparison_base" <<\'PY\'\n'
+    start = workflow.index(marker) + len(marker)
+    end = workflow.index("\n          PY", start)
+    return textwrap.dedent(workflow[start:end]) + "\n"
+
+
+def _run_workflow_gate(
+    repo: Path, base: str, *, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-I", "-S", "-", base],
+        cwd=repo,
+        input=_workflow_gate_script(),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=env,
+    )
+
+
+def _verify_trust_fixture(
+    tmp_path: Path, relative_script: str
+) -> tuple[Path, str, Path]:
+    repo, _ = _init_gate_repo(tmp_path)
+    script = repo / relative_script
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_bytes((zero_footprint.REPO_ROOT / relative_script).read_bytes())
+    base = _commit(repo, "add verifier")
+
+    trust_path = repo / "extensions/ai-research/module-boundary.json"
+    _write(repo, "extensions/ai-research/module-boundary.json", "{}")
+    _commit(repo, "commit malicious trust change")
+    trusted = _git(
+        repo,
+        "show",
+        f"{base}:extensions/ai-research/module-boundary.json",
+    ).stdout
+    trust_path.write_text(trusted, encoding="utf-8")
+    return repo, base, script
+
+
+def _dist(root: Path, value: str = "same") -> dict[str, object]:
+    root.mkdir(parents=True)
+    (root / "index.html").write_text(value, encoding="utf-8")
+    return zero_footprint.client_dist(root)
+
+
+def _source_lock(
+    locked_commit: str, source_proof: dict[str, object]
+) -> dict[str, object]:
+    return {
+        "modelMirrorBaseCommit": locked_commit,
+        "coreBaseline": {
+            "clientDistGate": {"baseCommit": locked_commit},
+            "clientDistReference": source_proof,
+            "trackedFiles": {
+                "docker-compose.yml": zero_footprint.sha256_bytes(b"locked compose"),
+                "server/requirements.txt": zero_footprint.sha256_bytes(b"locked requirements"),
+            },
+        },
+    }
+
+
+def test_locked_source_evidence_is_read_from_locked_commit_not_current_tree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    locked = "1" * 40
+    source_proof = _dist(tmp_path / "source")
+    source_lock = _source_lock(locked, source_proof)
+    blobs = {
+        "docker-compose.yml": b"locked compose",
+        "server/requirements.txt": b"locked requirements",
+    }
+    calls: list[tuple[str, str]] = []
+
+    def fake_blob(commit: str, relative: str) -> bytes:
+        calls.append((commit, relative))
+        return blobs[relative]
+
+    monkeypatch.setattr(zero_footprint, "git_blob", fake_blob)
+
+    zero_footprint.validate_locked_source(source_lock, locked, source_proof)
+
+    assert calls == [
+        (locked, "docker-compose.yml"),
+        (locked, "server/requirements.txt"),
+    ]
+
+
+def test_locked_source_hash_drift_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    locked = "1" * 40
+    source_proof = _dist(tmp_path / "source")
+    source_lock = _source_lock(locked, source_proof)
+    monkeypatch.setattr(zero_footprint, "git_blob", lambda *_: b"tampered")
+
+    with pytest.raises(zero_footprint.BaselineFailure, match="locked source hash drifted"):
+        zero_footprint.validate_locked_source(source_lock, locked, source_proof)
+
+
+def test_locked_source_client_proof_drift_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    locked = "1" * 40
+    source_lock = _source_lock(locked, _dist(tmp_path / "expected", "expected"))
+
+    monkeypatch.setattr(
+        zero_footprint,
+        "git_blob",
+        lambda commit, relative: {
+            "docker-compose.yml": b"locked compose",
+            "server/requirements.txt": b"locked requirements",
+        }[relative],
+    )
+    with pytest.raises(
+        zero_footprint.BaselineFailure, match="locked source client proof drifted"
+    ):
+        zero_footprint.validate_locked_source(
+            source_lock,
+            locked,
+            _dist(tmp_path / "actual", "actual"),
+        )
+
+
+def test_current_batch_allows_module_and_declared_parent_files(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        zero_footprint,
+        "changed_paths",
+        lambda *_: {
+            "extensions/ai-research/scripts/zero_footprint.py",
+            ".github/workflows/ai-research.yml",
+            "server/main.py",
+        },
+    )
+
+    changed = zero_footprint.validate_current_scope(
+        "2" * 40,
+        "3" * 40,
+        {
+            "allowedParentFiles": [
+                ".github/workflows/ai-research.yml",
+                "server/main.py",
+            ]
+        },
+    )
+
+    assert changed == [
+        ".github/workflows/ai-research.yml",
+        "extensions/ai-research/scripts/zero_footprint.py",
+        "server/main.py",
+    ]
+
+
+def test_current_batch_rejects_unapproved_parent_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        zero_footprint,
+        "changed_paths",
+        lambda *_: {"extensions/ai-research/README.md", "server/unapproved.py"},
+    )
+
+    with pytest.raises(
+        zero_footprint.BaselineFailure, match="forbidden current-batch paths changed"
+    ):
+        zero_footprint.validate_current_scope(
+            "2" * 40, "3" * 40, {"allowedParentFiles": []}
+        )
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["client/src/App.tsx", ".github/workflows/quality.yml"],
+)
+def test_current_batch_rejects_unapproved_client_and_workflow_paths(
+    monkeypatch: pytest.MonkeyPatch, path: str
+) -> None:
+    monkeypatch.setattr(zero_footprint, "changed_paths", lambda *_: {path})
+
+    with pytest.raises(zero_footprint.BaselineFailure, match="forbidden current-batch"):
+        zero_footprint.validate_current_scope(
+            "2" * 40, "3" * 40, {"allowedParentFiles": []}
+        )
+
+
+def test_deleted_unapproved_parent_file_is_still_in_current_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_git_paths(*args: str) -> set[str]:
+        calls.append(args)
+        return {"server/deleted_unapproved.py"}
+
+    monkeypatch.setattr(zero_footprint, "git_paths", fake_git_paths)
+
+    with pytest.raises(
+        zero_footprint.BaselineFailure, match="deleted_unapproved.py"
+    ):
+        zero_footprint.validate_current_scope(
+            "2" * 40, "3" * 40, {"allowedParentFiles": []}
+        )
+
+    assert "--diff-filter=ACDMRTUXB" in calls[0]
+
+
+def test_boundary_changed_paths_includes_deletions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_git_paths(*args: str) -> list[str]:
+        calls.append(args)
+        return ["server/deleted_unapproved.py"] if args[0] == "diff" else []
+
+    monkeypatch.setattr(validate_boundary, "git_paths", fake_git_paths)
+
+    assert validate_boundary.changed_paths("base") == {"server/deleted_unapproved.py"}
+    assert "--diff-filter=ACDMRTUXB" in calls[0]
+    assert calls[0][-3:] == ("base", "HEAD", "--")
+    assert calls[1][-3:] == ("--cached", "HEAD", "--")
+    assert calls[2][-1:] == ("--",)
+
+
+def test_boundary_changed_paths_keeps_committed_violation_when_workspace_restores_base(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo, base = _init_gate_repo(tmp_path)
+    relative = "server/unapproved.py"
+    _write(repo, relative, "committed violation")
+    _commit(repo, "commit forbidden path")
+    (repo / relative).unlink()
+
+    monkeypatch.setattr(validate_boundary, "REPO_ROOT", repo)
+    monkeypatch.setattr(
+        validate_boundary,
+        "MODULE_ROOT",
+        Path(__file__).parent / "missing-module-root",
+    )
+
+    assert relative in validate_boundary.changed_paths(base)
+    with pytest.raises(
+        validate_boundary.BoundaryFailure, match="outside the approved boundary"
+    ):
+        validate_boundary.validate_paths(base, {"allowedParentFiles": []})
+
+
+@pytest.mark.parametrize(
+    "layer",
+    [
+        "base_to_head",
+        "head_to_index",
+        "index_to_workspace",
+        "untracked",
+        "index_workspace_cancellation",
+    ],
+)
+def test_boundary_rejects_forbidden_paths_from_each_repository_layer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, layer: str
+) -> None:
+    repo, _ = _init_gate_repo(tmp_path)
+    tracked_relative = "server/unapproved-layer.py"
+    _write(repo, tracked_relative, "base value")
+    base = _commit(repo, "add pre-existing parent path")
+    relative = tracked_relative
+
+    if layer == "base_to_head":
+        _write(repo, relative, "committed violation")
+        _commit(repo, "commit forbidden change")
+    elif layer == "head_to_index":
+        _write(repo, relative, "staged violation")
+        _git(repo, "add", relative)
+    elif layer == "index_to_workspace":
+        _write(repo, relative, "worktree violation")
+    elif layer == "untracked":
+        relative = "server/untracked-violation.py"
+        _write(repo, relative, "untracked violation")
+    else:
+        _write(repo, relative, "staged violation")
+        _git(repo, "add", relative)
+        _write(repo, relative, "base value")
+
+    monkeypatch.setattr(validate_boundary, "REPO_ROOT", repo)
+    monkeypatch.setattr(
+        validate_boundary,
+        "MODULE_ROOT",
+        repo / "extensions/ai-research",
+    )
+
+    assert relative in validate_boundary.changed_paths(base)
+    with pytest.raises(
+        validate_boundary.BoundaryFailure, match="outside the approved boundary"
+    ):
+        validate_boundary.validate_paths(base, {"allowedParentFiles": []})
+
+
+def test_bash_verifier_keeps_committed_trust_violation_when_workspace_restores_base(
+    tmp_path: Path,
+) -> None:
+    bash = shutil.which("bash")
+    if not bash or sys.platform == "win32":
+        pytest.skip("Bash verifier behavior is exercised on the Linux control runner")
+    repo, base, script = _verify_trust_fixture(
+        tmp_path, "extensions/ai-research/scripts/verify.sh"
+    )
+
+    result = subprocess.run(
+        [bash, str(script), base, "quick", "external-pull"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert result.returncode == 2
+    assert "trust configuration changed in the candidate" in result.stderr
+
+
+def test_powershell_verifier_keeps_committed_trust_violation_when_workspace_restores_base(
+    tmp_path: Path,
+) -> None:
+    powershell = shutil.which("powershell") or shutil.which("pwsh")
+    if not powershell:
+        pytest.skip("PowerShell verifier behavior requires PowerShell")
+    repo, base, script = _verify_trust_fixture(
+        tmp_path, "extensions/ai-research/scripts/verify.ps1"
+    )
+
+    result = subprocess.run(
+        [
+            powershell,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script),
+            "-Base",
+            base,
+            "-Mode",
+            "Quick",
+            "-DistributionMode",
+            "ExternalPull",
+        ],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert result.returncode != 0
+    assert "trust configuration changed in the candidate" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "relative_script",
+    [
+        "extensions/ai-research/scripts/verify.sh",
+        "extensions/ai-research/scripts/verify.ps1",
+    ],
+    ids=["bash", "powershell"],
+)
+def test_verifier_keeps_staged_trust_violation_when_worktree_restores_head(
+    tmp_path: Path, relative_script: str
+) -> None:
+    if relative_script.endswith(".sh"):
+        executable = shutil.which("bash")
+        if not executable or sys.platform == "win32":
+            pytest.skip("Bash verifier behavior is exercised on the Linux control runner")
+    else:
+        executable = shutil.which("powershell") or shutil.which("pwsh")
+        if not executable:
+            pytest.skip("PowerShell verifier behavior requires PowerShell")
+
+    repo, _ = _init_gate_repo(tmp_path)
+    script = repo / relative_script
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_bytes((zero_footprint.REPO_ROOT / relative_script).read_bytes())
+    base = _commit(repo, "add verifier")
+    trust_path = repo / "extensions/ai-research/module-boundary.json"
+    trusted = trust_path.read_text(encoding="utf-8")
+    trust_path.write_text("{}", encoding="utf-8")
+    _git(repo, "add", "extensions/ai-research/module-boundary.json")
+    trust_path.write_text(trusted, encoding="utf-8")
+
+    if relative_script.endswith(".sh"):
+        command = [
+            executable,
+            str(script),
+            base,
+            "quick",
+            "external-pull",
+        ]
+    else:
+        command = [
+            executable,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script),
+            "-Base",
+            base,
+            "-Mode",
+            "Quick",
+            "-DistributionMode",
+            "ExternalPull",
+        ]
+    result = subprocess.run(
+        command,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert result.returncode != 0
+    assert "trust configuration changed in the workspace index" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "module,error_type",
+    [
+        (zero_footprint, zero_footprint.BaselineFailure),
+        (validate_boundary, validate_boundary.BoundaryFailure),
+    ],
+)
+def test_git_path_parser_rejects_backslash_names(
+    monkeypatch: pytest.MonkeyPatch, module: object, error_type: type[Exception]
+) -> None:
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout=b"server\\main.py\0"),
+    )
+
+    with pytest.raises(error_type, match="unsafe backslash"):
+        module.git_paths("diff")
+
+
+@pytest.mark.parametrize("module", [zero_footprint, validate_boundary])
+def test_git_path_parser_keeps_newline_filename_as_one_path(
+    monkeypatch: pytest.MonkeyPatch, module: object
+) -> None:
+    raw = b"server/main.py\nserver/model_router/ai_research_bridge.py\0"
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout=raw),
+    )
+
+    assert list(module.git_paths("diff")) == [raw[:-1].decode("utf-8")]
+
+
+@pytest.mark.parametrize(
+    "module,error_type",
+    [
+        (zero_footprint, zero_footprint.BaselineFailure),
+        (validate_boundary, validate_boundary.BoundaryFailure),
+    ],
+)
+def test_git_path_parser_rejects_non_utf8_names(
+    monkeypatch: pytest.MonkeyPatch, module: object, error_type: type[Exception]
+) -> None:
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout=b"unsafe-\xff\0"),
+    )
+
+    with pytest.raises(error_type, match="not valid UTF-8"):
+        module.git_paths("diff")
+
+
+def test_trusted_configuration_is_loaded_only_from_caller_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base = "2" * 40
+    trusted = {
+        zero_footprint.TRUST_FILES[0]: json.dumps(
+            {"modelMirrorBaseCommit": "1" * 40}
+        ).encode(),
+        zero_footprint.TRUST_FILES[1]: json.dumps(
+            {"allowedParentFiles": ["server/main.py"]}
+        ).encode(),
+    }
+    calls: list[tuple[str, str]] = []
+
+    def fake_blob(commit: str, relative: str) -> bytes:
+        calls.append((commit, relative))
+        return trusted[relative]
+
+    monkeypatch.setattr(zero_footprint, "git_blob", fake_blob)
+
+    source_lock, boundary = zero_footprint.load_trusted_configuration(base)
+
+    assert source_lock["modelMirrorBaseCommit"] == "1" * 40
+    assert boundary["allowedParentFiles"] == ["server/main.py"]
+    assert calls == [(base, path) for path in zero_footprint.TRUST_FILES]
+
+
+def test_malformed_trusted_configuration_fails_without_assertions(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    locked = "1" * 40
+    source_proof = _dist(tmp_path / "source")
+    monkeypatch.setattr(zero_footprint, "git_blob", lambda *_: b"unused")
+
+    with pytest.raises(zero_footprint.BaselineFailure, match="coreBaseline"):
+        zero_footprint.validate_locked_source(
+            {"modelMirrorBaseCommit": locked, "coreBaseline": []},
+            locked,
+            source_proof,
+        )
+    with pytest.raises(zero_footprint.BaselineFailure, match="allowedParentFiles"):
+        zero_footprint.validate_current_scope(
+            "2" * 40,
+            "3" * 40,
+            {"allowedParentFiles": "server/unapproved.py"},
+        )
+
+
+@pytest.mark.parametrize(
+    "relative,candidate",
+    [
+        (
+            "extensions/ai-research/source-lock.json",
+            b'{"modelMirrorBaseCommit":"9999999999999999999999999999999999999999"}',
+        ),
+        (
+            "extensions/ai-research/source-lock.json",
+            b'{"coreBaseline":{"trackedFiles":{}}}',
+        ),
+        (
+            "extensions/ai-research/module-boundary.json",
+            b'{"allowedParentFiles":["server/unapproved.py"]}',
+        ),
+    ],
+)
+def test_candidate_cannot_self_authorize_by_changing_trust_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    relative: str,
+    candidate: bytes,
+) -> None:
+    base = "2" * 40
+    head = "3" * 40
+    trusted = b"trusted"
+    repo_root = tmp_path / "repo"
+    for path in zero_footprint.TRUST_FILES:
+        target = repo_root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(candidate if path == relative else trusted)
+
+    def fake_blob(commit: str, path: str) -> bytes:
+        if commit == head and path == relative:
+            return candidate
+        return trusted
+
+    monkeypatch.setattr(zero_footprint, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(zero_footprint, "git_blob", fake_blob)
+
+    with pytest.raises(
+        zero_footprint.BaselineFailure, match="trusted configuration changed"
+    ):
+        zero_footprint.validate_trust_files_unchanged(base, head)
+
+
+def test_deleted_trust_file_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    base = "2" * 40
+    head = "3" * 40
+    repo_root = tmp_path / "repo"
+    for relative in zero_footprint.TRUST_FILES:
+        target = repo_root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"trusted")
+
+    def fake_blob(commit: str, relative: str) -> bytes:
+        if commit == head and relative == zero_footprint.TRUST_FILES[0]:
+            raise subprocess.CalledProcessError(128, ["git", "show"])
+        return b"trusted"
+
+    monkeypatch.setattr(zero_footprint, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(zero_footprint, "git_blob", fake_blob)
+
+    with pytest.raises(zero_footprint.BaselineFailure, match="trusted configuration is missing"):
+        zero_footprint.validate_trust_files_unchanged(base, head)
+
+
+def test_dirty_worktree_cannot_override_trusted_configuration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    base = "2" * 40
+    head = "3" * 40
+    repo_root = tmp_path / "repo"
+    for relative in zero_footprint.TRUST_FILES:
+        target = repo_root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"trusted")
+    (repo_root / zero_footprint.TRUST_FILES[1]).write_bytes(b"dirty expanded whitelist")
+    monkeypatch.setattr(zero_footprint, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(zero_footprint, "git_blob", lambda *_: b"trusted")
+
+    with pytest.raises(
+        zero_footprint.BaselineFailure, match="trusted configuration changed"
+    ):
+        zero_footprint.validate_trust_files_unchanged(base, head)
+
+
+def test_protected_files_compare_caller_base_to_head_not_locked_source(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    locked = "1" * 40
+    base = "2" * 40
+    head = "3" * 40
+    source_lock = _source_lock(locked, _dist(tmp_path / "source"))
+    current = {
+        "docker-compose.yml": b"legitimately advanced compose",
+        "server/requirements.txt": b"legitimately advanced requirements",
+    }
+    monkeypatch.setattr(
+        zero_footprint,
+        "git_blob",
+        lambda commit, relative: current[relative] if commit in {base, head} else b"locked",
+    )
+
+    zero_footprint.validate_protected_batch_files(source_lock, base, head)
+
+
+def test_protected_file_changed_in_current_batch_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    locked = "1" * 40
+    base = "2" * 40
+    head = "3" * 40
+    source_lock = _source_lock(locked, _dist(tmp_path / "source"))
+
+    def fake_blob(commit: str, relative: str) -> bytes:
+        if relative == "docker-compose.yml" and commit == head:
+            return b"changed"
+        return b"same"
+
+    monkeypatch.setattr(zero_footprint, "git_blob", fake_blob)
+
+    with pytest.raises(
+        zero_footprint.BaselineFailure, match="protected core file changed"
+    ):
+        zero_footprint.validate_protected_batch_files(source_lock, base, head)
+
+
+def test_lineage_requires_locked_to_base_and_base_to_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    locked = "1" * 40
+    base = "2" * 40
+    head = "3" * 40
+    commits = {locked: locked, "requested": base, "HEAD": head}
+    ancestry: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(zero_footprint, "resolve_commit", lambda ref: commits[ref])
+    monkeypatch.setattr(
+        zero_footprint,
+        "require_ancestor",
+        lambda ancestor, descendant, message: ancestry.append(
+            (ancestor, descendant, message)
+        ),
+    )
+
+    assert zero_footprint.validate_lineage(locked, "requested") == (locked, base, head)
+    assert [(ancestor, descendant) for ancestor, descendant, _ in ancestry] == [
+        (locked, base),
+        (base, head),
+    ]
+
+
+def test_non_ancestor_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        zero_footprint,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+
+    with pytest.raises(zero_footprint.BaselineFailure, match="not an ancestor"):
+        zero_footprint.require_ancestor("1" * 40, "2" * 40, "not an ancestor")
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--baseline-client-dist", "base", "--client-dist", "head", "--base", "base"],
+        ["--source-client-dist", "source", "--client-dist", "head", "--base", "base"],
+        [
+            "--source-client-dist",
+            "source",
+            "--baseline-client-dist",
+            "base",
+            "--base",
+            "base",
+        ],
+        [
+            "--source-client-dist",
+            "source",
+            "--baseline-client-dist",
+            "base",
+            "--client-dist",
+            "head",
+        ],
+    ],
+)
+def test_all_three_proofs_and_base_are_required(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        zero_footprint.main(argv)
+
+    assert exc_info.value.code == 2
+
+
+def test_all_zero_base_is_rejected() -> None:
+    with pytest.raises(zero_footprint.BaselineFailure, match="all-zero"):
+        zero_footprint.resolve_commit("0" * 40)
+
+
+def test_main_receipt_records_locked_base_head_and_three_proofs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    locked = "1" * 40
+    base = "2" * 40
+    head = "3" * 40
+    source_proof_path = tmp_path / "source-proof"
+    base_proof_path = tmp_path / "base-proof"
+    head_proof_path = tmp_path / "head-proof"
+    source_proof = _dist(source_proof_path, "locked")
+    base_proof = _dist(base_proof_path, "current")
+    _dist(head_proof_path, "current")
+    source_lock = _source_lock(locked, source_proof)
+    boundary = {"baseCommit": locked, "allowedParentFiles": []}
+    commits = {base: base, "HEAD": head}
+    monkeypatch.setattr(zero_footprint, "resolve_commit", lambda ref: commits[ref])
+    monkeypatch.setattr(
+        zero_footprint,
+        "load_trusted_configuration",
+        lambda *_: (source_lock, boundary),
+    )
+    monkeypatch.setattr(zero_footprint, "validate_trust_files_unchanged", lambda *_: None)
+    monkeypatch.setattr(
+        zero_footprint, "validate_lineage", lambda *_: (locked, base, head)
+    )
+    monkeypatch.setattr(zero_footprint, "validate_locked_source", lambda *_: None)
+    monkeypatch.setattr(zero_footprint, "validate_current_scope", lambda *_: ["safe"])
+    monkeypatch.setattr(zero_footprint, "validate_protected_batch_files", lambda *_: None)
+    monkeypatch.setattr(
+        zero_footprint, "render_current_compose", lambda: (["server"], ["data"])
+    )
+
+    assert (
+        zero_footprint.main(
+            [
+                "--source-client-dist",
+                str(source_proof_path),
+                "--baseline-client-dist",
+                str(base_proof_path),
+                "--client-dist",
+                str(head_proof_path),
+                "--base",
+                base,
+            ]
+        )
+        == 0
+    )
+
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["lockedSourceCommit"] == locked
+    assert receipt["baseCommit"] == base
+    assert receipt["headCommit"] == head
+    assert receipt["sourceClientDist"] == source_proof
+    assert receipt["baselineClientDist"] == base_proof
+    assert receipt["clientDist"] == base_proof
+
+
+def test_base_and_head_client_proofs_must_match(tmp_path: Path) -> None:
+    base = _dist(tmp_path / "base-proof", "before")
+    head = _dist(tmp_path / "head-proof", "after")
+
+    with pytest.raises(zero_footprint.BaselineFailure, match="root client changed"):
+        zero_footprint.validate_current_client_proof(base, head)
+
+
+def test_current_compose_only_requires_successful_current_render(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        zero_footprint,
+        "command",
+        lambda *_: json.dumps(
+            {"services": {"server": {}, "client": {}}, "volumes": {"data": {}}}
+        ),
+    )
+
+    services, volumes = zero_footprint.render_current_compose()
+
+    assert services == ["client", "server"]
+    assert volumes == ["data"]
+
+
+def test_current_compose_render_failure_is_not_suppressed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failure = subprocess.CalledProcessError(1, ["docker", "compose", "config"])
+    monkeypatch.setattr(
+        zero_footprint,
+        "command",
+        lambda *_: (_ for _ in ()).throw(failure),
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        zero_footprint.render_current_compose()
+
+
+@pytest.mark.parametrize(
+    "relative",
+    ["extensions/ai-research/new.py", *DEFAULT_ALLOWED_PARENT],
+)
+def test_workflow_early_gate_accepts_module_and_base_allowlist(
+    tmp_path: Path, relative: str
+) -> None:
+    repo, base = _init_gate_repo(tmp_path)
+    _write(repo, relative, f"allowed:{relative}")
+    _commit(repo, "allowed candidate")
+
+    result = _run_workflow_gate(repo, base)
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        "server/unapproved.py",
+        "client/src/unapproved.ts",
+        "deploy/unapproved.yml",
+        "new-api-data/unapproved.json",
+        "unexpected-root.txt",
+    ],
+)
+def test_workflow_early_gate_rejects_unapproved_paths(
+    tmp_path: Path, relative: str
+) -> None:
+    repo, base = _init_gate_repo(tmp_path)
+    _write(repo, relative, "forbidden")
+    _commit(repo, "forbidden candidate")
+
+    result = _run_workflow_gate(repo, base)
+
+    assert result.returncode != 0
+    assert "forbidden current-batch paths changed" in result.stderr
+    assert relative in result.stderr
+
+
+@pytest.mark.parametrize("relative", PROTECTED_PATHS)
+def test_workflow_early_gate_rejects_protected_files_even_if_base_allowlists_them(
+    tmp_path: Path, relative: str
+) -> None:
+    repo, base = _init_gate_repo(
+        tmp_path, allowed_parent=[*DEFAULT_ALLOWED_PARENT, relative]
+    )
+    _write(repo, relative, "tampered protected file")
+    _commit(repo, "protected candidate")
+
+    result = _run_workflow_gate(repo, base)
+
+    assert result.returncode != 0
+    assert "protected core files changed" in result.stderr
+    assert relative in result.stderr
+
+
+@pytest.mark.parametrize("operation", ["delete", "rename"])
+@pytest.mark.parametrize("relative", PROTECTED_PATHS)
+def test_workflow_early_gate_rejects_protected_delete_and_rename(
+    tmp_path: Path, relative: str, operation: str
+) -> None:
+    repo, base = _init_gate_repo(
+        tmp_path, allowed_parent=[*DEFAULT_ALLOWED_PARENT, relative]
+    )
+    if operation == "delete":
+        (repo / relative).unlink()
+    else:
+        _git(repo, "mv", relative, ".dockerignore")
+    _commit(repo, f"protected {operation}")
+
+    result = _run_workflow_gate(repo, base)
+
+    assert result.returncode != 0
+    assert "protected core files changed" in result.stderr
+    assert relative in result.stderr
+
+
+@pytest.mark.parametrize("relative", sorted(TRUST_PATHS))
+def test_workflow_early_gate_rejects_trust_file_self_authorization(
+    tmp_path: Path, relative: str
+) -> None:
+    repo, base = _init_gate_repo(tmp_path)
+    _write(repo, relative, "{}")
+    _commit(repo, "trust self authorization")
+
+    result = _run_workflow_gate(repo, base)
+
+    assert result.returncode != 0
+    assert "AI Research trust configuration changed" in result.stderr
+    assert relative in result.stderr
+
+
+@pytest.mark.parametrize(
+    "source,target",
+    [
+        ("server/unapproved.py", "server/main.py"),
+        ("server/main.py", "server/unapproved.py"),
+    ],
+)
+def test_workflow_early_gate_expands_renames_and_rejects_forbidden_endpoint(
+    tmp_path: Path, source: str, target: str
+) -> None:
+    repo, base = _init_gate_repo(tmp_path)
+    _write(repo, source, "rename source")
+    base = _commit(repo, "add rename source")
+    target_path = repo / target
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    _git(repo, "mv", source, target)
+    _commit(repo, "rename candidate")
+
+    result = _run_workflow_gate(repo, base)
+
+    assert result.returncode != 0
+    assert "server/unapproved.py" in result.stderr
+
+
+def test_workflow_early_gate_rejects_deleted_forbidden_path(tmp_path: Path) -> None:
+    repo, base = _init_gate_repo(tmp_path)
+    _write(repo, "server/unapproved.py", "delete me")
+    base = _commit(repo, "add forbidden path to base")
+    (repo / "server/unapproved.py").unlink()
+    _commit(repo, "delete forbidden path")
+
+    result = _run_workflow_gate(repo, base)
+
+    assert result.returncode != 0
+    assert "server/unapproved.py" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "relative,value,message",
+    [
+        (
+            "extensions/ai-research/module-boundary.json",
+            {"baseCommit": "mismatch", "allowedParentFiles": []},
+            "module boundary and source lock disagree",
+        ),
+        (
+            "extensions/ai-research/module-boundary.json",
+            {"baseCommit": None, "allowedParentFiles": "server/main.py"},
+            "allowedParentFiles is invalid",
+        ),
+        (
+            "extensions/ai-research/source-lock.json",
+            {"modelMirrorBaseCommit": "invalid", "coreBaseline": {}},
+            "source-lock commit is invalid",
+        ),
+    ],
+)
+def test_workflow_early_gate_rejects_malformed_base_trust(
+    tmp_path: Path, relative: str, value: dict[str, object], message: str
+) -> None:
+    repo, _ = _init_gate_repo(tmp_path)
+    if relative.endswith("module-boundary.json") and value.get("baseCommit") is None:
+        source_lock = json.loads(
+            (repo / "extensions/ai-research/source-lock.json").read_text(encoding="utf-8")
+        )
+        value["baseCommit"] = source_lock["modelMirrorBaseCommit"]
+    _write(repo, relative, json.dumps(value))
+    base = _commit(repo, "malformed trusted base")
+    _write(repo, "extensions/ai-research/candidate.txt", "trigger")
+    _commit(repo, "candidate")
+
+    result = _run_workflow_gate(repo, base)
+
+    assert result.returncode != 0
+    assert message in result.stderr
+
+
+@pytest.mark.parametrize("unsafe", ["../server/main.py", "/server/main.py", "C:/server/main.py"])
+def test_workflow_early_gate_rejects_unsafe_base_allowlist_paths(
+    tmp_path: Path, unsafe: str
+) -> None:
+    repo, _ = _init_gate_repo(tmp_path)
+    boundary_path = repo / "extensions/ai-research/module-boundary.json"
+    boundary = json.loads(boundary_path.read_text(encoding="utf-8"))
+    boundary["allowedParentFiles"] = [unsafe]
+    boundary_path.write_text(json.dumps(boundary), encoding="utf-8")
+    base = _commit(repo, "unsafe trusted base")
+    _write(repo, "extensions/ai-research/candidate.txt", "trigger")
+    _commit(repo, "candidate")
+
+    result = _run_workflow_gate(repo, base)
+
+    assert result.returncode != 0
+    assert "allowedParentFiles contains an unsafe path" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["extensions/ai-research/space name.txt", "extensions/ai-research/中文.txt"],
+)
+def test_workflow_early_gate_handles_nul_delimited_special_paths(
+    tmp_path: Path, path: str
+) -> None:
+    repo, base = _init_gate_repo(tmp_path)
+    _write(repo, path, "allowed special path")
+    _commit(repo, "special path")
+
+    result = _run_workflow_gate(repo, base)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_workflow_early_gate_rejects_raw_backslash_git_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    locked = "1" * 40
+
+    def fake_run(args: list[str], **_: object) -> SimpleNamespace:
+        command = args[1]
+        if command == "show":
+            relative = args[2].split(":", 1)[1]
+            value = (
+                {
+                    "modelMirrorBaseCommit": locked,
+                    "coreBaseline": {
+                        "trackedFiles": {"server/requirements.txt": "hash"}
+                    },
+                }
+                if relative.endswith("source-lock.json")
+                else {
+                    "baseCommit": locked,
+                    "allowedParentFiles": ["server/main.py"],
+                }
+            )
+            return SimpleNamespace(stdout=json.dumps(value).encode(), returncode=0)
+        if command == "merge-base":
+            return SimpleNamespace(stdout=b"", returncode=0)
+        if command == "diff":
+            return SimpleNamespace(stdout=b"server\\main.py\0", returncode=0)
+        raise AssertionError(f"unexpected Git command: {args}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["workflow-gate", "2" * 40])
+
+    with pytest.raises(SystemExit, match="current-batch paths contain an unsafe backslash"):
+        exec(compile(_workflow_gate_script(), "<workflow-gate>", "exec"), {})
+
+
+def test_workflow_selects_event_base_and_never_coalesces_push_runs() -> None:
+    workflow = (zero_footprint.REPO_ROOT / ".github/workflows/ai-research.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "github.event.pull_request.base.sha" in workflow
+    assert "github.event.before" in workflow
+    assert "github.event.pull_request.number || github.sha" in workflow
+    assert "cancel-in-progress: ${{ github.event_name == 'pull_request' }}" in workflow
+    assert '      - "server/main.py"' not in workflow
+    assert '      - "server/tests/test_ai_research_bridge.py"' in workflow
+    assert "extensions/ai-research/source-lock.json" in workflow
+    assert "extensions/ai-research/module-boundary.json" in workflow
+    scope_gate = workflow.index("Resolve comparison base and enforce trusted scope")
+    assert scope_gate < workflow.index("Set up Docker 29.7.2")
+    assert scope_gate < workflow.index("Set up Python 3.12")
+    assert scope_gate < workflow.index("Install core server test dependencies")
+    assert scope_gate < workflow.index("Verify restricted model bridge")
+    assert scope_gate < workflow.index("Verify V0.1 development candidate")
+    assert "allowedParentFiles" in workflow
+    assert "trackedFiles" in workflow
+    assert 'python3 -I -S - "$comparison_base"' in workflow
+    assert "--no-renames" in workflow
+    assert "--diff-filter=ACDMRTUXB" in workflow
+    assert "current-batch paths contain an unsafe backslash" in workflow
+
+
+@pytest.mark.parametrize(
+    "relative",
+    ["extensions/ai-research/scripts/verify.sh", "extensions/ai-research/scripts/verify.ps1"],
+)
+def test_verify_scripts_build_three_proofs_and_pass_full_zero_footprint_interface(
+    relative: str,
+) -> None:
+    script = (zero_footprint.REPO_ROOT / relative).read_text(encoding="utf-8")
+
+    assert "source-client-dist" in script
+    assert "baseline-client-dist" in script
+    assert '"--client-dist"' in script or "--client-dist" in script
+    assert '"--base"' in script or "--base" in script
+    assert "client-source" in script
+    assert "client-baseline" in script
+    assert "client-current" in script
+    assert "source-lock.json" in script
+    assert "module-boundary.json" in script
+    assert "diff --quiet --no-ext-diff" in script
+    if relative.endswith(".sh"):
+        assert 'diff --quiet --no-ext-diff "$BASE" HEAD --' in script
+        assert 'diff --quiet --no-ext-diff --cached HEAD --' in script
+        assert 'diff --quiet --no-ext-diff -- "${TRUST_FILES[@]}"' in script
+    else:
+        assert "diff --quiet --no-ext-diff $comparisonBase HEAD --" in script
+        assert "diff --quiet --no-ext-diff --cached HEAD --" in script
+        assert "diff --quiet --no-ext-diff -- @trustFiles" in script

--- a/server/tests/test_ai_research_bridge.py
+++ b/server/tests/test_ai_research_bridge.py
@@ -9,7 +9,12 @@ import httpx
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from server.model_router.ai_research_bridge import router, stable_service
+from server.model_router.ai_research_bridge import (
+    chat_completions,
+    models,
+    router,
+    stable_service,
+)
 
 
 MODEL_ID = "provider/fixed-research-model"
@@ -103,6 +108,43 @@ def enable(monkeypatch) -> None:
 
 def headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {TOKEN}"}
+
+
+def test_main_app_registers_restricted_ai_research_routes(monkeypatch) -> None:
+    from server.main import app as main_app
+
+    registered = [
+        (route.path, tuple(sorted(route.methods or set())), route.endpoint)
+        for route in main_app.routes
+        if route.path.startswith("/api/ai-research/v1")
+    ]
+    assert len(registered) == 2
+    assert registered == [
+        ("/api/ai-research/v1/models", ("GET",), models),
+        ("/api/ai-research/v1/chat/completions", ("POST",), chat_completions),
+    ]
+
+    client = TestClient(main_app)
+    monkeypatch.delenv("AI_RESEARCH_S2S_ENABLED", raising=False)
+    monkeypatch.delenv("AI_RESEARCH_S2S_TOKEN", raising=False)
+    monkeypatch.delenv("AI_RESEARCH_LITERATURE_MODEL_ID", raising=False)
+    assert client.get("/api/ai-research/v1/models").status_code == 503
+    assert client.post(
+        "/api/ai-research/v1/chat/completions", json=valid_payload()
+    ).status_code == 503
+
+    enable(monkeypatch)
+    models_response = client.get(
+        "/api/ai-research/v1/models",
+        headers={"Authorization": "Bearer wrong-service-token"},
+    )
+    assert models_response.status_code == 401
+    chat_response = client.post(
+        "/api/ai-research/v1/chat/completions",
+        json=valid_payload(),
+        headers={"Authorization": "Bearer wrong-service-token"},
+    )
+    assert chat_response.status_code == 401
 
 
 def valid_payload(*, stream: bool = False) -> dict[str, Any]:


### PR DESCRIPTION
## 摘要

- 将不可移动的 source-lock、事件提供的实际比较 Base 与候选 HEAD 分离验证。
- 普通 server/main.py 修改不再单独触发 AI Research；真正触发后仍按父文件白名单 fail-closed。
- Bash、PowerShell 与零足迹脚本分别证明锁定来源、实际 Base 和 HEAD，并覆盖 Base→HEAD、HEAD→index、index→workspace 与未跟踪文件。
- 强化受限模型桥路由身份检查，防止重复或错误路由被测试遮蔽。

## 验证

- AI Research Bash quick：Host 94 passed / 2 skipped；Control 96 passed / 1 skipped；Worker 14 passed；exit 0
- AI Research PowerShell quick：同上，exit 0
- 后端全量：5260 passed，29 skipped
- 前端：126 个测试文件、820 个测试全部通过；Header 测试通过
- 前端生产构建与 git diff --check 通过

## 边界

本 PR 不修改工作流 Registry、NodeContract、Store、API 或 563 行能力矩阵。验证器仍属于 defense-in-depth，最终可信性依赖必需检查、分支保护及 CODEOWNERS/人工审查。