### PR TITLE
feature: 建立 Meta Planner 无头编排与类型化 Patch 闭环

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,7 +354,7 @@ npm.cmd run build
 - 所有 `NativeNodeKind` 必须在 `NodeContractRegistry` 中唯一登记；未知或缺失契约必须 fail-closed。
 - `contract_status=complete` 不等于 Planner、Evaluator、Evolution 或 App 可用。入口许可必须由契约显式声明。
 - Capability Snapshot 只允许完整契约、真实 Adapter、Adapter 版本和 compiler checksum 一致的节点；当前范围仍严格为既有七类。
-- NodeContract 版本与 Planner IR 版本独立。Capability Snapshot V4 声明
+- NodeContract 版本与 Planner IR 版本独立。Capability Snapshot V5 声明
   `ir_version=3` 与 `supported_ir_versions=[2,3]`，但仍只开放既有七类能力。
 - `checksum` 覆盖完整契约，`compiler_checksum` 仅覆盖编译关键事实；标题、图标和分类不得使 Adapter 失效。
 - 前端 fallback 只能保存展示信息，不得伪造 Planner 状态、端口、安全策略或 checksum。
@@ -370,6 +370,17 @@ npm.cmd run build
 - 鼓励复用、适配或重写宽松许可证开源实现，但必须逐文件锁定官方 commit、相对路径、许可证、第三方依赖、SHA-256、`reuse/adapt/rewrite/reject`、NOTICE 和测试映射。
 - AGPL、source-available、混合许可证或来源不明实现默认仅作行为参考并独立重写；任何例外必须先完成新的许可证与架构审计。
 - Planner、Optimizer 和 Migration 能力始终只能生成候选、差异和报告，不得自动批准、静默覆盖人工草稿或发布线上版本。
+
+### 8.1.3 Meta Planner Headless Authoring 护栏
+
+- V3 候选和可无损恢复的 V2 候选必须使用 `GraphPatchEnvelopeV1`；不得把前端或模型输出的完整 Native Workflow 直接持久化。
+- Patch 只能引用 Planner ref、命名端口和 Adapter config。资源版本、Handle、Schema、执行策略和 checksum 必须由服务端推导。
+- Preview 必须无副作用；Apply 必须重新读取 Proposal、目标 Xpert 和 Capability Snapshot，并同时绑定 revision、Graph checksum、candidate checksum 与 Preview checksum。
+- `input/output` 为 compiler-managed。无法表达的画布修改、资源漂移、类型或基数错误必须显式 fail-closed，不得静默忽略。
+- Headless Apply 只更新 pending Proposal 一次；不得创建 Xpert 草稿、版本或运行。安全 receipt 不得保存 Prompt 正文、资源内容、工具输出或凭据。
+- Meta Planner Proposal 创建时的授权范围不得被后续整包 PATCH 扩大；Headless 请求必须遵守正文大小和 JSON 深度上限，持久化失败不得在内存中留下已递增 revision。
+- 有损 V2 转换继续走兼容读取、校验和审批路径，禁止 Headless Apply。旧整包 Proposal PATCH 必须将 Graph IR 标记为 stale。
+- 当前节点范围仍严格为既有七类；Headless Authoring 完成不等于开放 JSON、控制流、知识检索、数据库或视觉节点。
 
 ### 8.2 EvoAgentX Evaluator 护栏
 

--- a/client/src/components/meta/MetaPlannerV2.test.tsx
+++ b/client/src/components/meta/MetaPlannerV2.test.tsx
@@ -1,6 +1,23 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
+import { type WorkflowDefinition } from "../../types/workflow";
+
+vi.mock("../workflow/WorkflowEditor", () => ({
+  default: ({
+    initialDefinition,
+    onSave,
+    saveLabel,
+  }: {
+    initialDefinition: WorkflowDefinition;
+    onSave: (definition: WorkflowDefinition) => Promise<void>;
+    saveLabel: string;
+  }) => (
+    <button onClick={() => void onSave(initialDefinition)} type="button">
+      {saveLabel}
+    </button>
+  ),
+}));
 
 import { plannerModelOptions } from "../../pages/MetaAgentPage";
 import MetaPlannerV2, { candidateGenerationOutcome } from "./MetaPlannerV2";
@@ -141,5 +158,160 @@ describe("Meta Planner managed compatibility", () => {
       expect(screen.getByText("已纳管")).toBeInTheDocument();
       expect(screen.getByText("1 次模型调用")).toBeInTheDocument();
     });
+  });
+
+  it("previews a V3 editor diff before applying it and never uses whole-payload PATCH", async () => {
+    let revision = 1;
+    let applyCalls = 0;
+    const proposal = () => ({
+      proposal_id: "proposal_headless",
+      revision,
+      apply_key: "apply-key",
+      status: "pending",
+      kind: "xpert_create",
+      title: "Meta Planner: Headless",
+      target_id: null,
+      base_revision: null,
+      payload: {
+        name: "Headless",
+        description: "Typed authoring",
+        tags: [],
+        starters: [],
+        draft: {
+          workflow: {
+            id: "workflow_headless",
+            title: "Headless",
+            nodes: [],
+            edges: [],
+          },
+        },
+        meta_planner_report: {
+          ir_version: 3,
+          graph_ir: { version: 3 },
+          plan: { summary: "Headless plan", assumptions: [], tasks: [] },
+          warnings: [],
+        },
+      },
+      validation: { valid: true, stages: [] },
+      applied_resource_id: null,
+      updated_at: 1,
+    });
+    const jsonResponse = (body: unknown, status = 200) =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/meta-agent/capabilities") {
+        return jsonResponse({
+          version: "snapshot-v3",
+          ir_version: 3,
+          supported_ir_versions: [2, 3],
+          snapshot_hash: "snapshot-hash",
+          generated_at: 1,
+          nodes: [],
+          middleware: [],
+          external_xperts: [],
+          knowledge_bases: [],
+          toolsets: [],
+          plugins: [],
+          prompt_profiles: [],
+          default_scope: {
+            allowed_node_kinds: [],
+            external_xpert_ids: [],
+            knowledge_base_ids: [],
+            toolset_ids: [],
+            plugin_ids: [],
+            prompt_profile_ids: [],
+            middleware_ids: [],
+          },
+        });
+      }
+      if (url.startsWith("/api/xperts?")) return jsonResponse({ items: [], total: 0 });
+      if (url.startsWith("/api/runtime/authoring-proposals?")) {
+        return jsonResponse({ items: [{ proposal_id: "proposal_headless" }] });
+      }
+      if (url === "/api/runtime/authoring-proposals/proposal_headless") {
+        return jsonResponse(proposal());
+      }
+      if (url === "/api/meta-agent/authoring/proposals/proposal_headless") {
+        return jsonResponse({
+          proposal_id: "proposal_headless",
+          proposal_revision: revision,
+          authoring_protocol_version: "graph-patch-v1",
+          can_author: true,
+          graph_checksum: `graph-${revision}`,
+          candidate_checksum: `candidate-${revision}`,
+          graph_ir: { version: 3 },
+          allowed_node_kinds: ["input", "output", "workflow_agent"],
+          compiler_managed_node_kinds: ["input", "output"],
+          compatibility: { source_version: 3, lossy: false },
+        });
+      }
+      if (url.endsWith("/editor-diff") && init?.method === "POST") {
+        return jsonResponse({
+          patch: {
+            protocol_version: 1,
+            proposal_revision: revision,
+            expected_graph_checksum: `graph-${revision}`,
+            expected_candidate_checksum: `candidate-${revision}`,
+            operations: [{ op: "move_node", ref: "agent-main", x: 20, y: 30 }],
+          },
+        });
+      }
+      if (url.endsWith("/patch/preview") && init?.method === "POST") {
+        return jsonResponse({
+          preview_checksum: "preview-checksum",
+          can_apply: true,
+          diagnostics: [],
+          warnings: [],
+          diff: { layout_changed: true },
+        });
+      }
+      if (url.endsWith("/patch/apply") && init?.method === "POST") {
+        applyCalls += 1;
+        revision = 2;
+        return jsonResponse({
+          version: "meta-planner-headless-authoring-v1",
+          proposal_id: "proposal_headless",
+          proposal_revision: revision,
+          status: "pending",
+          validation: { valid: true, stages: [] },
+          graph_checksum: "graph-2",
+          candidate_checksum: "candidate-2",
+          receipt_count: 1,
+        });
+      }
+      if (url === "/api/runtime/authoring-proposals/proposal_headless" && init?.method === "PATCH") {
+        throw new Error("V3 authoring must not use whole-payload PATCH");
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <MemoryRouter>
+        <MetaPlannerV2 />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("无头编排已启用。", { exact: false });
+    fireEvent.click(screen.getByRole("button", { name: "预览候选画布" }));
+
+    await screen.findByRole("dialog", { name: "确认类型化变更" });
+    expect(applyCalls).toBe(0);
+    expect(screen.getByText("move_node")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "确认应用" }));
+
+    await screen.findByText("Proposal r2");
+    expect(applyCalls).toBe(1);
+    expect(
+      fetchMock.mock.calls.some(
+        ([url, init]) =>
+          String(url) === "/api/runtime/authoring-proposals/proposal_headless" &&
+          (init as RequestInit | undefined)?.method === "PATCH",
+      ),
+    ).toBe(false);
   });
 });

--- a/client/src/components/meta/MetaPlannerV2.tsx
+++ b/client/src/components/meta/MetaPlannerV2.tsx
@@ -8,6 +8,18 @@ import { listXperts, toXpertDraftWorkflow } from "../../utils/xpertApi";
 import ProviderRouteReceiptSummary, {
   type ProviderRouteReceipt,
 } from "./ProviderRouteReceiptSummary";
+import {
+  authoringDiffSummary,
+  buildMetadataPatch,
+  headlessStateMode,
+  normalizeGraphPatchEnvelope,
+  normalizeGraphPatchPreview,
+  normalizeHeadlessProposalState,
+  normalizeAuthoringDiagnostics,
+  type GraphPatchEnvelopeV1,
+  type GraphPatchPreview,
+  type HeadlessAuthoringProposalState,
+} from "./metaAuthoring";
 import WorkflowEditor from "../workflow/WorkflowEditor";
 
 type ScopeKey =
@@ -55,6 +67,8 @@ interface CapabilitySnapshot {
   plugins: CapabilityItem[];
   prompt_profiles: CapabilityItem[];
   default_scope: MetaPlannerScope;
+  authoring_protocol_version?: string | number;
+  authoring_limits?: Record<string, unknown>;
 }
 
 const DEFAULT_META_PLANNER_MODEL_ID = models.some(
@@ -136,6 +150,17 @@ interface AuthoringProposal {
   updated_at: number;
 }
 
+type AuthoringAvailability =
+  | { mode: "legacy"; reason: string }
+  | { mode: "headless"; state: HeadlessAuthoringProposalState }
+  | { mode: "unavailable"; reason: string };
+
+interface PendingAuthoringPreview {
+  patch: GraphPatchEnvelopeV1;
+  preview: GraphPatchPreview;
+  source: "canvas" | "metadata";
+}
+
 const emptyScope = (): MetaPlannerScope => ({
   allowed_node_kinds: [],
   external_xpert_ids: [],
@@ -150,10 +175,27 @@ function readError(payload: unknown, fallback: string) {
   if (typeof payload === "object" && payload !== null) {
     const detail = (payload as { detail?: unknown }).detail;
     if (typeof detail === "string") return detail;
+    if (typeof detail === "object" && detail !== null) {
+      const message = (detail as { message?: unknown }).message;
+      if (typeof message === "string") return message;
+    }
     const error = (payload as { error?: unknown }).error;
     if (typeof error === "string") return error;
   }
   return fallback;
+}
+
+function readAuthoringError(payload: unknown, fallback: string) {
+  const base = readError(payload, fallback);
+  if (typeof payload !== "object" || payload === null) return base;
+  const detail = (payload as { detail?: unknown }).detail;
+  const diagnostics = normalizeAuthoringDiagnostics(
+    typeof detail === "object" && detail !== null
+      ? (detail as { diagnostics?: unknown }).diagnostics
+      : (payload as { diagnostics?: unknown }).diagnostics,
+  );
+  if (!diagnostics.length) return base;
+  return `${base} ${diagnostics.map((item) => item.message).join("；")}`;
 }
 
 export function candidateGenerationOutcome(
@@ -303,6 +345,13 @@ export default function MetaPlannerV2() {
   const [maxAgents, setMaxAgents] = useState(5);
   const [proposal, setProposal] = useState<AuthoringProposal | null>(null);
   const [candidate, setCandidate] = useState<CandidateXpert | null>(null);
+  const [authoringAvailability, setAuthoringAvailability] =
+    useState<AuthoringAvailability>({
+      mode: "legacy",
+      reason: "尚未加载候选。",
+    });
+  const [pendingAuthoringPreview, setPendingAuthoringPreview] =
+    useState<PendingAuthoringPreview | null>(null);
   const [plan, setPlan] = useState<PlannerPlan | null>(null);
   const [warnings, setWarnings] = useState<string[]>([]);
   const [repairUsed, setRepairUsed] = useState(false);
@@ -375,6 +424,7 @@ export default function MetaPlannerV2() {
     }
     const restored = payload as AuthoringProposal;
     const report = reportFromProposal(restored);
+    setPendingAuthoringPreview(null);
     setProposal(restored);
     setCandidate(candidateFromProposal(restored));
     setMode(restored.kind === "xpert_update" ? "update" : "create");
@@ -394,7 +444,56 @@ export default function MetaPlannerV2() {
           "",
       ),
     );
+    await loadAuthoringState(restored);
     if (showNotice) setNotice("已恢复持久化候选。");
+  }
+
+  async function loadAuthoringState(restored: AuthoringProposal) {
+    const report = reportFromProposal(restored);
+    const compatibility =
+      typeof report.compatibility === "object" && report.compatibility !== null
+        ? (report.compatibility as { lossy?: unknown })
+        : null;
+    if (compatibility?.lossy === true) {
+      setAuthoringAvailability({
+        mode: "legacy",
+        reason: "该候选存在有损 V2/V3 转换，继续使用兼容保存路径。",
+      });
+      return;
+    }
+    try {
+      const response = await fetch(
+        `/api/meta-agent/authoring/proposals/${restored.proposal_id}`,
+      );
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(readError(payload, "无法加载无头编排状态。"));
+      }
+      const state = normalizeHeadlessProposalState(payload);
+      if (!state) throw new Error("无头编排状态响应不完整。候选未降级保存。");
+      if (
+        state.proposal_id !== restored.proposal_id ||
+        state.proposal_revision !== restored.revision
+      ) {
+        throw new Error("Proposal revision 已变化，请重新加载候选后再编辑。");
+      }
+      if (headlessStateMode(state) !== "headless") {
+        setAuthoringAvailability({
+          mode: "unavailable",
+          reason: state.compatibility.lossy
+            ? "该候选无法无损反编译；类型化编辑已锁定。"
+            : "该候选无法满足类型化编排门禁；请处理诊断并重新加载，系统不会降级为整包保存。",
+        });
+        return;
+      }
+      setAuthoringAvailability({ mode: "headless", state });
+    } catch (stateError) {
+      setAuthoringAvailability({
+        mode: "unavailable",
+        reason:
+          stateError instanceof Error ? stateError.message : "无头编排状态加载失败。",
+      });
+    }
   }
 
   function toggleScope(key: ScopeKey, value: string) {
@@ -487,7 +586,7 @@ export default function MetaPlannerV2() {
     };
   }
 
-  async function saveCandidate(definition?: WorkflowDefinition) {
+  async function saveLegacyCandidate(definition?: WorkflowDefinition) {
     if (!proposal || !candidate) return;
     const nextCandidate: CandidateXpert = definition
       ? {
@@ -498,34 +597,191 @@ export default function MetaPlannerV2() {
           },
         }
       : candidate;
+    const response = await fetch(
+      `/api/runtime/authoring-proposals/${proposal.proposal_id}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          revision: proposal.revision,
+          title: `Meta Planner: ${nextCandidate.name}`,
+          payload: proposalPayload(nextCandidate),
+          base_revision: proposal.base_revision,
+        }),
+      },
+    );
+    const payload = (await response.json().catch(() => null)) as
+      | AuthoringProposal
+      | { detail?: string }
+      | null;
+    if (!response.ok || !payload || !("proposal_id" in payload)) {
+      throw new Error(readError(payload, "保存候选失败。"));
+    }
+    setProposal(payload as AuthoringProposal);
+    setCandidate(candidateFromProposal(payload as AuthoringProposal));
+    setNotice("兼容候选已保存，Proposal revision 已更新。");
+  }
+
+  async function previewGraphPatch(
+    patch: GraphPatchEnvelopeV1,
+    source: PendingAuthoringPreview["source"],
+  ) {
+    if (!proposal) return;
+    const response = await fetch(
+      `/api/meta-agent/authoring/proposals/${proposal.proposal_id}/patch/preview`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      },
+    );
+    const payload = await response.json().catch(() => null);
+    if (!response.ok) {
+      const prefix = response.status === 409 ? "预览冲突" : "Patch 预览失败";
+      throw new Error(`${prefix}：${readAuthoringError(payload, "服务端拒绝了当前变更。")}`);
+    }
+    const preview = normalizeGraphPatchPreview(payload);
+    if (!preview) throw new Error("Patch 预览响应不完整，未执行任何写入。");
+    setPendingAuthoringPreview({ patch, preview, source });
+    setNotice(
+      preview.can_apply
+        ? "变更预览已生成；确认前 Proposal 保持不变。"
+        : "变更未通过门禁；请查看预览诊断。",
+    );
+  }
+
+  async function previewEditorDiff(definition: WorkflowDefinition) {
+    if (!proposal) return;
+    const response = await fetch(
+      `/api/meta-agent/authoring/proposals/${proposal.proposal_id}/editor-diff`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          proposal_revision: proposal.revision,
+          definition,
+        }),
+      },
+    );
+    const payload = await response.json().catch(() => null);
+    if (!response.ok) {
+      const prefix = response.status === 409 ? "编辑冲突" : "画布差异转换失败";
+      throw new Error(`${prefix}：${readAuthoringError(payload, "存在无法表达的画布修改。")}`);
+    }
+    const patch = normalizeGraphPatchEnvelope(payload);
+    if (!patch) throw new Error("服务端未返回有效的 Graph Patch；Proposal 未发生变化。");
+    if (patch.operations.length === 0) {
+      setNotice("画布没有需要应用的语义或布局变更。");
+      return;
+    }
+    await previewGraphPatch(patch, "canvas");
+  }
+
+  async function saveCandidate(definition?: WorkflowDefinition) {
+    if (!proposal || !candidate) return;
+    setIsSaving(true);
+    setError("");
+    setNotice("");
+    try {
+      if (authoringAvailability.mode === "headless") {
+        if (definition) {
+          await previewEditorDiff(definition);
+        } else {
+          await previewGraphPatch(
+            buildMetadataPatch(authoringAvailability.state, {
+              name: candidate.name,
+              description: candidate.description,
+              tags: candidate.tags,
+              starters: candidate.starters,
+            }),
+            "metadata",
+          );
+        }
+      } else if (authoringAvailability.mode === "legacy") {
+        await saveLegacyCandidate(definition);
+      } else {
+        throw new Error(
+          `${authoringAvailability.reason} 为避免绕过类型化门禁，V3 候选不会降级为整包保存。`,
+        );
+      }
+    } catch (saveError) {
+      const message = saveError instanceof Error ? saveError.message : "保存候选失败。";
+      setError(message);
+      throw saveError instanceof Error ? saveError : new Error(message);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function applyPendingPreview() {
+    if (!proposal || !pendingAuthoringPreview) return;
     setIsSaving(true);
     setError("");
     try {
       const response = await fetch(
-        `/api/runtime/authoring-proposals/${proposal.proposal_id}`,
+        `/api/meta-agent/authoring/proposals/${proposal.proposal_id}/patch/apply`,
         {
-          method: "PATCH",
+          method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            revision: proposal.revision,
-            title: `Meta Planner: ${nextCandidate.name}`,
-            payload: proposalPayload(nextCandidate),
-            base_revision: proposal.base_revision,
+            patch: pendingAuthoringPreview.patch,
+            preview_checksum: pendingAuthoringPreview.preview.preview_checksum,
           }),
         },
       );
-      const payload = (await response.json().catch(() => null)) as
-        | AuthoringProposal
-        | { detail?: string }
-        | null;
-      if (!response.ok || !payload || !("proposal_id" in payload)) {
-        throw new Error(readError(payload, "保存候选失败。"));
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        if (response.status === 409) {
+          setPendingAuthoringPreview(null);
+          throw new Error(
+            `应用冲突：${readAuthoringError(payload, "Proposal、目标草稿或能力快照已变化，请重新加载并预览。")}`,
+          );
+        }
+        throw new Error(readAuthoringError(payload, "应用 Graph Patch 失败。"));
       }
-      setProposal(payload as AuthoringProposal);
-      setCandidate(candidateFromProposal(payload as AuthoringProposal));
-      setNotice("候选已保存，Proposal revision 已更新。");
-    } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : "保存候选失败。");
+      // A successful Apply is authoritative even if the follow-up read fails.
+      // Clear the one-shot preview before reloading so it cannot be submitted twice.
+      setPendingAuthoringPreview(null);
+      const applied =
+        typeof payload === "object" && payload !== null && "proposal" in payload
+          ? (payload as { proposal?: unknown }).proposal
+          : payload;
+      if (
+        typeof applied !== "object" ||
+        applied === null ||
+        !("proposal_id" in applied) ||
+        typeof (applied as { proposal_id?: unknown }).proposal_id !== "string"
+      ) {
+        throw new Error(
+          "服务端已接受 Patch，但回执缺少 Proposal 标识；请重新加载确认状态，不要重复应用。",
+        );
+      }
+      const appliedProposalId = String(
+        (applied as { proposal_id: unknown }).proposal_id,
+      );
+      const appliedRevision =
+        typeof (applied as { proposal_revision?: unknown }).proposal_revision === "number"
+          ? Number((applied as { proposal_revision: number }).proposal_revision)
+          : typeof (applied as { revision?: unknown }).revision === "number"
+            ? Number((applied as { revision: number }).revision)
+            : null;
+      const expectedRevision = proposal.revision + 1;
+      try {
+        await loadProposal(appliedProposalId, false);
+      } catch (reloadError) {
+        const message =
+          reloadError instanceof Error ? reloadError.message : "无法重新加载候选。";
+        throw new Error(
+          `类型化变更已应用，但刷新候选失败：${message} 请重新加载确认状态，不要重复应用。`,
+        );
+      }
+      setNotice(
+        appliedRevision === expectedRevision
+          ? "类型化变更已原子应用，Proposal revision 增加一次。"
+          : "变更已应用，但 revision 回执异常；请在继续审批前重新核对候选。",
+      );
+    } catch (applyError) {
+      setError(applyError instanceof Error ? applyError.message : "应用 Graph Patch 失败。");
     } finally {
       setIsSaving(false);
     }
@@ -852,14 +1108,16 @@ export default function MetaPlannerV2() {
                     <button
                       className="rounded-md border border-white/10 px-3 py-2 text-xs font-semibold text-slate-200 hover:bg-white/5"
                       disabled={isSaving}
-                      onClick={() => void saveCandidate()}
+                      onClick={() => void saveCandidate().catch(() => undefined)}
                       type="button"
                     >
-                      保存元数据
+                      {authoringAvailability.mode === "headless"
+                        ? "预览元数据变更"
+                        : "保存元数据"}
                     </button>
                     <button
                       className="rounded-md border border-cyan-300/30 bg-cyan-300/10 px-3 py-2 text-xs font-semibold text-cyan-100 hover:bg-cyan-300/15"
-                      disabled={isSaving}
+                      disabled={isSaving || Boolean(pendingAuthoringPreview)}
                       onClick={() => void proposalAction("validate")}
                       type="button"
                     >
@@ -867,7 +1125,7 @@ export default function MetaPlannerV2() {
                     </button>
                     <button
                       className="rounded-md bg-emerald-300 px-3 py-2 text-xs font-semibold text-emerald-950 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500"
-                      disabled={isSaving}
+                      disabled={isSaving || Boolean(pendingAuthoringPreview)}
                       onClick={() => void proposalAction("approve")}
                       type="button"
                     >
@@ -932,14 +1190,95 @@ export default function MetaPlannerV2() {
                 </div>
               </div>
 
+              <div
+                className={`rounded-lg border px-3 py-2 text-xs leading-5 ${
+                  authoringAvailability.mode === "headless"
+                    ? "border-cyan-300/20 bg-cyan-300/[0.07] text-cyan-100"
+                    : authoringAvailability.mode === "legacy"
+                      ? "border-amber-300/20 bg-amber-300/[0.07] text-amber-100"
+                      : "border-rose-300/25 bg-rose-300/[0.08] text-rose-100"
+                }`}
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <p>
+                    {authoringAvailability.mode === "headless" ? (
+                      <>
+                        无头编排已启用。画布与元数据修改会先转换为类型化 Patch；确认应用前不会修改
+                        Proposal。当前授权 {authoringAvailability.state.allowed_node_kinds.length} 类节点。
+                      </>
+                    ) : (
+                      authoringAvailability.reason
+                    )}
+                  </p>
+                  <button
+                    className="rounded-md border border-current/20 px-2.5 py-1 font-semibold hover:bg-white/5 disabled:opacity-50"
+                    disabled={isSaving}
+                    onClick={() => {
+                      setIsSaving(true);
+                      setError("");
+                      void loadProposal(proposal.proposal_id)
+                        .catch((reloadError) => {
+                          setError(
+                            reloadError instanceof Error
+                              ? reloadError.message
+                              : "重新加载候选失败。",
+                          );
+                        })
+                        .finally(() => setIsSaving(false));
+                    }}
+                    type="button"
+                  >
+                    重新加载候选
+                  </button>
+                </div>
+              </div>
+
               <div className="h-[820px] overflow-hidden rounded-lg border border-white/10 bg-slate-950">
-                <WorkflowEditor
+                {authoringAvailability.mode === "unavailable" ? (
+                  <div className="flex h-full items-center justify-center p-8 text-center">
+                    <div className="max-w-xl rounded-lg border border-rose-300/20 bg-rose-300/[0.06] p-5 text-sm leading-6 text-rose-100">
+                      <p className="font-semibold">候选画布已锁定为只读</p>
+                      <p className="mt-2 text-rose-100/75">
+                        {authoringAvailability.reason}
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <WorkflowEditor
+                  authoringPolicy={
+                    authoringAvailability.mode === "headless"
+                      ? {
+                          allowedNodeKinds: [
+                            ...authoringAvailability.state.allowed_node_kinds,
+                            ...(authoringAvailability.state.allowed_middleware_ids.length
+                              ? (["runtime_middleware"] as const)
+                              : []),
+                          ],
+                          compilerManagedNodeKinds:
+                            authoringAvailability.state.compiler_managed_node_kinds,
+                          allowedRuntimeMiddlewareIds:
+                            authoringAvailability.state.allowed_middleware_ids,
+                          allowedSourceAgentIds:
+                            authoringAvailability.state.allowed_source_agent_ids,
+                        }
+                      : undefined
+                  }
                   initialDefinition={workflow}
                   key={`${proposal.proposal_id}-${proposal.revision}`}
                   onSave={saveCandidate}
-                  saveLabel="保存候选画布"
+                  saveCompletionLabel={
+                    authoringAvailability.mode === "headless"
+                      ? "变更预览已生成，等待确认应用"
+                      : "候选画布已保存"
+                  }
+                  saveLabel={
+                    authoringAvailability.mode === "headless"
+                      ? "预览候选画布"
+                      : "保存候选画布"
+                  }
                   workflowId={`meta-planner-${proposal.proposal_id}`}
-                />
+                  />
+                )}
               </div>
             </>
           ) : (
@@ -968,6 +1307,97 @@ export default function MetaPlannerV2() {
           ) : null}
         </div>
       </div>
+      {pendingAuthoringPreview ? (
+        <div
+          aria-labelledby="meta-authoring-preview-title"
+          aria-modal="true"
+          className="fixed inset-0 z-[90] flex items-center justify-center bg-slate-950/80 p-4 backdrop-blur-sm"
+          role="dialog"
+        >
+          <div className="max-h-[86vh] w-full max-w-2xl overflow-y-auto rounded-lg border border-cyan-300/25 bg-slate-950 p-5 shadow-2xl">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-base font-semibold text-white" id="meta-authoring-preview-title">
+                  确认类型化变更
+                </h2>
+                <p className="mt-1 text-xs leading-5 text-slate-400">
+                  {pendingAuthoringPreview.source === "canvas" ? "候选画布" : "候选元数据"}
+                  已完成无副作用预览。只有点击“确认应用”后 Proposal revision 才会更新一次。
+                </p>
+              </div>
+              <button
+                aria-label="关闭变更预览"
+                className="flex h-8 w-8 items-center justify-center rounded-md border border-white/10 text-slate-400 hover:bg-white/5 hover:text-white"
+                onClick={() => setPendingAuthoringPreview(null)}
+                type="button"
+              >
+                ×
+              </button>
+            </div>
+
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div className="rounded-md border border-white/10 bg-white/[0.035] p-3">
+                <p className="text-xs font-semibold text-slate-200">Patch 操作</p>
+                <div className="mt-2 space-y-1 text-xs text-slate-400">
+                  {pendingAuthoringPreview.patch.operations.map((operation, index) => (
+                    <p key={`${operation.op}-${index}`}>
+                      {index + 1}. <span className="font-mono text-cyan-100">{operation.op}</span>
+                    </p>
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-md border border-white/10 bg-white/[0.035] p-3">
+                <p className="text-xs font-semibold text-slate-200">结构差异</p>
+                <div className="mt-2 space-y-1 text-xs text-slate-400">
+                  {authoringDiffSummary(pendingAuthoringPreview.preview.diff).map((line) => (
+                    <p key={line}>{line}</p>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {pendingAuthoringPreview.preview.diagnostics.length ? (
+              <div className="mt-3 rounded-md border border-rose-300/20 bg-rose-300/[0.07] p-3">
+                <p className="text-xs font-semibold text-rose-100">门禁诊断</p>
+                <div className="mt-2 space-y-1 text-xs text-rose-100/90">
+                  {pendingAuthoringPreview.preview.diagnostics.map((diagnostic, index) => (
+                    <p key={`${diagnostic.code ?? "diagnostic"}-${index}`}>
+                      {diagnostic.code ? `[${diagnostic.code}] ` : ""}{diagnostic.message}
+                    </p>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {pendingAuthoringPreview.preview.warnings.length ? (
+              <div className="mt-3 rounded-md border border-amber-300/20 bg-amber-300/[0.07] p-3 text-xs text-amber-100">
+                {pendingAuthoringPreview.preview.warnings.map((warning) => (
+                  <p key={warning}>{warning}</p>
+                ))}
+              </div>
+            ) : null}
+
+            <div className="mt-5 flex flex-wrap justify-end gap-2">
+              <button
+                className="rounded-md border border-white/10 px-4 py-2 text-sm font-semibold text-slate-200 hover:bg-white/5"
+                disabled={isSaving}
+                onClick={() => setPendingAuthoringPreview(null)}
+                type="button"
+              >
+                放弃预览
+              </button>
+              <button
+                className="rounded-md bg-cyan-300 px-4 py-2 text-sm font-semibold text-slate-950 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500"
+                disabled={isSaving || !pendingAuthoringPreview.preview.can_apply}
+                onClick={() => void applyPendingPreview()}
+                type="button"
+              >
+                {isSaving ? "正在应用..." : "确认应用"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/client/src/components/meta/metaAuthoring.test.ts
+++ b/client/src/components/meta/metaAuthoring.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  authoringDiffSummary,
+  buildMetadataPatch,
+  canUseTypedHeadlessAuthoring,
+  headlessStateMode,
+  normalizeGraphPatchEnvelope,
+  normalizeGraphPatchPreview,
+  normalizeHeadlessProposalState,
+} from "./metaAuthoring";
+
+describe("Meta Planner headless authoring contracts", () => {
+  it("normalizes a V3 proposal state without inventing resource authority", () => {
+    const state = normalizeHeadlessProposalState({
+      proposal_id: "proposal_v3",
+      proposal_revision: 4,
+      authoring_protocol_version: "graph-patch-v1",
+      ir_version: 3,
+      can_author: true,
+      graph_checksum: "graph-checksum",
+      candidate_checksum: "candidate-checksum",
+      allowed_node_kinds: ["input", "output", "workflow_agent"],
+      compiler_managed_node_kinds: ["input", "output"],
+      authorized_scope: {
+        agent_ids: ["expert-reviewer"],
+      },
+      compatibility: { source_version: 3, lossy: false },
+    });
+
+    expect(state).toMatchObject({
+      proposal_id: "proposal_v3",
+      proposal_revision: 4,
+      can_author: true,
+      allowed_node_kinds: ["input", "output", "workflow_agent"],
+      allowed_source_agent_ids: ["expert-reviewer"],
+    });
+    expect(state?.allowed_node_kinds).not.toContain("json_serialize");
+  });
+
+  it("allows a lossless V2 proposal to upgrade through typed apply", () => {
+    const state = normalizeHeadlessProposalState({
+      proposal_id: "proposal_v2",
+      proposal_revision: 2,
+      authoring_protocol_version: 1,
+      ir_version: 2,
+      can_author: true,
+      graph_checksum: "graph-v2",
+      candidate_checksum: "candidate-v2",
+      compatibility: {
+        source_version: 2,
+        upgraded: true,
+        lossy: false,
+      },
+    });
+
+    expect(state).not.toBeNull();
+    expect(canUseTypedHeadlessAuthoring(state!)).toBe(true);
+    expect(
+      canUseTypedHeadlessAuthoring({
+        ...state!,
+        compatibility: { ...state!.compatibility, lossy: true },
+      }),
+    ).toBe(false);
+  });
+
+  it("never downgrades a server-denied typed state to legacy authoring", () => {
+    const state = normalizeHeadlessProposalState({
+      proposal_id: "proposal_denied",
+      proposal_revision: 2,
+      authoring_protocol_version: 1,
+      ir_version: 3,
+      can_author: false,
+      graph_checksum: "graph-checksum",
+      candidate_checksum: "candidate-checksum",
+      compatibility: { source_version: 3, lossy: false },
+    });
+
+    expect(state).not.toBeNull();
+    expect(headlessStateMode(state!)).toBe("unavailable");
+    expect(canUseTypedHeadlessAuthoring(state!)).toBe(false);
+  });
+
+  it("rejects malformed editor diff envelopes before preview", () => {
+    expect(normalizeGraphPatchEnvelope({
+      proposal_revision: 2,
+      expected_graph_checksum: "graph",
+      operations: [{ op: "add_node" }],
+    })).toBeNull();
+    expect(normalizeGraphPatchEnvelope({
+      proposal_revision: 2,
+      expected_graph_checksum: "graph",
+      expected_candidate_checksum: "candidate",
+      operations: Array.from({ length: 65 }, () => ({ op: "move_node" })),
+    })).toBeNull();
+    expect(normalizeGraphPatchEnvelope({
+      protocol_version: 2,
+      proposal_revision: 2,
+      expected_graph_checksum: "graph",
+      expected_candidate_checksum: "candidate",
+      operations: [{ op: "move_node" }],
+    })).toBeNull();
+    expect(normalizeGraphPatchEnvelope({
+      protocol_version: 1,
+      proposal_revision: 2,
+      expected_graph_checksum: "graph",
+      expected_candidate_checksum: "candidate",
+      operations: [{ op: "move_node" }, { injected: true }],
+    })).toBeNull();
+  });
+
+  it("builds metadata edits as a revision and checksum bound patch", () => {
+    const state = normalizeHeadlessProposalState({
+      proposal_id: "proposal_v3",
+      proposal_revision: 7,
+      protocol_version: 1,
+      ir_version: 3,
+      graph_ir_checksum: "graph-v7",
+      compiled_candidate_checksum: "candidate-v7",
+      allowed_node_kinds: ["workflow_agent"],
+      compatibility: { lossy: false },
+    });
+    expect(state).not.toBeNull();
+    const patch = buildMetadataPatch(state!, {
+      name: "Research Xpert",
+      description: "Bounded research workflow",
+      tags: ["research"],
+      starters: [],
+    });
+    expect(patch).toEqual({
+      protocol_version: 1,
+      proposal_revision: 7,
+      expected_graph_checksum: "graph-v7",
+      expected_candidate_checksum: "candidate-v7",
+      operations: [{
+        op: "set_xpert_metadata",
+        name: "Research Xpert",
+        description: "Bounded research workflow",
+        tags: ["research"],
+        starters: [],
+      }],
+    });
+  });
+
+  it("keeps failed preview diagnostics visible and non-applicable", () => {
+    const preview = normalizeGraphPatchPreview({
+      preview_checksum: "preview-1",
+      can_apply: false,
+      diagnostics: [{ code: "TYPE_MISMATCH", message: "Port types differ" }],
+      warnings: ["snapshot drift"],
+      diff: { nodes_updated: ["agent-a"] },
+    });
+    expect(preview?.can_apply).toBe(false);
+    expect(preview?.diagnostics[0]?.code).toBe("TYPE_MISMATCH");
+    expect(authoringDiffSummary(preview?.diff ?? {})).toContain("nodes_updated: 1");
+  });
+});

--- a/client/src/components/meta/metaAuthoring.ts
+++ b/client/src/components/meta/metaAuthoring.ts
@@ -1,0 +1,306 @@
+import { type WorkflowNodeKind } from "../../types/workflow";
+
+export interface AuthoringDiagnostic {
+  code?: string;
+  message: string;
+  severity?: "error" | "warning" | "info";
+  path?: string;
+}
+
+export interface GraphPatchOperationV1 {
+  op: string;
+  [key: string]: unknown;
+}
+
+export interface GraphPatchEnvelopeV1 {
+  protocol_version: 1;
+  proposal_revision: number;
+  expected_graph_checksum: string;
+  expected_candidate_checksum: string;
+  operations: GraphPatchOperationV1[];
+}
+
+export interface HeadlessAuthoringCompatibility {
+  source_version?: 2 | 3;
+  upgraded?: boolean;
+  lossy?: boolean;
+  warnings?: string[];
+}
+
+export interface HeadlessAuthoringProposalState {
+  proposal_id: string;
+  proposal_revision: number;
+  authoring_protocol_version: string | number;
+  ir_version: 2 | 3;
+  can_author: boolean;
+  graph_checksum: string;
+  candidate_checksum: string;
+  allowed_node_kinds: WorkflowNodeKind[];
+  allowed_middleware_ids: string[];
+  allowed_source_agent_ids: string[];
+  compiler_managed_node_kinds: WorkflowNodeKind[];
+  compatibility: HeadlessAuthoringCompatibility;
+  diagnostics: AuthoringDiagnostic[];
+}
+
+export interface GraphPatchPreview {
+  preview_checksum: string;
+  can_apply: boolean;
+  diagnostics: AuthoringDiagnostic[];
+  warnings: string[];
+  diff: Record<string, unknown>;
+  graph_ir_checksum?: string;
+  candidate_checksum?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown) {
+  return typeof value === "string" ? value : "";
+}
+
+function numberValue(value: unknown, fallback = 0) {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function stringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+export function normalizeAuthoringDiagnostics(value: unknown): AuthoringDiagnostic[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (typeof item === "string") return [{ message: item }];
+    if (!isRecord(item) || typeof item.message !== "string") return [];
+    const severity = ["error", "warning", "info"].includes(String(item.severity))
+      ? (item.severity as AuthoringDiagnostic["severity"])
+      : undefined;
+    return [{
+      code: stringValue(item.code) || undefined,
+      message: item.message,
+      severity,
+      path: stringValue(item.path) || undefined,
+    }];
+  });
+}
+
+export function normalizeHeadlessProposalState(
+  payload: unknown,
+): HeadlessAuthoringProposalState | null {
+  if (!isRecord(payload)) return null;
+  const compatibility = isRecord(payload.compatibility) ? payload.compatibility : {};
+  const scope = isRecord(payload.scope) ? payload.scope : {};
+  const authorizedScope = isRecord(payload.authorized_scope)
+    ? payload.authorized_scope
+    : scope;
+  const graphChecksum = stringValue(
+    payload.graph_checksum ?? payload.graph_ir_checksum,
+  );
+  const candidateChecksum = stringValue(
+    payload.candidate_checksum ??
+      payload.compiled_workflow_checksum ??
+      payload.compiled_candidate_checksum ??
+      payload.authoring_candidate_checksum,
+  );
+  const requestedIrVersion = numberValue(payload.ir_version);
+  const irVersion = requestedIrVersion === 2 || requestedIrVersion === 3
+    ? requestedIrVersion
+    : payload.graph_ir && payload.authoring_protocol_version != null
+      ? 3
+      : 0;
+  const proposalRevision = numberValue(
+    payload.proposal_revision ?? payload.revision,
+  );
+  const allowedKinds = stringArray(
+    payload.allowed_node_kinds ?? authorizedScope.allowed_node_kinds,
+  ) as WorkflowNodeKind[];
+  const lossy = compatibility.lossy === true;
+  const explicitCanAuthor =
+    payload.can_author ?? payload.can_edit ?? payload.can_apply ?? payload.headless_apply_allowed;
+  const protocol = payload.authoring_protocol_version ?? payload.protocol_version;
+  if (
+    typeof payload.proposal_id !== "string" ||
+    proposalRevision < 1 ||
+    (irVersion !== 2 && irVersion !== 3) ||
+    protocol == null
+  ) {
+    return null;
+  }
+  return {
+    proposal_id: payload.proposal_id,
+    proposal_revision: proposalRevision,
+    authoring_protocol_version:
+      typeof protocol === "string" || typeof protocol === "number" ? protocol : 1,
+    ir_version: irVersion,
+    can_author:
+      typeof explicitCanAuthor === "boolean"
+        ? explicitCanAuthor
+        : irVersion === 3 && !lossy,
+    graph_checksum: graphChecksum,
+    candidate_checksum: candidateChecksum,
+    allowed_node_kinds: allowedKinds,
+    allowed_middleware_ids: stringArray(authorizedScope.middleware_ids),
+    allowed_source_agent_ids: stringArray(authorizedScope.agent_ids),
+    compiler_managed_node_kinds: (
+      stringArray(payload.compiler_managed_node_kinds).length
+        ? stringArray(payload.compiler_managed_node_kinds)
+        : ["input", "output"]
+    ) as WorkflowNodeKind[],
+    compatibility: {
+      source_version:
+        compatibility.source_version === 2 || compatibility.source_version === 3
+          ? compatibility.source_version
+          : undefined,
+      upgraded: compatibility.upgraded === true,
+      lossy,
+      warnings: stringArray(compatibility.warnings),
+    },
+    diagnostics: normalizeAuthoringDiagnostics(payload.diagnostics),
+  };
+}
+
+export function normalizeGraphPatchEnvelope(
+  payload: unknown,
+): GraphPatchEnvelopeV1 | null {
+  if (!isRecord(payload)) return null;
+  const source = isRecord(payload.patch)
+    ? payload.patch
+    : isRecord(payload.envelope)
+      ? payload.envelope
+      : payload;
+  if (
+    source.protocol_version != null &&
+    numberValue(source.protocol_version) !== 1
+  ) {
+    return null;
+  }
+  if (!Array.isArray(source.operations)) return null;
+  const operations = source.operations;
+  if (
+    operations.some(
+      (item) => !isRecord(item) || typeof item.op !== "string" || !item.op.trim(),
+    )
+  ) {
+    return null;
+  }
+  const revision = numberValue(source.proposal_revision);
+  const graphChecksum = stringValue(
+    source.expected_graph_checksum ?? source.graph_checksum,
+  );
+  const candidateChecksum = stringValue(
+    source.expected_candidate_checksum ??
+      source.expected_compiled_workflow_checksum ??
+      source.compiled_workflow_checksum ??
+      source.compiled_candidate_checksum,
+  );
+  if (
+    revision < 1 ||
+    operations.length > 64 ||
+    !graphChecksum ||
+    !candidateChecksum
+  ) {
+    return null;
+  }
+  return {
+    protocol_version: 1,
+    proposal_revision: revision,
+    expected_graph_checksum: graphChecksum,
+    expected_candidate_checksum: candidateChecksum,
+    operations: operations as GraphPatchOperationV1[],
+  };
+}
+
+export function canUseTypedHeadlessAuthoring(
+  state: HeadlessAuthoringProposalState,
+) {
+  const losslessV2Upgrade =
+    state.ir_version === 2 && state.compatibility.upgraded === true;
+  return (
+    state.can_author &&
+    !state.compatibility.lossy &&
+    (state.ir_version === 3 || losslessV2Upgrade) &&
+    Boolean(state.graph_checksum) &&
+    Boolean(state.candidate_checksum)
+  );
+}
+
+export function headlessStateMode(
+  state: HeadlessAuthoringProposalState,
+): "headless" | "unavailable" {
+  return canUseTypedHeadlessAuthoring(state) ? "headless" : "unavailable";
+}
+
+export function normalizeGraphPatchPreview(payload: unknown): GraphPatchPreview | null {
+  if (!isRecord(payload) || typeof payload.preview_checksum !== "string") return null;
+  return {
+    preview_checksum: payload.preview_checksum,
+    can_apply: payload.can_apply === true,
+    diagnostics: normalizeAuthoringDiagnostics(payload.diagnostics),
+    warnings: stringArray(payload.warnings),
+    diff: isRecord(payload.diff) ? payload.diff : {},
+    graph_ir_checksum:
+      stringValue(payload.graph_ir_checksum ?? payload.graph_checksum) || undefined,
+    candidate_checksum:
+      stringValue(
+        payload.candidate_checksum ??
+          payload.compiled_workflow_checksum ??
+          payload.compiled_candidate_checksum,
+      ) || undefined,
+  };
+}
+
+export function buildMetadataPatch(
+  state: HeadlessAuthoringProposalState,
+  metadata: {
+    name: string;
+    description: string;
+    tags: string[];
+    starters: string[];
+  },
+): GraphPatchEnvelopeV1 {
+  return {
+    protocol_version: 1,
+    proposal_revision: state.proposal_revision,
+    expected_graph_checksum: state.graph_checksum,
+    expected_candidate_checksum: state.candidate_checksum,
+    operations: [{ op: "set_xpert_metadata", ...metadata }],
+  };
+}
+
+export function authoringDiffSummary(diff: Record<string, unknown>): string[] {
+  const preferredKeys = [
+    "summary",
+    "operation_count",
+    "operation_types",
+    "graph_changed",
+    "candidate_changed",
+    "nodes_added",
+    "nodes_removed",
+    "nodes_updated",
+    "edges_added",
+    "edges_removed",
+    "bindings_changed",
+    "metadata_changed",
+    "layout_changed",
+  ];
+  const lines: string[] = [];
+  for (const key of preferredKeys) {
+    const value = diff[key];
+    if (typeof value === "string" && value.trim()) lines.push(value.trim());
+    else if (typeof value === "number" && value > 0) lines.push(`${key}: ${value}`);
+    else if (Array.isArray(value) && value.length > 0) lines.push(`${key}: ${value.length}`);
+    else if (isRecord(value) && Object.keys(value).length > 0) {
+      lines.push(
+        `${key}: ${Object.entries(value)
+          .map(([name, count]) => `${name} ${String(count)}`)
+          .join(", ")}`,
+      );
+    }
+    else if (value === true) lines.push(key);
+  }
+  return lines.length ? lines : ["服务端未返回可展示的结构差异摘要。"];
+}

--- a/client/src/components/workflow/WorkflowEditor.test.ts
+++ b/client/src/components/workflow/WorkflowEditor.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { type WorkflowNode } from "../../types/workflow";
 
 import {
+  authoringNodeMutationError,
+  constrainAuthoringNodeDataPatch,
   createNodeData,
   dataMergeConnectionError,
   errorOutputConnectionError,
@@ -9,10 +13,13 @@ import {
   migrateDocumentExtractorFileToV3,
   normalizeWorkflowNodePositions,
   parseSkillRuntimeIds,
+  prepareAuthoringNodeForInsert,
   reconcileMcpArgumentBindings,
   updateSkillRuntimeIds,
   workflowProjectPending,
   workflowTypesForMcpSchema,
+  HeadlessWorkflowAgentAdapterPanel,
+  HEADLESS_WORKFLOW_AGENT_EDITABLE_FIELDS,
 } from "./WorkflowEditor";
 import {
   knowledgePipelineItems,
@@ -20,6 +27,160 @@ import {
 } from "./workflowNodeRegistry";
 
 describe("WorkflowEditor palette defaults", () => {
+  it("fails closed for unauthorized authoring nodes and protects compiler nodes", () => {
+    const policy = {
+      allowedNodeKinds: ["input", "output", "workflow_agent"] as const,
+      compilerManagedNodeKinds: ["input", "output"] as const,
+    };
+    expect(
+      authoringNodeMutationError("workflow_agent", "add", {
+        allowedNodeKinds: [...policy.allowedNodeKinds],
+        compilerManagedNodeKinds: [...policy.compilerManagedNodeKinds],
+      }),
+    ).toBeNull();
+    expect(
+      authoringNodeMutationError("json_serialize", "add", {
+        allowedNodeKinds: [...policy.allowedNodeKinds],
+        compilerManagedNodeKinds: [...policy.compilerManagedNodeKinds],
+      }),
+    ).toContain("授权能力范围");
+    expect(
+      authoringNodeMutationError("input", "delete", {
+        allowedNodeKinds: [...policy.allowedNodeKinds],
+        compilerManagedNodeKinds: [...policy.compilerManagedNodeKinds],
+      }),
+    ).toContain("编译器管理");
+    expect(authoringNodeMutationError("input", "delete")).toBeNull();
+  });
+
+  it("allows only Adapter-backed workflow_agent fields during headless authoring", () => {
+    expect(HEADLESS_WORKFLOW_AGENT_EDITABLE_FIELDS).toEqual([
+      "title",
+      "description",
+      "rolePrompt",
+      "taskInput",
+      "modelId",
+      "sourceAgentId",
+      "methodSkillIds",
+      "outputVariable",
+    ]);
+    const policy = {
+      allowedNodeKinds: ["input", "output", "workflow_agent"] as const,
+      compilerManagedNodeKinds: ["input", "output"] as const,
+    };
+    const attemptedPatch = {
+      rolePrompt: "Review the evidence.",
+      outputVariable: "review_result",
+      toolNames: "search",
+      maxIterations: "20",
+      maxToolCalls: "50",
+      memoryWriteEnabled: "true",
+    };
+    const constrained = constrainAuthoringNodeDataPatch(
+      "workflow_agent",
+      attemptedPatch,
+      {
+        allowedNodeKinds: [...policy.allowedNodeKinds],
+        compilerManagedNodeKinds: [...policy.compilerManagedNodeKinds],
+      },
+    );
+
+    expect(constrained.patch).toEqual({
+      rolePrompt: "Review the evidence.",
+      outputVariable: "review_result",
+    });
+    expect(constrained.rejectedFields).toEqual([
+      "maxIterations",
+      "maxToolCalls",
+      "memoryWriteEnabled",
+      "toolNames",
+    ]);
+    expect(
+      constrainAuthoringNodeDataPatch("workflow_agent", attemptedPatch),
+    ).toEqual({ patch: attemptedPatch, rejectedFields: [] });
+
+    const freshAgent = {
+      id: "new-agent",
+      type: "workflowNode",
+      position: { x: 100, y: 100 },
+      data: {
+        ...createNodeData("workflow_agent"),
+        rolePrompt: "Review evidence.",
+        maxIterations: "20",
+        toolNames: "search",
+        plannerIRVersion: 3,
+        plannerRef: "copied-ref",
+      },
+    } as WorkflowNode;
+    const prepared = prepareAuthoringNodeForInsert(freshAgent, {
+      allowedNodeKinds: [...policy.allowedNodeKinds],
+      compilerManagedNodeKinds: [...policy.compilerManagedNodeKinds],
+    });
+    expect(prepared.data.kind).toBe("workflow_agent");
+    expect(prepared.data.rolePrompt).toBe("Review evidence.");
+    expect(prepared.data.maxIterations).toBeUndefined();
+    expect(prepared.data.toolNames).toBeUndefined();
+    expect(prepared.data.plannerIRVersion).toBeUndefined();
+    expect(prepared.data.plannerRef).toBeUndefined();
+    expect(prepareAuthoringNodeForInsert(freshAgent)).toBe(freshAgent);
+  });
+
+  it("renders only Adapter-backed workflow_agent controls in headless mode", () => {
+    const data = {
+      ...createNodeData("workflow_agent"),
+      sourceAgentId: "expert-reviewer",
+      methodSkillIds: ["research-review"],
+      toolNames: "search",
+      maxIterations: "20",
+      maxToolCalls: "50",
+      memoryWriteEnabled: "true",
+    };
+    const node = {
+      id: "agent-review",
+      type: "workflowNode",
+      position: { x: 100, y: 100 },
+      data,
+    } as WorkflowNode;
+    const update = vi.fn();
+
+    render(
+      createElement(HeadlessWorkflowAgentAdapterPanel, {
+        node,
+        nodes: [node],
+        edges: [],
+        declarations: [],
+        variableContract: null,
+        data,
+        update,
+        allowedSourceAgentIds: ["expert-reviewer"],
+      }),
+    );
+
+    expect(screen.getByText("Headless Adapter 受控编辑")).toBeInTheDocument();
+    expect(screen.getByLabelText("调用模型")).toBeInTheDocument();
+    expect(screen.getByLabelText("角色提示词（支持 {{变量}}）")).toBeInTheDocument();
+    expect(screen.getByText("任务输入（支持 {{变量}}）")).toBeInTheDocument();
+    expect(screen.getByLabelText("来源专家 ID（可选）")).toBeInTheDocument();
+    expect(screen.getByLabelText("方法 Skill ID（可选，最多 1 个）")).toBeInTheDocument();
+    expect(screen.getByText("输出变量")).toBeInTheDocument();
+
+    expect(
+      screen.queryByLabelText("允许工具名（逗号分隔，留空代表全部已注册工具）"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("最大工具循环次数")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("总调用预算")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("异常处理")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("输出结构模式")).not.toBeInTheDocument();
+    expect(screen.queryByText("记忆写入")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("角色提示词（支持 {{变量}}）"), {
+      target: { value: "Act as a strict reviewer." },
+    });
+    expect(update).toHaveBeenCalledWith({
+      rolePrompt: "Act as a strict reviewer.",
+    });
+  });
+
   it("blocks a server workflow run until its draft revision is loaded", () => {
     expect(workflowProjectPending("wf_server", false, null)).toBe(true);
     expect(workflowProjectPending("wf_server", false, 1)).toBe(false);

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -363,11 +363,13 @@ function QuickNodePicker({
   y,
   onClose,
   onPick,
+  allowedKinds,
 }: {
   x: number;
   y: number;
   onClose: () => void;
   onPick: (kind: string) => void;
+  allowedKinds?: ReadonlySet<WorkflowNodeKind>;
 }) {
   const [query, setQuery] = useState("");
   const [registry, setRegistry] = useState<WorkflowNodeRegistryResponse>(
@@ -401,13 +403,14 @@ function QuickNodePicker({
     return registry.sections
       .flatMap((section) => section.items)
       .filter((item) => item.enabled !== false)
+      .filter((item) => !allowedKinds || allowedKinds.has(item.kind))
       .filter(
         (item) =>
           !normalized ||
           item.title.toLowerCase().includes(normalized) ||
           item.description.toLowerCase().includes(normalized),
       );
-  }, [query, registry.sections]);
+  }, [allowedKinds, query, registry.sections]);
 
   return (
     <>
@@ -2099,6 +2102,175 @@ function HandoffExecutionConfig({
   );
 }
 
+interface HeadlessWorkflowAgentAdapterPanelProps {
+  node: WorkflowNode;
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+  declarations: WorkflowVariableDeclaration[];
+  variableContract: WorkflowNodeContractProjection | null;
+  data: WorkflowNodeData;
+  update: (patch: Partial<WorkflowNodeData>) => void;
+  allowedSourceAgentIds: string[];
+}
+
+export function HeadlessWorkflowAgentAdapterPanel({
+  node,
+  nodes,
+  edges,
+  declarations,
+  variableContract,
+  data,
+  update,
+  allowedSourceAgentIds,
+}: HeadlessWorkflowAgentAdapterPanelProps) {
+  const sourceAgentId = String(data.sourceAgentId ?? "");
+  const sourceOptions = Array.from(
+    new Set(allowedSourceAgentIds.map((item) => item.trim()).filter(Boolean)),
+  );
+  const sourceOutsideScope = Boolean(
+    sourceAgentId && !sourceOptions.includes(sourceAgentId),
+  );
+  const methodSkillId = Array.isArray(data.methodSkillIds)
+    ? String(data.methodSkillIds[0] ?? "")
+    : "";
+  const methodSkillValid =
+    !methodSkillId || /^[a-z0-9][a-z0-9-]{0,159}$/.test(methodSkillId);
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-lg border border-cyan-300/25 bg-cyan-300/10 px-3 py-3 text-xs leading-5 text-cyan-50">
+        <p className="font-semibold">Headless Adapter 受控编辑</p>
+        <p className="mt-1 text-cyan-100/80">
+          此模式只会提交当前 Adapter 可表达的提示词、模型、来源专家、方法 Skill 和输出变量。
+          工具、并发与调用预算、知识、记忆、异常策略和输出 Schema 均已锁定，资源与中间件请通过绑定边调整。
+        </p>
+      </div>
+
+      <ConfigSection
+        description="这些字段会进入 workflow_agent Adapter，并在应用前经过类型、授权与版本预检。"
+        title="Agent Adapter"
+      >
+        <Field label="调用模型">
+          <select
+            className={textInputClass()}
+            onChange={(event) => update({ modelId: event.target.value })}
+            value={data.modelId ?? ""}
+          >
+            <option className="bg-slate-950" value="">
+              使用候选默认模型
+            </option>
+            {models.map((model) => (
+              <option
+                className="bg-slate-950 text-white"
+                key={model.id}
+                value={model.id}
+              >
+                {model.name}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field label="角色提示词（支持 {{变量}}）">
+          <WorkflowVariableField
+            className="min-h-32 resize-none leading-6"
+            contract={variableContract}
+            declarations={declarations}
+            edges={edges}
+            fieldName="rolePrompt"
+            multiline
+            node={node}
+            nodes={nodes}
+            onChange={(value) => update({ rolePrompt: value })}
+            value={data.rolePrompt ?? ""}
+          />
+        </Field>
+
+        <Field label="任务输入（支持 {{变量}}）">
+          <WorkflowVariableField
+            className="min-h-32 resize-none leading-6"
+            contract={variableContract}
+            declarations={declarations}
+            edges={edges}
+            fieldName="taskInput"
+            multiline
+            node={node}
+            nodes={nodes}
+            onChange={(value) => update({ taskInput: value })}
+            value={data.taskInput ?? ""}
+          />
+        </Field>
+
+        <Field label="来源专家 ID（可选）">
+          <select
+            className={textInputClass()}
+            onChange={(event) => update({ sourceAgentId: event.target.value })}
+            value={sourceAgentId}
+          >
+            <option className="bg-slate-950" value="">
+              不绑定来源专家
+            </option>
+            {sourceOutsideScope ? (
+              <option className="bg-slate-950" disabled value={sourceAgentId}>
+                {sourceAgentId}（已不在授权范围）
+              </option>
+            ) : null}
+            {sourceOptions.map((agentId) => (
+              <option className="bg-slate-950" key={agentId} value={agentId}>
+                {agentId}
+              </option>
+            ))}
+          </select>
+          {!sourceOptions.length ? (
+            <p className="mt-2 text-xs text-slate-500">
+              当前 Proposal 未授权来源专家；该字段只能保持为空。
+            </p>
+          ) : null}
+        </Field>
+
+        <Field label="方法 Skill ID（可选，最多 1 个）">
+          <input
+            aria-invalid={!methodSkillValid}
+            className={textInputClass()}
+            maxLength={160}
+            onChange={(event) =>
+              update({
+                methodSkillIds: event.target.value ? [event.target.value] : [],
+              })
+            }
+            pattern="[a-z0-9][a-z0-9-]{0,159}"
+            placeholder="例如 research-review"
+            value={methodSkillId}
+          />
+          {!methodSkillValid ? (
+            <p className="mt-2 text-xs text-rose-200">
+              Skill ID 只能包含小写字母、数字和连字符，并且必须以字母或数字开头。
+            </p>
+          ) : null}
+        </Field>
+      </ConfigSection>
+
+      <ConfigSection
+        description="位置通过画布移动修改；标题和说明位于本面板上方。"
+        title="输出"
+      >
+        <Field label="输出变量">
+          <WorkflowVariableField
+            contract={variableContract}
+            declarations={declarations}
+            edges={edges}
+            fieldName="outputVariable"
+            node={node}
+            nodes={nodes}
+            onChange={(value) => update({ outputVariable: value })}
+            value={data.outputVariable ?? ""}
+          />
+        </Field>
+      </ConfigSection>
+    </div>
+  );
+}
+
 function AgentStudioPanel({
   node,
   nodes,
@@ -2112,6 +2284,8 @@ function AgentStudioPanel({
   boundMiddlewares,
   boundResources,
   onSelectNode,
+  headlessAuthoring = false,
+  allowedSourceAgentIds = [],
 }: {
   node: WorkflowNode;
   nodes: WorkflowNode[];
@@ -2125,6 +2299,8 @@ function AgentStudioPanel({
   boundMiddlewares: WorkflowNode[];
   boundResources: WorkflowNode[];
   onSelectNode: (nodeId: string) => void;
+  headlessAuthoring?: boolean;
+  allowedSourceAgentIds?: string[];
 }) {
   const isWorkflowAgent = data.kind === "workflow_agent";
   const toolsEnabled = isWorkflowAgent
@@ -2147,7 +2323,7 @@ function AgentStudioPanel({
   );
 
   useEffect(() => {
-    if (!isWorkflowAgent) return;
+    if (!isWorkflowAgent || headlessAuthoring) return;
     let cancelled = false;
     void fetch("/api/rag/knowledge_bases")
       .then(async (response) => {
@@ -2172,7 +2348,7 @@ function AgentStudioPanel({
     return () => {
       cancelled = true;
     };
-  }, [isWorkflowAgent]);
+  }, [headlessAuthoring, isWorkflowAgent]);
 
   function toggleKnowledgeBase(kbId: string, checked: boolean) {
     const next = new Set(selectedKnowledgeBaseIds);
@@ -2195,6 +2371,21 @@ function AgentStudioPanel({
   const toolNamesPlaceholder = registryTools.length
     ? registryTools.map((tool) => tool.name).slice(0, 3).join(", ")
     : "先在 MCP 页面连接工具 Server";
+
+  if (headlessAuthoring && isWorkflowAgent) {
+    return (
+      <HeadlessWorkflowAgentAdapterPanel
+        allowedSourceAgentIds={allowedSourceAgentIds}
+        data={data}
+        declarations={declarations}
+        edges={edges}
+        node={node}
+        nodes={nodes}
+        update={update}
+        variableContract={variableContract}
+      />
+    );
+  }
 
   return (
     <div className="space-y-3">
@@ -3587,6 +3778,7 @@ function LegacyKnowledgeCitationConfig({
 interface NodeConfigProps {
   workflowId: string;
   node: WorkflowNode | null;
+  authoringPolicy?: WorkflowEditorAuthoringPolicy;
   declarations: WorkflowVariableDeclaration[];
   onChange: (nodeId: string, data: Partial<WorkflowNodeData>) => void;
   onRuntimeMiddlewareConfigChange: (
@@ -3610,6 +3802,7 @@ interface NodeConfigProps {
 function NodeConfig({
   workflowId,
   node,
+  authoringPolicy,
   declarations,
   onChange,
   onRuntimeMiddlewareConfigChange,
@@ -5409,6 +5602,7 @@ function NodeConfig({
 
       {data.kind === "agent" || data.kind === "workflow_agent" ? (
         <AgentStudioPanel
+          allowedSourceAgentIds={authoringPolicy?.allowedSourceAgentIds}
           boundMiddlewares={boundMiddlewares}
           boundResources={boundResources}
           data={data}
@@ -5419,6 +5613,9 @@ function NodeConfig({
           onSelectNode={onSelectNode}
           registryTools={registryTools}
           registryToolsError={registryToolsError}
+          headlessAuthoring={Boolean(
+            authoringPolicy && data.kind === "workflow_agent",
+          )}
           update={update}
           variableContract={variableContract}
         />
@@ -6465,6 +6662,88 @@ interface WorkflowCanvasProps {
   initialDefinition?: WorkflowDefinition;
   onSave?: (definition: WorkflowDefinition) => Promise<void> | void;
   saveLabel?: string;
+  saveCompletionLabel?: string;
+  authoringPolicy?: WorkflowEditorAuthoringPolicy;
+}
+
+export interface WorkflowEditorAuthoringPolicy {
+  allowedNodeKinds: WorkflowNodeKind[];
+  compilerManagedNodeKinds?: WorkflowNodeKind[];
+  allowedRuntimeMiddlewareIds?: string[];
+  allowedSourceAgentIds?: string[];
+}
+
+export const HEADLESS_WORKFLOW_AGENT_EDITABLE_FIELDS = [
+  "title",
+  "description",
+  "rolePrompt",
+  "taskInput",
+  "modelId",
+  "sourceAgentId",
+  "methodSkillIds",
+  "outputVariable",
+] as const;
+
+const headlessWorkflowAgentEditableFieldSet = new Set<string>(
+  HEADLESS_WORKFLOW_AGENT_EDITABLE_FIELDS,
+);
+
+export function constrainAuthoringNodeDataPatch(
+  kind: WorkflowNodeKind,
+  patch: Partial<WorkflowNodeData>,
+  policy?: WorkflowEditorAuthoringPolicy,
+): {
+  patch: Partial<WorkflowNodeData>;
+  rejectedFields: string[];
+} {
+  if (!policy || kind !== "workflow_agent") {
+    return { patch, rejectedFields: [] };
+  }
+  const allowedPatch: Partial<WorkflowNodeData> = {};
+  const rejectedFields: string[] = [];
+  Object.entries(patch).forEach(([field, value]) => {
+    if (headlessWorkflowAgentEditableFieldSet.has(field)) {
+      (allowedPatch as Record<string, unknown>)[field] = value;
+    } else {
+      rejectedFields.push(field);
+    }
+  });
+  return {
+    patch: allowedPatch,
+    rejectedFields: rejectedFields.sort(),
+  };
+}
+
+export function prepareAuthoringNodeForInsert(
+  node: WorkflowNode,
+  policy?: WorkflowEditorAuthoringPolicy,
+): WorkflowNode {
+  if (!policy || node.data.kind !== "workflow_agent") return node;
+  const data = Object.fromEntries(
+    Object.entries(node.data).filter(
+      ([field]) =>
+        field === "kind" || headlessWorkflowAgentEditableFieldSet.has(field),
+    ),
+  ) as WorkflowNodeData;
+  return { ...node, data };
+}
+
+export function authoringNodeMutationError(
+  kind: WorkflowNodeKind,
+  action: "add" | "delete",
+  policy?: WorkflowEditorAuthoringPolicy,
+): string | null {
+  if (!policy) return null;
+  const compilerManaged = new Set(policy.compilerManagedNodeKinds ?? ["input", "output"]);
+  if (compilerManaged.has(kind)) {
+    return action === "delete"
+      ? "该节点由编译器管理，不能从候选画布删除。"
+      : "该节点由编译器管理，不能手动新增或复制。";
+  }
+  if (!new Set(policy.allowedNodeKinds).has(kind)) {
+    return "该节点不在当前 Proposal 的授权能力范围内。";
+  }
+  return null;
 }
 
 type WorkflowWorkspaceTab = "config" | "run";
@@ -6487,6 +6766,8 @@ function WorkflowCanvas({
   initialDefinition: controlledDefinition,
   onSave,
   saveLabel = "保存草稿",
+  saveCompletionLabel = "智能体草稿已保存",
+  authoringPolicy,
 }: WorkflowCanvasProps) {
   const localDraftCandidate = useMemo(() => {
     if (controlledDefinition || onSave || workflowId !== "draft") return null;
@@ -6582,6 +6863,43 @@ function WorkflowCanvas({
   const hasEmailEntry = nodes.some((node) => node.data.kind === "email_event_entry");
   const { screenToFlowPosition, fitView } = useReactFlow();
   const navigate = useNavigate();
+  const allowedAuthoringKinds = useMemo(
+    () => authoringPolicy ? new Set(authoringPolicy.allowedNodeKinds) : undefined,
+    [authoringPolicy],
+  );
+  const compilerManagedKinds = useMemo(
+    () => new Set(
+      authoringPolicy
+        ? (authoringPolicy.compilerManagedNodeKinds ?? ["input", "output"])
+        : [],
+    ),
+    [authoringPolicy],
+  );
+  const addableAuthoringKinds = useMemo(() => {
+    if (!allowedAuthoringKinds) return undefined;
+    return new Set(
+      Array.from(allowedAuthoringKinds).filter((kind) => !compilerManagedKinds.has(kind)),
+    );
+  }, [allowedAuthoringKinds, compilerManagedKinds]);
+  const restrictedAuthoringPaletteItems = useMemo(() => {
+    if (!authoringPolicy || !xpertRegistry || !addableAuthoringKinds) return [];
+    const unique = new Map(
+      [
+        ...xpertRegistry.sections.flatMap((section) => section.items),
+        ...xpertRegistry.knowledge_pipeline.items,
+      ].map((item) => [item.kind, item]),
+    );
+    return Array.from(unique.values()).filter(
+      (item) => item.enabled !== false && addableAuthoringKinds.has(item.kind),
+    );
+  }, [addableAuthoringKinds, authoringPolicy, xpertRegistry]);
+  const restrictedAuthoringMiddleware = useMemo(() => {
+    if (!authoringPolicy) return [];
+    const allowedIds = new Set(authoringPolicy.allowedRuntimeMiddlewareIds ?? []);
+    return runtimeMiddlewareRegistry.filter(
+      (item) => item.enabled && allowedIds.has(item.id),
+    );
+  }, [authoringPolicy, runtimeMiddlewareRegistry]);
 
   useEffect(() => {
     let cancelled = false;
@@ -6751,6 +7069,7 @@ function WorkflowCanvas({
   }, [setEdges, setNodes, workflowId]);
   const xpertEntryRepair = useMemo(() => {
     if (
+      authoringPolicy ||
       !onSave ||
       !xpertRegistry ||
       nodes.some((node) => node.data.kind === "input") ||
@@ -6763,7 +7082,11 @@ function WorkflowCanvas({
       xpertRegistry,
       conversionInputVariable || undefined,
     );
-  }, [conversionInputVariable, definition, nodes, onSave, xpertRegistry]);
+  }, [authoringPolicy, conversionInputVariable, definition, nodes, onSave, xpertRegistry]);
+
+  useEffect(() => {
+    if (authoringPolicy) setWorkspaceTab("config");
+  }, [authoringPolicy]);
 
   const selectedNode = useMemo(
     () => nodes.find((node) => node.id === selectedNodeId) ?? null,
@@ -7023,9 +7346,17 @@ function WorkflowCanvas({
 
   const handleNodesChange = useCallback(
     (changes: NodeChange<WorkflowNode>[]) => {
-      onNodesChange(changes);
+      const permittedChanges = changes.filter((change) => {
+        if (change.type !== "remove" || !authoringPolicy) return true;
+        const node = nodes.find((item) => item.id === change.id);
+        if (!node) return true;
+        const reason = authoringNodeMutationError(node.data.kind, "delete", authoringPolicy);
+        if (reason) setErrorNotice(reason);
+        return !reason;
+      });
+      if (permittedChanges.length > 0) onNodesChange(permittedChanges);
     },
-    [onNodesChange],
+    [authoringPolicy, nodes, onNodesChange],
   );
 
   const handleEdgesChange = useCallback(
@@ -7052,6 +7383,14 @@ function WorkflowCanvas({
 
   const deleteSelectedNode = useCallback(() => {
     if (!selectedNodeId) return;
+    const selected = nodes.find((node) => node.id === selectedNodeId);
+    if (!selected) return;
+    const reason = authoringNodeMutationError(selected.data.kind, "delete", authoringPolicy);
+    if (reason) {
+      setErrorNotice(reason);
+      setContextMenu(null);
+      return;
+    }
     commitHistory();
     setNodes((currentNodes) =>
       currentNodes.filter((node) => node.id !== selectedNodeId),
@@ -7062,20 +7401,35 @@ function WorkflowCanvas({
       ),
     );
     setSelectedNodeId(null);
-  }, [commitHistory, selectedNodeId, setEdges, setNodes]);
+  }, [authoringPolicy, commitHistory, nodes, selectedNodeId, setEdges, setNodes]);
 
   function updateNodeData(nodeId: string, patch: Partial<WorkflowNodeData>) {
     // 配置面板与保存/运行共用同一份同步状态，避免输入后立即操作时
     // 仍有防抖 patch 留在计时器中而被序列化遗漏。
+    const targetNode = nodes.find((node) => node.id === nodeId);
+    if (!targetNode) return;
+    const constrained = constrainAuthoringNodeDataPatch(
+      targetNode.data.kind,
+      patch,
+      authoringPolicy,
+    );
+    if (constrained.rejectedFields.length) {
+      setErrorNotice(
+        `Headless Adapter 无法表达字段：${constrained.rejectedFields.join(
+          "、",
+        )}。这些修改未写入候选。`,
+      );
+    }
+    if (!Object.keys(constrained.patch).length) return;
     setNodes((currentNodes) =>
       currentNodes.map((node) =>
         node.id === nodeId
           ? {
               ...node,
-              data: {
-                ...node.data,
-                ...patch,
-              },
+            data: {
+              ...node.data,
+              ...constrained.patch,
+            },
             }
           : node,
       ),
@@ -7311,13 +7665,21 @@ function WorkflowCanvas({
   const pasteClipboard = useCallback(
     (position: { x: number; y: number }) => {
       if (!clipboard || clipboard.nodes.length === 0) return;
+      const blocked = clipboard.nodes
+        .map((node) => authoringNodeMutationError(node.data.kind, "add", authoringPolicy))
+        .find(Boolean);
+      if (blocked) {
+        setErrorNotice(blocked);
+        setContextMenu(null);
+        return;
+      }
       const stamp = `${Date.now().toString(36)}${Math.random().toString(16).slice(2, 5)}`;
       const anchor = clipboard.nodes[0];
       const idMap = new Map<string, string>();
       const pastedNodes = clipboard.nodes.map((node) => {
         const newId = `${node.data.kind}-${stamp}-${node.id}`;
         idMap.set(node.id, newId);
-        return {
+        return prepareAuthoringNodeForInsert({
           ...node,
           id: newId,
           position: {
@@ -7325,7 +7687,7 @@ function WorkflowCanvas({
             y: position.y + (node.position.y - anchor.position.y),
           },
           data: { ...node.data, runStatus: undefined },
-        };
+        }, authoringPolicy);
       });
       const pastedEdges = clipboard.edges
         .map((edge) => ({
@@ -7347,7 +7709,7 @@ function WorkflowCanvas({
       setSelectedNodeId(pastedNodes[0]?.id ?? null);
       setContextMenu(null);
     },
-    [clipboard, commitHistory, setEdges, setNodes],
+    [authoringPolicy, clipboard, commitHistory, setEdges, setNodes],
   );
 
   const pasteAtViewportCenter = useCallback(() => {
@@ -7361,18 +7723,34 @@ function WorkflowCanvas({
 
   const addAnnotationAt = useCallback(
     (position: { x: number; y: number }) => {
+      const reason = authoringNodeMutationError("annotation", "add", authoringPolicy);
+      if (reason) {
+        setErrorNotice(reason);
+        setContextMenu(null);
+        return;
+      }
       commitHistory();
       const node = createNode("annotation", position.x, position.y);
       setNodes((currentNodes) => [...currentNodes, node]);
       setSelectedNodeId(node.id);
       setContextMenu(null);
     },
-    [commitHistory, setNodes],
+    [authoringPolicy, commitHistory, setNodes],
   );
 
   const handleQuickAddPick = useCallback(
     (kind: string) => {
       if (!quickAddMenu) return;
+      const authoringError = authoringNodeMutationError(
+        kind as WorkflowNodeKind,
+        "add",
+        authoringPolicy,
+      );
+      if (authoringError) {
+        setErrorNotice(authoringError);
+        setQuickAddMenu(null);
+        return;
+      }
       if (onSave && INDEPENDENT_DEPLOYMENT_NODE_KINDS.has(kind as WorkflowNodeKind)) {
         setErrorNotice("Xpert 内嵌画布不能使用独立部署节点。");
         setQuickAddMenu(null);
@@ -7393,7 +7771,10 @@ function WorkflowCanvas({
         x: quickAddMenu.x,
         y: quickAddMenu.y,
       });
-      const node = createNode(kind as WorkflowNodeKind, position.x, position.y);
+      const node = prepareAuthoringNodeForInsert(
+        createNode(kind as WorkflowNodeKind, position.x, position.y),
+        authoringPolicy,
+      );
       commitHistory();
       setNodes((currentNodes) => [...currentNodes, node]);
       setEdges((currentEdges) =>
@@ -7410,7 +7791,7 @@ function WorkflowCanvas({
       setSelectedNodeId(node.id);
       setQuickAddMenu(null);
     },
-    [commitHistory, edges, nodes, onSave, quickAddMenu, screenToFlowPosition, setEdges, setNodes],
+    [authoringPolicy, commitHistory, edges, nodes, onSave, quickAddMenu, screenToFlowPosition, setEdges, setNodes],
   );
 
   const handleConnectEnd: OnConnectEnd = useCallback((event, connectionState) => {
@@ -7485,7 +7866,7 @@ function WorkflowCanvas({
     try {
       if (onSave) {
         await onSave(savedDefinition);
-        setSaveNotice("智能体草稿已保存");
+        setSaveNotice(saveCompletionLabel);
       } else {
         savedProjectId = await persistIndependentWorkflow(savedDefinition);
         setSaveNotice("服务端草稿已保存；本地副本已保留");
@@ -7726,7 +8107,7 @@ function WorkflowCanvas({
   }
 
   function repairXpertEntry() {
-    if (!onSave || !xpertRegistry || !xpertEntryRepair || isConverting) return;
+    if (authoringPolicy || !onSave || !xpertRegistry || !xpertEntryRepair || isConverting) return;
     const selectedInput =
       conversionInputVariable || xpertEntryRepair.selectedInputVariable;
     const analysis = analyzeXpertWorkflowConversion(
@@ -7758,13 +8139,21 @@ function WorkflowCanvas({
 
   const handlePaletteAddNode = useCallback(
     (kind: WorkflowNodeKind) => {
+      const authoringError = authoringNodeMutationError(kind, "add", authoringPolicy);
+      if (authoringError) {
+        setErrorNotice(authoringError);
+        return;
+      }
       if (onSave && INDEPENDENT_DEPLOYMENT_NODE_KINDS.has(kind)) {
         setErrorNotice("Xpert 内嵌画布不能使用独立部署节点。");
         return;
       }
       const position = paletteInsertPosition();
       try {
-        const nextNode = createNode(kind, position.x, position.y);
+        const nextNode = prepareAuthoringNodeForInsert(
+          createNode(kind, position.x, position.y),
+          authoringPolicy,
+        );
         commitHistory();
         setNodes((currentNodes) => [...currentNodes, nextNode]);
         setSelectedNodeId(nextNode.id);
@@ -7777,11 +8166,27 @@ function WorkflowCanvas({
         );
       }
     },
-    [commitHistory, onSave, paletteInsertPosition, setNodes],
+    [authoringPolicy, commitHistory, onSave, paletteInsertPosition, setNodes],
   );
 
   const handlePaletteAddRuntimeMiddleware = useCallback(
     (middleware: RuntimeMiddlewareNode) => {
+      const authoringError = authoringNodeMutationError(
+        "runtime_middleware",
+        "add",
+        authoringPolicy,
+      );
+      if (authoringError) {
+        setErrorNotice(authoringError);
+        return;
+      }
+      if (
+        authoringPolicy &&
+        !(authoringPolicy.allowedRuntimeMiddlewareIds ?? []).includes(middleware.id)
+      ) {
+        setErrorNotice("该中间件不在当前 Proposal 的授权范围内。");
+        return;
+      }
       const position = paletteInsertPosition();
       const payload: RuntimeMiddlewareDragPayload = {
         kind: "runtime_middleware",
@@ -7805,7 +8210,7 @@ function WorkflowCanvas({
       setSaveNotice("");
       setErrorNotice("");
     },
-    [commitHistory, paletteInsertPosition, setNodes],
+    [authoringPolicy, commitHistory, paletteInsertPosition, setNodes],
   );
 
   function onDrop(event: React.DragEvent<HTMLDivElement>) {
@@ -7822,6 +8227,25 @@ function WorkflowCanvas({
       ? parseRuntimeMiddlewarePayload(runtimeMiddlewareRaw)
       : null;
     if (runtimeMiddlewarePayload) {
+      const authoringError = authoringNodeMutationError(
+        "runtime_middleware",
+        "add",
+        authoringPolicy,
+      );
+      if (authoringError) {
+        setErrorNotice(authoringError);
+        return;
+      }
+      if (
+        authoringPolicy &&
+        (!runtimeMiddlewarePayload.runtimeMiddlewareId ||
+          !(authoringPolicy.allowedRuntimeMiddlewareIds ?? []).includes(
+            runtimeMiddlewarePayload.runtimeMiddlewareId,
+          ))
+      ) {
+        setErrorNotice("该中间件不在当前 Proposal 的授权范围内。");
+        return;
+      }
       const nextNode = createNode(
         "runtime_middleware",
         position.x,
@@ -7838,6 +8262,25 @@ function WorkflowCanvas({
     const rawKind = event.dataTransfer.getData("application/modelmirror-node");
     const fallbackPayload = parseRuntimeMiddlewarePayload(rawKind);
     if (fallbackPayload) {
+      const authoringError = authoringNodeMutationError(
+        "runtime_middleware",
+        "add",
+        authoringPolicy,
+      );
+      if (authoringError) {
+        setErrorNotice(authoringError);
+        return;
+      }
+      if (
+        authoringPolicy &&
+        (!fallbackPayload.runtimeMiddlewareId ||
+          !(authoringPolicy.allowedRuntimeMiddlewareIds ?? []).includes(
+            fallbackPayload.runtimeMiddlewareId,
+          ))
+      ) {
+        setErrorNotice("该中间件不在当前 Proposal 的授权范围内。");
+        return;
+      }
       const nextNode = createNode(
         "runtime_middleware",
         position.x,
@@ -7853,13 +8296,21 @@ function WorkflowCanvas({
 
     const kind = rawKind as WorkflowNodeKind;
     if (!kind) return;
+    const authoringError = authoringNodeMutationError(kind, "add", authoringPolicy);
+    if (authoringError) {
+      setErrorNotice(authoringError);
+      return;
+    }
     if (onSave && INDEPENDENT_DEPLOYMENT_NODE_KINDS.has(kind)) {
       setErrorNotice("Xpert 内嵌画布不能使用独立部署节点。");
       return;
     }
 
     try {
-      const nextNode = createNode(kind, position.x, position.y);
+      const nextNode = prepareAuthoringNodeForInsert(
+        createNode(kind, position.x, position.y),
+        authoringPolicy,
+      );
       commitHistory();
       setNodes((currentNodes) => [...currentNodes, nextNode]);
       setSelectedNodeId(nextNode.id);
@@ -7983,11 +8434,70 @@ function WorkflowCanvas({
             </button>
           </div>
           <div className="mt-4">
-            <NodePalette
-              excludeKinds={onSave ? Array.from(INDEPENDENT_DEPLOYMENT_NODE_KINDS) : []}
-              onAddNode={handlePaletteAddNode}
-              onAddRuntimeMiddleware={handlePaletteAddRuntimeMiddleware}
-            />
+            {authoringPolicy ? (
+              <div className="space-y-2">
+                {!xpertRegistry ? (
+                  <p className="rounded-md border border-amber-300/20 bg-amber-300/10 px-3 py-2 text-xs leading-5 text-amber-100">
+                    节点 Registry 不可用；受控候选编辑器已暂停新增节点。
+                  </p>
+                ) : null}
+                {xpertRegistry &&
+                restrictedAuthoringPaletteItems.length === 0 &&
+                restrictedAuthoringMiddleware.length === 0 ? (
+                  <p className="rounded-md border border-dashed border-white/10 px-3 py-5 text-center text-xs leading-5 text-slate-500">
+                    当前 Proposal 没有可手动新增的节点能力。
+                  </p>
+                ) : null}
+                {restrictedAuthoringPaletteItems.map((item) => (
+                  <button
+                    aria-label={`添加节点：${item.title}`}
+                    className="w-full rounded-lg border border-white/10 bg-[#101828] p-3 text-left transition hover:border-white/25 hover:bg-[#151f33]"
+                    draggable
+                    key={item.kind}
+                    onClick={() => handlePaletteAddNode(item.kind)}
+                    onDragStart={(event) => {
+                      event.dataTransfer.setData("application/modelmirror-node", item.kind);
+                      event.dataTransfer.effectAllowed = "move";
+                    }}
+                    type="button"
+                  >
+                    <span className="flex items-start gap-3">
+                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-hire-300/25 bg-hire-300/10 text-[11px] font-semibold text-hire-100">
+                        {item.icon}
+                      </span>
+                      <span className="min-w-0">
+                        <span className="block text-sm font-semibold text-white">{item.title}</span>
+                        <span className="mt-1 block text-xs leading-5 text-slate-400">
+                          {item.description}
+                        </span>
+                      </span>
+                    </span>
+                  </button>
+                ))}
+                {restrictedAuthoringMiddleware.map((middleware) => (
+                  <button
+                    aria-label={`添加中间件：${middleware.title}`}
+                    className="w-full rounded-lg border border-indigo-300/15 bg-indigo-300/[0.06] p-3 text-left transition hover:border-indigo-200/30 hover:bg-indigo-300/10"
+                    key={middleware.id}
+                    onClick={() => handlePaletteAddRuntimeMiddleware(middleware)}
+                    type="button"
+                  >
+                    <span className="block text-sm font-semibold text-indigo-100">
+                      {middleware.title}
+                    </span>
+                    <span className="mt-1 block text-xs leading-5 text-slate-400">
+                      {middleware.description}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <NodePalette
+                excludeKinds={onSave ? Array.from(INDEPENDENT_DEPLOYMENT_NODE_KINDS) : []}
+                onAddNode={handlePaletteAddNode}
+                onAddRuntimeMiddleware={handlePaletteAddRuntimeMiddleware}
+              />
+            )}
           </div>
         </aside>
       ) : null}
@@ -8005,27 +8515,35 @@ function WorkflowCanvas({
             </p>
           </div>
           <div className="relative flex flex-wrap items-center gap-1.5">
-            <button
-              aria-expanded={isVariableCenterOpen}
-              aria-haspopup="dialog"
-              className={`rounded-md border px-3 py-1.5 text-xs font-semibold transition ${
-                isVariableCenterOpen
-                  ? "border-brand-300/50 bg-brand-300/15 text-brand-100"
-                  : "border-white/10 bg-white/[0.05] text-slate-200 hover:border-brand-300/45 hover:bg-brand-300/10 hover:text-brand-100"
-              }`}
-              onClick={() => setIsVariableCenterOpen(true)}
-              ref={variableCenterTriggerRef}
-              type="button"
-            >
-              变量 {workflowVariables.length}
-            </button>
-            <button
-              className="rounded-md border border-white/10 bg-white/[0.05] px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-emerald-200/45 hover:bg-emerald-300/10 hover:text-emerald-100"
-              onClick={() => navigate("/data-tables")}
-              type="button"
-            >
-              数据表
-            </button>
+            {!authoringPolicy ? (
+              <>
+                <button
+                  aria-expanded={isVariableCenterOpen}
+                  aria-haspopup="dialog"
+                  className={`rounded-md border px-3 py-1.5 text-xs font-semibold transition ${
+                    isVariableCenterOpen
+                      ? "border-brand-300/50 bg-brand-300/15 text-brand-100"
+                      : "border-white/10 bg-white/[0.05] text-slate-200 hover:border-brand-300/45 hover:bg-brand-300/10 hover:text-brand-100"
+                  }`}
+                  onClick={() => setIsVariableCenterOpen(true)}
+                  ref={variableCenterTriggerRef}
+                  type="button"
+                >
+                  变量 {workflowVariables.length}
+                </button>
+                <button
+                  className="rounded-md border border-white/10 bg-white/[0.05] px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-emerald-200/45 hover:bg-emerald-300/10 hover:text-emerald-100"
+                  onClick={() => navigate("/data-tables")}
+                  type="button"
+                >
+                  数据表
+                </button>
+              </>
+            ) : (
+              <span className="rounded-md border border-cyan-300/20 bg-cyan-300/[0.07] px-2.5 py-1 text-[11px] font-semibold text-cyan-100">
+                类型化 Patch 编辑
+              </span>
+            )}
             <button
               className={`rounded-md border px-3 py-1.5 text-xs font-semibold transition ${
                 isNodePaletteOpen
@@ -8536,7 +9054,7 @@ function WorkflowCanvas({
                 </button>
               </Panel>
             ) : null}
-            {selectedNodeId ? (
+            {selectedNodeId && selectedNode && !compilerManagedKinds.has(selectedNode.data.kind) ? (
               <Panel position="bottom-left">
                 <button
                   className="mb-16 rounded-full border border-rose-300/35 bg-rose-400/15 px-3 py-1.5 text-xs font-semibold text-rose-100 shadow-lg shadow-rose-950/30 transition hover:bg-rose-400/25"
@@ -8582,8 +9100,18 @@ function WorkflowCanvas({
                   <MenuItem onClick={() => setContextMenu(null)}>
                     配置节点
                   </MenuItem>
-                  <MenuItem onClick={copySelectedNode}>复制</MenuItem>
                   <MenuItem
+                    disabled={Boolean(
+                      selectedNode && compilerManagedKinds.has(selectedNode.data.kind),
+                    )}
+                    onClick={copySelectedNode}
+                  >
+                    复制
+                  </MenuItem>
+                  <MenuItem
+                    disabled={Boolean(
+                      selectedNode && compilerManagedKinds.has(selectedNode.data.kind),
+                    )}
                     onClick={() => {
                       setContextMenu(null);
                       deleteSelectedNode();
@@ -8592,6 +9120,9 @@ function WorkflowCanvas({
                     删除
                   </MenuItem>
                   <MenuItem
+                    disabled={Boolean(
+                      authoringNodeMutationError("annotation", "add", authoringPolicy),
+                    )}
                     onClick={() => {
                       const node = nodes.find(
                         (item) => item.id === contextMenu.nodeId,
@@ -8657,6 +9188,7 @@ function WorkflowCanvas({
 
         {quickAddMenu ? (
           <QuickNodePicker
+            allowedKinds={addableAuthoringKinds}
             onClose={() => setQuickAddMenu(null)}
             onPick={handleQuickAddPick}
             x={quickAddMenu.x}
@@ -8685,19 +9217,21 @@ function WorkflowCanvas({
             >
               配置
             </button>
-            <button
-              className={`rounded-full px-3 py-1.5 text-xs font-semibold transition ${
-                workspaceTab === "run"
-                  ? "bg-hire-300 text-ink-950"
-                  : "text-slate-400 hover:text-slate-100"
-              } disabled:cursor-wait disabled:opacity-45`}
-              disabled={projectPending}
-              onClick={() => setWorkspaceTab("run")}
-              title={projectPending ? "正在加载服务端工作流草稿" : undefined}
-              type="button"
-            >
-              运行
-            </button>
+            {!authoringPolicy ? (
+              <button
+                className={`rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+                  workspaceTab === "run"
+                    ? "bg-hire-300 text-ink-950"
+                    : "text-slate-400 hover:text-slate-100"
+                } disabled:cursor-wait disabled:opacity-45`}
+                disabled={projectPending}
+                onClick={() => setWorkspaceTab("run")}
+                title={projectPending ? "正在加载服务端工作流草稿" : undefined}
+                type="button"
+              >
+                运行
+              </button>
+            ) : null}
           </div>
         </div>
 
@@ -8714,6 +9248,7 @@ function WorkflowCanvas({
           </p>
           <div className="mt-4">
             <NodeConfig
+              authoringPolicy={authoringPolicy}
               declarations={variables}
               edges={edges}
               node={selectedNode}

--- a/docs/EVOAGENTX_ALIGNMENT.md
+++ b/docs/EVOAGENTX_ALIGNMENT.md
@@ -76,6 +76,7 @@ Client Tools、Automation、Plugin 和 Prompt。Meta Planner V2 已补齐候选�
 | 能力域 | ModelMirror 当前状态 | 审计判定 | 目标产物 |
 | --- | --- | --- | --- |
 | Workflow generation | Graph IR V3 已表达 Agent DAG、类型化 data 边与五类绑定 | `adapt` | V3 首轮已交付，节点开放继续分轮 |
+| Headless authoring | 类型化 Graph Patch、无副作用预览、冲突绑定 Apply | `rewrite` | 复用 ModelMirror NodeContract、Adapter、Proposal 与发布预检，不引入上游 Runtime |
 | Agent generation | V2 已覆盖当前 Agent 配置、资源与 middleware | `adapt` | 候选 Xpert 草稿已交付 |
 | Task planning | V2 已生成 1–8 个带依赖与契约的任务 | `adapt` | 结构化规划已交付 |
 | Evaluator | 已支持只读安全的固定版本/Proposal 快照评测 | `adapt` | Evaluator 已交付 |

--- a/docs/META_AGENT.md
+++ b/docs/META_AGENT.md
@@ -9,7 +9,7 @@
 已经可以从实时 Registry 编译 `workflow_agent`、资源绑定、中间件和发布预检所需配置；
 旧生成器仍保留用于兼容经典工作流导入与既有 AgentTask/Handoff 操作。
 
-当前实现是 **Capability Snapshot V4 + Graph IR V3 单写、Typed IR V2 双读**。后续升级已经锁定为
+当前实现是 **Capability Snapshot V5 + Graph IR V3 单写、Typed IR V2 双读**。后续升级已经锁定为
 “V3 十轮 + V4 轮次待定”，唯一方向文档是
 [META_PLANNER_V3_V4_ROADMAP.md](./META_PLANNER_V3_V4_ROADMAP.md)。V3 先补齐
 Graph IR、无头编排、节点 Adapter、效果语义和评测，再逐类开放真实节点；V4 只有在
@@ -136,14 +136,14 @@ EvoAgentX 的来源与已交付历史见
 
 ### NodeContract V3 能力门禁
 
-Meta Planner 的节点事实统一来自 `NodeContractRegistry`。Capability Snapshot V4
+Meta Planner 的节点事实统一来自 `NodeContractRegistry`。Capability Snapshot V5
 只暴露满足以下全部条件的节点：契约状态完整、Planner 显式启用、编译模式真实存在、
 Adapter 版本一致，并且契约与 Adapter 的 compiler checksum 匹配。UI Registry 中出现
 节点不等于 Planner 可以生成该节点。
 
 当前开放范围仍严格保持为 `input`、`output`、`workflow_agent`、
 `external_xpert`、`knowledge_base`、`toolset_resource` 和 `plugin_resource`。
-NodeContract V3 与 Planner IR 独立演进。Capability Snapshot 当前为 V4，
+NodeContract V3 与 Planner IR 独立演进。Capability Snapshot 当前为 V5，
 `ir_version=3` 且声明 `supported_ir_versions=[2,3]`。旧 V2 Snapshot 保持可读，详见
 [NODE_CONTRACT_V3.md](./NODE_CONTRACT_V3.md)。
 
@@ -163,13 +163,24 @@ data 边只表达类型化变量来源，不进入 classic runner 的拓扑或�
 V3；歧义来源返回结构化 `lossy_conversion`，不得猜测。生成入口已经单写 V3，模型
 调用预算仍为任务规划、能力编译和最多一次修复。
 
+### Headless Authoring 边界
+
+管理端候选编辑不再把完整 Workflow 作为可信持久化输入。V3 候选及可无损恢复的 V2
+候选统一经过 `editor-diff -> Graph Patch preview -> checksum-bound apply`。服务端从实际
+Proposal、NodeContract、Adapter 与资源 Store 重新解析并预检，Preview 不持久化，Apply
+只更新 pending Proposal 一次。Proposal、目标 Xpert 或相关资源发生漂移时 fail-closed。
+
+旧整包 Proposal PATCH 保持兼容并将 IR 标记为 `stale`；有损 V2 候选不得进入 Headless
+Apply。操作、接口、安全 receipt 和回退边界见
+[META_PLANNER_HEADLESS_AUTHORING.md](./META_PLANNER_HEADLESS_AUTHORING.md)。
+
 ### Typed IR V2 兼容边界
 
 旧候选可继续读取 `MetaPlannerTypedBlueprintV2`，其中显式声明节点引用、任务覆盖、
 类型化输入/输出变量、控制边、资源/中间件目标和唯一最终输出。任务和 Agent 不再
 强制一一对应：一个 Agent 可以覆盖多个任务，一个任务也可以由多个节点共同完成。
 
-Capability Snapshot V4 只暴露当前存在且与 NodeContract 校验一致的编译能力。首轮可执行 IR 节点只有
+Capability Snapshot V5 只暴露当前存在且与 NodeContract 校验一致的编译能力。首轮可执行 IR 节点只有
 `workflow_agent`；`input/output` 由编译器管理，外部 Xpert、知识库、Toolset 和
 Plugin 通过绑定记录编译。JSON、Agent Table、知识检索和视觉理解尚无 Planner
 适配器，因此不会进入授权快照，也不会被模型生成。

--- a/docs/META_PLANNER_HEADLESS_AUTHORING.md
+++ b/docs/META_PLANNER_HEADLESS_AUTHORING.md
@@ -1,0 +1,82 @@
+# Meta Planner Headless Authoring
+
+最后更新日期：2026-08-30
+状态：V3 Round 2 实现契约
+
+## 目标
+
+Headless Authoring 是 Meta Planner、管理端编辑器和后续 Optimizer 共用的候选编排协议。
+它只修改 pending `AuthoringProposal`，不写 Xpert 草稿、不发布版本，也不启动 Workflow。
+
+固定链路：
+
+```text
+Proposal state -> editor diff / typed patch -> side-effect-free preview
+-> checksum-bound apply -> existing proposal validation -> human approval
+```
+
+## Patch 边界
+
+`GraphPatchEnvelopeV1` 最多包含 64 个有序操作，并绑定 Proposal revision、当前 Graph
+authoring checksum 和当前 compiled candidate checksum。
+
+四个 Headless API 的 JSON 正文最多 2 MiB、嵌套最多 32 层；超限请求在进入
+Pydantic、Adapter 或 Proposal 服务前失败关闭。
+
+Patch 只接受 Planner ref、命名端口和 Adapter config。原生节点 ID、Handle、资源版本、
+NodeContract Schema、执行策略与 checksum 均由服务端推导，客户端或模型不能注入。
+
+支持 Xpert 元数据、Workflow Agent、控制/data 边、输出变量、四类资源、中间件、
+Prompt Profile、最终输出和布局。`input/output` 由编译器管理；布局不会改变 Graph
+checksum，但会改变 candidate checksum。
+
+## 预览与应用
+
+Preview 从实际 Proposal 反编译 GraphIntent，重新解析 Graph IR、编译候选，并执行
+Workflow、资源和发布预检。Preview 不持久化、不调用模型，也不创建运行。
+
+Apply 必须携带 Preview checksum。服务端重新读取 Proposal、能力快照和目标 Xpert，
+再完整重算 Preview。以下任一变化均拒绝应用：
+
+- Proposal revision 或候选 checksum 漂移。
+- 更新目标的 draft revision 漂移。
+- 相关 NodeContract、Adapter、资源版本或动态 Schema 失效。
+- Patch 端口、类型、基数、控制图、授权或最终输出不合法。
+
+无关 Capability Snapshot 变化只产生 warning。Apply 成功只增加一次 Proposal revision，
+随后复用现有 Authoring validation。安全 receipt 最多保留 20 条，只记录操作类型、前后
+checksum、诊断计数和时间。历史 receipt 会按安全字段重新规范化，未知字段和无法验证的
+记录不会继续进入 typed Apply。Proposal 写盘失败时，内存 revision 与 payload 同步回滚。
+
+## 编辑器与兼容
+
+管理端画布先调用 `editor-diff` 将差异转换成 Graph Patch，再执行 Preview 和用户确认。
+原始 `WorkflowDefinition` 从不直接进入 Headless 持久化。Proposal 授权范围之外的节点、
+未授权中间件和 compiler-managed 节点修改均 fail-closed；无法表达的编辑返回逐项诊断。
+Meta Planner Proposal 创建时的 `authorized_scope` 是不可扩大的授权上界；旧整包 PATCH
+可以编辑候选内容，但不能修改该上界，运行时仍只使用它与当前能力快照的交集。
+
+- Graph IR V3 使用 Headless Authoring。
+- 可唯一恢复变量来源的 V2 候选可 Preview，并在首次 Apply 时升级为 V3。
+- `lossy_conversion` 的 V2 候选保持旧兼容读取、校验和审批路径，禁止 Headless Apply。
+- 旧整包 Proposal PATCH 继续可用，但会将 Graph IR 标记为 `stale`。
+
+模型首次生成仍输出 GraphIntent V3。若输出可解析但门禁失败，唯一修复调用必须返回
+Graph Patch；完全无法解析时才允许一次完整 GraphIntent V3 修复。总模型调用上限仍为 3。
+
+## API
+
+```text
+GET  /api/meta-agent/authoring/proposals/{proposal_id}
+POST /api/meta-agent/authoring/proposals/{proposal_id}/editor-diff
+POST /api/meta-agent/authoring/proposals/{proposal_id}/patch/preview
+POST /api/meta-agent/authoring/proposals/{proposal_id}/patch/apply
+```
+
+Capability Snapshot V5 暴露 authoring protocol、操作 JSON Schema、Adapter authoring
+checksum 和限制，但节点范围仍严格保持原有七类。
+
+## 回退
+
+本轮没有数据迁移。回退时可移除 Headless API 和管理端入口，现有 Proposal、V2/V3 IR、
+Xpert 草稿与发布版本仍可读取。不得通过回退清理 Runtime Store 或覆盖用户 Proposal。

--- a/docs/META_PLANNER_V3_V4_ROADMAP.md
+++ b/docs/META_PLANNER_V3_V4_ROADMAP.md
@@ -1,6 +1,6 @@
 # Meta Planner V3/V4 锁定路线
 
-最后更新日期：2026-08-28
+最后更新日期：2026-08-30
 状态：目标/锁定路线
 维护人：模镜团队
 
@@ -91,6 +91,10 @@ Graph IR V3 至少需要表达：
 - 提供 Adapter SDK/测试夹具，后续每开放一种节点只增加 Adapter，不新增旁路编译器。
 
 本轮仍不开放新节点。没有这一层，后续节点扩张会再次把 Planner Prompt 变成第二套 Registry。
+
+实现契约与回退边界记录在
+[META_PLANNER_HEADLESS_AUTHORING.md](./META_PLANNER_HEADLESS_AUTHORING.md)。Round 2 保持
+七类能力不变，并采用 V3 单写、V2 无损升级、有损候选兼容只读的边界。
 
 ### Round 3：Pure Nodes
 

--- a/docs/NODE_CONTRACT_V3.md
+++ b/docs/NODE_CONTRACT_V3.md
@@ -104,8 +104,10 @@ Planner claims. If the server response is absent, incomplete, or has a checksum
 shape other than V3, contract-dependent operations stay disabled while the
 classic palette may continue to render.
 
-Meta Planner Capability Snapshot version is V4 with `ir_version=3` and
-`supported_ir_versions=[2,3]`. Persisted V2 snapshots without contract metadata remain readable. Contract
+Meta Planner Capability Snapshot version is V5 with `ir_version=3` and
+`supported_ir_versions=[2,3]`. V5 also projects the typed Headless Authoring
+operation schema and per-kind authoring checksum without widening the node set.
+Persisted V2 snapshots without contract metadata remain readable. Contract
 drift is a warning for an existing proposal; missing or invalid resources still
 block approval.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 这里集中记录 ModelMirror 的产品叙事、当前实现、目标架构、模块契约和历史决策。阅读时应先区分“今天怎样运行”和“未来希望怎样设计”。
 
-最后更新日期：2026-08-28
+最后更新日期：2026-08-30
 维护人：模镜团队
 
 ## 文档状态规则
@@ -62,6 +62,7 @@
 | [SKILL_INTEGRATION.md](./SKILL_INTEGRATION.md) | 当前 | Skill 安装、注入和供应链边界。 |
 | [SKILL_EXPERIENCE_AUDIT.md](./SKILL_EXPERIENCE_AUDIT.md) | 当前 | Skill 目录治理、Creator V1 质量门与后续资源化增强边界。 |
 | [META_AGENT.md](./META_AGENT.md) | 当前 | Meta Planner 当前契约。 |
+| [META_PLANNER_HEADLESS_AUTHORING.md](./META_PLANNER_HEADLESS_AUTHORING.md) | 当前 | 类型化 Graph Patch、无副作用预览和冲突绑定 Apply。 |
 | [META_PLANNER_V3_V4_ROADMAP.md](./META_PLANNER_V3_V4_ROADMAP.md) | 目标/锁定路线 | Meta Planner V3 十轮、V4 准入、变更控制与开源复用边界。 |
 | [AGENCY_ORCHESTRATOR_INTEGRATION.md](./AGENCY_ORCHESTRATOR_INTEGRATION.md) | 当前/可选 | 专家团智能组队预览、Worker 边界、开关与回退。 |
 | [BENCHMARKS.md](./BENCHMARKS.md) | 当前 | 标准 Benchmark 目录、数据来源、实例化和后续生成边界。 |

--- a/server/main.py
+++ b/server/main.py
@@ -616,6 +616,14 @@ try:
         MetaPlannerGenerateResponse,
         MetaPlannerScope,
         MetaPlannerV2Service,
+        GRAPH_PATCH_MAX_JSON_DEPTH,
+        GRAPH_PATCH_MAX_REQUEST_BYTES,
+        GraphPatchApplyRequest,
+        GraphPatchEditorDiffRequest,
+        GraphPatchEnvelopeV1,
+        HeadlessAuthoringError,
+        HeadlessAuthoringService,
+        safe_headless_error_message,
         build_capability_snapshot,
         build_meta_agent_prompt,
         build_workflow_from_plan,
@@ -758,6 +766,14 @@ except ModuleNotFoundError:
         MetaPlannerGenerateResponse,
         MetaPlannerScope,
         MetaPlannerV2Service,
+        GRAPH_PATCH_MAX_JSON_DEPTH,
+        GRAPH_PATCH_MAX_REQUEST_BYTES,
+        GraphPatchApplyRequest,
+        GraphPatchEditorDiffRequest,
+        GraphPatchEnvelopeV1,
+        HeadlessAuthoringError,
+        HeadlessAuthoringService,
+        safe_headless_error_message,
         build_capability_snapshot,
         build_meta_agent_prompt,
         build_workflow_from_plan,
@@ -7296,6 +7312,144 @@ def build_meta_planner_capability_snapshot(
 @app.get("/api/meta-agent/capabilities")
 async def get_meta_planner_capabilities():
     return build_meta_planner_capability_snapshot().model_dump(mode="json")
+
+
+def get_headless_authoring_service() -> HeadlessAuthoringService:
+    return HeadlessAuthoringService(
+        authoring_service=authoring_service,
+        planner_service=MetaPlannerV2Service(
+            authoring_service=authoring_service,
+            preflight=preview_xpert_for_publish,
+        ),
+        capability_snapshot_builder=build_meta_planner_capability_snapshot,
+    )
+
+
+def _raise_headless_authoring_error(exc: HeadlessAuthoringError) -> None:
+    raise HTTPException(
+        status_code=exc.status_code,
+        detail={
+            "code": exc.code,
+            "message": str(exc),
+            "diagnostics": exc.diagnostics,
+        },
+    ) from exc
+
+
+def _parse_headless_authoring_request(model, payload: Any):
+    try:
+        return model.model_validate(payload)
+    except ValidationError as exc:
+        message = safe_headless_error_message(exc)
+        _raise_headless_authoring_error(
+            HeadlessAuthoringError(
+                message,
+                code="headless_request_invalid",
+                diagnostics=[
+                    {
+                        "code": "request_validation",
+                        "severity": "error",
+                        "message": message,
+                    }
+                ],
+            )
+        )
+
+
+async def _read_headless_authoring_json(request: Request) -> Any:
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > GRAPH_PATCH_MAX_REQUEST_BYTES:
+                raise HeadlessAuthoringError(
+                    "Headless authoring request body is too large.",
+                    code="headless_request_too_large",
+                    status_code=413,
+                )
+        except ValueError:
+            pass
+    try:
+        chunks: list[bytes] = []
+        total_bytes = 0
+        async for chunk in request.stream():
+            total_bytes += len(chunk)
+            if total_bytes > GRAPH_PATCH_MAX_REQUEST_BYTES:
+                raise HeadlessAuthoringError(
+                    "Headless authoring request body is too large.",
+                    code="headless_request_too_large",
+                    status_code=413,
+                )
+            chunks.append(chunk)
+        payload = json.loads(b"".join(chunks))
+    except Exception as exc:
+        if isinstance(exc, HeadlessAuthoringError):
+            raise
+        raise HeadlessAuthoringError(
+            "Request body must contain valid JSON.",
+            code="headless_request_invalid",
+        ) from exc
+    stack = [(payload, 1)]
+    while stack:
+        value, depth = stack.pop()
+        if depth > GRAPH_PATCH_MAX_JSON_DEPTH:
+            raise HeadlessAuthoringError(
+                "Headless authoring request body is nested too deeply.",
+                code="headless_request_too_deep",
+            )
+        if isinstance(value, dict):
+            stack.extend((item, depth + 1) for item in value.values())
+        elif isinstance(value, list):
+            stack.extend((item, depth + 1) for item in value)
+    return payload
+
+
+@app.get("/api/meta-agent/authoring/proposals/{proposal_id}")
+async def get_meta_planner_authoring_proposal(proposal_id: str):
+    try:
+        return get_headless_authoring_service().proposal_state(proposal_id)
+    except HeadlessAuthoringError as exc:
+        _raise_headless_authoring_error(exc)
+
+
+@app.post("/api/meta-agent/authoring/proposals/{proposal_id}/editor-diff")
+async def diff_meta_planner_authoring_proposal(
+    proposal_id: str,
+    request: Request,
+):
+    try:
+        payload = await _read_headless_authoring_json(request)
+        parsed = _parse_headless_authoring_request(
+            GraphPatchEditorDiffRequest, payload
+        )
+        return get_headless_authoring_service().editor_diff(proposal_id, parsed)
+    except HeadlessAuthoringError as exc:
+        _raise_headless_authoring_error(exc)
+
+
+@app.post("/api/meta-agent/authoring/proposals/{proposal_id}/patch/preview")
+async def preview_meta_planner_authoring_patch(
+    proposal_id: str,
+    request: Request,
+):
+    try:
+        payload = await _read_headless_authoring_json(request)
+        parsed = _parse_headless_authoring_request(GraphPatchEnvelopeV1, payload)
+        return get_headless_authoring_service().preview(proposal_id, parsed)
+    except HeadlessAuthoringError as exc:
+        _raise_headless_authoring_error(exc)
+
+
+@app.post("/api/meta-agent/authoring/proposals/{proposal_id}/patch/apply")
+async def apply_meta_planner_authoring_patch(
+    proposal_id: str,
+    request: Request,
+):
+    try:
+        payload = await _read_headless_authoring_json(request)
+        parsed = _parse_headless_authoring_request(GraphPatchApplyRequest, payload)
+        return get_headless_authoring_service().apply(proposal_id, parsed)
+    except HeadlessAuthoringError as exc:
+        _raise_headless_authoring_error(exc)
 
 
 def expert_team_agency_planner_enabled() -> bool:

--- a/server/meta_agent/__init__.py
+++ b/server/meta_agent/__init__.py
@@ -27,6 +27,19 @@ from .managed_gateway import (
     ManagedMetaAgentRun,
 )
 from .meta_planner_v2 import MetaPlannerV2Service
+from .graph_patch import (
+    GRAPH_PATCH_MAX_JSON_DEPTH,
+    GRAPH_PATCH_MAX_REQUEST_BYTES,
+    GraphPatchApplyRequest,
+    GraphPatchEditorDiffRequest,
+    GraphPatchEnvelopeV1,
+)
+from .headless_authoring import (
+    HeadlessAuthoringConflictError,
+    HeadlessAuthoringError,
+    HeadlessAuthoringService,
+    safe_headless_error_message,
+)
 
 __all__ = [
     "MetaAgentGenerateRequest",
@@ -39,6 +52,15 @@ __all__ = [
     "MetaPlannerScope",
     "ResolvedGraphIRV3",
     "MetaPlannerV2Service",
+    "GRAPH_PATCH_MAX_JSON_DEPTH",
+    "GRAPH_PATCH_MAX_REQUEST_BYTES",
+    "GraphPatchApplyRequest",
+    "GraphPatchEditorDiffRequest",
+    "GraphPatchEnvelopeV1",
+    "HeadlessAuthoringConflictError",
+    "HeadlessAuthoringError",
+    "HeadlessAuthoringService",
+    "safe_headless_error_message",
     "ManagedMetaAgentGateway",
     "ManagedMetaAgentRoutingError",
     "ManagedMetaAgentRun",

--- a/server/meta_agent/capabilities.py
+++ b/server/meta_agent/capabilities.py
@@ -10,6 +10,13 @@ from .node_adapters import (
     META_PLANNER_COMPILABLE_NODE_KINDS,
     planner_capability_metadata,
 )
+from .graph_patch import (
+    GRAPH_PATCH_MAX_JSON_DEPTH,
+    GRAPH_PATCH_MAX_OPERATIONS,
+    GRAPH_PATCH_MAX_REQUEST_BYTES,
+    GRAPH_PATCH_PROTOCOL_VERSION,
+    graph_patch_schema,
+)
 from .schemas import MetaPlannerCapabilitySnapshot, MetaPlannerScope
 
 
@@ -64,6 +71,31 @@ def _safe_resource(
     }
 
 
+def _immutable_version_catalog(resource: Any) -> list[dict[str, Any]]:
+    """Project immutable version identity without exposing version contents."""
+
+    catalog: list[dict[str, Any]] = []
+    for version in list(getattr(resource, "versions", None) or []):
+        if hasattr(version, "model_dump"):
+            payload = version.model_dump(mode="json")
+        elif isinstance(version, dict):
+            payload = dict(version)
+        else:
+            payload = dict(vars(version))
+        try:
+            version_number = int(payload.get("version"))
+        except (TypeError, ValueError):
+            continue
+        checksum = str(
+            payload.get("checksum")
+            or payload.get("schema_hash")
+            or payload.get("package_checksum")
+            or _canonical_hash(payload)
+        )
+        catalog.append({"version": version_number, "checksum": checksum})
+    return sorted(catalog, key=lambda item: int(item["version"]))
+
+
 def build_capability_snapshot(
     *,
     workflow_registry: Any,
@@ -110,6 +142,7 @@ def build_capability_snapshot(
                         "contract_checksum": compiler["contract_checksum"],
                         "compiler_checksum": compiler["compiler_checksum"],
                         "adapter_checksum": compiler["adapter_checksum"],
+                        "authoring_checksum": compiler["authoring_checksum"],
                         "default_data": dict(planner.get("default_data") or {}),
                         "config_constraints": dict(
                             planner.get("config_constraints") or {}
@@ -149,6 +182,7 @@ def build_capability_snapshot(
                         "contract_checksum": compiler["contract_checksum"],
                         "compiler_checksum": compiler["compiler_checksum"],
                         "adapter_checksum": compiler["adapter_checksum"],
+                        "authoring_checksum": compiler["authoring_checksum"],
                         "default_data": dict(planner.get("default_data") or {}),
                         "config_constraints": dict(
                             planner.get("config_constraints") or {}
@@ -205,7 +239,10 @@ def build_capability_snapshot(
             description=item.description,
             status=item.status,
             version=item.published_version,
-            metadata={"slug": item.slug},
+            metadata={
+                "slug": item.slug,
+                "available_versions": _immutable_version_catalog(item),
+            },
         )
         for item in external_xperts
         if item.status == "published" and item.published_version
@@ -235,7 +272,10 @@ def build_capability_snapshot(
             description=item.description,
             status=item.status,
             version=item.published_version,
-            metadata={"kind": item.kind},
+            metadata={
+                "kind": item.kind,
+                "available_versions": _immutable_version_catalog(item),
+            },
         )
         for item in toolsets
         if item.status == "published" and item.published_version
@@ -247,7 +287,10 @@ def build_capability_snapshot(
             description=item.description,
             status=item.status,
             version=item.published_version,
-            metadata={"slug": item.slug},
+            metadata={
+                "slug": item.slug,
+                "available_versions": _immutable_version_catalog(item),
+            },
         )
         for item in plugins
         if item.status == "published" and item.published_version
@@ -259,7 +302,11 @@ def build_capability_snapshot(
             description=item.description,
             status=item.status,
             version=item.published_version,
-            metadata={"slug": item.slug, "aliases": list(item.aliases)[:5]},
+            metadata={
+                "slug": item.slug,
+                "aliases": list(item.aliases)[:5],
+                "available_versions": _immutable_version_catalog(item),
+            },
         )
         for item in prompt_profiles
         if item.status == "published" and item.published_version
@@ -315,7 +362,7 @@ def build_capability_snapshot(
         agent_ids=[item["id"] for item in expert_summaries],
     )
     payload = {
-        "version": "evoagentx-meta-planner-capabilities-v4",
+        "version": "evoagentx-meta-planner-capabilities-v5",
         "ir_version": 3,
         "supported_ir_versions": [2, 3],
         "contract_version": int(node_payload.get("contract_version") or 0),
@@ -331,6 +378,18 @@ def build_capability_snapshot(
         "models": models,
         "agents": expert_summaries,
         "default_scope": default_scope.model_dump(mode="json"),
+        "authoring_protocol_version": GRAPH_PATCH_PROTOCOL_VERSION,
+        "authoring_operation_schema": graph_patch_schema(),
+        "authoring_adapter_checksums": {
+            item["kind"]: str(item["planner"]["authoring_checksum"])
+            for item in nodes
+        },
+        "authoring_limits": {
+            "max_operations": GRAPH_PATCH_MAX_OPERATIONS,
+            "max_receipts": 20,
+            "max_request_bytes": GRAPH_PATCH_MAX_REQUEST_BYTES,
+            "max_json_depth": GRAPH_PATCH_MAX_JSON_DEPTH,
+        },
     }
     return MetaPlannerCapabilitySnapshot(
         **payload,

--- a/server/meta_agent/graph_ir_v3.py
+++ b/server/meta_agent/graph_ir_v3.py
@@ -54,7 +54,8 @@ SUPPORTED_GRAPH_IR_VERSIONS = (2, 3)
 _TEMPLATE_PATTERN = re.compile(r"\{\{\s*(.*?)\s*\}\}", re.DOTALL)
 _SENSITIVE_CONFIG_KEY = re.compile(
     r"(?:^|[_-])(?:authorization|cookie|credential|password|passwd|secret|"
-    r"api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key)"
+    r"api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|"
+    r"client[_-]?secret|private[_-]?key)"
     r"(?:$|[_-])",
     re.IGNORECASE,
 )
@@ -92,7 +93,9 @@ def _template_variables(template: str) -> set[str]:
 def _contains_sensitive_config(value: Any) -> bool:
     if isinstance(value, dict):
         return any(
-            _SENSITIVE_CONFIG_KEY.search(str(key))
+            _SENSITIVE_CONFIG_KEY.search(
+                re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", str(key))
+            )
             or _contains_sensitive_config(item)
             for key, item in value.items()
         )
@@ -186,6 +189,37 @@ def graph_ir_checksum(graph_ir: ResolvedGraphIRV3 | dict[str, Any]) -> str:
     return canonical_checksum(payload)
 
 
+def graph_authoring_checksum(
+    graph_ir: ResolvedGraphIRV3 | dict[str, Any]
+) -> str:
+    """Hash graph-relevant resolved facts without global Snapshot identity."""
+
+    payload = (
+        graph_ir.model_dump(mode="json")
+        if isinstance(graph_ir, ResolvedGraphIRV3)
+        else deepcopy(graph_ir)
+    )
+    payload.pop("graph_checksum", None)
+    payload.pop("capability_snapshot_version", None)
+    payload.pop("capability_snapshot_hash", None)
+    payload["tags"] = sorted(set(payload.get("tags") or []))
+    payload["starters"] = sorted(set(payload.get("starters") or []))
+    payload["nodes"] = sorted(
+        payload.get("nodes") or [], key=lambda item: str(item.get("ref") or "")
+    )
+    payload["edges"] = sorted(
+        payload.get("edges") or [], key=lambda item: str(item.get("ref") or "")
+    )
+    payload["prompt_profiles"] = sorted(
+        payload.get("prompt_profiles") or [],
+        key=lambda item: (
+            str(item.get("profile_id") or ""),
+            int(item.get("pinned_version") or 0),
+        ),
+    )
+    return canonical_checksum(payload)
+
+
 def workflow_semantic_checksum(candidate: dict[str, Any]) -> str:
     workflow = dict(candidate.get("draft", {}).get("workflow") or {})
     payload = {
@@ -227,6 +261,32 @@ def workflow_semantic_checksum(candidate: dict[str, Any]) -> str:
             ),
         ),
     }
+    return canonical_checksum(payload)
+
+
+def workflow_authoring_checksum(candidate: dict[str, Any]) -> str:
+    """Checksum the complete candidate, including deterministic editor layout."""
+
+    payload = deepcopy(candidate)
+    draft = payload.get("draft")
+    if isinstance(draft, dict):
+        workflow = draft.get("workflow")
+        if isinstance(workflow, dict):
+            workflow["nodes"] = sorted(
+                list(workflow.get("nodes") or []),
+                key=lambda item: str(item.get("id") or ""),
+            )
+            workflow["edges"] = sorted(
+                list(workflow.get("edges") or []),
+                key=lambda item: str(item.get("id") or ""),
+            )
+        draft["prompt_profiles"] = sorted(
+            list(draft.get("prompt_profiles") or []),
+            key=lambda item: (
+                str(item.get("profile_id") or ""),
+                int(item.get("pinned_version") or 0),
+            ),
+        )
     return canonical_checksum(payload)
 
 
@@ -522,6 +582,41 @@ def _resolved_node(
         execution=contract.execution.model_dump(mode="json"),
         resource_contracts=[item.model_dump(mode="json") for item in contract.resources],
     )
+
+
+def _resolve_immutable_resource_version(
+    resource: dict[str, Any],
+    *,
+    expected_version: int | None,
+    label: str,
+) -> tuple[int, str]:
+    """Resolve an exact immutable version independently from the latest pointer."""
+
+    latest = resource.get("published_version")
+    if not latest:
+        raise ValueError(f"{label} has no published version.")
+    target = int(expected_version or latest)
+    available = list((resource.get("metadata") or {}).get("available_versions") or [])
+    if available:
+        match = next(
+            (
+                item
+                for item in available
+                if isinstance(item, dict) and int(item.get("version") or 0) == target
+            ),
+            None,
+        )
+        if match is None:
+            raise ValueError(f"{label} pinned version {target} is unavailable.")
+        checksum = str(match.get("checksum") or "").strip()
+        return target, checksum or canonical_checksum(
+            {"id": resource.get("id"), "version": target}
+        )
+    if target != int(latest):
+        raise ValueError(
+            f"{label} drifted from pinned version {target} to {int(latest)}."
+        )
+    return target, canonical_checksum(resource)
 
 
 def resolve_graph_intent(
@@ -841,18 +936,15 @@ def resolve_graph_intent(
             config["top_k"] = binding.top_k
             config["score_threshold"] = binding.score_threshold
         else:
-            version = resource.get("published_version")
-            if not version:
-                raise ValueError(f"Resource {binding.resource_id} has no published version.")
             expected_version = intent._pinned_resource_versions.get(
-                (binding.kind, binding.resource_id)
+                (binding.kind, binding.resource_id, binding.target_ref)
             )
-            if expected_version is not None and int(version) != expected_version:
-                raise ValueError(
-                    f"Resource {binding.resource_id} drifted from pinned version "
-                    f"{expected_version} to {version}."
-                )
-            config["pinned_version"] = expected_version or int(version)
+            version, version_checksum = _resolve_immutable_resource_version(
+                resource,
+                expected_version=expected_version,
+                label=f"Resource {binding.resource_id}",
+            )
+            config["pinned_version"] = version
         if binding.kind == "external_xpert":
             tool_name = _safe_identifier(
                 binding.tool_name or f"xpert_{binding.resource_id[:12]}",
@@ -866,7 +958,11 @@ def resolve_graph_intent(
                 )
             seen_external_tools.add(tool_key)
             config["tool_name"] = tool_name
-        config["resource_checksum"] = canonical_checksum(resource)
+        config["resource_checksum"] = (
+            version_checksum
+            if binding.kind != "knowledge_base"
+            else canonical_checksum(resource)
+        )
         resolved_resource = _resolved_node(
             ref=ref,
             node_id=ref,
@@ -1012,18 +1108,17 @@ def resolve_graph_intent(
         resource = prompt_lookup.get(profile_id)
         if resource is None or not resource.get("published_version"):
             raise ValueError(f"Prompt Profile {profile_id} is unavailable.")
-        version = int(resource["published_version"])
         expected_version = intent._pinned_prompt_profile_versions.get(profile_id)
-        if expected_version is not None and version != expected_version:
-            raise ValueError(
-                f"Prompt Profile {profile_id} drifted from pinned version "
-                f"{expected_version} to {version}."
-            )
+        version, version_checksum = _resolve_immutable_resource_version(
+            resource,
+            expected_version=expected_version,
+            label=f"Prompt Profile {profile_id}",
+        )
         prompt_profiles.append(
             ResolvedPromptProfileV3(
                 profile_id=profile_id,
-                pinned_version=expected_version or version,
-                checksum=canonical_checksum(resource),
+                pinned_version=version,
+                checksum=version_checksum,
             )
         )
 
@@ -1070,10 +1165,10 @@ def annotate_candidate_with_graph_ir(
             ]
 
 
-def decompile_candidate_to_graph_intent(
+def decompile_candidate_to_graph_intent_compat(
     candidate: dict[str, Any],
-) -> GraphIntentV3:
-    from .node_adapters import decompile_planner_node_v3
+) -> tuple[GraphIntentV3 | None, MetaPlannerIRCompatibility]:
+    from .node_adapters import decompile_planner_node, decompile_planner_node_v3
 
     try:
         from server.workflow_native.schemas import NativeWorkflowNode
@@ -1084,60 +1179,161 @@ def decompile_candidate_to_graph_intent(
     workflow = draft.get("workflow") or {}
     raw_nodes = list(workflow.get("nodes") or [])
     node_by_id = {str(node.get("id") or ""): node for node in raw_nodes}
+    if len(node_by_id) != len(raw_nodes) or "" in node_by_id:
+        raise ValueError("Compiled candidate node IDs must be present and unique.")
+    kind_by_id = {
+        node_id: str(
+            (node.get("data") or {}).get("kind") or node.get("type") or ""
+        )
+        for node_id, node in node_by_id.items()
+    }
+    supported_kinds = {
+        "input",
+        "output",
+        "workflow_agent",
+        "external_xpert",
+        "knowledge_base",
+        "toolset_resource",
+        "plugin_resource",
+        "runtime_middleware",
+    }
+    unsupported = sorted(
+        f"{node_id}:{kind or '<missing>'}"
+        for node_id, kind in kind_by_id.items()
+        if kind not in supported_kinds
+    )
+    if unsupported:
+        raise ValueError(
+            "Compiled candidate contains nodes outside the recoverable Planner graph: "
+            + ", ".join(unsupported)
+        )
+    input_ids = sorted(
+        node_id for node_id, kind in kind_by_id.items() if kind == "input"
+    )
+    output_ids = sorted(
+        node_id for node_id, kind in kind_by_id.items() if kind == "output"
+    )
+    if input_ids != ["input"] or output_ids != ["output"]:
+        raise ValueError(
+            "Compiled candidate must contain the canonical input and output nodes exactly once."
+        )
+    workflow_agents = [
+        raw_node
+        for raw_node in raw_nodes
+        if str(
+            (raw_node.get("data") or {}).get("kind")
+            or raw_node.get("type")
+            or ""
+        )
+        == "workflow_agent"
+    ]
+    if not workflow_agents:
+        raise ValueError("Compiled candidate has no Workflow Agent node.")
+    marker_versions = {
+        int((raw_node.get("data") or {}).get("plannerIRVersion") or 0)
+        for raw_node in workflow_agents
+    }
+    if not marker_versions.issubset({0, GRAPH_IR_VERSION}):
+        raise ValueError("Compiled candidate carries an unknown Graph IR marker.")
+    if len(marker_versions) != 1:
+        raise ValueError(
+            "Compiled candidate mixes Graph IR V2 and V3 Workflow Agent markers."
+        )
+    use_v3 = marker_versions == {GRAPH_IR_VERSION}
     ref_by_id: dict[str, str] = {}
     business_nodes: list[GraphIntentNodeV3] = []
-    for raw_node in raw_nodes:
-        data = raw_node.get("data") or {}
-        kind = str(data.get("kind") or raw_node.get("type") or "")
-        if kind != "workflow_agent":
-            continue
-        restored = decompile_planner_node_v3(
-            NativeWorkflowNode.model_validate(raw_node)
+    legacy_nodes: list[MetaPlannerIRNode] = []
+    for raw_node in workflow_agents:
+        native_node = NativeWorkflowNode.model_validate(raw_node)
+        restored = (
+            decompile_planner_node_v3(native_node)
+            if use_v3
+            else decompile_planner_node(native_node)
         )
         node_id = str(raw_node.get("id") or "")
         ref_by_id[node_id] = restored.ref
-        business_nodes.append(restored)
+        if use_v3:
+            business_nodes.append(restored)
+        else:
+            legacy_nodes.append(restored)
 
     control_edges: list[GraphIntentControlEdgeV3] = []
     resources: list[MetaPlannerIRResourceBinding] = []
-    pinned_resource_versions: dict[tuple[str, str], int] = {}
+    pinned_resource_versions: dict[tuple[str, str, str], int] = {}
     middleware: list[MetaPlannerIRMiddlewareBinding] = []
+    consumed_node_ids = {"input", "output", *ref_by_id}
+    input_root_refs: set[str] = set()
+    input_root_edges: list[str] = []
+    terminal_edges: list[dict[str, Any]] = []
+    seen_edge_ids: set[str] = set()
     for raw_edge in workflow.get("edges") or []:
+        edge_id = str(raw_edge.get("id") or "")
+        if not edge_id or edge_id in seen_edge_ids:
+            raise ValueError("Compiled candidate edge IDs must be present and unique.")
+        seen_edge_ids.add(edge_id)
         source_id = str(raw_edge.get("source") or "")
         target_id = str(raw_edge.get("target") or "")
+        if source_id not in node_by_id or target_id not in node_by_id:
+            raise ValueError(f"Compiled edge {edge_id} has an unknown endpoint.")
         source_ref = ref_by_id.get(source_id)
         target_ref = ref_by_id.get(target_id)
         source_handle = str(raw_edge.get("sourceHandle") or "")
         target_handle = str(raw_edge.get("targetHandle") or "")
-        if source_ref and target_ref and not source_handle and not target_handle:
-            control_edges.append(
-                GraphIntentControlEdgeV3(
-                    source_ref=source_ref,
-                    target_ref=target_ref,
+        source_kind = kind_by_id[source_id]
+        target_kind = kind_by_id[target_id]
+        if not source_handle and not target_handle:
+            if source_kind == "input" and target_ref:
+                input_root_edges.append(target_ref)
+                input_root_refs.add(target_ref)
+                continue
+            if source_ref and target_ref:
+                control_edges.append(
+                    GraphIntentControlEdgeV3(
+                        source_ref=source_ref,
+                        target_ref=target_ref,
+                    )
                 )
+                continue
+            if source_ref and target_kind == "output":
+                terminal_edges.append(raw_edge)
+                continue
+            raise ValueError(
+                f"Compiled control edge {edge_id} is outside the recoverable Planner graph."
             )
-            continue
         if not target_ref:
-            continue
+            raise ValueError(
+                f"Compiled binding edge {edge_id} must target a Workflow Agent."
+            )
         source_node = node_by_id.get(source_id) or {}
         source_data = source_node.get("data") or {}
-        source_kind = str(source_data.get("kind") or source_node.get("type") or "")
-        if target_handle == "middleware" and source_kind == "runtime_middleware":
+        expected_handles = {
+            "external_xpert": ("expert-binding", "expert"),
+            "knowledge_base": ("knowledge-binding", "knowledge"),
+            "toolset_resource": ("toolset-binding", "toolset"),
+            "plugin_resource": ("plugin-binding", "plugin"),
+            "runtime_middleware": ("middleware-binding", "middleware"),
+        }.get(source_kind)
+        if expected_handles != (source_handle, target_handle):
+            raise ValueError(
+                f"Compiled binding edge {edge_id} has invalid source/target Handles."
+            )
+        if source_id in consumed_node_ids:
+            raise ValueError(
+                f"Compiled resource node {source_id} is bound more than once."
+            )
+        consumed_node_ids.add(source_id)
+        if source_kind == "runtime_middleware":
+            middleware_id = str(source_data.get("runtimeMiddlewareId") or "")
+            if not middleware_id:
+                raise ValueError("Compiled middleware binding has no middleware ID.")
             middleware.append(
                 MetaPlannerIRMiddlewareBinding(
                     target_ref=target_ref,
-                    middleware_id=str(source_data.get("runtimeMiddlewareId") or ""),
+                    middleware_id=middleware_id,
                     priority=int(source_data.get("middlewarePriority") or 100),
                     config=dict(source_data.get("runtimeMiddlewareConfig") or {}),
                 )
             )
-            continue
-        if source_kind not in {
-            "external_xpert",
-            "knowledge_base",
-            "toolset_resource",
-            "plugin_resource",
-        }:
             continue
         id_fields = {
             "external_xpert": "xpertId",
@@ -1146,6 +1342,8 @@ def decompile_candidate_to_graph_intent(
             "plugin_resource": "pluginId",
         }
         resource_id = str(source_data.get(id_fields[source_kind]) or "")
+        if not resource_id:
+            raise ValueError(f"Compiled {source_kind} binding has no resource ID.")
         if source_kind != "knowledge_base":
             try:
                 pinned_version = int(source_data.get("pinnedVersion"))
@@ -1153,7 +1351,7 @@ def decompile_candidate_to_graph_intent(
                 raise ValueError(
                     f"Compiled {source_kind} resource has no pinned version."
                 ) from None
-            pin_key = (source_kind, resource_id)
+            pin_key = (source_kind, resource_id, target_ref)
             previous_pin = pinned_resource_versions.get(pin_key)
             if previous_pin is not None and previous_pin != pinned_version:
                 raise ValueError(
@@ -1172,6 +1370,23 @@ def decompile_candidate_to_graph_intent(
             )
         )
 
+    unconsumed_nodes = sorted(set(node_by_id) - consumed_node_ids)
+    if unconsumed_nodes:
+        raise ValueError(
+            "Compiled candidate contains unbound or unconsumed nodes: "
+            + ", ".join(unconsumed_nodes)
+        )
+    parents = {ref: set() for ref in ref_by_id.values()}
+    for edge in control_edges:
+        parents[edge.target_ref].add(edge.source_ref)
+    expected_roots = {ref for ref, values in parents.items() if not values}
+    if len(input_root_edges) != len(input_root_refs) or input_root_refs != expected_roots:
+        raise ValueError(
+            "Compiled input edges do not match the semantic control roots."
+        )
+    if len(terminal_edges) != 1:
+        raise ValueError("Compiled candidate must contain exactly one terminal edge.")
+
     output_node = next(
         (
             node
@@ -1185,17 +1400,8 @@ def decompile_candidate_to_graph_intent(
         raise ValueError("Compiled candidate has no output node.")
     output_data = output_node.get("data") or {}
     output_variable = str(output_data.get("outputVariable") or "")
-    terminal_edge = next(
-        (
-            edge
-            for edge in workflow.get("edges") or []
-            if str(edge.get("target") or "") == str(output_node.get("id") or "")
-            and not edge.get("sourceHandle")
-            and not edge.get("targetHandle")
-        ),
-        None,
-    )
-    terminal_ref = ref_by_id.get(str((terminal_edge or {}).get("source") or ""))
+    terminal_edge = terminal_edges[0]
+    terminal_ref = ref_by_id.get(str(terminal_edge.get("source") or ""))
     if not terminal_ref or not output_variable:
         raise ValueError("Compiled candidate final output metadata is incomplete.")
     prompt_items = [
@@ -1216,25 +1422,64 @@ def decompile_candidate_to_graph_intent(
             raise ValueError(
                 f"Compiled Prompt Profile {profile_id} has no pinned version."
             ) from None
-    intent = GraphIntentV3(
-        name=str(candidate.get("name") or workflow.get("title") or "Xpert"),
-        description=str(candidate.get("description") or ""),
-        tags=list(candidate.get("tags") or []),
-        starters=list(candidate.get("starters") or []),
-        nodes=sorted(business_nodes, key=lambda item: item.ref),
-        control_edges=sorted(
-            control_edges, key=lambda item: (item.source_ref, item.target_ref)
-        ),
-        resources=resources,
-        middleware=middleware,
-        prompt_profile_ids=prompt_ids,
-        final_output=GraphIntentFinalOutputV3(
-            node_ref=terminal_ref,
-            variable=output_variable,
-        ),
-    )
+    metadata = {
+        "name": str(candidate.get("name") or workflow.get("title") or "Xpert"),
+        "description": str(candidate.get("description") or ""),
+        "tags": list(candidate.get("tags") or []),
+        "starters": list(candidate.get("starters") or []),
+    }
+    if use_v3:
+        compatibility = MetaPlannerIRCompatibility(source_version=3)
+        intent = GraphIntentV3(
+            **metadata,
+            nodes=sorted(business_nodes, key=lambda item: item.ref),
+            control_edges=sorted(
+                control_edges, key=lambda item: (item.source_ref, item.target_ref)
+            ),
+            resources=resources,
+            middleware=middleware,
+            prompt_profile_ids=prompt_ids,
+            final_output=GraphIntentFinalOutputV3(
+                node_ref=terminal_ref,
+                variable=output_variable,
+            ),
+        )
+    else:
+        blueprint = MetaPlannerTypedBlueprintV2(
+            **metadata,
+            nodes=sorted(legacy_nodes, key=lambda item: item.ref),
+            control_edges=[
+                MetaPlannerIRControlEdge(
+                    source_ref=edge.source_ref,
+                    target_ref=edge.target_ref,
+                )
+                for edge in sorted(
+                    control_edges,
+                    key=lambda item: (item.source_ref, item.target_ref),
+                )
+            ],
+            resources=resources,
+            middleware=middleware,
+            prompt_profile_ids=prompt_ids,
+            final_output=MetaPlannerIRFinalOutput(
+                node_ref=terminal_ref,
+                variable=output_variable,
+            ),
+        )
+        intent, compatibility = v2_to_graph_intent(blueprint)
+        if intent is None:
+            return None, compatibility
     intent._pinned_resource_versions = pinned_resource_versions
     intent._pinned_prompt_profile_versions = pinned_prompt_versions
+    return intent, compatibility
+
+
+def decompile_candidate_to_graph_intent(
+    candidate: dict[str, Any],
+) -> GraphIntentV3:
+    intent, compatibility = decompile_candidate_to_graph_intent_compat(candidate)
+    if intent is None:
+        raise ValueError("; ".join(compatibility.warnings))
     return intent
 
 

--- a/server/meta_agent/graph_patch.py
+++ b/server/meta_agent/graph_patch.py
@@ -1,0 +1,915 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Annotated, Any, Literal, Union
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+try:
+    from server.workflow_native.node_contracts import (
+        WorkflowValueSchema,
+        canonical_checksum,
+        workflow_node_contract_registry,
+    )
+except ModuleNotFoundError:
+    from workflow_native.node_contracts import (
+        WorkflowValueSchema,
+        canonical_checksum,
+        workflow_node_contract_registry,
+    )
+
+from .node_adapters import get_planner_node_adapter
+from .schemas import (
+    GraphIntentControlEdgeV3,
+    GraphIntentFinalOutputV3,
+    GraphIntentInputBindingV3,
+    GraphIntentNodeV3,
+    GraphIntentOutputBindingV3,
+    GraphIntentV3,
+    MetaPlannerIRMiddlewareBinding,
+    MetaPlannerIRResourceBinding,
+)
+
+
+GRAPH_PATCH_PROTOCOL_VERSION = 1
+GRAPH_PATCH_MAX_OPERATIONS = 64
+GRAPH_PATCH_MAX_REQUEST_BYTES = 2 * 1024 * 1024
+GRAPH_PATCH_MAX_JSON_DEPTH = 32
+GRAPH_PATCH_REF_PATTERN = r"^[a-z][a-z0-9_-]{0,63}$"
+GRAPH_PATCH_PORT_PATTERN = r"^[A-Za-z_][A-Za-z0-9_-]{0,63}$"
+GRAPH_PATCH_VARIABLE_PATTERN = r"^[A-Za-z_][A-Za-z0-9_]{0,127}$"
+GRAPH_PATCH_CHECKSUM_PATTERN = r"^[a-f0-9]{64}$"
+
+
+class GraphPatchModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class SetXpertMetadataOperation(GraphPatchModel):
+    op: Literal["set_xpert_metadata"] = "set_xpert_metadata"
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=2_000)
+    tags: list[str] | None = Field(default=None, max_length=20)
+    starters: list[str] | None = Field(default=None, max_length=8)
+
+    @model_validator(mode="after")
+    def require_change(self) -> "SetXpertMetadataOperation":
+        if all(
+            value is None
+            for value in (self.name, self.description, self.tags, self.starters)
+        ):
+            raise ValueError("set_xpert_metadata needs at least one field")
+        return self
+
+
+class AddNodeOperation(GraphPatchModel):
+    op: Literal["add_node"] = "add_node"
+    ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    kind: str = Field(min_length=1, max_length=80)
+    title: str = Field(min_length=1, max_length=120)
+    description: str = Field(default="", max_length=2_000)
+    task_ids: list[str] = Field(min_length=1, max_length=8)
+    config: dict[str, Any] = Field(default_factory=dict)
+    output_variables: dict[str, str] = Field(default_factory=dict, max_length=16)
+
+
+class UpdateNodeOperation(GraphPatchModel):
+    op: Literal["update_node"] = "update_node"
+    ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    title: str | None = Field(default=None, min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=2_000)
+    task_ids: list[str] | None = Field(default=None, min_length=1, max_length=8)
+    config: dict[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def require_change(self) -> "UpdateNodeOperation":
+        if all(
+            value is None
+            for value in (self.title, self.description, self.task_ids, self.config)
+        ):
+            raise ValueError("update_node needs at least one field")
+        return self
+
+
+class RemoveNodeOperation(GraphPatchModel):
+    op: Literal["remove_node"] = "remove_node"
+    ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+
+
+class ConnectControlOperation(GraphPatchModel):
+    op: Literal["connect_control"] = "connect_control"
+    source_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    target_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+
+
+class DisconnectControlOperation(GraphPatchModel):
+    op: Literal["disconnect_control"] = "disconnect_control"
+    source_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    target_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+
+
+class ConnectDataOperation(GraphPatchModel):
+    op: Literal["connect_data"] = "connect_data"
+    source_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    source_port: str = Field(pattern=GRAPH_PATCH_PORT_PATTERN)
+    target_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    target_port: str = Field(pattern=GRAPH_PATCH_PORT_PATTERN)
+
+
+class DisconnectDataOperation(GraphPatchModel):
+    op: Literal["disconnect_data"] = "disconnect_data"
+    source_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    source_port: str = Field(pattern=GRAPH_PATCH_PORT_PATTERN)
+    target_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    target_port: str = Field(pattern=GRAPH_PATCH_PORT_PATTERN)
+
+
+class SetOutputVariableOperation(GraphPatchModel):
+    op: Literal["set_output_variable"] = "set_output_variable"
+    node_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    port: str = Field(pattern=GRAPH_PATCH_PORT_PATTERN)
+    variable: str = Field(pattern=GRAPH_PATCH_VARIABLE_PATTERN)
+
+
+class BindResourceOperation(GraphPatchModel):
+    op: Literal["bind_resource"] = "bind_resource"
+    target_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    kind: Literal[
+        "external_xpert",
+        "knowledge_base",
+        "toolset_resource",
+        "plugin_resource",
+    ]
+    resource_id: str = Field(min_length=1, max_length=200)
+    tool_name: str = Field(default="", max_length=120)
+    description: str = Field(default="", max_length=1_000)
+    top_k: int = Field(default=5, ge=1, le=50)
+    score_threshold: float = Field(default=0.0, ge=0, le=1)
+
+
+class UnbindResourceOperation(GraphPatchModel):
+    op: Literal["unbind_resource"] = "unbind_resource"
+    target_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    kind: Literal[
+        "external_xpert",
+        "knowledge_base",
+        "toolset_resource",
+        "plugin_resource",
+    ]
+    resource_id: str = Field(min_length=1, max_length=200)
+
+
+class BindMiddlewareOperation(GraphPatchModel):
+    op: Literal["bind_middleware"] = "bind_middleware"
+    target_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    middleware_id: str = Field(min_length=1, max_length=160)
+    priority: int = Field(default=100, ge=0, le=10_000)
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class UnbindMiddlewareOperation(GraphPatchModel):
+    op: Literal["unbind_middleware"] = "unbind_middleware"
+    target_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    middleware_id: str = Field(min_length=1, max_length=160)
+
+
+class BindPromptProfileOperation(GraphPatchModel):
+    op: Literal["bind_prompt_profile"] = "bind_prompt_profile"
+    profile_id: str = Field(min_length=1, max_length=200)
+
+
+class UnbindPromptProfileOperation(GraphPatchModel):
+    op: Literal["unbind_prompt_profile"] = "unbind_prompt_profile"
+    profile_id: str = Field(min_length=1, max_length=200)
+
+
+class SetFinalOutputOperation(GraphPatchModel):
+    op: Literal["set_final_output"] = "set_final_output"
+    node_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    port: str = Field(default="result", pattern=GRAPH_PATCH_PORT_PATTERN)
+
+
+class MoveNodeOperation(GraphPatchModel):
+    op: Literal["move_node"] = "move_node"
+    ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    x: float = Field(ge=-100_000, le=100_000)
+    y: float = Field(ge=-100_000, le=100_000)
+
+
+GraphPatchOperation = Annotated[
+    Union[
+        SetXpertMetadataOperation,
+        AddNodeOperation,
+        UpdateNodeOperation,
+        RemoveNodeOperation,
+        ConnectControlOperation,
+        DisconnectControlOperation,
+        ConnectDataOperation,
+        DisconnectDataOperation,
+        SetOutputVariableOperation,
+        BindResourceOperation,
+        UnbindResourceOperation,
+        BindMiddlewareOperation,
+        UnbindMiddlewareOperation,
+        BindPromptProfileOperation,
+        UnbindPromptProfileOperation,
+        SetFinalOutputOperation,
+        MoveNodeOperation,
+    ],
+    Field(discriminator="op"),
+]
+
+
+class GraphPatchEnvelopeV1(GraphPatchModel):
+    protocol_version: Literal[1] = GRAPH_PATCH_PROTOCOL_VERSION
+    proposal_revision: int = Field(ge=1)
+    expected_graph_checksum: str = Field(pattern=GRAPH_PATCH_CHECKSUM_PATTERN)
+    expected_candidate_checksum: str = Field(pattern=GRAPH_PATCH_CHECKSUM_PATTERN)
+    operations: list[GraphPatchOperation] = Field(
+        default_factory=list,
+        max_length=GRAPH_PATCH_MAX_OPERATIONS,
+    )
+
+
+class GraphPatchApplyRequest(GraphPatchModel):
+    patch: GraphPatchEnvelopeV1
+    preview_checksum: str = Field(pattern=GRAPH_PATCH_CHECKSUM_PATTERN)
+
+
+class GraphPatchEditorDiffRequest(GraphPatchModel):
+    proposal_revision: int = Field(ge=1)
+    definition: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class GraphPatchResult:
+    intent: GraphIntentV3
+    layout: dict[str, dict[str, float]]
+    operation_types: tuple[str, ...]
+
+
+def graph_patch_schema() -> dict[str, Any]:
+    return GraphPatchEnvelopeV1.model_json_schema()
+
+
+def graph_patch_checksum(patch: GraphPatchEnvelopeV1) -> str:
+    return canonical_checksum(patch.model_dump(mode="json"))
+
+
+def _port_schema(kind: str, port_name: str, direction: str) -> WorkflowValueSchema:
+    contract = workflow_node_contract_registry.require(kind)
+    for port in contract.ports:
+        if port.name == port_name and port.direction == direction:
+            return port.value_schema
+    raise ValueError(f"Node kind {kind} has no {direction} port {port_name}.")
+
+
+def _source_output(
+    intent: GraphIntentV3,
+    source_ref: str,
+    source_port: str,
+) -> GraphIntentOutputBindingV3:
+    if source_ref == "input":
+        inputs = {
+            "user_input": GraphIntentOutputBindingV3(
+                port="user_input",
+                variable="user_input",
+                value_schema=WorkflowValueSchema(type="string"),
+            ),
+            "conversation_history": GraphIntentOutputBindingV3(
+                port="conversation_history",
+                variable="conversation_history",
+                value_schema=WorkflowValueSchema(
+                    type="array", items=WorkflowValueSchema(type="object")
+                ),
+            ),
+        }
+        binding = inputs.get(source_port)
+        if binding is None:
+            raise ValueError(f"Input has no output port {source_port}.")
+        return binding
+    source = next((node for node in intent.nodes if node.ref == source_ref), None)
+    if source is None:
+        raise ValueError(f"Unknown source node ref {source_ref}.")
+    binding = next((item for item in source.outputs if item.port == source_port), None)
+    if binding is None:
+        raise ValueError(f"Node {source_ref} has no output port {source_port}.")
+    return binding
+
+
+def _node(intent: GraphIntentV3, ref: str) -> GraphIntentNodeV3:
+    if ref in {"input", "output"}:
+        raise ValueError(f"Compiler-managed node {ref} cannot be patched.")
+    node = next((item for item in intent.nodes if item.ref == ref), None)
+    if node is None:
+        raise ValueError(f"Unknown node ref {ref}.")
+    return node
+
+
+def _validate_task_ids(task_ids: list[str], plan_task_ids: set[str]) -> None:
+    unknown = sorted(set(task_ids) - plan_task_ids)
+    if unknown:
+        raise ValueError("Patch references unknown plan tasks: " + ", ".join(unknown))
+
+
+def _replace_node(intent: GraphIntentV3, replacement: GraphIntentNodeV3) -> None:
+    intent.nodes = [
+        replacement if node.ref == replacement.ref else node for node in intent.nodes
+    ]
+
+
+def _resource_key(binding: MetaPlannerIRResourceBinding) -> tuple[str, str, str]:
+    return binding.target_ref, binding.kind, binding.resource_id
+
+
+def _middleware_key(binding: MetaPlannerIRMiddlewareBinding) -> tuple[str, str]:
+    return binding.target_ref, binding.middleware_id
+
+
+def _data_key(binding: GraphIntentInputBindingV3, target_ref: str) -> tuple[str, str, str, str]:
+    return binding.source_ref, binding.source_port, target_ref, binding.port
+
+
+def apply_graph_patch(
+    intent: GraphIntentV3,
+    patch: GraphPatchEnvelopeV1,
+    *,
+    plan_task_ids: set[str],
+    layout: dict[str, dict[str, float]] | None = None,
+    allowed_node_kinds: set[str] | None = None,
+    movable_refs: set[str] | None = None,
+) -> GraphPatchResult:
+    """Apply an ordered semantic patch without resolving runtime-owned facts."""
+
+    result = intent.model_copy(deep=True)
+    result._pinned_resource_versions = dict(intent._pinned_resource_versions)
+    result._pinned_prompt_profile_versions = dict(
+        intent._pinned_prompt_profile_versions
+    )
+    original_resource_pins = dict(intent._pinned_resource_versions)
+    next_layout = deepcopy(layout or {})
+    pending_removals: set[str] = set()
+
+    for operation in patch.operations:
+        if isinstance(operation, SetXpertMetadataOperation):
+            updates: dict[str, Any] = {}
+            for field_name in ("name", "description", "tags", "starters"):
+                value = getattr(operation, field_name)
+                if value is not None:
+                    updates[field_name] = list(dict.fromkeys(value)) if isinstance(value, list) else value
+            result = result.model_copy(update=updates)
+            continue
+
+        if isinstance(operation, AddNodeOperation):
+            if operation.ref in {"input", "output"}:
+                raise ValueError("Compiler-managed refs cannot be added.")
+            if any(node.ref == operation.ref for node in result.nodes):
+                raise ValueError(f"Node ref {operation.ref} already exists.")
+            if allowed_node_kinds is not None and operation.kind not in allowed_node_kinds:
+                raise ValueError(f"Node kind {operation.kind} is not authorized.")
+            adapter = get_planner_node_adapter(operation.kind)
+            if adapter is None:
+                raise ValueError(f"Node kind {operation.kind} has no authoring adapter.")
+            _validate_task_ids(operation.task_ids, plan_task_ids)
+            parsed_config = adapter.validate_authoring_config(operation.config)
+            contract = workflow_node_contract_registry.require(operation.kind)
+            output_ports = {
+                port.name: port
+                for port in contract.ports
+                if port.direction == "output"
+            }
+            unknown_ports = sorted(set(operation.output_variables) - set(output_ports))
+            if unknown_ports:
+                raise ValueError(
+                    f"Node {operation.ref} declares unknown output ports: "
+                    + ", ".join(unknown_ports)
+                )
+            outputs = [
+                GraphIntentOutputBindingV3(
+                    port=port_name,
+                    variable=variable,
+                    value_schema=output_ports[port_name].value_schema,
+                )
+                for port_name, variable in sorted(operation.output_variables.items())
+            ]
+            result.nodes.append(
+                GraphIntentNodeV3(
+                    ref=operation.ref,
+                    kind=operation.kind,
+                    title=operation.title,
+                    description=operation.description,
+                    task_ids=operation.task_ids,
+                    config=parsed_config,
+                    outputs=outputs,
+                )
+            )
+            continue
+
+        if isinstance(operation, UpdateNodeOperation):
+            current = _node(result, operation.ref)
+            updates: dict[str, Any] = {}
+            if operation.title is not None:
+                updates["title"] = operation.title
+            if operation.description is not None:
+                updates["description"] = operation.description
+            if operation.task_ids is not None:
+                _validate_task_ids(operation.task_ids, plan_task_ids)
+                updates["task_ids"] = operation.task_ids
+            if operation.config is not None:
+                adapter = get_planner_node_adapter(current.kind)
+                if adapter is None:
+                    raise ValueError(
+                        f"Node kind {current.kind} has no authoring adapter."
+                    )
+                updates["config"] = adapter.validate_authoring_config(operation.config)
+            _replace_node(result, current.model_copy(update=updates))
+            continue
+
+        if isinstance(operation, RemoveNodeOperation):
+            _node(result, operation.ref)
+            pending_removals.add(operation.ref)
+            continue
+
+        if isinstance(operation, ConnectControlOperation):
+            _node(result, operation.source_ref)
+            _node(result, operation.target_ref)
+            key = (operation.source_ref, operation.target_ref)
+            if any(
+                (edge.source_ref, edge.target_ref) == key
+                for edge in result.control_edges
+            ):
+                raise ValueError("Control edge already exists.")
+            result.control_edges.append(
+                GraphIntentControlEdgeV3(
+                    source_ref=operation.source_ref,
+                    target_ref=operation.target_ref,
+                )
+            )
+            continue
+
+        if isinstance(operation, DisconnectControlOperation):
+            before = len(result.control_edges)
+            result.control_edges = [
+                edge
+                for edge in result.control_edges
+                if (edge.source_ref, edge.target_ref)
+                != (operation.source_ref, operation.target_ref)
+            ]
+            if len(result.control_edges) == before:
+                raise ValueError("Control edge does not exist.")
+            continue
+
+        if isinstance(operation, ConnectDataOperation):
+            target = _node(result, operation.target_ref)
+            _port_schema(target.kind, operation.target_port, "input")
+            source = _source_output(result, operation.source_ref, operation.source_port)
+            if any(
+                _data_key(binding, target.ref)
+                == (
+                    operation.source_ref,
+                    operation.source_port,
+                    operation.target_ref,
+                    operation.target_port,
+                )
+                for binding in target.inputs
+            ):
+                raise ValueError("Data edge already exists.")
+            updated = target.model_copy(
+                update={
+                    "inputs": [
+                        *target.inputs,
+                        GraphIntentInputBindingV3(
+                            port=operation.target_port,
+                            variable=source.variable,
+                            source_ref=operation.source_ref,
+                            source_port=operation.source_port,
+                            value_schema=source.value_schema,
+                        ),
+                    ]
+                }
+            )
+            _replace_node(result, updated)
+            continue
+
+        if isinstance(operation, DisconnectDataOperation):
+            target = _node(result, operation.target_ref)
+            key = (
+                operation.source_ref,
+                operation.source_port,
+                operation.target_ref,
+                operation.target_port,
+            )
+            filtered = [
+                binding
+                for binding in target.inputs
+                if _data_key(binding, target.ref) != key
+            ]
+            if len(filtered) == len(target.inputs):
+                raise ValueError("Data edge does not exist.")
+            _replace_node(result, target.model_copy(update={"inputs": filtered}))
+            continue
+
+        if isinstance(operation, SetOutputVariableOperation):
+            target = _node(result, operation.node_ref)
+            selected = next(
+                (item for item in target.outputs if item.port == operation.port), None
+            )
+            if selected is None:
+                selected = GraphIntentOutputBindingV3(
+                    port=operation.port,
+                    variable=operation.variable,
+                    value_schema=_port_schema(target.kind, operation.port, "output"),
+                )
+                old_variable = ""
+                updated_outputs = [*target.outputs, selected]
+            else:
+                old_variable = selected.variable
+                updated_outputs = [
+                    item.model_copy(update={"variable": operation.variable})
+                    if item.port == operation.port
+                    else item
+                    for item in target.outputs
+                ]
+            _replace_node(result, target.model_copy(update={"outputs": updated_outputs}))
+            updated_nodes: list[GraphIntentNodeV3] = []
+            for node in result.nodes:
+                updated_inputs = [
+                    binding.model_copy(update={"variable": operation.variable})
+                    if binding.source_ref == operation.node_ref
+                    and binding.source_port == operation.port
+                    and binding.variable == old_variable
+                    else binding
+                    for binding in node.inputs
+                ]
+                updated_nodes.append(node.model_copy(update={"inputs": updated_inputs}))
+            result.nodes = updated_nodes
+            if (
+                result.final_output.node_ref == operation.node_ref
+                and result.final_output.port == operation.port
+            ):
+                result.final_output = result.final_output.model_copy(
+                    update={"variable": operation.variable}
+                )
+            continue
+
+        if isinstance(operation, BindResourceOperation):
+            _node(result, operation.target_ref)
+            candidate = MetaPlannerIRResourceBinding(
+                target_ref=operation.target_ref,
+                kind=operation.kind,
+                resource_id=operation.resource_id,
+                tool_name=operation.tool_name,
+                description=operation.description,
+                top_k=operation.top_k,
+                score_threshold=operation.score_threshold,
+            )
+            if any(_resource_key(item) == _resource_key(candidate) for item in result.resources):
+                raise ValueError("Resource binding already exists.")
+            result.resources.append(candidate)
+            pin_key = (
+                operation.kind,
+                operation.resource_id,
+                operation.target_ref,
+            )
+            if pin_key in original_resource_pins:
+                result._pinned_resource_versions[pin_key] = original_resource_pins[
+                    pin_key
+                ]
+            continue
+
+        if isinstance(operation, UnbindResourceOperation):
+            key = (operation.target_ref, operation.kind, operation.resource_id)
+            before = len(result.resources)
+            result.resources = [
+                item for item in result.resources if _resource_key(item) != key
+            ]
+            if len(result.resources) == before:
+                raise ValueError("Resource binding does not exist.")
+            result._pinned_resource_versions.pop(
+                (operation.kind, operation.resource_id, operation.target_ref), None
+            )
+            continue
+
+        if isinstance(operation, BindMiddlewareOperation):
+            _node(result, operation.target_ref)
+            candidate = MetaPlannerIRMiddlewareBinding(
+                target_ref=operation.target_ref,
+                middleware_id=operation.middleware_id,
+                priority=operation.priority,
+                config=operation.config,
+            )
+            if any(
+                _middleware_key(item) == _middleware_key(candidate)
+                for item in result.middleware
+            ):
+                raise ValueError("Middleware binding already exists.")
+            result.middleware.append(candidate)
+            continue
+
+        if isinstance(operation, UnbindMiddlewareOperation):
+            key = (operation.target_ref, operation.middleware_id)
+            before = len(result.middleware)
+            result.middleware = [
+                item for item in result.middleware if _middleware_key(item) != key
+            ]
+            if len(result.middleware) == before:
+                raise ValueError("Middleware binding does not exist.")
+            continue
+
+        if isinstance(operation, BindPromptProfileOperation):
+            if operation.profile_id in result.prompt_profile_ids:
+                raise ValueError("Prompt Profile binding already exists.")
+            result.prompt_profile_ids.append(operation.profile_id)
+            continue
+
+        if isinstance(operation, UnbindPromptProfileOperation):
+            if operation.profile_id not in result.prompt_profile_ids:
+                raise ValueError("Prompt Profile binding does not exist.")
+            result.prompt_profile_ids = [
+                item for item in result.prompt_profile_ids if item != operation.profile_id
+            ]
+            result._pinned_prompt_profile_versions.pop(operation.profile_id, None)
+            continue
+
+        if isinstance(operation, SetFinalOutputOperation):
+            target = _node(result, operation.node_ref)
+            output = next(
+                (item for item in target.outputs if item.port == operation.port), None
+            )
+            if output is None:
+                raise ValueError(
+                    f"Node {operation.node_ref} has no output port {operation.port}."
+                )
+            result.final_output = GraphIntentFinalOutputV3(
+                node_ref=operation.node_ref,
+                port=operation.port,
+                variable=output.variable,
+            )
+            continue
+
+        if isinstance(operation, MoveNodeOperation):
+            if movable_refs is not None:
+                if operation.ref not in movable_refs:
+                    raise ValueError(f"Unknown movable node ref {operation.ref}.")
+            elif operation.ref not in {"input", "output"}:
+                _node(result, operation.ref)
+            next_layout[operation.ref] = {"x": operation.x, "y": operation.y}
+            continue
+
+        raise ValueError("Unsupported Graph Patch operation.")
+
+    for ref in sorted(pending_removals):
+        incidents: list[str] = []
+        incidents.extend(
+            f"control:{edge.source_ref}->{edge.target_ref}"
+            for edge in result.control_edges
+            if ref in {edge.source_ref, edge.target_ref}
+        )
+        for node in result.nodes:
+            incidents.extend(
+                f"data:{binding.source_ref}.{binding.source_port}->{node.ref}.{binding.port}"
+                for binding in node.inputs
+                if ref in {binding.source_ref, node.ref}
+            )
+        incidents.extend(
+            f"resource:{item.kind}:{item.resource_id}"
+            for item in result.resources
+            if item.target_ref == ref
+        )
+        incidents.extend(
+            f"middleware:{item.middleware_id}"
+            for item in result.middleware
+            if item.target_ref == ref
+        )
+        if result.final_output.node_ref == ref:
+            incidents.append("final_output")
+        if incidents:
+            raise ValueError(
+                f"Node {ref} still has dependencies; explicitly detach them in the same patch: "
+                + ", ".join(incidents[:12])
+            )
+        result.nodes = [node for node in result.nodes if node.ref != ref]
+        next_layout.pop(ref, None)
+
+    covered_tasks = {task_id for node in result.nodes for task_id in node.task_ids}
+    missing_tasks = sorted(plan_task_ids - covered_tasks)
+    if missing_tasks:
+        raise ValueError(
+            "Graph Patch cannot change the fixed plan; uncovered tasks: "
+            + ", ".join(missing_tasks)
+        )
+    if not result.nodes:
+        raise ValueError("Graph Patch cannot remove every executable node.")
+    validated = GraphIntentV3.model_validate(result.model_dump(mode="json"))
+    validated._pinned_resource_versions = dict(result._pinned_resource_versions)
+    validated._pinned_prompt_profile_versions = dict(
+        result._pinned_prompt_profile_versions
+    )
+    return GraphPatchResult(
+        intent=validated,
+        layout=next_layout,
+        operation_types=tuple(operation.op for operation in patch.operations),
+    )
+
+
+def diff_graph_intents(
+    source: GraphIntentV3,
+    target: GraphIntentV3,
+    *,
+    proposal_revision: int,
+    expected_graph_checksum: str,
+    expected_candidate_checksum: str,
+    source_layout: dict[str, dict[str, float]] | None = None,
+    target_layout: dict[str, dict[str, float]] | None = None,
+) -> GraphPatchEnvelopeV1:
+    operations: list[GraphPatchOperation] = []
+    metadata: dict[str, Any] = {}
+    for field_name in ("name", "description", "tags", "starters"):
+        if getattr(source, field_name) != getattr(target, field_name):
+            metadata[field_name] = getattr(target, field_name)
+    if metadata:
+        operations.append(SetXpertMetadataOperation(**metadata))
+
+    source_nodes = {node.ref: node for node in source.nodes}
+    target_nodes = {node.ref: node for node in target.nodes}
+    source_data = {
+        _data_key(binding, node.ref)
+        for node in source.nodes
+        for binding in node.inputs
+    }
+    target_data = {
+        _data_key(binding, node.ref)
+        for node in target.nodes
+        for binding in node.inputs
+    }
+    source_control = {
+        (edge.source_ref, edge.target_ref) for edge in source.control_edges
+    }
+    target_control = {
+        (edge.source_ref, edge.target_ref) for edge in target.control_edges
+    }
+    source_resources = {_resource_key(item): item for item in source.resources}
+    target_resources = {_resource_key(item): item for item in target.resources}
+    source_middleware = {_middleware_key(item): item for item in source.middleware}
+    target_middleware = {_middleware_key(item): item for item in target.middleware}
+
+    for key in sorted(source_data - target_data):
+        operations.append(
+            DisconnectDataOperation(
+                source_ref=key[0],
+                source_port=key[1],
+                target_ref=key[2],
+                target_port=key[3],
+            )
+        )
+    for source_ref, target_ref in sorted(source_control - target_control):
+        operations.append(
+            DisconnectControlOperation(
+                source_ref=source_ref, target_ref=target_ref
+            )
+        )
+    for key in sorted(set(source_resources) - set(target_resources)):
+        operations.append(
+            UnbindResourceOperation(
+                target_ref=key[0], kind=key[1], resource_id=key[2]
+            )
+        )
+    for key in sorted(set(source_middleware) - set(target_middleware)):
+        operations.append(
+            UnbindMiddlewareOperation(
+                target_ref=key[0], middleware_id=key[1]
+            )
+        )
+
+    for ref in sorted(set(source_nodes) - set(target_nodes)):
+        operations.append(RemoveNodeOperation(ref=ref))
+    for ref in sorted(set(target_nodes) - set(source_nodes)):
+        node = target_nodes[ref]
+        operations.append(
+            AddNodeOperation(
+                ref=node.ref,
+                kind=node.kind,
+                title=node.title,
+                description=node.description,
+                task_ids=node.task_ids,
+                config=node.config,
+                output_variables={item.port: item.variable for item in node.outputs},
+            )
+        )
+
+    for ref in sorted(set(source_nodes) & set(target_nodes)):
+        before = source_nodes[ref]
+        after = target_nodes[ref]
+        if before.kind != after.kind:
+            raise ValueError(
+                f"Editor change for {ref} replaces its node kind and is not expressible."
+            )
+        updates: dict[str, Any] = {"ref": ref}
+        for field_name in ("title", "description", "task_ids", "config"):
+            if getattr(before, field_name) != getattr(after, field_name):
+                updates[field_name] = getattr(after, field_name)
+        if len(updates) > 1:
+            operations.append(UpdateNodeOperation(**updates))
+        before_outputs = {item.port: item for item in before.outputs}
+        after_outputs = {item.port: item for item in after.outputs}
+        if set(before_outputs) != set(after_outputs):
+            raise ValueError(
+                f"Editor change for {ref} changes contract-owned output ports."
+            )
+        for port in sorted(before_outputs):
+            if before_outputs[port].value_schema != after_outputs[port].value_schema:
+                raise ValueError(
+                    f"Editor change for {ref}.{port} changes a contract-owned schema."
+                )
+            if before_outputs[port].variable != after_outputs[port].variable:
+                operations.append(
+                    SetOutputVariableOperation(
+                        node_ref=ref,
+                        port=port,
+                        variable=after_outputs[port].variable,
+                    )
+                )
+
+    for source_ref, target_ref in sorted(target_control - source_control):
+        operations.append(
+            ConnectControlOperation(source_ref=source_ref, target_ref=target_ref)
+        )
+    for key in sorted(target_data - source_data):
+        operations.append(
+            ConnectDataOperation(
+                source_ref=key[0],
+                source_port=key[1],
+                target_ref=key[2],
+                target_port=key[3],
+            )
+        )
+    for key in sorted(set(target_resources) - set(source_resources)):
+        item = target_resources[key]
+        operations.append(BindResourceOperation(**item.model_dump(mode="json")))
+    for key in sorted(set(target_middleware) - set(source_middleware)):
+        item = target_middleware[key]
+        operations.append(BindMiddlewareOperation(**item.model_dump(mode="json")))
+
+    for key in sorted(set(source_resources) & set(target_resources)):
+        if source_resources[key] != target_resources[key]:
+            before = source_resources[key]
+            after = target_resources[key]
+            operations.extend(
+                [
+                    UnbindResourceOperation(
+                        target_ref=before.target_ref,
+                        kind=before.kind,
+                        resource_id=before.resource_id,
+                    ),
+                    BindResourceOperation(**after.model_dump(mode="json")),
+                ]
+            )
+    for key in sorted(set(source_middleware) & set(target_middleware)):
+        if source_middleware[key] != target_middleware[key]:
+            before = source_middleware[key]
+            after = target_middleware[key]
+            operations.extend(
+                [
+                    UnbindMiddlewareOperation(
+                        target_ref=before.target_ref,
+                        middleware_id=before.middleware_id,
+                    ),
+                    BindMiddlewareOperation(**after.model_dump(mode="json")),
+                ]
+            )
+
+    for profile_id in sorted(
+        set(source.prompt_profile_ids) - set(target.prompt_profile_ids)
+    ):
+        operations.append(UnbindPromptProfileOperation(profile_id=profile_id))
+    for profile_id in sorted(
+        set(target.prompt_profile_ids) - set(source.prompt_profile_ids)
+    ):
+        operations.append(BindPromptProfileOperation(profile_id=profile_id))
+    if source.final_output != target.final_output:
+        operations.append(
+            SetFinalOutputOperation(
+                node_ref=target.final_output.node_ref,
+                port=target.final_output.port,
+            )
+        )
+
+    before_layout = source_layout or {}
+    after_layout = target_layout or {}
+    for ref in sorted(set(after_layout)):
+        if before_layout.get(ref) != after_layout.get(ref):
+            point = after_layout[ref]
+            operations.append(MoveNodeOperation(ref=ref, x=point["x"], y=point["y"]))
+
+    if len(operations) > GRAPH_PATCH_MAX_OPERATIONS:
+        raise ValueError(
+            f"Editor diff requires {len(operations)} operations; the limit is "
+            f"{GRAPH_PATCH_MAX_OPERATIONS}."
+        )
+    return GraphPatchEnvelopeV1(
+        proposal_revision=proposal_revision,
+        expected_graph_checksum=expected_graph_checksum,
+        expected_candidate_checksum=expected_candidate_checksum,
+        operations=operations,
+    )

--- a/server/meta_agent/headless_authoring.py
+++ b/server/meta_agent/headless_authoring.py
@@ -1,0 +1,1418 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import time
+from collections import Counter, defaultdict, deque
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from pydantic import ValidationError
+
+try:
+    from server.workflow_native.node_contracts import (
+        NODE_CONTRACT_VERSION,
+        WorkflowValueSchema,
+        canonical_checksum,
+        workflow_node_contract_registry,
+    )
+    from server.workflow_native.schemas import NativeWorkflowDefinition
+    from server.xpert_runtime.authoring_service import AuthoringService
+    from server.xpert_runtime.authoring_store import (
+        AuthoringProposal,
+        AuthoringProposalConflictError,
+        AuthoringProposalNotFoundError,
+        AuthoringProposalValidationError,
+    )
+    from server.xperts.models import XpertDefinition
+except ModuleNotFoundError:
+    from workflow_native.node_contracts import (
+        NODE_CONTRACT_VERSION,
+        WorkflowValueSchema,
+        canonical_checksum,
+        workflow_node_contract_registry,
+    )
+    from workflow_native.schemas import NativeWorkflowDefinition
+    from xpert_runtime.authoring_service import AuthoringService
+    from xpert_runtime.authoring_store import (
+        AuthoringProposal,
+        AuthoringProposalConflictError,
+        AuthoringProposalNotFoundError,
+        AuthoringProposalValidationError,
+    )
+    from xperts.models import XpertDefinition
+
+from .graph_ir_v3 import (
+    decompile_candidate_to_graph_intent,
+    decompile_candidate_to_graph_intent_compat,
+    graph_authoring_checksum,
+    resolve_graph_intent,
+    workflow_authoring_checksum,
+    workflow_semantic_checksum,
+)
+from .graph_patch import (
+    GRAPH_PATCH_PROTOCOL_VERSION,
+    GraphPatchApplyRequest,
+    GraphPatchEditorDiffRequest,
+    GraphPatchEnvelopeV1,
+    apply_graph_patch,
+    diff_graph_intents,
+    graph_patch_checksum,
+)
+from .meta_planner_v2 import MetaPlannerV2Service
+from .node_adapters import get_planner_node_adapter
+from .schemas import (
+    GraphIntentInputBindingV3,
+    GraphIntentOutputBindingV3,
+    GraphIntentV3,
+    MetaPlannerCapabilitySnapshot,
+    MetaPlannerGenerateRequest,
+    MetaPlannerIRCompatibility,
+    MetaPlannerScope,
+    MetaPlannerTaskPlan,
+    ResolvedGraphIRV3,
+)
+
+
+HEADLESS_AUTHORING_MAX_RECEIPTS = 20
+HEADLESS_AUTHORING_VERSION = "meta-planner-headless-authoring-v1"
+_TEMPLATE_VARIABLE = re.compile(
+    r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}"
+)
+_AUTHORABLE_WORKFLOW_AGENT_DATA_FIELDS = frozenset(
+    {
+        "kind",
+        "title",
+        "description",
+        "modelId",
+        "rolePrompt",
+        "taskInput",
+        "sourceAgentId",
+        "methodSkillIds",
+        "outputVariable",
+    }
+)
+_SENSITIVE_ERROR_VALUE = re.compile(
+    r"(?i)(?:sk-[A-Za-z0-9_-]{8,}|gh[pousr]_[A-Za-z0-9]{8,}|"
+    r"bearer\s+[A-Za-z0-9._-]{8,}|"
+    r"(?:api[_-]?key|access[_-]?token|secret|password)\s*[:=]\s*[^\s,;]+)"
+)
+_RECEIPT_CHECKSUM = re.compile(r"^[a-f0-9]{64}$")
+_RECEIPT_OPERATION = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+
+def safe_headless_error_message(error: Exception | str) -> str:
+    if isinstance(error, ValidationError):
+        parts: list[str] = []
+        for item in error.errors(include_input=False, include_url=False)[:20]:
+            location = ".".join(str(value) for value in item.get("loc") or [])
+            message = str(item.get("msg") or item.get("type") or "Invalid input")
+            parts.append(f"{location}: {message}" if location else message)
+        raw = "; ".join(parts) or "Request validation failed."
+    else:
+        raw = str(error)
+    return _SENSITIVE_ERROR_VALUE.sub("[REDACTED]", raw)[:1_000]
+
+
+def _canonical_patch_receipts(value: Any) -> list[dict[str, Any]]:
+    receipts: list[dict[str, Any]] = []
+    for item in list(value or [])[-HEADLESS_AUTHORING_MAX_RECEIPTS:]:
+        if not isinstance(item, dict):
+            continue
+        if item.get("protocol_version") != GRAPH_PATCH_PROTOCOL_VERSION:
+            continue
+        operation_types = item.get("operation_types")
+        if (
+            not isinstance(operation_types, list)
+            or len(operation_types) > 64
+            or any(
+                not isinstance(operation, str)
+                or not _RECEIPT_OPERATION.fullmatch(operation)
+                for operation in operation_types
+            )
+        ):
+            continue
+        checksum_fields = (
+            "before_graph_checksum",
+            "after_graph_checksum",
+            "before_candidate_checksum",
+            "after_candidate_checksum",
+        )
+        if any(
+            not isinstance(item.get(field_name), str)
+            or not _RECEIPT_CHECKSUM.fullmatch(item[field_name])
+            for field_name in checksum_fields
+        ):
+            continue
+        raw_counts = item.get("diagnostic_counts")
+        if not isinstance(raw_counts, dict):
+            continue
+        diagnostic_counts = {
+            key: count
+            for key in ("info", "warning", "error")
+            if isinstance((count := raw_counts.get(key)), int)
+            and not isinstance(count, bool)
+            and 0 <= count <= 10_000
+        }
+        applied_at = item.get("applied_at")
+        if not isinstance(applied_at, (int, float)) or isinstance(
+            applied_at, bool
+        ):
+            continue
+        receipts.append(
+            {
+                "protocol_version": GRAPH_PATCH_PROTOCOL_VERSION,
+                "operation_types": list(operation_types),
+                **{
+                    field_name: item[field_name]
+                    for field_name in checksum_fields
+                },
+                "diagnostic_counts": diagnostic_counts,
+                "applied_at": float(applied_at),
+            }
+        )
+    return receipts
+
+
+class HeadlessAuthoringError(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "headless_authoring_validation",
+        status_code: int = 422,
+        diagnostics: list[dict[str, Any]] | None = None,
+    ) -> None:
+        clean_message = safe_headless_error_message(message)
+        super().__init__(clean_message)
+        self.code = code
+        self.status_code = status_code
+        self.diagnostics = [
+            {
+                "code": str(item.get("code") or "headless_authoring_validation"),
+                "severity": str(item.get("severity") or "error"),
+                "message": safe_headless_error_message(
+                    str(item.get("message") or clean_message)
+                )[:500],
+            }
+            for item in list(diagnostics or [])[:20]
+            if isinstance(item, dict)
+        ]
+
+
+class HeadlessAuthoringConflictError(HeadlessAuthoringError):
+    def __init__(self, message: str, *, code: str = "headless_authoring_conflict"):
+        super().__init__(message, code=code, status_code=409)
+
+
+@dataclass(slots=True)
+class _ProposalState:
+    proposal: AuthoringProposal
+    candidate: dict[str, Any]
+    report: dict[str, Any]
+    plan: MetaPlannerTaskPlan
+    intent: GraphIntentV3
+    graph_ir: ResolvedGraphIRV3
+    snapshot: MetaPlannerCapabilitySnapshot
+    scope: MetaPlannerScope
+    request: MetaPlannerGenerateRequest
+    target: XpertDefinition | None
+    layout: dict[str, dict[str, float]]
+    graph_checksum: str
+    candidate_checksum: str
+    ir_state: str
+    compatibility: MetaPlannerIRCompatibility
+    warnings: list[str]
+    target_conflict: bool
+
+
+def candidate_authoring_checksum(candidate: dict[str, Any]) -> str:
+    """Checksum the compiled candidate including presentation coordinates."""
+
+    return workflow_authoring_checksum(candidate)
+
+
+def _round_trip_candidate_projection(
+    candidate: dict[str, Any], *, source_version: int
+) -> dict[str, Any]:
+    """Normalize only fields introduced by the lossless V2-to-V3 upgrade."""
+
+    projected = deepcopy(candidate)
+    if source_version != 2:
+        return projected
+    workflow = (projected.get("draft") or {}).get("workflow") or {}
+    # V2 and V3 compiler provenance use different workflow version labels.
+    # The label is not an execution setting, so exclude it from the behavioral
+    # losslessness proof while retaining every runtime-owned node field.
+    workflow.pop("version", None)
+    for node in workflow.get("nodes") or []:
+        data = node.get("data") or {}
+        if str(data.get("kind") or node.get("type") or "") != "workflow_agent":
+            continue
+        data.pop("plannerIRVersion", None)
+        data.pop("plannerInputsV3", None)
+        data.pop("plannerOutputsV3", None)
+    return projected
+
+
+def _candidate_from_proposal(proposal: AuthoringProposal) -> dict[str, Any]:
+    if proposal.kind == "xpert_create":
+        return {
+            key: deepcopy(value)
+            for key, value in proposal.payload.items()
+            if key in {"name", "description", "tags", "starters", "draft"}
+        }
+    if proposal.kind == "xpert_update":
+        return deepcopy(dict(proposal.payload.get("patch") or {}))
+    raise HeadlessAuthoringError(
+        "Headless authoring only supports Xpert proposals.",
+        code="headless_authoring_kind",
+    )
+
+
+def _report_from_proposal(proposal: AuthoringProposal) -> dict[str, Any]:
+    report = proposal.payload.get("meta_planner_report")
+    if proposal.source_type != "meta_planner" or not isinstance(report, dict):
+        raise HeadlessAuthoringError(
+            "Proposal is not a Meta Planner candidate.",
+            code="headless_authoring_source",
+        )
+    return deepcopy(report)
+
+
+def _layout_from_candidate(candidate: dict[str, Any]) -> dict[str, dict[str, float]]:
+    layout: dict[str, dict[str, float]] = {}
+    workflow = dict((candidate.get("draft") or {}).get("workflow") or {})
+    for node in workflow.get("nodes") or []:
+        data = node.get("data") or {}
+        ref = str(data.get("plannerRef") or "").strip()
+        if not ref and str(node.get("id") or "") in {"input", "output"}:
+            ref = str(node.get("id"))
+        position = node.get("position")
+        if not ref or not isinstance(position, dict):
+            continue
+        try:
+            layout[ref] = {
+                "x": float(position.get("x") or 0),
+                "y": float(position.get("y") or 0),
+            }
+        except (TypeError, ValueError):
+            continue
+    return layout
+
+
+def _apply_layout(
+    candidate: dict[str, Any], layout: dict[str, dict[str, float]]
+) -> None:
+    workflow = dict((candidate.get("draft") or {}).get("workflow") or {})
+    for node in workflow.get("nodes") or []:
+        data = node.get("data") or {}
+        ref = str(data.get("plannerRef") or "").strip()
+        if not ref and str(node.get("id") or "") in {"input", "output"}:
+            ref = str(node.get("id"))
+        point = layout.get(ref)
+        if point is not None:
+            node["position"] = {"x": point["x"], "y": point["y"]}
+
+
+def _intersect_scope(
+    stored_scope: MetaPlannerScope,
+    snapshot: MetaPlannerCapabilitySnapshot,
+) -> MetaPlannerScope:
+    available = {
+        "allowed_node_kinds": {str(item.get("kind") or "") for item in snapshot.nodes},
+        "external_xpert_ids": {str(item.get("id") or "") for item in snapshot.external_xperts},
+        "knowledge_base_ids": {str(item.get("id") or "") for item in snapshot.knowledge_bases},
+        "toolset_ids": {str(item.get("id") or "") for item in snapshot.toolsets},
+        "plugin_ids": {str(item.get("id") or "") for item in snapshot.plugins},
+        "prompt_profile_ids": {str(item.get("id") or "") for item in snapshot.prompt_profiles},
+        "middleware_ids": {str(item.get("id") or "") for item in snapshot.middleware},
+        "agent_ids": {str(item.get("id") or "") for item in snapshot.agents},
+    }
+    return MetaPlannerScope(
+        **{
+            field_name: [
+                item
+                for item in getattr(stored_scope, field_name)
+                if item in available[field_name]
+            ]
+            for field_name in available
+        }
+    )
+
+
+def _default_agent_model(intent: GraphIntentV3, report: dict[str, Any]) -> str:
+    generation = report.get("generation_config")
+    if isinstance(generation, dict):
+        configured = str(generation.get("default_agent_model_id") or "").strip()
+        if configured:
+            return configured
+    for node in intent.nodes:
+        configured = str(node.config.get("model_id") or "").strip()
+        if configured:
+            return configured
+    return "deepseek/deepseek-chat"
+
+
+def _validate_intent_authorization(
+    intent: GraphIntentV3,
+    scope: MetaPlannerScope,
+) -> None:
+    allowed_resources = {
+        "external_xpert": set(scope.external_xpert_ids),
+        "knowledge_base": set(scope.knowledge_base_ids),
+        "toolset_resource": set(scope.toolset_ids),
+        "plugin_resource": set(scope.plugin_ids),
+    }
+    violations: list[str] = []
+    for node in intent.nodes:
+        if node.kind not in set(scope.allowed_node_kinds):
+            violations.append(f"node:{node.kind}")
+        source_agent_id = str(node.config.get("source_agent_id") or "").strip()
+        if source_agent_id and source_agent_id not in set(scope.agent_ids):
+            violations.append(f"source_agent:{source_agent_id}")
+    for binding in intent.resources:
+        if binding.resource_id not in allowed_resources[binding.kind]:
+            violations.append(f"resource:{binding.kind}:{binding.resource_id}")
+    for binding in intent.middleware:
+        if binding.middleware_id not in set(scope.middleware_ids):
+            violations.append(f"middleware:{binding.middleware_id}")
+    for profile_id in intent.prompt_profile_ids:
+        if profile_id not in set(scope.prompt_profile_ids):
+            violations.append(f"prompt_profile:{profile_id}")
+    if violations:
+        raise ValueError(
+            "Graph intent references capabilities outside the Proposal authorization "
+            "scope: "
+            + ", ".join(sorted(set(violations))[:20])
+        )
+
+
+def _candidate_payload(
+    proposal: AuthoringProposal,
+    candidate: dict[str, Any],
+    report: dict[str, Any],
+) -> dict[str, Any]:
+    if proposal.kind == "xpert_create":
+        return {**deepcopy(candidate), "meta_planner_report": report}
+    payload = deepcopy(proposal.payload)
+    payload["patch"] = deepcopy(candidate)
+    payload["meta_planner_report"] = report
+    return payload
+
+
+class HeadlessAuthoringService:
+    def __init__(
+        self,
+        *,
+        authoring_service: AuthoringService,
+        planner_service: MetaPlannerV2Service,
+        capability_snapshot_builder: Callable[[], MetaPlannerCapabilitySnapshot],
+    ) -> None:
+        self.authoring_service = authoring_service
+        self.planner_service = planner_service
+        self.capability_snapshot_builder = capability_snapshot_builder
+
+    def proposal_state(self, proposal_id: str) -> dict[str, Any]:
+        state = self._state(proposal_id)
+        return self._state_payload(state)
+
+    def editor_diff(
+        self, proposal_id: str, request: GraphPatchEditorDiffRequest
+    ) -> dict[str, Any]:
+        state = self._state(proposal_id)
+        self._check_revision(state, request.proposal_revision)
+        try:
+            target_intent, target_layout = self._editor_intent(
+                state, request.definition
+            )
+            patch = diff_graph_intents(
+                state.intent,
+                target_intent,
+                proposal_revision=state.proposal.revision,
+                expected_graph_checksum=state.graph_checksum,
+                expected_candidate_checksum=state.candidate_checksum,
+                source_layout=state.layout,
+                target_layout=target_layout,
+            )
+        except (ValidationError, ValueError) as exc:
+            message = safe_headless_error_message(exc)
+            raise HeadlessAuthoringError(
+                message,
+                code="headless_editor_diff_unrepresentable",
+                diagnostics=[
+                    {
+                        "code": "editor_change_unrepresentable",
+                        "severity": "error",
+                        "message": message[:500],
+                    }
+                ],
+            ) from exc
+        return {
+            "version": HEADLESS_AUTHORING_VERSION,
+            "proposal_id": proposal_id,
+            "proposal_revision": state.proposal.revision,
+            "patch": patch.model_dump(mode="json"),
+            "empty": not patch.operations,
+            "diagnostics": [],
+        }
+
+    def preview(
+        self, proposal_id: str, patch: GraphPatchEnvelopeV1
+    ) -> dict[str, Any]:
+        state = self._state(proposal_id)
+        return self._preview(state, patch)
+
+    def apply(
+        self, proposal_id: str, request: GraphPatchApplyRequest
+    ) -> dict[str, Any]:
+        state = self._state(proposal_id)
+        preview = self._preview(state, request.patch)
+        if preview["preview_checksum"] != request.preview_checksum:
+            raise HeadlessAuthoringConflictError(
+                "Preview checksum changed. Re-run preview before applying.",
+                code="headless_preview_changed",
+            )
+        if not preview["can_apply"]:
+            raise HeadlessAuthoringError(
+                "Graph Patch did not pass the authoring gates.",
+                code="headless_patch_not_applicable",
+                diagnostics=list(preview.get("diagnostics") or []),
+            )
+
+        report = deepcopy(state.report)
+        receipts = _canonical_patch_receipts(
+            report.get("authoring_patch_receipts")
+        )
+        receipts.append(
+            {
+                "protocol_version": GRAPH_PATCH_PROTOCOL_VERSION,
+                "operation_types": [
+                    operation.op for operation in request.patch.operations
+                ],
+                "before_graph_checksum": state.graph_checksum,
+                "after_graph_checksum": preview["graph_checksum"],
+                "before_candidate_checksum": state.candidate_checksum,
+                "after_candidate_checksum": preview["candidate_checksum"],
+                "diagnostic_counts": dict(
+                    Counter(
+                        str(item.get("severity") or "info")
+                        for item in preview.get("diagnostics") or []
+                    )
+                ),
+                "applied_at": time.time(),
+            }
+        )
+        report.update(
+            {
+                "planner_version": HEADLESS_AUTHORING_VERSION,
+                "ir_version": 3,
+                "typed_ir_version": 3,
+                "graph_ir": deepcopy(preview["graph_ir"]),
+                "graph_ir_checksum": str(
+                    (preview["graph_ir"] or {}).get("graph_checksum") or ""
+                ),
+                "authoring_graph_checksum": preview["graph_checksum"],
+                "graph_ir_status": "current",
+                "compiled_workflow_checksum": workflow_semantic_checksum(
+                    preview["candidate"]
+                ),
+                "authoring_candidate_checksum": preview["candidate_checksum"],
+                "capability_snapshot": {
+                    "version": state.snapshot.version,
+                    "hash": state.snapshot.snapshot_hash,
+                },
+                "validation": deepcopy(preview["validation"]),
+                "compatibility": {
+                    "source_version": state.compatibility.source_version,
+                    "upgraded": (
+                        state.compatibility.source_version == 2
+                        or state.compatibility.upgraded
+                    ),
+                    "lossy": False,
+                    "warnings": list(state.compatibility.warnings),
+                },
+                "human_modified": True,
+                "authoring_patch_receipts": receipts[
+                    -HEADLESS_AUTHORING_MAX_RECEIPTS:
+                ],
+            }
+        )
+        next_payload = _candidate_payload(
+            state.proposal, preview["candidate"], report
+        )
+        try:
+            updated = self.authoring_service.apply_headless_authoring_payload(
+                proposal_id,
+                revision=request.patch.proposal_revision,
+                payload=next_payload,
+                expected_target_id=state.proposal.target_id,
+                expected_target_revision=state.proposal.base_revision,
+            )
+        except AuthoringProposalConflictError as exc:
+            raise HeadlessAuthoringConflictError(str(exc)) from exc
+        except AuthoringProposalValidationError as exc:
+            raise HeadlessAuthoringError(str(exc)) from exc
+        return {
+            "version": HEADLESS_AUTHORING_VERSION,
+            "proposal_id": updated.proposal_id,
+            "proposal_revision": updated.revision,
+            "status": updated.status,
+            "validation": deepcopy(updated.validation),
+            "graph_checksum": preview["graph_checksum"],
+            "candidate_checksum": preview["candidate_checksum"],
+            "receipt_count": len(receipts[-HEADLESS_AUTHORING_MAX_RECEIPTS:]),
+        }
+
+    def _state(self, proposal_id: str) -> _ProposalState:
+        try:
+            proposal = self.authoring_service.proposal_store.require(proposal_id)
+        except AuthoringProposalNotFoundError as exc:
+            raise HeadlessAuthoringError(
+                str(exc), code="headless_proposal_not_found", status_code=404
+            ) from exc
+        candidate = _candidate_from_proposal(proposal)
+        report = _report_from_proposal(proposal)
+        try:
+            plan = MetaPlannerTaskPlan.model_validate(report.get("plan"))
+        except ValidationError as exc:
+            raise HeadlessAuthoringError(
+                "Proposal has no recoverable fixed task plan.",
+                code="headless_plan_unavailable",
+            ) from exc
+        compatibility = report.get("compatibility")
+        if isinstance(compatibility, dict) and compatibility.get("lossy") is True:
+            raise HeadlessAuthoringError(
+                "Lossy V2/V3 conversion cannot enter typed headless authoring.",
+                code="headless_lossy_conversion",
+            )
+        try:
+            intent, recovered_compatibility = (
+                decompile_candidate_to_graph_intent_compat(candidate)
+            )
+        except Exception as exc:
+            message = safe_headless_error_message(exc)
+            raise HeadlessAuthoringError(
+                "Candidate cannot be losslessly decompiled to GraphIntent V3.",
+                code="headless_lossy_conversion",
+                diagnostics=[
+                    {
+                        "code": "lossy_conversion",
+                        "severity": "error",
+                        "message": message[:500],
+                    }
+                ],
+            ) from exc
+        if intent is None:
+            raise HeadlessAuthoringError(
+                "Candidate cannot be losslessly upgraded to GraphIntent V3.",
+                code="headless_lossy_conversion",
+                diagnostics=[
+                    {
+                        "code": "lossy_conversion",
+                        "severity": "error",
+                        "message": warning[:500],
+                    }
+                    for warning in recovered_compatibility.warnings[:20]
+                ],
+            )
+
+        snapshot = self.capability_snapshot_builder()
+        try:
+            stored_scope = MetaPlannerScope.model_validate(
+                report.get("authorized_scope") or {}
+            )
+        except ValidationError as exc:
+            raise HeadlessAuthoringError(
+                "Proposal has no valid original authorization scope.",
+                code="headless_scope_unavailable",
+            ) from exc
+        scope = _intersect_scope(stored_scope, snapshot)
+        try:
+            _validate_intent_authorization(intent, scope)
+        except ValueError as exc:
+            message = safe_headless_error_message(exc)
+            raise HeadlessAuthoringError(
+                message,
+                code="headless_contract_or_resource_drift",
+                diagnostics=[
+                    {
+                        "code": "authorization_scope_drift",
+                        "severity": "error",
+                        "message": message[:500],
+                    }
+                ],
+            ) from exc
+        default_model = _default_agent_model(intent, report)
+        target = None
+        target_conflict = False
+        if proposal.kind == "xpert_update":
+            target_id = proposal.target_id or str(proposal.payload.get("xpert_id") or "")
+            target = self.authoring_service.xpert_store.get_xpert(target_id)
+            target_conflict = proposal.base_revision != target.draft_revision
+        generation = report.get("generation_config")
+        max_agents = (
+            int(generation.get("max_agents") or 0)
+            if isinstance(generation, dict)
+            else 0
+        )
+        max_agents = max(max_agents, len(intent.nodes), 1)
+        request = MetaPlannerGenerateRequest(
+            goal=str(report.get("goal") or "Safely edit the Meta Planner candidate."),
+            mode="update" if proposal.kind == "xpert_update" else "create",
+            target_xpert_id=proposal.target_id,
+            planner_model_id=(
+                str(generation.get("planner_model_id") or "headless-authoring")
+                if isinstance(generation, dict)
+                else "headless-authoring"
+            ),
+            default_agent_model_id=default_model,
+            temperature=0,
+            max_agents=min(8, max_agents),
+            scope=scope,
+        )
+        try:
+            graph_ir = resolve_graph_intent(
+                intent, snapshot, default_agent_model_id=default_model
+            )
+        except Exception as exc:
+            message = safe_headless_error_message(exc)
+            raise HeadlessAuthoringError(
+                message,
+                code="headless_contract_or_resource_drift",
+                diagnostics=[
+                    {
+                        "code": "contract_or_resource_drift",
+                        "severity": "error",
+                        "message": message[:500],
+                    }
+                ],
+            ) from exc
+        if not target_conflict:
+            round_trip = self.planner_service.preview(
+                request,
+                snapshot,
+                plan=plan,
+                blueprint=intent,
+                target=target,
+                warnings=[],
+            ).candidate
+            _apply_layout(round_trip, _layout_from_candidate(candidate))
+            current_workflow = candidate.get("draft", {}).get("workflow")
+            round_trip_workflow = round_trip.get("draft", {}).get("workflow")
+            if isinstance(current_workflow, dict) and isinstance(
+                round_trip_workflow, dict
+            ):
+                # Workflow IDs include the global Snapshot hash. Preserve the
+                # current presentation identity so unrelated capability drift
+                # cannot turn a lossless candidate into a false mismatch.
+                round_trip_workflow["id"] = current_workflow.get("id")
+            source_version = recovered_compatibility.source_version
+            if candidate_authoring_checksum(
+                _round_trip_candidate_projection(
+                    round_trip, source_version=source_version
+                )
+            ) != candidate_authoring_checksum(
+                _round_trip_candidate_projection(
+                    candidate, source_version=source_version
+                )
+            ):
+                raise HeadlessAuthoringError(
+                    "Candidate contains native fields that cannot be represented by "
+                    "the typed authoring Adapters.",
+                    code="headless_lossy_conversion",
+                    diagnostics=[
+                        {
+                            "code": "lossy_round_trip",
+                            "severity": "error",
+                            "message": (
+                                "The candidate changed during deterministic "
+                                "decompile/compile verification."
+                            ),
+                        }
+                    ],
+                )
+        graph_checksum = graph_authoring_checksum(graph_ir)
+        stored_checksum = str(report.get("authoring_graph_checksum") or "")
+        if not stored_checksum and report.get("graph_ir"):
+            try:
+                stored_checksum = graph_authoring_checksum(report["graph_ir"])
+            except Exception:
+                stored_checksum = ""
+        ir_state = "current" if stored_checksum == graph_checksum else "stale_recoverable"
+        warnings: list[str] = []
+        stored_snapshot = report.get("capability_snapshot")
+        if (
+            isinstance(stored_snapshot, dict)
+            and stored_snapshot.get("hash")
+            and stored_snapshot.get("hash") != snapshot.snapshot_hash
+        ):
+            warnings.append(
+                "Capability Snapshot changed; referenced contracts and resources were re-resolved."
+            )
+        if ir_state == "stale_recoverable":
+            warnings.append(
+                "Candidate differs from its stored IR but was losslessly recovered."
+            )
+        if recovered_compatibility.source_version == 2:
+            warnings.append(
+                "Legacy Graph IR V2 was losslessly recovered and will upgrade on apply."
+            )
+        if target_conflict:
+            warnings.append("Target Xpert draft revision changed after proposal creation.")
+        return _ProposalState(
+            proposal=proposal,
+            candidate=candidate,
+            report=report,
+            plan=plan,
+            intent=intent,
+            graph_ir=graph_ir,
+            snapshot=snapshot,
+            scope=scope,
+            request=request,
+            target=target,
+            layout=_layout_from_candidate(candidate),
+            graph_checksum=graph_checksum,
+            candidate_checksum=candidate_authoring_checksum(candidate),
+            ir_state=ir_state,
+            compatibility=recovered_compatibility,
+            warnings=warnings,
+            target_conflict=target_conflict,
+        )
+
+    @staticmethod
+    def _check_revision(state: _ProposalState, revision: int) -> None:
+        if state.proposal.revision != revision:
+            raise HeadlessAuthoringConflictError(
+                "Proposal revision changed. Reload before editing."
+            )
+        if state.proposal.status != "pending":
+            raise HeadlessAuthoringConflictError(
+                f"Proposal is already {state.proposal.status}."
+            )
+
+    def _preview(
+        self, state: _ProposalState, patch: GraphPatchEnvelopeV1
+    ) -> dict[str, Any]:
+        self._check_revision(state, patch.proposal_revision)
+        if patch.expected_graph_checksum != state.graph_checksum:
+            raise HeadlessAuthoringConflictError(
+                "Graph checksum changed. Reload before previewing.",
+                code="headless_graph_changed",
+            )
+        if patch.expected_candidate_checksum != state.candidate_checksum:
+            raise HeadlessAuthoringConflictError(
+                "Compiled candidate changed. Reload before previewing.",
+                code="headless_candidate_changed",
+            )
+        if state.target_conflict:
+            raise HeadlessAuthoringConflictError(
+                "Target Xpert draft changed after proposal creation.",
+                code="headless_target_changed",
+            )
+        try:
+            patched = apply_graph_patch(
+                state.intent,
+                patch,
+                plan_task_ids={task.task_id for task in state.plan.tasks},
+                layout=state.layout,
+                allowed_node_kinds=set(state.scope.allowed_node_kinds),
+                movable_refs={node.ref for node in state.graph_ir.nodes}
+                | {
+                    str(getattr(operation, "ref", ""))
+                    for operation in patch.operations
+                    if operation.op == "add_node"
+                },
+            )
+            _validate_intent_authorization(patched.intent, state.scope)
+            preview = self.planner_service.preview(
+                state.request,
+                state.snapshot,
+                plan=state.plan,
+                blueprint=patched.intent,
+                target=state.target,
+                warnings=state.warnings,
+            )
+        except (ValidationError, ValueError) as exc:
+            message = safe_headless_error_message(exc)
+            raise HeadlessAuthoringError(
+                message,
+                code="headless_patch_invalid",
+                diagnostics=[
+                    {
+                        "code": "patch_invalid",
+                        "severity": "error",
+                        "message": message[:500],
+                    }
+                ],
+            ) from exc
+        candidate = deepcopy(preview.candidate)
+        _apply_layout(candidate, patched.layout)
+        graph_payload = deepcopy(preview.graph_ir or {})
+        next_graph_checksum = graph_authoring_checksum(graph_payload)
+        next_candidate_checksum = candidate_authoring_checksum(candidate)
+        diagnostics = [
+            deepcopy(issue)
+            for issue in list(preview.validation.get("issues") or [])[:20]
+            if isinstance(issue, dict)
+        ]
+        if not patch.operations:
+            diagnostics.append(
+                {
+                    "code": "empty_patch",
+                    "severity": "info",
+                    "message": "The editor produced no semantic or layout changes.",
+                }
+            )
+        has_effect = (
+            next_graph_checksum != state.graph_checksum
+            or next_candidate_checksum != state.candidate_checksum
+        )
+        if patch.operations and not has_effect:
+            diagnostics.append(
+                {
+                    "code": "no_effect",
+                    "severity": "info",
+                    "message": "The Graph Patch does not change the candidate.",
+                }
+            )
+        can_apply = (
+            bool(preview.validation.get("valid"))
+            and bool(patch.operations)
+            and has_effect
+        )
+        checksum_payload = {
+            "proposal_id": state.proposal.proposal_id,
+            "proposal_revision": state.proposal.revision,
+            "ir_version": state.compatibility.source_version,
+            "patch_checksum": graph_patch_checksum(patch),
+            "before_graph_checksum": state.graph_checksum,
+            "before_candidate_checksum": state.candidate_checksum,
+            "after_graph_checksum": next_graph_checksum,
+            "after_candidate_checksum": next_candidate_checksum,
+            "validation": preview.validation,
+        }
+        return {
+            "version": HEADLESS_AUTHORING_VERSION,
+            "proposal_id": state.proposal.proposal_id,
+            "proposal_revision": state.proposal.revision,
+            "patch_checksum": graph_patch_checksum(patch),
+            "preview_checksum": canonical_checksum(checksum_payload),
+            "can_apply": can_apply,
+            "candidate": candidate,
+            "graph_ir": graph_payload,
+            "graph_checksum": next_graph_checksum,
+            "candidate_checksum": next_candidate_checksum,
+            "validation": deepcopy(preview.validation),
+            "warnings": list(dict.fromkeys([*state.warnings, *preview.warnings])),
+            "diagnostics": diagnostics,
+            "diff": {
+                "operation_count": len(patch.operations),
+                "operation_types": dict(
+                    Counter(operation.op for operation in patch.operations)
+                ),
+                "graph_changed": next_graph_checksum != state.graph_checksum,
+                "candidate_changed": (
+                    next_candidate_checksum != state.candidate_checksum
+                ),
+            },
+        }
+
+    def _state_payload(self, state: _ProposalState) -> dict[str, Any]:
+        return {
+            "version": HEADLESS_AUTHORING_VERSION,
+            "authoring_protocol_version": GRAPH_PATCH_PROTOCOL_VERSION,
+            "proposal_id": state.proposal.proposal_id,
+            "proposal_revision": state.proposal.revision,
+            "ir_version": state.compatibility.source_version,
+            "proposal_status": state.proposal.status,
+            "kind": state.proposal.kind,
+            "target_xpert_id": state.proposal.target_id,
+            "base_revision": state.proposal.base_revision,
+            "candidate": deepcopy(state.candidate),
+            "ir_state": state.ir_state,
+            "graph_ir": state.graph_ir.model_dump(mode="json"),
+            "graph_checksum": state.graph_checksum,
+            "candidate_checksum": state.candidate_checksum,
+            "capability_snapshot": {
+                "version": state.snapshot.version,
+                "hash": state.snapshot.snapshot_hash,
+            },
+            "authorized_scope": state.scope.model_dump(mode="json"),
+            "allowed_node_kinds": list(state.scope.allowed_node_kinds),
+            "compiler_managed_node_kinds": ["input", "output"],
+            "can_edit": (
+                state.proposal.status == "pending" and not state.target_conflict
+            ),
+            "can_author": (
+                state.proposal.status == "pending" and not state.target_conflict
+            ),
+            "compatibility": state.compatibility.model_dump(mode="json"),
+            "diagnostics": [],
+            "warnings": list(state.warnings),
+            "receipt_count": len(
+                _canonical_patch_receipts(
+                    state.report.get("authoring_patch_receipts")
+                )
+            ),
+        }
+
+    def _editor_intent(
+        self, state: _ProposalState, raw_definition: dict[str, Any]
+    ) -> tuple[GraphIntentV3, dict[str, dict[str, float]]]:
+        definition = NativeWorkflowDefinition.model_validate(raw_definition)
+        current_workflow = NativeWorkflowDefinition.model_validate(
+            (state.candidate.get("draft") or {}).get("workflow") or {}
+        )
+        current_ids = {node.id for node in current_workflow.nodes}
+        allowed_kinds = {
+            "input",
+            "output",
+            "runtime_middleware",
+            "workflow_agent",
+            "external_xpert",
+            "knowledge_base",
+            "toolset_resource",
+            "plugin_resource",
+        }
+        for node in definition.nodes:
+            kind = str((node.data or {}).get("kind") or node.type or "")
+            if kind not in allowed_kinds:
+                raise ValueError(f"Editor node kind {kind} is not authorized.")
+            if node.id not in current_ids and kind not in {
+                "workflow_agent",
+                "runtime_middleware",
+                "external_xpert",
+                "knowledge_base",
+                "toolset_resource",
+                "plugin_resource",
+            }:
+                raise ValueError(f"Compiler-managed node {kind} cannot be added.")
+        for managed_id in ("input", "output"):
+            if not any(node.id == managed_id for node in definition.nodes):
+                raise ValueError(f"Compiler-managed node {managed_id} cannot be removed.")
+
+        self._validate_compiler_managed_editor_nodes(definition, current_workflow)
+        self._validate_editor_edges(definition)
+        self._validate_editor_agent_fields(definition, current_workflow)
+        self._annotate_editor_agents(state, definition)
+        self._resolve_editor_resource_versions(state, definition)
+        candidate = deepcopy(state.candidate)
+        candidate.setdefault("draft", {})["workflow"] = definition.model_dump(
+            mode="json"
+        )
+        target_intent = decompile_candidate_to_graph_intent(candidate)
+        self._validate_compiler_managed_editor_edges(definition, target_intent)
+        source_resource_keys = {
+            (item.kind, item.resource_id, item.target_ref)
+            for item in state.intent.resources
+        }
+        target_resource_keys = {
+            (item.kind, item.resource_id, item.target_ref)
+            for item in target_intent.resources
+        }
+        for key in sorted(source_resource_keys & target_resource_keys):
+            if key[0] == "knowledge_base":
+                continue
+            if (
+                target_intent._pinned_resource_versions.get(key)
+                != state.intent._pinned_resource_versions.get(key)
+            ):
+                raise ValueError(
+                    f"Editor cannot change the pinned version for {key[0]}:{key[1]} "
+                    f"on {key[2]}."
+                )
+        if (
+            target_intent._pinned_prompt_profile_versions
+            != state.intent._pinned_prompt_profile_versions
+        ):
+            raise ValueError("Editor cannot change runtime-owned Prompt Profile versions.")
+        target_layout = _layout_from_candidate(candidate)
+        return target_intent, target_layout
+
+    @staticmethod
+    def _validate_editor_agent_fields(
+        definition: NativeWorkflowDefinition,
+        current: NativeWorkflowDefinition,
+    ) -> None:
+        current_by_ref = {
+            str((node.data or {}).get("plannerRef") or ""): dict(node.data or {})
+            for node in current.nodes
+            if str((node.data or {}).get("kind") or node.type or "")
+            == "workflow_agent"
+            and str((node.data or {}).get("plannerRef") or "")
+        }
+        for node in definition.nodes:
+            data = dict(node.data or {})
+            if str(data.get("kind") or node.type or "") != "workflow_agent":
+                continue
+            ref = str(data.get("plannerRef") or "").strip()
+            before = current_by_ref.get(ref)
+            if before is None:
+                unsupported = sorted(
+                    set(data) - _AUTHORABLE_WORKFLOW_AGENT_DATA_FIELDS
+                )
+            else:
+                unsupported = sorted(
+                    key
+                    for key in set(before) | set(data)
+                    if key not in _AUTHORABLE_WORKFLOW_AGENT_DATA_FIELDS
+                    and before.get(key) != data.get(key)
+                )
+            if unsupported:
+                raise ValueError(
+                    f"Workflow Agent {ref or node.id} changes fields outside its "
+                    "authoring Adapter: "
+                    + ", ".join(unsupported)
+                )
+
+    @staticmethod
+    def _resolve_editor_resource_versions(
+        state: _ProposalState,
+        definition: NativeWorkflowDefinition,
+    ) -> None:
+        resource_lookup = {
+            "external_xpert": {
+                str(item.get("id") or ""): item
+                for item in state.snapshot.external_xperts
+            },
+            "toolset_resource": {
+                str(item.get("id") or ""): item for item in state.snapshot.toolsets
+            },
+            "plugin_resource": {
+                str(item.get("id") or ""): item for item in state.snapshot.plugins
+            },
+        }
+        id_fields = {
+            "external_xpert": "xpertId",
+            "toolset_resource": "toolsetId",
+            "plugin_resource": "pluginId",
+        }
+        node_by_id = {node.id: node for node in definition.nodes}
+        target_ref_by_resource_node: dict[str, str] = {}
+        for edge in definition.edges:
+            source = node_by_id.get(edge.source)
+            target = node_by_id.get(edge.target)
+            source_kind = str(
+                ((source.data if source else {}) or {}).get("kind")
+                or (source.type if source else "")
+                or ""
+            )
+            target_kind = str(
+                ((target.data if target else {}) or {}).get("kind")
+                or (target.type if target else "")
+                or ""
+            )
+            if source_kind not in id_fields or target_kind != "workflow_agent":
+                continue
+            target_ref_by_resource_node[source.id] = str(
+                (target.data or {}).get("plannerRef") or ""
+            ).strip()
+        for node in definition.nodes:
+            data = node.data or {}
+            kind = str(data.get("kind") or node.type or "")
+            id_field = id_fields.get(kind)
+            if id_field is None:
+                continue
+            resource_id = str(data.get(id_field) or "").strip()
+            if not resource_id:
+                raise ValueError(f"Editor {kind} node has no resource ID.")
+            target_ref = target_ref_by_resource_node.get(node.id, "")
+            if not target_ref:
+                raise ValueError(
+                    f"Editor {kind}:{resource_id} is not bound to a Workflow Agent."
+                )
+            key = (kind, resource_id, target_ref)
+            expected = state.intent._pinned_resource_versions.get(key)
+            if expected is not None:
+                try:
+                    supplied = int(data.get("pinnedVersion"))
+                except (TypeError, ValueError):
+                    raise ValueError(
+                        f"Editor retained {kind}:{resource_id} without its pinned version."
+                    ) from None
+                if supplied != expected:
+                    raise ValueError(
+                        f"Editor cannot change the pinned version for {kind}:{resource_id}."
+                    )
+            else:
+                resource = resource_lookup[kind].get(resource_id)
+                published = (resource or {}).get("published_version")
+                if not published:
+                    raise ValueError(
+                        f"Editor resource {kind}:{resource_id} is not an authorized "
+                        "published resource."
+                    )
+                expected = int(published)
+            data["versionPolicy"] = "pinned"
+            data["pinnedVersion"] = expected
+
+    @staticmethod
+    def _validate_compiler_managed_editor_nodes(
+        definition: NativeWorkflowDefinition,
+        current: NativeWorkflowDefinition,
+    ) -> None:
+        current_by_id = {node.id: node for node in current.nodes}
+        edited_by_id = {node.id: node for node in definition.nodes}
+        for node_id in ("input", "output"):
+            before = current_by_id.get(node_id)
+            after = edited_by_id.get(node_id)
+            if before is None or after is None:
+                raise ValueError(
+                    f"Compiler-managed node {node_id} is missing from the candidate."
+                )
+            kind = str((after.data or {}).get("kind") or after.type or "")
+            if kind != node_id:
+                raise ValueError(
+                    f"Compiler-managed node {node_id} cannot change its kind."
+                )
+            before_data = dict(before.data or {})
+            after_data = dict(after.data or {})
+            if node_id == "output":
+                before_data.pop("outputVariable", None)
+                after_data.pop("outputVariable", None)
+            if before_data != after_data:
+                raise ValueError(
+                    f"Compiler-managed node {node_id} contains an unexpressible edit."
+                )
+
+    @staticmethod
+    def _validate_compiler_managed_editor_edges(
+        definition: NativeWorkflowDefinition,
+        intent: GraphIntentV3,
+    ) -> None:
+        ref_by_id = {
+            node.id: str((node.data or {}).get("plannerRef") or "").strip()
+            for node in definition.nodes
+            if str((node.data or {}).get("kind") or node.type or "")
+            == "workflow_agent"
+        }
+        parents = {node.ref: set() for node in intent.nodes}
+        for edge in intent.control_edges:
+            parents[edge.target_ref].add(edge.source_ref)
+        expected_roots = {ref for ref, values in parents.items() if not values}
+        actual_roots: set[str] = set()
+        terminal_refs: list[str] = []
+        for edge in definition.edges:
+            if edge.sourceHandle or edge.targetHandle:
+                continue
+            if edge.target == "input" or edge.source == "output":
+                raise ValueError("Compiler-managed control edges cannot run backwards.")
+            if edge.source == "input":
+                target_ref = ref_by_id.get(edge.target)
+                if not target_ref:
+                    raise ValueError(
+                        "Compiler-managed input edge must target a Workflow Agent."
+                    )
+                actual_roots.add(target_ref)
+            if edge.target == "output":
+                source_ref = ref_by_id.get(edge.source)
+                if not source_ref:
+                    raise ValueError(
+                        "Compiler-managed output edge must source a Workflow Agent."
+                    )
+                terminal_refs.append(source_ref)
+        if actual_roots != expected_roots:
+            raise ValueError(
+                "Compiler-managed input edges do not match the semantic root nodes."
+            )
+        if terminal_refs != [intent.final_output.node_ref]:
+            raise ValueError(
+                "Compiler-managed output edge does not match the semantic final output."
+            )
+
+    @staticmethod
+    def _validate_editor_edges(definition: NativeWorkflowDefinition) -> None:
+        nodes = {node.id: node for node in definition.nodes}
+        for edge in definition.edges:
+            source = nodes.get(edge.source)
+            target = nodes.get(edge.target)
+            if source is None or target is None:
+                raise ValueError(f"Editor edge {edge.id} has an unknown endpoint.")
+            source_kind = str((source.data or {}).get("kind") or source.type or "")
+            target_kind = str((target.data or {}).get("kind") or target.type or "")
+            if not edge.sourceHandle and not edge.targetHandle:
+                continue
+            expected = {
+                "external_xpert": ("expert-binding", "expert"),
+                "knowledge_base": ("knowledge-binding", "knowledge"),
+                "toolset_resource": ("toolset-binding", "toolset"),
+                "plugin_resource": ("plugin-binding", "plugin"),
+                "runtime_middleware": ("middleware-binding", "middleware"),
+            }.get(source_kind)
+            if (
+                expected is None
+                or target_kind != "workflow_agent"
+                or (edge.sourceHandle, edge.targetHandle) != expected
+            ):
+                raise ValueError(
+                    f"Editor edge {edge.id} attempts to inject an invalid Handle."
+                )
+
+    @staticmethod
+    def _annotate_editor_agents(
+        state: _ProposalState, definition: NativeWorkflowDefinition
+    ) -> None:
+        node_by_id = {node.id: node for node in definition.nodes}
+        current_refs = {
+            node.id: str((node.data or {}).get("plannerRef") or "")
+            for node in definition.nodes
+            if str((node.data or {}).get("plannerRef") or "")
+        }
+        used_refs = set(current_refs.values())
+        ref_by_id: dict[str, str] = {}
+        for node in definition.nodes:
+            kind = str((node.data or {}).get("kind") or node.type or "")
+            if kind != "workflow_agent":
+                continue
+            ref = str((node.data or {}).get("plannerRef") or "").strip()
+            if not ref:
+                suffix = hashlib.sha256(node.id.encode("utf-8")).hexdigest()[:10]
+                ref = f"agent_{suffix}"
+                while ref in used_refs:
+                    suffix = hashlib.sha256((node.id + ref).encode("utf-8")).hexdigest()[:10]
+                    ref = f"agent_{suffix}"
+            used_refs.add(ref)
+            ref_by_id[node.id] = ref
+
+        control_edges: list[tuple[str, str]] = []
+        for edge in definition.edges:
+            if edge.sourceHandle or edge.targetHandle:
+                continue
+            if edge.source in ref_by_id and edge.target in ref_by_id:
+                control_edges.append((ref_by_id[edge.source], ref_by_id[edge.target]))
+        parents: dict[str, set[str]] = {ref: set() for ref in ref_by_id.values()}
+        children: dict[str, set[str]] = {ref: set() for ref in ref_by_id.values()}
+        for source_ref, target_ref in control_edges:
+            parents[target_ref].add(source_ref)
+            children[source_ref].add(target_ref)
+        indegree = {ref: len(values) for ref, values in parents.items()}
+        queue = deque(sorted(ref for ref, count in indegree.items() if count == 0))
+        order: list[str] = []
+        while queue:
+            ref = queue.popleft()
+            order.append(ref)
+            for child in sorted(children[ref]):
+                indegree[child] -= 1
+                if indegree[child] == 0:
+                    queue.append(child)
+        ancestors: dict[str, set[str]] = {ref: set() for ref in parents}
+        for ref in order:
+            for parent in parents[ref]:
+                ancestors[ref].add(parent)
+                ancestors[ref].update(ancestors[parent])
+
+        output_by_ref: dict[str, tuple[str, str]] = {}
+        for node_id, ref in ref_by_id.items():
+            node = node_by_id[node_id]
+            variable = str((node.data or {}).get("outputVariable") or "").strip()
+            output_by_ref[ref] = (variable or f"{ref}_result", "result")
+        plan_task_ids = {task.task_id for task in state.plan.tasks}
+        default_task_id = state.plan.tasks[0].task_id
+        contract = workflow_node_contract_registry.require("workflow_agent")
+        for node_id, ref in ref_by_id.items():
+            node = node_by_id[node_id]
+            data = node.data
+            raw_task_ids = data.get("plannerTaskIds")
+            task_ids = (
+                [str(item) for item in raw_task_ids if str(item) in plan_task_ids]
+                if isinstance(raw_task_ids, list)
+                else []
+            )
+            if not task_ids:
+                task_ids = [default_task_id]
+            output_variable = output_by_ref[ref][0]
+            referenced = {
+                match.group(1)
+                for field in ("rolePrompt", "taskInput")
+                for match in _TEMPLATE_VARIABLE.finditer(str(data.get(field) or ""))
+            }
+            inputs: list[GraphIntentInputBindingV3] = []
+            for variable in sorted(referenced):
+                if variable in {"user_input", "conversation_history"}:
+                    source_ref = "input"
+                    source_port = variable
+                    schema = (
+                        WorkflowValueSchema(type="string")
+                        if variable == "user_input"
+                        else WorkflowValueSchema(
+                            type="array", items=WorkflowValueSchema(type="object")
+                        )
+                    )
+                else:
+                    candidates = [
+                        (candidate_ref, port)
+                        for candidate_ref, (candidate_variable, port) in output_by_ref.items()
+                        if candidate_variable == variable
+                        and candidate_ref in ancestors.get(ref, set())
+                    ]
+                    if len(candidates) != 1:
+                        raise ValueError(
+                            f"Editor variable {variable} for {ref} has no unique control-reachable producer."
+                        )
+                    source_ref, source_port = candidates[0]
+                    schema = WorkflowValueSchema(type="string")
+                inputs.append(
+                    GraphIntentInputBindingV3(
+                        port="task",
+                        variable=variable,
+                        source_ref=source_ref,
+                        source_port=source_port,
+                        value_schema=schema,
+                    )
+                )
+            data.update(
+                {
+                    "plannerIRVersion": 3,
+                    "plannerRef": ref,
+                    "plannerTaskIds": task_ids,
+                    "plannerContractVersion": NODE_CONTRACT_VERSION,
+                    "plannerCompilerChecksum": contract.compiler_checksum,
+                    "plannerInputsV3": [item.model_dump(mode="json") for item in inputs],
+                    "plannerOutputsV3": [
+                        GraphIntentOutputBindingV3(
+                            port="result",
+                            variable=output_variable,
+                            value_schema=WorkflowValueSchema(type="string"),
+                        ).model_dump(mode="json")
+                    ],
+                    "plannerInputs": [
+                        {
+                            "port": f"task_{index + 1}",
+                            "variable": item.variable,
+                            "value_type": item.value_schema.type,
+                        }
+                        for index, item in enumerate(inputs)
+                    ],
+                    "plannerOutputs": [
+                        {
+                            "port": "result",
+                            "variable": output_variable,
+                            "value_type": "string",
+                        }
+                    ],
+                    "outputVariable": output_variable,
+                }
+            )
+            adapter = get_planner_node_adapter("workflow_agent")
+            assert adapter is not None
+            config = {
+                "role_prompt": str(data.get("rolePrompt") or "").strip(),
+                "task_input": str(data.get("taskInput") or "").strip(),
+                "model_id": str(data.get("modelId") or "").strip() or None,
+                "source_agent_id": str(data.get("sourceAgentId") or "").strip()
+                or None,
+                "method_skill_ids": (
+                    list(data.get("methodSkillIds") or [])
+                    if isinstance(data.get("methodSkillIds"), list)
+                    else []
+                ),
+            }
+            if not config["role_prompt"] or not config["task_input"]:
+                defaults = adapter.default_intent_config()
+                config["role_prompt"] = config["role_prompt"] or defaults["role_prompt"]
+                config["task_input"] = config["task_input"] or defaults["task_input"]
+                data["rolePrompt"] = config["role_prompt"]
+                data["taskInput"] = config["task_input"]
+            adapter.validate_authoring_config(config)

--- a/server/meta_agent/meta_planner_v2.py
+++ b/server/meta_agent/meta_planner_v2.py
@@ -18,6 +18,7 @@ try:
         NativeWorkflowNode,
         WorkflowPosition,
     )
+    from server.workflow_native.node_contracts import canonical_checksum
     from server.workflow_native.validate import node_kind, validate_workflow_graph
     from server.xpert_runtime.authoring_service import AuthoringService
     from server.xpert_runtime.authoring_store import AuthoringProposal
@@ -30,6 +31,7 @@ except ModuleNotFoundError:
         NativeWorkflowNode,
         WorkflowPosition,
     )
+    from workflow_native.node_contracts import canonical_checksum
     from workflow_native.validate import node_kind, validate_workflow_graph
     from xpert_runtime.authoring_service import AuthoringService
     from xpert_runtime.authoring_store import AuthoringProposal
@@ -39,12 +41,15 @@ from .capabilities import assert_scope_is_authorized
 from .graph_ir_v3 import (
     GRAPH_IR_VERSION,
     annotate_candidate_with_graph_ir,
+    graph_authoring_checksum,
     graph_intent_to_v2,
     resolve_middleware_config,
     resolve_graph_intent,
     v2_to_graph_intent,
+    workflow_authoring_checksum,
     workflow_semantic_checksum,
 )
+from .graph_patch import GraphPatchEnvelopeV1, apply_graph_patch
 from .node_adapters import (
     META_PLANNER_BINDING_KINDS,
     META_PLANNER_COMPILER_MANAGED_KINDS,
@@ -112,6 +117,16 @@ executable nodes; input/output and resource nodes are compiler-managed.
 Make the smallest changes required by the structured validation issues. Do not add
 capabilities outside the supplied authorized snapshot. This is the only repair pass.
 Return the complete blueprint and obey every supplied typed_ir_constraint.
+"""
+
+
+PATCH_REPAIR_SYSTEM_PROMPT = """\
+You repair one parsed ModelMirror GraphIntentV3 using GraphPatchEnvelopeV1.
+Return one strict JSON object only. Never return a complete workflow or GraphIntent.
+Use only the listed semantic refs, named ports, Adapter config, and authorized IDs.
+Do not emit native node IDs, Handles, resource versions, schemas, policies, checksums
+other than the exact expected checksums supplied in the envelope. Make the smallest
+ordered patch that addresses the validation issues. This is the only repair pass.
 """
 
 
@@ -1487,7 +1502,10 @@ def compile_xpert_candidate(
         node_id = resolved_resource_ids[
             (binding.kind, binding.resource_id, binding.target_ref)
         ]
-        published_version = resource.get("published_version")
+        published_version = intent._pinned_resource_versions.get(
+            (binding.kind, binding.resource_id, binding.target_ref),
+            resource.get("published_version"),
+        )
         if binding.kind == "external_xpert":
             data = {
                 "kind": binding.kind,
@@ -1648,7 +1666,9 @@ def compile_xpert_candidate(
         PromptProfileBinding(
             profile_id=profile_id,
             version_policy="pinned",
-            pinned_version=prompt_lookup[profile_id]["published_version"],
+            pinned_version=intent._pinned_prompt_profile_versions.get(
+                profile_id, prompt_lookup[profile_id]["published_version"]
+            ),
         )
         for profile_id in dict.fromkeys(typed.prompt_profile_ids)
     ]
@@ -1871,35 +1891,105 @@ class MetaPlannerV2Service:
             snapshot=snapshot,
             target=target,
         )
+        repair_protocol = "none"
         if issues:
             repair_used = True
-            repaired_raw = await self.completion(
-                request.planner_model_id,
-                REPAIR_SYSTEM_PROMPT,
-                self._repair_prompt(
-                    request,
-                    plan,
-                    snapshot,
-                    raw_blueprint,
+            if blueprint is not None:
+                repair_protocol = "graph_patch_v1"
+                base_graph_checksum = canonical_checksum(
+                    blueprint.model_dump(mode="json")
+                )
+                base_candidate_checksum = canonical_checksum(candidate or {})
+                repaired_raw = await self.completion(
+                    request.planner_model_id,
+                    PATCH_REPAIR_SYSTEM_PROMPT,
+                    self._patch_repair_prompt(
+                        request,
+                        plan,
+                        snapshot,
+                        blueprint,
+                        issues,
+                        expected_graph_checksum=base_graph_checksum,
+                        expected_candidate_checksum=base_candidate_checksum,
+                    ),
+                    0,
+                    8_192,
+                )
+                try:
+                    repair_patch = GraphPatchEnvelopeV1.model_validate(
+                        _json_payload(repaired_raw)
+                    )
+                    if repair_patch.proposal_revision != 1:
+                        raise ValueError(
+                            "Planner repair patch must use synthetic revision 1."
+                        )
+                    if (
+                        repair_patch.expected_graph_checksum
+                        != base_graph_checksum
+                        or repair_patch.expected_candidate_checksum
+                        != base_candidate_checksum
+                    ):
+                        raise ValueError(
+                            "Planner repair patch changed its base checksums."
+                        )
+                    patched = apply_graph_patch(
+                        blueprint,
+                        repair_patch,
+                        plan_task_ids={task.task_id for task in plan.tasks},
+                        allowed_node_kinds=set(request.scope.allowed_node_kinds),
+                    )
+                    repaired_raw = json.dumps(
+                        patched.intent.model_dump(mode="json"), ensure_ascii=False
+                    )
+                    (
+                        blueprint,
+                        candidate,
+                        validation,
+                        issues,
+                        graph_ir,
+                        compatibility,
+                    ) = self._compile_and_validate(
+                        request=request,
+                        plan=plan,
+                        raw_blueprint=repaired_raw,
+                        snapshot=snapshot,
+                        target=target,
+                    )
+                except Exception as exc:
+                    message = _safe_exception_message(exc)
+                    candidate = {}
+                    graph_ir = None
+                    issues = [message]
+                    validation = {"valid": False, "issues": [message]}
+            else:
+                repair_protocol = "graph_intent_v3"
+                repaired_raw = await self.completion(
+                    request.planner_model_id,
+                    REPAIR_SYSTEM_PROMPT,
+                    self._repair_prompt(
+                        request,
+                        plan,
+                        snapshot,
+                        raw_blueprint,
+                        issues,
+                    ),
+                    0,
+                    8_192,
+                )
+                (
+                    blueprint,
+                    candidate,
+                    validation,
                     issues,
-                ),
-                0,
-                8_192,
-            )
-            (
-                blueprint,
-                candidate,
-                validation,
-                issues,
-                graph_ir,
-                compatibility,
-            ) = self._compile_and_validate(
-                request=request,
-                plan=plan,
-                raw_blueprint=repaired_raw,
-                snapshot=snapshot,
-                target=target,
-            )
+                    graph_ir,
+                    compatibility,
+                ) = self._compile_and_validate(
+                    request=request,
+                    plan=plan,
+                    raw_blueprint=repaired_raw,
+                    snapshot=snapshot,
+                    target=target,
+                )
             if issues:
                 warnings.append(
                     "The single repair pass did not produce an approvable candidate."
@@ -1949,8 +2039,12 @@ class MetaPlannerV2Service:
             "graph_ir_checksum": (
                 graph_ir.graph_checksum if graph_ir is not None else ""
             ),
+            "authoring_graph_checksum": (
+                graph_authoring_checksum(graph_ir) if graph_ir is not None else ""
+            ),
             "graph_ir_status": "current" if graph_ir is not None else "unavailable",
             "compiled_workflow_checksum": workflow_semantic_checksum(candidate),
+            "authoring_candidate_checksum": workflow_authoring_checksum(candidate),
             "compatibility": compatibility.model_dump(mode="json"),
             "goal": request.goal,
             "mode": request.mode,
@@ -1961,8 +2055,14 @@ class MetaPlannerV2Service:
                 "hash": snapshot.snapshot_hash,
             },
             "authorized_scope": request.scope.model_dump(mode="json"),
+            "generation_config": {
+                "planner_model_id": request.planner_model_id,
+                "default_agent_model_id": request.default_agent_model_id,
+                "max_agents": request.max_agents,
+            },
             "validation": validation,
             "repair_used": repair_used,
+            "repair_protocol": repair_protocol,
             "warnings": warnings,
             "human_modified": False,
         }
@@ -2336,6 +2436,45 @@ class MetaPlannerV2Service:
                     request, plan
                 ),
                 "typed_ir_constraints": _typed_ir_prompt_constraints(request, plan),
+            },
+            ensure_ascii=False,
+        )
+
+    @staticmethod
+    def _patch_repair_prompt(
+        request: MetaPlannerGenerateRequest,
+        plan: MetaPlannerTaskPlan,
+        snapshot: MetaPlannerCapabilitySnapshot,
+        blueprint: GraphIntentV3,
+        issues: list[str],
+        *,
+        expected_graph_checksum: str,
+        expected_candidate_checksum: str,
+    ) -> str:
+        prompt_snapshot = _planner_prompt_snapshot(request, snapshot)
+        return json.dumps(
+            {
+                "goal": request.goal,
+                "task_plan": plan.model_dump(mode="json"),
+                "authorized_scope": request.scope.model_dump(mode="json"),
+                "capability_snapshot_hash": snapshot.snapshot_hash,
+                "capability_snapshot": prompt_snapshot,
+                "base_graph_intent": blueprint.model_dump(mode="json"),
+                "validation_issues": issues[:30],
+                "required_schema": GraphPatchEnvelopeV1.model_json_schema(),
+                "required_envelope": {
+                    "protocol_version": 1,
+                    "proposal_revision": 1,
+                    "expected_graph_checksum": expected_graph_checksum,
+                    "expected_candidate_checksum": expected_candidate_checksum,
+                },
+                "rules": [
+                    "Return GraphPatchEnvelopeV1, never a complete GraphIntent or Native Workflow.",
+                    "Copy every required_envelope value exactly.",
+                    "Use Adapter config only; do not emit resource versions, Handles, schemas, policies, or native node IDs.",
+                    "Do not change the fixed task plan or add unauthorized capabilities.",
+                    "This is the only repair pass.",
+                ],
             },
             ensure_ascii=False,
         )

--- a/server/meta_agent/node_adapters.py
+++ b/server/meta_agent/node_adapters.py
@@ -66,6 +66,47 @@ class PlannerNodeAdapter:
     def validate_config(self, node: MetaPlannerIRNode) -> BaseModel:
         return self.config_model.model_validate(node.config)
 
+    def validate_authoring_config(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Normalize editor/model config through the same compiler contract."""
+
+        unknown = sorted(set(config) - set(self.config_model.model_fields))
+        if unknown:
+            raise ValueError(
+                f"Node kind {self.kind} has undeclared Adapter config fields: "
+                + ", ".join(unknown)
+            )
+        return self.config_model.model_validate(config).model_dump(mode="json")
+
+    def default_intent_config(self) -> dict[str, Any]:
+        """Return the contract-owned authoring seed for a newly added node."""
+
+        contract = workflow_node_contract_registry.require(self.kind)
+        raw_default = dict(contract.planner.default_data or {})
+        field_map = {
+            "rolePrompt": "role_prompt",
+            "taskInput": "task_input",
+            "modelId": "model_id",
+            "sourceAgentId": "source_agent_id",
+            "methodSkillIds": "method_skill_ids",
+        }
+        normalized = {
+            field_map.get(key, key): value
+            for key, value in raw_default.items()
+            if field_map.get(key, key) in self.config_model.model_fields
+        }
+        if self.kind == "workflow_agent":
+            normalized.setdefault(
+                "role_prompt", "Complete the assigned plan task accurately."
+            )
+            normalized.setdefault("task_input", "{{user_input}}")
+        return self.validate_authoring_config(normalized)
+
+    def editor_config(self, node: NativeWorkflowNode) -> dict[str, Any]:
+        """Convert a native editor node into validated Adapter config only."""
+
+        restored = self.decompile_node_v3(node)
+        return self.validate_authoring_config(restored.config)
+
     @property
     def config_schema_checksum(self) -> str:
         return canonical_checksum(self.config_model.model_json_schema())
@@ -79,6 +120,20 @@ class PlannerNodeAdapter:
                 "ir_version": META_PLANNER_IR_VERSION,
                 "adapter_version": META_PLANNER_ADAPTER_VERSION,
                 "config_schema_checksum": self.config_schema_checksum,
+                "compiler_checksum": contract.compiler_checksum,
+            }
+        )
+
+    @property
+    def authoring_checksum(self) -> str:
+        contract = workflow_node_contract_registry.require(self.kind)
+        return canonical_checksum(
+            {
+                "kind": self.kind,
+                "authoring_protocol_version": 1,
+                "adapter_checksum": self.adapter_checksum,
+                "config_schema_checksum": self.config_schema_checksum,
+                "default_intent_config": self.default_intent_config(),
                 "compiler_checksum": contract.compiler_checksum,
             }
         )
@@ -286,4 +341,17 @@ def planner_capability_metadata(kind: str) -> dict[str, Any] | None:
         "contract_checksum": contract.checksum,
         "compiler_checksum": contract.compiler_checksum,
         "adapter_checksum": adapter_checksum,
+        "authoring_checksum": (
+            adapter.authoring_checksum
+            if adapter is not None
+            else canonical_checksum(
+                {
+                    "kind": kind,
+                    "authoring_protocol_version": 1,
+                    "adapter_checksum": adapter_checksum,
+                    "support": support,
+                    "compiler_checksum": contract.compiler_checksum,
+                }
+            )
+        ),
     }

--- a/server/meta_agent/schemas.py
+++ b/server/meta_agent/schemas.py
@@ -364,7 +364,7 @@ class GraphIntentV3(BaseModel):
 
     # Trusted decompilation constraints are deliberately absent from the JSON
     # schema, so model output cannot forge immutable resource versions.
-    _pinned_resource_versions: dict[tuple[str, str], int] = PrivateAttr(
+    _pinned_resource_versions: dict[tuple[str, str, str], int] = PrivateAttr(
         default_factory=dict
     )
     _pinned_prompt_profile_versions: dict[str, int] = PrivateAttr(
@@ -490,6 +490,10 @@ class MetaPlannerCapabilitySnapshot(BaseModel):
     models: list[dict[str, Any]]
     agents: list[dict[str, Any]] = Field(default_factory=list)
     default_scope: MetaPlannerScope
+    authoring_protocol_version: int = 0
+    authoring_operation_schema: dict[str, Any] = Field(default_factory=dict)
+    authoring_adapter_checksums: dict[str, str] = Field(default_factory=dict)
+    authoring_limits: dict[str, int] = Field(default_factory=dict)
 
 
 class MetaPlannerPreviewResponse(BaseModel):

--- a/server/tests/test_meta_planner_headless_authoring.py
+++ b/server/tests/test_meta_planner_headless_authoring.py
@@ -1,0 +1,1905 @@
+from __future__ import annotations
+
+import json
+import threading
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+import server.main as main_module
+from server.meta_agent.capabilities import build_capability_snapshot
+from server.meta_agent.graph_ir_v3 import (
+    graph_authoring_checksum,
+    resolve_graph_intent,
+    workflow_authoring_checksum,
+    workflow_semantic_checksum,
+)
+from server.meta_agent.graph_patch import (
+    ConnectDataOperation,
+    DisconnectControlOperation,
+    GraphPatchApplyRequest,
+    GraphPatchEditorDiffRequest,
+    GraphPatchEnvelopeV1,
+    MoveNodeOperation,
+    RemoveNodeOperation,
+    SetFinalOutputOperation,
+    SetOutputVariableOperation,
+    SetXpertMetadataOperation,
+    UpdateNodeOperation,
+    apply_graph_patch,
+)
+from server.meta_agent.headless_authoring import (
+    HeadlessAuthoringConflictError,
+    HeadlessAuthoringError,
+    HeadlessAuthoringService,
+)
+from server.meta_agent.meta_planner_v2 import (
+    MetaPlannerV2Service,
+    compile_xpert_candidate,
+)
+from server.meta_agent.schemas import (
+    GraphIntentFinalOutputV3,
+    GraphIntentInputBindingV3,
+    GraphIntentNodeV3,
+    GraphIntentOutputBindingV3,
+    GraphIntentV3,
+    MetaPlannerGenerateRequest,
+    MetaPlannerIRResourceBinding,
+    MetaPlannerScope,
+    MetaPlannerTask,
+    MetaPlannerTaskPlan,
+)
+from server.skills.draft_store import WorkspaceSkillDraftStore
+from server.workflow_native.node_contracts import WorkflowValueSchema
+from server.xpert_runtime.authoring_service import AuthoringService
+from server.xpert_runtime.authoring_store import AuthoringProposalStore
+from server.xpert_runtime.middleware_registry import runtime_middleware_registry
+from server.xpert_runtime.workflow_node_registry import workflow_node_registry
+from server.xperts.store import XpertStore
+from server.xperts.validation import validate_xpert_definition
+
+
+def _snapshot(
+    *,
+    extra_model: str | None = None,
+    toolset_version: int | None = None,
+    all_resources: bool = False,
+):
+    model_ids = ["model/planner", "model/agent"]
+    if extra_model:
+        model_ids.append(extra_model)
+    return build_capability_snapshot(
+        workflow_registry=workflow_node_registry,
+        middleware_registry=runtime_middleware_registry,
+        external_xperts=(
+            [
+                SimpleNamespace(
+                    id="xpert-safe",
+                    slug="xpert-safe",
+                    name="Safe expert",
+                    description="Published expert",
+                    status="published",
+                    published_version=2,
+                    kind="xpert",
+                    aliases=[],
+                )
+            ]
+            if all_resources
+            else []
+        ),
+        knowledge_bases=(
+            [
+                {
+                    "id": "kb-safe",
+                    "name": "Safe knowledge",
+                    "active_version_id": "kb-version-2",
+                }
+            ]
+            if all_resources
+            else []
+        ),
+        toolsets=(
+            [
+                SimpleNamespace(
+                    id="toolset-safe",
+                    slug="toolset-safe",
+                    name="Safe tools",
+                    description="Read-only tools",
+                    status="published",
+                    published_version=(
+                        toolset_version if toolset_version is not None else 2
+                    ),
+                    kind="mcp",
+                    aliases=[],
+                )
+            ]
+            if toolset_version is not None or all_resources
+            else []
+        ),
+        plugins=(
+            [
+                SimpleNamespace(
+                    id="plugin-safe",
+                    slug="plugin-safe",
+                    name="Safe plugin",
+                    description="Published plugin",
+                    status="published",
+                    published_version=2,
+                    kind="plugin",
+                    aliases=[],
+                )
+            ]
+            if all_resources
+            else []
+        ),
+        prompt_profiles=[],
+        model_ids=model_ids,
+    )
+
+
+def _scope(snapshot) -> MetaPlannerScope:
+    return MetaPlannerScope(
+        allowed_node_kinds=[item["kind"] for item in snapshot.nodes],
+        external_xpert_ids=[item["id"] for item in snapshot.external_xperts],
+        knowledge_base_ids=[item["id"] for item in snapshot.knowledge_bases],
+        toolset_ids=[item["id"] for item in snapshot.toolsets],
+        plugin_ids=[item["id"] for item in snapshot.plugins],
+    )
+
+
+def _request(snapshot) -> MetaPlannerGenerateRequest:
+    return MetaPlannerGenerateRequest(
+        goal="Create a focused answer from the supplied user request.",
+        planner_model_id="model/planner",
+        default_agent_model_id="model/agent",
+        max_agents=3,
+        scope=_scope(snapshot),
+    )
+
+
+def _plan() -> MetaPlannerTaskPlan:
+    return MetaPlannerTaskPlan(
+        summary="Produce one bounded answer.",
+        tasks=[
+            MetaPlannerTask(
+                task_id="answer",
+                title="Answer",
+                objective="Answer the request accurately.",
+                output_contract="A concise response.",
+            )
+        ],
+    )
+
+
+def _intent() -> GraphIntentV3:
+    return GraphIntentV3(
+        name="Headless candidate",
+        nodes=[
+            GraphIntentNodeV3(
+                ref="answerer",
+                kind="workflow_agent",
+                title="Answerer",
+                task_ids=["answer"],
+                inputs=[
+                    GraphIntentInputBindingV3(
+                        port="task",
+                        variable="user_input",
+                        source_ref="input",
+                        source_port="user_input",
+                        value_schema=WorkflowValueSchema(type="string"),
+                    )
+                ],
+                outputs=[
+                    GraphIntentOutputBindingV3(
+                        port="result",
+                        variable="agent_output",
+                        value_schema=WorkflowValueSchema(type="string"),
+                    )
+                ],
+                config={
+                    "role_prompt": "Answer accurately.",
+                    "task_input": "{{user_input}}",
+                    "model_id": "model/agent",
+                },
+            )
+        ],
+        final_output=GraphIntentFinalOutputV3(
+            node_ref="answerer", variable="agent_output"
+        ),
+    )
+
+
+def _preflight(candidate):
+    result = validate_xpert_definition(candidate)
+    return result, candidate.draft.workflow, []
+
+
+def _headless_fixture(
+    tmp_path: Path,
+    *,
+    legacy_v2: bool = False,
+    with_toolset: bool = False,
+    update_target: bool = False,
+    all_resources: bool = False,
+    exclude_plugin_from_scope: bool = False,
+    exclude_toolset_from_scope: bool = False,
+):
+    snapshot = _snapshot(
+        toolset_version=2 if with_toolset else None,
+        all_resources=all_resources,
+    )
+    request = _request(snapshot)
+    if exclude_plugin_from_scope:
+        request.scope.plugin_ids = []
+    if exclude_toolset_from_scope:
+        request.scope.toolset_ids = []
+    plan = _plan()
+    intent = _intent()
+    if with_toolset:
+        intent.resources.append(
+            MetaPlannerIRResourceBinding(
+                target_ref="answerer",
+                kind="toolset_resource",
+                resource_id="toolset-safe",
+            )
+        )
+    xpert_store = XpertStore(tmp_path / "xperts")
+    target = (
+        xpert_store.create_xpert(name="Existing Xpert")
+        if update_target
+        else None
+    )
+    graph = resolve_graph_intent(
+        intent, snapshot, default_agent_model_id=request.default_agent_model_id
+    )
+    candidate = compile_xpert_candidate(
+        request=request,
+        plan=plan,
+        blueprint=intent,
+        snapshot=snapshot,
+        target=target,
+    )
+    if legacy_v2:
+        candidate["draft"]["workflow"]["version"] = "evoagentx-meta-planner-v2"
+        for node in candidate["draft"]["workflow"]["nodes"]:
+            data = node.get("data") or {}
+            if data.get("kind") == "workflow_agent":
+                data.pop("plannerIRVersion", None)
+                data.pop("plannerInputsV3", None)
+                data.pop("plannerOutputsV3", None)
+    proposal_store = AuthoringProposalStore(tmp_path / "runtime")
+    authoring = AuthoringService(
+        proposal_store,
+        xpert_store,
+        WorkspaceSkillDraftStore(tmp_path / "skills"),
+        xpert_preflight=_preflight,
+    )
+    report = {
+        "planner_version": "evoagentx-meta-planner-graph-ir-v3",
+        "typed_ir_version": 3,
+        "ir_version": 3,
+        "graph_ir": graph.model_dump(mode="json"),
+        "graph_ir_checksum": graph.graph_checksum,
+        "authoring_graph_checksum": graph_authoring_checksum(graph),
+        "graph_ir_status": "current",
+        "compiled_workflow_checksum": workflow_semantic_checksum(candidate),
+        "authoring_candidate_checksum": workflow_authoring_checksum(candidate),
+        "compatibility": {
+            "source_version": 2 if legacy_v2 else 3,
+            "upgraded": legacy_v2,
+            "lossy": False,
+            "warnings": [],
+        },
+        "goal": request.goal,
+        "mode": "update" if update_target else "create",
+        "plan": plan.model_dump(mode="json"),
+        "capability_snapshot": {
+            "version": snapshot.version,
+            "hash": snapshot.snapshot_hash,
+        },
+        "authorized_scope": request.scope.model_dump(mode="json"),
+        "generation_config": {
+            "planner_model_id": request.planner_model_id,
+            "default_agent_model_id": request.default_agent_model_id,
+            "max_agents": request.max_agents,
+        },
+        "validation": {"valid": True, "issues": []},
+        "human_modified": False,
+    }
+    payload = (
+        {
+            "xpert_id": target.id,
+            "patch": candidate,
+            "meta_planner_report": report,
+        }
+        if target is not None
+        else {**candidate, "meta_planner_report": report}
+    )
+    proposal = proposal_store.create(
+        kind="xpert_update" if target is not None else "xpert_create",
+        title="Headless candidate",
+        payload=payload,
+        source_type="meta_planner",
+        source_id="meta-planner:test",
+        target_id=target.id if target is not None else None,
+        base_revision=target.draft_revision if target is not None else None,
+    )
+    service = HeadlessAuthoringService(
+        authoring_service=authoring,
+        planner_service=MetaPlannerV2Service(
+            authoring_service=authoring, preflight=_preflight
+        ),
+        capability_snapshot_builder=lambda: snapshot,
+    )
+    return service, authoring, proposal
+
+
+def test_capability_snapshot_exposes_patch_protocol_without_new_nodes():
+    snapshot = _snapshot()
+
+    assert snapshot.version == "evoagentx-meta-planner-capabilities-v5"
+    assert snapshot.authoring_protocol_version == 1
+    assert snapshot.authoring_limits["max_operations"] == 64
+    assert snapshot.authoring_limits["max_receipts"] == 20
+    assert snapshot.authoring_limits["max_request_bytes"] == 2 * 1024 * 1024
+    assert snapshot.authoring_limits["max_json_depth"] == 32
+    assert set(snapshot.authoring_adapter_checksums) == {
+        item["kind"] for item in snapshot.nodes
+    }
+    assert {item["kind"] for item in snapshot.nodes} == {
+        "input",
+        "output",
+        "workflow_agent",
+        "external_xpert",
+        "knowledge_base",
+        "toolset_resource",
+        "plugin_resource",
+    }
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        {
+            "op": "bind_resource",
+            "target_ref": "answerer",
+            "kind": "toolset_resource",
+            "resource_id": "toolset-a",
+            "pinned_version": 99,
+        },
+        {
+            "op": "connect_control",
+            "source_ref": "answerer",
+            "target_ref": "writer",
+            "source_handle": "forged",
+        },
+        {
+            "op": "connect_data",
+            "source_ref": "input",
+            "source_port": "user_input",
+            "target_ref": "answerer",
+            "target_port": "task",
+            "value_schema": {"type": "string"},
+        },
+    ],
+)
+def test_patch_schema_rejects_runtime_owned_fields(operation):
+    with pytest.raises(ValidationError):
+        GraphPatchEnvelopeV1(
+            proposal_revision=1,
+            expected_graph_checksum="a" * 64,
+            expected_candidate_checksum="b" * 64,
+            operations=[operation],
+        )
+
+
+def test_patch_rejects_undeclared_nested_adapter_config_fields():
+    intent = _intent()
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=1,
+        expected_graph_checksum="a" * 64,
+        expected_candidate_checksum="b" * 64,
+        operations=[
+            {
+                "op": "update_node",
+                "ref": "answerer",
+                "config": {
+                    "role_prompt": "Answer accurately.",
+                    "task_input": "{{user_input}}",
+                    "api_key": "must-not-be-accepted",
+                },
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="undeclared Adapter config fields: api_key"):
+        apply_graph_patch(
+            intent,
+            patch,
+            plan_task_ids={"answer"},
+            allowed_node_kinds={"workflow_agent"},
+        )
+
+
+def test_patch_infers_data_schema_and_requires_explicit_detach():
+    intent = _intent()
+    intent.nodes.append(
+        GraphIntentNodeV3(
+            ref="writer",
+            kind="workflow_agent",
+            title="Writer",
+            task_ids=["answer"],
+            outputs=[],
+            config={
+                "role_prompt": "Write from evidence.",
+                "task_input": "{{agent_output}}",
+                "model_id": "model/agent",
+            },
+        )
+    )
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=1,
+        expected_graph_checksum="a" * 64,
+        expected_candidate_checksum="b" * 64,
+        operations=[
+            DisconnectControlOperation(
+                source_ref="answerer", target_ref="writer"
+            ),
+            ConnectDataOperation(
+                source_ref="answerer",
+                source_port="result",
+                target_ref="writer",
+                target_port="task",
+            ),
+            SetOutputVariableOperation(
+                node_ref="writer", port="result", variable="writer_output"
+            ),
+            SetFinalOutputOperation(node_ref="writer", port="result"),
+        ],
+    )
+    with pytest.raises(ValueError, match="does not exist"):
+        apply_graph_patch(intent, patch, plan_task_ids={"answer"})
+
+    intent.control_edges = []
+    applied = apply_graph_patch(
+        intent,
+        patch.model_copy(update={"operations": patch.operations[1:]}),
+        plan_task_ids={"answer"},
+    )
+    writer = next(node for node in applied.intent.nodes if node.ref == "writer")
+    assert writer.inputs[0].value_schema.type == "string"
+    assert writer.inputs[0].variable == "agent_output"
+    assert writer.outputs[0].value_schema.type == "string"
+    assert applied.intent.final_output.variable == "writer_output"
+
+    remove = GraphPatchEnvelopeV1(
+        proposal_revision=1,
+        expected_graph_checksum="a" * 64,
+        expected_candidate_checksum="b" * 64,
+        operations=[RemoveNodeOperation(ref="answerer")],
+    )
+    with pytest.raises(ValueError, match="explicitly detach"):
+        apply_graph_patch(applied.intent, remove, plan_task_ids={"answer"})
+
+
+def test_all_graph_patch_operations_form_an_atomic_round_trip():
+    base = _intent()
+    add_patch = GraphPatchEnvelopeV1(
+        proposal_revision=1,
+        expected_graph_checksum="a" * 64,
+        expected_candidate_checksum="b" * 64,
+        operations=[
+            {
+                "op": "set_xpert_metadata",
+                "description": "Edited through typed authoring.",
+                "tags": ["review"],
+            },
+            {
+                "op": "add_node",
+                "ref": "writer",
+                "kind": "workflow_agent",
+                "title": "Writer",
+                "task_ids": ["answer"],
+                "config": {
+                    "role_prompt": "Write a final response.",
+                    "task_input": "{{draft_output}}",
+                    "model_id": "model/agent",
+                },
+                "output_variables": {"result": "draft_output"},
+            },
+            {
+                "op": "update_node",
+                "ref": "writer",
+                "description": "Adapter-backed writer.",
+                "config": {
+                    "role_prompt": "Write and verify a final response.",
+                    "task_input": "{{agent_output}}",
+                    "model_id": "model/agent",
+                },
+            },
+            {
+                "op": "connect_control",
+                "source_ref": "answerer",
+                "target_ref": "writer",
+            },
+            {
+                "op": "connect_data",
+                "source_ref": "answerer",
+                "source_port": "result",
+                "target_ref": "writer",
+                "target_port": "task",
+            },
+            {
+                "op": "set_output_variable",
+                "node_ref": "writer",
+                "port": "result",
+                "variable": "writer_output",
+            },
+            {
+                "op": "bind_resource",
+                "target_ref": "answerer",
+                "kind": "knowledge_base",
+                "resource_id": "kb-safe",
+            },
+            {
+                "op": "bind_middleware",
+                "target_ref": "answerer",
+                "middleware_id": "guardrail",
+                "priority": 80,
+                "config": {},
+            },
+            {"op": "bind_prompt_profile", "profile_id": "prompt-safe"},
+            {
+                "op": "set_final_output",
+                "node_ref": "writer",
+                "port": "result",
+            },
+            {"op": "move_node", "ref": "writer", "x": 720, "y": 240},
+        ],
+    )
+    added = apply_graph_patch(
+        base,
+        add_patch,
+        plan_task_ids={"answer"},
+        allowed_node_kinds={"workflow_agent"},
+    )
+
+    assert added.intent.description == "Edited through typed authoring."
+    assert added.intent.final_output.node_ref == "writer"
+    assert added.intent.final_output.variable == "writer_output"
+    assert added.layout["writer"] == {"x": 720.0, "y": 240.0}
+    assert len(added.intent.resources) == 1
+    assert len(added.intent.middleware) == 1
+    assert added.intent.prompt_profile_ids == ["prompt-safe"]
+
+    remove_patch = GraphPatchEnvelopeV1(
+        proposal_revision=1,
+        expected_graph_checksum="c" * 64,
+        expected_candidate_checksum="d" * 64,
+        operations=[
+            {
+                "op": "disconnect_data",
+                "source_ref": "answerer",
+                "source_port": "result",
+                "target_ref": "writer",
+                "target_port": "task",
+            },
+            {
+                "op": "disconnect_control",
+                "source_ref": "answerer",
+                "target_ref": "writer",
+            },
+            {
+                "op": "unbind_resource",
+                "target_ref": "answerer",
+                "kind": "knowledge_base",
+                "resource_id": "kb-safe",
+            },
+            {
+                "op": "unbind_middleware",
+                "target_ref": "answerer",
+                "middleware_id": "guardrail",
+            },
+            {"op": "unbind_prompt_profile", "profile_id": "prompt-safe"},
+            {
+                "op": "set_final_output",
+                "node_ref": "answerer",
+                "port": "result",
+            },
+            {"op": "remove_node", "ref": "writer"},
+        ],
+    )
+    removed = apply_graph_patch(
+        added.intent,
+        remove_patch,
+        plan_task_ids={"answer"},
+        layout=added.layout,
+        allowed_node_kinds={"workflow_agent"},
+    )
+
+    assert [node.ref for node in removed.intent.nodes] == ["answerer"]
+    assert removed.intent.resources == []
+    assert removed.intent.middleware == []
+    assert removed.intent.prompt_profile_ids == []
+    assert removed.intent.final_output.node_ref == "answerer"
+    assert "writer" not in removed.layout
+
+
+def test_preview_is_side_effect_free_and_apply_increments_once(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    state = service.proposal_state(proposal.proposal_id)
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=proposal.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[
+            UpdateNodeOperation(
+                ref="answerer",
+                config={
+                    "role_prompt": "Answer accurately and cite uncertainty.",
+                    "task_input": "{{user_input}}",
+                    "model_id": "model/agent",
+                    "source_agent_id": None,
+                    "method_skill_ids": [],
+                },
+            ),
+            MoveNodeOperation(ref="answerer", x=640, y=240),
+        ],
+    )
+
+    preview = service.preview(proposal.proposal_id, patch)
+    unchanged = authoring.proposal_store.require(proposal.proposal_id)
+    assert unchanged.revision == 1
+    assert preview["can_apply"] is True
+    assert preview["graph_checksum"] != state["graph_checksum"]
+    assert preview["candidate_checksum"] != state["candidate_checksum"]
+
+    result = service.apply(
+        proposal.proposal_id,
+        GraphPatchApplyRequest(
+            patch=patch, preview_checksum=preview["preview_checksum"]
+        ),
+    )
+    assert result["proposal_revision"] == 2
+    updated = authoring.proposal_store.require(proposal.proposal_id)
+    assert updated.validation["valid"] is True
+    report = updated.payload["meta_planner_report"]
+    assert report["graph_ir_status"] == "current"
+    assert report["human_modified"] is True
+    assert len(report["authoring_patch_receipts"]) == 1
+    receipt_json = json.dumps(report["authoring_patch_receipts"])
+    assert "cite uncertainty" not in receipt_json
+    assert authoring.xpert_store.list_xperts() == []
+
+
+def test_proposal_state_rejects_unconsumed_native_nodes(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    payload = deepcopy(proposal.payload)
+    payload["draft"]["workflow"]["nodes"].append(
+        {
+            "id": "smuggled-node",
+            "type": "json_serialize",
+            "position": {"x": 900, "y": 900},
+            "data": {"kind": "json_serialize", "apiKey": "not-a-real-key"},
+        }
+    )
+    authoring.update_pending(
+        proposal.proposal_id,
+        revision=proposal.revision,
+        payload=payload,
+    )
+
+    with pytest.raises(HeadlessAuthoringError) as error:
+        service.proposal_state(proposal.proposal_id)
+
+    assert error.value.code == "headless_lossy_conversion"
+    assert "not-a-real-key" not in str(error.value)
+
+
+def test_editor_diff_rejects_non_adapter_agent_field_changes(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    state = service.proposal_state(proposal.proposal_id)
+    definition = deepcopy(state["candidate"]["draft"]["workflow"])
+    agent = next(
+        node
+        for node in definition["nodes"]
+        if (node.get("data") or {}).get("kind") == "workflow_agent"
+    )
+    agent["data"]["maxIterations"] = "99"
+
+    with pytest.raises(HeadlessAuthoringError) as error:
+        service.editor_diff(
+            proposal.proposal_id,
+            GraphPatchEditorDiffRequest(
+                proposal_revision=proposal.revision,
+                definition=definition,
+            ),
+        )
+
+    assert error.value.code == "headless_editor_diff_unrepresentable"
+    assert "maxIterations" in str(error.value)
+    assert authoring.proposal_store.require(proposal.proposal_id).revision == 1
+
+
+def test_stale_full_payload_with_non_adapter_agent_edit_is_lossy(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    payload = deepcopy(proposal.payload)
+    agent = next(
+        node
+        for node in payload["draft"]["workflow"]["nodes"]
+        if (node.get("data") or {}).get("kind") == "workflow_agent"
+    )
+    agent["data"]["maxIterations"] = "99"
+    authoring.update_pending(
+        proposal.proposal_id,
+        revision=proposal.revision,
+        payload=payload,
+    )
+
+    with pytest.raises(HeadlessAuthoringError) as error:
+        service.proposal_state(proposal.proposal_id)
+
+    assert error.value.code == "headless_lossy_conversion"
+    assert "maxIterations" not in str(error.value)
+
+
+def test_v2_full_payload_cannot_bypass_round_trip_with_runtime_field_edit(
+    tmp_path: Path,
+):
+    service, authoring, proposal = _headless_fixture(tmp_path, legacy_v2=True)
+    payload = deepcopy(proposal.payload)
+    agent = next(
+        node
+        for node in payload["draft"]["workflow"]["nodes"]
+        if (node.get("data") or {}).get("kind") == "workflow_agent"
+    )
+    agent["data"]["maxIterations"] = "99"
+    authoring.update_pending(
+        proposal.proposal_id,
+        revision=proposal.revision,
+        payload=payload,
+    )
+
+    with pytest.raises(HeadlessAuthoringError) as error:
+        service.proposal_state(proposal.proposal_id)
+
+    assert error.value.code == "headless_lossy_conversion"
+    assert authoring.proposal_store.require(proposal.proposal_id).revision == 2
+
+
+def test_mixed_v2_v3_agent_markers_fail_closed(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    payload = deepcopy(proposal.payload)
+    agent = next(
+        node
+        for node in payload["draft"]["workflow"]["nodes"]
+        if (node.get("data") or {}).get("kind") == "workflow_agent"
+    )
+    mixed = deepcopy(agent)
+    mixed["id"] = "mixed-agent"
+    mixed["data"]["plannerRef"] = "mixed_agent"
+    mixed["data"].pop("plannerIRVersion", None)
+    mixed["data"].pop("plannerInputsV3", None)
+    mixed["data"].pop("plannerOutputsV3", None)
+    payload["draft"]["workflow"]["nodes"].append(mixed)
+    authoring.update_pending(
+        proposal.proposal_id,
+        revision=proposal.revision,
+        payload=payload,
+    )
+
+    with pytest.raises(HeadlessAuthoringError) as error:
+        service.proposal_state(proposal.proposal_id)
+
+    assert error.value.code == "headless_lossy_conversion"
+    assert "mixes Graph IR V2 and V3" in json.dumps(error.value.diagnostics)
+
+
+@pytest.mark.parametrize(
+    ("kind", "resource_id", "id_field", "source_handle", "target_handle"),
+    [
+        (
+            "external_xpert",
+            "xpert-safe",
+            "xpertId",
+            "expert-binding",
+            "expert",
+        ),
+        (
+            "knowledge_base",
+            "kb-safe",
+            "knowledgeBaseId",
+            "knowledge-binding",
+            "knowledge",
+        ),
+        (
+            "toolset_resource",
+            "toolset-safe",
+            "toolsetId",
+            "toolset-binding",
+            "toolset",
+        ),
+        (
+            "plugin_resource",
+            "plugin-safe",
+            "pluginId",
+            "plugin-binding",
+            "plugin",
+        ),
+    ],
+)
+def test_editor_diff_can_add_authorized_resources_with_server_owned_versions(
+    tmp_path: Path,
+    kind: str,
+    resource_id: str,
+    id_field: str,
+    source_handle: str,
+    target_handle: str,
+):
+    service, _, proposal = _headless_fixture(tmp_path, all_resources=True)
+    state = service.proposal_state(proposal.proposal_id)
+    definition = deepcopy(state["candidate"]["draft"]["workflow"])
+    agent = next(
+        node
+        for node in definition["nodes"]
+        if (node.get("data") or {}).get("kind") == "workflow_agent"
+    )
+    resource_node_id = f"editor-{kind}"
+    data = {
+        "kind": kind,
+        "title": kind,
+        "description": "Editor-selected resource",
+        id_field: resource_id,
+    }
+    if kind == "external_xpert":
+        data["toolName"] = "safe_expert"
+    elif kind == "knowledge_base":
+        data.update({"topK": "5", "scoreThreshold": "0"})
+    if kind != "knowledge_base":
+        data.update({"versionPolicy": "pinned", "pinnedVersion": 999})
+    definition["nodes"].append(
+        {
+            "id": resource_node_id,
+            "type": kind,
+            "position": {"x": 240, "y": 420},
+            "data": data,
+        }
+    )
+    definition["edges"].append(
+        {
+            "id": f"edge-{resource_node_id}",
+            "source": resource_node_id,
+            "target": agent["id"],
+            "sourceHandle": source_handle,
+            "targetHandle": target_handle,
+        }
+    )
+
+    diff = service.editor_diff(
+        proposal.proposal_id,
+        GraphPatchEditorDiffRequest(
+            proposal_revision=proposal.revision,
+            definition=definition,
+        ),
+    )
+    patch = GraphPatchEnvelopeV1.model_validate(diff["patch"])
+    assert [operation.op for operation in patch.operations] == ["bind_resource"]
+    preview = service.preview(proposal.proposal_id, patch)
+
+    assert preview["can_apply"] is True
+    compiled = next(
+        node
+        for node in preview["candidate"]["draft"]["workflow"]["nodes"]
+        if (node.get("data") or {}).get(id_field) == resource_id
+    )
+    if kind != "knowledge_base":
+        assert compiled["data"]["pinnedVersion"] == 2
+
+
+def test_editor_diff_can_remove_existing_fixed_resource_binding(tmp_path: Path):
+    service, _, proposal = _headless_fixture(tmp_path, with_toolset=True)
+    state = service.proposal_state(proposal.proposal_id)
+    definition = deepcopy(state["candidate"]["draft"]["workflow"])
+    resource = next(
+        node
+        for node in definition["nodes"]
+        if (node.get("data") or {}).get("kind") == "toolset_resource"
+    )
+    definition["nodes"] = [
+        node for node in definition["nodes"] if node["id"] != resource["id"]
+    ]
+    definition["edges"] = [
+        edge
+        for edge in definition["edges"]
+        if edge["source"] != resource["id"] and edge["target"] != resource["id"]
+    ]
+
+    diff = service.editor_diff(
+        proposal.proposal_id,
+        GraphPatchEditorDiffRequest(
+            proposal_revision=proposal.revision,
+            definition=definition,
+        ),
+    )
+    patch = GraphPatchEnvelopeV1.model_validate(diff["patch"])
+
+    assert [operation.op for operation in patch.operations] == ["unbind_resource"]
+    assert service.preview(proposal.proposal_id, patch)["can_apply"] is True
+
+
+def test_editor_diff_preserves_pin_when_existing_resource_metadata_changes(
+    tmp_path: Path,
+):
+    service, _, proposal = _headless_fixture(tmp_path, with_toolset=True)
+    drifted = _snapshot(toolset_version=3)
+    drifted.toolsets[0]["metadata"]["available_versions"] = [
+        {"version": 2, "checksum": "toolset-v2"},
+        {"version": 3, "checksum": "toolset-v3"},
+    ]
+    service.capability_snapshot_builder = lambda: drifted
+    state = service.proposal_state(proposal.proposal_id)
+    definition = deepcopy(state["candidate"]["draft"]["workflow"])
+    resource = next(
+        node
+        for node in definition["nodes"]
+        if (node.get("data") or {}).get("kind") == "toolset_resource"
+    )
+    resource["data"]["description"] = "Updated editor description"
+
+    diff = service.editor_diff(
+        proposal.proposal_id,
+        GraphPatchEditorDiffRequest(
+            proposal_revision=proposal.revision,
+            definition=definition,
+        ),
+    )
+    patch = GraphPatchEnvelopeV1.model_validate(diff["patch"])
+    assert [operation.op for operation in patch.operations] == [
+        "unbind_resource",
+        "bind_resource",
+    ]
+
+    preview = service.preview(proposal.proposal_id, patch)
+    resolved_resource = next(
+        node
+        for node in preview["graph_ir"]["nodes"]
+        if node["kind"] == "toolset_resource"
+    )
+    compiled_resource = next(
+        node
+        for node in preview["candidate"]["draft"]["workflow"]["nodes"]
+        if (node.get("data") or {}).get("kind") == "toolset_resource"
+    )
+    assert preview["can_apply"] is True
+    assert resolved_resource["config"]["pinned_version"] == 2
+    assert compiled_resource["data"]["pinnedVersion"] == 2
+
+
+def test_editor_diff_resolves_same_resource_for_new_second_agent_binding(
+    tmp_path: Path,
+):
+    service, _, proposal = _headless_fixture(tmp_path, with_toolset=True)
+    state = service.proposal_state(proposal.proposal_id)
+    definition = deepcopy(state["candidate"]["draft"]["workflow"])
+    first_agent = next(
+        node
+        for node in definition["nodes"]
+        if (node.get("data") or {}).get("kind") == "workflow_agent"
+    )
+    second_agent = {
+        "id": "editor-agent-second",
+        "type": "workflow_agent",
+        "position": {"x": 720, "y": 280},
+        "data": {
+            "kind": "workflow_agent",
+            "title": "Second agent",
+            "description": "Continue from the first result.",
+            "modelId": "model/agent",
+            "rolePrompt": "Produce a checked final answer.",
+            "taskInput": "{{agent_output}}",
+            "methodSkillIds": [],
+            "outputVariable": "second_output",
+        },
+    }
+    definition["nodes"].append(second_agent)
+    output_edge = next(edge for edge in definition["edges"] if edge["target"] == "output")
+    output_edge["source"] = second_agent["id"]
+    definition["edges"].append(
+        {
+            "id": "edge-first-second",
+            "source": first_agent["id"],
+            "target": second_agent["id"],
+        }
+    )
+    definition["nodes"].append(
+        {
+            "id": "editor-toolset-second",
+            "type": "toolset_resource",
+            "position": {"x": 720, "y": 460},
+            "data": {
+                "kind": "toolset_resource",
+                "title": "Safe tools",
+                "toolsetId": "toolset-safe",
+                "versionPolicy": "pinned",
+                "pinnedVersion": 999,
+            },
+        }
+    )
+    definition["edges"].append(
+        {
+            "id": "edge-toolset-second",
+            "source": "editor-toolset-second",
+            "target": second_agent["id"],
+            "sourceHandle": "toolset-binding",
+            "targetHandle": "toolset",
+        }
+    )
+
+    diff = service.editor_diff(
+        proposal.proposal_id,
+        GraphPatchEditorDiffRequest(
+            proposal_revision=proposal.revision,
+            definition=definition,
+        ),
+    )
+    patch = GraphPatchEnvelopeV1.model_validate(diff["patch"])
+    preview = service.preview(proposal.proposal_id, patch)
+
+    assert preview["can_apply"] is True
+    compiled = preview["candidate"]["draft"]["workflow"]
+    second_binding = next(
+        edge
+        for edge in compiled["edges"]
+        if edge.get("targetHandle") == "toolset"
+        and edge["target"]
+        == next(
+            node["id"]
+            for node in compiled["nodes"]
+            if (node.get("data") or {}).get("title") == "Second agent"
+        )
+    )
+    second_resource = next(
+        node for node in compiled["nodes"] if node["id"] == second_binding["source"]
+    )
+    assert second_resource["data"]["pinnedVersion"] == 2
+
+
+def test_patch_cannot_bind_globally_available_but_unauthorized_resource(
+    tmp_path: Path,
+):
+    service, _, proposal = _headless_fixture(
+        tmp_path,
+        all_resources=True,
+        exclude_plugin_from_scope=True,
+    )
+    state = service.proposal_state(proposal.proposal_id)
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=proposal.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[
+            {
+                "op": "bind_resource",
+                "target_ref": "answerer",
+                "kind": "plugin_resource",
+                "resource_id": "plugin-safe",
+            }
+        ],
+    )
+
+    with pytest.raises(HeadlessAuthoringError) as error:
+        service.preview(proposal.proposal_id, patch)
+
+    assert error.value.code == "headless_patch_invalid"
+    assert "outside the Proposal authorization scope" in str(error.value)
+
+
+def test_existing_intent_outside_original_scope_fails_closed(tmp_path: Path):
+    service, _, proposal = _headless_fixture(
+        tmp_path,
+        with_toolset=True,
+        exclude_toolset_from_scope=True,
+    )
+
+    with pytest.raises(HeadlessAuthoringError) as error:
+        service.proposal_state(proposal.proposal_id)
+
+    assert error.value.code == "headless_contract_or_resource_drift"
+    assert "outside the Proposal authorization scope" in str(error.value)
+
+
+def test_apply_final_validation_failure_is_atomic(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    state = service.proposal_state(proposal.proposal_id)
+    before_payload = deepcopy(proposal.payload)
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=proposal.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[MoveNodeOperation(ref="answerer", x=680, y=320)],
+    )
+    preview = service.preview(proposal.proposal_id, patch)
+    authoring.xpert_preflight = lambda candidate: (
+        SimpleNamespace(
+            valid=False,
+            issues=[SimpleNamespace(message="Final gate blocked the candidate.")],
+            node_count=0,
+        ),
+        candidate.draft.workflow,
+        [],
+    )
+
+    with pytest.raises(HeadlessAuthoringError, match="Final gate blocked"):
+        service.apply(
+            proposal.proposal_id,
+            GraphPatchApplyRequest(
+                patch=patch,
+                preview_checksum=preview["preview_checksum"],
+            ),
+        )
+
+    unchanged = authoring.proposal_store.require(proposal.proposal_id)
+    assert unchanged.revision == proposal.revision
+    assert unchanged.payload == before_payload
+
+
+def test_semantic_noop_patch_does_not_consume_revision(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    state = service.proposal_state(proposal.proposal_id)
+    preview = service.preview(
+        proposal.proposal_id,
+        GraphPatchEnvelopeV1(
+            proposal_revision=proposal.revision,
+            expected_graph_checksum=state["graph_checksum"],
+            expected_candidate_checksum=state["candidate_checksum"],
+            operations=[SetXpertMetadataOperation(name="Headless candidate")],
+        ),
+    )
+
+    assert preview["can_apply"] is False
+    assert any(item.get("code") == "no_effect" for item in preview["diagnostics"])
+    assert authoring.proposal_store.require(proposal.proposal_id).revision == 1
+
+
+def test_apply_fails_closed_after_concurrent_proposal_edit(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    state = service.proposal_state(proposal.proposal_id)
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=proposal.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[MoveNodeOperation(ref="answerer", x=500, y=300)],
+    )
+    preview = service.preview(proposal.proposal_id, patch)
+    authoring.update_pending(
+        proposal.proposal_id,
+        revision=proposal.revision,
+        title="Concurrent edit",
+    )
+
+    with pytest.raises(HeadlessAuthoringConflictError):
+        service.apply(
+            proposal.proposal_id,
+            GraphPatchApplyRequest(
+                patch=patch, preview_checksum=preview["preview_checksum"]
+            ),
+        )
+
+
+def test_unrelated_snapshot_drift_keeps_authoring_graph_checksum(tmp_path: Path):
+    service, _, proposal = _headless_fixture(tmp_path)
+    before = service.proposal_state(proposal.proposal_id)
+    drifted = _snapshot(extra_model="model/unrelated")
+    service.capability_snapshot_builder = lambda: drifted
+
+    after = service.proposal_state(proposal.proposal_id)
+
+    assert after["graph_checksum"] == before["graph_checksum"]
+    assert any("Snapshot changed" in warning for warning in after["warnings"])
+
+
+def test_latest_resource_advance_keeps_an_existing_immutable_pin_valid(
+    tmp_path: Path,
+):
+    service, _, proposal = _headless_fixture(tmp_path, with_toolset=True)
+    drifted = _snapshot(toolset_version=3)
+    drifted.toolsets[0]["metadata"]["available_versions"] = [
+        {"version": 2, "checksum": "toolset-v2"},
+        {"version": 3, "checksum": "toolset-v3"},
+    ]
+    service.capability_snapshot_builder = lambda: drifted
+
+    state = service.proposal_state(proposal.proposal_id)
+
+    resource = next(
+        node
+        for node in state["graph_ir"]["nodes"]
+        if node["kind"] == "toolset_resource"
+    )
+    assert state["can_author"] is True
+    assert resource["config"]["pinned_version"] == 2
+    assert resource["config"]["resource_checksum"] == "toolset-v2"
+
+
+def test_missing_immutable_resource_pin_blocks_headless_authoring(tmp_path: Path):
+    service, _, proposal = _headless_fixture(tmp_path, with_toolset=True)
+    drifted = _snapshot(toolset_version=3)
+    drifted.toolsets[0]["metadata"]["available_versions"] = [
+        {"version": 3, "checksum": "toolset-v3"},
+    ]
+    service.capability_snapshot_builder = lambda: drifted
+
+    with pytest.raises(HeadlessAuthoringError) as error:
+        service.proposal_state(proposal.proposal_id)
+
+    assert error.value.code == "headless_contract_or_resource_drift"
+    assert "pinned version 2 is unavailable" in str(error.value)
+
+
+def test_lossless_v2_candidate_upgrades_on_first_typed_apply(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path, legacy_v2=True)
+    state = service.proposal_state(proposal.proposal_id)
+
+    assert state["ir_version"] == 2
+    assert state["compatibility"] == {
+        "source_version": 2,
+        "upgraded": True,
+        "lossy": False,
+        "warnings": [],
+    }
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=proposal.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[MoveNodeOperation(ref="answerer", x=700, y=260)],
+    )
+    preview = service.preview(proposal.proposal_id, patch)
+    result = service.apply(
+        proposal.proposal_id,
+        GraphPatchApplyRequest(
+            patch=patch,
+            preview_checksum=preview["preview_checksum"],
+        ),
+    )
+
+    assert result["proposal_revision"] == 2
+    updated = authoring.proposal_store.require(proposal.proposal_id)
+    agent = next(
+        node
+        for node in updated.payload["draft"]["workflow"]["nodes"]
+        if (node.get("data") or {}).get("kind") == "workflow_agent"
+    )
+    assert agent["data"]["plannerIRVersion"] == 3
+    assert updated.payload["meta_planner_report"]["graph_ir_status"] == "current"
+
+
+def test_apply_rejects_tampered_preview_checksum(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    state = service.proposal_state(proposal.proposal_id)
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=proposal.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[MoveNodeOperation(ref="answerer", x=520, y=300)],
+    )
+    service.preview(proposal.proposal_id, patch)
+
+    with pytest.raises(HeadlessAuthoringConflictError, match="Preview checksum"):
+        service.apply(
+            proposal.proposal_id,
+            GraphPatchApplyRequest(patch=patch, preview_checksum="f" * 64),
+        )
+    assert authoring.proposal_store.require(proposal.proposal_id).revision == 1
+
+
+def test_attack_late_invalid_operation_leaves_source_and_layout_untouched():
+    intent = _intent()
+    intent._pinned_resource_versions = {
+        ("toolset_resource", "toolset-safe", "answerer"): (2, "toolset-v2")
+    }
+    layout = {"answerer": {"x": 320.0, "y": 180.0}}
+    before_intent = intent.model_dump(mode="json")
+    before_pins = dict(intent._pinned_resource_versions)
+    before_layout = deepcopy(layout)
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=1,
+        expected_graph_checksum="a" * 64,
+        expected_candidate_checksum="b" * 64,
+        operations=[
+            SetXpertMetadataOperation(
+                description="This valid first operation must be rolled back."
+            ),
+            MoveNodeOperation(ref="answerer", x=900, y=420),
+            DisconnectControlOperation(
+                source_ref="answerer", target_ref="missing"
+            ),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="does not exist"):
+        apply_graph_patch(
+            intent,
+            patch,
+            plan_task_ids={"answer"},
+            layout=layout,
+            allowed_node_kinds={"workflow_agent"},
+        )
+
+    assert intent.model_dump(mode="json") == before_intent
+    assert intent._pinned_resource_versions == before_pins
+    assert layout == before_layout
+
+
+def test_attack_preview_checksum_cannot_cross_proposal_boundary(tmp_path: Path):
+    service_a, _, proposal_a = _headless_fixture(tmp_path / "a")
+    service_b, authoring_b, proposal_b = _headless_fixture(tmp_path / "b")
+    state_a = service_a.proposal_state(proposal_a.proposal_id)
+    state_b = service_b.proposal_state(proposal_b.proposal_id)
+    assert state_a["graph_checksum"] == state_b["graph_checksum"]
+
+    patch_a = GraphPatchEnvelopeV1(
+        proposal_revision=proposal_a.revision,
+        expected_graph_checksum=state_a["graph_checksum"],
+        expected_candidate_checksum=state_a["candidate_checksum"],
+        operations=[MoveNodeOperation(ref="answerer", x=610, y=310)],
+    )
+    patch_b = patch_a.model_copy(
+        update={
+            "proposal_revision": proposal_b.revision,
+            "expected_graph_checksum": state_b["graph_checksum"],
+            "expected_candidate_checksum": state_b["candidate_checksum"],
+        }
+    )
+    preview_a = service_a.preview(proposal_a.proposal_id, patch_a)
+
+    with pytest.raises(HeadlessAuthoringConflictError, match="Preview checksum"):
+        service_b.apply(
+            proposal_b.proposal_id,
+            GraphPatchApplyRequest(
+                patch=patch_b,
+                preview_checksum=preview_a["preview_checksum"],
+            ),
+        )
+
+    unchanged = authoring_b.proposal_store.require(proposal_b.proposal_id)
+    assert unchanged.revision == proposal_b.revision
+    assert (
+        unchanged.payload["meta_planner_report"].get("authoring_patch_receipts")
+        is None
+    )
+
+
+def test_attack_successful_apply_request_cannot_be_replayed(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    state = service.proposal_state(proposal.proposal_id)
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=proposal.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[MoveNodeOperation(ref="answerer", x=620, y=320)],
+    )
+    preview = service.preview(proposal.proposal_id, patch)
+    request = GraphPatchApplyRequest(
+        patch=patch,
+        preview_checksum=preview["preview_checksum"],
+    )
+
+    first = service.apply(proposal.proposal_id, request)
+    with pytest.raises(HeadlessAuthoringConflictError, match="Proposal revision"):
+        service.apply(proposal.proposal_id, request)
+
+    persisted = authoring.proposal_store.require(proposal.proposal_id)
+    assert first["proposal_revision"] == 2
+    assert persisted.revision == 2
+    assert len(
+        persisted.payload["meta_planner_report"]["authoring_patch_receipts"]
+    ) == 1
+
+
+def test_attack_patch_receipts_are_bounded_and_do_not_retain_content(
+    tmp_path: Path,
+):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    sentinel = "receipt-secret-content-must-not-survive"
+
+    for index in range(21):
+        state = service.proposal_state(proposal.proposal_id)
+        operation = (
+            SetXpertMetadataOperation(description=sentinel)
+            if index == 0
+            else MoveNodeOperation(
+                ref="answerer",
+                x=500 + index,
+                y=300 + index,
+            )
+        )
+        patch = GraphPatchEnvelopeV1(
+            proposal_revision=state["proposal_revision"],
+            expected_graph_checksum=state["graph_checksum"],
+            expected_candidate_checksum=state["candidate_checksum"],
+            operations=[operation],
+        )
+        preview = service.preview(proposal.proposal_id, patch)
+        assert preview["can_apply"] is True
+        service.apply(
+            proposal.proposal_id,
+            GraphPatchApplyRequest(
+                patch=patch,
+                preview_checksum=preview["preview_checksum"],
+            ),
+        )
+
+    persisted = authoring.proposal_store.require(proposal.proposal_id)
+    receipts = persisted.payload["meta_planner_report"][
+        "authoring_patch_receipts"
+    ]
+    receipt_json = json.dumps(receipts)
+
+    assert persisted.revision == 22
+    assert len(receipts) == 20
+    assert all(item["operation_types"] == ["move_node"] for item in receipts)
+    assert sentinel not in receipt_json
+
+
+def test_attack_legacy_payload_cannot_expand_original_authorization_scope(
+    tmp_path: Path,
+):
+    service, authoring, proposal = _headless_fixture(
+        tmp_path,
+        all_resources=True,
+        exclude_plugin_from_scope=True,
+    )
+    malicious_payload = deepcopy(proposal.payload)
+    malicious_payload["meta_planner_report"]["authorized_scope"][
+        "plugin_ids"
+    ] = ["plugin-safe"]
+    tampered = authoring.update_pending(
+        proposal.proposal_id,
+        revision=proposal.revision,
+        payload=malicious_payload,
+    )
+
+    state = service.proposal_state(proposal.proposal_id)
+    assert state["authorized_scope"]["plugin_ids"] == []
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=tampered.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[
+            {
+                "op": "bind_resource",
+                "target_ref": "answerer",
+                "kind": "plugin_resource",
+                "resource_id": "plugin-safe",
+            }
+        ],
+    )
+
+    with pytest.raises(HeadlessAuthoringError, match="outside the Proposal"):
+        service.preview(proposal.proposal_id, patch)
+
+
+def test_attack_headless_apply_storage_failure_rolls_back_memory_and_disk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    state = service.proposal_state(proposal.proposal_id)
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=proposal.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[MoveNodeOperation(ref="answerer", x=630, y=330)],
+    )
+    preview = service.preview(proposal.proposal_id, patch)
+    store = authoring.proposal_store
+    before = store.require(proposal.proposal_id)
+    before_disk = store.snapshot_path.read_bytes()
+
+    def fail_save() -> None:
+        raise OSError("simulated storage failure")
+
+    monkeypatch.setattr(store, "_save_unlocked", fail_save)
+    with pytest.raises(
+        HeadlessAuthoringError, match="final validation failed"
+    ):
+        service.apply(
+            proposal.proposal_id,
+            GraphPatchApplyRequest(
+                patch=patch,
+                preview_checksum=preview["preview_checksum"],
+            ),
+        )
+
+    in_memory = store.require(proposal.proposal_id)
+    reloaded = AuthoringProposalStore(store.storage_dir).require(
+        proposal.proposal_id
+    )
+    assert in_memory.revision == before.revision
+    assert in_memory.payload == before.payload
+    assert reloaded.revision == before.revision
+    assert reloaded.payload == before.payload
+    assert store.snapshot_path.read_bytes() == before_disk
+
+
+def test_attack_tainted_legacy_receipts_are_recanonicalized_on_typed_apply(
+    tmp_path: Path,
+):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    sentinel = "sk-adversarial-legacy-receipt-123456"
+    malicious_payload = deepcopy(proposal.payload)
+    malicious_payload["meta_planner_report"]["authoring_patch_receipts"] = [
+        {
+            "operation_types": ["move_node"],
+            "before_graph_checksum": "a" * 64,
+            "after_graph_checksum": "b" * 64,
+            "before_candidate_checksum": "c" * 64,
+            "after_candidate_checksum": "d" * 64,
+            "diagnostic_counts": {"info": 1},
+            "applied_at": 1.0,
+            "prompt": sentinel,
+        }
+    ]
+    updated = authoring.update_pending(
+        proposal.proposal_id,
+        revision=proposal.revision,
+        payload=malicious_payload,
+    )
+    state = service.proposal_state(proposal.proposal_id)
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=updated.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[MoveNodeOperation(ref="answerer", x=640, y=340)],
+    )
+    preview = service.preview(proposal.proposal_id, patch)
+    service.apply(
+        proposal.proposal_id,
+        GraphPatchApplyRequest(
+            patch=patch,
+            preview_checksum=preview["preview_checksum"],
+        ),
+    )
+
+    persisted = authoring.proposal_store.require(proposal.proposal_id)
+    receipts = persisted.payload["meta_planner_report"][
+        "authoring_patch_receipts"
+    ]
+    safe_keys = {
+        "protocol_version",
+        "operation_types",
+        "before_graph_checksum",
+        "after_graph_checksum",
+        "before_candidate_checksum",
+        "after_candidate_checksum",
+        "diagnostic_counts",
+        "applied_at",
+    }
+    assert all(set(receipt) <= safe_keys for receipt in receipts)
+    assert sentinel not in json.dumps(receipts)
+
+
+def test_apply_rejects_target_xpert_drift_after_preview(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path, update_target=True)
+    state = service.proposal_state(proposal.proposal_id)
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=proposal.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[MoveNodeOperation(ref="answerer", x=540, y=320)],
+    )
+    preview = service.preview(proposal.proposal_id, patch)
+    target = authoring.xpert_store.get_xpert(proposal.target_id or "")
+    authoring.xpert_store.update_xpert(
+        target.id,
+        {"draft": target.draft.model_dump(mode="json")},
+    )
+
+    with pytest.raises(HeadlessAuthoringConflictError, match="Target Xpert"):
+        service.apply(
+            proposal.proposal_id,
+            GraphPatchApplyRequest(
+                patch=patch,
+                preview_checksum=preview["preview_checksum"],
+            ),
+        )
+    assert authoring.proposal_store.require(proposal.proposal_id).revision == 1
+
+
+def test_target_revision_guard_covers_final_validation_and_proposal_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    service, authoring, proposal = _headless_fixture(tmp_path, update_target=True)
+    state = service.proposal_state(proposal.proposal_id)
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=proposal.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[MoveNodeOperation(ref="answerer", x=545, y=325)],
+    )
+    preview = service.preview(proposal.proposal_id, patch)
+    original_validate = authoring._validate_payload
+    update_started = threading.Event()
+    update_finished = threading.Event()
+    update_thread: threading.Thread | None = None
+
+    def guarded_validate(candidate):
+        nonlocal update_thread
+        target = authoring.xpert_store.get_xpert(proposal.target_id or "")
+
+        def update_target() -> None:
+            update_started.set()
+            authoring.xpert_store.update_xpert(
+                target.id,
+                {"draft": target.draft.model_dump(mode="json")},
+            )
+            update_finished.set()
+
+        update_thread = threading.Thread(target=update_target)
+        update_thread.start()
+        assert update_started.wait(timeout=1)
+        assert not update_finished.wait(timeout=0.05)
+        return original_validate(candidate)
+
+    monkeypatch.setattr(authoring, "_validate_payload", guarded_validate)
+
+    result = service.apply(
+        proposal.proposal_id,
+        GraphPatchApplyRequest(
+            patch=patch,
+            preview_checksum=preview["preview_checksum"],
+        ),
+    )
+    assert update_thread is not None
+    update_thread.join(timeout=2)
+
+    assert result["proposal_revision"] == 2
+    assert update_finished.is_set()
+    assert authoring.proposal_store.require(proposal.proposal_id).revision == 2
+
+
+def test_apply_rejects_resource_version_drift_after_preview(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path, with_toolset=True)
+    state = service.proposal_state(proposal.proposal_id)
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=proposal.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[MoveNodeOperation(ref="answerer", x=560, y=340)],
+    )
+    preview = service.preview(proposal.proposal_id, patch)
+    service.capability_snapshot_builder = lambda: _snapshot(toolset_version=3)
+
+    with pytest.raises(HeadlessAuthoringError) as error:
+        service.apply(
+            proposal.proposal_id,
+            GraphPatchApplyRequest(
+                patch=patch,
+                preview_checksum=preview["preview_checksum"],
+            ),
+        )
+    assert error.value.code == "headless_contract_or_resource_drift"
+    assert authoring.proposal_store.require(proposal.proposal_id).revision == 1
+
+
+def test_editor_diff_rejects_forged_binding_handle(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path, with_toolset=True)
+    state = service.proposal_state(proposal.proposal_id)
+    definition = deepcopy(state["candidate"]["draft"]["workflow"])
+    binding = next(
+        edge for edge in definition["edges"] if edge.get("targetHandle") == "toolset"
+    )
+    binding["targetHandle"] = "forged"
+
+    with pytest.raises(HeadlessAuthoringError) as error:
+        service.editor_diff(
+            proposal.proposal_id,
+            GraphPatchEditorDiffRequest(
+                proposal_revision=proposal.revision,
+                definition=definition,
+            ),
+        )
+    assert error.value.code == "headless_editor_diff_unrepresentable"
+    assert authoring.proposal_store.require(proposal.proposal_id).revision == 1
+
+
+def test_editor_diff_rejects_unexpressible_compiler_managed_edit(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    state = service.proposal_state(proposal.proposal_id)
+    definition = deepcopy(state["candidate"]["draft"]["workflow"])
+    input_node = next(node for node in definition["nodes"] if node["id"] == "input")
+    input_node["data"]["variableName"] = "forged_input"
+
+    with pytest.raises(HeadlessAuthoringError) as error:
+        service.editor_diff(
+            proposal.proposal_id,
+            GraphPatchEditorDiffRequest(
+                proposal_revision=proposal.revision,
+                definition=definition,
+            ),
+        )
+    assert error.value.code == "headless_editor_diff_unrepresentable"
+    assert "unexpressible" in str(error.value)
+    assert authoring.proposal_store.require(proposal.proposal_id).revision == 1
+
+
+def test_headless_authoring_routes_preserve_conflict_error_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    monkeypatch.setattr(
+        main_module,
+        "get_headless_authoring_service",
+        lambda: service,
+    )
+    client = TestClient(main_module.app)
+    state_response = client.get(
+        f"/api/meta-agent/authoring/proposals/{proposal.proposal_id}"
+    )
+    assert state_response.status_code == 200
+    state = state_response.json()
+    patch = {
+        "protocol_version": 1,
+        "proposal_revision": proposal.revision,
+        "expected_graph_checksum": state["graph_checksum"],
+        "expected_candidate_checksum": state["candidate_checksum"],
+        "operations": [
+            {"op": "move_node", "ref": "answerer", "x": 620, "y": 360}
+        ],
+    }
+    preview_response = client.post(
+        f"/api/meta-agent/authoring/proposals/{proposal.proposal_id}/patch/preview",
+        json=patch,
+    )
+    assert preview_response.status_code == 200
+    authoring.update_pending(
+        proposal.proposal_id,
+        revision=proposal.revision,
+        title="Concurrent editor",
+    )
+    apply_response = client.post(
+        f"/api/meta-agent/authoring/proposals/{proposal.proposal_id}/patch/apply",
+        json={
+            "patch": patch,
+            "preview_checksum": preview_response.json()["preview_checksum"],
+        },
+    )
+
+    assert apply_response.status_code == 409
+    assert apply_response.json()["detail"]["code"] == "headless_authoring_conflict"
+
+
+def test_headless_authoring_route_validation_does_not_echo_secret_input(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    service, _, proposal = _headless_fixture(tmp_path)
+    monkeypatch.setattr(
+        main_module,
+        "get_headless_authoring_service",
+        lambda: service,
+    )
+    client = TestClient(main_module.app)
+    secret = "sk-super-secret-value"
+
+    response = client.post(
+        f"/api/meta-agent/authoring/proposals/{proposal.proposal_id}/patch/preview",
+        json={
+            "protocol_version": 1,
+            "proposal_revision": proposal.revision,
+            "expected_graph_checksum": "a" * 64,
+            "expected_candidate_checksum": "b" * 64,
+            "operations": [
+                {
+                    "op": "move_node",
+                    "ref": "answerer",
+                    "x": 100,
+                    "y": 200,
+                    "api_key": secret,
+                }
+            ],
+        },
+    )
+
+    body = response.text
+    assert response.status_code == 422
+    assert secret not in body
+    assert "input_value" not in body
+
+    non_object = client.post(
+        f"/api/meta-agent/authoring/proposals/{proposal.proposal_id}/patch/preview",
+        json=[secret],
+    )
+    assert non_object.status_code == 422
+    assert secret not in non_object.text
+    assert "input_value" not in non_object.text
+
+    malformed = client.post(
+        f"/api/meta-agent/authoring/proposals/{proposal.proposal_id}/patch/preview",
+        content=f'{{"api_key":"{secret}"',
+        headers={"Content-Type": "application/json"},
+    )
+    assert malformed.status_code == 422
+    assert secret not in malformed.text
+
+
+def test_attack_headless_route_rejects_oversized_json_before_service(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    service_called = False
+
+    def forbidden_service():
+        nonlocal service_called
+        service_called = True
+        raise AssertionError("oversized input reached the authoring service")
+
+    monkeypatch.setattr(
+        main_module,
+        "get_headless_authoring_service",
+        forbidden_service,
+    )
+    client = TestClient(main_module.app, raise_server_exceptions=False)
+    body = json.dumps(
+        {"padding": "x" * (2 * 1024 * 1024)},
+        separators=(",", ":"),
+    )
+
+    response = client.post(
+        "/api/meta-agent/authoring/proposals/proposal-attack/patch/preview",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"]["code"] == "headless_request_too_large"
+    assert service_called is False
+
+
+def test_attack_headless_route_rejects_excessive_json_depth_before_service(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    service_called = False
+
+    def forbidden_service():
+        nonlocal service_called
+        service_called = True
+        raise AssertionError("deep input reached the authoring service")
+
+    monkeypatch.setattr(
+        main_module,
+        "get_headless_authoring_service",
+        forbidden_service,
+    )
+    nested: dict[str, object] = {"leaf": "safe"}
+    for _ in range(40):
+        nested = {"nested": nested}
+    payload = {
+        "protocol_version": 1,
+        "proposal_revision": 1,
+        "expected_graph_checksum": "a" * 64,
+        "expected_candidate_checksum": "b" * 64,
+        "operations": [
+            {
+                "op": "bind_middleware",
+                "target_ref": "answerer",
+                "middleware_id": "structured_output",
+                "config": {"schema_json": nested},
+            }
+        ],
+    }
+    client = TestClient(main_module.app, raise_server_exceptions=False)
+
+    response = client.post(
+        "/api/meta-agent/authoring/proposals/proposal-attack/patch/preview",
+        json=payload,
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "headless_request_too_deep"
+    assert service_called is False

--- a/server/tests/test_meta_planner_v2.py
+++ b/server/tests/test_meta_planner_v2.py
@@ -478,7 +478,9 @@ def test_capability_api_returns_stable_safe_contract():
     response = client.get("/api/meta-agent/capabilities")
     assert response.status_code == 200
     payload = response.json()
-    assert payload["version"] == "evoagentx-meta-planner-capabilities-v4"
+    assert payload["version"] == "evoagentx-meta-planner-capabilities-v5"
+    assert payload["authoring_protocol_version"] == 1
+    assert payload["authoring_limits"]["max_operations"] == 64
     assert payload["ir_version"] == 3
     assert payload["supported_ir_versions"] == [2, 3]
     assert payload["contract_version"] == 3
@@ -798,6 +800,71 @@ async def test_generation_persists_proposal_and_uses_at_most_one_repair(
     created = xpert_store.get_xpert(approved.applied_resource_id or "")
     assert created.published_version is None
     assert created.status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_parseable_v3_repair_uses_one_typed_graph_patch(tmp_path: Path):
+    proposal_store = AuthoringProposalStore(tmp_path / "runtime")
+    xpert_store = XpertStore(tmp_path / "xperts")
+    authoring = AuthoringService(
+        proposal_store,
+        xpert_store,
+        WorkspaceSkillDraftStore(tmp_path / "skills"),
+        xpert_preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+    )
+    graph_intent, _ = v2_to_graph_intent(_typed_blueprint())
+    assert graph_intent is not None
+    invalid = graph_intent.model_copy(deep=True)
+    invalid.final_output.variable = "missing_output"
+    calls: list[dict[str, object]] = []
+
+    async def complete(model_id, system_prompt, user_prompt, temperature, max_tokens):
+        calls.append(
+            {
+                "system_prompt": system_prompt,
+                "temperature": temperature,
+            }
+        )
+        if len(calls) == 1:
+            return _plan().model_dump_json()
+        if len(calls) == 2:
+            return invalid.model_dump_json()
+        prompt = json.loads(user_prompt)
+        return json.dumps(
+            {
+                **prompt["required_envelope"],
+                "operations": [
+                    {
+                        "op": "set_final_output",
+                        "node_ref": graph_intent.final_output.node_ref,
+                        "port": "result",
+                    }
+                ],
+            }
+        )
+
+    service = MetaPlannerV2Service(
+        authoring_service=authoring,
+        preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+        completion=complete,
+    )
+    response = await service.generate(_request(), _snapshot())
+
+    assert len(calls) == 3
+    assert "GraphPatchEnvelopeV1" in str(calls[-1]["system_prompt"])
+    assert calls[-1]["temperature"] == 0
+    assert response.repair_used is True
+    assert response.validation["valid"] is True
+    proposal = proposal_store.require(response.proposal_id)
+    assert proposal.payload["meta_planner_report"]["repair_protocol"] == "graph_patch_v1"
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_meta_planner_v3_falsification.py
+++ b/server/tests/test_meta_planner_v3_falsification.py
@@ -24,6 +24,7 @@ from server.meta_agent.schemas import (
     GraphIntentOutputBindingV3,
     GraphIntentV3,
     MetaPlannerIRInputBinding,
+    MetaPlannerIRMiddlewareBinding,
     MetaPlannerIROutputBinding,
     MetaPlannerIRResourceBinding,
 )
@@ -411,6 +412,31 @@ def test_attack_allowed_middleware_field_rejects_embedded_secret_value():
     intent.middleware[0].config["system_prompt"] = (
         f"Use this credential {synthetic_secret} for requests."
     )
+
+    issues = validate_blueprint_authorization(
+        _request(), _plan(), intent, _snapshot()
+    )
+
+    assert any("credential material" in issue for issue in issues)
+
+
+@pytest.mark.parametrize("credential_key", ["clientSecret", "authToken"])
+def test_attack_json_middleware_rejects_nested_credential_aliases(
+    credential_key: str,
+):
+    intent = _intent().model_copy(deep=True)
+    intent.middleware = [
+        MetaPlannerIRMiddlewareBinding(
+            target_ref=intent.nodes[0].ref,
+            middleware_id="structured_output",
+            config={
+                "schema_json": {
+                    "type": "object",
+                    "extensions": {credential_key: "adversarial-sentinel"},
+                }
+            },
+        )
+    ]
 
     issues = validate_blueprint_authorization(
         _request(), _plan(), intent, _snapshot()

--- a/server/xpert_runtime/authoring_service.py
+++ b/server/xpert_runtime/authoring_service.py
@@ -5,6 +5,8 @@ import threading
 import time
 import uuid
 from collections.abc import Callable
+from contextlib import nullcontext
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -16,14 +18,18 @@ try:
         WorkspaceSkillDraftStore,
     )
     from server.xperts.models import XpertDefinition, XpertDraft
-    from server.xperts.store import XpertStore, default_xpert_workflow
+    from server.xperts.store import (
+        XpertConflictError,
+        XpertStore,
+        default_xpert_workflow,
+    )
     from server.xperts.validation import validate_xpert_definition
 except ModuleNotFoundError:
     from prompts.store import PromptProfileStore
     from skills.creator_quality import evaluate_creator_payload
     from skills.draft_store import SkillDraftValidationError, WorkspaceSkillDraftStore
     from xperts.models import XpertDefinition, XpertDraft
-    from xperts.store import XpertStore, default_xpert_workflow
+    from xperts.store import XpertConflictError, XpertStore, default_xpert_workflow
     from xperts.validation import validate_xpert_definition
 
 from .authoring_store import (
@@ -146,6 +152,79 @@ class AuthoringService:
                 payload=payload,
                 base_revision=base_revision,
             )
+
+    def apply_headless_authoring_payload(
+        self,
+        proposal_id: str,
+        *,
+        revision: int,
+        payload: dict[str, Any],
+        expected_target_id: str | None = None,
+        expected_target_revision: int | None = None,
+    ) -> AuthoringProposal:
+        """Validate a detached candidate, then persist one atomic Proposal revision."""
+
+        with self._apply_lock:
+            current_proposal = self.proposal_store.require(proposal_id)
+            if current_proposal.revision != revision:
+                raise AuthoringProposalConflictError(
+                    "Proposal changed. Reload it before applying the Graph Patch."
+                )
+            if current_proposal.status != "pending":
+                raise AuthoringProposalConflictError(
+                    f"Proposal is already {current_proposal.status}."
+                )
+            try:
+                target_guard = (
+                    self.xpert_store.revision_guard(
+                        expected_target_id, expected_target_revision
+                    )
+                    if expected_target_id
+                    else nullcontext()
+                )
+                with target_guard:
+                    detached = deepcopy(current_proposal)
+                    detached.payload = deepcopy(payload)
+                    details = self._validate_payload(detached)
+                    creator_quality = details.get("creator_quality")
+                    quality_ready = not isinstance(creator_quality, dict) or bool(
+                        creator_quality.get("ready")
+                    )
+                    validation = {
+                        "valid": quality_ready,
+                        "issues": (
+                            []
+                            if quality_ready
+                            else list(creator_quality.get("issues") or [])[:20]
+                        ),
+                        **details,
+                    }
+                    if not validation["valid"]:
+                        raise AuthoringProposalValidationError(
+                            "Headless authoring candidate did not pass final validation.",
+                            issues=list(validation.get("issues") or [])[:20],
+                        )
+                    return self.proposal_store.update_pending_from_headless_authoring(
+                        proposal_id,
+                        revision=revision,
+                        payload=payload,
+                        validation=validation,
+                        content_digest=details.get("content_digest"),
+                        base_digest=details.get("base_digest"),
+                    )
+            except XpertConflictError as exc:
+                raise AuthoringProposalConflictError(
+                    "Target Xpert draft changed after preview."
+                ) from exc
+            except (
+                AuthoringProposalConflictError,
+                AuthoringProposalValidationError,
+            ):
+                raise
+            except Exception as exc:
+                raise AuthoringProposalValidationError(
+                    "Headless authoring final validation failed."
+                ) from exc
 
     def approve(
         self,

--- a/server/xpert_runtime/authoring_store.py
+++ b/server/xpert_runtime/authoring_store.py
@@ -6,6 +6,7 @@ import os
 import threading
 import time
 import uuid
+from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -313,9 +314,62 @@ class AuthoringProposalStore:
         payload: dict[str, Any] | None = None,
         base_revision: int | None = None,
     ) -> AuthoringProposal:
+        return self._update_pending(
+            proposal_id,
+            revision=revision,
+            title=title,
+            payload=payload,
+            base_revision=base_revision,
+            preserve_meta_planner_ir=False,
+        )
+
+    def update_pending_from_headless_authoring(
+        self,
+        proposal_id: str,
+        *,
+        revision: int,
+        payload: dict[str, Any],
+        validation: dict[str, Any],
+        content_digest: str | None = None,
+        base_digest: str | None = None,
+    ) -> AuthoringProposal:
+        """Apply a server-validated Graph Patch without invalidating its IR."""
+
+        return self._update_pending(
+            proposal_id,
+            revision=revision,
+            payload=payload,
+            preserve_meta_planner_ir=True,
+            prevalidated_validation=validation,
+            content_digest=content_digest,
+            base_digest=base_digest,
+        )
+
+    def _update_pending(
+        self,
+        proposal_id: str,
+        *,
+        revision: int,
+        title: str | None = None,
+        payload: dict[str, Any] | None = None,
+        base_revision: int | None = None,
+        preserve_meta_planner_ir: bool,
+        prevalidated_validation: dict[str, Any] | None = None,
+        content_digest: str | None = None,
+        base_digest: str | None = None,
+    ) -> AuthoringProposal:
         with self._lock:
-            item = self._require_unlocked(proposal_id)
-            self._require_pending_revision(item, revision)
+            current = self._require_unlocked(proposal_id)
+            self._require_pending_revision(current, revision)
+            item = self._copy(current)
+            if preserve_meta_planner_ir:
+                if item.source_type != "meta_planner" or item.kind not in {
+                    "xpert_create",
+                    "xpert_update",
+                }:
+                    raise AuthoringProposalValidationError(
+                        "Headless authoring only accepts Meta Planner Xpert proposals."
+                    )
             if title is not None:
                 clean_title = str(title).strip()
                 if not clean_title or len(clean_title) > 200:
@@ -333,8 +387,26 @@ class AuthoringProposalStore:
                 item.title = clean_title
             if payload is not None:
                 next_payload = self._validate_payload(payload, kind=item.kind)
+                if item.source_type == "meta_planner" and item.kind in {
+                    "xpert_create",
+                    "xpert_update",
+                }:
+                    current_report = item.payload.get("meta_planner_report")
+                    next_report = next_payload.get("meta_planner_report")
+                    if isinstance(current_report, dict) and isinstance(
+                        next_report, dict
+                    ):
+                        original_scope = current_report.get("authorized_scope")
+                        if isinstance(original_scope, dict):
+                            next_report["authorized_scope"] = deepcopy(
+                                original_scope
+                            )
                 payload_changed = next_payload != item.payload
-                if item.source_type == "meta_planner" and payload_changed:
+                if (
+                    item.source_type == "meta_planner"
+                    and payload_changed
+                    and not preserve_meta_planner_ir
+                ):
                     report = next_payload.get("meta_planner_report")
                     if isinstance(report, dict):
                         report["human_modified"] = True
@@ -351,14 +423,25 @@ class AuthoringProposalStore:
                         "base_revision must be positive."
                     )
                 item.base_revision = base_revision
-            item.validation = {}
+            item.validation = dict(prevalidated_validation or {})
+            if content_digest is not None:
+                item.content_digest = self._optional_digest(
+                    content_digest, "content_digest"
+                )
+            if base_digest is not None:
+                item.base_digest = self._optional_digest(base_digest, "base_digest")
             item.error = None
             item.revision += 1
             item.apply_key = f"apply_{uuid.uuid4().hex}"
             item.applied_apply_key = None
             item.applied_from_revision = None
             item.updated_at = time.time()
-            self._save_unlocked()
+            self._items[proposal_id] = item
+            try:
+                self._save_unlocked()
+            except Exception:
+                self._items[proposal_id] = current
+                raise
             return self._copy(item)
 
     def set_validation(

--- a/server/xperts/store.py
+++ b/server/xperts/store.py
@@ -7,6 +7,8 @@ import re
 import threading
 import time
 import uuid
+from contextlib import contextmanager
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -150,6 +152,20 @@ class XpertStore:
         with self._lock:
             item = self._find_unlocked(self._read_unlocked(), xpert_id)
             return item.model_copy(deep=True)
+
+    @contextmanager
+    def revision_guard(
+        self, xpert_id: str, expected_revision: int | None
+    ) -> Iterator[XpertDefinition]:
+        """Keep a target draft revision stable across a dependent atomic write."""
+
+        with self._lock:
+            item = self._find_unlocked(self._read_unlocked(), xpert_id)
+            if item.draft_revision != expected_revision:
+                raise XpertConflictError(
+                    "Xpert draft changed during the guarded operation."
+                )
+            yield item.model_copy(deep=True)
 
     def resolve_xpert(self, reference: str) -> XpertDefinition:
         """Resolve an Xpert by stable id first, then by its unique slug."""


### PR DESCRIPTION
## 概要

- 新增 GraphPatchEnvelopeV1 与 Adapter authoring SDK，使用语义 ref、命名端口和类型化操作编辑 Graph IR V3。
- 新增无副作用 Proposal 状态、editor diff、Patch preview/apply API，并以 revision、Graph/candidate checksum 和 preview checksum 阻断 TOCTOU。
- Meta Planner 编辑器改为变更预览后确认应用；仍只更新 pending Proposal，不创建草稿、版本或运行。
- 固化原始授权范围、资源版本解析、Store 落盘回滚、受限 Patch receipt、2 MiB 请求体和 32 层 JSON 深度护栏。
- Capability Snapshot 仍只开放原有七类能力；Runner、Workflow SSE、发布和审批语义不变。

## 严格证伪

- 红测后修复：旧整包 payload 扩张授权范围。
- 红测后修复：Store 保存失败导致内存半提交。
- 红测后修复：历史 receipt 污染字段传播。
- 红测后修复：clientSecret/authToken 绕过敏感键检测。
- 红测后修复：请求体大小和 JSON 嵌套深度无界。

## 验证

- Headless Authoring + Graph IR V3 证伪矩阵：72 passed。
- Meta Planner、Authoring、Publish、Evolution 受影响回归：93 passed。
- 变基后前端关键测试：40 passed。
- 完整前端：127 files / 830 tests passed；Node headers 1 passed。
- npm.cmd run build：通过，仅保留既有 chunk-size warning。
- 修改后端文件 py_compile、git diff --check、敏感信息扫描：通过。

## 已知基线边界

- Windows 全量 server/tests/ 被两个未修改模块的可复现基线问题阻断：agent_upstream 子进程关闭竞态，以及 coding_applier 使用 Windows 不支持的 os.fchmod。相关文件与 origin/main 无差异，本 PR 的定向与受影响回归均通过。
- 真实额度 UI 冒烟未执行：本地预览页的自动浏览器控制在模型请求前被安全策略阻断，因此未消耗额度。

## 回退

- 回退该提交即可恢复旧 Meta Planner 保存入口；现有 Proposal、XpertVersion、Workflow schema 与运行数据无需迁移。