### PR TITLE
docs: 修正 GoGraph 版本与构建状态说明

### DIFF
--- a/docs/MCP_CATALOG_EXPANSION_REVIEW.md
+++ b/docs/MCP_CATALOG_EXPANSION_REVIEW.md
@@ -5,6 +5,12 @@
 > 100 项已经逐项归入 `ready`、`planned` 或 `blocked`。只有通过固定工具、隔离和代表调用门槛的条目可执行。
 > 非 ready 条目不包含命令、端点、凭据槽、工具策略或功能开关绕过路径。
 
+> **2026-08-31 更正：**本表保留审查与历史晋级快照，不等同于当前供应链可用性。
+> 第 94 项 GoGraph v1.5.6 的 tag/commit 仍存在，但 GitHub Release 对象与 Linux 发布资产已删除；
+> 当前 Dockerfile 冷构建返回 404。该行的 `ready` 只表示既有镜像曾通过验收，不是要求成员
+> 获取 v1.5.6 的现行规范，也不得作为新部署可重建证据。恢复门槛见
+> [MCP 第 20 批代码索引](./MCP_WAVE20_CODE_INDEX.md)。
+
 ## 固定来源
 
 - `awesome-mcp-zh`：`b29e114d95fa26338b092423fd1ede1e5598e4df`，README SHA-256 `854802528cb508a6f6d00e2d142b57a44bc5393bfd4321ddd96e1e9a2b10b51a`
@@ -121,7 +127,7 @@
 | 91 | `g0t4-mcp-server-commands` | [g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands) | 开发与代码 | 232 | MIT | blocked | `blocked-arbitrary-command-or-code-execution` |
 | 92 | `keboola-keboola-mcp-server` | [keboola/mcp-server](https://github.com/keboola/mcp-server) | 数据分析 | 84 | MIT | planned | `planned-real-account-readonly-preflight-required` |
 | 93 | `line-line-bot-mcp-server` | [line/line-bot-mcp-server](https://github.com/line/line-bot-mcp-server) | 通讯与协作 | 756 | Apache-2.0 | blocked | `blocked-broad-account-or-message-write` |
-| 94 | `ozgurcd-gograph` | [ozgurcd/gograph](https://github.com/ozgurcd/gograph) | 开发与代码 | 209 | MIT | ready | `ready-isolated-code-index-facade` |
+| 94 | `ozgurcd-gograph` | [ozgurcd/gograph](https://github.com/ozgurcd/gograph) | 开发与代码 | 209 | MIT | ready（历史快照；当前冷构建 blocked） | `ready-isolated-code-index-facade`；当前供应链状态见更正说明 |
 | 95 | `patdolitse-piia-engram` | [Patdolitse/piia-engram](https://github.com/Patdolitse/piia-engram) | 知识与记忆 | 169 | AGPL-3.0 | planned | `planned-wave21-stateful-foundation-required` |
 | 96 | `taisly-agent` | [taisly/agent](https://github.com/taisly/agent) | 社交与内容 | 264 | MIT | blocked | `blocked-social-publishing-or-session-reuse` |
 | 97 | `zinja-coder-jadx-ai-mcp` | [zinja-coder/jadx-ai-mcp](https://github.com/zinja-coder/jadx-ai-mcp) | 安全分析 | 2621 | Apache-2.0 | blocked | `blocked-desktop-host-instance-unverified` |

--- a/docs/MCP_CATALOG_ROADMAP.md
+++ b/docs/MCP_CATALOG_ROADMAP.md
@@ -1,6 +1,6 @@
 # MCP 目录扩充与适配路线
 
-最后更新日期：2026-08-13
+最后更新日期：2026-08-31
 维护人：模镜团队
 
 ## 1. 目标与当前范围
@@ -33,7 +33,7 @@ Wave 28—31 的实现、真实验收、许可证阻断与回退边界见 [Wave 
 
 批次 19B 的 Milvus、Neo4j 与 ArcadeDB 已完成固定原生只读 facade，并在 Wave 23 最新主线基线重新通过真实隔离验收：绑定 database/collection、原生只读账号、查询语法门禁、Schema、代表调用、429、超时、拒写、重启和清理均已验证。用户已明确批准三项晋级 `ready` 并加入生产数据库精确 allowlist，详见 [19B 图与向量数据库](./MCP_WAVE19B_GRAPH_VECTOR_SERVICES.md)。
 
-批次 20 选择 GoGraph v1.5.6 作为唯一实现：仅接受封存 Go 工作区、构建 session 内存索引并开放六个固定结构读取工具；Codebase Memory 因无法在不放宽 Landlock 根目录遍历的前提下启动，CodeGraphContext 因多数据库和宽控制面，均转为 superseded blocked。GoGraph 已通过真实断网镜像、隔离 UDS 与用户验收并进入精确默认 allowlist，详见 [20 代码索引](./MCP_WAVE20_CODE_INDEX.md)。
+批次 20 曾以 GoGraph v1.5.6 作为唯一实现：仅接受封存 Go 工作区、构建 session 内存索引并开放六个固定结构读取工具；Codebase Memory 与 CodeGraphContext 转为 superseded blocked。v1.5.6 的既有镜像在 2026-08-11 通过真实断网镜像、隔离 UDS 与用户验收并进入精确默认 allowlist，但该版本的上游 GitHub Release 资产现已删除，当前 Dockerfile 的冷构建会返回 404。v1.5.6 仅是历史验收快照，不是现行版本要求；恢复同摘要内部制品或选择现行版本完成全套复验前，不得把该条目描述为当前可重建 `ready`。详见 [20 代码索引](./MCP_WAVE20_CODE_INDEX.md)。
 
 批次 21 的七个状态化资源与批次 22 的多租户/OAuth 恢复组只完成归组和退出门槛，不新增运行时；详见 [21—22 暂缓实现收口](./MCP_WAVE21_22_DEFERRED.md)。
 
@@ -135,7 +135,7 @@ Wave 26A 仅晋级断网 Calculator，ImageSorcery 继续 planned；Wave 26B 为
 | 18B | 受控文件分析 | 3 | **已实现并验收**：llm-context、Excel MCP、Dingo；Excel 仅输出副本并拒绝宏/外链，Dingo 仅固定规则；[边界与验收](./MCP_WAVE18B_FILE_ANALYSIS.md) |
 | 19A | 只读数据服务 | 3 | **已实现并验收**：Prometheus、Qdrant、Elasticsearch 固定资源、原生只读账号与查询上限；[边界与验收](./MCP_WAVE19A_DATA_SERVICES.md) |
 | 19B / 23A | 图与向量数据库 | 3 | **已晋级 ready**：Milvus、Neo4j、ArcadeDB 在最新基线完成真实复验并进入精确数据库 allowlist；[验收证据](./MCP_WAVE19B_GRAPH_VECTOR_SERVICES.md) |
-| 20 | 代码索引收敛 | 3 | **已实现并验收**：GoGraph v1.5.6 仅索引封存 Go 工作区并开放六个固定结构读取工具；Codebase Memory 与 CodeGraphContext 转为 superseded blocked；[边界与验收](./MCP_WAVE20_CODE_INDEX.md) |
+| 20 | 代码索引收敛 | 3 | **历史验收完成，当前冷构建受阻**：GoGraph v1.5.6 既有镜像仅索引封存 Go 工作区并开放六个固定结构读取工具；上游 Release 资产删除后不得将 v1.5.6 当作现行要求或可重建证据；Codebase Memory 与 CodeGraphContext 保持 superseded blocked；[边界、历史证据与恢复门槛](./MCP_WAVE20_CODE_INDEX.md) |
 | 21 | 状态化资源 | 7 | **暂缓**：等待项目级持久卷、所有权、配额、保留/导出/删除、模型费用和写入审批基础；[恢复条件](./MCP_WAVE21_22_DEFERRED.md) |
 | 22 | 多租户与 OAuth | 17 | **暂缓**：等待不可伪造主体、租户隔离、PKCE/state、刷新/撤销/解绑和最小只读 Scope；写入与管理工具继续 blocked；[恢复条件](./MCP_WAVE21_22_DEFERRED.md) |
 

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -1,6 +1,6 @@
 # MCP 原生集成说明
 
-最后更新日期：2026-08-06
+最后更新日期：2026-08-31
 维护人：模镜团队
 
 ## 0. 产品入口与预算层级
@@ -94,7 +94,7 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 - 批次 18B 已在同一断网文件 sidecar 中冻结 llm-context、Excel MCP 与 Dingo 的受控兼容层，并通过 staged 镜像与用户验收；三项已晋级 ready，生产文件 allowlist 仅增加这三个精确 ID。固定输入、输出副本与规则模式边界见 [18B 受控文件分析](./MCP_WAVE18B_FILE_ANALYSIS.md)。
 - 批次 19A 已在 `mcp-database` 中冻结 Prometheus、Qdrant 与 Elasticsearch 的原生只读兼容层，并通过真实服务、原生只读凭据、429、超时、拒写、清理与用户验收；三项已晋级 ready 并加入精确数据库 allowlist。边界见 [19A 只读数据服务](./MCP_WAVE19A_DATA_SERVICES.md)。
 - 批次 19B 已在同一 sidecar 中完成 Milvus、Neo4j 与 ArcadeDB 的固定原生只读 facade，并在 Wave 23 最新主线基线重新通过真实服务、原生只读账号、代表调用、429、超时、拒写、重启与清理验收。用户已明确批准三项晋级 `ready` 并进入生产数据库精确 allowlist；边界见 [19B 图与向量数据库](./MCP_WAVE19B_GRAPH_VECTOR_SERVICES.md)。
-- 批次 20 按 Codebase Memory → CodeGraphContext → GoGraph 顺序复审，只实现 GoGraph v1.5.6 的封存 Go 仓库、一次性内存索引和六工具 facade；另外两项转为 superseded blocked。GoGraph 已通过真实断网镜像、隔离 UDS 与用户验收并进入精确默认 allowlist，边界见 [20 代码索引](./MCP_WAVE20_CODE_INDEX.md)。
+- 批次 20 按 Codebase Memory → CodeGraphContext → GoGraph 顺序复审，历史实现固定为 GoGraph v1.5.6 的封存 Go 仓库、一次性内存索引和六工具 facade；另外两项转为 superseded blocked。该 v1.5.6 镜像在 2026-08-11 通过真实断网镜像、隔离 UDS 与用户验收，但上游 Release 资产截至 2026-08-31 已不可用，当前 Dockerfile 冷构建返回 404。目录和 allowlist 中的 `ready` 是遗留运行时元数据，不代表当前可重建；v1.5.6 不是现行版本要求，恢复供应链并重新验收前不得用于新部署交付声明。边界、历史证据与恢复门槛见 [20 代码索引](./MCP_WAVE20_CODE_INDEX.md)。
 - 批次 21—22 暂缓实现：状态化资源等待持久化、所有权、配额、保留/删除和写入审批基础；多租户/OAuth 等待不可伪造主体、租户隔离、PKCE/state、刷新/撤销/解绑和最小只读 Scope。当前没有运行时或真实凭据，恢复条件见 [21—22 暂缓实现收口](./MCP_WAVE21_22_DEFERRED.md)。
 - Wave 25A 已为 DexPaprika、Chess 与 AniList 冻结匿名公共读取兼容层，完成隔离双轮与用户验收，并只把三个精确 ID 加入生产 allowlist；MCP-NixOS 已 blocked。固定身份、Schema、真实调用和回退边界见 [Wave 25A 匿名公共读取](./MCP_WAVE25A_ANONYMOUS_PUBLIC_READ.md)。
 - 批次 16A/16B 的冻结身份、Schema、真实调用和回退证据分别见 [16A 匿名公共读取](./MCP_WAVE16A_PUBLIC_READ.md) 与 [16B 研究与安全公共读取](./MCP_WAVE16B_RESEARCH_SECURITY.md)。

--- a/docs/MCP_WAVE20_CODE_INDEX.md
+++ b/docs/MCP_WAVE20_CODE_INDEX.md
@@ -3,28 +3,46 @@
 ## 当前结论
 
 本批按 Codebase Memory → CodeGraphContext → GoGraph 顺序复审，只保留一个候选运行时。
-`ozgurcd-gograph` 已作为现有 `mcp-files` sidecar 内的固定 facade 完成真实隔离验收与用户验收，
-现已晋级 `ready` 并加入文件 sidecar 的精确默认 allowlist。另两个实现转为
-`blocked/superseded`，不进入镜像。
+GoGraph v1.5.6 曾于 2026-08-11 作为现有 `mcp-files` sidecar 内的固定 facade 完成真实隔离
+验收与用户验收，并据此晋级 `ready`、加入文件 sidecar 的精确默认 allowlist；这是历史
+验收快照，不是要求成员继续获取或使用 v1.5.6 的现行版本规范。
+
+截至 2026-08-31，上游 `v1.5.6` tag 与提交
+`aa4d6d549e64f35c492664263630ba1350c66920` 仍存在，但 GitHub Release 对象及两个受支持
+Linux 架构的发布资产均已不可用，精确下载 URL 返回 HTTP 404。当前
+`server/sandbox_sidecar/Dockerfile.files` 仍直接下载这些资产，因此全新构建会在
+`gograph-fetch` 阶段失败。目录和 allowlist 中遗留的 `ready` 只反映既有运行时元数据，
+不得作为当前可重建、可交付或供应链健康的证据。另两个实现仍为 `blocked/superseded`。
 
 | 目录 ID | 固定上游 | 状态 | 结论 |
 |---|---|---|---|
 | `deusdata-codebase-memory-mcp` | v0.10.1 / `564d32cc87d520afd1b007babdbe71a89d3ea119` / MIT | blocked | 一次性 CLI 仍强制在 `/tmp` 建立进程协调树；在不授予 Landlock 根目录遍历的前提下无法启动 |
 | `shashankss1205-codegraphcontext` | v0.5.7 / `0ae10a15885038aec4413769c1a283e8fb4642da` / MIT | blocked | 必装多种图数据库、Watcher 与宽管理面，无法在本批保持小型固定产品身份 |
-| `ozgurcd-gograph` | v1.5.6 / `aa4d6d549e64f35c492664263630ba1350c66920` / MIT | ready | Go 专用、一次性内存索引、六个固定分析工具；真实隔离与用户验收通过 |
+| `ozgurcd-gograph` | 历史验收：v1.5.6 / `aa4d6d549e64f35c492664263630ba1350c66920` / MIT | 历史 `ready`；当前冷构建 blocked | Go 专用、一次性内存索引、六个固定分析工具；既有镜像通过历史验收，但上游发布资产已不可用 |
 
 Codebase Memory 的直接断网原型能够解析固定 Go fixture，但在真实 UDS + Landlock
 边界下因上游不可关闭的 `/tmp/cbm-daemon-UID` 协调机制失败。放行 `/` 的递归目录读取会
 暴露同一挂载中的其他工作区名称，因此没有以削弱隔离换取兼容。
 
-## 固定供应链与工具
+## 历史固定供应链与当前恢复门槛
 
-GoGraph 使用官方 v1.5.6 原生发布包：
+2026-08-11 的验收镜像使用过官方 v1.5.6 原生发布包；下列摘要是历史制品身份，
+不表示该发布包当前仍可下载：
 
 - linux-amd64 SHA-256：
   `1ef375a88cc8825ca7879b1170720352702e59723d1e3b06d33101a50a6f7030`；
 - linux-arm64 SHA-256：
   `c8b6d8a42326264858f14c7819200f47d00d0fcd58520b6c6d1e1b16b022a6b5`。
+
+恢复冷构建只能选择以下一种路径，并形成新的供应链收据：
+
+1. 从受信内部制品库恢复与上述摘要完全一致的 v1.5.6 归档；不得从未知镜像替代。
+2. 选择仍有官方发布资产的现行版本，重新固定 commit、双架构 SHA-256、许可证、Go
+   工具链、上游 Schema 与公开 Schema，并重跑多架构构建、隔离 runtime smoke 和用户验收。
+
+截至 2026-08-31，上游最新 Release 为 v1.6.8；该事实不构成升级批准或新的规范版本。
+只修改 `GOGRAPH_VERSION`、绕过摘要/Schema 校验或继续依赖可删除的外部 Release 资产均不
+满足恢复门槛。
 
 镜像同时固定 Go 1.26.5 工具链，官方多架构镜像摘要为
 `sha256:53eeac89074db483fdf0ab3be1df32bf6e47562263d2d0d6baa7f26acb4957dd`。
@@ -60,7 +78,7 @@ ModelMirror 公开六工具 Schema digest 为
 - 上游身份、六个子集 Schema、输出大小、绝对路径和未知响应全部 fail closed；公开结果
   上限 240 KiB。
 
-## 真实验收证据
+## 历史真实验收证据（2026-08-11）
 
 构建镜像：`modelmirror-mcp-files:wave20-gograph-staged`；本次 manifest list 为
 `sha256:44a118617ef8ee6fa26dfd01afb09d857a96a659c7628e3a30df2cd47c25668a`，
@@ -86,8 +104,10 @@ wave20_code_index_runtime_smoke=ok network=none source_immutable=true rounds=2 t
 
 ## 晋级与回退
 
-当前目录为 `68 ready / 31 planned / 101 blocked`；扩充 100 项为
-`23 ready / 17 planned / 60 blocked`。Compose 默认文件 allowlist 只增加 `ozgurcd-gograph`。
+历史晋级时目录为 `68 ready / 31 planned / 101 blocked`；扩充 100 项为
+`23 ready / 17 planned / 60 blocked`。当前提交中的目录元数据与 Compose 默认文件 allowlist
+仍包含 `ozgurcd-gograph`，但这些计数和配置不证明冷构建可用；在供应链恢复并重新验收前，
+不得对新部署宣称 GoGraph `ready`。
 
 Codebase Memory 与 CodeGraphContext 保持 blocked。回退只需从默认 allowlist 移除
 `ozgurcd-gograph`、恢复 planned 并断开相关目录会话；本批没有数据迁移或持久索引。

--- a/scripts/mcp_catalog_integrate_approved.py
+++ b/scripts/mcp_catalog_integrate_approved.py
@@ -25,6 +25,13 @@ BACKEND_PATH = ROOT / "server" / "mcp" / "catalog_expansion_v2.py"
 
 SNAPSHOT_DATE = "2026-08-09"
 WAVE = 13
+GOGRAPH_SUPPLY_CHAIN_CORRECTION = (
+    "> **2026-08-31 更正：**本表保留审查与历史晋级快照，不等同于当前供应链可用性。",
+    "> 第 94 项 GoGraph v1.5.6 的 tag/commit 仍存在，但 GitHub Release 对象与 Linux 发布资产已删除；",
+    "> 当前 Dockerfile 冷构建返回 404。该行的 `ready` 只表示既有镜像曾通过验收，不是要求成员",
+    "> 获取 v1.5.6 的现行规范，也不得作为新部署可重建证据。恢复门槛见",
+    "> [MCP 第 20 批代码索引](./MCP_WAVE20_CODE_INDEX.md)。",
+)
 
 READY_DECISIONS = {
     "brave-brave-search-mcp-server": {
@@ -1306,6 +1313,8 @@ def render_report(payload: dict[str, Any]) -> str:
         "> 100 项已经逐项归入 `ready`、`planned` 或 `blocked`。只有通过固定工具、隔离和代表调用门槛的条目可执行。",
         "> 非 ready 条目不包含命令、端点、凭据槽、工具策略或功能开关绕过路径。",
         "",
+        *GOGRAPH_SUPPLY_CHAIN_CORRECTION,
+        "",
         "## 固定来源",
         "",
     ]
@@ -1339,11 +1348,15 @@ def render_report(payload: dict[str, Any]) -> str:
     for item in payload["candidates"]:
         github = item["github"]
         license_spdx = github["licenseInfo"]["spdxId"]
+        availability = item["proposed_availability"]
+        reason = f"`{item['decision_reason_code']}`"
+        if item["catalog_id"] == "ozgurcd-gograph":
+            availability = "ready（历史快照；当前冷构建 blocked）"
+            reason += "；当前供应链状态见更正说明"
         lines.append(
             f"| {item['rank']} | `{item['catalog_id']}` | "
             f"[{github['nameWithOwner']}]({github['url']}) | {item['category']} | "
-            f"{github['stargazerCount']} | {license_spdx} | {item['proposed_availability']} | "
-            f"`{item['decision_reason_code']}` |"
+            f"{github['stargazerCount']} | {license_spdx} | {availability} | {reason} |"
         )
     lines.extend(
         [


### PR DESCRIPTION
## Summary

- correct the Wave 20 documentation so GoGraph v1.5.6 is identified as a historical 2026-08-11 acceptance snapshot, not a current version requirement
- record that the upstream tag and commit remain available while the GitHub Release object and Linux assets are gone, which blocks cold Docker builds
- define the recovery gate: restore the exact trusted artifacts internally or select a current release and repeat the full supply-chain, schema, multi-architecture, isolation, and user acceptance checks
- persist the correction in the offline catalog report generator so regeneration does not restore the misleading wording

## Validation

- passed: `python scripts/mcp_catalog_integrate_approved.py --check`
- passed: `git diff --cached --check`
- passed: obsolete wording scan for the previous current-ready claims
- verified against upstream: v1.5.6 tag/commit exist; Release API and both pinned Linux asset URLs return 404; latest observed Release on 2026-08-31 is v1.6.8
- not run: `server/tests/test_mcp_catalog_expansion_review.py` because the available isolated Python runtime does not include pytest; no dependency installation was performed for this documentation-only change

## Scope and remaining risk

This PR does not change the Dockerfile, runtime adapter, catalog availability, default allowlist, or deployed images. The implementation still pins v1.5.6 and cold builds remain blocked until a separately reviewed runtime fix is completed. Existing `ready` metadata is documented as historical evidence only.

## Help Center Impact

None. This corrects engineering and supply-chain documentation; it does not change a user-visible workflow, UI contract, help-center procedure, or screenshot.

## Rollback

Revert commit `2080e2a0` to restore the previous documentation and generated report wording.
