### PR TITLE
feature: 开放 Meta Planner 无副作用类型化纯节点

### DIFF
--- a/client/src/components/meta/MetaPlannerV2.test.tsx
+++ b/client/src/components/meta/MetaPlannerV2.test.tsx
@@ -41,6 +41,73 @@ describe("Meta Planner managed compatibility", () => {
     });
   });
 
+  it("shows pure Planner nodes as auxiliary capabilities without exposing deferred nodes", async () => {
+    const jsonResponse = (body: unknown) =>
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/meta-agent/capabilities") {
+          return jsonResponse({
+            version: "evoagentx-meta-planner-capabilities-v6",
+            ir_version: 3,
+            supported_ir_versions: [2, 3],
+            snapshot_hash: "snapshot-hash",
+            generated_at: 1,
+            nodes: [
+              {
+                kind: "workflow_agent",
+                title: "工作流智能体",
+                planner: { task_binding: "required" },
+              },
+              {
+                kind: "json_serialize",
+                title: "JSON 序列化",
+                planner: { task_binding: "forbidden" },
+              },
+            ],
+            middleware: [],
+            external_xperts: [],
+            knowledge_bases: [],
+            toolsets: [],
+            plugins: [],
+            prompt_profiles: [],
+            default_scope: {
+              allowed_node_kinds: ["workflow_agent", "json_serialize"],
+              external_xpert_ids: [],
+              knowledge_base_ids: [],
+              toolset_ids: [],
+              plugin_ids: [],
+              prompt_profile_ids: [],
+              middleware_ids: [],
+            },
+          });
+        }
+        if (url.startsWith("/api/xperts?")) {
+          return jsonResponse({ items: [], total: 0 });
+        }
+        if (url.startsWith("/api/runtime/authoring-proposals?")) {
+          return jsonResponse({ items: [] });
+        }
+        throw new Error(`Unexpected request: ${url}`);
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <MetaPlannerV2 />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("JSON 序列化")).toBeInTheDocument();
+    expect(screen.getByText("辅助节点")).toBeInTheDocument();
+    expect(screen.queryByText("知识检索")).not.toBeInTheDocument();
+  });
+
   it("preserves the paid-call receipt when the follow-up proposal load fails", async () => {
     const receipt = {
       contract_version: "modelmirror-provider-workload-routing-v1",

--- a/client/src/components/meta/MetaPlannerV2.tsx
+++ b/client/src/components/meta/MetaPlannerV2.tsx
@@ -41,6 +41,10 @@ interface CapabilityItem {
   published_version?: number | null;
   high_risk?: boolean;
   security_category?: string;
+  task_binding?: "required" | "optional" | "forbidden";
+  planner?: {
+    task_binding?: "required" | "optional" | "forbidden";
+  };
 }
 
 interface MetaPlannerScope extends Record<ScopeKey, string[]> {
@@ -1007,6 +1011,12 @@ export default function MetaPlannerV2() {
                                     {item.high_risk ? (
                                       <span className="rounded border border-amber-300/30 bg-amber-300/10 px-1 text-[9px] text-amber-100">
                                         高风险
+                                      </span>
+                                    ) : null}
+                                    {(item.task_binding ?? item.planner?.task_binding) ===
+                                    "forbidden" ? (
+                                      <span className="rounded border border-cyan-300/30 bg-cyan-300/10 px-1 text-[9px] text-cyan-100">
+                                        辅助节点
                                       </span>
                                     ) : null}
                                   </span>

--- a/client/src/components/meta/metaAuthoring.test.ts
+++ b/client/src/components/meta/metaAuthoring.test.ts
@@ -20,7 +20,16 @@ describe("Meta Planner headless authoring contracts", () => {
       can_author: true,
       graph_checksum: "graph-checksum",
       candidate_checksum: "candidate-checksum",
-      allowed_node_kinds: ["input", "output", "workflow_agent"],
+      allowed_node_kinds: [
+        "input",
+        "output",
+        "workflow_agent",
+        "json_serialize",
+        "json_deserialize",
+        "variable_aggregator",
+        "data_aggregate",
+        "dataset_compare",
+      ],
       compiler_managed_node_kinds: ["input", "output"],
       authorized_scope: {
         agent_ids: ["expert-reviewer"],
@@ -32,10 +41,20 @@ describe("Meta Planner headless authoring contracts", () => {
       proposal_id: "proposal_v3",
       proposal_revision: 4,
       can_author: true,
-      allowed_node_kinds: ["input", "output", "workflow_agent"],
+      allowed_node_kinds: [
+        "input",
+        "output",
+        "workflow_agent",
+        "json_serialize",
+        "json_deserialize",
+        "variable_aggregator",
+        "data_aggregate",
+        "dataset_compare",
+      ],
       allowed_source_agent_ids: ["expert-reviewer"],
     });
-    expect(state?.allowed_node_kinds).not.toContain("json_serialize");
+    expect(state?.allowed_node_kinds).toContain("json_serialize");
+    expect(state?.allowed_node_kinds).not.toContain("knowledge_retrieval");
   });
 
   it("allows a lossless V2 proposal to upgrade through typed apply", () => {

--- a/client/src/components/workflow/NodePalette.test.ts
+++ b/client/src/components/workflow/NodePalette.test.ts
@@ -48,7 +48,7 @@ describe("NodePalette disabled workflow nodes", () => {
         }
         return new Response(
           JSON.stringify({
-            version: "xpert-workflow-node-registry-v4",
+            version: "xpert-workflow-node-registry-v5",
             contract_version: 3,
             contract_checksum: "a".repeat(64),
             tabs: [
@@ -112,7 +112,7 @@ describe("NodePalette disabled workflow nodes", () => {
         }
         return new Response(
           JSON.stringify({
-            version: "xpert-workflow-node-registry-v4",
+            version: "xpert-workflow-node-registry-v5",
             contract_version: 3,
             contract_checksum: "a".repeat(64),
             tabs: [

--- a/client/src/components/workflow/WorkflowEditor.conversion.test.tsx
+++ b/client/src/components/workflow/WorkflowEditor.conversion.test.tsx
@@ -39,7 +39,7 @@ function registry(): WorkflowNodeRegistryResponse {
     "output",
   ];
   return {
-    version: "xpert-workflow-node-registry-v4",
+    version: "xpert-workflow-node-registry-v5",
     contract_version: 3,
     contract_checksum: "a".repeat(64),
     tabs: [],

--- a/client/src/components/workflow/WorkflowTypedDataNodeConfig.test.tsx
+++ b/client/src/components/workflow/WorkflowTypedDataNodeConfig.test.tsx
@@ -85,6 +85,40 @@ afterEach(() => {
 });
 
 describe("WorkflowTypedDataNodeConfig", () => {
+  it("edits JSON deserialize V2 expected schema through a restricted parser", async () => {
+    render(
+      <Harness
+        initial={{
+          kind: "json_deserialize",
+          title: "JSON 反序列化",
+          description: "typed",
+          contractVersion: 2,
+          inputVariable: "json_text",
+          outputVariable: "json_value",
+          expectedSchema: {
+            type: "object",
+            properties: { answer: { type: "string" } },
+            required: ["answer"],
+          },
+        }}
+      />,
+    );
+
+    const editor = screen.getByRole("textbox", { name: "期望值 Schema" });
+    expect((editor as HTMLTextAreaElement).value).toContain('"answer"');
+
+    fireEvent.change(editor, {
+      target: { value: '{"type":"string","secretPolicy":"ignore"}' },
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent("不支持字段");
+
+    fireEvent.change(editor, {
+      target: { value: '{"type":"array","items":{"type":"number"}}' },
+    });
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+    expect((editor as HTMLTextAreaElement).value).toContain('"array"');
+  });
+
   it("loads a published table and exposes query schema configuration", async () => {
     mockAgentTables();
     render(

--- a/client/src/components/workflow/WorkflowTypedDataNodeConfig.tsx
+++ b/client/src/components/workflow/WorkflowTypedDataNodeConfig.tsx
@@ -45,6 +45,91 @@ const dataTableKinds = new Set([
   "data_table_delete",
 ]);
 
+const workflowSchemaTypes = new Set([
+  "any",
+  "null",
+  "string",
+  "number",
+  "integer",
+  "boolean",
+  "object",
+  "array",
+]);
+
+function validateExpectedSchema(
+  value: unknown,
+  path = "$",
+  depth = 0,
+): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return `${path} 必须是对象。`;
+  }
+  if (depth > 8) return `${path} 嵌套超过 8 层。`;
+  const schema = value as Record<string, unknown>;
+  const allowedKeys = new Set([
+    "type",
+    "nullable",
+    "items",
+    "properties",
+    "required",
+    "any_of",
+  ]);
+  const unknown = Object.keys(schema).filter((key) => !allowedKeys.has(key));
+  if (unknown.length > 0) return `${path} 包含不支持字段：${unknown.join("、")}。`;
+  if (typeof schema.type !== "string" || !workflowSchemaTypes.has(schema.type)) {
+    return `${path}.type 不是受支持的工作流类型。`;
+  }
+  if (schema.nullable !== undefined && typeof schema.nullable !== "boolean") {
+    return `${path}.nullable 必须是布尔值。`;
+  }
+  if (schema.items !== undefined) {
+    if (schema.type !== "array") return `${path}.items 仅可用于 array。`;
+    const error = validateExpectedSchema(schema.items, `${path}.items`, depth + 1);
+    if (error) return error;
+  }
+  if (schema.properties !== undefined) {
+    if (schema.type !== "object") return `${path}.properties 仅可用于 object。`;
+    if (!schema.properties || typeof schema.properties !== "object" || Array.isArray(schema.properties)) {
+      return `${path}.properties 必须是对象。`;
+    }
+    const entries = Object.entries(schema.properties as Record<string, unknown>);
+    if (entries.length > 50) return `${path}.properties 最多 50 项。`;
+    for (const [name, child] of entries) {
+      if (!/^[A-Za-z_][A-Za-z0-9_]{0,63}$/.test(name)) {
+        return `${path}.properties.${name} 不是合法字段名。`;
+      }
+      const error = validateExpectedSchema(child, `${path}.properties.${name}`, depth + 1);
+      if (error) return error;
+    }
+  }
+  if (schema.required !== undefined) {
+    if (schema.type !== "object" || !Array.isArray(schema.required)) {
+      return `${path}.required 仅可用于 object 且必须是数组。`;
+    }
+    const properties = schema.properties && typeof schema.properties === "object"
+      ? schema.properties as Record<string, unknown>
+      : {};
+    const required = schema.required as unknown[];
+    if (required.some((item) => typeof item !== "string" || !(item in properties))) {
+      return `${path}.required 必须引用已声明属性。`;
+    }
+  }
+  if (schema.any_of !== undefined) {
+    if (!Array.isArray(schema.any_of) || schema.any_of.length > 4) {
+      return `${path}.any_of 最多包含 4 个 Schema。`;
+    }
+    for (let index = 0; index < schema.any_of.length; index += 1) {
+      const error = validateExpectedSchema(
+        schema.any_of[index],
+        `${path}.any_of[${index}]`,
+        depth + 1,
+      );
+      if (error) return error;
+    }
+  }
+  return null;
+}
+
 const systemFields: AgentTableField[] = [
   {
     field_id: "system-record-id",
@@ -595,6 +680,35 @@ export default function WorkflowTypedDataNodeConfig({
   const [detail, setDetail] = useState<AgentTableDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const expectedSchemaValue = useMemo(
+    () => JSON.stringify(data.expectedSchema ?? { type: "any" }, null, 2),
+    [data.expectedSchema],
+  );
+  const [expectedSchemaDraft, setExpectedSchemaDraft] = useState(
+    expectedSchemaValue,
+  );
+  const [expectedSchemaError, setExpectedSchemaError] = useState("");
+
+  useEffect(() => {
+    setExpectedSchemaDraft(expectedSchemaValue);
+    setExpectedSchemaError("");
+  }, [expectedSchemaValue]);
+
+  function updateExpectedSchema(raw: string) {
+    setExpectedSchemaDraft(raw);
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      const validationError = validateExpectedSchema(parsed);
+      if (validationError) {
+        setExpectedSchemaError(validationError);
+        return;
+      }
+      setExpectedSchemaError("");
+      onChange({ expectedSchema: parsed as Record<string, unknown> });
+    } catch {
+      setExpectedSchemaError("请输入有效 JSON Schema。");
+    }
+  }
 
   const loadTables = useCallback(async () => {
     if (!isDataTable) return;
@@ -680,6 +794,31 @@ export default function WorkflowTypedDataNodeConfig({
         <LabeledField label="类型化输出变量">
           <WorkflowVariableField ariaLabel="类型化输出变量" contract={contract} edges={edges} fieldName="outputVariable" inputClassName={inputClass} node={node} nodes={nodes} onChange={(value) => onChange({ outputVariable: value })} value={String(data.outputVariable ?? "")} />
         </LabeledField>
+        {Number(data.contractVersion ?? 1) === 2 ? (
+          <LabeledField label="期望值 Schema">
+            <textarea
+              aria-invalid={Boolean(expectedSchemaError)}
+              aria-label="期望值 Schema"
+              className={`${inputClass} min-h-36 resize-y font-mono text-xs leading-5`}
+              onChange={(event) => updateExpectedSchema(event.target.value)}
+              spellCheck={false}
+              value={expectedSchemaDraft}
+            />
+            {expectedSchemaError ? (
+              <p className="mt-1.5 text-xs leading-5 text-rose-200" role="alert">
+                {expectedSchemaError}
+              </p>
+            ) : (
+              <p className="mt-1.5 text-xs leading-5 text-slate-500">
+                运行时将按此受限 Schema 校验真实解析值；不匹配时节点立即失败。
+              </p>
+            )}
+          </LabeledField>
+        ) : (
+          <p className="text-xs leading-5 text-amber-100">
+            旧版节点保留兼容错误行为；Meta Planner 只生成带期望 Schema 的 V2 节点。
+          </p>
+        )}
       </Section>
     );
   }

--- a/client/src/components/workflow/workflowDataTableNodeDefaults.test.ts
+++ b/client/src/components/workflow/workflowDataTableNodeDefaults.test.ts
@@ -58,7 +58,15 @@ describe("Agent Table workflow node defaults", () => {
     expect(createTypedCanvasNodeData(kind)).toMatchObject({
       kind,
       title,
+      contractVersion: 2,
       outputVariable,
+    });
+  });
+
+  it("creates JSON deserialize with an explicit non-narrowing V2 schema", () => {
+    expect(createTypedCanvasNodeData("json_deserialize")).toMatchObject({
+      contractVersion: 2,
+      expectedSchema: { type: "any" },
     });
   });
 

--- a/client/src/components/workflow/workflowDataTableNodeDefaults.ts
+++ b/client/src/components/workflow/workflowDataTableNodeDefaults.ts
@@ -24,6 +24,7 @@ export function createTypedCanvasNodeData(
       kind: "json_serialize",
       title: "JSON 序列化",
       description: "将类型化工作流变量转换为 JSON 字符串。",
+      contractVersion: 2,
       inputVariable: "json_value",
       outputVariable: "json_text",
       format: "compact",
@@ -32,8 +33,10 @@ export function createTypedCanvasNodeData(
       kind: "json_deserialize",
       title: "JSON 反序列化",
       description: "将 JSON 字符串解析为真实的类型化工作流变量。",
+      contractVersion: 2,
       inputVariable: "json_text",
       outputVariable: "json_value",
+      expectedSchema: { type: "any" },
     },
     annotation: {
       kind: "annotation",

--- a/client/src/components/workflow/workflowNodeRegistry.test.ts
+++ b/client/src/components/workflow/workflowNodeRegistry.test.ts
@@ -66,7 +66,7 @@ describe("workflowNodeRegistry NodeContract V3 guard", () => {
   it("rejects a nominal V3 registry without per-node contracts", () => {
     expect(hasNodeContractV3({
       ...workflowNodeRegistryFallback,
-      version: "xpert-workflow-node-registry-v4",
+      version: "xpert-workflow-node-registry-v5",
       contract_version: 3,
       contract_checksum: "registry-checksum",
     })).toBe(false);
@@ -74,7 +74,7 @@ describe("workflowNodeRegistry NodeContract V3 guard", () => {
 
   it("rejects an empty registry even with V3 metadata", () => {
     expect(hasNodeContractV3({
-      version: "xpert-workflow-node-registry-v4",
+      version: "xpert-workflow-node-registry-v5",
       contract_version: 3,
       contract_checksum: "registry-checksum",
       tabs: [],

--- a/client/src/components/workflow/workflowNodeRegistry.ts
+++ b/client/src/components/workflow/workflowNodeRegistry.ts
@@ -569,7 +569,7 @@ export function hasNodeContractV3(
   registry: WorkflowNodeRegistryResponse,
 ): boolean {
   if (
-    registry.version !== "xpert-workflow-node-registry-v4" ||
+    registry.version !== "xpert-workflow-node-registry-v5" ||
     registry.contract_version !== 3 ||
     !isSha256(registry.contract_checksum)
   ) {

--- a/client/src/components/workflow/workflowXpertConversion.test.ts
+++ b/client/src/components/workflow/workflowXpertConversion.test.ts
@@ -36,7 +36,7 @@ function registry(
   denied: WorkflowNodeKind[] = ["workflow_call_entry"],
 ): WorkflowNodeRegistryResponse {
   return {
-    version: "xpert-workflow-node-registry-v4",
+    version: "xpert-workflow-node-registry-v5",
     contract_version: 3,
     contract_checksum: "a".repeat(64),
     tabs: [],

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -323,6 +323,7 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   contentVariable?: string;
   tags?: string[];
   contractVersion?: number | string;
+  expectedSchema?: Record<string, unknown>;
   toolsetId?: string;
   pluginId?: string;
   xpertId?: string;

--- a/docs/META_AGENT.md
+++ b/docs/META_AGENT.md
@@ -1,6 +1,6 @@
 # 元智能体集成说明
 
-最后更新日期：2026-08-28
+最后更新日期：2026-08-31
 维护人：模镜团队
 
 ## 定位
@@ -9,7 +9,7 @@
 已经可以从实时 Registry 编译 `workflow_agent`、资源绑定、中间件和发布预检所需配置；
 旧生成器仍保留用于兼容经典工作流导入与既有 AgentTask/Handoff 操作。
 
-当前实现是 **Capability Snapshot V5 + Graph IR V3 单写、Typed IR V2 双读**。后续升级已经锁定为
+当前实现是 **Capability Snapshot V6 + Graph IR V3 单写、Typed IR V2 双读**。后续升级已经锁定为
 “V3 十轮 + V4 轮次待定”，唯一方向文档是
 [META_PLANNER_V3_V4_ROADMAP.md](./META_PLANNER_V3_V4_ROADMAP.md)。V3 先补齐
 Graph IR、无头编排、节点 Adapter、效果语义和评测，再逐类开放真实节点；V4 只有在
@@ -136,14 +136,15 @@ EvoAgentX 的来源与已交付历史见
 
 ### NodeContract V3 能力门禁
 
-Meta Planner 的节点事实统一来自 `NodeContractRegistry`。Capability Snapshot V5
+Meta Planner 的节点事实统一来自 `NodeContractRegistry`。Capability Snapshot V6
 只暴露满足以下全部条件的节点：契约状态完整、Planner 显式启用、编译模式真实存在、
 Adapter 版本一致，并且契约与 Adapter 的 compiler checksum 匹配。UI Registry 中出现
 节点不等于 Planner 可以生成该节点。
 
-当前开放范围仍严格保持为 `input`、`output`、`workflow_agent`、
-`external_xpert`、`knowledge_base`、`toolset_resource` 和 `plugin_resource`。
-NodeContract V3 与 Planner IR 独立演进。Capability Snapshot 当前为 V5，
+当前开放范围为 `input`、`output`、`workflow_agent`、四类资源绑定，以及
+`json_serialize`、`json_deserialize`、`variable_aggregator`、`data_aggregate`、
+`dataset_compare` 五种无副作用类型化纯节点。NodeContract V3 与 Planner IR 独立演进。
+Capability Snapshot 当前为 V6，
 `ir_version=3` 且声明 `supported_ir_versions=[2,3]`。旧 V2 Snapshot 保持可读，详见
 [NODE_CONTRACT_V3.md](./NODE_CONTRACT_V3.md)。
 
@@ -180,10 +181,20 @@ Apply。操作、接口、安全 receipt 和回退边界见
 类型化输入/输出变量、控制边、资源/中间件目标和唯一最终输出。任务和 Agent 不再
 强制一一对应：一个 Agent 可以覆盖多个任务，一个任务也可以由多个节点共同完成。
 
-Capability Snapshot V5 只暴露当前存在且与 NodeContract 校验一致的编译能力。首轮可执行 IR 节点只有
-`workflow_agent`；`input/output` 由编译器管理，外部 Xpert、知识库、Toolset 和
-Plugin 通过绑定记录编译。JSON、Agent Table、知识检索和视觉理解尚无 Planner
-适配器，因此不会进入授权快照，也不会被模型生成。
+Capability Snapshot V6 只暴露当前存在且与 NodeContract、Adapter checksum 校验一致的
+编译能力。`workflow_agent` 的 `task_binding=required`，每个计划任务仍必须由 Agent
+覆盖；五种纯节点的 `task_binding=forbidden`，只能作为 Agent 之间的确定性辅助步骤，
+不能承担任务或成为最终输出。`input/output` 由编译器管理，外部 Xpert、知识库、
+Toolset 和 Plugin 通过绑定记录编译。
+
+Meta Planner 只生成 JSON `contractVersion=2`：Deserialize 必须携带受限
+`expectedSchema`，输入、解析结果和输出均受 5 MiB 限制，非法 JSON 或类型不符立即
+失败。缺少版本的旧 JSON 节点继续保留历史 inline-error/null 行为，不被 Planner
+生成或自动升级。Variable Aggregator V2、Data Aggregate 和 Dataset Compare 复用
+现有 Runtime，并由 Adapter 从 Graph IR data 边派生原生变量绑定。
+
+`variable_assign`、`list_operation`、`object_transform`、`data_merge`、Agent Table、
+知识检索、视觉理解和控制流仍无本轮 Planner Adapter，不会进入授权快照。
 
 旧 `MetaPlannerBlueprint` 仅用于 Expert Team Agency 等兼容入口，进入编译器前会
 转换为 Typed IR。旧计划也必须只有一个终点。更新已有 Xpert 时，如目标工作流含

--- a/docs/META_PLANNER_HEADLESS_AUTHORING.md
+++ b/docs/META_PLANNER_HEADLESS_AUTHORING.md
@@ -1,7 +1,7 @@
 # Meta Planner Headless Authoring
 
-最后更新日期：2026-08-30
-状态：V3 Round 2 实现契约
+最后更新日期：2026-08-31
+状态：V3 Round 3 实现契约
 
 ## 目标
 
@@ -26,9 +26,10 @@ Pydantic、Adapter 或 Proposal 服务前失败关闭。
 Patch 只接受 Planner ref、命名端口和 Adapter config。原生节点 ID、Handle、资源版本、
 NodeContract Schema、执行策略与 checksum 均由服务端推导，客户端或模型不能注入。
 
-支持 Xpert 元数据、Workflow Agent、控制/data 边、输出变量、四类资源、中间件、
-Prompt Profile、最终输出和布局。`input/output` 由编译器管理；布局不会改变 Graph
-checksum，但会改变 candidate checksum。
+支持 Xpert 元数据、Workflow Agent、五种纯数据 Adapter、控制/data 边、输出变量、
+四类资源、中间件、Prompt Profile、最终输出和布局。`input/output` 由编译器管理；
+布局不会改变 Graph checksum，但会改变 candidate checksum。纯节点配置、原生变量名、
+端口 Schema 和 binding ID 由 Adapter 推导，不能通过 Patch 注入。
 
 ## 预览与应用
 
@@ -63,6 +64,8 @@ Meta Planner Proposal 创建时的 `authorized_scope` 是不可扩大的授权�
 
 模型首次生成仍输出 GraphIntent V3。若输出可解析但门禁失败，唯一修复调用必须返回
 Graph Patch；完全无法解析时才允许一次完整 GraphIntent V3 修复。总模型调用上限仍为 3。
+唯一 Graph Patch 修复应用后，服务端会按 Adapter 配置刷新其派生输出 Schema，并记录
+安全 warning；正常生成路径中的 Schema 伪造、未知端口和非法配置仍然 fail-closed。
 
 ## API
 
@@ -73,8 +76,9 @@ POST /api/meta-agent/authoring/proposals/{proposal_id}/patch/preview
 POST /api/meta-agent/authoring/proposals/{proposal_id}/patch/apply
 ```
 
-Capability Snapshot V5 暴露 authoring protocol、操作 JSON Schema、Adapter authoring
-checksum 和限制，但节点范围仍严格保持原有七类。
+Capability Snapshot V6 暴露 authoring protocol、操作 JSON Schema、Adapter authoring
+checksum、`task_binding` 和限制。Headless 编辑范围为原有七类加五种纯节点；纯节点
+不得承担任务、绑定资源/中间件或成为最终输出。
 
 ## 回退
 

--- a/docs/META_PLANNER_V3_V4_ROADMAP.md
+++ b/docs/META_PLANNER_V3_V4_ROADMAP.md
@@ -98,14 +98,15 @@ Graph IR V3 至少需要表达：
 
 ### Round 3：Pure Nodes
 
-首批开放无副作用且可确定性评测的节点，候选范围以真实 NodeContract 和 Runner 支持为准，目标包括：
+本轮实际开放范围锁定为 `json_serialize`、`json_deserialize`、
+`variable_aggregator` V2、`data_aggregate` 和 `dataset_compare`。它们只作为 Agent
+之间的确定性辅助步骤，不承担计划任务，也不成为最终输出。JSON V2 使用严格失败、
+5 MiB 边界和 Deserialize `expectedSchema`；旧 JSON 契约保持兼容读取。
 
-- JSON 序列化与反序列化。
-- 变量赋值、变量聚合和列表操作。
-- 对象变换、数据聚合、数据合并和数据集比较。
-- Annotation 仅作为元数据保留，不参与执行。
-
-每个节点必须补齐输入输出类型、默认值、错误策略、Adapter、反编译和确定性评测。不得为了快速开放而把复杂值退化为字符串。
+`variable_assign`、`list_operation`、`object_transform` 和 `data_merge` 因动态端口、
+表达式或多输入 Join 契约尚未成熟而延期。Annotation 继续只作为元数据保留，不参与
+执行，也不获得 Planner Adapter。所有已开放节点必须保持 Adapter 往返、Headless Patch、
+输入输出类型和确定性评测稳定，不得把复杂值退化为字符串。
 
 ### Round 4：Control Flow
 

--- a/docs/NODE_CONTRACT_V3.md
+++ b/docs/NODE_CONTRACT_V3.md
@@ -22,6 +22,7 @@ Every `NativeNodeKind` has exactly one `NodeContract` with:
 - Workflow, Xpert, Goal, Handoff, App, Evaluator, and Evolution availability;
 - resource IDs, pinning fields, authorization needs, and dynamic-schema flags;
 - Planner support, compilation mode, adapter version, and IR configuration schema.
+- Planner task binding: `required`, `optional`, or `forbidden`.
 
 Edge contracts declare every supported edge mode separately from the modes
 that participate in topology. This preserves compatibility nodes such as
@@ -56,23 +57,28 @@ The first complete-contract group is:
 | Group | Node kinds | Planner state |
 | --- | --- | --- |
 | Compiler managed | `input`, `output` | enabled in Graph IR V3 |
-| Adapter | `workflow_agent` | enabled in Graph IR V3 |
+| Task adapter | `workflow_agent` | enabled, `task_binding=required` |
 | Resource bindings | `external_xpert`, `knowledge_base`, `toolset_resource`, `plugin_resource` | binding only |
-| Pure-data targets | `json_serialize`, `json_deserialize` | unsupported |
+| Pure-data adapters | `json_serialize`, `json_deserialize`, `variable_aggregator`, `data_aggregate`, `dataset_compare` | enabled, `task_binding=forbidden` |
 | Read targets | `knowledge_retrieval`, `data_table_query`, `vision_understanding` | unsupported |
 | Write targets | `data_table_insert`, `data_table_update`, `data_table_delete` | unsupported |
 | Metadata and middleware | `annotation`, `runtime_middleware` | metadata or binding contract only |
 
-All other nodes have compatibility contracts and remain executable through the
-existing classic validator and runner. Capability Snapshot still exposes only
-the existing seven node kinds. Graph IR V3 is the write format; Typed IR V2 is
-read-only compatibility input.
+All other nodes have compatibility or explicitly unsupported contracts and
+remain executable through the existing classic validator and runner when their
+legacy validation permits it. Capability Snapshot V6 exposes the previous seven
+kinds plus the five pure-data adapters. Graph IR V3 is the write format; Typed
+IR V2 is read-only compatibility input.
 
-JSON nodes retain their current inline-error behavior until the separate pure
-node round. Agent Table Query remains disabled in Evaluator. Vision remains
+Unversioned JSON nodes retain their historical inline-error/null behavior.
+Planner-generated JSON nodes use `contractVersion=2`, strict failure semantics,
+a 5 MiB boundary, and a trusted `WorkflowValueSchema` for Deserialize output.
+The other pure adapters keep their existing bounded Runtime contracts. Pure
+nodes cannot cover plan tasks, bind resources or middleware, or provide the
+final output. Agent Table Query remains disabled in Evaluator. Vision remains
 disabled in Evaluator until evaluation datasets can carry explicit file assets.
-Condition, loop, and list contracts may describe current handles, but Planner
-cannot compile them yet.
+Condition, loop, list, assignment, object transform, and data merge contracts
+may describe current behavior, but Planner cannot compile them yet.
 
 ## Policy service
 
@@ -96,7 +102,7 @@ must still pass.
 ## API and frontend
 
 `GET /api/workflow/node-registry` returns registry version
-`xpert-workflow-node-registry-v3`, `contract_version=3`, the registry checksum,
+`xpert-workflow-node-registry-v5`, `contract_version=3`, the registry checksum,
 and a safe contract projection for each palette node.
 
 The frontend fallback contains presentation facts only. It has no contract or
@@ -104,9 +110,10 @@ Planner claims. If the server response is absent, incomplete, or has a checksum
 shape other than V3, contract-dependent operations stay disabled while the
 classic palette may continue to render.
 
-Meta Planner Capability Snapshot version is V5 with `ir_version=3` and
-`supported_ir_versions=[2,3]`. V5 also projects the typed Headless Authoring
-operation schema and per-kind authoring checksum without widening the node set.
+Meta Planner Capability Snapshot version is V6 with `ir_version=3` and
+`supported_ir_versions=[2,3]`. V6 projects the typed Headless Authoring
+operation schema, `task_binding`, versioned execution semantics, and per-kind
+authoring checksum for the twelve enabled kinds.
 Persisted V2 snapshots without contract metadata remain readable. Contract
 drift is a warning for an existing proposal; missing or invalid resources still
 block approval.

--- a/docs/XPERT_RUNTIME.md
+++ b/docs/XPERT_RUNTIME.md
@@ -353,6 +353,14 @@ Store 解析执行效果、端口、Handle 与固定版本。语义 data 边不�
 调度；新 Proposal 保存安全 IR、Graph checksum 和编译产物 checksum，人工编辑后将
 IR 标记为 stale。Typed IR V2 仅作为无损双读兼容输入。
 
+Capability Snapshot V6 additionally exposes five deterministic pure-node
+adapters: JSON serialize/deserialize V2, variable aggregation V2, data
+aggregation, and dataset comparison. Their native variable bindings and output
+schemas are compiler-derived. They cannot satisfy plan tasks, bind resources or
+middleware, or become the final output. Unversioned JSON nodes retain their
+legacy behavior; Planner-generated V2 nodes fail closed on invalid JSON, schema
+mismatch, or the 5 MiB boundary.
+
 ## Versioned MCP And API Toolset Runtime
 
 `ToolsetStore` persists editable MCP, OpenAPI, OData, and builtin Provider Toolset definitions plus immutable published versions. A version fixes the transport, API, or Provider profile, credential references, enabled tools, aliases, default arguments, JSON Schema hashes, tool semantics, prefix, and release metadata. Xpert publication resolves `latest` to a concrete Toolset version; later discovery, import, or draft edits cannot expand an already published Xpert.

--- a/docs/audits/N8N_NODE_CAPABILITY_MATRIX.md
+++ b/docs/audits/N8N_NODE_CAPABILITY_MATRIX.md
@@ -22,7 +22,7 @@
 - R2.7 结果：新增完整合同 `rss_event_entry`，以仅公网 HTTPS、逐跳安全校验、首次无回放基线和持久条目去重提供 RSS 2.0/Atom 1.0 订阅入口；认证源、附件、WebSub、Xpert 与等待节点禁用
 - R2.8 结果：新增完整合同 `email_event_entry`，以只读 IMAPS 993、首次无回放 UID 基线和持久 UID 重读恢复提供固定 INBOX 邮件入口；OAuth2、IDLE、多文件夹、附件内容、原始 HTML、Xpert 与等待节点禁用
 - R2.9 PR2 结果：不新增节点类型；为 `http_request` V2、`data_table_query` 与 `knowledge_retrieval` V2 增加结构化失败出口。仅明确归一化的读取运行故障可被处理，成功与错误出口互斥；凭据、权限、安全、配置、资源漂移、取消和未知异常仍失败关闭，且本批次不提供自动重试
-- 当前 Registry 事实：55 Native、51 个已登记 Palette 项、默认 50 个可拖拽 Palette 项、52 个完整合同、3 个 compatibility 合同、7 个 Planner 节点
+- 当前 Registry 事实：55 Native、51 个已登记 Palette 项、默认 50 个可拖拽 Palette 项、52 个完整合同、3 个 compatibility 合同、12 个 Planner 节点
 - 默认运行功能门禁：3 个已登记项（`email_event_entry`、`knowledge_write_proposal`、`rss_event_entry`）允许编辑但执行面关闭；该口径与 Palette 是否登记、是否可拖拽相互独立
 - 参考清单：563 条节点名称/类型，其中 `.ee` 2 条仅保留名称审计
 
@@ -152,4 +152,4 @@ R1 为单实例、原子文件持久化版本，不宣称多 Worker、HA 或多�
 - 前端 `WorkflowNodeKind`、后端 `NativeNodeKind`、NodeContract Registry 必须完全一致。
 - Palette 必须是 NodeContract 合法子集；每个启用项必须有默认数据和配置入口。
 - compatibility 合同不得超过 #213 冻结白名单；新节点必须直接提供完整合同。
-- Planner 只接受完整合同、匹配 checksum 且显式启用的节点；R1–R2.9 增量节点均禁止 Planner 自动生成，Planner 可生成类型仍固定为 7 类。
+- Planner 只接受完整合同、匹配 checksum 且显式启用的节点；R1–R2.9 增量节点均禁止 Planner 自动生成，Planner 可生成类型仍固定为 12 类。

--- a/server/main.py
+++ b/server/main.py
@@ -746,6 +746,7 @@ try:
         workflow_batch_input_digest,
     )
     from server.workflow_native.values import (
+        MAX_WORKFLOW_JSON_BYTES,
         WorkflowValue,
         deserialize_workflow_value,
         normalize_workflow_value,
@@ -896,6 +897,7 @@ except ModuleNotFoundError:
         workflow_batch_input_digest,
     )
     from workflow_native.values import (
+        MAX_WORKFLOW_JSON_BYTES,
         WorkflowValue,
         deserialize_workflow_value,
         normalize_workflow_value,
@@ -8872,6 +8874,9 @@ async def generate_meta_planner_xpert_candidate(
             ],
             temperature=temperature,
             max_tokens=max_tokens,
+            response_format={"type": "json_object"},
+            reasoning={"effort": "none", "exclude": True},
+            allow_json_reasoning_fallback=True,
         )
 
     try:
@@ -17314,19 +17319,24 @@ async def _run_workflow_response(
                         )
 
                 elif kind == "json_serialize":
-                    try:
-                        input_variable = str(node.data.get("inputVariable") or "")
-                        output_variable = str(
-                            node.data.get("outputVariable") or "json_text"
-                        )
+                    input_variable = str(node.data.get("inputVariable") or "")
+                    output_variable = str(
+                        node.data.get("outputVariable") or "json_text"
+                    )
+                    if r20_contract_version(node.data) == 2:
                         if input_variable not in variables:
                             raise ValueError(
                                 f"Workflow variable '{input_variable}' is not available."
                             )
-                        pretty = str(node.data.get("format") or "compact") == "pretty"
+                        json_format = str(node.data.get("format") or "")
+                        if json_format not in {"compact", "pretty"}:
+                            raise ValueError(
+                                "JSON_SERIALIZE_FORMAT_INVALID: format must be compact or pretty."
+                            )
                         output = serialize_workflow_value(
                             variables[input_variable],
-                            pretty=pretty,
+                            pretty=json_format == "pretty",
+                            max_bytes=MAX_WORKFLOW_JSON_BYTES,
                         )
                         variables[output_variable] = output
                         yield sse_payload(
@@ -17339,26 +17349,62 @@ async def _run_workflow_response(
                                 "variable": output_variable,
                             }
                         )
-                    except Exception as exc:
-                        logger.warning("Workflow json_serialize node failed: %s", exc)
-                        yield sse_payload(
-                            {
-                                "event": "error",
-                                "node_id": node.id,
-                                "message": str(exc),
-                            }
-                        )
+                    else:
+                        try:
+                            if input_variable not in variables:
+                                raise ValueError(
+                                    f"Workflow variable '{input_variable}' is not available."
+                                )
+                            pretty = (
+                                str(node.data.get("format") or "compact") == "pretty"
+                            )
+                            output = serialize_workflow_value(
+                                variables[input_variable],
+                                pretty=pretty,
+                            )
+                            variables[output_variable] = output
+                            yield sse_payload(
+                                {
+                                    "event": "node_delta",
+                                    "node_id": node.id,
+                                    "node_title": title,
+                                    "node_type": kind,
+                                    "output": output,
+                                    "variable": output_variable,
+                                }
+                            )
+                        except Exception as exc:
+                            logger.warning(
+                                "Workflow json_serialize node failed: %s", exc
+                            )
+                            yield sse_payload(
+                                {
+                                    "event": "error",
+                                    "node_id": node.id,
+                                    "message": str(exc),
+                                }
+                            )
 
                 elif kind == "json_deserialize":
-                    try:
-                        input_variable = str(node.data.get("inputVariable") or "")
-                        output_variable = str(
-                            node.data.get("outputVariable") or "json_value"
-                        )
+                    input_variable = str(node.data.get("inputVariable") or "")
+                    output_variable = str(
+                        node.data.get("outputVariable") or "json_value"
+                    )
+                    if r20_contract_version(node.data) == 2:
                         source = variables.get(input_variable)
                         if not isinstance(source, str):
                             raise ValueError("JSON deserialize input must be a string.")
-                        stored_output = deserialize_workflow_value(source)
+                        expected_schema = node.data.get("expectedSchema")
+                        if not isinstance(expected_schema, dict):
+                            raise ValueError(
+                                "JSON_DESERIALIZE_SCHEMA_REQUIRED: "
+                                "JSON deserialize V2 requires expectedSchema."
+                            )
+                        stored_output = deserialize_workflow_value(
+                            source,
+                            expected_schema=expected_schema,
+                            max_bytes=MAX_WORKFLOW_JSON_BYTES,
+                        )
                         variables[output_variable] = stored_output
                         output = workflow_value_to_text(stored_output)
                         yield sse_payload(
@@ -17371,16 +17417,38 @@ async def _run_workflow_response(
                                 "variable": output_variable,
                             }
                         )
-                    except Exception as exc:
-                        logger.warning("Workflow json_deserialize node failed: %s", exc)
-                        variables[output_variable] = None
-                        yield sse_payload(
-                            {
-                                "event": "error",
-                                "node_id": node.id,
-                                "message": str(exc),
-                            }
-                        )
+                    else:
+                        try:
+                            source = variables.get(input_variable)
+                            if not isinstance(source, str):
+                                raise ValueError(
+                                    "JSON deserialize input must be a string."
+                                )
+                            stored_output = deserialize_workflow_value(source)
+                            variables[output_variable] = stored_output
+                            output = workflow_value_to_text(stored_output)
+                            yield sse_payload(
+                                {
+                                    "event": "node_delta",
+                                    "node_id": node.id,
+                                    "node_title": title,
+                                    "node_type": kind,
+                                    "output": output,
+                                    "variable": output_variable,
+                                }
+                            )
+                        except Exception as exc:
+                            logger.warning(
+                                "Workflow json_deserialize node failed: %s", exc
+                            )
+                            variables[output_variable] = None
+                            yield sse_payload(
+                                {
+                                    "event": "error",
+                                    "node_id": node.id,
+                                    "message": str(exc),
+                                }
+                            )
 
                 elif kind == "parameter_extractor":
                     try:

--- a/server/meta_agent/NOTICE.md
+++ b/server/meta_agent/NOTICE.md
@@ -53,11 +53,12 @@ implementation uses its own Pydantic contracts, Workflow Node Registry,
 Runtime Middleware Registry, AuthoringProposalStore, XpertStore, workflow
 validator, and publish preflight.
 
-NodeContract V3 and Graph IR V3 independently apply the audited parameter-schema and layered
-validation concepts to ModelMirror's own node, entrypoint-policy, compiler
-adapter, intent, and resolved-graph contracts. No EvoAgentX schema or runtime
-object is copied. Graph IR remains a ModelMirror contract and EvoAgentX is not
-used to execute workflows.
+NodeContract V3, Graph IR V3, Headless Authoring, and the pure-node Adapter pack
+independently apply the audited parameter-schema and layered validation concepts
+to ModelMirror's own node, entrypoint-policy, compiler adapter, intent,
+resolved-graph, and typed Patch contracts. No EvoAgentX schema or runtime object
+is copied. Graph IR remains a ModelMirror contract and EvoAgentX is not used to
+execute workflows.
 
 No EvoAgentX source file is copied into this package and EvoAgentX is not a
 runtime dependency. Provider, RAG, storage, HITL, memory, tool, workflow, and

--- a/server/meta_agent/capabilities.py
+++ b/server/meta_agent/capabilities.py
@@ -138,6 +138,7 @@ def build_capability_snapshot(
                         "compilable": True,
                         "ir_version": compiler["ir_version"],
                         "adapter_version": compiler["adapter_version"],
+                        "task_binding": compiler["task_binding"],
                         "contract_version": compiler["contract_version"],
                         "contract_checksum": compiler["contract_checksum"],
                         "compiler_checksum": compiler["compiler_checksum"],
@@ -178,6 +179,7 @@ def build_capability_snapshot(
                         "compilable": True,
                         "ir_version": compiler["ir_version"],
                         "adapter_version": compiler["adapter_version"],
+                        "task_binding": compiler["task_binding"],
                         "contract_version": compiler["contract_version"],
                         "contract_checksum": compiler["contract_checksum"],
                         "compiler_checksum": compiler["compiler_checksum"],
@@ -362,7 +364,7 @@ def build_capability_snapshot(
         agent_ids=[item["id"] for item in expert_summaries],
     )
     payload = {
-        "version": "evoagentx-meta-planner-capabilities-v5",
+        "version": "evoagentx-meta-planner-capabilities-v6",
         "ir_version": 3,
         "supported_ir_versions": [2, 3],
         "contract_version": int(node_payload.get("contract_version") or 0),

--- a/server/meta_agent/graph_ir_v3.py
+++ b/server/meta_agent/graph_ir_v3.py
@@ -453,6 +453,31 @@ def v2_to_graph_intent(
     )
 
 
+def _graph_intent_inputs_to_v2(
+    node: GraphIntentNodeV3,
+) -> list[MetaPlannerIRInputBinding]:
+    totals: dict[str, int] = defaultdict(int)
+    for item in node.inputs:
+        totals[item.port] += 1
+    seen: dict[str, int] = defaultdict(int)
+    converted: list[MetaPlannerIRInputBinding] = []
+    for item in node.inputs:
+        seen[item.port] += 1
+        legacy_port = (
+            f"{item.port}_{seen[item.port]}"
+            if totals[item.port] > 1
+            else item.port
+        )
+        converted.append(
+            MetaPlannerIRInputBinding(
+                port=legacy_port,
+                variable=item.variable,
+                value_type=item.value_schema.type,
+            )
+        )
+    return converted
+
+
 def graph_intent_to_v2(intent: GraphIntentV3) -> MetaPlannerTypedBlueprintV2:
     return MetaPlannerTypedBlueprintV2(
         name=intent.name,
@@ -466,14 +491,7 @@ def graph_intent_to_v2(intent: GraphIntentV3) -> MetaPlannerTypedBlueprintV2:
                 title=node.title,
                 description=node.description,
                 task_ids=node.task_ids,
-                inputs=[
-                    MetaPlannerIRInputBinding(
-                        port=f"{item.port}_{index + 1}",
-                        variable=item.variable,
-                        value_type=item.value_schema.type,
-                    )
-                    for index, item in enumerate(node.inputs)
-                ],
+                inputs=_graph_intent_inputs_to_v2(node),
                 outputs=[
                     MetaPlannerIROutputBinding(
                         port=item.port,
@@ -564,8 +582,14 @@ def _resolved_node(
     description: str = "",
     task_ids: list[str] | None = None,
     config: dict[str, Any] | None = None,
+    execution_version: int | None = None,
 ) -> ResolvedGraphNodeV3:
     contract = workflow_node_contract_registry.require(kind)
+    execution_data = (
+        {"contractVersion": execution_version}
+        if execution_version is not None
+        else config
+    )
     return ResolvedGraphNodeV3(
         ref=ref,
         node_id=node_id,
@@ -579,7 +603,7 @@ def _resolved_node(
         contract_version=NODE_CONTRACT_VERSION,
         contract_checksum=contract.checksum,
         compiler_checksum=contract.compiler_checksum,
-        execution=contract.execution.model_dump(mode="json"),
+        execution=contract.effective_execution(execution_data).model_dump(mode="json"),
         resource_contracts=[item.model_dump(mode="json") for item in contract.resources],
     )
 
@@ -734,20 +758,23 @@ def resolve_graph_intent(
             resolved_config["model_id"] = default_agent_model_id
         adapter = get_planner_node_adapter(node.kind)
         assert adapter is not None
-        resolved_config = adapter.config_model.model_validate(
-            resolved_config
-        ).model_dump(mode="json")
+        effective_node = node.model_copy(update={"config": resolved_config})
+        parsed_config = adapter.validate_intent_node(effective_node)
+        resolved_config = parsed_config.model_dump(mode="json")
+        contract = workflow_node_contract_registry.require(node.kind)
+        if len(node.task_ids) != len(set(node.task_ids)):
+            raise ValueError(f"Node {node.ref} task IDs must be unique.")
+        if contract.planner.task_binding == "required" and not node.task_ids:
+            raise ValueError(f"Node {node.ref} must cover at least one plan task.")
+        if contract.planner.task_binding == "forbidden" and node.task_ids:
+            raise ValueError(f"Node {node.ref} cannot cover plan tasks.")
         model_id = str(resolved_config.get("model_id") or "")
         if model_id and model_id not in available_models:
             raise ValueError(
                 f"Agent model {model_id} is unavailable in the Capability Snapshot."
             )
         declared_inputs = {binding.variable for binding in node.inputs}
-        referenced: set[str] = set()
-        for field in ("role_prompt", "task_input"):
-            referenced.update(
-                _template_variables(str(resolved_config.get(field) or ""))
-            )
+        referenced = adapter.referenced_input_variables(parsed_config)
         missing_bindings = sorted(referenced - declared_inputs)
         if missing_bindings:
             raise ValueError(
@@ -763,6 +790,11 @@ def resolve_graph_intent(
             description=node.description,
             task_ids=node.task_ids,
             config=resolved_config,
+            execution_version=(
+                2
+                if node.kind in {"json_serialize", "json_deserialize"}
+                else None
+            ),
         )
         contract_outputs = {
             port.name: port for port in resolved.ports if port.direction == "output"
@@ -773,9 +805,16 @@ def resolve_graph_intent(
                 raise ValueError(
                     f"Node {node.ref} declares unknown output port {output.port}."
                 )
-            if not _schemas_compatible(output.value_schema, contract_port.value_schema):
+            authoritative_schema = adapter.authoritative_output_schema(
+                output.port,
+                parsed_config,
+            )
+            if canonical_checksum(
+                output.value_schema.model_dump(mode="json")
+            ) != canonical_checksum(authoritative_schema.model_dump(mode="json")):
                 raise ValueError(
-                    f"Node {node.ref} output {output.port} has an incompatible type."
+                    f"Node {node.ref} output {output.port} does not match its "
+                    "authoritative Adapter type."
                 )
             key = (node.ref, output.port)
             if key in declared_outputs:
@@ -1048,6 +1087,9 @@ def resolve_graph_intent(
     final_source = declared_outputs.get(
         (intent.final_output.node_ref, intent.final_output.port)
     )
+    final_node = resolved_by_ref.get(intent.final_output.node_ref)
+    if final_node is None or final_node.kind != "workflow_agent":
+        raise ValueError("Graph IR final output must come from a workflow_agent.")
     if final_source is None or final_source[0] != intent.final_output.variable:
         raise ValueError("Graph IR final output does not match its source port.")
     output_node = _resolved_node(
@@ -1168,7 +1210,11 @@ def annotate_candidate_with_graph_ir(
 def decompile_candidate_to_graph_intent_compat(
     candidate: dict[str, Any],
 ) -> tuple[GraphIntentV3 | None, MetaPlannerIRCompatibility]:
-    from .node_adapters import decompile_planner_node, decompile_planner_node_v3
+    from .node_adapters import (
+        META_PLANNER_ADAPTER_KINDS,
+        decompile_planner_node,
+        decompile_planner_node_v3,
+    )
 
     try:
         from server.workflow_native.schemas import NativeWorkflowNode
@@ -1190,12 +1236,12 @@ def decompile_candidate_to_graph_intent_compat(
     supported_kinds = {
         "input",
         "output",
-        "workflow_agent",
         "external_xpert",
         "knowledge_base",
         "toolset_resource",
         "plugin_resource",
         "runtime_middleware",
+        *META_PLANNER_ADAPTER_KINDS,
     }
     unsupported = sorted(
         f"{node_id}:{kind or '<missing>'}"
@@ -1217,21 +1263,19 @@ def decompile_candidate_to_graph_intent_compat(
         raise ValueError(
             "Compiled candidate must contain the canonical input and output nodes exactly once."
         )
-    workflow_agents = [
+    planner_nodes = [
         raw_node
         for raw_node in raw_nodes
-        if str(
-            (raw_node.get("data") or {}).get("kind")
-            or raw_node.get("type")
-            or ""
-        )
-        == "workflow_agent"
+        if kind_by_id[str(raw_node.get("id") or "")] in META_PLANNER_ADAPTER_KINDS
     ]
-    if not workflow_agents:
+    if not any(
+        kind_by_id[str(raw_node.get("id") or "")] == "workflow_agent"
+        for raw_node in planner_nodes
+    ):
         raise ValueError("Compiled candidate has no Workflow Agent node.")
     marker_versions = {
         int((raw_node.get("data") or {}).get("plannerIRVersion") or 0)
-        for raw_node in workflow_agents
+        for raw_node in planner_nodes
     }
     if not marker_versions.issubset({0, GRAPH_IR_VERSION}):
         raise ValueError("Compiled candidate carries an unknown Graph IR marker.")
@@ -1243,7 +1287,7 @@ def decompile_candidate_to_graph_intent_compat(
     ref_by_id: dict[str, str] = {}
     business_nodes: list[GraphIntentNodeV3] = []
     legacy_nodes: list[MetaPlannerIRNode] = []
-    for raw_node in workflow_agents:
+    for raw_node in planner_nodes:
         native_node = NativeWorkflowNode.model_validate(raw_node)
         restored = (
             decompile_planner_node_v3(native_node)
@@ -1301,6 +1345,10 @@ def decompile_candidate_to_graph_intent_compat(
                 f"Compiled control edge {edge_id} is outside the recoverable Planner graph."
             )
         if not target_ref:
+            raise ValueError(
+                f"Compiled binding edge {edge_id} must target a Workflow Agent."
+            )
+        if target_kind != "workflow_agent":
             raise ValueError(
                 f"Compiled binding edge {edge_id} must target a Workflow Agent."
             )
@@ -1404,6 +1452,9 @@ def decompile_candidate_to_graph_intent_compat(
     terminal_ref = ref_by_id.get(str(terminal_edge.get("source") or ""))
     if not terminal_ref or not output_variable:
         raise ValueError("Compiled candidate final output metadata is incomplete.")
+    terminal_node_id = str(terminal_edge.get("source") or "")
+    if kind_by_id.get(terminal_node_id) != "workflow_agent":
+        raise ValueError("Compiled candidate final output must use a Workflow Agent.")
     prompt_items = [
         item
         for item in draft.get("prompt_profiles") or []

--- a/server/meta_agent/graph_patch.py
+++ b/server/meta_agent/graph_patch.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 try:
     from server.workflow_native.node_contracts import (
@@ -65,13 +65,27 @@ class SetXpertMetadataOperation(GraphPatchModel):
 
 class AddNodeOperation(GraphPatchModel):
     op: Literal["add_node"] = "add_node"
-    ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
+    ref: str = Field(
+        pattern=GRAPH_PATCH_REF_PATTERN,
+        description=(
+            "A new semantic node ref. The compiler-managed refs input and output "
+            "are forbidden."
+        ),
+        json_schema_extra={"not": {"enum": ["input", "output"]}},
+    )
     kind: str = Field(min_length=1, max_length=80)
     title: str = Field(min_length=1, max_length=120)
     description: str = Field(default="", max_length=2_000)
-    task_ids: list[str] = Field(min_length=1, max_length=8)
+    task_ids: list[str] = Field(default_factory=list, max_length=8)
     config: dict[str, Any] = Field(default_factory=dict)
     output_variables: dict[str, str] = Field(default_factory=dict, max_length=16)
+
+    @field_validator("ref")
+    @classmethod
+    def reject_compiler_managed_ref(cls, value: str) -> str:
+        if value in {"input", "output"}:
+            raise ValueError(f"{value} is a compiler-managed ref and cannot be added")
+        return value
 
 
 class UpdateNodeOperation(GraphPatchModel):
@@ -79,7 +93,7 @@ class UpdateNodeOperation(GraphPatchModel):
     ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
     title: str | None = Field(default=None, min_length=1, max_length=120)
     description: str | None = Field(default=None, max_length=2_000)
-    task_ids: list[str] | None = Field(default=None, min_length=1, max_length=8)
+    task_ids: list[str] | None = Field(default=None, max_length=8)
     config: dict[str, Any] | None = None
 
     @model_validator(mode="after")
@@ -307,10 +321,19 @@ def _node(intent: GraphIntentV3, ref: str) -> GraphIntentNodeV3:
     return node
 
 
-def _validate_task_ids(task_ids: list[str], plan_task_ids: set[str]) -> None:
+def _validate_task_ids(
+    kind: str,
+    task_ids: list[str],
+    plan_task_ids: set[str],
+) -> None:
     unknown = sorted(set(task_ids) - plan_task_ids)
     if unknown:
         raise ValueError("Patch references unknown plan tasks: " + ", ".join(unknown))
+    contract = workflow_node_contract_registry.require(kind)
+    if contract.planner.task_binding == "required" and not task_ids:
+        raise ValueError(f"Node kind {kind} must cover at least one plan task.")
+    if contract.planner.task_binding == "forbidden" and task_ids:
+        raise ValueError(f"Node kind {kind} cannot cover plan tasks.")
 
 
 def _replace_node(intent: GraphIntentV3, replacement: GraphIntentNodeV3) -> None:
@@ -371,8 +394,9 @@ def apply_graph_patch(
             adapter = get_planner_node_adapter(operation.kind)
             if adapter is None:
                 raise ValueError(f"Node kind {operation.kind} has no authoring adapter.")
-            _validate_task_ids(operation.task_ids, plan_task_ids)
+            _validate_task_ids(operation.kind, operation.task_ids, plan_task_ids)
             parsed_config = adapter.validate_authoring_config(operation.config)
+            parsed_model = adapter.config_model.model_validate(parsed_config)
             contract = workflow_node_contract_registry.require(operation.kind)
             output_ports = {
                 port.name: port
@@ -389,21 +413,23 @@ def apply_graph_patch(
                 GraphIntentOutputBindingV3(
                     port=port_name,
                     variable=variable,
-                    value_schema=output_ports[port_name].value_schema,
+                    value_schema=adapter.authoritative_output_schema(
+                        port_name,
+                        parsed_model,
+                    ),
                 )
                 for port_name, variable in sorted(operation.output_variables.items())
             ]
-            result.nodes.append(
-                GraphIntentNodeV3(
-                    ref=operation.ref,
-                    kind=operation.kind,
-                    title=operation.title,
-                    description=operation.description,
-                    task_ids=operation.task_ids,
-                    config=parsed_config,
-                    outputs=outputs,
-                )
+            added_node = GraphIntentNodeV3(
+                ref=operation.ref,
+                kind=operation.kind,
+                title=operation.title,
+                description=operation.description,
+                task_ids=operation.task_ids,
+                config=parsed_config,
+                outputs=outputs,
             )
+            result.nodes.append(added_node)
             continue
 
         if isinstance(operation, UpdateNodeOperation):
@@ -414,7 +440,11 @@ def apply_graph_patch(
             if operation.description is not None:
                 updates["description"] = operation.description
             if operation.task_ids is not None:
-                _validate_task_ids(operation.task_ids, plan_task_ids)
+                _validate_task_ids(
+                    current.kind,
+                    operation.task_ids,
+                    plan_task_ids,
+                )
                 updates["task_ids"] = operation.task_ids
             if operation.config is not None:
                 adapter = get_planner_node_adapter(current.kind)
@@ -422,8 +452,25 @@ def apply_graph_patch(
                     raise ValueError(
                         f"Node kind {current.kind} has no authoring adapter."
                     )
-                updates["config"] = adapter.validate_authoring_config(operation.config)
-            _replace_node(result, current.model_copy(update=updates))
+                normalized_config = adapter.validate_authoring_config(operation.config)
+                parsed_model = adapter.config_model.model_validate(normalized_config)
+                updates["config"] = normalized_config
+                updates["outputs"] = [
+                    output.model_copy(
+                        update={
+                            "value_schema": adapter.authoritative_output_schema(
+                                output.port,
+                                parsed_model,
+                            )
+                        }
+                    )
+                    for output in current.outputs
+                ]
+            updated_node = current.model_copy(update=updates)
+            adapter = get_planner_node_adapter(current.kind)
+            assert adapter is not None
+            adapter.validate_intent_node(updated_node)
+            _replace_node(result, updated_node)
             continue
 
         if isinstance(operation, RemoveNodeOperation):
@@ -634,6 +681,8 @@ def apply_graph_patch(
 
         if isinstance(operation, SetFinalOutputOperation):
             target = _node(result, operation.node_ref)
+            if target.kind != "workflow_agent":
+                raise ValueError("Final output must come from a workflow_agent.")
             output = next(
                 (item for item in target.outputs if item.port == operation.port), None
             )
@@ -692,7 +741,21 @@ def apply_graph_patch(
         result.nodes = [node for node in result.nodes if node.ref != ref]
         next_layout.pop(ref, None)
 
-    covered_tasks = {task_id for node in result.nodes for task_id in node.task_ids}
+    for node in result.nodes:
+        adapter = get_planner_node_adapter(node.kind)
+        if adapter is None:
+            raise ValueError(f"Node kind {node.kind} has no authoring adapter.")
+        adapter.validate_intent_node(node)
+
+    covered_tasks = {
+        task_id
+        for node in result.nodes
+        if workflow_node_contract_registry.require(
+            node.kind
+        ).planner.task_binding
+        == "required"
+        for task_id in node.task_ids
+    }
     missing_tasks = sorted(plan_task_ids - covered_tasks)
     if missing_tasks:
         raise ValueError(

--- a/server/meta_agent/headless_authoring.py
+++ b/server/meta_agent/headless_authoring.py
@@ -61,7 +61,7 @@ from .graph_patch import (
     graph_patch_checksum,
 )
 from .meta_planner_v2 import MetaPlannerV2Service
-from .node_adapters import get_planner_node_adapter
+from .node_adapters import META_PLANNER_ADAPTER_KINDS, get_planner_node_adapter
 from .schemas import (
     GraphIntentInputBindingV3,
     GraphIntentOutputBindingV3,
@@ -77,9 +77,6 @@ from .schemas import (
 
 HEADLESS_AUTHORING_MAX_RECEIPTS = 20
 HEADLESS_AUTHORING_VERSION = "meta-planner-headless-authoring-v1"
-_TEMPLATE_VARIABLE = re.compile(
-    r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}"
-)
 _AUTHORABLE_WORKFLOW_AGENT_DATA_FIELDS = frozenset(
     {
         "kind",
@@ -93,6 +90,63 @@ _AUTHORABLE_WORKFLOW_AGENT_DATA_FIELDS = frozenset(
         "outputVariable",
     }
 )
+_AUTHORABLE_PURE_NODE_DATA_FIELDS: dict[str, frozenset[str]] = {
+    "json_serialize": frozenset(
+        {
+            "kind",
+            "title",
+            "description",
+            "contractVersion",
+            "inputVariable",
+            "outputVariable",
+            "format",
+        }
+    ),
+    "json_deserialize": frozenset(
+        {
+            "kind",
+            "title",
+            "description",
+            "contractVersion",
+            "inputVariable",
+            "outputVariable",
+            "expectedSchema",
+        }
+    ),
+    "variable_aggregator": frozenset(
+        {
+            "kind",
+            "title",
+            "description",
+            "contractVersion",
+            "bindings",
+            "outputVariable",
+        }
+    ),
+    "data_aggregate": frozenset(
+        {
+            "kind",
+            "title",
+            "description",
+            "inputVariable",
+            "outputVariable",
+            "groupByFields",
+            "measures",
+        }
+    ),
+    "dataset_compare": frozenset(
+        {
+            "kind",
+            "title",
+            "description",
+            "leftVariable",
+            "rightVariable",
+            "outputVariable",
+            "keyFields",
+            "includeUnchanged",
+        }
+    ),
+}
 _SENSITIVE_ERROR_VALUE = re.compile(
     r"(?i)(?:sk-[A-Za-z0-9_-]{8,}|gh[pousr]_[A-Za-z0-9]{8,}|"
     r"bearer\s+[A-Za-z0-9._-]{8,}|"
@@ -966,28 +1020,29 @@ class HeadlessAuthoringService:
             (state.candidate.get("draft") or {}).get("workflow") or {}
         )
         current_ids = {node.id for node in current_workflow.nodes}
+        allowed_adapter_kinds = set(state.scope.allowed_node_kinds) & set(
+            META_PLANNER_ADAPTER_KINDS
+        )
         allowed_kinds = {
             "input",
             "output",
             "runtime_middleware",
-            "workflow_agent",
             "external_xpert",
             "knowledge_base",
             "toolset_resource",
             "plugin_resource",
-        }
+        } | allowed_adapter_kinds
         for node in definition.nodes:
             kind = str((node.data or {}).get("kind") or node.type or "")
             if kind not in allowed_kinds:
                 raise ValueError(f"Editor node kind {kind} is not authorized.")
             if node.id not in current_ids and kind not in {
-                "workflow_agent",
                 "runtime_middleware",
                 "external_xpert",
                 "knowledge_base",
                 "toolset_resource",
                 "plugin_resource",
-            }:
+            } | allowed_adapter_kinds:
                 raise ValueError(f"Compiler-managed node {kind} cannot be added.")
         for managed_id in ("input", "output"):
             if not any(node.id == managed_id for node in definition.nodes):
@@ -995,8 +1050,8 @@ class HeadlessAuthoringService:
 
         self._validate_compiler_managed_editor_nodes(definition, current_workflow)
         self._validate_editor_edges(definition)
-        self._validate_editor_agent_fields(definition, current_workflow)
-        self._annotate_editor_agents(state, definition)
+        self._validate_editor_adapter_fields(definition, current_workflow)
+        self._annotate_editor_adapter_nodes(state, definition)
         self._resolve_editor_resource_versions(state, definition)
         candidate = deepcopy(state.candidate)
         candidate.setdefault("draft", {})["workflow"] = definition.model_dump(
@@ -1032,37 +1087,46 @@ class HeadlessAuthoringService:
         return target_intent, target_layout
 
     @staticmethod
-    def _validate_editor_agent_fields(
+    def _validate_editor_adapter_fields(
         definition: NativeWorkflowDefinition,
         current: NativeWorkflowDefinition,
     ) -> None:
-        current_by_ref = {
-            str((node.data or {}).get("plannerRef") or ""): dict(node.data or {})
-            for node in current.nodes
-            if str((node.data or {}).get("kind") or node.type or "")
-            == "workflow_agent"
-            and str((node.data or {}).get("plannerRef") or "")
-        }
+        current_by_id = {node.id: node for node in current.nodes}
         for node in definition.nodes:
             data = dict(node.data or {})
-            if str(data.get("kind") or node.type or "") != "workflow_agent":
+            kind = str(data.get("kind") or node.type or "")
+            if kind not in META_PLANNER_ADAPTER_KINDS:
                 continue
-            ref = str(data.get("plannerRef") or "").strip()
-            before = current_by_ref.get(ref)
-            if before is None:
-                unsupported = sorted(
-                    set(data) - _AUTHORABLE_WORKFLOW_AGENT_DATA_FIELDS
+            current_node = current_by_id.get(node.id)
+            before = dict(current_node.data or {}) if current_node else None
+            if current_node is not None:
+                current_kind = str(
+                    (current_node.data or {}).get("kind")
+                    or current_node.type
+                    or ""
                 )
+                if current_kind != kind:
+                    raise ValueError(
+                        f"Editor node {node.id} cannot change kind from "
+                        f"{current_kind} to {kind}."
+                    )
+            allowed_fields = (
+                _AUTHORABLE_WORKFLOW_AGENT_DATA_FIELDS
+                if kind == "workflow_agent"
+                else _AUTHORABLE_PURE_NODE_DATA_FIELDS.get(kind, frozenset())
+            )
+            if before is None:
+                unsupported = sorted(set(data) - allowed_fields)
             else:
                 unsupported = sorted(
                     key
                     for key in set(before) | set(data)
-                    if key not in _AUTHORABLE_WORKFLOW_AGENT_DATA_FIELDS
+                    if key not in allowed_fields
                     and before.get(key) != data.get(key)
                 )
             if unsupported:
                 raise ValueError(
-                    f"Workflow Agent {ref or node.id} changes fields outside its "
+                    f"Editor node {node.id} changes fields outside its "
                     "authoring Adapter: "
                     + ", ".join(unsupported)
                 )
@@ -1186,7 +1250,11 @@ class HeadlessAuthoringService:
             node.id: str((node.data or {}).get("plannerRef") or "").strip()
             for node in definition.nodes
             if str((node.data or {}).get("kind") or node.type or "")
-            == "workflow_agent"
+            in META_PLANNER_ADAPTER_KINDS
+        }
+        kind_by_id = {
+            node.id: str((node.data or {}).get("kind") or node.type or "")
+            for node in definition.nodes
         }
         parents = {node.ref: set() for node in intent.nodes}
         for edge in intent.control_edges:
@@ -1203,12 +1271,12 @@ class HeadlessAuthoringService:
                 target_ref = ref_by_id.get(edge.target)
                 if not target_ref:
                     raise ValueError(
-                        "Compiler-managed input edge must target a Workflow Agent."
+                        "Compiler-managed input edge must target an Adapter node."
                     )
                 actual_roots.add(target_ref)
             if edge.target == "output":
                 source_ref = ref_by_id.get(edge.source)
-                if not source_ref:
+                if not source_ref or kind_by_id.get(edge.source) != "workflow_agent":
                     raise ValueError(
                         "Compiler-managed output edge must source a Workflow Agent."
                     )
@@ -1251,30 +1319,35 @@ class HeadlessAuthoringService:
                 )
 
     @staticmethod
-    def _annotate_editor_agents(
+    def _annotate_editor_adapter_nodes(
         state: _ProposalState, definition: NativeWorkflowDefinition
     ) -> None:
         node_by_id = {node.id: node for node in definition.nodes}
         current_refs = {
             node.id: str((node.data or {}).get("plannerRef") or "")
             for node in definition.nodes
-            if str((node.data or {}).get("plannerRef") or "")
+            if str((node.data or {}).get("kind") or node.type or "")
+            in META_PLANNER_ADAPTER_KINDS
+            and str((node.data or {}).get("plannerRef") or "")
         }
         used_refs = set(current_refs.values())
         ref_by_id: dict[str, str] = {}
+        kind_by_id: dict[str, str] = {}
         for node in definition.nodes:
             kind = str((node.data or {}).get("kind") or node.type or "")
-            if kind != "workflow_agent":
+            if kind not in META_PLANNER_ADAPTER_KINDS:
                 continue
             ref = str((node.data or {}).get("plannerRef") or "").strip()
             if not ref:
                 suffix = hashlib.sha256(node.id.encode("utf-8")).hexdigest()[:10]
-                ref = f"agent_{suffix}"
+                prefix = "agent" if kind == "workflow_agent" else "node"
+                ref = f"{prefix}_{suffix}"
                 while ref in used_refs:
                     suffix = hashlib.sha256((node.id + ref).encode("utf-8")).hexdigest()[:10]
-                    ref = f"agent_{suffix}"
+                    ref = f"{prefix}_{suffix}"
             used_refs.add(ref)
             ref_by_id[node.id] = ref
+            kind_by_id[node.id] = kind
 
         control_edges: list[tuple[str, str]] = []
         for edge in definition.edges:
@@ -1297,39 +1370,78 @@ class HeadlessAuthoringService:
                 indegree[child] -= 1
                 if indegree[child] == 0:
                     queue.append(child)
+        if len(order) != len(ref_by_id):
+            raise ValueError("Editor Adapter control graph must be acyclic.")
         ancestors: dict[str, set[str]] = {ref: set() for ref in parents}
         for ref in order:
             for parent in parents[ref]:
                 ancestors[ref].add(parent)
                 ancestors[ref].update(ancestors[parent])
 
-        output_by_ref: dict[str, tuple[str, str]] = {}
-        for node_id, ref in ref_by_id.items():
-            node = node_by_id[node_id]
-            variable = str((node.data or {}).get("outputVariable") or "").strip()
-            output_by_ref[ref] = (variable or f"{ref}_result", "result")
-        plan_task_ids = {task.task_id for task in state.plan.tasks}
-        default_task_id = state.plan.tasks[0].task_id
-        contract = workflow_node_contract_registry.require("workflow_agent")
+        parsed_by_ref: dict[str, Any] = {}
+        output_bindings_by_ref: dict[str, list[GraphIntentOutputBindingV3]] = {}
+        output_by_variable: dict[
+            str, list[tuple[str, str, WorkflowValueSchema]]
+        ] = defaultdict(list)
         for node_id, ref in ref_by_id.items():
             node = node_by_id[node_id]
             data = node.data
+            kind = kind_by_id[node_id]
+            adapter = get_planner_node_adapter(kind)
+            assert adapter is not None
+            if kind == "workflow_agent":
+                role_prompt = str(data.get("rolePrompt") or "").strip()
+                task_input = str(data.get("taskInput") or "").strip()
+                if not role_prompt or not task_input:
+                    defaults = adapter.default_intent_config()
+                    data["rolePrompt"] = role_prompt or defaults["role_prompt"]
+                    data["taskInput"] = task_input or defaults["task_input"]
+            parsed = adapter.authoring_config_from_native(data)
+            output_variables = adapter.editor_output_variables(data, parsed)
+            outputs = [
+                GraphIntentOutputBindingV3(
+                    port=port,
+                    variable=variable,
+                    value_schema=adapter.authoritative_output_schema(port, parsed),
+                )
+                for port, variable in output_variables.items()
+            ]
+            parsed_by_ref[ref] = parsed
+            output_bindings_by_ref[ref] = outputs
+            for output in outputs:
+                output_by_variable[output.variable].append(
+                    (ref, output.port, output.value_schema)
+                )
+        plan_task_ids = {task.task_id for task in state.plan.tasks}
+        default_task_id = state.plan.tasks[0].task_id
+        for node_id, ref in ref_by_id.items():
+            node = node_by_id[node_id]
+            data = node.data
+            kind = kind_by_id[node_id]
+            adapter = get_planner_node_adapter(kind)
+            assert adapter is not None
+            parsed = parsed_by_ref[ref]
+            contract = workflow_node_contract_registry.require(kind)
             raw_task_ids = data.get("plannerTaskIds")
-            task_ids = (
-                [str(item) for item in raw_task_ids if str(item) in plan_task_ids]
+            supplied_task_ids = (
+                [str(item) for item in raw_task_ids]
                 if isinstance(raw_task_ids, list)
                 else []
             )
-            if not task_ids:
-                task_ids = [default_task_id]
-            output_variable = output_by_ref[ref][0]
-            referenced = {
-                match.group(1)
-                for field in ("rolePrompt", "taskInput")
-                for match in _TEMPLATE_VARIABLE.finditer(str(data.get(field) or ""))
-            }
+            unknown_task_ids = sorted(set(supplied_task_ids) - plan_task_ids)
+            if unknown_task_ids:
+                raise ValueError(
+                    f"Editor node {ref} references unknown plan tasks: "
+                    + ", ".join(unknown_task_ids)
+                )
+            if contract.planner.task_binding == "required":
+                task_ids = supplied_task_ids or [default_task_id]
+            else:
+                if supplied_task_ids:
+                    raise ValueError(f"Editor node {ref} cannot cover plan tasks.")
+                task_ids = []
             inputs: list[GraphIntentInputBindingV3] = []
-            for variable in sorted(referenced):
+            for port, variable in adapter.editor_input_variables(data, parsed):
                 if variable in {"user_input", "conversation_history"}:
                     source_ref = "input"
                     source_port = variable
@@ -1342,26 +1454,44 @@ class HeadlessAuthoringService:
                     )
                 else:
                     candidates = [
-                        (candidate_ref, port)
-                        for candidate_ref, (candidate_variable, port) in output_by_ref.items()
-                        if candidate_variable == variable
-                        and candidate_ref in ancestors.get(ref, set())
+                        (candidate_ref, candidate_port, schema)
+                        for candidate_ref, candidate_port, schema in output_by_variable.get(
+                            variable, []
+                        )
+                        if candidate_ref in ancestors.get(ref, set())
                     ]
                     if len(candidates) != 1:
                         raise ValueError(
                             f"Editor variable {variable} for {ref} has no unique control-reachable producer."
                         )
-                    source_ref, source_port = candidates[0]
-                    schema = WorkflowValueSchema(type="string")
+                    source_ref, source_port, schema = candidates[0]
                 inputs.append(
                     GraphIntentInputBindingV3(
-                        port="task",
+                        port=port,
                         variable=variable,
                         source_ref=source_ref,
                         source_port=source_port,
                         value_schema=schema,
                     )
                 )
+            port_totals = Counter(item.port for item in inputs)
+            port_seen: Counter[str] = Counter()
+            legacy_inputs: list[dict[str, Any]] = []
+            for item in inputs:
+                port_seen[item.port] += 1
+                legacy_port = (
+                    f"{item.port}_{port_seen[item.port]}"
+                    if port_totals[item.port] > 1
+                    else item.port
+                )
+                legacy_inputs.append(
+                    {
+                        "port": legacy_port,
+                        "variable": item.variable,
+                        "value_type": item.value_schema.type,
+                    }
+                )
+            outputs = output_bindings_by_ref[ref]
             data.update(
                 {
                     "plannerIRVersion": 3,
@@ -1371,48 +1501,17 @@ class HeadlessAuthoringService:
                     "plannerCompilerChecksum": contract.compiler_checksum,
                     "plannerInputsV3": [item.model_dump(mode="json") for item in inputs],
                     "plannerOutputsV3": [
-                        GraphIntentOutputBindingV3(
-                            port="result",
-                            variable=output_variable,
-                            value_schema=WorkflowValueSchema(type="string"),
-                        ).model_dump(mode="json")
+                        item.model_dump(mode="json") for item in outputs
                     ],
-                    "plannerInputs": [
+                    "plannerInputs": legacy_inputs,
+                    "plannerOutputs": [
                         {
-                            "port": f"task_{index + 1}",
+                            "port": item.port,
                             "variable": item.variable,
                             "value_type": item.value_schema.type,
                         }
-                        for index, item in enumerate(inputs)
+                        for item in outputs
                     ],
-                    "plannerOutputs": [
-                        {
-                            "port": "result",
-                            "variable": output_variable,
-                            "value_type": "string",
-                        }
-                    ],
-                    "outputVariable": output_variable,
                 }
             )
-            adapter = get_planner_node_adapter("workflow_agent")
-            assert adapter is not None
-            config = {
-                "role_prompt": str(data.get("rolePrompt") or "").strip(),
-                "task_input": str(data.get("taskInput") or "").strip(),
-                "model_id": str(data.get("modelId") or "").strip() or None,
-                "source_agent_id": str(data.get("sourceAgentId") or "").strip()
-                or None,
-                "method_skill_ids": (
-                    list(data.get("methodSkillIds") or [])
-                    if isinstance(data.get("methodSkillIds"), list)
-                    else []
-                ),
-            }
-            if not config["role_prompt"] or not config["task_input"]:
-                defaults = adapter.default_intent_config()
-                config["role_prompt"] = config["role_prompt"] or defaults["role_prompt"]
-                config["task_input"] = config["task_input"] or defaults["task_input"]
-                data["rolePrompt"] = config["role_prompt"]
-                data["taskInput"] = config["task_input"]
-            adapter.validate_authoring_config(config)
+            adapter.validate_authoring_config(parsed.model_dump(mode="json"))

--- a/server/meta_agent/meta_planner_v2.py
+++ b/server/meta_agent/meta_planner_v2.py
@@ -18,7 +18,10 @@ try:
         NativeWorkflowNode,
         WorkflowPosition,
     )
-    from server.workflow_native.node_contracts import canonical_checksum
+    from server.workflow_native.node_contracts import (
+        canonical_checksum,
+        workflow_node_contract_registry,
+    )
     from server.workflow_native.validate import node_kind, validate_workflow_graph
     from server.xpert_runtime.authoring_service import AuthoringService
     from server.xpert_runtime.authoring_store import AuthoringProposal
@@ -31,7 +34,10 @@ except ModuleNotFoundError:
         NativeWorkflowNode,
         WorkflowPosition,
     )
-    from workflow_native.node_contracts import canonical_checksum
+    from workflow_native.node_contracts import (
+        canonical_checksum,
+        workflow_node_contract_registry,
+    )
     from workflow_native.validate import node_kind, validate_workflow_graph
     from xpert_runtime.authoring_service import AuthoringService
     from xpert_runtime.authoring_store import AuthoringProposal
@@ -91,6 +97,8 @@ You are the task-planning stage of ModelMirror Meta Planner Graph IR V3.
 Return one strict JSON object only. Do not include markdown or hidden reasoning.
 Create a bounded task DAG. Every task must have a stable lowercase task_id,
 explicit dependencies, an input contract, and one output contract.
+Tasks represent model-driven responsibilities. Deterministic helper-node operations
+must not become tasks; obey the supplied task_planning_contract.
 """
 
 
@@ -102,7 +110,8 @@ only; compiler-managed input/output and resource-binding nodes are never emitted
 Use only IDs and middleware listed in the authorized capability snapshot.
 Compile the task DAG into explicit typed IR nodes, control edges, resource bindings,
 middleware bindings, and one explicit final output. A node may cover multiple tasks
-and a task may require multiple nodes. Bindings must target a workflow_agent node ref.
+and every task must be covered by a workflow_agent. Auxiliary pure nodes must have an
+empty task_ids list. Bindings must target a workflow_agent node ref.
 Every node input must identify its source node and source port. Use the workflow_agent
 task port for each task input; that port accepts multiple typed variables.
 Respect the supplied typed_ir_constraints, including its workflow-agent node limit.
@@ -127,6 +136,8 @@ Use only the listed semantic refs, named ports, Adapter config, and authorized I
 Do not emit native node IDs, Handles, resource versions, schemas, policies, checksums
 other than the exact expected checksums supplied in the envelope. Make the smallest
 ordered patch that addresses the validation issues. This is the only repair pass.
+The virtual refs input and output may be referenced where allowed but can never be
+added, updated, removed, or moved as nodes.
 """
 
 
@@ -218,6 +229,202 @@ def _typed_ir_prompt_constraints(
     }
 
 
+def _task_planning_contract(
+    request: MetaPlannerGenerateRequest,
+    snapshot: MetaPlannerCapabilitySnapshot,
+) -> dict[str, Any]:
+    allowed_kinds = set(request.scope.allowed_node_kinds)
+    auxiliary_node_contracts: list[dict[str, Any]] = []
+    for item in snapshot.nodes:
+        kind = str(item.get("kind") or "")
+        planner = dict(item.get("planner") or {})
+        if (
+            kind not in allowed_kinds
+            or get_planner_node_adapter(kind) is None
+            or planner.get("task_binding") != "forbidden"
+        ):
+            continue
+        contracts = dict(item.get("contracts") or {})
+
+        def port_summary(port: Any) -> dict[str, Any]:
+            payload = dict(port) if isinstance(port, dict) else {}
+            value_schema = dict(payload.get("value_schema") or {})
+            return {
+                "name": str(payload.get("name") or ""),
+                "type": str(value_schema.get("type") or "any"),
+                "cardinality": str(payload.get("cardinality") or "one"),
+            }
+
+        auxiliary_node_contracts.append(
+            {
+                "kind": kind,
+                "title": str(item.get("title") or kind),
+                "purpose": str(item.get("description") or ""),
+                "task_binding": "forbidden",
+                "inputs": [
+                    port_summary(port)
+                    for port in list(contracts.get("inputs") or [])
+                ],
+                "outputs": [
+                    port_summary(port)
+                    for port in list(contracts.get("outputs") or [])
+                ],
+            }
+        )
+    auxiliary_node_contracts.sort(key=lambda item: item["kind"])
+    auxiliary_node_kinds = [item["kind"] for item in auxiliary_node_contracts]
+    return {
+        "expert_task_binding": "required",
+        "max_workflow_agent_nodes": request.max_agents,
+        "auxiliary_node_kinds": auxiliary_node_kinds,
+        "auxiliary_node_contracts": auxiliary_node_contracts,
+        "expert_task_test": {
+            "question": (
+                "After all authorized auxiliary nodes are available, does this "
+                "step still require model judgment, interpretation, extraction "
+                "from unstructured content, or synthesis?"
+            ),
+            "required_answer": "yes",
+        },
+        "non_task_examples": [
+            "Parse a JSON string into a typed value.",
+            "Serialize a typed value to JSON.",
+            "Pack named variables into one object.",
+            "Group rows and calculate deterministic measures.",
+            "Compare two datasets by stable keys.",
+        ],
+        "expert_task_examples": [
+            "Extract audit controls from unstructured evidence.",
+            "Interpret deterministic comparison results and write a professional conclusion.",
+        ],
+        "rules": [
+            "Plan tasks describe model-driven judgment, responsibility, or synthesis that a workflow_agent must perform.",
+            "Deterministic operations represented by auxiliary_node_kinds must not become plan tasks; they are compiled later as task-free helper nodes.",
+            "Do not create one expert task per requested JSON conversion, packing, aggregation, or dataset comparison step.",
+            "Apply expert_task_test to every proposed task and omit the task unless the required answer is yes.",
+            "Use auxiliary_node_contracts purpose and ports to recognize deterministic steps before emitting tasks.",
+            "Keep distinct expert responsibilities separate, but do not split a single responsibility merely to name its deterministic data transforms.",
+        ],
+    }
+
+
+def _graph_patch_repair_contract(
+    request: MetaPlannerGenerateRequest,
+    blueprint: GraphIntentV3,
+    issues: list[str],
+) -> dict[str, Any]:
+    existing_nodes = sorted(
+        (
+            {
+                "ref": node.ref,
+                "kind": node.kind,
+                "task_ids": list(node.task_ids),
+                "input_sources": sorted(
+                    {
+                        f"{binding.source_ref}.{binding.source_port}"
+                        for binding in node.inputs
+                    }
+                ),
+                "output_ports": sorted(output.port for output in node.outputs),
+            }
+            for node in blueprint.nodes
+        ),
+        key=lambda item: item["ref"],
+    )
+    workflow_agent_count = sum(
+        node.kind == "workflow_agent" for node in blueprint.nodes
+    )
+    agent_overflow = workflow_agent_count > request.max_agents
+    issue_playbook: list[str] = []
+    if agent_overflow or any("exceeds max_agents" in issue for issue in issues):
+        issue_playbook.append(
+            "For max_agents overflow, consolidate task_ids into at most "
+            f"{request.max_agents} retained workflow_agent nodes, reconnect their "
+            "control and data edges, set a retained workflow_agent as final output, "
+            "then remove surplus agents; do not add workflow_agent nodes."
+        )
+    return {
+        "compiler_managed_refs": ["input", "output"],
+        "existing_node_refs": [item["ref"] for item in existing_nodes],
+        "existing_nodes": existing_nodes,
+        "max_workflow_agent_nodes": request.max_agents,
+        "current_workflow_agent_nodes": workflow_agent_count,
+        "allow_add_workflow_agent": workflow_agent_count < request.max_agents,
+        "addable_node_kinds": sorted(
+            kind
+            for kind in set(request.scope.allowed_node_kinds)
+            if get_planner_node_adapter(kind) is not None
+        ),
+        "issue_playbook": issue_playbook,
+        "rules": [
+            "The refs input and output are compiler-managed virtual refs: never add, update, remove, or move them.",
+            "input may only be referenced as an existing source_ref; output is created from set_final_output.",
+            "add_node must use a new ref outside compiler_managed_refs and existing_node_refs.",
+            "update_node, remove_node, and move_node may target only existing_node_refs.",
+            "Pure nodes use empty task_ids; workflow_agent nodes cover all fixed plan tasks.",
+            "Do not add a workflow_agent when allow_add_workflow_agent is false.",
+            "Adapter-derived output Schemas are recomputed by the server after this repair; never inject or patch output Schemas directly.",
+        ],
+    }
+
+
+def _normalize_adapter_outputs_for_repair(
+    intent: GraphIntentV3,
+) -> tuple[GraphIntentV3, list[str]]:
+    """Refresh Adapter-owned outputs and their derived data-edge schemas."""
+
+    normalized_refs: set[str] = set()
+    authoritative_outputs: dict[
+        tuple[str, str], tuple[str, Any]
+    ] = {}
+    output_normalized_nodes = []
+    for node in intent.nodes:
+        adapter = get_planner_node_adapter(node.kind)
+        if adapter is None:
+            output_normalized_nodes.append(node)
+            continue
+        parsed = adapter.validate_intent_node(node)
+        outputs = []
+        for output in node.outputs:
+            authoritative = adapter.authoritative_output_schema(output.port, parsed)
+            authoritative_outputs[(node.ref, output.port)] = (
+                output.variable,
+                authoritative,
+            )
+            if canonical_checksum(
+                output.value_schema.model_dump(mode="json")
+            ) != canonical_checksum(authoritative.model_dump(mode="json")):
+                normalized_refs.add(node.ref)
+                output = output.model_copy(
+                    update={"value_schema": authoritative}
+                )
+            outputs.append(output)
+        output_normalized_nodes.append(node.model_copy(update={"outputs": outputs}))
+
+    normalized_nodes = []
+    for node in output_normalized_nodes:
+        inputs = []
+        for binding in node.inputs:
+            source = authoritative_outputs.get(
+                (binding.source_ref, binding.source_port)
+            )
+            if source is not None and binding.variable == source[0]:
+                authoritative = source[1]
+                if canonical_checksum(
+                    binding.value_schema.model_dump(mode="json")
+                ) != canonical_checksum(authoritative.model_dump(mode="json")):
+                    normalized_refs.add(binding.source_ref)
+                    binding = binding.model_copy(
+                        update={"value_schema": authoritative}
+                    )
+            inputs.append(binding)
+        normalized_nodes.append(node.model_copy(update={"inputs": inputs}))
+    return (
+        intent.model_copy(update={"nodes": normalized_nodes}),
+        sorted(normalized_refs),
+    )
+
+
 def _graph_intent_prompt_contract(
     request: MetaPlannerGenerateRequest,
     snapshot: MetaPlannerCapabilitySnapshot,
@@ -237,6 +444,17 @@ def _graph_intent_prompt_contract(
         for item in snapshot.nodes
         if isinstance(item, dict)
     }
+    node_contracts = {
+        str(item.get("kind") or ""): {
+            "task_binding": dict(item.get("planner") or {}).get("task_binding"),
+            "config_schema": dict(
+                (item.get("contract") or {}).get("planner") or {}
+            ).get("ir_config_schema", {}),
+            "ports": list((item.get("contract") or {}).get("ports") or []),
+        }
+        for item in snapshot.nodes
+        if str(item.get("kind") or "") in executable_kinds
+    }
 
     return {
         "required_ir_version": GRAPH_IR_VERSION,
@@ -244,6 +462,7 @@ def _graph_intent_prompt_contract(
             "executable_node_kinds": executable_kinds,
             "compiler_managed_node_kinds": compiler_managed_kinds,
             "resource_binding_kinds": binding_kinds,
+            "executable_node_contracts": node_contracts,
         },
         "workflow_agent": {
             "config_schema": MetaPlannerWorkflowAgentConfig.model_json_schema(),
@@ -276,11 +495,15 @@ def _graph_intent_prompt_contract(
             "Represent resources only in resources and target a workflow_agent ref.",
             "Use snake_case workflow_agent config fields exactly as config_field_names; never emit outputVariable, taskInput, rolePrompt, or agent_id in config.",
             "Every workflow_agent declares exactly one string output on port result with a unique variable.",
+            "Every workflow_agent has one or more task_ids; nodes whose task_binding is forbidden have an empty task_ids list.",
+            "Pure nodes are deterministic auxiliary transforms only; do not use redundant serialize-deserialize round trips or duplicate aggregates.",
+            "Pure node config, named ports, and output Schema must exactly match executable_node_contracts.",
             "Every root workflow_agent binds user_input from source_ref input and source_port user_input to input port task.",
             "Every dependency input binds the exact ancestor result variable from source_port result to input port task.",
             "Every {{variable}} used in role_prompt or task_input has a matching explicit input binding.",
             "Control edges represent every cross-node task dependency and form one acyclic graph with one terminal node.",
             "final_output references the terminal workflow_agent result port and its exact output variable.",
+            "Resources and middleware may target workflow_agent nodes only, never pure nodes.",
             "middleware may contain only authorized middleware_ids; when that list is empty, middleware must be empty.",
         ],
         "snapshot_node_kinds": sorted(snapshot_kinds & allowed_kinds),
@@ -741,7 +964,11 @@ def validate_blueprint_authorization(
         if item.get("safe") is True and item.get("id")
     }
     available_models.add(request.default_agent_model_id)
-    parsed_configs: dict[str, MetaPlannerWorkflowAgentConfig] = {}
+    graph_nodes_by_ref = (
+        {node.ref: node for node in blueprint.nodes}
+        if isinstance(blueprint, GraphIntentV3)
+        else {}
+    )
     for node in typed.nodes:
         if node.kind not in request.scope.allowed_node_kinds:
             issues.append(f"Node kind {node.kind} is not authorized.")
@@ -755,39 +982,37 @@ def validate_blueprint_authorization(
             continue
         try:
             parsed = adapter.validate_config(node)
-            config = MetaPlannerWorkflowAgentConfig.model_validate(parsed)
-            parsed_configs[node.ref] = config
-        except ValidationError as exc:
+            if isinstance(blueprint, GraphIntentV3):
+                adapter.validate_intent_node(graph_nodes_by_ref[node.ref])
+        except (ValidationError, ValueError) as exc:
             issues.append(
                 f"Node {node.ref} config is invalid: {_safe_exception_message(exc)}"
             )
             continue
+        contract = workflow_node_contract_registry.require(node.kind)
+        task_binding = contract.planner.task_binding
+        if task_binding == "required" and not node.task_ids:
+            issues.append(f"Node {node.ref} must cover at least one plan task.")
+        if task_binding == "forbidden" and node.task_ids:
+            issues.append(f"Node {node.ref} cannot cover plan tasks.")
         if isinstance(blueprint, GraphIntentV3):
-            graph_node = next(
-                item for item in blueprint.nodes if item.ref == node.ref
-            )
+            graph_node = graph_nodes_by_ref[node.ref]
             declared_inputs = {item.variable for item in graph_node.inputs}
-            referenced = {
-                match.group(1)
-                for template in (config.role_prompt, config.task_input)
-                for match in re.finditer(
-                    r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}",
-                    template,
-                )
-            }
+            referenced = adapter.referenced_input_variables(parsed)
             for variable in sorted(referenced - declared_inputs):
                 issues.append(
                     f"Node {node.ref} template variable {variable} needs an "
                     "explicit data binding."
                 )
-        if len(node.outputs) != 1 or node.outputs[0].port != "result":
-            issues.append(
-                f"Node {node.ref} must expose exactly one result output port."
-            )
-        elif node.outputs[0].value_type != "string":
-            issues.append(
-                f"Node {node.ref} workflow_agent result must be a string."
-            )
+        if node.kind == "workflow_agent":
+            if len(node.outputs) != 1 or node.outputs[0].port != "result":
+                issues.append(
+                    f"Node {node.ref} must expose exactly one result output port."
+                )
+            elif node.outputs[0].value_type != "string":
+                issues.append(
+                    f"Node {node.ref} workflow_agent result must be a string."
+                )
         if len({item.port for item in node.inputs}) != len(node.inputs):
             issues.append(f"Node {node.ref} input ports must be unique.")
         if len({item.variable for item in node.outputs}) != len(node.outputs):
@@ -798,6 +1023,11 @@ def validate_blueprint_authorization(
                 f"Node {node.ref} references unknown tasks: "
                 + ", ".join(unknown_tasks)
             )
+        if task_binding != "required":
+            continue
+        config = MetaPlannerWorkflowAgentConfig.model_validate(
+            parsed.model_dump(mode="json")
+        )
         for task_id in set(node.task_ids) & plan_ids:
             task_nodes[task_id].append(node)
             planned_task = next(
@@ -858,6 +1088,8 @@ def validate_blueprint_authorization(
     )
     if final_node is None:
         issues.append("Typed IR final_output references an unknown node.")
+    elif final_node.kind != "workflow_agent":
+        issues.append("Typed IR final_output must come from a workflow_agent.")
     elif typed.final_output.variable not in {
         item.variable for item in final_node.outputs
     }:
@@ -1848,7 +2080,7 @@ class MetaPlannerV2Service:
                     + ". Use create mode or wait for a dedicated compiler adapter."
                 )
 
-        plan_prompt = self._plan_prompt(request)
+        plan_prompt = self._plan_prompt(request, snapshot)
         raw_plan = await self.completion(
             request.planner_model_id,
             TASK_PLAN_SYSTEM_PROMPT,
@@ -1938,8 +2170,20 @@ class MetaPlannerV2Service:
                         plan_task_ids={task.task_id for task in plan.tasks},
                         allowed_node_kinds=set(request.scope.allowed_node_kinds),
                     )
+                    normalized_intent, normalized_refs = (
+                        _normalize_adapter_outputs_for_repair(patched.intent)
+                    )
+                    if normalized_refs:
+                        warnings.append(
+                            "The single Graph Patch repair refreshed "
+                            "Adapter-derived output Schemas and dependent data "
+                            "bindings for: "
+                            + ", ".join(normalized_refs)
+                            + "."
+                        )
                     repaired_raw = json.dumps(
-                        patched.intent.model_dump(mode="json"), ensure_ascii=False
+                        normalized_intent.model_dump(mode="json"),
+                        ensure_ascii=False,
                     )
                     (
                         blueprint,
@@ -2222,6 +2466,7 @@ class MetaPlannerV2Service:
         workflow = candidate["draft"]["workflow"]
         for node in workflow["nodes"]:
             if node.get("type") == "workflow_agent":
+                # Keep the emergency fallback unapprovable until a human repairs it.
                 node["data"]["modelId"] = ""
                 break
         return candidate, graph_ir, compatibility
@@ -2243,6 +2488,9 @@ class MetaPlannerV2Service:
         MetaPlannerIRCompatibility,
     ]:
         compatibility = MetaPlannerIRCompatibility(source_version=3)
+        # A parsed Intent remains eligible for the one typed Patch repair even
+        # when a later semantic gate rejects it.
+        blueprint: GraphIntentV3 | None = None
         try:
             payload = _json_payload(raw_blueprint)
             if payload.get("ir_version") == 2:
@@ -2308,7 +2556,7 @@ class MetaPlannerV2Service:
         except Exception as exc:
             message = _safe_exception_message(exc)
             return (
-                None,
+                blueprint,
                 {},
                 {"valid": False, "issues": [message]},
                 [message],
@@ -2317,7 +2565,10 @@ class MetaPlannerV2Service:
             )
 
     @staticmethod
-    def _plan_prompt(request: MetaPlannerGenerateRequest) -> str:
+    def _plan_prompt(
+        request: MetaPlannerGenerateRequest,
+        snapshot: MetaPlannerCapabilitySnapshot,
+    ) -> str:
         required_schema = MetaPlannerTaskPlan.model_json_schema()
         task_schema = (
             required_schema.get("$defs", {}).get("MetaPlannerTask", {})
@@ -2343,6 +2594,9 @@ class MetaPlannerV2Service:
                 "max_tasks": 8,
                 "max_workflow_agents": request.max_agents,
                 "authorized_agent_ids": list(request.scope.agent_ids),
+                "task_planning_contract": _task_planning_contract(
+                    request, snapshot
+                ),
                 "required_schema": required_schema,
                 "rules": [
                     "agent_id may only use an exact value from authorized_agent_ids.",
@@ -2462,6 +2716,12 @@ class MetaPlannerV2Service:
                 "base_graph_intent": blueprint.model_dump(mode="json"),
                 "validation_issues": issues[:30],
                 "required_schema": GraphPatchEnvelopeV1.model_json_schema(),
+                "typed_ir_constraints": _typed_ir_prompt_constraints(
+                    request, plan
+                ),
+                "repair_contract": _graph_patch_repair_contract(
+                    request, blueprint, issues
+                ),
                 "required_envelope": {
                     "protocol_version": 1,
                     "proposal_revision": 1,
@@ -2472,6 +2732,7 @@ class MetaPlannerV2Service:
                     "Return GraphPatchEnvelopeV1, never a complete GraphIntent or Native Workflow.",
                     "Copy every required_envelope value exactly.",
                     "Use Adapter config only; do not emit resource versions, Handles, schemas, policies, or native node IDs.",
+                    "Obey repair_contract ref scopes and issue_playbook exactly.",
                     "Do not change the fixed task plan or add unauthorized capabilities.",
                     "This is the only repair pass.",
                 ],

--- a/server/meta_agent/node_adapters.py
+++ b/server/meta_agent/node_adapters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -13,14 +14,26 @@ from .schemas import (
 
 try:
     from server.workflow_native.node_contracts import (
+        DataAggregatePlannerConfig,
+        DatasetComparePlannerConfig,
+        JsonDeserializePlannerConfig,
+        JsonSerializePlannerConfig,
         NODE_CONTRACT_VERSION,
+        VariableAggregatorPlannerConfig,
+        WorkflowValueSchema,
         canonical_checksum,
         workflow_node_contract_registry,
     )
     from server.workflow_native.schemas import NativeWorkflowNode, WorkflowPosition
 except ModuleNotFoundError:
     from workflow_native.node_contracts import (
+        DataAggregatePlannerConfig,
+        DatasetComparePlannerConfig,
+        JsonDeserializePlannerConfig,
+        JsonSerializePlannerConfig,
         NODE_CONTRACT_VERSION,
+        VariableAggregatorPlannerConfig,
+        WorkflowValueSchema,
         canonical_checksum,
         workflow_node_contract_registry,
     )
@@ -61,10 +74,81 @@ class PlannerNodeAdapter:
     ]
     decompile_node: Callable[[NativeWorkflowNode], MetaPlannerIRNode]
     decompile_node_v3: Callable[[NativeWorkflowNode], GraphIntentNodeV3]
+    referenced_variables: Callable[[BaseModel], set[str]] | None = None
+    output_schema: Callable[[str, BaseModel], WorkflowValueSchema] | None = None
+    validate_node_shape: Callable[
+        [MetaPlannerIRNode | GraphIntentNodeV3, BaseModel], None
+    ] | None = None
+    native_config: Callable[[dict[str, Any]], dict[str, Any]] | None = None
+    native_inputs: Callable[
+        [dict[str, Any], BaseModel], list[tuple[str, str]]
+    ] | None = None
+    native_outputs: Callable[
+        [dict[str, Any], BaseModel], dict[str, str]
+    ] | None = None
     contract_version: int = NODE_CONTRACT_VERSION
 
     def validate_config(self, node: MetaPlannerIRNode) -> BaseModel:
-        return self.config_model.model_validate(node.config)
+        parsed = self.config_model.model_validate(node.config)
+        if self.validate_node_shape is not None:
+            self.validate_node_shape(node, parsed)
+        return parsed
+
+    def validate_intent_node(self, node: GraphIntentNodeV3) -> BaseModel:
+        parsed = self.config_model.model_validate(node.config)
+        if self.validate_node_shape is not None:
+            self.validate_node_shape(node, parsed)
+        return parsed
+
+    def referenced_input_variables(self, parsed: BaseModel) -> set[str]:
+        if self.referenced_variables is None:
+            return set()
+        return set(self.referenced_variables(parsed))
+
+    def authoritative_output_schema(
+        self,
+        port: str,
+        parsed: BaseModel,
+    ) -> WorkflowValueSchema:
+        if self.output_schema is not None:
+            return self.output_schema(port, parsed)
+        contract = workflow_node_contract_registry.require(self.kind)
+        match = next(
+            (
+                item
+                for item in contract.ports
+                if item.direction == "output" and item.name == port
+            ),
+            None,
+        )
+        if match is None:
+            raise ValueError(f"Node kind {self.kind} has no output port {port}.")
+        return match.value_schema
+
+    def authoring_config_from_native(self, data: dict[str, Any]) -> BaseModel:
+        if self.native_config is None:
+            raise ValueError(
+                f"Node kind {self.kind} cannot be projected from editor data."
+            )
+        return self.config_model.model_validate(self.native_config(data))
+
+    def editor_input_variables(
+        self,
+        data: dict[str, Any],
+        parsed: BaseModel,
+    ) -> list[tuple[str, str]]:
+        if self.native_inputs is None:
+            raise ValueError(f"Node kind {self.kind} has no editor input projection.")
+        return list(self.native_inputs(data, parsed))
+
+    def editor_output_variables(
+        self,
+        data: dict[str, Any],
+        parsed: BaseModel,
+    ) -> dict[str, str]:
+        if self.native_outputs is None:
+            raise ValueError(f"Node kind {self.kind} has no editor output projection.")
+        return dict(self.native_outputs(data, parsed))
 
     def validate_authoring_config(self, config: dict[str, Any]) -> dict[str, Any]:
         """Normalize editor/model config through the same compiler contract."""
@@ -137,6 +221,327 @@ class PlannerNodeAdapter:
                 "compiler_checksum": contract.compiler_checksum,
             }
         )
+
+
+def _port_matches(actual: str, expected: str) -> bool:
+    return actual == expected or actual.startswith(f"{expected}_")
+
+
+def _input_bindings(
+    node: MetaPlannerIRNode | GraphIntentNodeV3,
+    port: str,
+) -> list[Any]:
+    return [item for item in node.inputs if _port_matches(item.port, port)]
+
+
+def _require_single_input(
+    node: MetaPlannerIRNode | GraphIntentNodeV3,
+    port: str,
+) -> Any:
+    matches = _input_bindings(node, port)
+    if len(matches) != 1:
+        raise ValueError(f"Node {node.ref} requires exactly one {port} input.")
+    return matches[0]
+
+
+def _require_single_output(
+    node: MetaPlannerIRNode | GraphIntentNodeV3,
+    port: str,
+) -> Any:
+    matches = [item for item in node.outputs if item.port == port]
+    if len(matches) != 1 or len(node.outputs) != 1:
+        raise ValueError(f"Node {node.ref} requires exactly one {port} output.")
+    return matches[0]
+
+
+def _validate_json_serialize_shape(
+    node: MetaPlannerIRNode | GraphIntentNodeV3,
+    _parsed: BaseModel,
+) -> None:
+    _require_single_input(node, "value")
+    _require_single_output(node, "json")
+
+
+def _validate_json_deserialize_shape(
+    node: MetaPlannerIRNode | GraphIntentNodeV3,
+    _parsed: BaseModel,
+) -> None:
+    _require_single_input(node, "json")
+    _require_single_output(node, "value")
+
+
+def _validate_variable_aggregator_shape(
+    node: MetaPlannerIRNode | GraphIntentNodeV3,
+    parsed: BaseModel,
+) -> None:
+    config = VariableAggregatorPlannerConfig.model_validate(parsed)
+    inputs = _input_bindings(node, "values")
+    if not inputs or len(inputs) != len(node.inputs):
+        raise ValueError(f"Node {node.ref} accepts only values inputs.")
+    if len(inputs) != len(config.output_fields):
+        raise ValueError(
+            f"Node {node.ref} output_fields must map one-to-one to values inputs."
+        )
+    _require_single_output(node, "result")
+
+
+def _validate_data_aggregate_shape(
+    node: MetaPlannerIRNode | GraphIntentNodeV3,
+    _parsed: BaseModel,
+) -> None:
+    _require_single_input(node, "rows")
+    _require_single_output(node, "result")
+
+
+def _validate_dataset_compare_shape(
+    node: MetaPlannerIRNode | GraphIntentNodeV3,
+    _parsed: BaseModel,
+) -> None:
+    _require_single_input(node, "left")
+    _require_single_input(node, "right")
+    if len(node.inputs) != 2:
+        raise ValueError(f"Node {node.ref} accepts only left and right inputs.")
+    _require_single_output(node, "result")
+
+
+def _workflow_agent_references(parsed: BaseModel) -> set[str]:
+    config = MetaPlannerWorkflowAgentConfig.model_validate(parsed)
+    referenced: set[str] = set()
+    for template in (config.role_prompt, config.task_input):
+        for match in re.finditer(r"\{\{\s*(.*?)\s*\}\}", template, re.DOTALL):
+            expression = match.group(1).strip()
+            if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", expression):
+                raise ValueError(
+                    "Template contains an unsupported template expression."
+                )
+            referenced.add(expression)
+    return referenced
+
+
+def _workflow_agent_config_from_native(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "role_prompt": str(data.get("rolePrompt") or "").strip(),
+        "task_input": str(data.get("taskInput") or "").strip(),
+        "model_id": str(data.get("modelId") or "").strip() or None,
+        "source_agent_id": str(data.get("sourceAgentId") or "").strip() or None,
+        "method_skill_ids": (
+            list(data.get("methodSkillIds") or [])
+            if isinstance(data.get("methodSkillIds"), list)
+            else []
+        ),
+    }
+
+
+def _workflow_agent_native_inputs(
+    _data: dict[str, Any], parsed: BaseModel
+) -> list[tuple[str, str]]:
+    return [
+        ("task", variable)
+        for variable in sorted(_workflow_agent_references(parsed))
+    ]
+
+
+def _single_native_input(field: str, port: str) -> Callable[
+    [dict[str, Any], BaseModel], list[tuple[str, str]]
+]:
+    def project(data: dict[str, Any], _parsed: BaseModel) -> list[tuple[str, str]]:
+        return [(port, str(data.get(field) or "").strip())]
+
+    return project
+
+
+def _single_native_output(field: str, port: str) -> Callable[
+    [dict[str, Any], BaseModel], dict[str, str]
+]:
+    def project(data: dict[str, Any], _parsed: BaseModel) -> dict[str, str]:
+        return {port: str(data.get(field) or "").strip()}
+
+    return project
+
+
+def _variable_aggregator_native_inputs(
+    data: dict[str, Any], _parsed: BaseModel
+) -> list[tuple[str, str]]:
+    bindings = data.get("bindings")
+    if not isinstance(bindings, list):
+        raise ValueError("Planner variable pack node is missing bindings.")
+    return [
+        ("values", str(item.get("sourceVariable") or "").strip())
+        for item in bindings
+        if isinstance(item, dict)
+    ]
+
+
+def _dataset_compare_native_inputs(
+    data: dict[str, Any], _parsed: BaseModel
+) -> list[tuple[str, str]]:
+    return [
+        ("left", str(data.get("leftVariable") or "").strip()),
+        ("right", str(data.get("rightVariable") or "").strip()),
+    ]
+
+
+def _json_deserialize_output_schema(
+    port: str,
+    parsed: BaseModel,
+) -> WorkflowValueSchema:
+    if port != "value":
+        raise ValueError(f"JSON deserialize has no output port {port}.")
+    return JsonDeserializePlannerConfig.model_validate(parsed).expected_schema
+
+
+def _planner_metadata(node: MetaPlannerIRNode, *, kind: str) -> dict[str, Any]:
+    contract = workflow_node_contract_registry.require(kind)
+    return {
+        "plannerContractVersion": NODE_CONTRACT_VERSION,
+        "plannerCompilerChecksum": contract.compiler_checksum,
+        "plannerRef": node.ref,
+        "plannerTaskIds": list(node.task_ids),
+        "plannerInputs": [item.model_dump(mode="json") for item in node.inputs],
+        "plannerOutputs": [item.model_dump(mode="json") for item in node.outputs],
+    }
+
+
+def _base_pure_node_data(node: MetaPlannerIRNode) -> dict[str, Any]:
+    return {
+        "kind": node.kind,
+        "title": node.title,
+        "description": node.description,
+        **_planner_metadata(node, kind=node.kind),
+    }
+
+
+def _compile_json_serialize(
+    node: MetaPlannerIRNode,
+    parsed: BaseModel,
+    context: PlannerNodeCompileContext,
+) -> NativeWorkflowNode:
+    config = JsonSerializePlannerConfig.model_validate(parsed)
+    source = _require_single_input(node, "value")
+    output = _require_single_output(node, "json")
+    return NativeWorkflowNode(
+        id=context.node_id,
+        type="json_serialize",
+        position=context.position,
+        data={
+            **_base_pure_node_data(node),
+            "contractVersion": 2,
+            "inputVariable": source.variable,
+            "outputVariable": output.variable,
+            "format": config.format,
+        },
+    )
+
+
+def _compile_json_deserialize(
+    node: MetaPlannerIRNode,
+    parsed: BaseModel,
+    context: PlannerNodeCompileContext,
+) -> NativeWorkflowNode:
+    config = JsonDeserializePlannerConfig.model_validate(parsed)
+    source = _require_single_input(node, "json")
+    output = _require_single_output(node, "value")
+    return NativeWorkflowNode(
+        id=context.node_id,
+        type="json_deserialize",
+        position=context.position,
+        data={
+            **_base_pure_node_data(node),
+            "contractVersion": 2,
+            "inputVariable": source.variable,
+            "outputVariable": output.variable,
+            "expectedSchema": config.expected_schema.model_dump(mode="json"),
+        },
+    )
+
+
+def _compile_variable_aggregator(
+    node: MetaPlannerIRNode,
+    parsed: BaseModel,
+    context: PlannerNodeCompileContext,
+) -> NativeWorkflowNode:
+    config = VariableAggregatorPlannerConfig.model_validate(parsed)
+    inputs = _input_bindings(node, "values")
+    output = _require_single_output(node, "result")
+    bindings = []
+    for index, (source, output_field) in enumerate(
+        zip(inputs, config.output_fields, strict=True)
+    ):
+        binding_checksum = canonical_checksum(
+            {"ref": node.ref, "index": index, "field": output_field}
+        )
+        binding_id = f"binding_{binding_checksum[:16]}"
+        bindings.append(
+            {
+                "id": binding_id,
+                "sourceVariable": source.variable,
+                "outputField": output_field,
+            }
+        )
+    return NativeWorkflowNode(
+        id=context.node_id,
+        type="variable_aggregator",
+        position=context.position,
+        data={
+            **_base_pure_node_data(node),
+            "contractVersion": 2,
+            "bindings": bindings,
+            "outputVariable": output.variable,
+        },
+    )
+
+
+def _compile_data_aggregate(
+    node: MetaPlannerIRNode,
+    parsed: BaseModel,
+    context: PlannerNodeCompileContext,
+) -> NativeWorkflowNode:
+    config = DataAggregatePlannerConfig.model_validate(parsed)
+    source = _require_single_input(node, "rows")
+    output = _require_single_output(node, "result")
+    return NativeWorkflowNode(
+        id=context.node_id,
+        type="data_aggregate",
+        position=context.position,
+        data={
+            **_base_pure_node_data(node),
+            "inputVariable": source.variable,
+            "outputVariable": output.variable,
+            "groupByFields": list(config.group_by_fields),
+            "measures": [
+                {
+                    "outputField": item.output_field,
+                    "operation": item.operation,
+                    "sourceField": item.source_field,
+                }
+                for item in config.measures
+            ],
+        },
+    )
+
+
+def _compile_dataset_compare(
+    node: MetaPlannerIRNode,
+    parsed: BaseModel,
+    context: PlannerNodeCompileContext,
+) -> NativeWorkflowNode:
+    config = DatasetComparePlannerConfig.model_validate(parsed)
+    left = _require_single_input(node, "left")
+    right = _require_single_input(node, "right")
+    output = _require_single_output(node, "result")
+    return NativeWorkflowNode(
+        id=context.node_id,
+        type="dataset_compare",
+        position=context.position,
+        data={
+            **_base_pure_node_data(node),
+            "leftVariable": left.variable,
+            "rightVariable": right.variable,
+            "keyFields": list(config.key_fields),
+            "includeUnchanged": config.include_unchanged,
+            "outputVariable": output.variable,
+        },
+    )
 
 
 def _compile_workflow_agent(
@@ -256,6 +661,126 @@ def _decompile_workflow_agent_v3(node: NativeWorkflowNode) -> GraphIntentNodeV3:
     )
 
 
+def _pure_config_from_native(kind: str, data: dict[str, Any]) -> dict[str, Any]:
+    if kind == "json_serialize":
+        if int(data.get("contractVersion") or 0) != 2:
+            raise ValueError("Planner JSON serialize nodes require contractVersion 2.")
+        return {"format": str(data.get("format") or "")}
+    if kind == "json_deserialize":
+        if int(data.get("contractVersion") or 0) != 2:
+            raise ValueError("Planner JSON deserialize nodes require contractVersion 2.")
+        return {"expected_schema": data.get("expectedSchema")}
+    if kind == "variable_aggregator":
+        if int(data.get("contractVersion") or 0) != 2:
+            raise ValueError("Planner variable pack nodes require contractVersion 2.")
+        bindings = data.get("bindings")
+        if not isinstance(bindings, list):
+            raise ValueError("Planner variable pack node is missing bindings.")
+        return {
+            "output_fields": [
+                str(item.get("outputField") or "")
+                for item in bindings
+                if isinstance(item, dict)
+            ]
+        }
+    if kind == "data_aggregate":
+        measures = data.get("measures")
+        if not isinstance(measures, list):
+            raise ValueError("Planner data aggregate node is missing measures.")
+        return {
+            "group_by_fields": list(data.get("groupByFields") or []),
+            "measures": [
+                {
+                    "output_field": str(item.get("outputField") or ""),
+                    "operation": str(item.get("operation") or ""),
+                    "source_field": str(item.get("sourceField") or ""),
+                }
+                for item in measures
+                if isinstance(item, dict)
+            ],
+        }
+    if kind == "dataset_compare":
+        return {
+            "key_fields": list(data.get("keyFields") or []),
+            "include_unchanged": bool(data.get("includeUnchanged", False)),
+        }
+    raise ValueError(f"Node kind {kind} is not a pure Planner node.")
+
+
+def _decompile_pure_node(
+    node: NativeWorkflowNode,
+    *,
+    kind: str,
+    graph_ir_v3: bool,
+) -> MetaPlannerIRNode | GraphIntentNodeV3:
+    data = node.data if isinstance(node.data, dict) else {}
+    contract = workflow_node_contract_registry.require(kind)
+    if int(data.get("plannerContractVersion") or 0) != NODE_CONTRACT_VERSION:
+        raise ValueError(f"{kind} does not carry a NodeContract V3 marker.")
+    if str(data.get("plannerCompilerChecksum") or "") != contract.compiler_checksum:
+        raise ValueError(f"{kind} compiler contract has drifted.")
+    if graph_ir_v3 and int(data.get("plannerIRVersion") or 0) != META_PLANNER_IR_VERSION:
+        raise ValueError(f"{kind} does not carry Graph IR V3 metadata.")
+    node_ref = str(data.get("plannerRef") or "").strip()
+    task_ids = data.get("plannerTaskIds")
+    inputs = data.get("plannerInputsV3" if graph_ir_v3 else "plannerInputs")
+    outputs = data.get("plannerOutputsV3" if graph_ir_v3 else "plannerOutputs")
+    if not node_ref or not isinstance(task_ids, list):
+        raise ValueError(f"{kind} is missing planner round-trip metadata.")
+    if not isinstance(inputs, list) or not isinstance(outputs, list):
+        raise ValueError(f"{kind} is missing planner port metadata.")
+    payload = {
+        "ref": node_ref,
+        "kind": kind,
+        "title": str(data.get("title") or node_ref),
+        "description": str(data.get("description") or ""),
+        "task_ids": task_ids,
+        "inputs": inputs,
+        "outputs": outputs,
+        "config": _pure_config_from_native(kind, data),
+    }
+    model: type[MetaPlannerIRNode] | type[GraphIntentNodeV3] = (
+        GraphIntentNodeV3 if graph_ir_v3 else MetaPlannerIRNode
+    )
+    return model.model_validate(payload)
+
+
+def _pure_decompilers(
+    kind: str,
+) -> tuple[
+    Callable[[NativeWorkflowNode], MetaPlannerIRNode],
+    Callable[[NativeWorkflowNode], GraphIntentNodeV3],
+]:
+    def legacy(node: NativeWorkflowNode) -> MetaPlannerIRNode:
+        restored = _decompile_pure_node(node, kind=kind, graph_ir_v3=False)
+        assert isinstance(restored, MetaPlannerIRNode)
+        return restored
+
+    def v3(node: NativeWorkflowNode) -> GraphIntentNodeV3:
+        restored = _decompile_pure_node(node, kind=kind, graph_ir_v3=True)
+        assert isinstance(restored, GraphIntentNodeV3)
+        return restored
+
+    return legacy, v3
+
+
+_decompile_json_serialize, _decompile_json_serialize_v3 = _pure_decompilers(
+    "json_serialize"
+)
+_decompile_json_deserialize, _decompile_json_deserialize_v3 = _pure_decompilers(
+    "json_deserialize"
+)
+_decompile_variable_aggregator, _decompile_variable_aggregator_v3 = (
+    _pure_decompilers("variable_aggregator")
+)
+_decompile_data_aggregate, _decompile_data_aggregate_v3 = _pure_decompilers(
+    "data_aggregate"
+)
+_decompile_dataset_compare, _decompile_dataset_compare_v3 = _pure_decompilers(
+    "dataset_compare"
+)
+
+
 PLANNER_NODE_ADAPTERS: dict[str, PlannerNodeAdapter] = {
     "workflow_agent": PlannerNodeAdapter(
         kind="workflow_agent",
@@ -263,7 +788,69 @@ PLANNER_NODE_ADAPTERS: dict[str, PlannerNodeAdapter] = {
         compile_node=_compile_workflow_agent,
         decompile_node=_decompile_workflow_agent,
         decompile_node_v3=_decompile_workflow_agent_v3,
-    )
+        referenced_variables=_workflow_agent_references,
+        native_config=_workflow_agent_config_from_native,
+        native_inputs=_workflow_agent_native_inputs,
+        native_outputs=_single_native_output("outputVariable", "result"),
+    ),
+    "json_serialize": PlannerNodeAdapter(
+        kind="json_serialize",
+        config_model=JsonSerializePlannerConfig,
+        compile_node=_compile_json_serialize,
+        decompile_node=_decompile_json_serialize,
+        decompile_node_v3=_decompile_json_serialize_v3,
+        validate_node_shape=_validate_json_serialize_shape,
+        native_config=lambda data: _pure_config_from_native("json_serialize", data),
+        native_inputs=_single_native_input("inputVariable", "value"),
+        native_outputs=_single_native_output("outputVariable", "json"),
+    ),
+    "json_deserialize": PlannerNodeAdapter(
+        kind="json_deserialize",
+        config_model=JsonDeserializePlannerConfig,
+        compile_node=_compile_json_deserialize,
+        decompile_node=_decompile_json_deserialize,
+        decompile_node_v3=_decompile_json_deserialize_v3,
+        output_schema=_json_deserialize_output_schema,
+        validate_node_shape=_validate_json_deserialize_shape,
+        native_config=lambda data: _pure_config_from_native("json_deserialize", data),
+        native_inputs=_single_native_input("inputVariable", "json"),
+        native_outputs=_single_native_output("outputVariable", "value"),
+    ),
+    "variable_aggregator": PlannerNodeAdapter(
+        kind="variable_aggregator",
+        config_model=VariableAggregatorPlannerConfig,
+        compile_node=_compile_variable_aggregator,
+        decompile_node=_decompile_variable_aggregator,
+        decompile_node_v3=_decompile_variable_aggregator_v3,
+        validate_node_shape=_validate_variable_aggregator_shape,
+        native_config=lambda data: _pure_config_from_native(
+            "variable_aggregator", data
+        ),
+        native_inputs=_variable_aggregator_native_inputs,
+        native_outputs=_single_native_output("outputVariable", "result"),
+    ),
+    "data_aggregate": PlannerNodeAdapter(
+        kind="data_aggregate",
+        config_model=DataAggregatePlannerConfig,
+        compile_node=_compile_data_aggregate,
+        decompile_node=_decompile_data_aggregate,
+        decompile_node_v3=_decompile_data_aggregate_v3,
+        validate_node_shape=_validate_data_aggregate_shape,
+        native_config=lambda data: _pure_config_from_native("data_aggregate", data),
+        native_inputs=_single_native_input("inputVariable", "rows"),
+        native_outputs=_single_native_output("outputVariable", "result"),
+    ),
+    "dataset_compare": PlannerNodeAdapter(
+        kind="dataset_compare",
+        config_model=DatasetComparePlannerConfig,
+        compile_node=_compile_dataset_compare,
+        decompile_node=_decompile_dataset_compare,
+        decompile_node_v3=_decompile_dataset_compare_v3,
+        validate_node_shape=_validate_dataset_compare_shape,
+        native_config=lambda data: _pure_config_from_native("dataset_compare", data),
+        native_inputs=_dataset_compare_native_inputs,
+        native_outputs=_single_native_output("outputVariable", "result"),
+    ),
 }
 
 META_PLANNER_ADAPTER_KINDS = frozenset(PLANNER_NODE_ADAPTERS)
@@ -335,6 +922,7 @@ def planner_capability_metadata(kind: str) -> dict[str, Any] | None:
     return {
         "compilable": True,
         "support": support,
+        "task_binding": contract.planner.task_binding,
         "ir_version": META_PLANNER_IR_VERSION,
         "adapter_version": META_PLANNER_ADAPTER_VERSION,
         "contract_version": NODE_CONTRACT_VERSION,

--- a/server/meta_agent/schemas.py
+++ b/server/meta_agent/schemas.py
@@ -240,8 +240,8 @@ class MetaPlannerIRNode(BaseModel):
     kind: str = Field(min_length=1, max_length=80)
     title: str = Field(min_length=1, max_length=120)
     description: str = Field(default="", max_length=2_000)
-    task_ids: list[str] = Field(min_length=1, max_length=8)
-    inputs: list[MetaPlannerIRInputBinding] = Field(default_factory=list, max_length=16)
+    task_ids: list[str] = Field(default_factory=list, max_length=8)
+    inputs: list[MetaPlannerIRInputBinding] = Field(default_factory=list, max_length=50)
     outputs: list[MetaPlannerIROutputBinding] = Field(
         default_factory=list, max_length=16
     )
@@ -332,9 +332,9 @@ class GraphIntentNodeV3(BaseModel):
     kind: str = Field(min_length=1, max_length=80)
     title: str = Field(min_length=1, max_length=120)
     description: str = Field(default="", max_length=2_000)
-    task_ids: list[str] = Field(min_length=1, max_length=8)
+    task_ids: list[str] = Field(default_factory=list, max_length=8)
     inputs: list[GraphIntentInputBindingV3] = Field(
-        default_factory=list, max_length=16
+        default_factory=list, max_length=50
     )
     outputs: list[GraphIntentOutputBindingV3] = Field(
         default_factory=list, max_length=16

--- a/server/tests/test_meta_agent_managed_endpoints.py
+++ b/server/tests/test_meta_agent_managed_endpoints.py
@@ -278,6 +278,50 @@ async def test_xpert_candidate_endpoint_records_plan_blueprint_and_one_repair(
 
 
 @pytest.mark.asyncio
+async def test_xpert_candidate_legacy_gateway_requests_json_without_reasoning(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_gateway = FakeManagedGateway(FakeManagedRun([]), mode="legacy")
+    _install_gateway(monkeypatch, legacy_gateway)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://mock", "key"),
+    )
+    outputs = _planner_outputs()
+    observed: list[dict[str, object]] = []
+
+    async def legacy_completion(*_args, **kwargs):
+        observed.append(dict(kwargs))
+        return outputs.pop(0)
+
+    monkeypatch.setattr(
+        main_module, "collect_chat_completion_text", legacy_completion
+    )
+
+    response = await client.post(
+        "/api/meta-agent/generate-xpert-candidate",
+        json={
+            "goal": "Generate a bounded Xpert candidate through the legacy route.",
+            "mode": "create",
+            "planner_model_id": MODEL_ID,
+            "default_agent_model_id": MODEL_ID,
+            "temperature": 0.2,
+            "max_agents": 3,
+            "scope": {},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert len(observed) == 3
+    for call in observed:
+        assert call["response_format"] == {"type": "json_object"}
+        assert call["reasoning"] == {"effort": "none", "exclude": True}
+        assert call["allow_json_reasoning_fallback"] is True
+
+
+@pytest.mark.asyncio
 async def test_xpert_candidate_validation_failure_marks_managed_run_failed(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/server/tests/test_meta_planner_headless_authoring.py
+++ b/server/tests/test_meta_planner_headless_authoring.py
@@ -338,10 +338,10 @@ def _headless_fixture(
     return service, authoring, proposal
 
 
-def test_capability_snapshot_exposes_patch_protocol_without_new_nodes():
+def test_capability_snapshot_exposes_patch_protocol_and_pure_node_pack():
     snapshot = _snapshot()
 
-    assert snapshot.version == "evoagentx-meta-planner-capabilities-v5"
+    assert snapshot.version == "evoagentx-meta-planner-capabilities-v6"
     assert snapshot.authoring_protocol_version == 1
     assert snapshot.authoring_limits["max_operations"] == 64
     assert snapshot.authoring_limits["max_receipts"] == 20
@@ -351,12 +351,17 @@ def test_capability_snapshot_exposes_patch_protocol_without_new_nodes():
         item["kind"] for item in snapshot.nodes
     }
     assert {item["kind"] for item in snapshot.nodes} == {
+        "data_aggregate",
+        "dataset_compare",
         "input",
+        "json_deserialize",
+        "json_serialize",
         "output",
         "workflow_agent",
         "external_xpert",
         "knowledge_base",
         "toolset_resource",
+        "variable_aggregator",
         "plugin_resource",
     }
 
@@ -900,6 +905,88 @@ def test_editor_diff_can_add_authorized_resources_with_server_owned_versions(
         assert compiled["data"]["pinnedVersion"] == 2
 
 
+def test_editor_diff_adds_pure_node_through_adapter_projection(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    state = service.proposal_state(proposal.proposal_id)
+    definition = deepcopy(state["candidate"]["draft"]["workflow"])
+    agent = next(
+        node
+        for node in definition["nodes"]
+        if (node.get("data") or {}).get("kind") == "workflow_agent"
+    )
+    agent["data"]["rolePrompt"] = "Answer from {{encoded_request}}."
+    agent["data"]["taskInput"] = "{{encoded_request}}"
+    serializer_id = "editor-json-serialize"
+    definition["nodes"].append(
+        {
+            "id": serializer_id,
+            "type": "json_serialize",
+            "position": {"x": 260, "y": 180},
+            "data": {
+                "kind": "json_serialize",
+                "title": "Encode request",
+                "description": "Deterministic JSON encoding",
+                "contractVersion": 2,
+                "inputVariable": "user_input",
+                "outputVariable": "encoded_request",
+                "format": "compact",
+            },
+        }
+    )
+    definition["edges"] = [
+        edge
+        for edge in definition["edges"]
+        if not (edge["source"] == "input" and edge["target"] == agent["id"])
+    ]
+    definition["edges"].extend(
+        [
+            {
+                "id": "edge-input-serializer",
+                "source": "input",
+                "target": serializer_id,
+            },
+            {
+                "id": "edge-serializer-agent",
+                "source": serializer_id,
+                "target": agent["id"],
+            },
+        ]
+    )
+
+    diff = service.editor_diff(
+        proposal.proposal_id,
+        GraphPatchEditorDiffRequest(
+            proposal_revision=proposal.revision,
+            definition=definition,
+        ),
+    )
+    patch = GraphPatchEnvelopeV1.model_validate(diff["patch"])
+    add = next(operation for operation in patch.operations if operation.op == "add_node")
+    assert add.kind == "json_serialize"
+    assert add.task_ids == []
+
+    preview = service.preview(proposal.proposal_id, patch)
+    assert preview["can_apply"] is True
+    result = service.apply(
+        proposal.proposal_id,
+        GraphPatchApplyRequest(
+            patch=patch,
+            preview_checksum=preview["preview_checksum"],
+        ),
+    )
+
+    assert result["proposal_revision"] == 2
+    persisted = authoring.proposal_store.require(proposal.proposal_id)
+    pure_nodes = [
+        node
+        for node in persisted.payload["draft"]["workflow"]["nodes"]
+        if (node.get("data") or {}).get("kind") == "json_serialize"
+    ]
+    assert len(pure_nodes) == 1
+    assert pure_nodes[0]["data"]["contractVersion"] == 2
+    assert pure_nodes[0]["data"]["plannerTaskIds"] == []
+
+
 def test_editor_diff_can_remove_existing_fixed_resource_binding(tmp_path: Path):
     service, _, proposal = _headless_fixture(tmp_path, with_toolset=True)
     state = service.proposal_state(proposal.proposal_id)
@@ -1275,6 +1362,91 @@ def test_lossless_v2_candidate_upgrades_on_first_typed_apply(tmp_path: Path):
     )
     assert agent["data"]["plannerIRVersion"] == 3
     assert updated.payload["meta_planner_report"]["graph_ir_status"] == "current"
+
+
+def test_headless_preview_and_apply_persists_pure_node_atomically(tmp_path: Path):
+    service, authoring, proposal = _headless_fixture(tmp_path)
+    state = service.proposal_state(proposal.proposal_id)
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=proposal.revision,
+        expected_graph_checksum=state["graph_checksum"],
+        expected_candidate_checksum=state["candidate_checksum"],
+        operations=[
+            {
+                "op": "add_node",
+                "ref": "encode_request",
+                "kind": "json_serialize",
+                "title": "Encode request",
+                "task_ids": [],
+                "config": {"format": "compact"},
+                "output_variables": {"json": "encoded_request"},
+            },
+            {
+                "op": "connect_control",
+                "source_ref": "encode_request",
+                "target_ref": "answerer",
+            },
+            {
+                "op": "disconnect_data",
+                "source_ref": "input",
+                "source_port": "user_input",
+                "target_ref": "answerer",
+                "target_port": "task",
+            },
+            {
+                "op": "connect_data",
+                "source_ref": "input",
+                "source_port": "user_input",
+                "target_ref": "encode_request",
+                "target_port": "value",
+            },
+            {
+                "op": "connect_data",
+                "source_ref": "encode_request",
+                "source_port": "json",
+                "target_ref": "answerer",
+                "target_port": "task",
+            },
+            {
+                "op": "update_node",
+                "ref": "answerer",
+                "config": {
+                    "role_prompt": "Answer from {{encoded_request}}.",
+                    "task_input": "{{encoded_request}}",
+                    "model_id": "model/agent",
+                    "source_agent_id": None,
+                    "method_skill_ids": [],
+                },
+            },
+        ],
+    )
+
+    preview = service.preview(proposal.proposal_id, patch)
+    assert preview["can_apply"] is True
+    assert authoring.proposal_store.require(proposal.proposal_id).revision == 1
+
+    result = service.apply(
+        proposal.proposal_id,
+        GraphPatchApplyRequest(
+            patch=patch,
+            preview_checksum=preview["preview_checksum"],
+        ),
+    )
+
+    assert result["proposal_revision"] == 2
+    updated = authoring.proposal_store.require(proposal.proposal_id)
+    assert updated.revision == 2
+    workflow_nodes = updated.payload["draft"]["workflow"]["nodes"]
+    serializer = next(
+        node
+        for node in workflow_nodes
+        if (node.get("data") or {}).get("kind") == "json_serialize"
+    )
+    assert serializer["data"]["contractVersion"] == 2
+    assert serializer["data"]["plannerTaskIds"] == []
+    report = updated.payload["meta_planner_report"]
+    assert report["graph_ir_status"] == "current"
+    assert len(report["authoring_patch_receipts"]) == 1
 
 
 def test_apply_rejects_tampered_preview_checksum(tmp_path: Path):

--- a/server/tests/test_meta_planner_pure_nodes.py
+++ b/server/tests/test_meta_planner_pure_nodes.py
@@ -1,0 +1,875 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+import pytest
+
+from server.meta_agent.graph_ir_v3 import (
+    decompile_candidate_to_graph_intent,
+    resolve_graph_intent,
+    workflow_semantic_checksum,
+)
+from server.meta_agent.graph_patch import GraphPatchEnvelopeV1, apply_graph_patch
+from server.meta_agent.meta_planner_v2 import (
+    MetaPlannerV2Service,
+    _normalize_adapter_outputs_for_repair,
+    compile_xpert_candidate,
+    validate_blueprint_authorization,
+)
+from server.meta_agent.schemas import (
+    GraphIntentControlEdgeV3,
+    GraphIntentFinalOutputV3,
+    GraphIntentInputBindingV3,
+    GraphIntentNodeV3,
+    GraphIntentOutputBindingV3,
+    GraphIntentV3,
+)
+from server.tests.test_meta_planner_v2 import _plan, _request, _snapshot
+from server.skills.draft_store import WorkspaceSkillDraftStore
+from server.workflow_native.node_contracts import WorkflowValueSchema
+from server.xpert_runtime.authoring_service import AuthoringService
+from server.xpert_runtime.authoring_store import AuthoringProposalStore
+from server.xperts.store import XpertStore
+from server.xperts.validation import validate_xpert_definition
+
+
+PURE_NODE_KINDS = {
+    "json_serialize",
+    "json_deserialize",
+    "variable_aggregator",
+    "data_aggregate",
+    "dataset_compare",
+}
+STRING = WorkflowValueSchema(type="string")
+ROWS = WorkflowValueSchema(
+    type="array",
+    items=WorkflowValueSchema(type="object"),
+)
+OBJECT = WorkflowValueSchema(type="object")
+
+
+def _authorized_request():
+    request = _request().model_copy(deep=True)
+    request.scope.allowed_node_kinds = sorted(
+        set(request.scope.allowed_node_kinds) | PURE_NODE_KINDS
+    )
+    return request
+
+
+def test_task_plan_prompt_keeps_pure_nodes_out_of_expert_tasks() -> None:
+    request = _authorized_request()
+
+    prompt = json.loads(MetaPlannerV2Service._plan_prompt(request, _snapshot()))
+    contract = prompt["task_planning_contract"]
+
+    assert contract["expert_task_binding"] == "required"
+    assert set(contract["auxiliary_node_kinds"]) == PURE_NODE_KINDS
+    assert all(
+        item["task_binding"] == "forbidden"
+        for item in contract["auxiliary_node_contracts"]
+    )
+    contracts = {
+        item["kind"]: item for item in contract["auxiliary_node_contracts"]
+    }
+    assert contracts["data_aggregate"]["purpose"]
+    assert contracts["data_aggregate"]["inputs"] == [
+        {"name": "rows", "type": "array", "cardinality": "one"}
+    ]
+    assert contracts["dataset_compare"]["outputs"] == [
+        {"name": "result", "type": "object", "cardinality": "one"}
+    ]
+    assert contract["expert_task_test"]["required_answer"] == "yes"
+    assert "Group rows and calculate deterministic measures." in contract[
+        "non_task_examples"
+    ]
+    assert any(
+        "must not become plan tasks" in rule for rule in contract["rules"]
+    )
+
+
+@pytest.mark.parametrize("ref", ["input", "output"])
+def test_patch_schema_rejects_materializing_compiler_managed_refs(ref: str) -> None:
+    payload = {
+        "protocol_version": 1,
+        "proposal_revision": 1,
+        "expected_graph_checksum": "a" * 64,
+        "expected_candidate_checksum": "b" * 64,
+        "operations": [
+            {
+                "op": "add_node",
+                "ref": ref,
+                "kind": "json_deserialize",
+                "title": "Input",
+                "task_ids": [],
+                "config": {"expected_schema": {"type": "object"}},
+                "output_variables": {"value": "decoded"},
+            }
+        ],
+    }
+
+    with pytest.raises(ValueError, match="compiler-managed"):
+        GraphPatchEnvelopeV1.model_validate(payload)
+
+
+def test_patch_repair_prompt_has_issue_scoped_ref_and_agent_limits() -> None:
+    request = _authorized_request().model_copy(update={"max_agents": 1})
+    intent = _aggregate_intent()
+
+    prompt = json.loads(
+        MetaPlannerV2Service._patch_repair_prompt(
+            request,
+            _plan(),
+            _snapshot(),
+            intent,
+            ["Typed IR exceeds max_agents=1."],
+            expected_graph_checksum="a" * 64,
+            expected_candidate_checksum="b" * 64,
+        )
+    )
+    contract = prompt["repair_contract"]
+
+    assert contract["compiler_managed_refs"] == ["input", "output"]
+    assert set(contract["existing_node_refs"]) == {
+        node.ref for node in intent.nodes
+    }
+    assert contract["max_workflow_agent_nodes"] == 1
+    assert contract["current_workflow_agent_nodes"] == 2
+    assert contract["allow_add_workflow_agent"] is False
+    assert any(
+        "never add, update, remove, or move" in rule
+        for rule in contract["rules"]
+    )
+    assert any(
+        "consolidate task_ids" in rule for rule in contract["issue_playbook"]
+    )
+    assert any(
+        "recomputed by the server" in rule for rule in contract["rules"]
+    )
+
+
+def test_repair_normalizes_only_adapter_derived_output_schema() -> None:
+    intent = _aggregate_intent()
+    decode = next(node for node in intent.nodes if node.ref == "decode_rows")
+    decode.outputs[0].value_schema = OBJECT
+
+    normalized, refs = _normalize_adapter_outputs_for_repair(intent)
+
+    normalized_decode = next(
+        node for node in normalized.nodes if node.ref == "decode_rows"
+    )
+    assert refs == ["decode_rows"]
+    assert normalized_decode.outputs[0].value_schema == ROWS
+    assert decode.outputs[0].value_schema == OBJECT
+
+    forged = intent.model_copy(deep=True)
+    forged_decode = next(
+        node for node in forged.nodes if node.ref == "decode_rows"
+    )
+    forged_decode.outputs[0].port = "forged"
+    with pytest.raises(ValueError, match="requires exactly one value output"):
+        _normalize_adapter_outputs_for_repair(forged)
+
+
+@pytest.mark.asyncio
+async def test_single_patch_repair_refreshes_dynamic_deserialize_schema(
+    tmp_path: Path,
+) -> None:
+    proposal_store = AuthoringProposalStore(tmp_path / "runtime")
+    xpert_store = XpertStore(tmp_path / "xperts")
+
+    def preflight(candidate):
+        result = validate_xpert_definition(candidate)
+        return result, candidate.draft.workflow, []
+
+    authoring = AuthoringService(
+        proposal_store,
+        xpert_store,
+        WorkspaceSkillDraftStore(tmp_path / "skills"),
+        xpert_preflight=preflight,
+    )
+    invalid = _aggregate_intent()
+    decode = next(node for node in invalid.nodes if node.ref == "decode_rows")
+    decode.outputs[0].value_schema = OBJECT
+    calls: list[dict[str, object]] = []
+
+    async def complete(model_id, system_prompt, user_prompt, temperature, max_tokens):
+        calls.append({"system_prompt": system_prompt, "user_prompt": user_prompt})
+        if len(calls) == 1:
+            return _plan().model_dump_json()
+        if len(calls) == 2:
+            return invalid.model_dump_json()
+        prompt = json.loads(user_prompt)
+        return json.dumps({**prompt["required_envelope"], "operations": []})
+
+    response = await MetaPlannerV2Service(
+        authoring_service=authoring,
+        preflight=preflight,
+        completion=complete,
+    ).generate(_authorized_request(), _snapshot())
+
+    assert len(calls) == 3
+    assert response.repair_used is True
+    assert response.validation["valid"] is True
+    assert any(
+        "Adapter-derived output Schemas" in warning
+        for warning in response.warnings
+    )
+    proposal = proposal_store.require(response.proposal_id)
+    decode_node = next(
+        node
+        for node in proposal.payload["draft"]["workflow"]["nodes"]
+        if node["type"] == "json_deserialize"
+    )
+    assert decode_node["data"]["expectedSchema"]["type"] == "array"
+
+
+@pytest.mark.asyncio
+async def test_semantic_adapter_failure_preserves_intent_for_patch_repair(
+    tmp_path: Path,
+) -> None:
+    proposal_store = AuthoringProposalStore(tmp_path / "runtime")
+    xpert_store = XpertStore(tmp_path / "xperts")
+
+    def preflight(candidate):
+        result = validate_xpert_definition(candidate)
+        return result, candidate.draft.workflow, []
+
+    authoring = AuthoringService(
+        proposal_store,
+        xpert_store,
+        WorkspaceSkillDraftStore(tmp_path / "skills"),
+        xpert_preflight=preflight,
+    )
+    invalid = _aggregate_intent()
+    aggregate = next(node for node in invalid.nodes if node.ref == "aggregate_rows")
+    aggregate.outputs[0].value_schema = OBJECT
+    encode = next(node for node in invalid.nodes if node.ref == "encode_summary")
+    encode.inputs[0].value_schema = OBJECT
+    calls: list[dict[str, object]] = []
+
+    async def complete(model_id, system_prompt, user_prompt, temperature, max_tokens):
+        calls.append({"system_prompt": system_prompt, "user_prompt": user_prompt})
+        if len(calls) == 1:
+            return _plan().model_dump_json()
+        if len(calls) == 2:
+            return invalid.model_dump_json()
+        prompt = json.loads(user_prompt)
+        return json.dumps({**prompt["required_envelope"], "operations": []})
+
+    response = await MetaPlannerV2Service(
+        authoring_service=authoring,
+        preflight=preflight,
+        completion=complete,
+    ).generate(_authorized_request(), _snapshot())
+
+    assert len(calls) == 3
+    assert response.repair_used is True
+    assert response.validation["valid"] is True
+    assert any(
+        "aggregate_rows" in warning and "Adapter-derived output Schemas" in warning
+        for warning in response.warnings
+    )
+    proposal = proposal_store.require(response.proposal_id)
+    report = proposal.payload["meta_planner_report"]
+    assert report["repair_protocol"] == "graph_patch_v1"
+
+
+def _input(
+    *,
+    port: str,
+    variable: str,
+    source_ref: str,
+    source_port: str,
+    schema: WorkflowValueSchema,
+) -> GraphIntentInputBindingV3:
+    return GraphIntentInputBindingV3(
+        port=port,
+        variable=variable,
+        source_ref=source_ref,
+        source_port=source_port,
+        value_schema=schema,
+    )
+
+
+def _output(
+    port: str,
+    variable: str,
+    schema: WorkflowValueSchema,
+) -> GraphIntentOutputBindingV3:
+    return GraphIntentOutputBindingV3(
+        port=port,
+        variable=variable,
+        value_schema=schema,
+    )
+
+
+def _agent(
+    *,
+    ref: str,
+    task_id: str,
+    source_ref: str,
+    source_port: str,
+    input_variable: str,
+    output_variable: str,
+) -> GraphIntentNodeV3:
+    return GraphIntentNodeV3(
+        ref=ref,
+        kind="workflow_agent",
+        title=ref.replace("_", " ").title(),
+        task_ids=[task_id],
+        inputs=[
+            _input(
+                port="task",
+                variable=input_variable,
+                source_ref=source_ref,
+                source_port=source_port,
+                schema=STRING,
+            )
+        ],
+        outputs=[_output("result", output_variable, STRING)],
+        config={
+            "role_prompt": f"Complete {task_id} from {{{{{input_variable}}}}}.",
+            "task_input": f"{{{{{input_variable}}}}}",
+            "model_id": "model/agent",
+        },
+    )
+
+
+def _aggregate_intent() -> GraphIntentV3:
+    nodes = [
+        _agent(
+            ref="researcher",
+            task_id="research",
+            source_ref="input",
+            source_port="user_input",
+            input_variable="user_input",
+            output_variable="rows_json",
+        ),
+        GraphIntentNodeV3(
+            ref="decode_rows",
+            kind="json_deserialize",
+            title="Decode rows",
+            inputs=[
+                _input(
+                    port="json",
+                    variable="rows_json",
+                    source_ref="researcher",
+                    source_port="result",
+                    schema=STRING,
+                )
+            ],
+            outputs=[_output("value", "rows", ROWS)],
+            config={"expected_schema": ROWS.model_dump(mode="json")},
+        ),
+        GraphIntentNodeV3(
+            ref="aggregate_rows",
+            kind="data_aggregate",
+            title="Aggregate rows",
+            inputs=[
+                _input(
+                    port="rows",
+                    variable="rows",
+                    source_ref="decode_rows",
+                    source_port="value",
+                    schema=ROWS,
+                )
+            ],
+            outputs=[_output("result", "summary_rows", ROWS)],
+            config={
+                "group_by_fields": ["category"],
+                "measures": [
+                    {
+                        "output_field": "count",
+                        "operation": "count",
+                        "source_field": "",
+                    }
+                ],
+            },
+        ),
+        GraphIntentNodeV3(
+            ref="encode_summary",
+            kind="json_serialize",
+            title="Encode summary",
+            inputs=[
+                _input(
+                    port="value",
+                    variable="summary_rows",
+                    source_ref="aggregate_rows",
+                    source_port="result",
+                    schema=ROWS,
+                )
+            ],
+            outputs=[_output("json", "summary_json", STRING)],
+            config={"format": "compact"},
+        ),
+        _agent(
+            ref="writer",
+            task_id="deliver",
+            source_ref="encode_summary",
+            source_port="json",
+            input_variable="summary_json",
+            output_variable="agent_output",
+        ),
+    ]
+    return GraphIntentV3(
+        name="Aggregate evidence",
+        nodes=nodes,
+        control_edges=[
+            GraphIntentControlEdgeV3(
+                source_ref=nodes[index].ref,
+                target_ref=nodes[index + 1].ref,
+            )
+            for index in range(len(nodes) - 1)
+        ],
+        final_output=GraphIntentFinalOutputV3(
+            node_ref="writer",
+            variable="agent_output",
+        ),
+    )
+
+
+def _pack_intent() -> GraphIntentV3:
+    pack = GraphIntentNodeV3(
+        ref="pack_inputs",
+        kind="variable_aggregator",
+        title="Pack inputs",
+        inputs=[
+            _input(
+                port="values",
+                variable="user_input",
+                source_ref="input",
+                source_port="user_input",
+                schema=STRING,
+            ),
+            _input(
+                port="values",
+                variable="conversation_history",
+                source_ref="input",
+                source_port="conversation_history",
+                schema=WorkflowValueSchema(
+                    type="array",
+                    items=WorkflowValueSchema(type="object"),
+                ),
+            ),
+        ],
+        outputs=[_output("result", "packed_context", OBJECT)],
+        config={"output_fields": ["request", "history"]},
+    )
+    encode = GraphIntentNodeV3(
+        ref="encode_context",
+        kind="json_serialize",
+        title="Encode context",
+        inputs=[
+            _input(
+                port="value",
+                variable="packed_context",
+                source_ref="pack_inputs",
+                source_port="result",
+                schema=OBJECT,
+            )
+        ],
+        outputs=[_output("json", "context_json", STRING)],
+        config={"format": "pretty"},
+    )
+    writer = _agent(
+        ref="writer",
+        task_id="deliver",
+        source_ref="encode_context",
+        source_port="json",
+        input_variable="context_json",
+        output_variable="agent_output",
+    )
+    return GraphIntentV3(
+        name="Pack context",
+        nodes=[pack, encode, writer],
+        control_edges=[
+            GraphIntentControlEdgeV3(
+                source_ref="pack_inputs", target_ref="encode_context"
+            ),
+            GraphIntentControlEdgeV3(
+                source_ref="encode_context", target_ref="writer"
+            ),
+        ],
+        final_output=GraphIntentFinalOutputV3(
+            node_ref="writer",
+            variable="agent_output",
+        ),
+    )
+
+
+def _compare_intent() -> GraphIntentV3:
+    intent = _aggregate_intent()
+    decoder = next(node for node in intent.nodes if node.ref == "decode_rows")
+    second_decoder = decoder.model_copy(deep=True)
+    second_decoder.ref = "decode_reference"
+    second_decoder.title = "Decode reference"
+    second_decoder.outputs[0].variable = "reference_rows"
+    compare = GraphIntentNodeV3(
+        ref="compare_rows",
+        kind="dataset_compare",
+        title="Compare rows",
+        inputs=[
+            _input(
+                port="left",
+                variable="rows",
+                source_ref="decode_rows",
+                source_port="value",
+                schema=ROWS,
+            ),
+            _input(
+                port="right",
+                variable="reference_rows",
+                source_ref="decode_reference",
+                source_port="value",
+                schema=ROWS,
+            ),
+        ],
+        outputs=[_output("result", "comparison", OBJECT)],
+        config={"key_fields": ["id"], "include_unchanged": False},
+    )
+    encoder = next(node for node in intent.nodes if node.ref == "encode_summary")
+    encoder.inputs = [
+        _input(
+            port="value",
+            variable="comparison",
+            source_ref="compare_rows",
+            source_port="result",
+            schema=OBJECT,
+        )
+    ]
+    intent.nodes = [
+        intent.nodes[0],
+        decoder,
+        second_decoder,
+        compare,
+        encoder,
+        intent.nodes[-1],
+    ]
+    intent.control_edges = [
+        GraphIntentControlEdgeV3(
+            source_ref="researcher", target_ref="decode_rows"
+        ),
+        GraphIntentControlEdgeV3(
+            source_ref="researcher", target_ref="decode_reference"
+        ),
+        GraphIntentControlEdgeV3(
+            source_ref="decode_rows", target_ref="compare_rows"
+        ),
+        GraphIntentControlEdgeV3(
+            source_ref="decode_reference", target_ref="compare_rows"
+        ),
+        GraphIntentControlEdgeV3(
+            source_ref="compare_rows", target_ref="encode_summary"
+        ),
+        GraphIntentControlEdgeV3(
+            source_ref="encode_summary", target_ref="writer"
+        ),
+    ]
+    return intent
+
+
+@pytest.mark.parametrize(
+    "intent_factory",
+    [_aggregate_intent, _compare_intent],
+)
+def test_pure_node_packs_compile_and_round_trip_stably(intent_factory) -> None:
+    request = _authorized_request()
+    snapshot = _snapshot()
+    plan = _plan()
+    intent = intent_factory()
+
+    assert validate_blueprint_authorization(request, plan, intent, snapshot) == []
+    graph = resolve_graph_intent(intent, snapshot)
+    candidate = compile_xpert_candidate(
+        request=request,
+        plan=plan,
+        blueprint=intent,
+        snapshot=snapshot,
+        target=None,
+    )
+    restored = decompile_candidate_to_graph_intent(candidate)
+    restored_graph = resolve_graph_intent(restored, snapshot)
+    rebuilt = compile_xpert_candidate(
+        request=request,
+        plan=plan,
+        blueprint=restored,
+        snapshot=snapshot,
+        target=None,
+    )
+
+    assert graph.graph_checksum == restored_graph.graph_checksum
+    assert workflow_semantic_checksum(candidate) == workflow_semantic_checksum(
+        rebuilt
+    )
+    native_kinds = {
+        (node.get("data") or {}).get("kind")
+        for node in candidate["draft"]["workflow"]["nodes"]
+    }
+    assert {node.kind for node in intent.nodes}.issubset(native_kinds)
+
+
+def test_pack_then_serialize_uses_repeated_many_port_without_covering_tasks() -> None:
+    request = _authorized_request()
+    snapshot = _snapshot()
+    plan = _plan().model_copy(deep=True)
+    plan.tasks = [plan.tasks[-1]]
+    plan.tasks[0].depends_on = []
+    intent = _pack_intent()
+
+    assert validate_blueprint_authorization(request, plan, intent, snapshot) == []
+    candidate = compile_xpert_candidate(
+        request=request,
+        plan=plan,
+        blueprint=intent,
+        snapshot=snapshot,
+        target=None,
+    )
+    pack = next(
+        node
+        for node in candidate["draft"]["workflow"]["nodes"]
+        if (node.get("data") or {}).get("kind") == "variable_aggregator"
+    )
+    assert pack["data"]["plannerTaskIds"] == []
+    assert [item["outputField"] for item in pack["data"]["bindings"]] == [
+        "request",
+        "history",
+    ]
+
+
+def test_resolver_rejects_pure_task_ownership_and_pure_final_output() -> None:
+    snapshot = _snapshot()
+    intent = _aggregate_intent()
+    pure = next(node for node in intent.nodes if node.ref == "decode_rows")
+    pure.task_ids = ["research"]
+
+    with pytest.raises(ValueError, match="cannot cover plan tasks"):
+        resolve_graph_intent(intent, snapshot)
+
+    intent = _aggregate_intent()
+    intent.final_output = GraphIntentFinalOutputV3(
+        node_ref="encode_summary",
+        port="json",
+        variable="summary_json",
+    )
+    intent.control_edges = [
+        edge
+        for edge in intent.control_edges
+        if edge.target_ref != "writer"
+    ]
+    intent.nodes = [node for node in intent.nodes if node.ref != "writer"]
+    with pytest.raises(ValueError, match="workflow_agent"):
+        resolve_graph_intent(intent, snapshot)
+
+
+def test_resolver_rejects_deserialize_schema_forgery_and_native_config_fields() -> None:
+    snapshot = _snapshot()
+    intent = _aggregate_intent()
+    decoder = next(node for node in intent.nodes if node.ref == "decode_rows")
+    decoder.outputs[0].value_schema = STRING
+
+    with pytest.raises(ValueError, match="authoritative Adapter type"):
+        resolve_graph_intent(intent, snapshot)
+
+    intent = _aggregate_intent()
+    decoder = next(node for node in intent.nodes if node.ref == "decode_rows")
+    decoder.config["outputVariable"] = "forged_native_variable"
+    with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+        resolve_graph_intent(intent, snapshot)
+
+
+def test_graph_patch_adds_pure_node_atomically_and_rejects_task_injection() -> None:
+    plan_task_ids = {"research", "deliver"}
+    base = _aggregate_intent()
+    base.nodes = [base.nodes[0], base.nodes[-1]]
+    base.control_edges = [
+        GraphIntentControlEdgeV3(source_ref="researcher", target_ref="writer")
+    ]
+    writer = next(node for node in base.nodes if node.ref == "writer")
+    writer.inputs = [
+        _input(
+            port="task",
+            variable="rows_json",
+            source_ref="researcher",
+            source_port="result",
+            schema=STRING,
+        )
+    ]
+    writer.config["role_prompt"] = "Write from {{rows_json}}."
+    writer.config["task_input"] = "{{rows_json}}"
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=1,
+        expected_graph_checksum="a" * 64,
+        expected_candidate_checksum="b" * 64,
+        operations=[
+            {
+                "op": "add_node",
+                "ref": "encode_rows",
+                "kind": "json_serialize",
+                "title": "Encode rows",
+                "task_ids": [],
+                "config": {"format": "compact"},
+                "output_variables": {"json": "encoded_rows"},
+            },
+            {
+                "op": "disconnect_control",
+                "source_ref": "researcher",
+                "target_ref": "writer",
+            },
+            {
+                "op": "connect_control",
+                "source_ref": "researcher",
+                "target_ref": "encode_rows",
+            },
+            {
+                "op": "connect_control",
+                "source_ref": "encode_rows",
+                "target_ref": "writer",
+            },
+            {
+                "op": "disconnect_data",
+                "source_ref": "researcher",
+                "source_port": "result",
+                "target_ref": "writer",
+                "target_port": "task",
+            },
+            {
+                "op": "connect_data",
+                "source_ref": "researcher",
+                "source_port": "result",
+                "target_ref": "encode_rows",
+                "target_port": "value",
+            },
+            {
+                "op": "connect_data",
+                "source_ref": "encode_rows",
+                "source_port": "json",
+                "target_ref": "writer",
+                "target_port": "task",
+            },
+            {
+                "op": "update_node",
+                "ref": "writer",
+                "config": {
+                    "role_prompt": "Write from {{encoded_rows}}.",
+                    "task_input": "{{encoded_rows}}",
+                    "model_id": "model/agent",
+                    "source_agent_id": None,
+                    "method_skill_ids": [],
+                },
+            },
+        ],
+    )
+    applied = apply_graph_patch(
+        base,
+        patch,
+        plan_task_ids=plan_task_ids,
+        allowed_node_kinds={"workflow_agent", "json_serialize"},
+    )
+    pure = next(node for node in applied.intent.nodes if node.ref == "encode_rows")
+    assert pure.task_ids == []
+    assert pure.outputs[0].value_schema == STRING
+    resolve_graph_intent(applied.intent, _snapshot())
+
+    attack = deepcopy(patch.model_dump(mode="json"))
+    attack["operations"][0]["task_ids"] = ["deliver"]
+    with pytest.raises(ValueError, match="cannot cover plan tasks"):
+        apply_graph_patch(
+            base,
+            GraphPatchEnvelopeV1.model_validate(attack),
+            plan_task_ids=plan_task_ids,
+            allowed_node_kinds={"workflow_agent", "json_serialize"},
+        )
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        {
+            "op": "bind_resource",
+            "target_ref": "decode_rows",
+            "kind": "knowledge_base",
+            "resource_id": "kb-docs",
+        },
+        {
+            "op": "bind_middleware",
+            "target_ref": "decode_rows",
+            "middleware_id": "system_prompt_injector",
+            "config": {"prompt": "must remain agent-only"},
+        },
+    ],
+)
+def test_attack_pure_nodes_cannot_receive_runtime_bindings(operation) -> None:
+    intent = _aggregate_intent()
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=1,
+        expected_graph_checksum="a" * 64,
+        expected_candidate_checksum="b" * 64,
+        operations=[operation],
+    )
+
+    applied = apply_graph_patch(
+        intent,
+        patch,
+        plan_task_ids={"research", "deliver"},
+        allowed_node_kinds={"workflow_agent", *PURE_NODE_KINDS},
+    )
+
+    with pytest.raises(ValueError, match="workflow_agent"):
+        resolve_graph_intent(applied.intent, _snapshot())
+
+
+def test_attack_pure_node_type_confusion_and_control_cycle_fail_closed() -> None:
+    snapshot = _snapshot()
+    intent = _aggregate_intent()
+    aggregate = next(node for node in intent.nodes if node.ref == "aggregate_rows")
+    aggregate.inputs[0] = _input(
+        port="rows",
+        variable="rows_json",
+        source_ref="researcher",
+        source_port="result",
+        schema=STRING,
+    )
+
+    with pytest.raises(ValueError) as type_error:
+        resolve_graph_intent(intent, snapshot)
+    assert any(
+        marker in str(type_error.value).lower()
+        for marker in ("schema", "type", "compatible")
+    )
+
+    intent = _aggregate_intent()
+    intent.control_edges.append(
+        GraphIntentControlEdgeV3(source_ref="writer", target_ref="researcher")
+    )
+    with pytest.raises(ValueError, match="acyclic|cycle"):
+        resolve_graph_intent(intent, snapshot)
+
+
+def test_attack_patch_update_cannot_inject_native_pure_node_fields() -> None:
+    intent = _aggregate_intent()
+    decoder = next(node for node in intent.nodes if node.ref == "decode_rows")
+    patch = GraphPatchEnvelopeV1(
+        proposal_revision=1,
+        expected_graph_checksum="a" * 64,
+        expected_candidate_checksum="b" * 64,
+        operations=[
+            {
+                "op": "update_node",
+                "ref": decoder.ref,
+                "config": {
+                    "expected_schema": ROWS.model_dump(mode="json"),
+                    "outputVariable": "forged_native_variable",
+                },
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="undeclared Adapter config fields"):
+        apply_graph_patch(
+            intent,
+            patch,
+            plan_task_ids={"research", "deliver"},
+            allowed_node_kinds={"workflow_agent", *PURE_NODE_KINDS},
+        )

--- a/server/tests/test_meta_planner_v2.py
+++ b/server/tests/test_meta_planner_v2.py
@@ -83,7 +83,9 @@ def test_generic_meta_planner_keeps_hitl_scoped_to_expert_team():
         "Generic Meta Planner task plans support expert tasks only; "
         "HITL is scoped to Expert Team: manual_gate."
     ]
-    prompt = json.loads(MetaPlannerV2Service._plan_prompt(_request()))
+    prompt = json.loads(
+        MetaPlannerV2Service._plan_prompt(_request(), _snapshot())
+    )
     task_properties = prompt["required_schema"]["$defs"]["MetaPlannerTask"][
         "properties"
     ]
@@ -111,7 +113,9 @@ def test_blueprint_and_repair_prompts_expose_typed_ir_agent_constraints():
     request = _request()
     plan = _plan()
     snapshot = _snapshot()
-    plan_prompt = json.loads(MetaPlannerV2Service._plan_prompt(request))
+    plan_prompt = json.loads(
+        MetaPlannerV2Service._plan_prompt(request, snapshot)
+    )
 
     blueprint_prompt = json.loads(
         MetaPlannerV2Service._blueprint_prompt(request, plan, snapshot, None)
@@ -157,16 +161,24 @@ def test_blueprint_and_repair_prompts_expose_typed_ir_agent_constraints():
             for rule in constraints["rules"]
         )
         assert graph_contract["required_ir_version"] == 3
-        assert graph_contract["node_roles"] == {
-            "executable_node_kinds": ["workflow_agent"],
-            "compiler_managed_node_kinds": ["input", "output"],
-            "resource_binding_kinds": [
-                "external_xpert",
-                "knowledge_base",
-                "plugin_resource",
-                "toolset_resource",
-            ],
+        node_roles = graph_contract["node_roles"]
+        assert node_roles["executable_node_kinds"] == ["workflow_agent"]
+        assert node_roles["compiler_managed_node_kinds"] == ["input", "output"]
+        assert node_roles["resource_binding_kinds"] == [
+            "external_xpert",
+            "knowledge_base",
+            "plugin_resource",
+            "toolset_resource",
+        ]
+        assert set(node_roles["executable_node_contracts"]) == {
+            "workflow_agent"
         }
+        assert (
+            node_roles["executable_node_contracts"]["workflow_agent"][
+                "task_binding"
+            ]
+            == "required"
+        )
         assert graph_contract["workflow_agent"]["config_field_names"] == list(
             MetaPlannerWorkflowAgentConfig.model_fields
         )
@@ -478,7 +490,7 @@ def test_capability_api_returns_stable_safe_contract():
     response = client.get("/api/meta-agent/capabilities")
     assert response.status_code == 200
     payload = response.json()
-    assert payload["version"] == "evoagentx-meta-planner-capabilities-v5"
+    assert payload["version"] == "evoagentx-meta-planner-capabilities-v6"
     assert payload["authoring_protocol_version"] == 1
     assert payload["authoring_limits"]["max_operations"] == 64
     assert payload["ir_version"] == 3
@@ -496,8 +508,13 @@ def test_capability_snapshot_only_exposes_compilable_node_kinds():
     kinds = {item["kind"] for item in snapshot.nodes}
 
     assert kinds == {
+        "data_aggregate",
+        "dataset_compare",
         "input",
+        "json_deserialize",
+        "json_serialize",
         "output",
+        "variable_aggregator",
         "workflow_agent",
         "external_xpert",
         "knowledge_base",
@@ -907,6 +924,16 @@ async def test_failed_repair_persists_unapprovable_candidate_until_human_edit(
     proposal = proposal_store.require(response.proposal_id)
     assert proposal.status == "pending"
     assert proposal.validation["valid"] is False
+    assert (
+        proposal.payload["meta_planner_report"]["repair_protocol"]
+        == "graph_intent_v3"
+    )
+    fallback_agent = next(
+        node
+        for node in proposal.payload["draft"]["workflow"]["nodes"]
+        if node["type"] == "workflow_agent"
+    )
+    assert fallback_agent["data"]["modelId"] == ""
     with pytest.raises(AuthoringProposalValidationError):
         authoring.approve(
             proposal.proposal_id,
@@ -1005,9 +1032,9 @@ async def test_update_with_unsupported_target_node_fails_before_model_call(
     target = xpert_store.create_xpert(name="Typed target")
     target.draft.workflow.nodes.append(
         NativeWorkflowNode(
-            id="json-node",
-            type="json_serialize",
-            data={"kind": "json_serialize", "outputVariable": "serialized"},
+            id="list-node",
+            type="list_operation",
+            data={"kind": "list_operation", "outputVariable": "items"},
         )
     )
 

--- a/server/tests/test_workflow_capability_audit.py
+++ b/server/tests/test_workflow_capability_audit.py
@@ -312,7 +312,26 @@ def test_capability_audit_tracks_baseline_and_r1_nodes() -> None:
     assert facts.palette_draggable == 50
     assert facts.complete == 52
     assert facts.compatibility == 3
-    assert facts.planner == 7
+    assert facts.planner == 12
+    planner_kinds = {
+        contract.kind
+        for contract in workflow_node_contract_registry.list()
+        if contract.planner.enabled
+    }
+    assert planner_kinds == {
+        "data_aggregate",
+        "dataset_compare",
+        "external_xpert",
+        "input",
+        "json_deserialize",
+        "json_serialize",
+        "knowledge_base",
+        "output",
+        "plugin_resource",
+        "toolset_resource",
+        "variable_aggregator",
+        "workflow_agent",
+    }
     assert facts.runtime_feature_gated == (
         "email_event_entry",
         "knowledge_write_proposal",
@@ -400,5 +419,5 @@ def test_capability_audit_tracks_baseline_and_r1_nodes() -> None:
     assert current_registry_line == (
         "当前 Registry 事实：55 Native、51 个已登记 Palette 项、"
         "默认 50 个可拖拽 Palette 项、52 个完整合同、"
-        "3 个 compatibility 合同、7 个 Planner 节点"
+        "3 个 compatibility 合同、12 个 Planner 节点"
     )

--- a/server/tests/test_workflow_node_contracts.py
+++ b/server/tests/test_workflow_node_contracts.py
@@ -30,8 +30,13 @@ from server.xpert_runtime.workflow_node_registry import workflow_node_registry
 
 
 EXPECTED_PLANNER_KINDS = {
+    "data_aggregate",
+    "dataset_compare",
     "input",
+    "json_deserialize",
+    "json_serialize",
     "output",
+    "variable_aggregator",
     "workflow_agent",
     "external_xpert",
     "knowledge_base",
@@ -82,7 +87,7 @@ PROMOTED_COMPLETE_KINDS = {
 }
 
 
-def test_r22_variable_pack_contract_is_complete_and_not_plannable() -> None:
+def test_r22_variable_pack_contract_is_complete_and_auxiliary_plannable() -> None:
     contract = workflow_node_contract_registry.require("variable_aggregator")
 
     assert contract.contract_status == "complete"
@@ -91,7 +96,9 @@ def test_r22_variable_pack_contract_is_complete_and_not_plannable() -> None:
     assert contract.execution.idempotent is True
     assert contract.execution.can_wait is False
     assert contract.execution.error_semantics == "fail_closed"
-    assert contract.planner.enabled is False
+    assert contract.planner.enabled is True
+    assert contract.planner.support == "full"
+    assert contract.planner.task_binding == "forbidden"
     assert contract.ports[0].name == "values"
     assert contract.ports[0].cardinality == "many"
     assert contract.ports[1].value_schema.type == "object"
@@ -186,7 +193,7 @@ def test_subworkflow_call_contract_does_not_overclaim_idempotency() -> None:
     assert contract.planner.enabled is False
 
 
-def test_r16_control_data_contracts_are_complete_local_and_not_plannable() -> None:
+def test_r16_control_data_contracts_are_complete_and_only_aggregate_is_plannable() -> None:
     kinds = {"terminate_error", "multi_route", "list_operation", "data_aggregate"}
 
     for kind in kinds:
@@ -196,7 +203,7 @@ def test_r16_control_data_contracts_are_complete_local_and_not_plannable() -> No
         assert contract.execution.deterministic is True
         assert contract.execution.external_io is False
         assert contract.execution.can_wait is False
-        assert contract.planner.enabled is False
+        assert contract.planner.enabled is (kind == "data_aggregate")
         assert node_policy_service.decision(kind, "workflow").allowed
         assert node_policy_service.decision(kind, "xpert").allowed
 
@@ -236,11 +243,11 @@ def test_r23_iteration_contract_is_complete_and_not_plannable() -> None:
     assert not node_policy_service.decision("iteration", "evolution").allowed
 
 
-def test_r17_http_condition_and_dataset_contracts_are_complete_and_not_plannable() -> None:
+def test_r17_only_dataset_compare_is_plannable_among_r17_contracts() -> None:
     for kind in {"http_request", "condition", "dataset_compare"}:
         contract = workflow_node_contract_registry.require(kind)
         assert contract.contract_status == "complete"
-        assert contract.planner.enabled is False
+        assert contract.planner.enabled is (kind == "dataset_compare")
         assert node_policy_service.decision(kind, "workflow").allowed
         assert node_policy_service.decision(kind, "xpert").allowed
 
@@ -506,7 +513,53 @@ def test_r18_v2_configs_cannot_match_legacy_contract_branches(
     assert errors
 
 
-def test_only_current_seven_nodes_have_valid_planner_contracts() -> None:
+def test_json_v2_contract_branches_require_schema_and_allow_planner_metadata() -> None:
+    deserialize = Draft202012Validator(
+        workflow_node_contract_registry.require("json_deserialize").config_schema
+    )
+    serialize = Draft202012Validator(
+        workflow_node_contract_registry.require("json_serialize").config_schema
+    )
+
+    assert not list(
+        deserialize.iter_errors(
+            {"inputVariable": "json_text", "outputVariable": "json_value"}
+        )
+    )
+    assert list(
+        deserialize.iter_errors(
+            {
+                "contractVersion": 2,
+                "inputVariable": "json_text",
+                "outputVariable": "json_value",
+            }
+        )
+    )
+    assert not list(
+        deserialize.iter_errors(
+            {
+                "contractVersion": 2,
+                "inputVariable": "json_text",
+                "outputVariable": "json_value",
+                "expectedSchema": {"type": "array", "items": {"type": "number"}},
+                "plannerRef": "decode_values",
+            }
+        )
+    )
+    assert not list(
+        serialize.iter_errors(
+            {
+                "contractVersion": 2,
+                "inputVariable": "json_value",
+                "outputVariable": "json_text",
+                "format": "compact",
+                "plannerRef": "encode_values",
+            }
+        )
+    )
+
+
+def test_only_current_planner_node_pack_has_valid_contracts() -> None:
     available = {
         kind
         for kind in workflow_node_contract_registry.kinds()
@@ -690,7 +743,7 @@ def test_old_capability_snapshot_remains_readable() -> None:
     assert snapshot.contract_checksum == ""
 
 
-def test_registry_ui_projection_is_v4_and_contains_no_runtime_payloads() -> None:
+def test_registry_ui_projection_is_v5_and_contains_no_runtime_payloads() -> None:
     payload = workflow_node_registry.to_payload()
     serialized = str(payload).lower()
     items = [
@@ -700,7 +753,7 @@ def test_registry_ui_projection_is_v4_and_contains_no_runtime_payloads() -> None
     ] + list(payload["knowledge_pipeline"]["items"])
 
     assert len({item["kind"] for item in items}) == 51
-    assert payload["version"] == "xpert-workflow-node-registry-v4"
+    assert payload["version"] == "xpert-workflow-node-registry-v5"
     assert payload["contract_version"] == 3
     assert payload["contract_checksum"] == workflow_node_contract_registry.checksum
     assert all(item["contract"]["kind"] == item["kind"] for item in items)

--- a/server/tests/test_workflow_typed_values.py
+++ b/server/tests/test_workflow_typed_values.py
@@ -15,6 +15,8 @@ from server.main import (
     render_workflow_template,
 )
 from server.workflow_native.schemas import NativeWorkflowDefinition
+from server.workflow_native.control_data import aggregate_rows
+from server.workflow_native.node_contracts import WorkflowValueSchema
 from server.workflow_native.validate import validate_workflow_graph
 from server.workflow_native.values import (
     deserialize_workflow_value,
@@ -274,6 +276,86 @@ def test_json_helpers_and_template_conversion_are_deterministic() -> None:
     )
     assert workflow_condition_matches(["draft", "published"], "contains", '"draft"')
     assert workflow_condition_matches({"status": "ready"}, "contains", "status")
+
+
+@pytest.mark.asyncio
+async def test_json_deserialize_v2_validates_declared_schema_and_fails_closed(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = _json_round_trip_workflow()
+    workflow["nodes"] = [
+        workflow["nodes"][0],
+        workflow["nodes"][2],
+        workflow["nodes"][3],
+    ]
+    workflow["nodes"][1]["data"].update(
+        {
+            "contractVersion": 2,
+            "inputVariable": "user_input",
+            "expectedSchema": {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+                "required": ["answer"],
+            },
+        }
+    )
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "deserialize"},
+        {"id": "e2", "source": "deserialize", "target": "output"},
+    ]
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "[]"}},
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    assert any(event.get("event") == "error" for event in events)
+    assert not any(event.get("event") == "workflow_end" for event in events)
+
+
+def test_json_deserialize_v2_static_validation_requires_expected_schema() -> None:
+    workflow = _json_round_trip_workflow()
+    workflow["nodes"][2]["data"]["contractVersion"] = 2
+
+    result = validate_workflow_graph(NativeWorkflowDefinition.model_validate(workflow))
+
+    assert result.valid is False
+    assert "invalid_json_deserialize_expected_schema" in {
+        issue.code for issue in result.issues
+    }
+
+
+def test_json_v2_schema_and_output_limits_are_fail_closed() -> None:
+    schema = WorkflowValueSchema(
+        type="object",
+        properties={"count": WorkflowValueSchema(type="integer")},
+        required=("count",),
+    )
+    schema.assert_value({"count": 2})
+    with pytest.raises(ValueError, match="must have type integer"):
+        schema.assert_value({"count": "2"})
+    WorkflowValueSchema(
+        type="string",
+        nullable=True,
+        any_of=(WorkflowValueSchema(type="string"),),
+    ).assert_value(None)
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        WorkflowValueSchema.model_validate(
+            {"type": "string", "forged_runtime_policy": "ignore"}
+        )
+    with pytest.raises(ValueError, match="JSON_SERIALIZE_OUTPUT_TOO_LARGE"):
+        serialize_workflow_value({"value": "0123456789"}, max_bytes=8)
+    with pytest.raises(ValueError, match="JSON_DESERIALIZE_INPUT_TOO_LARGE"):
+        deserialize_workflow_value('"0123456789"', max_bytes=8)
+    with pytest.raises(ValueError, match="AGGREGATE_OUTPUT_LIMIT_EXCEEDED"):
+        aggregate_rows(
+            [{"group": "a"}],
+            group_by_fields=["group"],
+            measures=[{"outputField": "count", "operation": "count"}],
+            max_output_bytes=8,
+        )
 
 
 def test_workflow_run_request_rejects_non_json_numbers() -> None:

--- a/server/tests/test_xpert_runtime_workflow_node_registry.py
+++ b/server/tests/test_xpert_runtime_workflow_node_registry.py
@@ -31,7 +31,7 @@ def _registry() -> WorkflowNodeRegistry:
 def test_workflow_node_registry_returns_workflow_and_knowledge_tabs() -> None:
     payload = _registry().to_payload()
 
-    assert payload["version"] == "xpert-workflow-node-registry-v4"
+    assert payload["version"] == "xpert-workflow-node-registry-v5"
     assert payload["contract_version"] == 3
     assert len(payload["contract_checksum"]) == 64
     assert {tab["id"] for tab in payload["tabs"]} == {"workflow", "knowledge"}
@@ -132,7 +132,7 @@ async def test_workflow_node_registry_api_returns_stable_shape(
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["version"] == "xpert-workflow-node-registry-v4"
+    assert payload["version"] == "xpert-workflow-node-registry-v5"
     assert payload["contract_version"] == 3
     assert len(payload["contract_checksum"]) == 64
     assert isinstance(payload["tabs"], list)

--- a/server/workflow_native/control_data.py
+++ b/server/workflow_native/control_data.py
@@ -35,6 +35,7 @@ LIST_OPERATORS = {
 }
 AGGREGATE_OPERATIONS = {"count", "sum", "avg", "min", "max"}
 MAX_COLLECTION_ITEMS = 10_000
+MAX_DATA_AGGREGATE_OUTPUT_BYTES = 5 * 1_024 * 1_024
 MAX_DATASET_COMPARE_OUTPUT_BYTES = 5 * 1_024 * 1_024
 VARIABLE_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
 ROUTE_ID_PATTERN = re.compile(r"^route_[1-8]$")
@@ -704,6 +705,7 @@ def aggregate_rows(
     *,
     group_by_fields: object,
     measures: object,
+    max_output_bytes: int = MAX_DATA_AGGREGATE_OUTPUT_BYTES,
 ) -> list[dict[str, WorkflowValue]]:
     rows = normalize_workflow_value(value, path="$.aggregate_input")
     if not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows):
@@ -771,6 +773,17 @@ def aggregate_rows(
             else:
                 result[output_field] = max(numeric_values) if numeric_values else None
         output.append(result)
+    encoded = json.dumps(
+        output,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if len(encoded) > max(1, int(max_output_bytes)):
+        _fail(
+            "AGGREGATE_OUTPUT_LIMIT_EXCEEDED",
+            "Data aggregate output exceeds the workflow persistence limit.",
+        )
     return output
 
 

--- a/server/workflow_native/node_contracts.py
+++ b/server/workflow_native/node_contracts.py
@@ -57,6 +57,7 @@ NodePlannerCompilationMode = Literal[
     "compiler_managed",
     "none",
 ]
+NodePlannerTaskBinding = Literal["required", "optional", "forbidden"]
 
 
 def canonical_checksum(value: Any) -> str:
@@ -72,7 +73,7 @@ def canonical_checksum(value: Any) -> str:
 
 
 class WorkflowValueSchema(BaseModel):
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     type: WorkflowValueType = "any"
     nullable: bool = False
@@ -92,6 +93,57 @@ class WorkflowValueSchema(BaseModel):
         if len(self.any_of) > 4:
             raise ValueError("any_of supports at most four alternatives")
         return self
+
+    def assert_value(self, value: Any, *, path: str = "$") -> None:
+        """Validate a normalized workflow value against this restricted schema."""
+
+        if value is None and (self.nullable or self.type in {"any", "null"}):
+            return
+        if self.any_of:
+            for candidate in self.any_of:
+                try:
+                    candidate.assert_value(value, path=path)
+                    return
+                except ValueError:
+                    continue
+            raise ValueError(
+                f"Workflow value at {path} does not match any allowed schema."
+            )
+        if value is None:
+            raise ValueError(f"Workflow value at {path} must not be null.")
+        if self.type == "any":
+            return
+        if self.type == "null":
+            raise ValueError(f"Workflow value at {path} must be null.")
+        if self.type == "string" and isinstance(value, str):
+            return
+        if self.type == "boolean" and isinstance(value, bool):
+            return
+        if self.type == "integer" and isinstance(value, int) and not isinstance(value, bool):
+            return
+        if (
+            self.type == "number"
+            and isinstance(value, (int, float))
+            and not isinstance(value, bool)
+        ):
+            return
+        if self.type == "array" and isinstance(value, list):
+            if self.items is not None:
+                for index, item in enumerate(value):
+                    self.items.assert_value(item, path=f"{path}[{index}]")
+            return
+        if self.type == "object" and isinstance(value, dict):
+            missing = sorted(set(self.required) - set(value))
+            if missing:
+                raise ValueError(
+                    f"Workflow object at {path} is missing required properties: "
+                    + ", ".join(missing)
+                )
+            for name, property_schema in self.properties.items():
+                if name in value:
+                    property_schema.assert_value(value[name], path=f"{path}.{name}")
+            return
+        raise ValueError(f"Workflow value at {path} must have type {self.type}.")
 
 
 class NodePortContract(BaseModel):
@@ -188,6 +240,7 @@ class NodePlannerContract(BaseModel):
     compilation_mode: NodePlannerCompilationMode = "none"
     ir_version: int = 3
     adapter_version: str = ""
+    task_binding: NodePlannerTaskBinding = "forbidden"
     default_data: dict[str, Any] = Field(default_factory=dict)
     config_constraints: dict[str, Any] = Field(default_factory=dict)
     ir_config_schema: dict[str, Any] = Field(default_factory=dict)
@@ -202,6 +255,7 @@ class NodeContract(BaseModel):
     ports: tuple[NodePortContract, ...] = ()
     edge: NodeEdgeContract = Field(default_factory=NodeEdgeContract)
     execution: NodeExecutionPolicy = Field(default_factory=NodeExecutionPolicy)
+    execution_variants: dict[int, NodeExecutionPolicy] = Field(default_factory=dict)
     availability: NodeAvailabilityPolicy = Field(default_factory=NodeAvailabilityPolicy)
     resources: tuple[NodeResourceContract, ...] = ()
     planner: NodePlannerContract = Field(default_factory=NodePlannerContract)
@@ -216,7 +270,17 @@ class NodeContract(BaseModel):
             raise ValueError("planner-enabled nodes need complete contracts")
         if self.planner.enabled and self.planner.support == "unsupported":
             raise ValueError("planner-enabled nodes cannot be unsupported")
+        if any(version < 2 for version in self.execution_variants):
+            raise ValueError("execution variants require contractVersion 2 or newer")
         return self
+
+    def effective_execution(self, data: dict[str, Any] | None = None) -> NodeExecutionPolicy:
+        raw_version = (data or {}).get("contractVersion")
+        try:
+            version = int(raw_version) if raw_version is not None else 1
+        except (TypeError, ValueError):
+            version = 0
+        return self.execution_variants.get(version, self.execution)
 
     def compiler_payload(self) -> dict[str, Any]:
         return {
@@ -231,6 +295,7 @@ class NodeContract(BaseModel):
                 "compilation_mode": self.planner.compilation_mode,
                 "ir_version": self.planner.ir_version,
                 "adapter_version": self.planner.adapter_version,
+                "task_binding": self.planner.task_binding,
                 "ir_config_schema": self.planner.ir_config_schema,
             },
         }
@@ -273,6 +338,84 @@ class WorkflowAgentPlannerConfig(BaseModel):
             for item in self.method_skill_ids
         ):
             raise ValueError("method_skill_ids contains an invalid Skill id")
+        return self
+
+
+class JsonSerializePlannerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    format: Literal["compact", "pretty"] = "compact"
+
+
+class JsonDeserializePlannerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_schema: WorkflowValueSchema
+
+
+class VariableAggregatorPlannerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    output_fields: list[str] = Field(min_length=1, max_length=50)
+
+    @model_validator(mode="after")
+    def validate_output_fields(self) -> "VariableAggregatorPlannerConfig":
+        pattern = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+        if any(not pattern.fullmatch(item) for item in self.output_fields):
+            raise ValueError("output_fields must contain valid workflow field names")
+        if len(self.output_fields) != len(set(self.output_fields)):
+            raise ValueError("output_fields must be unique")
+        return self
+
+
+class DataAggregatePlannerMeasure(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    output_field: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+    operation: Literal["count", "sum", "avg", "min", "max"]
+    source_field: str = Field(default="", max_length=64)
+
+    @model_validator(mode="after")
+    def validate_source_field(self) -> "DataAggregatePlannerMeasure":
+        if self.operation == "count" and self.source_field:
+            raise ValueError("count measures do not accept source_field")
+        if self.operation != "count" and not self.source_field:
+            raise ValueError("numeric measures require source_field")
+        return self
+
+
+class DataAggregatePlannerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    group_by_fields: list[str] = Field(default_factory=list, max_length=3)
+    measures: list[DataAggregatePlannerMeasure] = Field(min_length=1, max_length=10)
+
+    @model_validator(mode="after")
+    def validate_fields(self) -> "DataAggregatePlannerConfig":
+        if len(self.group_by_fields) != len(set(self.group_by_fields)):
+            raise ValueError("group_by_fields must be unique")
+        if any(not item or len(item) > 64 for item in self.group_by_fields):
+            raise ValueError("group_by_fields must be non-empty top-level fields")
+        output_fields = [item.output_field for item in self.measures]
+        if len(output_fields) != len(set(output_fields)):
+            raise ValueError("measure output fields must be unique")
+        if set(output_fields) & set(self.group_by_fields):
+            raise ValueError("measure output fields cannot replace group fields")
+        return self
+
+
+class DatasetComparePlannerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key_fields: list[str] = Field(min_length=1, max_length=3)
+    include_unchanged: bool = False
+
+    @model_validator(mode="after")
+    def validate_key_fields(self) -> "DatasetComparePlannerConfig":
+        if len(self.key_fields) != len(set(self.key_fields)):
+            raise ValueError("key_fields must be unique")
+        if any(not item or len(item) > 64 for item in self.key_fields):
+            raise ValueError("key_fields must be non-empty top-level fields")
         return self
 
 
@@ -365,6 +508,7 @@ class NodePolicyService:
             and contract.planner.enabled
             and contract.planner.support == "full"
             and contract.planner.compilation_mode == "adapter"
+            and contract.planner.task_binding == "required"
             and contract.availability.evolution.state == "allow"
         }
 
@@ -411,6 +555,7 @@ def _planner(
     support: NodePlannerSupport = "unsupported",
     compilation_mode: NodePlannerCompilationMode = "none",
     adapter_version: str = "",
+    task_binding: NodePlannerTaskBinding = "forbidden",
     default_data: dict[str, Any] | None = None,
     constraints: dict[str, Any] | None = None,
     ir_config_schema: dict[str, Any] | None = None,
@@ -420,6 +565,7 @@ def _planner(
         support=support,
         compilation_mode=compilation_mode,
         adapter_version=adapter_version,
+        task_binding=task_binding,
         default_data=dict(default_data or {}),
         config_constraints=dict(constraints or {}),
         ir_config_schema=dict(ir_config_schema or {}),
@@ -1239,7 +1385,15 @@ def _complete_contracts() -> dict[str, NodeContract]:
             evaluation=_rule("allow"),
             evolution=_rule("allow"),
         ),
-        planner=_planner(),
+        planner=_planner(
+            enabled=True,
+            support="full",
+            compilation_mode="adapter",
+            adapter_version=planner_adapter_version,
+            task_binding="forbidden",
+            default_data={"output_fields": ["value"]},
+            ir_config_schema=VariableAggregatorPlannerConfig.model_json_schema(),
+        ),
     )
 
     iteration_v1_schema = _object_schema(
@@ -2593,7 +2747,24 @@ def _complete_contracts() -> dict[str, NodeContract]:
             error_semantics="fail_closed",
             security_category="transform",
         ),
-        planner=_planner(),
+        planner=_planner(
+            enabled=True,
+            support="full",
+            compilation_mode="adapter",
+            adapter_version=planner_adapter_version,
+            task_binding="forbidden",
+            default_data={
+                "group_by_fields": [],
+                "measures": [
+                    {
+                        "output_field": "count",
+                        "operation": "count",
+                        "source_field": "",
+                    }
+                ],
+            },
+            ir_config_schema=DataAggregatePlannerConfig.model_json_schema(),
+        ),
     )
     contracts["data_merge"] = NodeContract(
         kind="data_merge",
@@ -2717,7 +2888,18 @@ def _complete_contracts() -> dict[str, NodeContract]:
             error_semantics="fail_closed",
             security_category="transform",
         ),
-        planner=_planner(),
+        planner=_planner(
+            enabled=True,
+            support="full",
+            compilation_mode="adapter",
+            adapter_version=planner_adapter_version,
+            task_binding="forbidden",
+            default_data={
+                "key_fields": ["id"],
+                "include_unchanged": False,
+            },
+            ir_config_schema=DatasetComparePlannerConfig.model_json_schema(),
+        ),
     )
     contracts["llm"] = NodeContract(
         kind="llm",
@@ -2827,6 +3009,7 @@ def _complete_contracts() -> dict[str, NodeContract]:
             support="full",
             compilation_mode="adapter",
             adapter_version=planner_adapter_version,
+            task_binding="required",
             default_data={
                 "toolMode": "none",
                 "maxIterations": "6",
@@ -2976,17 +3159,35 @@ def _complete_contracts() -> dict[str, NodeContract]:
             ),
         )
 
+    workflow_value_schema = WorkflowValueSchema.model_json_schema(
+        ref_template="#/$defs/{model}"
+    )
+    workflow_value_schema_defs = dict(workflow_value_schema.pop("$defs", {}))
+    json_serialize_legacy_schema = _object_schema(
+        {
+            "inputVariable": {"type": "string"},
+            "outputVariable": {"type": "string"},
+            "format": {"enum": ["compact", "pretty"]},
+        },
+        required=["inputVariable", "outputVariable"],
+    )
+    json_serialize_legacy_schema["not"] = {"required": ["contractVersion"]}
+    json_serialize_v2_schema = _object_schema(
+        {
+            "contractVersion": {"const": 2},
+            "inputVariable": {"type": "string"},
+            "outputVariable": {"type": "string"},
+            "format": {"enum": ["compact", "pretty"]},
+        },
+        required=["contractVersion", "inputVariable", "outputVariable", "format"],
+    )
     contracts["json_serialize"] = NodeContract(
         kind="json_serialize",
         contract_status="complete",
-        config_schema=_object_schema(
-            {
-                "inputVariable": {"type": "string"},
-                "outputVariable": {"type": "string"},
-                "format": {"enum": ["compact", "pretty"]},
-            },
-            required=["inputVariable", "outputVariable"],
-        ),
+        config_schema={
+            "type": "object",
+            "anyOf": [json_serialize_legacy_schema, json_serialize_v2_schema],
+        },
         ports=(
             NodePortContract(name="value", direction="input", value_schema=any_value),
             NodePortContract(name="json", direction="output", value_schema=string_value),
@@ -2998,28 +3199,58 @@ def _complete_contracts() -> dict[str, NodeContract]:
             error_semantics="legacy_inline_error",
             security_category="transform",
         ),
+        execution_variants={
+            2: NodeExecutionPolicy(
+                side_effect="none",
+                deterministic=True,
+                idempotent=True,
+                error_semantics="fail_closed",
+                security_category="transform",
+            )
+        },
         planner=_planner(
-            default_data={
-                "inputVariable": "json_value",
-                "outputVariable": "json_text",
-                "format": "compact",
-            },
+            enabled=True,
+            support="full",
+            compilation_mode="adapter",
+            adapter_version=planner_adapter_version,
+            task_binding="forbidden",
+            default_data={"format": "compact"},
             constraints={
-                "required": ["inputVariable", "outputVariable"],
                 "format": ["compact", "pretty"],
             },
+            ir_config_schema=JsonSerializePlannerConfig.model_json_schema(),
         ),
+    )
+    json_deserialize_legacy_schema = _object_schema(
+        {
+            "inputVariable": {"type": "string"},
+            "outputVariable": {"type": "string"},
+        },
+        required=["inputVariable", "outputVariable"],
+    )
+    json_deserialize_legacy_schema["not"] = {"required": ["contractVersion"]}
+    json_deserialize_v2_schema = _object_schema(
+        {
+            "contractVersion": {"const": 2},
+            "inputVariable": {"type": "string"},
+            "outputVariable": {"type": "string"},
+            "expectedSchema": workflow_value_schema,
+        },
+        required=[
+            "contractVersion",
+            "inputVariable",
+            "outputVariable",
+            "expectedSchema",
+        ],
     )
     contracts["json_deserialize"] = NodeContract(
         kind="json_deserialize",
         contract_status="complete",
-        config_schema=_object_schema(
-            {
-                "inputVariable": {"type": "string"},
-                "outputVariable": {"type": "string"},
-            },
-            required=["inputVariable", "outputVariable"],
-        ),
+        config_schema={
+            "type": "object",
+            "anyOf": [json_deserialize_legacy_schema, json_deserialize_v2_schema],
+            "$defs": workflow_value_schema_defs,
+        },
         ports=(
             NodePortContract(name="json", direction="input", value_schema=string_value),
             NodePortContract(name="value", direction="output", value_schema=any_value),
@@ -3031,12 +3262,24 @@ def _complete_contracts() -> dict[str, NodeContract]:
             error_semantics="legacy_inline_error",
             security_category="transform",
         ),
+        execution_variants={
+            2: NodeExecutionPolicy(
+                side_effect="none",
+                deterministic=True,
+                idempotent=True,
+                error_semantics="fail_closed",
+                security_category="transform",
+            )
+        },
         planner=_planner(
-            default_data={
-                "inputVariable": "json_text",
-                "outputVariable": "json_value",
-            },
-            constraints={"required": ["inputVariable", "outputVariable"]},
+            enabled=True,
+            support="full",
+            compilation_mode="adapter",
+            adapter_version=planner_adapter_version,
+            task_binding="forbidden",
+            default_data={"expected_schema": {"type": "object"}},
+            constraints={"required": ["expected_schema"]},
+            ir_config_schema=JsonDeserializePlannerConfig.model_json_schema(),
         ),
     )
 

--- a/server/workflow_native/validate.py
+++ b/server/workflow_native/validate.py
@@ -23,7 +23,7 @@ from .control_data import (
     validate_dataset_compare_config,
     validate_terminate_error_config,
 )
-from .node_contracts import workflow_node_contract_registry
+from .node_contracts import WorkflowValueSchema, workflow_node_contract_registry
 from .content_parser import (
     WorkflowContentParserError,
     is_document_extractor_v3,
@@ -1834,6 +1834,20 @@ def validate_node_configuration(
                     ValidationIssue(
                         code="invalid_json_serialize_format",
                         message="json_serialize format must be compact or pretty.",
+                        node_id=node.id,
+                    )
+                )
+        elif r20_contract_version(data) == 2:
+            try:
+                WorkflowValueSchema.model_validate(data.get("expectedSchema"))
+            except ValueError as exc:
+                issues.append(
+                    ValidationIssue(
+                        code="invalid_json_deserialize_expected_schema",
+                        message=(
+                            "json_deserialize V2 requires a valid restricted "
+                            f"expectedSchema: {str(exc)[:200]}"
+                        ),
                         node_id=node.id,
                     )
                 )

--- a/server/workflow_native/values.py
+++ b/server/workflow_native/values.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import json
 import math
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import JsonValue
 
+if TYPE_CHECKING:
+    from .node_contracts import WorkflowValueSchema
+
 
 WorkflowValue = JsonValue
+MAX_WORKFLOW_JSON_BYTES = 5 * 1_024 * 1_024
 
 
 def normalize_workflow_value(
@@ -68,25 +72,57 @@ def workflow_value_to_text(value: Any) -> str:
     )
 
 
-def serialize_workflow_value(value: Any, *, pretty: bool = False) -> str:
+def serialize_workflow_value(
+    value: Any,
+    *,
+    pretty: bool = False,
+    max_bytes: int | None = None,
+) -> str:
     normalized = normalize_workflow_value(value)
-    return json.dumps(
+    serialized = json.dumps(
         normalized,
         ensure_ascii=False,
         allow_nan=False,
         indent=2 if pretty else None,
         separators=None if pretty else (",", ":"),
     )
+    if max_bytes is not None and len(serialized.encode("utf-8")) > max_bytes:
+        raise ValueError(
+            f"JSON_SERIALIZE_OUTPUT_TOO_LARGE: JSON output exceeds {max_bytes} bytes."
+        )
+    return serialized
 
 
-def deserialize_workflow_value(value: str) -> WorkflowValue:
+def deserialize_workflow_value(
+    value: str,
+    *,
+    expected_schema: "WorkflowValueSchema | dict[str, Any] | None" = None,
+    max_bytes: int | None = None,
+) -> WorkflowValue:
     if not isinstance(value, str):
         raise ValueError("JSON deserialize input must be a string.")
+    if max_bytes is not None and len(value.encode("utf-8")) > max_bytes:
+        raise ValueError(
+            f"JSON_DESERIALIZE_INPUT_TOO_LARGE: JSON input exceeds {max_bytes} bytes."
+        )
     try:
         parsed = json.loads(value)
     except json.JSONDecodeError as exc:
         raise ValueError(f"JSON deserialize input is invalid: {exc.msg}.") from exc
-    return normalize_workflow_value(parsed)
+    normalized = normalize_workflow_value(parsed)
+    if expected_schema is not None:
+        from .node_contracts import WorkflowValueSchema
+
+        try:
+            schema = WorkflowValueSchema.model_validate(expected_schema)
+            schema.assert_value(normalized)
+        except ValueError as exc:
+            raise ValueError(
+                f"JSON_DESERIALIZE_SCHEMA_MISMATCH: {exc}"
+            ) from exc
+    if max_bytes is not None:
+        serialize_workflow_value(normalized, max_bytes=max_bytes)
+    return normalized
 
 
 def workflow_list_items(value: Any) -> tuple[list[WorkflowValue], bool]:

--- a/server/xpert_runtime/workflow_node_registry.py
+++ b/server/xpert_runtime/workflow_node_registry.py
@@ -78,6 +78,7 @@ class WorkflowPaletteItem:
                 "compilation_mode": contract.planner.compilation_mode,
                 "ir_version": contract.planner.ir_version,
                 "adapter_version": contract.planner.adapter_version,
+                "task_binding": contract.planner.task_binding,
                 "contract_checksum": contract.checksum,
                 "compiler_checksum": contract.compiler_checksum,
                 "default_data": {
@@ -153,7 +154,7 @@ class WorkflowNodeRegistry:
     """Xpert-style metadata registry for classic workflow palette nodes."""
 
     def __init__(self) -> None:
-        self.version = "xpert-workflow-node-registry-v4"
+        self.version = "xpert-workflow-node-registry-v5"
         self.contract_registry = workflow_node_contract_registry
         self._tabs: list[WorkflowPaletteTab] = []
         self._sections: list[WorkflowPaletteSection] = []


### PR DESCRIPTION
## 概要

- 向 Meta Planner 精确开放 json_serialize、json_deserialize V2、variable_aggregator V2、data_aggregate 和 dataset_compare。
- 纯节点不承担计划任务；workflow_agent 继续负责完整任务覆盖，最终输出保持 Agent 来源。
- 完成 NodeContract、Graph IR V3、Adapter、Headless Graph Patch 与前端配置投影的统一往返。
- JSON V2 增加 expectedSchema 运行时验证和 5 MiB 边界，旧 JSON 工作流行为保持兼容。

## 安全与兼容

- 不增加模型调用预算，不修改 Classic Runner、Workflow SSE、Proposal 审批或发布协议。
- Patch 仍只接受语义 ref、命名端口和 Adapter 配置，拒绝原生变量、Handle、checksum 与策略注入。
- Knowledge、Agent Table、Vision、控制流及其他延期节点继续保持 Planner 不可生成。
- 新增伪造任务归属、类型错连、Schema 注入、悬空依赖、循环与 TOCTOU 等证伪覆盖。

## 验证

- 真实 DeepSeek V4 Flash 0731 三阶段生成成功：任务规划、能力编译、唯一一次 Graph Patch 修复；生成的 Graph IR V3 Proposal 验证通过。
- 变基后后端重点回归：190 passed。
- 前端重点回归：68 passed。
- 前端 npm.cmd run build：通过。
- 修改后端模块 py_compile、git diff --check、敏感信息和本地绝对路径扫描：通过。
- 全量后端：5313 passed、29 skipped、20 failed。相同 20 个失败已在最新 origin/main 同环境复现，来源为未构建 Agency Worker 产物及容器内缺少 TypeScript/Node 生成链，本分支未新增失败。

## 回退

回退本提交即可关闭新增 Planner Adapter；现有 Workflow、Proposal 与已发布 Xpert 数据无需迁移。