### PR TITLE
feat: 增加 AI Research P2R 资格期受限控制面

### DIFF
--- a/server/model_router/ai_research_bridge.py
+++ b/server/model_router/ai_research_bridge.py
@@ -625,19 +625,15 @@ async def models(
         and settings.p2r_enabled
         and settings.p2r_tools_enabled
     ):
-        text_ready, text_reason = stable.readiness_scoped_certified(
-            settings.hypothesis_model_id, "chat_text"
+        hypothesis_ready, hypothesis_reason = stable.readiness_scoped_certified(
+            settings.hypothesis_model_id,
+            "chat_text",
+            required_capabilities=("chat_text", "chat_tools"),
         )
-        tools_ready, tools_reason = stable.readiness_scoped_certified(
-            settings.hypothesis_model_id, "chat_tools"
-        )
-        if text_ready and tools_ready:
+        if hypothesis_ready:
             model_ids.append(settings.hypothesis_model_id)
-        else:
-            for reason in (text_reason, tools_reason):
-                if reason:
-                    unavailable_reasons.append(reason)
-                    break
+        elif hypothesis_reason:
+            unavailable_reasons.append(hypothesis_reason)
     if not model_ids:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -713,15 +709,16 @@ async def chat_completions(
         raise HTTPException(status_code=422, detail="messages exceed the total text limit")
     capability = "chat_tools" if payload.tools else "chat_text"
     if scoped_certified:
-        for required_capability in required_scoped_capabilities:
-            ready, reason = stable.readiness_scoped_certified(
-                selected_model_id, required_capability
+        ready, reason = stable.readiness_scoped_certified(
+            selected_model_id,
+            capability,
+            required_capabilities=required_scoped_capabilities,
+        )
+        if not ready:
+            raise HTTPException(
+                status_code=503,
+                detail=reason or "fixed model control is not ready",
             )
-            if not ready:
-                raise HTTPException(
-                    status_code=503,
-                    detail=reason or "fixed model control is not ready",
-                )
     try:
         preflight = await (
             stable.begin_scoped_certified(
@@ -924,6 +921,7 @@ async def chat_completions(
                 tool.function.name for tool in (payload.tools or [])
             },
             p2r_context=p2r_context,
+            require_model_identity=scoped_certified,
         )
         usage = value.get("usage") if isinstance(value.get("usage"), dict) else {}
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -1170,11 +1168,12 @@ def _validate_completion_response(
     requested_model: str,
     allowed_tool_names: set[str],
     p2r_context: P2RRequestContext | None = None,
+    require_model_identity: bool = False,
 ) -> str | None:
     if not isinstance(value, dict):
         raise BridgeResponseError("ai_research_bridge_invalid_envelope")
     actual_model = value.get("model")
-    if p2r_context is not None and actual_model is None:
+    if (p2r_context is not None or require_model_identity) and actual_model is None:
         raise BridgeResponseError("ai_research_bridge_model_identity_required")
     if actual_model is not None and actual_model != requested_model:
         raise BridgeResponseError("ai_research_bridge_model_mismatch")

--- a/server/model_router/ai_research_bridge.py
+++ b/server/model_router/ai_research_bridge.py
@@ -752,6 +752,26 @@ async def chat_completions(
     client = httpx.AsyncClient(**stable.transport.client_kwargs())
     started = time.perf_counter()
     dispatched = False
+
+    def record_dispatch_failure(
+        *,
+        status: str,
+        result_class: str,
+        error_code: str,
+        client_cancelled: bool = False,
+    ) -> None:
+        if dispatched:
+            stable.complete(
+                dispatch,
+                status=status,
+                result_class=result_class,
+                error_code=error_code,
+                client_cancelled=client_cancelled,
+                e2e_ms=_elapsed_ms(started),
+            )
+            return
+        stable.fail_undispatched(dispatch, error_code=error_code)
+
     try:
         request = stable.transport.build_authorized_stream_request(
             client,
@@ -767,37 +787,38 @@ async def chat_completions(
         response = await stable.transport.send_authorized_stream(client, request)
     except asyncio.CancelledError:
         await _close_nonstream_after_cancellation(response=None, client=client)
-        if dispatched:
-            stable.complete(
-                dispatch,
+        try:
+            record_dispatch_failure(
                 status="cancelled",
                 result_class="client_cancelled",
                 error_code="provider_chat_client_cancelled",
                 client_cancelled=True,
-                e2e_ms=_elapsed_ms(started),
             )
+        except Exception:
+            pass
         raise
     except RouterServiceError as exc:
         await client.aclose()
+        record_dispatch_failure(
+            status="failed",
+            result_class="transient_failure",
+            error_code=exc.code,
+        )
         raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
     except (httpx.HTTPError, OSError, ValueError) as exc:
-        stable.complete(
-            dispatch,
+        record_dispatch_failure(
             status="failed",
             result_class="transient_failure",
             error_code="ai_research_bridge_transport_failed",
-            e2e_ms=_elapsed_ms(started),
         )
         await client.aclose()
         raise HTTPException(status_code=503, detail="fixed model transport failed") from exc
     except Exception as exc:
         try:
-            stable.complete(
-                dispatch,
+            record_dispatch_failure(
                 status="failed",
                 result_class="transient_failure",
                 error_code="ai_research_bridge_dispatch_failed",
-                e2e_ms=_elapsed_ms(started),
             )
         except Exception:
             pass
@@ -1612,6 +1633,10 @@ def _validate_p2r_completion_choices(
             > P2R_PYTHON_LIMITS["scriptBytes"]
         ):
             raise BridgeResponseError("ai_research_bridge_invalid_tool_call")
+        if choice.get("finish_reason") != "tool_calls":
+            raise BridgeResponseError(
+                "ai_research_bridge_invalid_p2r_finish_reason"
+            )
         return
     if tool_calls is not None and tool_calls != []:
         raise BridgeResponseError("ai_research_bridge_unexpected_p2r_tool_call")
@@ -1625,6 +1650,8 @@ def _validate_p2r_completion_choices(
         raise BridgeResponseError("ai_research_bridge_invalid_p2r_shape")
     if context.response_shape == "array" and not isinstance(structured, list):
         raise BridgeResponseError("ai_research_bridge_invalid_p2r_shape")
+    if choice.get("finish_reason") != "stop":
+        raise BridgeResponseError("ai_research_bridge_invalid_p2r_finish_reason")
 
 
 def _json_depth(value: object) -> int:

--- a/server/model_router/ai_research_bridge.py
+++ b/server/model_router/ai_research_bridge.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import re
 import secrets
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal
 
 import httpx
@@ -22,6 +23,7 @@ from .service import ModelRouterService, RouterServiceError
 
 MAX_MESSAGES = 128
 MAX_TOTAL_MESSAGE_CHARS = 128_000
+MAX_HYPOTHESIS_TOTAL_MESSAGE_CHARS = 512_000
 MAX_MESSAGE_CHARS = MAX_TOTAL_MESSAGE_CHARS
 MAX_TOOLS = 32
 MAX_TOOL_DESCRIPTION_CHARS = 2_048
@@ -30,13 +32,176 @@ MAX_TOOL_SCHEMA_BYTES = 65_536
 MAX_TOTAL_TOOL_SCHEMA_BYTES = 256_000
 MAX_REQUEST_BYTES = 1024 * 1024
 MAX_RESPONSE_BYTES = 64 * 1024 * 1024
+MAX_STREAM_IDENTITY_BUFFER_BYTES = 1024 * 1024
 TOOL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+P2R_COHERENCE_PROMPT_SHA256 = (
+    "b53c6ff219a1b4eb1689a9f5728c21e9c8b8b0de1e93babf1b5814214447bb02"
+)
+P2R_PHASE_REQUEST_PROTOCOL = "modelmirror-ai-research-p2r-phase-request-v1"
+P2R_QUALIFICATION_RUN_PATTERN = re.compile(r"^p2rq_[0-9a-f]{32}$")
+P2R_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+P2R_ARTIFACT_PATH_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*$")
+P2R_MAX_ARTIFACT_CHUNK_CHARS = 100_000
+P2R_FIXED_TEMPERATURE = 0.2
+P2R_FIXED_MAX_TOKENS = 30_000
+P2R_PYTHON_RECEIPT_PROTOCOL = "modelmirror-ai-research-p2r-v1"
+P2R_PYTHON_SANDBOX_IMAGE = (
+    "python@sha256:401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461"
+)
+P2R_PYTHON_LIMITS = {
+    "scriptBytes": 65_536,
+    "streamBytes": 262_144,
+    "timeoutSeconds": 30,
+    "visibleStreamBytes": 49_152,
+}
+P2R_LOCKED_STATIC_ARTIFACT_SHA256 = {
+    "references/ideation-patterns/overview.md": "20014a5167c41a0a71b492bb4b20e25947b4cf30c7f86234c020e8d45f7450b2",
+    "references/ideation-patterns/companion-combos.md": "d3165ba86ae1546da37f8de0cecff93499afa700847e491ec071acdad12d9f23",
+    "references/ideation-sub-patterns/overview.md": "bef036e8aed185e598f98caf45984b2444b47a45e3f35babe3bb038ff006a8fa",
+    "references/ideation-sub-patterns/C00.md": "0bc790076bc61bc5a902094b3b1326375b20a2210540b9665c97728f8a869d56",
+    "references/ideation-sub-patterns/C01.md": "a09198aec391b4beef0c9630b9c1a1793275ee6b72e8276646b76a95d69b7a3c",
+    "references/ideation-sub-patterns/C02.md": "c526fdc812d2e955da7de11c64be2a0858fa65f331ae0679b5d9170a1d96b5ff",
+    "references/ideation-sub-patterns/C03.md": "8c69e090645656f141b869a7701f6f611917395f2abf6578eced99520dea6da9",
+    "references/ideation-sub-patterns/C04.md": "e479b0ce12a37ce4c9bc052fa2dd3cc9c7f52b77be4b619253fda8defa0c23fe",
+    "references/ideation-sub-patterns/C05.md": "e6c07526be463b48ef858270dba3de30170ecb3fcde37ad66d4dc635e0f34d48",
+    "references/ideation-sub-patterns/C06.md": "d1570fddded634848788b33c6a731dbce440d0450e6f3c550f0f517d87a7bba8",
+    "references/ideation-sub-patterns/C07.md": "1cf23b65fbee15bbbffcda7f4af3542f60cc167134efce2e203cd0fc4aede69f",
+    "references/ideation-sub-patterns/C08.md": "dd9b19e9af3315d69cd3435f2033c87d1d6ca44126603db2595ece8952f0e16b",
+    "references/ideation-sub-patterns/C09.md": "e178b7925e08f94311f28639a88030f84ece1468b7080707472afe432ff4126e",
+    "references/ideation-sub-patterns/C10.md": "8724aaff35a9704544a9be7625e6a05d58c606335f3a65e99a825d3bbce8366a",
+    "references/ideation-sub-patterns/C11.md": "74f197a89da72069cef06640e425cb5fed8b36fa3f2247ac50690424ec904c65",
+    "references/ideation-sub-patterns/C12.md": "6157bfd876ba96f837c0f577399f6afc1602e419c45fe77424f57b5e446a8927",
+    "references/ideation-sub-patterns/C13.md": "7e19113e0aff6d02e77fc4a9898c6c5edae5a1b20f6c46bf65cd78fae0e62d9b",
+    "references/ideation-sub-patterns/C14.md": "5eb5d1ba44a72a8e8274a8958a1e9ac64b0badb96896f637d2072733e2312abe",
+    "references/ideation-sub-patterns/C15.md": "fce7d01cac2fe7f8562d5de2af87159547d7a7e9bb9b115560af14a00a6f8999",
+    "references/ideation-sub-patterns/C16.md": "0978269b1da55a84902d42087c8d481a3fb40c6d299870d760ff9a64df1ed70e",
+    "references/ideation-sub-patterns/C17.md": "7909db559de1066dee94d425dd43285f7a88c619ba65870632bf787629aaf167",
+    "references/ideation-sub-patterns/C18.md": "871ad780b2120f7f4bd0930a3ae0d2c66e3928368a5ffbf36f4777c3fb8d01a6",
+    "references/ideation-sub-patterns/C19.md": "80f960607eadbb4c61eb9e8c9b7394e76d36b568700fdcc73b53ea9cc7ac6cce",
+    "references/ideation-sub-patterns/C20.md": "44b744d5822c8c662171e2f9607e78f0dd57246938254a22354e05386841c63f",
+    "references/ideation-sub-patterns/C21.md": "5f37f2da95b53bfc32fa8a257293cbf549dc1959a45e933949e04bad4b65e89f",
+    "references/ideation-sub-patterns/C22.md": "094fa0747a14ae5f706575ad7be75604d7ccd307420e39ad22c79bc870c5a17c",
+    "references/ideation-sub-patterns/C23.md": "d301755650014fa6d6df8c14faadbdc32aea4952c2bca76e209981495682f455",
+    "references/ideation-sub-patterns/C24.md": "b4f8759c8da5248c192265a3b42dfd6356e98fcae95a8f8d6048dabeee28bd8a",
+    "references/ideation-sub-patterns/C25.md": "ced46168bbcc6ab1aeaf9a242b47631d6076097bd8758c08560c3faa888da4ff",
+    "references/ideation-sub-patterns/C26.md": "8b3b77eb217046fa5c64a7f5fd38a67bbfc96550b92cc6249a46241d222318ae",
+    "references/ideation-sub-patterns/C27.md": "1c6a3b88c1c50aab2841681e9eeea8e6279409b02f4221eca7aa8e3059795bf4",
+    "references/ideation-sub-patterns/C28.md": "d72af42e36a4333f45f633454858cada56aca66b4b3ac1c711f23abad3273b6c",
+    "references/ideation-sub-patterns/C29.md": "9f619738bcf908ebbb9b27a771b83007b4370ac5fc9f84738b3c823fb5789ca1",
+    "references/ideation-sub-patterns/C30.md": "7e91d3605898cddc818268020289617ca76496905342b58adc4358eedc146497",
+}
+
+# ResearchStudio IdeaSpark commit
+# a785e3aca7a2f0cb9775d45a7f2b5d3bf16f076a. This registry is a closed
+# qualification surface, not a generic prompt allowlist. Phase 0.5 uses the
+# exact navigator NOTES constant from the locked next_step.py because upstream
+# intentionally has no standalone prompt file for that step.
+P2R_PHASE_CONTRACTS: dict[str, dict[str, Any]] = {
+    "researchstudio.phase0.intent": {
+        "promptSha256": "5560bf6a8c27ea903ce8690e73ef6ca9fcf15f0460da9f630ac1855d513babbb",
+        "tools": False,
+        "responseShape": "object",
+        "artifactPaths": ("phase0/user_query.txt",),
+    },
+    "researchstudio.phase0.partition": {
+        "promptSha256": "a55ad7fc652252d0de2cc4b1ba07edbcee18324518c694942c2303b554116edf",
+        "tools": False,
+        "responseShape": "array",
+        "artifactPaths": ("phase0/user_query.txt", "phase0/lit_results.json"),
+    },
+    "researchstudio.phase0.pattern_summary": {
+        "promptSha256": "743bcb71345a96edb6d796b00b078a25a2d859981404fd07f4d5d1b7140ff755",
+        "tools": False,
+        "responseShape": "object",
+        "artifactPaths": ("phase0/lit_results.json",),
+    },
+    "researchstudio.phase0.coverage": {
+        "promptSha256": "9fb00f6f376fef3a7b85d4b00c7be5b0f4f1d18be2a0d189dbe4c4da3b62bce9",
+        "tools": False,
+        "responseShape": "array",
+        "artifactPaths": ("phase0/user_query.txt", "phase0/lit_table.md"),
+    },
+    "researchstudio.phase1.bottleneck": {
+        "promptSha256": "58b822ea26d9de94d10a9ad7dcf9a94879489361b435cbd610c5fb310adcf68c",
+        "tools": False,
+        "responseShape": "object",
+        "artifactPaths": (
+            "phase0/user_query.txt",
+            "phase0/lit_table.md",
+            "phase0/fulltext_cache.json",
+            "phase0/lit_results.json",
+        ),
+    },
+    "researchstudio.phase2.select": {
+        "promptSha256": "2acf389b68e0a3f752d4fc20299219c6332767f704ab36dc494b51c36c4ec435",
+        "tools": False,
+        "responseShape": "object",
+        "artifactPaths": (
+            "phase0/user_query.txt",
+            "phase1/phase1_output.json",
+            "references/ideation-patterns/overview.md",
+            "references/ideation-patterns/companion-combos.md",
+            "phase0/lit_table.md",
+            "phase2_generate/closest_abstracts.json",
+            "references/ideation-sub-patterns/overview.md",
+        ),
+    },
+    "researchstudio.phase2.generate": {
+        "promptSha256": "60728c5c2b351352b7bc49fafdbb320cd4413dcc33a0f40f3c73062679afa3c0",
+        "tools": False,
+        "responseShape": "object",
+        "artifactPaths": (
+            "phase2_select/phase2_select_output.json",
+            "phase1/phase1_output.json",
+            "phase2_generate/closest_abstracts.json",
+            "phase0/fulltext_cache.json",
+            "references/ideation-sub-patterns/overview.md",
+        ),
+        "dynamicArtifactPattern": r"references/ideation-sub-patterns/C(?:[0-2][0-9]|30)\.md",
+        "dynamicArtifactMin": 1,
+        "dynamicArtifactMax": 4,
+    },
+    "researchstudio.phase2.coherence": {
+        "promptSha256": P2R_COHERENCE_PROMPT_SHA256,
+        "tools": True,
+        "responseShape": "object",
+        "artifactPaths": (
+            "phase2_select/phase2_select_output.json",
+            "phase2_generate/phase2_generate_output.json",
+        ),
+    },
+}
+P2R_PYTHON_TOOL_DESCRIPTION = (
+    "Execute a bounded Python dry-run in the isolated P2R sandbox."
+)
+P2R_PYTHON_PARAMETERS = {
+    "type": "object",
+    "properties": {
+        "code": {
+            "type": "string",
+            "description": (
+                "A stdlib-only Python script used to test the candidate procedure."
+            ),
+        }
+    },
+    "required": ["code"],
+    "additionalProperties": False,
+}
 
 
 class BridgeResponseError(ValueError):
     def __init__(self, code: str) -> None:
         super().__init__(code)
         self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class P2RRequestContext:
+    phase: str
+    stage: Literal["text", "coherence_initial", "coherence_finalize"]
+    response_shape: Literal["object", "array"]
+    qualification_run_id: str
+    previous_receipt_sha256: str
 
 
 class StrictModel(BaseModel):
@@ -149,6 +314,8 @@ ToolChoice = Literal["none", "auto", "required"] | NamedToolChoice
 @dataclass(slots=True)
 class _BridgeStreamEvidence(ProviderChatCanaryStreamEvidence):
     tool_call_observed: bool = False
+    observed_models: set[str] = field(default_factory=set)
+    invalid_model_observed: bool = False
 
     def _consume_event(self, event: str) -> None:
         ProviderChatCanaryStreamEvidence._consume_event(self, event)
@@ -165,6 +332,14 @@ class _BridgeStreamEvidence(ProviderChatCanaryStreamEvidence):
             return
         if not isinstance(payload, dict):
             return
+        if payload.get("error") is not None:
+            self.invalid = True
+        if "model" in payload:
+            model = payload["model"]
+            if isinstance(model, str) and model:
+                self.observed_models.add(model)
+            else:
+                self.invalid_model_observed = True
         for choice in payload.get("choices") or []:
             if not isinstance(choice, dict):
                 continue
@@ -200,6 +375,10 @@ class StreamOptions(StrictModel):
     include_usage: bool = Field(default=False, alias="include_usage")
 
 
+class JsonObjectResponseFormat(StrictModel):
+    type: Literal["json_object"]
+
+
 class ChatCompletionRequest(StrictModel):
     model: str = Field(min_length=1, max_length=256)
     messages: list[ChatMessage] = Field(min_length=1, max_length=MAX_MESSAGES)
@@ -210,6 +389,7 @@ class ChatCompletionRequest(StrictModel):
     stop: str | list[str] | None = None
     stream: bool = False
     stream_options: StreamOptions | None = None
+    response_format: JsonObjectResponseFormat | None = None
     tools: list[FunctionTool] | None = Field(
         default=None, min_length=1, max_length=MAX_TOOLS
     )
@@ -259,10 +439,15 @@ class ChatCompletionRequest(StrictModel):
                 pending_calls.pop(message.tool_call_id)
         if pending_calls:
             raise ValueError("each assistant tool call requires a tool response")
-        if message_chars > MAX_TOTAL_MESSAGE_CHARS:
+        if message_chars > MAX_HYPOTHESIS_TOTAL_MESSAGE_CHARS:
             raise ValueError("messages exceed the total text limit")
         if self.stream_options is not None and not self.stream:
             raise ValueError("stream_options requires stream=true")
+        if self.response_format is not None and not any(
+            "json" in (getattr(message, "content", None) or "").casefold()
+            for message in self.messages
+        ):
+            raise ValueError("json_object response format requires a JSON instruction")
         if self.max_tokens is not None and self.max_completion_tokens is not None:
             raise ValueError(
                 "max_tokens and max_completion_tokens cannot both be provided"
@@ -283,43 +468,136 @@ class ChatCompletionRequest(StrictModel):
 class BridgeSettings:
     enabled: bool
     token: str
-    model_id: str
+    p2r_token: str
+    literature_model_id: str
+    hypothesis_model_id: str
+    p2r_enabled: bool
+    p2r_tools_enabled: bool
 
     @classmethod
     def from_env(cls) -> "BridgeSettings":
         enabled = os.getenv("AI_RESEARCH_S2S_ENABLED", "false").strip().casefold()
+        p2r_enabled = (
+            os.getenv("AI_RESEARCH_P2R_ENABLED", "false").strip().casefold()
+        )
+        p2r_tools_enabled = (
+            os.getenv("AI_RESEARCH_P2R_TOOLS_ENABLED", "false").strip().casefold()
+        )
         return cls(
             enabled=enabled in {"1", "true", "yes", "on"},
             token=os.getenv("AI_RESEARCH_S2S_TOKEN", ""),
-            model_id=os.getenv("AI_RESEARCH_LITERATURE_MODEL_ID", "").strip(),
+            p2r_token=os.getenv("AI_RESEARCH_P2R_S2S_TOKEN", ""),
+            literature_model_id=os.getenv(
+                "AI_RESEARCH_LITERATURE_MODEL_ID", ""
+            ).strip(),
+            hypothesis_model_id=os.getenv(
+                "AI_RESEARCH_HYPOTHESIS_MODEL_ID", ""
+            ).strip(),
+            p2r_enabled=p2r_enabled in {"1", "true", "yes", "on"},
+            p2r_tools_enabled=p2r_tools_enabled in {"1", "true", "yes", "on"},
         )
+
+
+@dataclass(frozen=True, slots=True)
+class ChatBridgeAuthorization:
+    settings: BridgeSettings
+    phase: str | None
 
 
 router = APIRouter(prefix="/api/ai-research/v1", tags=["ai-research-s2s"])
 
 
-def require_bridge(
-    authorization: Annotated[str | None, Header()] = None,
-) -> BridgeSettings:
+def bridge_configuration() -> BridgeSettings:
     settings = BridgeSettings.from_env()
-    if not settings.enabled or not settings.token or not settings.model_id:
+    if (
+        not settings.enabled
+        or not settings.token
+        or not settings.literature_model_id
+        or (
+            settings.hypothesis_model_id
+            and settings.hypothesis_model_id == settings.literature_model_id
+        )
+    ):
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="AI Research model bridge is not configured",
         )
+    return settings
+
+
+def _require_service_credential(
+    authorization: str | None,
+    *,
+    expected_token: str,
+) -> None:
     scheme, separator, credential = (authorization or "").partition(" ")
     if (
         not separator
         or scheme.casefold() != "bearer"
         or not credential
-        or not secrets.compare_digest(credential, settings.token)
+        or not secrets.compare_digest(credential, expected_token)
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="invalid AI Research service credential",
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+
+def require_bridge(
+    authorization: Annotated[str | None, Header()] = None,
+    x_modelmirror_p2r_phase: Annotated[
+        str | None, Header(alias="X-ModelMirror-P2R-Phase")
+    ] = None,
+) -> BridgeSettings:
+    settings = bridge_configuration()
+    _require_service_credential(authorization, expected_token=settings.token)
+    if x_modelmirror_p2r_phase is not None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid AI Research service credential",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     return settings
+
+
+def _require_chat_credential(
+    settings: BridgeSettings,
+    authorization: str | None,
+    *,
+    phase: str | None,
+) -> None:
+    if phase is None:
+        expected_token = settings.token
+    else:
+        if (
+            not settings.p2r_token
+            or secrets.compare_digest(settings.p2r_token, settings.token)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="AI Research P2R service credential is not configured",
+            )
+        expected_token = settings.p2r_token
+    _require_service_credential(authorization, expected_token=expected_token)
+
+
+def require_chat_bridge(
+    authorization: Annotated[str | None, Header()] = None,
+    x_modelmirror_p2r_phase: Annotated[
+        str | None, Header(alias="X-ModelMirror-P2R-Phase")
+    ] = None,
+    settings: BridgeSettings = Depends(bridge_configuration),
+) -> ChatBridgeAuthorization:
+    _require_chat_credential(
+        settings,
+        authorization,
+        phase=x_modelmirror_p2r_phase,
+    )
+    return ChatBridgeAuthorization(
+        settings=settings,
+        phase=x_modelmirror_p2r_phase,
+    )
 
 
 def stable_service(
@@ -333,21 +611,52 @@ async def models(
     settings: BridgeSettings = Depends(require_bridge),
     stable: ProviderChatStableService = Depends(stable_service),
 ) -> dict[str, Any]:
-    ready, reason = stable.readiness(settings.model_id, "chat_tools")
-    if not ready:
+    model_ids: list[str] = []
+    unavailable_reasons: list[str] = []
+    literature_ready, literature_reason = stable.readiness(
+        settings.literature_model_id, "chat_tools"
+    )
+    if literature_ready:
+        model_ids.append(settings.literature_model_id)
+    elif literature_reason:
+        unavailable_reasons.append(literature_reason)
+    if (
+        settings.hypothesis_model_id
+        and settings.p2r_enabled
+        and settings.p2r_tools_enabled
+    ):
+        text_ready, text_reason = stable.readiness_scoped_certified(
+            settings.hypothesis_model_id, "chat_text"
+        )
+        tools_ready, tools_reason = stable.readiness_scoped_certified(
+            settings.hypothesis_model_id, "chat_tools"
+        )
+        if text_ready and tools_ready:
+            model_ids.append(settings.hypothesis_model_id)
+        else:
+            for reason in (text_reason, tools_reason):
+                if reason:
+                    unavailable_reasons.append(reason)
+                    break
+    if not model_ids:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=reason or "fixed model control is not ready",
+            detail=(
+                unavailable_reasons[0]
+                if unavailable_reasons
+                else "fixed model control is not ready"
+            ),
         )
     return {
         "object": "list",
         "data": [
             {
-                "id": settings.model_id,
+                "id": model_id,
                 "object": "model",
                 "created": 0,
                 "owned_by": "modelmirror-control-plane",
             }
+            for model_id in model_ids
         ],
     }
 
@@ -355,14 +664,74 @@ async def models(
 @router.post("/chat/completions")
 async def chat_completions(
     payload: ChatCompletionRequest,
-    settings: BridgeSettings = Depends(require_bridge),
+    bridge_auth: ChatBridgeAuthorization = Depends(require_chat_bridge),
     stable: ProviderChatStableService = Depends(stable_service),
 ):
-    if payload.model != settings.model_id:
+    settings = bridge_auth.settings
+    x_modelmirror_p2r_phase = bridge_auth.phase
+    p2r_context: P2RRequestContext | None = None
+    required_scoped_capabilities: tuple[str, ...] = ()
+    if payload.model == settings.literature_model_id:
+        if x_modelmirror_p2r_phase is not None:
+            raise HTTPException(
+                status_code=422,
+                detail="P2R phase header is not accepted for the literature model",
+            )
+        selected_model_id = settings.literature_model_id
+        scoped_certified = False
+    elif (
+        settings.hypothesis_model_id
+        and payload.model == settings.hypothesis_model_id
+    ):
+        selected_model_id = settings.hypothesis_model_id
+        scoped_certified = True
+        if x_modelmirror_p2r_phase is None:
+            if payload.tools:
+                raise HTTPException(
+                    status_code=422,
+                    detail="tools are not enabled for ordinary hypothesis requests",
+                )
+            required_scoped_capabilities = ("chat_text",)
+        else:
+            p2r_context = _require_p2r_phase_request(
+                payload,
+                settings=settings,
+                phase=x_modelmirror_p2r_phase,
+            )
+            required_scoped_capabilities = ("chat_text", "chat_tools")
+    else:
         raise HTTPException(status_code=422, detail="model is not enabled for AI Research")
+    if payload.response_format is not None and not scoped_certified:
+        raise HTTPException(
+            status_code=422,
+            detail="response_format is only enabled for the hypothesis model",
+        )
+    if (
+        not scoped_certified
+        and _message_char_count(payload.messages) > MAX_TOTAL_MESSAGE_CHARS
+    ):
+        raise HTTPException(status_code=422, detail="messages exceed the total text limit")
     capability = "chat_tools" if payload.tools else "chat_text"
+    if scoped_certified:
+        for required_capability in required_scoped_capabilities:
+            ready, reason = stable.readiness_scoped_certified(
+                selected_model_id, required_capability
+            )
+            if not ready:
+                raise HTTPException(
+                    status_code=503,
+                    detail=reason or "fixed model control is not ready",
+                )
     try:
-        preflight = await stable.begin(settings.model_id, capability)
+        preflight = await (
+            stable.begin_scoped_certified(
+                selected_model_id,
+                capability,
+                required_capabilities=required_scoped_capabilities,
+            )
+            if scoped_certified
+            else stable.begin(selected_model_id, capability)
+        )
     except RouterServiceError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
     except Exception as exc:
@@ -382,6 +751,7 @@ async def chat_completions(
     dispatch = preflight.dispatch
     client = httpx.AsyncClient(**stable.transport.client_kwargs())
     started = time.perf_counter()
+    dispatched = False
     try:
         request = stable.transport.build_authorized_stream_request(
             client,
@@ -393,7 +763,20 @@ async def chat_completions(
             },
         )
         stable.mark_dispatched(dispatch)
+        dispatched = True
         response = await stable.transport.send_authorized_stream(client, request)
+    except asyncio.CancelledError:
+        await _close_nonstream_after_cancellation(response=None, client=client)
+        if dispatched:
+            stable.complete(
+                dispatch,
+                status="cancelled",
+                result_class="client_cancelled",
+                error_code="provider_chat_client_cancelled",
+                client_cancelled=True,
+                e2e_ms=_elapsed_ms(started),
+            )
+        raise
     except RouterServiceError as exc:
         await client.aclose()
         raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
@@ -424,16 +807,28 @@ async def chat_completions(
         ) from exc
 
     if response.status_code < 200 or response.status_code >= 300:
-        try:
-            await _read_bounded(response)
-        except (httpx.HTTPError, ValueError):
-            pass
-        finally:
-            await response.aclose()
-            await client.aclose()
         result_class, code, hard_failure = stable.classify_http_failure(
             response.status_code
         )
+        try:
+            try:
+                await _read_bounded_and_close(response=response, client=client)
+            except Exception:
+                pass
+        except asyncio.CancelledError:
+            await _close_nonstream_after_cancellation(
+                response=response,
+                client=client,
+            )
+            stable.complete(
+                dispatch,
+                status="failed",
+                result_class=result_class,
+                error_code=code,
+                hard_failure=hard_failure,
+                e2e_ms=_elapsed_ms(started),
+            )
+            raise
         stable.complete(
             dispatch,
             status="failed",
@@ -455,7 +850,7 @@ async def chat_completions(
                 dispatch=dispatch,
                 response=response,
                 client=client,
-                requested_model=settings.model_id,
+                requested_model=selected_model_id,
                 started=started,
                 allow_tool_calls=bool(payload.tools),
             ),
@@ -468,22 +863,18 @@ async def chat_completions(
         )
 
     try:
-        content = await _read_bounded(response)
-        value = json.loads(content)
-        _validate_completion_response(
-            value,
-            requested_model=settings.model_id,
-            allowed_tool_names={
-                tool.function.name for tool in (payload.tools or [])
-            },
+        content = await _read_bounded_and_close(response=response, client=client)
+    except asyncio.CancelledError:
+        await _close_nonstream_after_cancellation(response=response, client=client)
+        stable.complete(
+            dispatch,
+            status="cancelled",
+            result_class="client_cancelled",
+            error_code="provider_chat_client_cancelled",
+            client_cancelled=True,
+            e2e_ms=_elapsed_ms(started),
         )
-        usage = value.get("usage") if isinstance(value.get("usage"), dict) else {}
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        _reject_invalid_response(
-            stable, dispatch, "ai_research_bridge_invalid_json", started, exc
-        )
-    except BridgeResponseError as exc:
-        _reject_invalid_response(stable, dispatch, exc.code, started, exc)
+        raise
     except ValueError as exc:
         _reject_invalid_response(
             stable,
@@ -492,7 +883,7 @@ async def chat_completions(
             started,
             exc,
         )
-    except (httpx.HTTPError, OSError) as exc:
+    except Exception as exc:
         stable.complete(
             dispatch,
             status="failed",
@@ -500,15 +891,31 @@ async def chat_completions(
             error_code="ai_research_bridge_response_read_failed",
             e2e_ms=_elapsed_ms(started),
         )
-        raise HTTPException(status_code=503, detail="fixed model response failed") from exc
-    finally:
-        await response.aclose()
-        await client.aclose()
+        raise HTTPException(
+            status_code=503, detail="fixed model response failed"
+        ) from exc
+    try:
+        value = json.loads(content)
+        actual_model = _validate_completion_response(
+            value,
+            requested_model=selected_model_id,
+            allowed_tool_names={
+                tool.function.name for tool in (payload.tools or [])
+            },
+            p2r_context=p2r_context,
+        )
+        usage = value.get("usage") if isinstance(value.get("usage"), dict) else {}
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        _reject_invalid_response(
+            stable, dispatch, "ai_research_bridge_invalid_json", started, exc
+        )
+    except BridgeResponseError as exc:
+        _reject_invalid_response(stable, dispatch, exc.code, started, exc)
     stable.complete(
         dispatch,
         status="succeeded",
         result_class="success",
-        actual_model=settings.model_id,
+        actual_model=actual_model,
         e2e_ms=_elapsed_ms(started),
         prompt_tokens=_integer(usage.get("prompt_tokens")),
         completion_tokens=_integer(usage.get("completion_tokens")),
@@ -536,22 +943,59 @@ async def _stream_response(
     evidence = _BridgeStreamEvidence(started_at=started)
     total = 0
     finalized = False
+    identity_verified = False
+    pending_chunks: list[str] = []
+    pending_bytes = 0
     try:
         async for chunk in response.aiter_text():
             encoded_size = len(chunk.encode("utf-8"))
             total += encoded_size
             if total > MAX_RESPONSE_BYTES:
                 raise ValueError("stream exceeded bridge response limit")
+            pending_chunks.append(chunk)
+            pending_bytes += encoded_size
             evidence.feed(chunk)
-            yield chunk
+            if evidence.invalid:
+                raise BridgeResponseError("provider_chat_invalid_sse")
+            if evidence.invalid_model_observed:
+                raise BridgeResponseError(
+                    "ai_research_bridge_model_identity_invalid"
+                )
+            if evidence.observed_models - {requested_model}:
+                raise BridgeResponseError("ai_research_bridge_model_mismatch")
+            identity_verified = identity_verified or (
+                requested_model in evidence.observed_models
+            )
+            if pending_bytes > MAX_STREAM_IDENTITY_BUFFER_BYTES:
+                code = (
+                    "ai_research_bridge_stream_event_buffer_exceeded"
+                    if identity_verified
+                    else "ai_research_bridge_stream_identity_buffer_exceeded"
+                )
+                raise BridgeResponseError(code)
+            if evidence.buffer or not identity_verified:
+                continue
+            yield "".join(pending_chunks)
+            pending_chunks.clear()
+            pending_bytes = 0
         status_value, result_class, error_code = evidence.finish_for_bridge(
             transport_completed=True,
             allow_tool_calls=allow_tool_calls,
         )
-        if evidence.actual_model not in {None, requested_model}:
-            status_value = "failed"
-            result_class = "hard_failure"
-            error_code = "ai_research_bridge_model_mismatch"
+        if evidence.invalid_model_observed:
+            raise BridgeResponseError(
+                "ai_research_bridge_model_identity_invalid"
+            )
+        if evidence.observed_models - {requested_model}:
+            raise BridgeResponseError("ai_research_bridge_model_mismatch")
+        if requested_model not in evidence.observed_models:
+            raise BridgeResponseError(
+                "ai_research_bridge_model_identity_required"
+            )
+        if pending_chunks and status_value == "succeeded":
+            yield "".join(pending_chunks)
+            pending_chunks.clear()
+            pending_bytes = 0
         stable.complete(
             dispatch,
             status=status_value,
@@ -568,16 +1012,29 @@ async def _stream_response(
         finalized = True
         if status_value != "succeeded":
             raise RuntimeError(error_code or "ai_research_bridge_invalid_stream")
-    except asyncio.CancelledError:
-        stable.complete(
-            dispatch,
-            status="cancelled",
-            result_class="client_cancelled",
-            error_code="provider_chat_client_cancelled",
-            client_cancelled=True,
-            e2e_ms=_elapsed_ms(started),
-        )
-        finalized = True
+    except BridgeResponseError as exc:
+        if not finalized:
+            stable.complete(
+                dispatch,
+                status="failed",
+                result_class="hard_failure",
+                error_code=exc.code,
+                hard_failure=True,
+                e2e_ms=_elapsed_ms(started),
+            )
+            finalized = True
+        raise RuntimeError(exc.code) from exc
+    except (asyncio.CancelledError, GeneratorExit):
+        if not finalized:
+            stable.complete(
+                dispatch,
+                status="cancelled",
+                result_class="client_cancelled",
+                error_code="provider_chat_client_cancelled",
+                client_cancelled=True,
+                e2e_ms=_elapsed_ms(started),
+            )
+            finalized = True
         raise
     except Exception:
         if not finalized:
@@ -591,8 +1048,27 @@ async def _stream_response(
             finalized = True
         raise
     finally:
+        await _close_stream_resources(response=response, client=client)
+
+
+async def _close_stream_resources(
+    *, response: httpx.Response, client: httpx.AsyncClient
+) -> None:
+    close_error: BaseException | None = None
+    try:
         await response.aclose()
+    except asyncio.CancelledError as exc:
+        close_error = exc
+    except BaseException as exc:
+        close_error = exc
+    try:
         await client.aclose()
+    except asyncio.CancelledError as exc:
+        close_error = exc
+    except BaseException as exc:
+        close_error = close_error or exc
+    if close_error is not None:
+        raise close_error
 
 
 async def _read_bounded(response: httpx.Response) -> bytes:
@@ -606,20 +1082,87 @@ async def _read_bounded(response: httpx.Response) -> bytes:
     return b"".join(chunks)
 
 
+async def _read_bounded_and_close(
+    *,
+    response: httpx.Response,
+    client: httpx.AsyncClient,
+) -> bytes:
+    try:
+        content = await _read_bounded(response)
+    except asyncio.CancelledError:
+        await _close_nonstream_after_cancellation(
+            response=response,
+            client=client,
+        )
+        raise
+    except Exception:
+        await _close_nonstream_after_cancellation(
+            response=response,
+            client=client,
+        )
+        raise
+
+    close_error: Exception | None = None
+    try:
+        await response.aclose()
+    except asyncio.CancelledError:
+        await _close_nonstream_after_cancellation(response=None, client=client)
+        raise
+    except Exception as exc:
+        close_error = exc
+    try:
+        await client.aclose()
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        close_error = close_error or exc
+    if close_error is not None:
+        raise close_error
+    return content
+
+
+async def _close_nonstream_after_cancellation(
+    *,
+    response: httpx.Response | None,
+    client: httpx.AsyncClient,
+) -> None:
+    """Best-effort close without replacing the caller's cancellation."""
+
+    if response is not None:
+        try:
+            await response.aclose()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass
+    try:
+        await client.aclose()
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        pass
+
+
 def _validate_completion_response(
     value: object,
     *,
     requested_model: str,
     allowed_tool_names: set[str],
-) -> None:
+    p2r_context: P2RRequestContext | None = None,
+) -> str | None:
     if not isinstance(value, dict):
         raise BridgeResponseError("ai_research_bridge_invalid_envelope")
     actual_model = value.get("model")
+    if p2r_context is not None and actual_model is None:
+        raise BridgeResponseError("ai_research_bridge_model_identity_required")
     if actual_model is not None and actual_model != requested_model:
         raise BridgeResponseError("ai_research_bridge_model_mismatch")
     choices = value.get("choices")
     if not isinstance(choices, list) or not choices:
         raise BridgeResponseError("ai_research_bridge_missing_choices")
+    if p2r_context is not None:
+        _validate_p2r_completion_choices(choices, p2r_context)
+        return actual_model
     valid_choice = False
     for choice in choices:
         if not isinstance(choice, dict):
@@ -648,6 +1191,7 @@ def _validate_completion_response(
         valid_choice = True
     if not valid_choice:
         raise BridgeResponseError("ai_research_bridge_empty_completion")
+    return actual_model
 
 
 def _reject_invalid_response(
@@ -674,6 +1218,413 @@ def _json_size(value: object) -> int:
     return len(
         json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
     )
+
+
+def _message_char_count(messages: list[ChatMessage]) -> int:
+    total = 0
+    for message in messages:
+        content = getattr(message, "content", None)
+        if isinstance(content, str):
+            total += len(content)
+        if isinstance(message, AssistantMessage):
+            total += sum(len(call.function.arguments) for call in message.tool_calls)
+    return total
+
+
+def _require_p2r_phase_request(
+    payload: ChatCompletionRequest,
+    *,
+    settings: BridgeSettings,
+    phase: str | None,
+) -> P2RRequestContext:
+    if not settings.p2r_enabled or not settings.p2r_tools_enabled:
+        raise HTTPException(status_code=422, detail="P2R qualification is disabled")
+    if phase is None or phase not in P2R_PHASE_CONTRACTS:
+        raise HTTPException(status_code=422, detail="invalid P2R phase")
+    contract = P2R_PHASE_CONTRACTS[phase]
+    _validate_p2r_sampling(payload)
+    if not payload.messages or not isinstance(payload.messages[0], TextMessage):
+        raise HTTPException(status_code=422, detail="invalid P2R phase prompt")
+    system = payload.messages[0]
+    if system.role != "system" or any(
+        isinstance(message, TextMessage) and message.role == "system"
+        for message in payload.messages[1:]
+    ):
+        raise HTTPException(status_code=422, detail="invalid P2R phase prompt")
+    prompt_hash = hashlib.sha256(system.content.encode("utf-8")).hexdigest()
+    if not secrets.compare_digest(prompt_hash, contract["promptSha256"]):
+        raise HTTPException(status_code=422, detail="invalid P2R phase prompt")
+
+    artifact_messages: list[TextMessage] = []
+    tail: list[ChatMessage] = []
+    reached_tail = False
+    for message in payload.messages[1:]:
+        if (
+            not reached_tail
+            and isinstance(message, TextMessage)
+            and message.role == "user"
+        ):
+            artifact_messages.append(message)
+        else:
+            reached_tail = True
+            tail.append(message)
+    qualification_run_id, previous_receipt_sha256 = (
+        _validate_p2r_artifact_envelopes(
+            artifact_messages,
+            phase=phase,
+            contract=contract,
+        )
+    )
+
+    response_shape = contract["responseShape"]
+    if response_shape not in {"object", "array"}:
+        raise HTTPException(status_code=422, detail="invalid P2R phase registry")
+    if contract["tools"] is False:
+        if tail or payload.tools:
+            raise HTTPException(status_code=422, detail="invalid P2R text phase contract")
+        if (response_shape == "object") != (payload.response_format is not None):
+            raise HTTPException(status_code=422, detail="invalid P2R response contract")
+        return P2RRequestContext(
+            phase=phase,
+            stage="text",
+            response_shape=response_shape,
+            qualification_run_id=qualification_run_id,
+            previous_receipt_sha256=previous_receipt_sha256,
+        )
+
+    _validate_p2r_tool_contract(payload)
+    if not tail:
+        stage: Literal["coherence_initial", "coherence_finalize"] = (
+            "coherence_initial"
+        )
+    elif (
+        len(tail) == 2
+        and isinstance(tail[0], AssistantMessage)
+        and isinstance(tail[1], ToolMessage)
+    ):
+        _validate_p2r_python_receipt(tail[0], tail[1])
+        stage = "coherence_finalize"
+    else:
+        raise HTTPException(status_code=422, detail="invalid P2R coherence history")
+    return P2RRequestContext(
+        phase=phase,
+        stage=stage,
+        response_shape=response_shape,
+        qualification_run_id=qualification_run_id,
+        previous_receipt_sha256=previous_receipt_sha256,
+    )
+
+
+def _validate_p2r_sampling(payload: ChatCompletionRequest) -> None:
+    if (
+        payload.temperature != P2R_FIXED_TEMPERATURE
+        or payload.max_tokens != P2R_FIXED_MAX_TOKENS
+        or payload.max_completion_tokens is not None
+        or payload.top_p is not None
+        or payload.stop is not None
+        or payload.stream
+        or payload.stream_options is not None
+    ):
+        raise HTTPException(status_code=422, detail="invalid P2R sampling contract")
+
+
+def _validate_p2r_tool_contract(payload: ChatCompletionRequest) -> None:
+    tools = payload.tools or []
+    if len(tools) != 1:
+        raise HTTPException(status_code=422, detail="invalid P2R tool contract")
+    function = tools[0].function
+    if (
+        function.name != "python"
+        or function.description != P2R_PYTHON_TOOL_DESCRIPTION
+        or function.parameters != P2R_PYTHON_PARAMETERS
+        or function.strict is not True
+        or payload.tool_choice != "auto"
+        or payload.parallel_tool_calls is not False
+        or payload.response_format is None
+    ):
+        raise HTTPException(status_code=422, detail="invalid P2R tool contract")
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _validate_p2r_artifact_envelopes(
+    messages: list[TextMessage],
+    *,
+    phase: str,
+    contract: dict[str, Any],
+) -> tuple[str, str]:
+    if not messages:
+        raise HTTPException(status_code=422, detail="missing P2R artifact envelopes")
+    path_order: list[str] = []
+    groups: dict[str, list[dict[str, Any]]] = {}
+    qualification_run_id: str | None = None
+    previous_receipt_sha256: str | None = None
+    for message in messages:
+        try:
+            envelope = json.loads(message.content)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise HTTPException(status_code=422, detail="invalid P2R artifact envelope") from exc
+        if (
+            not isinstance(envelope, dict)
+            or _canonical_json(envelope) != message.content
+            or set(envelope)
+            != {
+                "protocol",
+                "qualificationRunId",
+                "phase",
+                "previousReceiptSha256",
+                "artifact",
+            }
+        ):
+            raise HTTPException(status_code=422, detail="invalid P2R artifact envelope")
+        artifact = envelope.get("artifact")
+        if (
+            not isinstance(artifact, dict)
+            or set(artifact)
+            != {
+                "path",
+                "sha256",
+                "sizeBytes",
+                "chunkIndex",
+                "chunkCount",
+                "chunkSha256",
+                "content",
+            }
+            or envelope.get("protocol") != P2R_PHASE_REQUEST_PROTOCOL
+            or envelope.get("phase") != phase
+        ):
+            raise HTTPException(status_code=422, detail="invalid P2R artifact envelope")
+        run_id = envelope.get("qualificationRunId")
+        previous = envelope.get("previousReceiptSha256")
+        if (
+            not isinstance(run_id, str)
+            or not P2R_QUALIFICATION_RUN_PATTERN.fullmatch(run_id)
+            or not isinstance(previous, str)
+            or not P2R_SHA256_PATTERN.fullmatch(previous)
+        ):
+            raise HTTPException(status_code=422, detail="invalid P2R artifact binding")
+        if qualification_run_id is None:
+            qualification_run_id = run_id
+            previous_receipt_sha256 = previous
+        elif run_id != qualification_run_id or previous != previous_receipt_sha256:
+            raise HTTPException(status_code=422, detail="mixed P2R artifact binding")
+
+        path = artifact.get("path")
+        full_sha = artifact.get("sha256")
+        chunk_sha = artifact.get("chunkSha256")
+        content = artifact.get("content")
+        size_bytes = artifact.get("sizeBytes")
+        chunk_index = artifact.get("chunkIndex")
+        chunk_count = artifact.get("chunkCount")
+        if (
+            not isinstance(path, str)
+            or not P2R_ARTIFACT_PATH_PATTERN.fullmatch(path)
+            or any(part in {"", ".", ".."} for part in path.split("/"))
+            or not isinstance(full_sha, str)
+            or not P2R_SHA256_PATTERN.fullmatch(full_sha)
+            or not isinstance(chunk_sha, str)
+            or not P2R_SHA256_PATTERN.fullmatch(chunk_sha)
+            or not isinstance(content, str)
+            or len(content) > P2R_MAX_ARTIFACT_CHUNK_CHARS
+            or isinstance(size_bytes, bool)
+            or not isinstance(size_bytes, int)
+            or size_bytes < 0
+            or isinstance(chunk_index, bool)
+            or not isinstance(chunk_index, int)
+            or isinstance(chunk_count, bool)
+            or not isinstance(chunk_count, int)
+            or chunk_count < 1
+            or chunk_count > MAX_MESSAGES
+            or chunk_index < 0
+            or chunk_index >= chunk_count
+        ):
+            raise HTTPException(status_code=422, detail="invalid P2R artifact metadata")
+        if hashlib.sha256(content.encode("utf-8")).hexdigest() != chunk_sha:
+            raise HTTPException(status_code=422, detail="invalid P2R artifact chunk hash")
+        if path not in groups:
+            path_order.append(path)
+            groups[path] = []
+        elif path_order[-1] != path:
+            raise HTTPException(status_code=422, detail="non-contiguous P2R artifact chunks")
+        if chunk_index != len(groups[path]):
+            raise HTTPException(status_code=422, detail="out-of-order P2R artifact chunk")
+        groups[path].append(artifact)
+
+    fixed_paths = list(contract["artifactPaths"])
+    if path_order[: len(fixed_paths)] != fixed_paths:
+        raise HTTPException(status_code=422, detail="invalid P2R artifact order")
+    dynamic_paths = path_order[len(fixed_paths) :]
+    dynamic_pattern = contract.get("dynamicArtifactPattern")
+    if dynamic_pattern is None:
+        if dynamic_paths or len(path_order) != len(fixed_paths):
+            raise HTTPException(status_code=422, detail="invalid P2R artifact set")
+    else:
+        minimum = contract["dynamicArtifactMin"]
+        maximum = contract["dynamicArtifactMax"]
+        if (
+            len(dynamic_paths) < minimum
+            or len(dynamic_paths) > maximum
+            or dynamic_paths != sorted(dynamic_paths)
+            or any(re.fullmatch(dynamic_pattern, path) is None for path in dynamic_paths)
+        ):
+            raise HTTPException(status_code=422, detail="invalid P2R dynamic artifacts")
+
+    for path in path_order:
+        chunks = groups[path]
+        expected_count = len(chunks)
+        if any(item["chunkCount"] != expected_count for item in chunks):
+            raise HTTPException(status_code=422, detail="incomplete P2R artifact chunks")
+        content = "".join(item["content"] for item in chunks)
+        raw = content.encode("utf-8")
+        if (
+            any(item["sha256"] != chunks[0]["sha256"] for item in chunks)
+            or any(item["sizeBytes"] != chunks[0]["sizeBytes"] for item in chunks)
+            or hashlib.sha256(raw).hexdigest() != chunks[0]["sha256"]
+            or len(raw) != chunks[0]["sizeBytes"]
+        ):
+            raise HTTPException(status_code=422, detail="invalid P2R artifact integrity")
+        locked_sha256 = P2R_LOCKED_STATIC_ARTIFACT_SHA256.get(path)
+        if locked_sha256 is not None and not secrets.compare_digest(
+            chunks[0]["sha256"], locked_sha256
+        ):
+            raise HTTPException(
+                status_code=422, detail="invalid P2R locked artifact"
+            )
+    assert qualification_run_id is not None
+    assert previous_receipt_sha256 is not None
+    return qualification_run_id, previous_receipt_sha256
+
+
+def _validate_p2r_python_receipt(
+    assistant: AssistantMessage, tool_message: ToolMessage
+) -> None:
+    if (assistant.content or "").strip() or len(assistant.tool_calls) != 1:
+        raise HTTPException(status_code=422, detail="invalid P2R coherence history")
+    call = assistant.tool_calls[0]
+    if call.function.name != "python" or tool_message.tool_call_id != call.id:
+        raise HTTPException(status_code=422, detail="invalid P2R tool receipt binding")
+    try:
+        arguments = json.loads(call.function.arguments)
+        receipt = json.loads(tool_message.content)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise HTTPException(status_code=422, detail="invalid P2R tool receipt") from exc
+    if (
+        not isinstance(arguments, dict)
+        or set(arguments) != {"code"}
+        or not isinstance(arguments.get("code"), str)
+        or not arguments["code"]
+        or len(arguments["code"].encode("utf-8")) > P2R_PYTHON_LIMITS["scriptBytes"]
+        or not isinstance(receipt, dict)
+        or _canonical_json(receipt) != tool_message.content
+        or set(receipt)
+        != {
+            "protocol",
+            "sandboxImage",
+            "command",
+            "scriptSha256",
+            "scriptSizeBytes",
+            "exitCode",
+            "stdout",
+            "stdoutSha256",
+            "stdoutSizeBytes",
+            "stderr",
+            "stderrSha256",
+            "stderrSizeBytes",
+            "limits",
+            "truncation",
+        }
+    ):
+        raise HTTPException(status_code=422, detail="invalid P2R tool receipt")
+    code = arguments["code"]
+    code_bytes = code.encode("utf-8")
+    if (
+        receipt.get("protocol") != P2R_PYTHON_RECEIPT_PROTOCOL
+        or receipt.get("sandboxImage") != P2R_PYTHON_SANDBOX_IMAGE
+        or receipt.get("command") != ["python3", "-"]
+        or receipt.get("scriptSha256") != hashlib.sha256(code_bytes).hexdigest()
+        or receipt.get("scriptSizeBytes") != len(code_bytes)
+        or receipt.get("limits") != P2R_PYTHON_LIMITS
+        or receipt.get("truncation")
+        != {"captureExceeded": False, "stderr": False, "stdout": False}
+        or isinstance(receipt.get("exitCode"), bool)
+        or not isinstance(receipt.get("exitCode"), int)
+    ):
+        raise HTTPException(status_code=422, detail="invalid P2R tool receipt")
+    for stream in ("stdout", "stderr"):
+        stream_value = receipt.get(stream)
+        if not isinstance(stream_value, str):
+            raise HTTPException(status_code=422, detail="invalid P2R tool receipt")
+        stream_bytes = stream_value.encode("utf-8")
+        if (
+            receipt.get(f"{stream}Sha256")
+            != hashlib.sha256(stream_bytes).hexdigest()
+            or receipt.get(f"{stream}SizeBytes") != len(stream_bytes)
+        ):
+            raise HTTPException(status_code=422, detail="invalid P2R tool receipt")
+
+
+def _validate_p2r_completion_choices(
+    choices: list[Any], context: P2RRequestContext
+) -> None:
+    if len(choices) != 1 or not isinstance(choices[0], dict):
+        raise BridgeResponseError("ai_research_bridge_invalid_p2r_choices")
+    choice = choices[0]
+    message = choice.get("message")
+    if not isinstance(message, dict) or message.get("role") not in {None, "assistant"}:
+        raise BridgeResponseError("ai_research_bridge_invalid_p2r_message")
+    content = message.get("content")
+    tool_calls = message.get("tool_calls")
+    if context.stage == "coherence_initial":
+        if (
+            (content is not None and content != "")
+            or not isinstance(tool_calls, list)
+            or len(tool_calls) != 1
+        ):
+            raise BridgeResponseError("ai_research_bridge_missing_p2r_tool_call")
+        call = tool_calls[0]
+        if (
+            not isinstance(call, dict)
+            or call.get("type") != "function"
+            or not isinstance(call.get("id"), str)
+            or not call["id"]
+            or not isinstance(call.get("function"), dict)
+            or call["function"].get("name") != "python"
+            or not isinstance(call["function"].get("arguments"), str)
+        ):
+            raise BridgeResponseError("ai_research_bridge_invalid_tool_call")
+        try:
+            arguments = json.loads(call["function"]["arguments"])
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise BridgeResponseError("ai_research_bridge_invalid_tool_call") from exc
+        if (
+            not isinstance(arguments, dict)
+            or set(arguments) != {"code"}
+            or not isinstance(arguments.get("code"), str)
+            or not arguments["code"]
+            or len(arguments["code"].encode("utf-8"))
+            > P2R_PYTHON_LIMITS["scriptBytes"]
+        ):
+            raise BridgeResponseError("ai_research_bridge_invalid_tool_call")
+        return
+    if tool_calls is not None and tool_calls != []:
+        raise BridgeResponseError("ai_research_bridge_unexpected_p2r_tool_call")
+    if not isinstance(content, str) or not content.strip():
+        raise BridgeResponseError("ai_research_bridge_empty_completion")
+    try:
+        structured = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise BridgeResponseError("ai_research_bridge_invalid_p2r_json") from exc
+    if context.response_shape == "object" and not isinstance(structured, dict):
+        raise BridgeResponseError("ai_research_bridge_invalid_p2r_shape")
+    if context.response_shape == "array" and not isinstance(structured, list):
+        raise BridgeResponseError("ai_research_bridge_invalid_p2r_shape")
 
 
 def _json_depth(value: object) -> int:

--- a/server/model_router/chat_control.py
+++ b/server/model_router/chat_control.py
@@ -761,6 +761,7 @@ class ProviderChatControlService:
         connection_id: str,
         model_id: str,
         capability: str,
+        require_exact_model: bool = False,
     ) -> tuple[dict[str, object] | None, str]:
         connection = self.repository.get_connection(
             self.router_service.tenant_id, connection_id
@@ -843,7 +844,9 @@ class ProviderChatControlService:
         if time_reason is not None:
             return None, time_reason
         actual_model = certification.get("actual_model")
-        if actual_model and str(actual_model) != model_id:
+        if require_exact_model and actual_model is None:
+            return None, "provider_chat_certification_model_identity_required"
+        if actual_model is not None and str(actual_model) != model_id:
             return None, "provider_chat_certification_model_mismatch"
         return (
             {
@@ -855,6 +858,23 @@ class ProviderChatControlService:
                 "contract_version": PROVIDER_CHAT_CONTRACT_VERSION,
             },
             "qualified",
+        )
+
+    def current_qualification(
+        self,
+        *,
+        connection_id: str,
+        model_id: str,
+        capability: str,
+        require_exact_model: bool = False,
+    ) -> tuple[dict[str, object] | None, str]:
+        """Return current certification evidence for one explicit route target."""
+
+        return self._current_qualification(
+            connection_id=connection_id,
+            model_id=model_id,
+            capability=capability,
+            require_exact_model=require_exact_model,
         )
 
     def _validate_route_connection(self, connection) -> None:

--- a/server/model_router/chat_stable.py
+++ b/server/model_router/chat_stable.py
@@ -173,6 +173,22 @@ class ProviderChatStableService:
             or (not scoped_certified and clean_model not in policy.stable_model_ids)
         ):
             return ProviderChatStablePreflight(intercepted=False)
+        try:
+            reconciliation = self._repository_method(
+                "reconcile_chat_control_completions"
+            )(self.router_service.tenant_id)
+        except RouterRepositoryError as exc:
+            raise RouterServiceError(
+                "provider_chat_completion_reconciliation_pending",
+                "上一次模型调用的终态仍待持久化，请稍后重试。",
+                status_code=503,
+            ) from exc
+        if int(reconciliation.get("pending", 0)):
+            raise RouterServiceError(
+                "provider_chat_completion_reconciliation_pending",
+                "上一次模型调用的终态仍待持久化，请稍后重试。",
+                status_code=503,
+            )
         runtime_allowed, runtime_error = self.control.required_runtime_allowed(policy)
         if not runtime_allowed:
             error_code = runtime_error or "provider_chat_required_gate_degraded"
@@ -591,16 +607,14 @@ class ProviderChatStableService:
         completion_tokens: int | None = None,
         total_tokens: int | None = None,
         reason_codes: list[str] | None = None,
-    ) -> None:
+    ) -> bool:
         codes = list(dispatch.reason_codes)
         if reason_codes:
             codes.extend(reason_codes)
         if error_code:
             codes.append(error_code)
         codes = list(dict.fromkeys(codes))
-        self._repository_method("complete_chat_control_dispatch")(
-            self.router_service.tenant_id,
-            dispatch.attempt_id,
+        fields = dict(
             expected_run_id=dispatch.run_id,
             status=status,
             result_class=result_class,
@@ -615,6 +629,18 @@ class ProviderChatStableService:
             completion_tokens=completion_tokens,
             total_tokens=total_tokens,
         )
+        self._repository_method("stage_chat_control_completion")(
+            self.router_service.tenant_id,
+            dispatch.attempt_id,
+            **fields,
+        )
+        reconciliation = self._repository_method(
+            "reconcile_chat_control_completions"
+        )(
+            self.router_service.tenant_id,
+            attempt_id=dispatch.attempt_id,
+        )
+        return int(reconciliation.get("pending", 0)) == 0
 
     @staticmethod
     def classify_http_failure(status_code: int) -> tuple[str, str, bool]:

--- a/server/model_router/chat_stable.py
+++ b/server/model_router/chat_stable.py
@@ -46,6 +46,7 @@ class ProviderChatStableDispatch:
     certification_id: str
     started_at: float
     required_certifications: tuple[ProviderChatCertificationBinding, ...]
+    gateway: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -168,27 +169,29 @@ class ProviderChatStableService:
             return ProviderChatStablePreflight(intercepted=False)
         policy = self.control.get_policy()
         clean_model = str(model_id or "").strip()
+        gateway = "ai_research_scoped" if scoped_certified else "default"
         if (
             policy.effective_mode == "legacy"
             or (not scoped_certified and clean_model not in policy.stable_model_ids)
         ):
             return ProviderChatStablePreflight(intercepted=False)
-        try:
-            reconciliation = self._repository_method(
-                "reconcile_chat_control_completions"
-            )(self.router_service.tenant_id)
-        except RouterRepositoryError as exc:
-            raise RouterServiceError(
-                "provider_chat_completion_reconciliation_pending",
-                "上一次模型调用的终态仍待持久化，请稍后重试。",
-                status_code=503,
-            ) from exc
-        if int(reconciliation.get("pending", 0)):
-            raise RouterServiceError(
-                "provider_chat_completion_reconciliation_pending",
-                "上一次模型调用的终态仍待持久化，请稍后重试。",
-                status_code=503,
-            )
+        if scoped_certified:
+            try:
+                reconciliation = self._repository_method(
+                    "reconcile_chat_control_completions"
+                )(self.router_service.tenant_id)
+            except RouterRepositoryError as exc:
+                raise RouterServiceError(
+                    "provider_chat_completion_reconciliation_pending",
+                    "上一次科研模型调用的终态仍待持久化，请稍后重试。",
+                    status_code=503,
+                ) from exc
+            if int(reconciliation.get("pending", 0)):
+                raise RouterServiceError(
+                    "provider_chat_completion_reconciliation_pending",
+                    "上一次科研模型调用的终态仍待持久化，请稍后重试。",
+                    status_code=503,
+                )
         runtime_allowed, runtime_error = self.control.required_runtime_allowed(policy)
         if not runtime_allowed:
             error_code = runtime_error or "provider_chat_required_gate_degraded"
@@ -200,7 +203,7 @@ class ProviderChatStableService:
                 capability=capability,
                 requested_model=clean_model,
                 strategy=policy.effective_mode,
-                gateway="ai_research_scoped" if scoped_certified else "default",
+                gateway=gateway,
                 is_real_user=True,
                 primary_newapi=True,
             )
@@ -239,7 +242,7 @@ class ProviderChatStableService:
             capability=capability,
             requested_model=clean_model,
             strategy=policy.effective_mode,
-            gateway="ai_research_scoped" if scoped_certified else "default",
+            gateway=gateway,
             epoch_id=str(epoch["id"]) if epoch is not None else None,
             is_real_user=True,
             primary_newapi=True,
@@ -366,6 +369,7 @@ class ProviderChatStableService:
                     required_certifications=tuple(
                         bindings[item] for item in required_capabilities
                     ),
+                    gateway=gateway,
                 ),
             )
 
@@ -445,6 +449,25 @@ class ProviderChatStableService:
                 "Chat 路由策略或资格已变化，请刷新设置后重试。",
                 status_code=409,
             ) from exc
+
+    def fail_undispatched(
+        self,
+        dispatch: ProviderChatStableDispatch,
+        *,
+        error_code: str,
+    ) -> bool:
+        """Fail a claimed attempt only if no provider dispatch occurred."""
+
+        return bool(
+            self._repository_method(
+                "fail_chat_control_preflight_if_undispatched"
+            )(
+                self.router_service.tenant_id,
+                dispatch.attempt_id,
+                expected_run_id=dispatch.run_id,
+                error_code=error_code,
+            )
+        )
 
     def ensure_dispatch_current(self, dispatch: ProviderChatStableDispatch) -> None:
         """Fail closed if a multi-step capability drifts between model calls."""
@@ -629,6 +652,42 @@ class ProviderChatStableService:
             completion_tokens=completion_tokens,
             total_tokens=total_tokens,
         )
+        if dispatch.gateway == "default":
+            self._repository_method("complete_chat_control_attempt")(
+                self.router_service.tenant_id,
+                dispatch.attempt_id,
+                status=status,
+                result_class=result_class,
+                error_code=error_code,
+                actual_model=actual_model,
+                ttft_ms=ttft_ms,
+                e2e_ms=e2e_ms,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+            )
+            self._repository_method("complete_chat_control_run")(
+                self.router_service.tenant_id,
+                dispatch.run_id,
+                status=status,
+                result_class=result_class,
+                reason_codes=codes,
+                actual_model=actual_model,
+                client_cancelled=client_cancelled,
+                hard_failure=hard_failure,
+                ttft_ms=ttft_ms,
+                e2e_ms=e2e_ms,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+            )
+            return True
+        if dispatch.gateway != "ai_research_scoped":
+            raise RouterServiceError(
+                "provider_chat_completion_gateway_invalid",
+                "模型调用完成范围无效。",
+                status_code=409,
+            )
         self._repository_method("stage_chat_control_completion")(
             self.router_service.tenant_id,
             dispatch.attempt_id,

--- a/server/model_router/chat_stable.py
+++ b/server/model_router/chat_stable.py
@@ -1,14 +1,33 @@
 from __future__ import annotations
 
+import os
 import time
 import uuid
 from dataclasses import dataclass
 
+from .chat_canary import (
+    DEFAULT_PROVIDER_CHAT_CERTIFICATION_MAX_AGE_SECONDS,
+    MAX_PROVIDER_CHAT_CERTIFICATION_MAX_AGE_SECONDS,
+    MIN_PROVIDER_CHAT_CERTIFICATION_MAX_AGE_SECONDS,
+    PROVIDER_CHAT_CERTIFICATION_MAX_AGE_ENV,
+)
 from .chat_control import ProviderChatControlService
 from .egress import AuthorizedProviderTarget, ProviderEgressError
-from .provider_chat import ProviderChatTarget, ProviderChatTransport
+from .provider_chat import (
+    PROVIDER_CHAT_CONTRACT_VERSION,
+    ProviderChatTarget,
+    ProviderChatTransport,
+)
+from .repository import RouterRepositoryError
 from .schemas import ProviderChatCapability
 from .service import ModelRouterService, RouterServiceError
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderChatCertificationBinding:
+    capability: ProviderChatCapability
+    connection_id: str
+    certification_id: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -20,10 +39,13 @@ class ProviderChatStableDispatch:
     capability: ProviderChatCapability
     requested_model: str
     target: ProviderChatTarget
+    connection_fingerprint: str
     authorized: AuthorizedProviderTarget
     position: int
     reason_codes: tuple[str, ...]
+    certification_id: str
     started_at: float
+    required_certifications: tuple[ProviderChatCertificationBinding, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,7 +70,26 @@ class ProviderChatStableService:
         model_id: str,
         capability: ProviderChatCapability = "chat_text",
     ) -> tuple[bool, str | None]:
-        """Inspect the current managed route without creating a run receipt."""
+        """Inspect the current stable managed route without creating a receipt."""
+
+        return self._readiness(model_id, capability, scoped_certified=False)
+
+    def readiness_scoped_certified(
+        self,
+        model_id: str,
+        capability: ProviderChatCapability = "chat_text",
+    ) -> tuple[bool, str | None]:
+        """Inspect an explicit workload model using current route certifications."""
+
+        return self._readiness(model_id, capability, scoped_certified=True)
+
+    def _readiness(
+        self,
+        model_id: str,
+        capability: ProviderChatCapability,
+        *,
+        scoped_certified: bool,
+    ) -> tuple[bool, str | None]:
 
         if not self.control.feature_enabled():
             return False, "provider_chat_control_feature_disabled"
@@ -56,7 +97,7 @@ class ProviderChatStableService:
         clean_model = str(model_id or "").strip()
         if (
             policy.effective_mode == "legacy"
-            or clean_model not in policy.stable_model_ids
+            or (not scoped_certified and clean_model not in policy.stable_model_ids)
         ):
             return False, "provider_chat_no_qualified_route"
         runtime_allowed, runtime_error = self.control.required_runtime_allowed(policy)
@@ -69,21 +110,21 @@ class ProviderChatStableService:
         route_ids = list(route.connection_ids if route else [])
         if policy.effective_mode == "newapi_required_default":
             route_ids = route_ids[:1]
-        qualifications = {
-            item.connection_id: item
-            for item in policy.qualifications
-            if item.capability == capability and item.model_id == clean_model
-        }
+        qualifications = self._policy_qualifications(
+            policy, model_id=clean_model, capability=capability
+        )
         failures: list[str] = []
         for connection_id in route_ids:
-            qualification = qualifications.get(connection_id)
-            if qualification is not None and qualification.valid:
-                return True, None
-            failures.append(
-                qualification.reason_code
-                if qualification is not None
-                else "provider_chat_qualification_missing"
+            certification_id, reason = self._qualification_for_route(
+                qualifications,
+                connection_id=connection_id,
+                model_id=clean_model,
+                capability=capability,
+                scoped_certified=scoped_certified,
             )
+            if certification_id is not None:
+                return True, None
+            failures.append(reason)
         return False, failures[-1] if failures else "provider_chat_no_qualified_route"
 
     async def begin(
@@ -91,13 +132,45 @@ class ProviderChatStableService:
         model_id: str,
         capability: ProviderChatCapability = "chat_text",
     ) -> ProviderChatStablePreflight:
+        return await self._begin(
+            model_id,
+            capability,
+            scoped_certified=False,
+            required_capabilities=(capability,),
+        )
+
+    async def begin_scoped_certified(
+        self,
+        model_id: str,
+        capability: ProviderChatCapability = "chat_text",
+        *,
+        required_capabilities: tuple[ProviderChatCapability, ...] = (),
+    ) -> ProviderChatStablePreflight:
+        """Begin a fixed workload call without adding the model to stable chat."""
+
+        normalized = tuple(dict.fromkeys((*required_capabilities, capability)))
+        return await self._begin(
+            model_id,
+            capability,
+            scoped_certified=True,
+            required_capabilities=normalized,
+        )
+
+    async def _begin(
+        self,
+        model_id: str,
+        capability: ProviderChatCapability,
+        *,
+        scoped_certified: bool,
+        required_capabilities: tuple[ProviderChatCapability, ...],
+    ) -> ProviderChatStablePreflight:
         if not self.control.feature_enabled():
             return ProviderChatStablePreflight(intercepted=False)
         policy = self.control.get_policy()
         clean_model = str(model_id or "").strip()
         if (
             policy.effective_mode == "legacy"
-            or clean_model not in policy.stable_model_ids
+            or (not scoped_certified and clean_model not in policy.stable_model_ids)
         ):
             return ProviderChatStablePreflight(intercepted=False)
         runtime_allowed, runtime_error = self.control.required_runtime_allowed(policy)
@@ -111,7 +184,7 @@ class ProviderChatStableService:
                 capability=capability,
                 requested_model=clean_model,
                 strategy=policy.effective_mode,
-                gateway="default",
+                gateway="ai_research_scoped" if scoped_certified else "default",
                 is_real_user=True,
                 primary_newapi=True,
             )
@@ -150,17 +223,47 @@ class ProviderChatStableService:
             capability=capability,
             requested_model=clean_model,
             strategy=policy.effective_mode,
-            gateway="default",
+            gateway="ai_research_scoped" if scoped_certified else "default",
             epoch_id=str(epoch["id"]) if epoch is not None else None,
             is_real_user=True,
             primary_newapi=True,
         )
 
-        qualification_by_connection = {
-            item.connection_id: item
-            for item in policy.qualifications
-            if item.capability == capability and item.model_id == clean_model
-        }
+        prebound_certifications: dict[
+            ProviderChatCapability, ProviderChatCertificationBinding
+        ] = {}
+        if scoped_certified:
+            for required_capability in required_capabilities:
+                if required_capability == capability:
+                    continue
+                binding, reason = self._current_scoped_binding(
+                    policy,
+                    model_id=clean_model,
+                    capability=required_capability,
+                )
+                if binding is None:
+                    self._repository_method("complete_chat_control_run")(
+                        self.router_service.tenant_id,
+                        run_id,
+                        status="failed",
+                        result_class="preflight_failure",
+                        reason_codes=[reason],
+                    )
+                    return ProviderChatStablePreflight(
+                        intercepted=True,
+                        error_code=reason,
+                        route_receipt=self.route_receipt(
+                            None,
+                            requested_model=clean_model,
+                            reason_codes=[reason],
+                            strategy=policy.effective_mode,
+                        ),
+                    )
+                prebound_certifications[required_capability] = binding
+
+        qualification_by_connection = self._policy_qualifications(
+            policy, model_id=clean_model, capability=capability
+        )
         failures: list[str] = []
         candidate_route_ids = (
             route_ids[:1]
@@ -168,8 +271,13 @@ class ProviderChatStableService:
             else route_ids
         )
         for position, connection_id in enumerate(candidate_route_ids):
-            connection = self.repository.get_connection(
-                self.router_service.tenant_id, connection_id
+            (
+                connection,
+                api_key,
+                connection_fingerprint,
+            ) = self.repository.get_connection_credential_snapshot(
+                self.router_service.tenant_id,
+                connection_id,
             )
             attempt_id = f"chatattempt_{uuid.uuid4().hex}"
             self._repository_method("claim_chat_control_attempt")(
@@ -181,13 +289,14 @@ class ProviderChatStableService:
                 connection_id=connection_id,
                 provider_kind=connection.kind,
             )
-            qualification = qualification_by_connection.get(connection_id)
-            if qualification is None or not qualification.valid:
-                reason = (
-                    qualification.reason_code
-                    if qualification is not None
-                    else "provider_chat_qualification_missing"
-                )
+            certification_id, reason = self._qualification_for_route(
+                qualification_by_connection,
+                connection_id=connection_id,
+                model_id=clean_model,
+                capability=capability,
+                scoped_certified=scoped_certified,
+            )
+            if certification_id is None:
                 self._complete_preflight_attempt(attempt_id, reason)
                 failures.append(reason)
                 continue
@@ -196,9 +305,7 @@ class ProviderChatStableService:
                     source="managed",
                     provider_kind=connection.kind,
                     base_url=connection.base_url,
-                    api_key=self.repository.resolve_api_key(
-                        self.router_service.tenant_id, connection_id
-                    ),
+                    api_key=api_key,
                     connection_id=connection_id,
                 )
                 authorized = await self.transport.authorize_managed_target(target)
@@ -215,6 +322,15 @@ class ProviderChatStableService:
             reason_codes = list(dict.fromkeys(failures))
             if position:
                 reason_codes.append("provider_chat_preflight_backup_selected")
+            actual_binding = ProviderChatCertificationBinding(
+                capability=capability,
+                connection_id=connection_id,
+                certification_id=certification_id,
+            )
+            bindings = {
+                **prebound_certifications,
+                capability: actual_binding,
+            }
             return ProviderChatStablePreflight(
                 intercepted=True,
                 dispatch=ProviderChatStableDispatch(
@@ -225,10 +341,15 @@ class ProviderChatStableService:
                     capability=capability,
                     requested_model=clean_model,
                     target=target,
+                    connection_fingerprint=connection_fingerprint,
                     authorized=authorized,
                     position=position,
                     reason_codes=tuple(reason_codes),
+                    certification_id=certification_id,
                     started_at=time.perf_counter(),
+                    required_certifications=tuple(
+                        bindings[item] for item in required_capabilities
+                    ),
                 ),
             )
 
@@ -254,46 +375,205 @@ class ProviderChatStableService:
     def mark_dispatched(self, dispatch: ProviderChatStableDispatch) -> None:
         try:
             self.ensure_dispatch_current(dispatch)
-        except RouterServiceError as exc:
-            self._complete_preflight_attempt(dispatch.attempt_id, exc.code)
-            self._repository_method("complete_chat_control_run")(
+            if not self.control.feature_enabled():
+                raise RouterServiceError(
+                    "provider_chat_policy_or_qualification_changed",
+                    "Chat 路由策略或资格已变化，请刷新设置后重试。",
+                    status_code=409,
+                )
+            self._repository_method(
+                "mark_chat_control_attempt_dispatched_if_current"
+            )(
                 self.router_service.tenant_id,
-                dispatch.run_id,
-                status="failed",
-                result_class="preflight_failure",
-                reason_codes=[exc.code],
+                dispatch.attempt_id,
+                expected_run_id=dispatch.run_id,
+                expected_policy_fingerprint=dispatch.policy_fingerprint,
+                expected_strategy=dispatch.strategy,
+                expected_model=dispatch.requested_model,
+                expected_capability=dispatch.capability,
+                expected_connection_id=dispatch.target.connection_id,
+                expected_connection_fingerprint=(
+                    dispatch.connection_fingerprint
+                ),
+                required_certifications=tuple(
+                    (
+                        binding.capability,
+                        binding.connection_id,
+                        binding.certification_id,
+                    )
+                    for binding in dispatch.required_certifications
+                ),
+                contract_version=PROVIDER_CHAT_CONTRACT_VERSION,
+                certification_max_age_seconds=(
+                    self._certification_max_age_seconds()
+                ),
             )
-            raise
-        self._repository_method("mark_chat_control_attempt_dispatched")(
-            self.router_service.tenant_id, dispatch.attempt_id
-        )
+        except (RouterServiceError, RouterRepositoryError) as exc:
+            code = (
+                exc.code
+                if isinstance(exc, RouterServiceError)
+                else str(exc)
+            )
+            self._repository_method(
+                "fail_chat_control_preflight_if_undispatched"
+            )(
+                self.router_service.tenant_id,
+                dispatch.attempt_id,
+                expected_run_id=dispatch.run_id,
+                error_code=code,
+            )
+            if isinstance(exc, RouterServiceError):
+                raise
+            raise RouterServiceError(
+                code,
+                "Chat 路由策略或资格已变化，请刷新设置后重试。",
+                status_code=409,
+            ) from exc
 
     def ensure_dispatch_current(self, dispatch: ProviderChatStableDispatch) -> None:
         """Fail closed if a multi-step capability drifts between model calls."""
 
         policy = self.control.get_policy()
-        qualification = next(
-            (
-                item
-                for item in policy.qualifications
-                if item.capability == dispatch.capability
-                and item.model_id == dispatch.requested_model
-                and item.connection_id == dispatch.target.connection_id
-            ),
-            None,
-        )
-        if (
+        bindings = dispatch.required_certifications
+        binding_capabilities = [binding.capability for binding in bindings]
+        actual_bindings = [
+            binding
+            for binding in bindings
+            if binding.capability == dispatch.capability
+        ]
+        invalid = (
             policy.effective_mode != dispatch.strategy
             or policy.policy_fingerprint != dispatch.policy_fingerprint
-            or qualification is None
-            or not qualification.valid
-        ):
+            or not bindings
+            or len(binding_capabilities) != len(set(binding_capabilities))
+            or len(actual_bindings) != 1
+            or actual_bindings[0].connection_id != dispatch.target.connection_id
+            or actual_bindings[0].certification_id != dispatch.certification_id
+        )
+        if not invalid:
+            for binding in bindings:
+                qualification, _ = self.control.current_qualification(
+                    connection_id=binding.connection_id,
+                    model_id=dispatch.requested_model,
+                    capability=binding.capability,
+                )
+                if (
+                    qualification is None
+                    or qualification["certification_id"] != binding.certification_id
+                ):
+                    invalid = True
+                    break
+        if invalid:
             code = "provider_chat_policy_or_qualification_changed"
             raise RouterServiceError(
                 code,
                 "Chat 路由策略或资格已变化，请刷新设置后重试。",
                 status_code=409,
             )
+
+    def _current_scoped_binding(
+        self,
+        policy,
+        *,
+        model_id: str,
+        capability: ProviderChatCapability,
+    ) -> tuple[ProviderChatCertificationBinding | None, str]:
+        route = next(
+            (item for item in policy.routes if item.capability == capability),
+            None,
+        )
+        route_ids = list(route.connection_ids if route else [])
+        if policy.effective_mode == "newapi_required_default":
+            route_ids = route_ids[:1]
+        failures: list[str] = []
+        for connection_id in route_ids:
+            qualification, reason = self.control.current_qualification(
+                connection_id=connection_id,
+                model_id=model_id,
+                capability=capability,
+                require_exact_model=True,
+            )
+            if qualification is not None:
+                return (
+                    ProviderChatCertificationBinding(
+                        capability=capability,
+                        connection_id=connection_id,
+                        certification_id=str(qualification["certification_id"]),
+                    ),
+                    "qualified",
+                )
+            failures.append(reason)
+        return None, (
+            failures[-1] if failures else "provider_chat_no_qualified_route"
+        )
+
+    @staticmethod
+    def _policy_qualifications(
+        policy,
+        *,
+        model_id: str,
+        capability: ProviderChatCapability,
+    ) -> dict[str, object]:
+        return {
+            item.connection_id: item
+            for item in policy.qualifications
+            if item.capability == capability and item.model_id == model_id
+        }
+
+    def _qualification_for_route(
+        self,
+        policy_qualifications: dict[str, object],
+        *,
+        connection_id: str,
+        model_id: str,
+        capability: ProviderChatCapability,
+        scoped_certified: bool,
+    ) -> tuple[str | None, str]:
+        if scoped_certified:
+            current, reason = self.control.current_qualification(
+                connection_id=connection_id,
+                model_id=model_id,
+                capability=capability,
+                require_exact_model=True,
+            )
+            return (
+                str(current["certification_id"]) if current is not None else None,
+                reason,
+            )
+        qualification = policy_qualifications.get(connection_id)
+        if qualification is not None and qualification.valid:
+            return str(qualification.certification_id), "qualified"
+        return (
+            None,
+            qualification.reason_code
+            if qualification is not None
+            else "provider_chat_qualification_missing",
+        )
+
+    @staticmethod
+    def _certification_max_age_seconds() -> int:
+        raw = os.getenv(PROVIDER_CHAT_CERTIFICATION_MAX_AGE_ENV, "").strip()
+        if not raw:
+            return DEFAULT_PROVIDER_CHAT_CERTIFICATION_MAX_AGE_SECONDS
+        try:
+            value = int(raw)
+        except ValueError as exc:
+            raise RouterServiceError(
+                "provider_chat_policy_or_qualification_changed",
+                "Chat 路由策略或资格已变化，请刷新设置后重试。",
+                status_code=409,
+            ) from exc
+        if not (
+            MIN_PROVIDER_CHAT_CERTIFICATION_MAX_AGE_SECONDS
+            <= value
+            <= MAX_PROVIDER_CHAT_CERTIFICATION_MAX_AGE_SECONDS
+        ):
+            raise RouterServiceError(
+                "provider_chat_policy_or_qualification_changed",
+                "Chat 路由策略或资格已变化，请刷新设置后重试。",
+                status_code=409,
+            )
+        return value
 
     def complete(
         self,
@@ -318,24 +598,13 @@ class ProviderChatStableService:
         if error_code:
             codes.append(error_code)
         codes = list(dict.fromkeys(codes))
-        self._repository_method("complete_chat_control_attempt")(
+        self._repository_method("complete_chat_control_dispatch")(
             self.router_service.tenant_id,
             dispatch.attempt_id,
+            expected_run_id=dispatch.run_id,
             status=status,
             result_class=result_class,
             error_code=error_code,
-            actual_model=actual_model,
-            ttft_ms=ttft_ms,
-            e2e_ms=e2e_ms,
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens,
-            total_tokens=total_tokens,
-        )
-        self._repository_method("complete_chat_control_run")(
-            self.router_service.tenant_id,
-            dispatch.run_id,
-            status=status,
-            result_class=result_class,
             reason_codes=codes,
             actual_model=actual_model,
             client_cancelled=client_cancelled,

--- a/server/model_router/chat_stable.py
+++ b/server/model_router/chat_stable.py
@@ -79,10 +79,18 @@ class ProviderChatStableService:
         self,
         model_id: str,
         capability: ProviderChatCapability = "chat_text",
+        *,
+        required_capabilities: tuple[ProviderChatCapability, ...] = (),
     ) -> tuple[bool, str | None]:
         """Inspect an explicit workload model using current route certifications."""
 
-        return self._readiness(model_id, capability, scoped_certified=True)
+        normalized = tuple(dict.fromkeys((*required_capabilities, capability)))
+        return self._readiness(
+            model_id,
+            capability,
+            scoped_certified=True,
+            required_capabilities=normalized,
+        )
 
     def _readiness(
         self,
@@ -90,6 +98,7 @@ class ProviderChatStableService:
         capability: ProviderChatCapability,
         *,
         scoped_certified: bool,
+        required_capabilities: tuple[ProviderChatCapability, ...] = (),
     ) -> tuple[bool, str | None]:
 
         if not self.control.feature_enabled():
@@ -111,6 +120,21 @@ class ProviderChatStableService:
         route_ids = list(route.connection_ids if route else [])
         if policy.effective_mode == "newapi_required_default":
             route_ids = route_ids[:1]
+        if scoped_certified:
+            failures: list[str] = []
+            for connection_id in route_ids:
+                bindings, reason = self._scoped_bindings_for_connection(
+                    policy,
+                    model_id=clean_model,
+                    connection_id=connection_id,
+                    required_capabilities=(required_capabilities or (capability,)),
+                )
+                if bindings is not None:
+                    return True, None
+                failures.append(reason)
+            return False, (
+                failures[-1] if failures else "provider_chat_no_qualified_route"
+            )
         qualifications = self._policy_qualifications(
             policy, model_id=clean_model, capability=capability
         )
@@ -248,38 +272,6 @@ class ProviderChatStableService:
             primary_newapi=True,
         )
 
-        prebound_certifications: dict[
-            ProviderChatCapability, ProviderChatCertificationBinding
-        ] = {}
-        if scoped_certified:
-            for required_capability in required_capabilities:
-                if required_capability == capability:
-                    continue
-                binding, reason = self._current_scoped_binding(
-                    policy,
-                    model_id=clean_model,
-                    capability=required_capability,
-                )
-                if binding is None:
-                    self._repository_method("complete_chat_control_run")(
-                        self.router_service.tenant_id,
-                        run_id,
-                        status="failed",
-                        result_class="preflight_failure",
-                        reason_codes=[reason],
-                    )
-                    return ProviderChatStablePreflight(
-                        intercepted=True,
-                        error_code=reason,
-                        route_receipt=self.route_receipt(
-                            None,
-                            requested_model=clean_model,
-                            reason_codes=[reason],
-                            strategy=policy.effective_mode,
-                        ),
-                    )
-                prebound_certifications[required_capability] = binding
-
         qualification_by_connection = self._policy_qualifications(
             policy, model_id=clean_model, capability=capability
         )
@@ -308,13 +300,29 @@ class ProviderChatStableService:
                 connection_id=connection_id,
                 provider_kind=connection.kind,
             )
-            certification_id, reason = self._qualification_for_route(
-                qualification_by_connection,
-                connection_id=connection_id,
-                model_id=clean_model,
-                capability=capability,
-                scoped_certified=scoped_certified,
-            )
+            bindings: dict[
+                ProviderChatCapability, ProviderChatCertificationBinding
+            ] = {}
+            if scoped_certified:
+                scoped_bindings, reason = self._scoped_bindings_for_connection(
+                    policy,
+                    model_id=clean_model,
+                    connection_id=connection_id,
+                    required_capabilities=required_capabilities,
+                )
+                if scoped_bindings is not None:
+                    bindings = scoped_bindings
+                    certification_id = bindings[capability].certification_id
+                else:
+                    certification_id = None
+            else:
+                certification_id, reason = self._qualification_for_route(
+                    qualification_by_connection,
+                    connection_id=connection_id,
+                    model_id=clean_model,
+                    capability=capability,
+                    scoped_certified=False,
+                )
             if certification_id is None:
                 self._complete_preflight_attempt(attempt_id, reason)
                 failures.append(reason)
@@ -346,10 +354,7 @@ class ProviderChatStableService:
                 connection_id=connection_id,
                 certification_id=certification_id,
             )
-            bindings = {
-                **prebound_certifications,
-                capability: actual_binding,
-            }
+            bindings[capability] = actual_binding
             return ProviderChatStablePreflight(
                 intercepted=True,
                 dispatch=ProviderChatStableDispatch(
@@ -510,41 +515,44 @@ class ProviderChatStableService:
                 status_code=409,
             )
 
-    def _current_scoped_binding(
+    def _scoped_bindings_for_connection(
         self,
         policy,
         *,
         model_id: str,
-        capability: ProviderChatCapability,
-    ) -> tuple[ProviderChatCertificationBinding | None, str]:
-        route = next(
-            (item for item in policy.routes if item.capability == capability),
-            None,
-        )
-        route_ids = list(route.connection_ids if route else [])
-        if policy.effective_mode == "newapi_required_default":
-            route_ids = route_ids[:1]
-        failures: list[str] = []
-        for connection_id in route_ids:
+        connection_id: str,
+        required_capabilities: tuple[ProviderChatCapability, ...],
+    ) -> tuple[
+        dict[ProviderChatCapability, ProviderChatCertificationBinding] | None,
+        str,
+    ]:
+        bindings: dict[
+            ProviderChatCapability, ProviderChatCertificationBinding
+        ] = {}
+        for capability in required_capabilities:
+            route = next(
+                (item for item in policy.routes if item.capability == capability),
+                None,
+            )
+            route_ids = list(route.connection_ids if route else [])
+            if policy.effective_mode == "newapi_required_default":
+                route_ids = route_ids[:1]
+            if connection_id not in route_ids:
+                return None, "provider_chat_no_qualified_route"
             qualification, reason = self.control.current_qualification(
                 connection_id=connection_id,
                 model_id=model_id,
                 capability=capability,
                 require_exact_model=True,
             )
-            if qualification is not None:
-                return (
-                    ProviderChatCertificationBinding(
-                        capability=capability,
-                        connection_id=connection_id,
-                        certification_id=str(qualification["certification_id"]),
-                    ),
-                    "qualified",
-                )
-            failures.append(reason)
-        return None, (
-            failures[-1] if failures else "provider_chat_no_qualified_route"
-        )
+            if qualification is None:
+                return None, reason
+            bindings[capability] = ProviderChatCertificationBinding(
+                capability=capability,
+                connection_id=connection_id,
+                certification_id=str(qualification["certification_id"]),
+            )
+        return bindings, "qualified"
 
     @staticmethod
     def _policy_qualifications(

--- a/server/model_router/cleanup_chat_receipts.py
+++ b/server/model_router/cleanup_chat_receipts.py
@@ -57,7 +57,10 @@ def main() -> int:
     before = (
         datetime.now(UTC) - timedelta(days=values.older_than_days)
     ).isoformat()
-    repository = SQLiteRouterRepository(values.storage_dir)
+    repository = SQLiteRouterRepository(
+        values.storage_dir,
+        recover_chat_control_on_startup=False,
+    )
     result = cleanup_receipts(
         repository,
         values.tenant_id,

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -109,17 +109,17 @@ class SQLiteRouterRepository:
         )
         self._lock = threading.RLock()
         self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self._master_key = self._resolve_master_key(master_key)
+        self._fernet = Fernet(self._master_key)
+        self._initialize()
+        self._verify_or_record_master_key()
         if self.chat_completion_outbox_dir.is_symlink():
             raise RouterRepositoryError(
                 "provider_chat_completion_outbox_path_unsafe"
             )
         self.chat_completion_outbox_dir.mkdir(parents=True, exist_ok=True)
-        self._master_key = self._resolve_master_key(master_key)
-        self._fernet = Fernet(self._master_key)
-        self._initialize()
         self._reconcile_startup_chat_control_completions()
         self._recover_unresolved_chat_control_after_restart()
-        self._verify_or_record_master_key()
 
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(self.database_path, timeout=15)
@@ -1302,9 +1302,13 @@ class SQLiteRouterRepository:
         with self._lock, self._connect() as connection:
             running_attempts = connection.execute(
                 """
-                SELECT tenant_id, id, run_id
-                FROM provider_chat_attempts
-                WHERE status = 'running'
+                SELECT attempt.tenant_id, attempt.id, attempt.run_id,
+                       run.gateway
+                FROM provider_chat_attempts AS attempt
+                JOIN provider_chat_runs AS run
+                  ON run.tenant_id = attempt.tenant_id
+                 AND run.id = attempt.run_id
+                WHERE attempt.status = 'running'
                 """
             ).fetchall()
             protected_runs: set[tuple[str, str]] = set()
@@ -1313,7 +1317,10 @@ class SQLiteRouterRepository:
                 attempt_id = str(attempt["id"])
                 run_id = str(attempt["run_id"])
                 pending_path = self._chat_completion_outbox_path(tenant_id, attempt_id)
-                if pending_path.is_symlink() or pending_path.exists():
+                if (
+                    str(attempt["gateway"]) == "ai_research_scoped"
+                    and (pending_path.is_symlink() or pending_path.exists())
+                ):
                     protected_runs.add((tenant_id, run_id))
                     continue
                 connection.execute(
@@ -3415,7 +3422,7 @@ class SQLiteRouterRepository:
         completion_tokens: int | None = None,
         total_tokens: int | None = None,
     ) -> dict[str, dict[str, object]]:
-        """Atomically terminalize a dispatched attempt, its run, and gate."""
+        """Atomically terminalize an AI Research scoped dispatch and gate."""
 
         clean_tenant = self._tenant_id(tenant_id)
         if status not in {"succeeded", "failed", "cancelled"}:
@@ -3446,6 +3453,10 @@ class SQLiteRouterRepository:
             ).fetchone()
             if run is None:
                 raise RouterRepositoryError("provider_chat_run_not_running")
+            if str(run["gateway"]) != "ai_research_scoped":
+                raise RouterRepositoryError(
+                    "provider_chat_completion_scope_invalid"
+                )
 
             if (
                 str(attempt["status"]) != "running"
@@ -3677,6 +3688,7 @@ class SQLiteRouterRepository:
             or not isinstance(payload.get("tenantId"), str)
             or not isinstance(payload.get("attemptId"), str)
             or not isinstance(payload.get("expectedRunId"), str)
+            or payload.get("gateway") != "ai_research_scoped"
             or payload.get("status") not in {"succeeded", "failed", "cancelled"}
             or not isinstance(payload.get("stagedAt"), str)
             or payload.get("payloadSha256")
@@ -3720,7 +3732,7 @@ class SQLiteRouterRepository:
         completion_tokens: int | None = None,
         total_tokens: int | None = None,
     ) -> dict[str, object]:
-        """Durably stage content-free completion facts outside router.sqlite3."""
+        """Durably stage content-free AI Research completion facts."""
 
         clean_tenant = self._tenant_id(tenant_id)
         if status not in {"succeeded", "failed", "cancelled"}:
@@ -3731,6 +3743,26 @@ class SQLiteRouterRepository:
             raise RouterRepositoryError(
                 "provider_chat_completion_run_id_invalid"
             )
+        with self._lock, self._connect() as connection:
+            scoped_run = connection.execute(
+                """
+                SELECT run.gateway
+                FROM provider_chat_attempts AS attempt
+                JOIN provider_chat_runs AS run
+                  ON run.tenant_id = attempt.tenant_id
+                 AND run.id = attempt.run_id
+                WHERE attempt.tenant_id = ? AND attempt.id = ?
+                  AND attempt.run_id = ?
+                """,
+                (clean_tenant, attempt_id, expected_run_id),
+            ).fetchone()
+        if (
+            scoped_run is None
+            or str(scoped_run["gateway"]) != "ai_research_scoped"
+        ):
+            raise RouterRepositoryError(
+                "provider_chat_completion_scope_invalid"
+            )
         clean_reasons = [
             str(item) for item in (reason_codes or []) if str(item).strip()
         ]
@@ -3739,6 +3771,7 @@ class SQLiteRouterRepository:
             "tenantId": clean_tenant,
             "attemptId": attempt_id,
             "expectedRunId": expected_run_id,
+            "gateway": "ai_research_scoped",
             "status": status,
             "resultClass": result_class,
             "errorCode": error_code,

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -4455,51 +4455,21 @@ class SQLiteRouterRepository:
         apply: bool = False,
     ) -> dict[str, int | bool | str]:
         clean_tenant = self._tenant_id(tenant_id)
-        with self._lock, self._connect() as connection:
-            connection.execute("BEGIN IMMEDIATE")
-            run_count = int(
-                connection.execute(
-                    """
-                    SELECT COUNT(*) FROM provider_chat_runs
-                    WHERE tenant_id = ? AND status != 'running'
-                        AND hard_failure = 0
-                        AND NOT EXISTS (
-                            SELECT 1 FROM provider_chat_attempts AS failed_attempt
-                            WHERE failed_attempt.tenant_id = provider_chat_runs.tenant_id
-                                AND failed_attempt.run_id = provider_chat_runs.id
-                                AND failed_attempt.result_class = 'hard_failure'
-                        )
-                        AND COALESCE(completed_at, updated_at) < ?
-                    """,
-                    (clean_tenant, before),
-                ).fetchone()[0]
-            )
-            attempt_count = int(
-                connection.execute(
-                    """
-                    SELECT COUNT(*) FROM provider_chat_attempts
-                    WHERE tenant_id = ? AND run_id IN (
-                        SELECT id FROM provider_chat_runs
-                        WHERE tenant_id = ? AND status != 'running'
-                            AND hard_failure = 0
-                            AND NOT EXISTS (
-                                SELECT 1 FROM provider_chat_attempts AS failed_attempt
-                                WHERE failed_attempt.tenant_id = provider_chat_runs.tenant_id
-                                    AND failed_attempt.run_id = provider_chat_runs.id
-                                    AND failed_attempt.result_class = 'hard_failure'
-                            )
-                            AND COALESCE(completed_at, updated_at) < ?
-                    )
-                    """,
-                    (clean_tenant, clean_tenant, before),
-                ).fetchone()[0]
-            )
+        with self._lock:
             if apply:
-                connection.execute(
-                    """
-                    DELETE FROM provider_chat_attempts
-                    WHERE tenant_id = ? AND run_id IN (
-                        SELECT id FROM provider_chat_runs
+                reconciliation = self.reconcile_chat_control_completions(
+                    clean_tenant
+                )
+                if int(reconciliation.get("pending", 0)):
+                    raise RouterRepositoryError(
+                        "provider_chat_completion_reconciliation_pending"
+                    )
+            with self._connect() as connection:
+                connection.execute("BEGIN IMMEDIATE")
+                run_count = int(
+                    connection.execute(
+                        """
+                        SELECT COUNT(*) FROM provider_chat_runs
                         WHERE tenant_id = ? AND status != 'running'
                             AND hard_failure = 0
                             AND NOT EXISTS (
@@ -4509,25 +4479,64 @@ class SQLiteRouterRepository:
                                     AND failed_attempt.result_class = 'hard_failure'
                             )
                             AND COALESCE(completed_at, updated_at) < ?
-                    )
-                    """,
-                    (clean_tenant, clean_tenant, before),
+                        """,
+                        (clean_tenant, before),
+                    ).fetchone()[0]
                 )
-                connection.execute(
-                    """
-                    DELETE FROM provider_chat_runs
-                    WHERE tenant_id = ? AND status != 'running'
-                        AND hard_failure = 0
-                        AND NOT EXISTS (
-                            SELECT 1 FROM provider_chat_attempts AS failed_attempt
-                            WHERE failed_attempt.tenant_id = provider_chat_runs.tenant_id
-                                AND failed_attempt.run_id = provider_chat_runs.id
-                                AND failed_attempt.result_class = 'hard_failure'
+                attempt_count = int(
+                    connection.execute(
+                        """
+                        SELECT COUNT(*) FROM provider_chat_attempts
+                        WHERE tenant_id = ? AND run_id IN (
+                            SELECT id FROM provider_chat_runs
+                            WHERE tenant_id = ? AND status != 'running'
+                                AND hard_failure = 0
+                                AND NOT EXISTS (
+                                    SELECT 1 FROM provider_chat_attempts AS failed_attempt
+                                    WHERE failed_attempt.tenant_id = provider_chat_runs.tenant_id
+                                        AND failed_attempt.run_id = provider_chat_runs.id
+                                        AND failed_attempt.result_class = 'hard_failure'
+                                )
+                                AND COALESCE(completed_at, updated_at) < ?
                         )
-                        AND COALESCE(completed_at, updated_at) < ?
-                    """,
-                    (clean_tenant, before),
+                        """,
+                        (clean_tenant, clean_tenant, before),
+                    ).fetchone()[0]
                 )
+                if apply:
+                    connection.execute(
+                        """
+                        DELETE FROM provider_chat_attempts
+                        WHERE tenant_id = ? AND run_id IN (
+                            SELECT id FROM provider_chat_runs
+                            WHERE tenant_id = ? AND status != 'running'
+                                AND hard_failure = 0
+                                AND NOT EXISTS (
+                                    SELECT 1 FROM provider_chat_attempts AS failed_attempt
+                                    WHERE failed_attempt.tenant_id = provider_chat_runs.tenant_id
+                                        AND failed_attempt.run_id = provider_chat_runs.id
+                                        AND failed_attempt.result_class = 'hard_failure'
+                                )
+                                AND COALESCE(completed_at, updated_at) < ?
+                        )
+                        """,
+                        (clean_tenant, clean_tenant, before),
+                    )
+                    connection.execute(
+                        """
+                        DELETE FROM provider_chat_runs
+                        WHERE tenant_id = ? AND status != 'running'
+                            AND hard_failure = 0
+                            AND NOT EXISTS (
+                                SELECT 1 FROM provider_chat_attempts AS failed_attempt
+                                WHERE failed_attempt.tenant_id = provider_chat_runs.tenant_id
+                                    AND failed_attempt.run_id = provider_chat_runs.id
+                                    AND failed_attempt.result_class = 'hard_failure'
+                            )
+                            AND COALESCE(completed_at, updated_at) < ?
+                        """,
+                        (clean_tenant, before),
+                    )
         return {
             "applied": bool(apply),
             "before": before,

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -104,11 +104,21 @@ class SQLiteRouterRepository:
         )
         self.database_path = self.storage_dir / "router.sqlite3"
         self.master_key_path = self.storage_dir / "credential-master.key"
+        self.chat_completion_outbox_dir = (
+            self.storage_dir / "chat-completion-outbox"
+        )
         self._lock = threading.RLock()
         self.storage_dir.mkdir(parents=True, exist_ok=True)
+        if self.chat_completion_outbox_dir.is_symlink():
+            raise RouterRepositoryError(
+                "provider_chat_completion_outbox_path_unsafe"
+            )
+        self.chat_completion_outbox_dir.mkdir(parents=True, exist_ok=True)
         self._master_key = self._resolve_master_key(master_key)
         self._fernet = Fernet(self._master_key)
         self._initialize()
+        self._reconcile_startup_chat_control_completions()
+        self._recover_unresolved_chat_control_after_restart()
         self._verify_or_record_master_key()
 
     def _connect(self) -> sqlite3.Connection:
@@ -1202,25 +1212,6 @@ class SQLiteRouterRepository:
             )
             connection.execute(
                 """
-                UPDATE provider_chat_attempts
-                SET status = 'uncertain', result_class = 'uncertain',
-                    error_code = 'server_restarted', updated_at = ?, completed_at = ?
-                WHERE status = 'running'
-                """,
-                (now, now),
-            )
-            connection.execute(
-                """
-                UPDATE provider_chat_runs
-                SET status = 'uncertain', result_class = 'uncertain',
-                    reason_codes_json = '["server_restarted"]',
-                    updated_at = ?, completed_at = ?
-                WHERE status = 'running'
-                """,
-                (now, now),
-            )
-            connection.execute(
-                """
                 UPDATE provider_workload_certifications
                 SET status = 'uncertain', error_code = 'server_restarted',
                     updated_at = ?, completed_at = COALESCE(completed_at, ?)
@@ -1290,6 +1281,72 @@ class SQLiteRouterRepository:
                 (now, now),
             )
             connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+
+    def _reconcile_startup_chat_control_completions(self) -> None:
+        """Apply durable terminal facts before restart recovery marks orphans."""
+
+        for path in sorted(self.chat_completion_outbox_dir.glob("*.json")):
+            try:
+                payload = self._read_chat_completion_outbox(path)
+                tenant_id = self._tenant_id(str(payload.get("tenantId") or ""))
+                self.reconcile_chat_control_completions(
+                    tenant_id,
+                    attempt_id=str(payload.get("attemptId") or ""),
+                )
+            except RouterRepositoryError:
+                # Keep invalid or uncommitted evidence for fail-closed inspection.
+                continue
+
+    def _recover_unresolved_chat_control_after_restart(self) -> None:
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            running_attempts = connection.execute(
+                """
+                SELECT tenant_id, id, run_id
+                FROM provider_chat_attempts
+                WHERE status = 'running'
+                """
+            ).fetchall()
+            protected_runs: set[tuple[str, str]] = set()
+            for attempt in running_attempts:
+                tenant_id = str(attempt["tenant_id"])
+                attempt_id = str(attempt["id"])
+                run_id = str(attempt["run_id"])
+                pending_path = self._chat_completion_outbox_path(tenant_id, attempt_id)
+                if pending_path.is_symlink() or pending_path.exists():
+                    protected_runs.add((tenant_id, run_id))
+                    continue
+                connection.execute(
+                    """
+                    UPDATE provider_chat_attempts
+                    SET status = 'uncertain', result_class = 'uncertain',
+                        error_code = 'server_restarted', updated_at = ?,
+                        completed_at = ?
+                    WHERE tenant_id = ? AND id = ? AND status = 'running'
+                    """,
+                    (now, now, tenant_id, attempt_id),
+                )
+            running_runs = connection.execute(
+                """
+                SELECT tenant_id, id FROM provider_chat_runs
+                WHERE status = 'running'
+                """
+            ).fetchall()
+            for run in running_runs:
+                tenant_id = str(run["tenant_id"])
+                run_id = str(run["id"])
+                if (tenant_id, run_id) in protected_runs:
+                    continue
+                connection.execute(
+                    """
+                    UPDATE provider_chat_runs
+                    SET status = 'uncertain', result_class = 'uncertain',
+                        reason_codes_json = '["server_restarted"]',
+                        updated_at = ?, completed_at = ?
+                    WHERE tenant_id = ? AND id = ? AND status = 'running'
+                    """,
+                    (now, now, tenant_id, run_id),
+                )
 
     def create_connection(
         self, tenant_id: str, payload: RouterConnectionCreate
@@ -3361,6 +3418,10 @@ class SQLiteRouterRepository:
         """Atomically terminalize a dispatched attempt, its run, and gate."""
 
         clean_tenant = self._tenant_id(tenant_id)
+        if status not in {"succeeded", "failed", "cancelled"}:
+            raise RouterRepositoryError(
+                "provider_chat_completion_status_invalid"
+            )
         now = utc_now()
         observed_hard_failure = (
             bool(hard_failure) or result_class == "hard_failure"
@@ -3374,12 +3435,7 @@ class SQLiteRouterRepository:
                 """,
                 (clean_tenant, attempt_id),
             ).fetchone()
-            if (
-                attempt is None
-                or str(attempt["run_id"]) != expected_run_id
-                or str(attempt["status"]) != "running"
-                or not bool(attempt["dispatched"])
-            ):
+            if attempt is None or str(attempt["run_id"]) != expected_run_id:
                 raise RouterRepositoryError("provider_chat_attempt_not_running")
             run = connection.execute(
                 """
@@ -3388,8 +3444,35 @@ class SQLiteRouterRepository:
                 """,
                 (clean_tenant, expected_run_id),
             ).fetchone()
-            if run is None or str(run["status"]) != "running":
+            if run is None:
                 raise RouterRepositoryError("provider_chat_run_not_running")
+
+            if (
+                str(attempt["status"]) != "running"
+                or str(run["status"]) != "running"
+            ):
+                if self._chat_control_completion_matches(
+                    attempt,
+                    run,
+                    status=status,
+                    result_class=result_class,
+                    error_code=error_code,
+                    reason_codes=reason_codes or [],
+                    actual_model=actual_model,
+                    client_cancelled=client_cancelled,
+                    hard_failure=observed_hard_failure,
+                    ttft_ms=ttft_ms,
+                    e2e_ms=e2e_ms,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    total_tokens=total_tokens,
+                ):
+                    return {"attempt": dict(attempt), "run": dict(run)}
+                raise RouterRepositoryError(
+                    "provider_chat_completion_conflict"
+                )
+            if not bool(attempt["dispatched"]):
+                raise RouterRepositoryError("provider_chat_attempt_not_running")
 
             attempt_cursor = connection.execute(
                 """
@@ -3495,6 +3578,277 @@ class SQLiteRouterRepository:
             "attempt": dict(completed_attempt),
             "run": dict(completed_run),
         }
+
+    @staticmethod
+    def _chat_control_completion_matches(
+        attempt: sqlite3.Row,
+        run: sqlite3.Row,
+        *,
+        status: str,
+        result_class: str | None,
+        error_code: str | None,
+        reason_codes: list[str],
+        actual_model: str | None,
+        client_cancelled: bool,
+        hard_failure: bool,
+        ttft_ms: float | None,
+        e2e_ms: float | None,
+        prompt_tokens: int | None,
+        completion_tokens: int | None,
+        total_tokens: int | None,
+    ) -> bool:
+        try:
+            stored_reasons = json.loads(str(run["reason_codes_json"]))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return False
+        return (
+            str(attempt["status"]) == status
+            and attempt["result_class"] == result_class
+            and attempt["error_code"] == error_code
+            and attempt["actual_model"] == actual_model
+            and attempt["ttft_ms"] == ttft_ms
+            and attempt["e2e_ms"] == e2e_ms
+            and attempt["prompt_tokens"] == prompt_tokens
+            and attempt["completion_tokens"] == completion_tokens
+            and attempt["total_tokens"] == total_tokens
+            and str(run["status"]) == status
+            and run["result_class"] == result_class
+            and stored_reasons == reason_codes
+            and run["actual_model"] == actual_model
+            and bool(run["client_cancelled"]) == bool(client_cancelled)
+            and bool(run["hard_failure"]) == bool(hard_failure)
+            and run["ttft_ms"] == ttft_ms
+            and run["e2e_ms"] == e2e_ms
+            and run["prompt_tokens"] == prompt_tokens
+            and run["completion_tokens"] == completion_tokens
+            and run["total_tokens"] == total_tokens
+        )
+
+    def _chat_completion_outbox_path(
+        self, tenant_id: str, attempt_id: str
+    ) -> Path:
+        if not isinstance(attempt_id, str) or not attempt_id.strip():
+            raise RouterRepositoryError(
+                "provider_chat_completion_attempt_id_invalid"
+            )
+        digest = hashlib.sha256(
+            f"{tenant_id}\0{attempt_id}".encode("utf-8")
+        ).hexdigest()
+        return self.chat_completion_outbox_dir / f"{digest}.json"
+
+    @staticmethod
+    def _chat_completion_identity(payload: dict[str, object]) -> str:
+        durable = {
+            key: value
+            for key, value in payload.items()
+            if key != "payloadSha256"
+        }
+        return hashlib.sha256(
+            json.dumps(
+                durable,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode("utf-8")
+        ).hexdigest()
+
+    def _read_chat_completion_outbox(self, path: Path) -> dict[str, object]:
+        if path.is_symlink() or path.parent != self.chat_completion_outbox_dir:
+            raise RouterRepositoryError(
+                "provider_chat_completion_outbox_path_unsafe"
+            )
+        try:
+            with path.open("rb") as handle:
+                raw = handle.read(64 * 1024 + 1)
+            if len(raw) > 64 * 1024:
+                raise RouterRepositoryError(
+                    "provider_chat_completion_outbox_oversized"
+                )
+            payload = json.loads(raw.decode("utf-8"))
+        except RouterRepositoryError:
+            raise
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RouterRepositoryError(
+                "provider_chat_completion_outbox_invalid"
+            ) from exc
+        if (
+            not isinstance(payload, dict)
+            or payload.get("schemaVersion") != 1
+            or not isinstance(payload.get("tenantId"), str)
+            or not isinstance(payload.get("attemptId"), str)
+            or not isinstance(payload.get("expectedRunId"), str)
+            or payload.get("status") not in {"succeeded", "failed", "cancelled"}
+            or not isinstance(payload.get("stagedAt"), str)
+            or payload.get("payloadSha256")
+            != self._chat_completion_identity(payload)
+        ):
+            raise RouterRepositoryError(
+                "provider_chat_completion_outbox_invalid"
+            )
+        if self._chat_completion_outbox_path(payload["tenantId"], payload["attemptId"]) != path:
+            raise RouterRepositoryError("provider_chat_completion_outbox_path_mismatch")
+        return payload
+
+    @staticmethod
+    def _same_chat_completion_facts(
+        existing: dict[str, object], candidate: dict[str, object]
+    ) -> bool:
+        return {
+            key: value for key, value in existing.items()
+            if key not in {"stagedAt", "payloadSha256"}
+        } == {
+            key: value for key, value in candidate.items()
+            if key not in {"stagedAt", "payloadSha256"}
+        }
+
+    def stage_chat_control_completion(
+        self,
+        tenant_id: str,
+        attempt_id: str,
+        *,
+        expected_run_id: str,
+        status: str,
+        result_class: str | None = None,
+        error_code: str | None = None,
+        reason_codes: list[str] | None = None,
+        actual_model: str | None = None,
+        client_cancelled: bool = False,
+        hard_failure: bool = False,
+        ttft_ms: float | None = None,
+        e2e_ms: float | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+    ) -> dict[str, object]:
+        """Durably stage content-free completion facts outside router.sqlite3."""
+
+        clean_tenant = self._tenant_id(tenant_id)
+        if status not in {"succeeded", "failed", "cancelled"}:
+            raise RouterRepositoryError(
+                "provider_chat_completion_status_invalid"
+            )
+        if not isinstance(expected_run_id, str) or not expected_run_id.strip():
+            raise RouterRepositoryError(
+                "provider_chat_completion_run_id_invalid"
+            )
+        clean_reasons = [
+            str(item) for item in (reason_codes or []) if str(item).strip()
+        ]
+        payload: dict[str, object] = {
+            "schemaVersion": 1,
+            "tenantId": clean_tenant,
+            "attemptId": attempt_id,
+            "expectedRunId": expected_run_id,
+            "status": status,
+            "resultClass": result_class,
+            "errorCode": error_code,
+            "reasonCodes": clean_reasons,
+            "actualModel": actual_model,
+            "clientCancelled": bool(client_cancelled),
+            "hardFailure": bool(hard_failure) or result_class == "hard_failure",
+            "ttftMs": ttft_ms,
+            "e2eMs": e2e_ms,
+            "promptTokens": prompt_tokens,
+            "completionTokens": completion_tokens,
+            "totalTokens": total_tokens,
+            "stagedAt": utc_now(),
+        }
+        payload["payloadSha256"] = self._chat_completion_identity(payload)
+        path = self._chat_completion_outbox_path(clean_tenant, attempt_id)
+        with self._lock:
+            if path.is_symlink() or path.exists():
+                existing = self._read_chat_completion_outbox(path)
+                if not self._same_chat_completion_facts(existing, payload):
+                    raise RouterRepositoryError(
+                        "provider_chat_completion_outbox_conflict"
+                    )
+                return existing
+            temporary = self.chat_completion_outbox_dir / (
+                f".{path.stem}.{uuid.uuid4().hex}.tmp"
+            )
+            encoded = json.dumps(
+                payload,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode("utf-8")
+            if len(encoded) > 64 * 1024:
+                raise RouterRepositoryError("provider_chat_completion_outbox_oversized")
+            try:
+                with temporary.open("xb") as handle:
+                    handle.write(encoded)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                try:
+                    os.link(temporary, path)
+                except FileExistsError:
+                    existing = self._read_chat_completion_outbox(path)
+                    if not self._same_chat_completion_facts(existing, payload):
+                        raise RouterRepositoryError(
+                            "provider_chat_completion_outbox_conflict"
+                        )
+                    return existing
+            except OSError as exc:
+                raise RouterRepositoryError(
+                    "provider_chat_completion_outbox_write_failed"
+                ) from exc
+            finally:
+                try:
+                    temporary.unlink(missing_ok=True)
+                except OSError:
+                    pass
+        return payload
+
+    def reconcile_chat_control_completions(
+        self,
+        tenant_id: str,
+        *,
+        attempt_id: str | None = None,
+    ) -> dict[str, int]:
+        """Apply staged completions; retain any envelope that cannot commit."""
+
+        clean_tenant = self._tenant_id(tenant_id)
+        paths = (
+            [self._chat_completion_outbox_path(clean_tenant, attempt_id)]
+            if attempt_id is not None
+            else sorted(self.chat_completion_outbox_dir.glob("*.json"))
+        )
+        applied = 0
+        pending = 0
+        for path in paths:
+            if not path.is_symlink() and not path.exists():
+                continue
+            payload = self._read_chat_completion_outbox(path)
+            if payload.get("tenantId") != clean_tenant:
+                continue
+            try:
+                self.complete_chat_control_dispatch(
+                    clean_tenant,
+                    str(payload["attemptId"]),
+                    expected_run_id=str(payload["expectedRunId"]),
+                    status=str(payload["status"]),
+                    result_class=payload.get("resultClass"),
+                    error_code=payload.get("errorCode"),
+                    reason_codes=list(payload.get("reasonCodes") or []),
+                    actual_model=payload.get("actualModel"),
+                    client_cancelled=bool(payload.get("clientCancelled")),
+                    hard_failure=bool(payload.get("hardFailure")),
+                    ttft_ms=payload.get("ttftMs"),
+                    e2e_ms=payload.get("e2eMs"),
+                    prompt_tokens=payload.get("promptTokens"),
+                    completion_tokens=payload.get("completionTokens"),
+                    total_tokens=payload.get("totalTokens"),
+                )
+            except (RouterRepositoryError, sqlite3.Error):
+                pending += 1
+                continue
+            try:
+                path.unlink()
+            except OSError:
+                pending += 1
+                continue
+            applied += 1
+        return {"applied": applied, "pending": pending}
 
     def complete_chat_control_run(
         self,
@@ -4069,11 +4423,19 @@ class SQLiteRouterRepository:
     ) -> dict[str, int | bool | str]:
         clean_tenant = self._tenant_id(tenant_id)
         with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
             run_count = int(
                 connection.execute(
                     """
                     SELECT COUNT(*) FROM provider_chat_runs
                     WHERE tenant_id = ? AND status != 'running'
+                        AND hard_failure = 0
+                        AND NOT EXISTS (
+                            SELECT 1 FROM provider_chat_attempts AS failed_attempt
+                            WHERE failed_attempt.tenant_id = provider_chat_runs.tenant_id
+                                AND failed_attempt.run_id = provider_chat_runs.id
+                                AND failed_attempt.result_class = 'hard_failure'
+                        )
                         AND COALESCE(completed_at, updated_at) < ?
                     """,
                     (clean_tenant, before),
@@ -4086,6 +4448,13 @@ class SQLiteRouterRepository:
                     WHERE tenant_id = ? AND run_id IN (
                         SELECT id FROM provider_chat_runs
                         WHERE tenant_id = ? AND status != 'running'
+                            AND hard_failure = 0
+                            AND NOT EXISTS (
+                                SELECT 1 FROM provider_chat_attempts AS failed_attempt
+                                WHERE failed_attempt.tenant_id = provider_chat_runs.tenant_id
+                                    AND failed_attempt.run_id = provider_chat_runs.id
+                                    AND failed_attempt.result_class = 'hard_failure'
+                            )
                             AND COALESCE(completed_at, updated_at) < ?
                     )
                     """,
@@ -4099,6 +4468,13 @@ class SQLiteRouterRepository:
                     WHERE tenant_id = ? AND run_id IN (
                         SELECT id FROM provider_chat_runs
                         WHERE tenant_id = ? AND status != 'running'
+                            AND hard_failure = 0
+                            AND NOT EXISTS (
+                                SELECT 1 FROM provider_chat_attempts AS failed_attempt
+                                WHERE failed_attempt.tenant_id = provider_chat_runs.tenant_id
+                                    AND failed_attempt.run_id = provider_chat_runs.id
+                                    AND failed_attempt.result_class = 'hard_failure'
+                            )
                             AND COALESCE(completed_at, updated_at) < ?
                     )
                     """,
@@ -4108,6 +4484,13 @@ class SQLiteRouterRepository:
                     """
                     DELETE FROM provider_chat_runs
                     WHERE tenant_id = ? AND status != 'running'
+                        AND hard_failure = 0
+                        AND NOT EXISTS (
+                            SELECT 1 FROM provider_chat_attempts AS failed_attempt
+                            WHERE failed_attempt.tenant_id = provider_chat_runs.tenant_id
+                                AND failed_attempt.run_id = provider_chat_runs.id
+                                AND failed_attempt.result_class = 'hard_failure'
+                        )
                         AND COALESCE(completed_at, updated_at) < ?
                     """,
                     (clean_tenant, before),

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -2623,6 +2623,7 @@ class SQLiteRouterRepository:
                 or not certification_id
                 or capability in bindings
                 or certification_id in certification_ids
+                or connection_id != expected_connection_id
             ):
                 cls._chat_dispatch_drift()
             bindings[capability] = (connection_id, certification_id)

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -95,6 +95,7 @@ class SQLiteRouterRepository:
         storage_dir: str | Path | None = None,
         *,
         master_key: str | bytes | None = None,
+        recover_chat_control_on_startup: bool = True,
     ) -> None:
         package_dir = Path(__file__).resolve().parent
         self.storage_dir = Path(
@@ -118,8 +119,9 @@ class SQLiteRouterRepository:
                 "provider_chat_completion_outbox_path_unsafe"
             )
         self.chat_completion_outbox_dir.mkdir(parents=True, exist_ok=True)
-        self._reconcile_startup_chat_control_completions()
-        self._recover_unresolved_chat_control_after_restart()
+        if recover_chat_control_on_startup:
+            self._reconcile_startup_chat_control_completions()
+            self._recover_unresolved_chat_control_after_restart()
 
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(self.database_path, timeout=15)
@@ -3878,6 +3880,8 @@ class SQLiteRouterRepository:
                 continue
             try:
                 path.unlink()
+            except FileNotFoundError:
+                pass
             except OSError:
                 pending += 1
                 continue

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -12,7 +12,7 @@ import time
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Protocol
+from typing import NoReturn, Protocol
 
 from cryptography.fernet import Fernet, InvalidToken
 
@@ -2528,6 +2528,766 @@ class SQLiteRouterRepository:
             if cursor.rowcount != 1:
                 raise RouterRepositoryError("provider_chat_attempt_not_running")
 
+    @staticmethod
+    def _chat_dispatch_drift() -> NoReturn:
+        raise RouterRepositoryError(
+            "provider_chat_policy_or_qualification_changed"
+        )
+
+    @classmethod
+    def _normalize_chat_dispatch_bindings(
+        cls,
+        required_certifications: tuple[tuple[str, str, str], ...],
+        *,
+        expected_capability: str,
+        expected_connection_id: str,
+    ) -> dict[str, tuple[str, str]]:
+        if not required_certifications:
+            cls._chat_dispatch_drift()
+        bindings: dict[str, tuple[str, str]] = {}
+        certification_ids: set[str] = set()
+        for binding in required_certifications:
+            if not isinstance(binding, tuple) or len(binding) != 3:
+                cls._chat_dispatch_drift()
+            capability, connection_id, certification_id = binding
+            if (
+                not isinstance(capability, str)
+                or not capability
+                or not isinstance(connection_id, str)
+                or not connection_id
+                or not isinstance(certification_id, str)
+                or not certification_id
+                or capability in bindings
+                or certification_id in certification_ids
+            ):
+                cls._chat_dispatch_drift()
+            bindings[capability] = (connection_id, certification_id)
+            certification_ids.add(certification_id)
+        actual_binding = bindings.get(expected_capability)
+        if actual_binding is None or actual_binding[0] != expected_connection_id:
+            cls._chat_dispatch_drift()
+        return bindings
+
+    @classmethod
+    def _validate_chat_dispatch_envelope(
+        cls,
+        connection: sqlite3.Connection,
+        *,
+        tenant_id: str,
+        attempt_id: str,
+        expected_run_id: str,
+        expected_policy_fingerprint: str,
+        expected_strategy: str,
+        expected_model: str,
+        expected_capability: str,
+        expected_connection_id: str,
+        bindings: dict[str, tuple[str, str]],
+    ) -> tuple[
+        sqlite3.Row,
+        str,
+        list[str],
+        dict[str, list[tuple[int, str]]],
+        str,
+    ]:
+        attempt = connection.execute(
+            """
+            SELECT * FROM provider_chat_attempts
+            WHERE tenant_id = ? AND id = ?
+            """,
+            (tenant_id, attempt_id),
+        ).fetchone()
+        if (
+            attempt is None
+            or str(attempt["run_id"]) != expected_run_id
+            or str(attempt["capability"]) != expected_capability
+            or str(attempt["connection_id"] or "") != expected_connection_id
+            or str(attempt["status"]) != "running"
+            or bool(attempt["dispatched"])
+        ):
+            cls._chat_dispatch_drift()
+
+        run = connection.execute(
+            """
+            SELECT * FROM provider_chat_runs
+            WHERE tenant_id = ? AND id = ?
+            """,
+            (tenant_id, expected_run_id),
+        ).fetchone()
+        if (
+            run is None
+            or str(run["status"]) != "running"
+            or str(run["policy_fingerprint"]) != expected_policy_fingerprint
+            or str(run["strategy"]) != expected_strategy
+            or str(run["requested_model"]) != expected_model
+            or str(run["capability"]) != expected_capability
+        ):
+            cls._chat_dispatch_drift()
+        gateway = str(run["gateway"])
+        if gateway not in {"default", "ai_research_scoped"}:
+            cls._chat_dispatch_drift()
+
+        policy = connection.execute(
+            """
+            SELECT * FROM provider_chat_stable_policies
+            WHERE tenant_id = ?
+            """,
+            (tenant_id,),
+        ).fetchone()
+        if (
+            policy is None
+            or str(policy["mode"]) != expected_strategy
+            or str(policy["policy_fingerprint"])
+            != expected_policy_fingerprint
+        ):
+            cls._chat_dispatch_drift()
+        try:
+            stable_models_value = json.loads(
+                str(policy["stable_models_json"] or "[]")
+            )
+        except (TypeError, ValueError):
+            cls._chat_dispatch_drift()
+        if not isinstance(stable_models_value, list) or any(
+            not isinstance(item, str) or not item
+            for item in stable_models_value
+        ):
+            cls._chat_dispatch_drift()
+        stable_models = [str(item) for item in stable_models_value]
+        if gateway == "default" and expected_model not in stable_models:
+            cls._chat_dispatch_drift()
+
+        route_rows = connection.execute(
+            """
+            SELECT capability, position, connection_id
+            FROM provider_chat_capability_routes
+            WHERE tenant_id = ?
+            ORDER BY capability ASC, position ASC
+            """,
+            (tenant_id,),
+        ).fetchall()
+        routes: dict[str, list[tuple[int, str]]] = {}
+        try:
+            for row in route_rows:
+                routes.setdefault(str(row["capability"]), []).append(
+                    (int(row["position"]), str(row["connection_id"]))
+                )
+            attempt_position = int(attempt["position"])
+        except (TypeError, ValueError):
+            cls._chat_dispatch_drift()
+        if (
+            attempt_position,
+            expected_connection_id,
+        ) not in routes.get(expected_capability, []):
+            cls._chat_dispatch_drift()
+        for capability, (connection_id, _) in bindings.items():
+            capability_routes = routes.get(capability, [])
+            if not any(
+                route_connection_id == connection_id
+                for _, route_connection_id in capability_routes
+            ):
+                cls._chat_dispatch_drift()
+            if (
+                expected_strategy == "newapi_required_default"
+                and (
+                    not capability_routes
+                    or capability_routes[0][1] != connection_id
+                )
+            ):
+                cls._chat_dispatch_drift()
+        if (
+            expected_strategy == "newapi_required_default"
+            and attempt_position != 0
+        ):
+            cls._chat_dispatch_drift()
+        return (
+            run,
+            gateway,
+            stable_models,
+            routes,
+            str(attempt["provider_kind"]),
+        )
+
+    def _current_dispatch_connection_fingerprint(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        tenant_id: str,
+        connection_id: str,
+        model_id: str,
+        expected_connection_id: str,
+        expected_provider_kind: str,
+        cache: dict[tuple[str, str], str],
+    ) -> str:
+        cache_key = (connection_id, model_id)
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
+        connection_row = connection.execute(
+            """
+            SELECT * FROM router_connections
+            WHERE tenant_id = ? AND id = ?
+            """,
+            (tenant_id, connection_id),
+        ).fetchone()
+        if connection_row is None:
+            self._chat_dispatch_drift()
+        if (
+            connection_id == expected_connection_id
+            and str(connection_row["kind"]) != expected_provider_kind
+        ):
+            self._chat_dispatch_drift()
+        try:
+            scopes = json.loads(str(connection_row["scopes_json"]))
+            decrypted_key = self._fernet.decrypt(
+                str(connection_row["api_key_ciphertext"]).encode("ascii")
+            ).decode("utf-8")
+            fingerprint = self._connection_config_fingerprint_row(
+                connection_row
+            )
+        except (InvalidToken, TypeError, ValueError, UnicodeError):
+            self._chat_dispatch_drift()
+        if (
+            not bool(connection_row["enabled"])
+            or str(connection_row["health"]) != "online"
+            or not isinstance(scopes, list)
+            or "chat" not in scopes
+            or not decrypted_key.strip()
+        ):
+            self._chat_dispatch_drift()
+        inventory = connection.execute(
+            """
+            SELECT * FROM provider_catalog_models
+            WHERE tenant_id = ? AND connection_id = ?
+              AND model_id = ? AND status = 'active'
+            LIMIT 1
+            """,
+            (tenant_id, connection_id, model_id),
+        ).fetchone()
+        if inventory is None:
+            self._chat_dispatch_drift()
+        refresh = connection.execute(
+            """
+            SELECT * FROM provider_catalog_refreshes
+            WHERE tenant_id = ? AND connection_id = ? AND id = ?
+            """,
+            (tenant_id, connection_id, str(inventory["last_refresh_id"])),
+        ).fetchone()
+        if (
+            refresh is None
+            or str(refresh["status"]) != "succeeded"
+            or bool(refresh["truncated"])
+            or not refresh["completed_at"]
+            or str(refresh["connection_fingerprint"]) != fingerprint
+        ):
+            self._chat_dispatch_drift()
+        cache[cache_key] = fingerprint
+        return fingerprint
+
+    @classmethod
+    def _parse_chat_dispatch_timestamp(cls, value: object) -> datetime:
+        try:
+            parsed = datetime.fromisoformat(
+                str(value or "").replace("Z", "+00:00")
+            )
+        except (TypeError, ValueError):
+            cls._chat_dispatch_drift()
+        if parsed.tzinfo is None:
+            cls._chat_dispatch_drift()
+        return parsed.astimezone(UTC)
+
+    def _validate_current_dispatch_certification(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        tenant_id: str,
+        capability: str,
+        connection_id: str,
+        model_id: str,
+        certification_id: str,
+        contract_version: str,
+        certification_max_age_seconds: int,
+        expected_connection_id: str,
+        expected_provider_kind: str,
+        connection_cache: dict[tuple[str, str], str],
+        expirations: list[datetime],
+        require_exact_model: bool = False,
+    ) -> str:
+        fingerprint = self._current_dispatch_connection_fingerprint(
+            connection,
+            tenant_id=tenant_id,
+            connection_id=connection_id,
+            model_id=model_id,
+            expected_connection_id=expected_connection_id,
+            expected_provider_kind=expected_provider_kind,
+            cache=connection_cache,
+        )
+        certification = connection.execute(
+            """
+            SELECT * FROM provider_chat_certifications
+            WHERE tenant_id = ? AND connection_id = ?
+              AND requested_model = ? AND capability = ?
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            """,
+            (tenant_id, connection_id, model_id, capability),
+        ).fetchone()
+        if (
+            certification is None
+            or str(certification["id"]) != certification_id
+            or str(certification["status"]) != "passed"
+            or str(certification["connection_fingerprint"]) != fingerprint
+            or str(certification["contract_version"]) != contract_version
+            or (require_exact_model and certification["actual_model"] is None)
+            or (
+                certification["actual_model"] is not None
+                and str(certification["actual_model"]) != model_id
+            )
+        ):
+            self._chat_dispatch_drift()
+        completed_at = self._parse_chat_dispatch_timestamp(
+            certification["completed_at"]
+        )
+        expirations.append(
+            completed_at
+            + timedelta(seconds=certification_max_age_seconds)
+        )
+        hard_failure = connection.execute(
+            """
+            SELECT COALESCE(
+                       failed_attempt.completed_at,
+                       run.completed_at
+                   ) AS completed_at
+            FROM provider_chat_runs AS run
+            JOIN provider_chat_attempts AS failed_attempt
+              ON failed_attempt.tenant_id = run.tenant_id
+             AND failed_attempt.run_id = run.id
+            WHERE run.tenant_id = ? AND run.capability = ?
+              AND run.requested_model = ?
+              AND (
+                  run.hard_failure = 1
+                  OR failed_attempt.result_class = 'hard_failure'
+              )
+              AND failed_attempt.connection_id = ?
+              AND failed_attempt.dispatched = 1
+            ORDER BY completed_at DESC, run.id DESC
+            LIMIT 1
+            """,
+            (tenant_id, capability, model_id, connection_id),
+        ).fetchone()
+        if (
+            hard_failure is not None
+            and self._parse_chat_dispatch_timestamp(
+                hard_failure["completed_at"]
+            )
+            >= completed_at
+        ):
+            self._chat_dispatch_drift()
+        return fingerprint
+
+    def _validate_default_dispatch_qualifications(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        tenant_id: str,
+        model_id: str,
+        bindings: dict[str, tuple[str, str]],
+        contract_version: str,
+        expected_connection_id: str,
+        expected_provider_kind: str,
+        connection_cache: dict[tuple[str, str], str],
+    ) -> None:
+        for capability, (connection_id, certification_id) in bindings.items():
+            qualification = connection.execute(
+                """
+                SELECT * FROM provider_chat_model_qualifications
+                WHERE tenant_id = ? AND capability = ?
+                  AND connection_id = ? AND model_id = ?
+                """,
+                (tenant_id, capability, connection_id, model_id),
+            ).fetchone()
+            if (
+                qualification is None
+                or str(qualification["certification_id"]) != certification_id
+                or str(qualification["contract_version"]) != contract_version
+                or str(qualification["connection_fingerprint"])
+                != self._current_dispatch_connection_fingerprint(
+                    connection,
+                    tenant_id=tenant_id,
+                    connection_id=connection_id,
+                    model_id=model_id,
+                    expected_connection_id=expected_connection_id,
+                    expected_provider_kind=expected_provider_kind,
+                    cache=connection_cache,
+                )
+            ):
+                self._chat_dispatch_drift()
+
+    def _validate_required_dispatch_gate(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        tenant_id: str,
+        run: sqlite3.Row,
+        policy_fingerprint: str,
+        stable_models: list[str],
+        routes: dict[str, list[tuple[int, str]]],
+        contract_version: str,
+        certification_max_age_seconds: int,
+        expected_connection_id: str,
+        expected_provider_kind: str,
+        connection_cache: dict[tuple[str, str], str],
+        expirations: list[datetime],
+    ) -> None:
+        epoch_id = str(run["epoch_id"] or "")
+        epoch = connection.execute(
+            """
+            SELECT * FROM provider_chat_gate_epochs
+            WHERE tenant_id = ? AND id = ?
+              AND policy_fingerprint = ? AND status = 'active'
+              AND closed_at IS NULL
+            """,
+            (tenant_id, epoch_id, policy_fingerprint),
+        ).fetchone()
+        approval = connection.execute(
+            """
+            SELECT * FROM provider_chat_gate_approvals
+            WHERE tenant_id = ? AND policy_fingerprint = ?
+              AND epoch_id = ? AND revoked_at IS NULL
+            """,
+            (tenant_id, policy_fingerprint, epoch_id),
+        ).fetchone()
+        if epoch is None or approval is None:
+            self._chat_dispatch_drift()
+        try:
+            drills = json.loads(str(approval["drills_json"] or "{}"))
+        except (TypeError, ValueError):
+            self._chat_dispatch_drift()
+        if (
+            not bool(approval["no_open_p0_p1"])
+            or not bool(approval["acknowledge_fail_closed"])
+            or not isinstance(drills, dict)
+            or bool(validate_provider_chat_drills(drills))
+        ):
+            self._chat_dispatch_drift()
+        evidence_rows = connection.execute(
+            """
+            SELECT evidence_kind FROM provider_chat_acceptance_evidence
+            WHERE tenant_id = ? AND policy_fingerprint = ?
+              AND epoch_id = ? AND passed = 1
+            """,
+            (tenant_id, policy_fingerprint, epoch_id),
+        ).fetchall()
+        passed_evidence = {str(row["evidence_kind"]) for row in evidence_rows}
+        if not {
+            "newapi_quota_decrement",
+            "newapi_usage_log",
+            "newapi_restart_persistence",
+        } <= passed_evidence:
+            self._chat_dispatch_drift()
+        if (
+            not stable_models
+            or not routes.get("chat_text")
+            or len(stable_models) != len(set(stable_models))
+        ):
+            self._chat_dispatch_drift()
+        policy_qualifications = connection.execute(
+            """
+            SELECT * FROM provider_chat_model_qualifications
+            WHERE tenant_id = ?
+            """,
+            (tenant_id,),
+        ).fetchall()
+        expected_qualification_keys = {
+            (capability, route_connection_id, model_id)
+            for capability, capability_routes in routes.items()
+            for _, route_connection_id in capability_routes
+            for model_id in stable_models
+        }
+        actual_qualification_keys = {
+            (
+                str(row["capability"]),
+                str(row["connection_id"]),
+                str(row["model_id"]),
+            )
+            for row in policy_qualifications
+        }
+        if actual_qualification_keys != expected_qualification_keys:
+            self._chat_dispatch_drift()
+        for qualification in policy_qualifications:
+            capability = str(qualification["capability"])
+            connection_id = str(qualification["connection_id"])
+            model_id = str(qualification["model_id"])
+            certification_id = str(qualification["certification_id"])
+            fingerprint = self._validate_current_dispatch_certification(
+                connection,
+                tenant_id=tenant_id,
+                capability=capability,
+                connection_id=connection_id,
+                model_id=model_id,
+                certification_id=certification_id,
+                contract_version=contract_version,
+                certification_max_age_seconds=certification_max_age_seconds,
+                expected_connection_id=expected_connection_id,
+                expected_provider_kind=expected_provider_kind,
+                connection_cache=connection_cache,
+                expirations=expirations,
+            )
+            if (
+                str(qualification["contract_version"]) != contract_version
+                or str(qualification["connection_fingerprint"]) != fingerprint
+            ):
+                self._chat_dispatch_drift()
+
+    def mark_chat_control_attempt_dispatched_if_current(
+        self,
+        tenant_id: str,
+        attempt_id: str,
+        *,
+        expected_run_id: str,
+        expected_policy_fingerprint: str,
+        expected_strategy: str,
+        expected_model: str,
+        expected_capability: str,
+        expected_connection_id: str,
+        expected_connection_fingerprint: str,
+        required_certifications: tuple[tuple[str, str, str], ...],
+        contract_version: str,
+        certification_max_age_seconds: int,
+    ) -> None:
+        """Atomically bind dispatch to the exact policy and certification state."""
+
+        clean_tenant = self._tenant_id(tenant_id)
+        if (
+            not isinstance(attempt_id, str)
+            or not attempt_id
+            or not isinstance(expected_run_id, str)
+            or not expected_run_id
+            or not isinstance(expected_policy_fingerprint, str)
+            or not expected_policy_fingerprint
+            or expected_strategy
+            not in {"newapi_preferred", "newapi_required_default"}
+            or not isinstance(expected_model, str)
+            or not expected_model
+            or not isinstance(expected_capability, str)
+            or not expected_capability
+            or not isinstance(expected_connection_id, str)
+            or not expected_connection_id
+            or not isinstance(expected_connection_fingerprint, str)
+            or not expected_connection_fingerprint
+            or not isinstance(contract_version, str)
+            or not contract_version
+            or not isinstance(certification_max_age_seconds, int)
+            or isinstance(certification_max_age_seconds, bool)
+            or certification_max_age_seconds <= 0
+        ):
+            self._chat_dispatch_drift()
+        bindings = self._normalize_chat_dispatch_bindings(
+            required_certifications,
+            expected_capability=expected_capability,
+            expected_connection_id=expected_connection_id,
+        )
+
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            (
+                run,
+                gateway,
+                stable_models,
+                routes,
+                expected_provider_kind,
+            ) = self._validate_chat_dispatch_envelope(
+                connection,
+                tenant_id=clean_tenant,
+                attempt_id=attempt_id,
+                expected_run_id=expected_run_id,
+                expected_policy_fingerprint=expected_policy_fingerprint,
+                expected_strategy=expected_strategy,
+                expected_model=expected_model,
+                expected_capability=expected_capability,
+                expected_connection_id=expected_connection_id,
+                bindings=bindings,
+            )
+            connection_state_cache: dict[tuple[str, str], str] = {}
+            certification_expirations: list[datetime] = []
+
+            for capability, (
+                connection_id,
+                certification_id,
+            ) in bindings.items():
+                self._validate_current_dispatch_certification(
+                    connection,
+                    tenant_id=clean_tenant,
+                    capability=capability,
+                    connection_id=connection_id,
+                    model_id=expected_model,
+                    certification_id=certification_id,
+                    contract_version=contract_version,
+                    certification_max_age_seconds=(
+                        certification_max_age_seconds
+                    ),
+                    expected_connection_id=expected_connection_id,
+                    expected_provider_kind=expected_provider_kind,
+                    connection_cache=connection_state_cache,
+                    expirations=certification_expirations,
+                    require_exact_model=(gateway == "ai_research_scoped"),
+                )
+
+            if gateway == "default":
+                self._validate_default_dispatch_qualifications(
+                    connection,
+                    tenant_id=clean_tenant,
+                    model_id=expected_model,
+                    bindings=bindings,
+                    contract_version=contract_version,
+                    expected_connection_id=expected_connection_id,
+                    expected_provider_kind=expected_provider_kind,
+                    connection_cache=connection_state_cache,
+                )
+
+            if expected_strategy == "newapi_required_default":
+                self._validate_required_dispatch_gate(
+                    connection,
+                    tenant_id=clean_tenant,
+                    run=run,
+                    policy_fingerprint=expected_policy_fingerprint,
+                    stable_models=stable_models,
+                    routes=routes,
+                    contract_version=contract_version,
+                    certification_max_age_seconds=(
+                        certification_max_age_seconds
+                    ),
+                    expected_connection_id=expected_connection_id,
+                    expected_provider_kind=expected_provider_kind,
+                    connection_cache=connection_state_cache,
+                    expirations=certification_expirations,
+                )
+
+            if (
+                connection_state_cache.get(
+                    (expected_connection_id, expected_model)
+                )
+                != expected_connection_fingerprint
+            ):
+                self._chat_dispatch_drift()
+
+            dispatch_now = datetime.now(UTC)
+            if not certification_expirations or dispatch_now >= min(
+                certification_expirations
+            ):
+                self._chat_dispatch_drift()
+            cursor = connection.execute(
+                """
+                UPDATE provider_chat_attempts
+                SET dispatched = 1, updated_at = ?
+                WHERE tenant_id = ? AND id = ? AND run_id = ?
+                  AND capability = ? AND connection_id = ?
+                  AND status = 'running' AND dispatched = 0
+                """,
+                (
+                    dispatch_now.isoformat(),
+                    clean_tenant,
+                    attempt_id,
+                    expected_run_id,
+                    expected_capability,
+                    expected_connection_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                self._chat_dispatch_drift()
+
+    def fail_chat_control_preflight_if_undispatched(
+        self,
+        tenant_id: str,
+        attempt_id: str,
+        *,
+        expected_run_id: str,
+        error_code: str,
+    ) -> bool:
+        """Atomically fail preflight only while the run has never dispatched."""
+
+        clean_tenant = self._tenant_id(tenant_id)
+        if not isinstance(error_code, str) or not error_code.strip():
+            raise RouterRepositoryError("provider_chat_preflight_error_code_required")
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            state = connection.execute(
+                """
+                SELECT attempt.status AS attempt_status,
+                       attempt.dispatched AS attempt_dispatched,
+                       run.status AS run_status
+                FROM provider_chat_attempts AS attempt
+                JOIN provider_chat_runs AS run
+                  ON run.tenant_id = attempt.tenant_id
+                 AND run.id = attempt.run_id
+                WHERE attempt.tenant_id = ? AND attempt.id = ?
+                  AND attempt.run_id = ?
+                """,
+                (clean_tenant, attempt_id, expected_run_id),
+            ).fetchone()
+            if (
+                state is None
+                or str(state["attempt_status"]) != "running"
+                or bool(state["attempt_dispatched"])
+                or str(state["run_status"]) != "running"
+            ):
+                return False
+            dispatched = connection.execute(
+                """
+                SELECT 1 FROM provider_chat_attempts
+                WHERE tenant_id = ? AND run_id = ? AND dispatched = 1
+                LIMIT 1
+                """,
+                (clean_tenant, expected_run_id),
+            ).fetchone()
+            if dispatched is not None:
+                return False
+
+            now = utc_now()
+            attempt_cursor = connection.execute(
+                """
+                UPDATE provider_chat_attempts
+                SET status = 'failed', result_class = 'preflight_failure',
+                    error_code = ?, updated_at = ?, completed_at = ?
+                WHERE tenant_id = ? AND id = ? AND run_id = ?
+                  AND status = 'running' AND dispatched = 0
+                """,
+                (
+                    error_code,
+                    now,
+                    now,
+                    clean_tenant,
+                    attempt_id,
+                    expected_run_id,
+                ),
+            )
+            run_cursor = connection.execute(
+                """
+                UPDATE provider_chat_runs
+                SET status = 'failed', result_class = 'preflight_failure',
+                    reason_codes_json = ?, updated_at = ?, completed_at = ?
+                WHERE tenant_id = ? AND id = ? AND status = 'running'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM provider_chat_attempts AS dispatched_attempt
+                      WHERE dispatched_attempt.tenant_id = ?
+                        AND dispatched_attempt.run_id = ?
+                        AND dispatched_attempt.dispatched = 1
+                  )
+                """,
+                (
+                    json.dumps([error_code], separators=(",", ":")),
+                    now,
+                    now,
+                    clean_tenant,
+                    expected_run_id,
+                    clean_tenant,
+                    expected_run_id,
+                ),
+            )
+            if attempt_cursor.rowcount != 1 or run_cursor.rowcount != 1:
+                raise RouterRepositoryError(
+                    "provider_chat_preflight_atomic_cleanup_failed"
+                )
+            return True
+
     def complete_chat_control_attempt(
         self,
         tenant_id: str,
@@ -2578,6 +3338,163 @@ class SQLiteRouterRepository:
                 (clean_tenant, attempt_id),
             ).fetchone()
         return dict(row)
+
+    def complete_chat_control_dispatch(
+        self,
+        tenant_id: str,
+        attempt_id: str,
+        *,
+        expected_run_id: str,
+        status: str,
+        result_class: str | None = None,
+        error_code: str | None = None,
+        reason_codes: list[str] | None = None,
+        actual_model: str | None = None,
+        client_cancelled: bool = False,
+        hard_failure: bool = False,
+        ttft_ms: float | None = None,
+        e2e_ms: float | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+    ) -> dict[str, dict[str, object]]:
+        """Atomically terminalize a dispatched attempt, its run, and gate."""
+
+        clean_tenant = self._tenant_id(tenant_id)
+        now = utc_now()
+        observed_hard_failure = (
+            bool(hard_failure) or result_class == "hard_failure"
+        )
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            attempt = connection.execute(
+                """
+                SELECT * FROM provider_chat_attempts
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (clean_tenant, attempt_id),
+            ).fetchone()
+            if (
+                attempt is None
+                or str(attempt["run_id"]) != expected_run_id
+                or str(attempt["status"]) != "running"
+                or not bool(attempt["dispatched"])
+            ):
+                raise RouterRepositoryError("provider_chat_attempt_not_running")
+            run = connection.execute(
+                """
+                SELECT * FROM provider_chat_runs
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (clean_tenant, expected_run_id),
+            ).fetchone()
+            if run is None or str(run["status"]) != "running":
+                raise RouterRepositoryError("provider_chat_run_not_running")
+
+            attempt_cursor = connection.execute(
+                """
+                UPDATE provider_chat_attempts
+                SET status = ?, result_class = ?, error_code = ?,
+                    actual_model = ?, ttft_ms = ?, e2e_ms = ?,
+                    prompt_tokens = ?, completion_tokens = ?, total_tokens = ?,
+                    updated_at = ?, completed_at = ?
+                WHERE tenant_id = ? AND id = ? AND run_id = ?
+                  AND status = 'running' AND dispatched = 1
+                """,
+                (
+                    status,
+                    result_class,
+                    error_code,
+                    actual_model,
+                    ttft_ms,
+                    e2e_ms,
+                    prompt_tokens,
+                    completion_tokens,
+                    total_tokens,
+                    now,
+                    now,
+                    clean_tenant,
+                    attempt_id,
+                    expected_run_id,
+                ),
+            )
+            run_cursor = connection.execute(
+                """
+                UPDATE provider_chat_runs
+                SET status = ?, result_class = ?, reason_codes_json = ?,
+                    actual_model = ?, client_cancelled = ?, hard_failure = ?,
+                    ttft_ms = ?, e2e_ms = ?, prompt_tokens = ?,
+                    completion_tokens = ?, total_tokens = ?,
+                    updated_at = ?, completed_at = ?
+                WHERE tenant_id = ? AND id = ? AND status = 'running'
+                """,
+                (
+                    status,
+                    result_class,
+                    json.dumps(reason_codes or [], separators=(",", ":")),
+                    actual_model,
+                    int(client_cancelled),
+                    int(observed_hard_failure),
+                    ttft_ms,
+                    e2e_ms,
+                    prompt_tokens,
+                    completion_tokens,
+                    total_tokens,
+                    now,
+                    now,
+                    clean_tenant,
+                    expected_run_id,
+                ),
+            )
+            if attempt_cursor.rowcount != 1:
+                raise RouterRepositoryError("provider_chat_attempt_not_running")
+            if run_cursor.rowcount != 1:
+                raise RouterRepositoryError("provider_chat_run_not_running")
+
+            if observed_hard_failure and run["epoch_id"]:
+                failure_code = next(
+                    (
+                        str(item)
+                        for item in reversed(reason_codes or [])
+                        if str(item).strip()
+                    ),
+                    str(result_class or "provider_chat_hard_failure"),
+                )
+                connection.execute(
+                    """
+                    UPDATE provider_chat_gate_epochs
+                    SET status = 'degraded', hard_failure_code = ?, closed_at = ?
+                    WHERE tenant_id = ? AND id = ? AND closed_at IS NULL
+                    """,
+                    (failure_code, now, clean_tenant, run["epoch_id"]),
+                )
+                connection.execute(
+                    """
+                    UPDATE provider_chat_gate_approvals
+                    SET revoked_at = ?
+                    WHERE tenant_id = ? AND epoch_id = ? AND revoked_at IS NULL
+                    """,
+                    (now, clean_tenant, run["epoch_id"]),
+                )
+
+            completed_attempt = connection.execute(
+                """
+                SELECT * FROM provider_chat_attempts
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (clean_tenant, attempt_id),
+            ).fetchone()
+            completed_run = connection.execute(
+                """
+                SELECT * FROM provider_chat_runs
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (clean_tenant, expected_run_id),
+            ).fetchone()
+        return {
+            "attempt": dict(completed_attempt),
+            "run": dict(completed_run),
+        }
 
     def complete_chat_control_run(
         self,
@@ -2984,14 +3901,22 @@ class SQLiteRouterRepository:
         with self._lock, self._connect() as connection:
             row = connection.execute(
                 """
-                SELECT run.completed_at, run.reason_codes_json, run.epoch_id
+                SELECT COALESCE(
+                           attempt.completed_at,
+                           run.completed_at
+                       ) AS completed_at,
+                       run.reason_codes_json, run.epoch_id
                 FROM provider_chat_runs AS run
                 JOIN provider_chat_attempts AS attempt
                   ON attempt.tenant_id = run.tenant_id AND attempt.run_id = run.id
                 WHERE run.tenant_id = ? AND run.capability = ?
-                  AND run.requested_model = ? AND run.hard_failure = 1
+                  AND run.requested_model = ?
+                  AND (
+                      run.hard_failure = 1
+                      OR attempt.result_class = 'hard_failure'
+                  )
                   AND attempt.connection_id = ? AND attempt.dispatched = 1
-                ORDER BY run.completed_at DESC, run.id DESC
+                ORDER BY completed_at DESC, run.id DESC
                 LIMIT 1
                 """,
                 (clean_tenant, capability, model_id, connection_id),

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -3883,8 +3883,16 @@ class SQLiteRouterRepository:
             except FileNotFoundError:
                 pass
             except OSError:
-                pending += 1
-                continue
+                try:
+                    path.lstat()
+                except FileNotFoundError:
+                    pass
+                except OSError:
+                    pending += 1
+                    continue
+                else:
+                    pending += 1
+                    continue
             applied += 1
         return {"applied": applied, "pending": pending}
 

--- a/server/tests/test_ai_research_bridge.py
+++ b/server/tests/test_ai_research_bridge.py
@@ -71,6 +71,7 @@ class FakeStable:
     def __init__(self, handler) -> None:
         self.transport = FakeTransport(handler)
         self.completed: list[dict[str, Any]] = []
+        self.failed_undispatched: list[str] = []
         self.dispatched = 0
         self.capabilities: list[str] = []
         self.scoped_capabilities: list[str] = []
@@ -121,6 +122,12 @@ class FakeStable:
 
     def complete(self, dispatch: FakeDispatch, **fields: Any) -> None:
         self.completed.append(fields)
+
+    def fail_undispatched(
+        self, dispatch: FakeDispatch, *, error_code: str
+    ) -> bool:
+        self.failed_undispatched.append(error_code)
+        return True
 
     @staticmethod
     def classify_http_failure(status_code: int) -> tuple[str, str, bool]:
@@ -751,6 +758,7 @@ def test_hypothesis_model_requires_text_and_tool_certification(
                     {
                         "index": 0,
                         "message": {"role": "assistant", "content": '{"state":"proceed"}'},
+                        "finish_reason": "stop",
                     }
                 ],
             },
@@ -919,6 +927,54 @@ def test_p2r_coherence_tools_require_exact_prompt_schema_and_scoped_qualificatio
     assert stable.dispatched == 1
 
 
+@pytest.mark.parametrize(
+    "finish_reason",
+    [None, "stop", "length", "content_filter", "future_reason"],
+)
+def test_p2r_coherence_initial_rejects_non_contract_finish_reason(
+    monkeypatch, finish_reason: object
+) -> None:
+    prompt = "Locked ResearchStudio coherence JSON prompt."
+    enable_p2r(monkeypatch, prompt)
+    stable = FakeStable(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "model": HYPOTHESIS_MODEL_ID,
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_python",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "python",
+                                        "arguments": '{"code":"print(1)"}',
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": finish_reason,
+                    }
+                ],
+            },
+        )
+    )
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=p2r_tool_payload(prompt),
+            headers=p2r_headers(COHERENCE_PHASE),
+        )
+    assert response.status_code == 502
+    assert stable.completed[0]["error_code"] == (
+        "ai_research_bridge_invalid_p2r_finish_reason"
+    )
+
+
 def test_p2r_tool_contract_mutations_fail_before_provider_dispatch(monkeypatch) -> None:
     prompt = "Locked ResearchStudio coherence JSON prompt."
     enable_p2r(monkeypatch, prompt)
@@ -1011,7 +1067,8 @@ def test_p2r_completion_requires_explicit_fixed_model_identity(monkeypatch) -> N
                         "message": {
                             "role": "assistant",
                             "content": '{"state":"proceed"}',
-                        }
+                        },
+                        "finish_reason": "stop",
                     }
                 ]
             },
@@ -1037,6 +1094,55 @@ def test_p2r_completion_requires_explicit_fixed_model_identity(monkeypatch) -> N
     assert "actual_model" not in stable.completed[0]
 
 
+@pytest.mark.parametrize("stage", ["text", "coherence_finalize"])
+@pytest.mark.parametrize(
+    "finish_reason",
+    [None, "tool_calls", "length", "content_filter", "future_reason"],
+)
+def test_p2r_text_and_finalize_require_stop_finish_reason(
+    monkeypatch,
+    stage: str,
+    finish_reason: object,
+) -> None:
+    prompt = "Locked ResearchStudio coherence JSON prompt."
+    if stage == "text":
+        enable_hypothesis(monkeypatch)
+        bind_phase_prompt(monkeypatch, TEXT_PHASE, LOCKED_TEXT_PHASE_PROMPT)
+        payload = p2r_text_payload()
+        phase = TEXT_PHASE
+    else:
+        enable_p2r(monkeypatch, prompt)
+        payload = p2r_finalize_payload(prompt)
+        phase = COHERENCE_PHASE
+    stable = FakeStable(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "model": HYPOTHESIS_MODEL_ID,
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": '{"state":"proceed"}',
+                        },
+                        "finish_reason": finish_reason,
+                    }
+                ],
+            },
+        )
+    )
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=payload,
+            headers=p2r_headers(phase),
+        )
+    assert response.status_code == 502
+    assert stable.completed[0]["error_code"] == (
+        "ai_research_bridge_invalid_p2r_finish_reason"
+    )
+
+
 def test_p2r_coherence_finalize_binds_receipt_and_forbids_tampering(
     monkeypatch,
 ) -> None:
@@ -1055,7 +1161,8 @@ def test_p2r_coherence_finalize_binds_receipt_and_forbids_tampering(
                         "message": {
                             "role": "assistant",
                             "content": '{"state":"proceed"}',
-                        }
+                        },
+                        "finish_reason": "stop",
                     }
                 ],
             },
@@ -1188,7 +1295,12 @@ def test_p2r_array_phase_uses_declared_top_level_shape(monkeypatch) -> None:
             200,
             json={
                 "model": HYPOTHESIS_MODEL_ID,
-                "choices": [{"message": {"role": "assistant", "content": "[]"}}],
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "[]"},
+                        "finish_reason": "stop",
+                    }
+                ],
             },
         )
     )
@@ -1376,6 +1488,7 @@ def test_json_object_response_format_is_bounded_and_preserved(monkeypatch) -> No
                     {
                         "index": 0,
                         "message": {"role": "assistant", "content": '{"ok":true}'},
+                        "finish_reason": "stop",
                     }
                 ],
             },
@@ -1970,6 +2083,7 @@ def test_hypothesis_model_accepts_bounded_canonical_chunked_artifact_context(
                     {
                         "index": 0,
                         "message": {"role": "assistant", "content": '{"ok":true}'},
+                        "finish_reason": "stop",
                     }
                 ],
             },
@@ -2441,3 +2555,28 @@ def test_unexpected_dispatch_failure_is_sanitized_and_finalized(monkeypatch) -> 
     assert "provider-secret" not in response.text
     assert stable.completed[0]["status"] == "failed"
     assert stable.completed[0]["error_code"] == "ai_research_bridge_dispatch_failed"
+
+
+def test_request_build_failure_aborts_undispatched_without_outbox_completion(
+    monkeypatch,
+) -> None:
+    enable(monkeypatch)
+    stable = FakeStable(lambda request: httpx.Response(500))
+
+    def fail_request_build(*args: Any, **kwargs: Any) -> httpx.Request:
+        raise ValueError("provider-secret-in-build-error")
+
+    stable.transport.build_authorized_stream_request = fail_request_build
+    with TestClient(app_for(stable), raise_server_exceptions=False) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=valid_payload(),
+            headers=headers(),
+        )
+    assert response.status_code == 503
+    assert "provider-secret" not in response.text
+    assert stable.dispatched == 0
+    assert stable.completed == []
+    assert stable.failed_undispatched == [
+        "ai_research_bridge_transport_failed"
+    ]

--- a/server/tests/test_ai_research_bridge.py
+++ b/server/tests/test_ai_research_bridge.py
@@ -98,8 +98,18 @@ class FakeStable:
             error_code=None,
         )
 
-    def readiness_scoped_certified(self, model_id: str, capability: str):
-        return self.readiness(model_id, capability)
+    def readiness_scoped_certified(
+        self,
+        model_id: str,
+        capability: str,
+        *,
+        required_capabilities: tuple[str, ...] = (),
+    ):
+        for required_capability in required_capabilities or (capability,):
+            ready, reason = self.readiness(model_id, required_capability)
+            if not ready:
+                return ready, reason
+        return True, None
 
     async def begin_scoped_certified(
         self,
@@ -1094,6 +1104,46 @@ def test_p2r_completion_requires_explicit_fixed_model_identity(monkeypatch) -> N
     assert "actual_model" not in stable.completed[0]
 
 
+def test_ordinary_hypothesis_requires_explicit_fixed_model_identity(
+    monkeypatch,
+) -> None:
+    enable_hypothesis(monkeypatch)
+    stable = FakeStable(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": '{"hypothesis":"unattributed"}',
+                        }
+                    }
+                ]
+            },
+        )
+    )
+
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=ordinary_hypothesis_payload(),
+            headers=headers(),
+        )
+
+    assert response.status_code == 502
+    assert stable.dispatched == 1
+    assert stable.completed == [
+        {
+            "status": "failed",
+            "result_class": "hard_failure",
+            "error_code": "ai_research_bridge_model_identity_required",
+            "hard_failure": True,
+            "e2e_ms": stable.completed[0]["e2e_ms"],
+        }
+    ]
+
+
 @pytest.mark.parametrize("stage", ["text", "coherence_finalize"])
 @pytest.mark.parametrize(
     "finish_reason",
@@ -1418,7 +1468,6 @@ def test_unqualified_hypothesis_model_does_not_break_literature_discovery(
     assert stable.readiness_calls == [
         (MODEL_ID, "chat_tools"),
         (HYPOTHESIS_MODEL_ID, "chat_text"),
-        (HYPOTHESIS_MODEL_ID, "chat_tools"),
     ]
 
 

--- a/server/tests/test_ai_research_bridge.py
+++ b/server/tests/test_ai_research_bridge.py
@@ -1,24 +1,31 @@
 from __future__ import annotations
 
+import asyncio
+import copy
 import json
+import hashlib
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
 
 import httpx
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from server.model_router.ai_research_bridge import (
-    chat_completions,
-    models,
-    router,
-    stable_service,
-)
+import server.model_router.ai_research_bridge as bridge
+from server.model_router.ai_research_bridge import router, stable_service
 
 
 MODEL_ID = "provider/fixed-research-model"
+HYPOTHESIS_MODEL_ID = "provider/fixed-hypothesis-model"
 TOKEN = "test-ai-research-service-token"
+P2R_TOKEN = "test-ai-research-p2r-service-token"
+LOCKED_TEXT_PHASE_PROMPT = "Locked ResearchStudio phase prompt. Return a JSON object."
+TEXT_PHASE = "researchstudio.phase0.intent"
+COHERENCE_PHASE = "researchstudio.phase2.coherence"
+QUALIFICATION_RUN_ID = "p2rq_" + "a" * 32
+PREVIOUS_RECEIPT_SHA256 = "b" * 64
 
 
 @dataclass
@@ -31,6 +38,7 @@ class FakeDispatch:
 class FakeTransport:
     def __init__(self, handler) -> None:
         self.handler = handler
+        self.last_client: httpx.AsyncClient | None = None
 
     def client_kwargs(self) -> dict[str, object]:
         return {
@@ -55,6 +63,7 @@ class FakeTransport:
     async def send_authorized_stream(
         self, client: httpx.AsyncClient, request: httpx.Request
     ) -> httpx.Response:
+        self.last_client = client
         return await client.send(request, stream=True)
 
 
@@ -64,18 +73,43 @@ class FakeStable:
         self.completed: list[dict[str, Any]] = []
         self.dispatched = 0
         self.capabilities: list[str] = []
+        self.scoped_capabilities: list[str] = []
+        self.scoped_requirements: list[tuple[str, ...]] = []
         self.ready = True
         self.readiness_reason: str | None = None
         self.readiness_calls: list[tuple[str, str]] = []
+        self.readiness_overrides: dict[tuple[str, str], tuple[bool, str | None]] = {}
+        self.service_resolutions = 0
 
     def readiness(self, model_id: str, capability: str):
-        assert model_id == MODEL_ID
+        assert model_id in {MODEL_ID, HYPOTHESIS_MODEL_ID}
         self.readiness_calls.append((model_id, capability))
+        if (model_id, capability) in self.readiness_overrides:
+            return self.readiness_overrides[(model_id, capability)]
         return self.ready, self.readiness_reason
 
     async def begin(self, model_id: str, capability: str):
-        assert model_id == MODEL_ID
+        assert model_id in {MODEL_ID, HYPOTHESIS_MODEL_ID}
         self.capabilities.append(capability)
+        return SimpleNamespace(
+            intercepted=True,
+            dispatch=FakeDispatch(),
+            error_code=None,
+        )
+
+    def readiness_scoped_certified(self, model_id: str, capability: str):
+        return self.readiness(model_id, capability)
+
+    async def begin_scoped_certified(
+        self,
+        model_id: str,
+        capability: str,
+        *,
+        required_capabilities: tuple[str, ...] = (),
+    ):
+        assert model_id == HYPOTHESIS_MODEL_ID
+        self.scoped_capabilities.append(capability)
+        self.scoped_requirements.append(required_capabilities)
         return SimpleNamespace(
             intercepted=True,
             dispatch=FakeDispatch(),
@@ -93,11 +127,102 @@ class FakeStable:
         return "transient_failure", f"provider_chat_http_{status_code}", False
 
 
+class CancelOnReadStream(httpx.AsyncByteStream):
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    async def __aiter__(self):
+        raise asyncio.CancelledError
+        yield b""  # pragma: no cover - keeps this an async iterator
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+
+
+class ChunkedStream(httpx.AsyncByteStream):
+    def __init__(self, *chunks: bytes) -> None:
+        self.chunks = chunks
+        self.close_calls = 0
+
+    async def __aiter__(self):
+        for chunk in self.chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+
+
+class UnexpectedReadStream(httpx.AsyncByteStream):
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    async def __aiter__(self):
+        raise RuntimeError("unexpected response read failure")
+        yield b""  # pragma: no cover - keeps this an async iterator
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+
+
+class UnexpectedCloseStream(ChunkedStream):
+    async def aclose(self) -> None:
+        self.close_calls += 1
+        raise RuntimeError("unexpected response close failure")
+
+
+class HardFailureStable(FakeStable):
+    @staticmethod
+    def classify_http_failure(status_code: int) -> tuple[str, str, bool]:
+        assert status_code == 401
+        return "hard_failure", "provider_chat_http_401", True
+
+
 def app_for(stable: FakeStable) -> FastAPI:
     app = FastAPI()
     app.include_router(router)
-    app.dependency_overrides[stable_service] = lambda: stable
+
+    def resolve_stable() -> FakeStable:
+        stable.service_resolutions += 1
+        return stable
+
+    app.dependency_overrides[stable_service] = resolve_stable
     return app
+
+
+async def call_direct(stable: FakeStable):
+    return await bridge.chat_completions(
+        bridge.ChatCompletionRequest.model_validate(valid_payload()),
+        bridge_auth=bridge.ChatBridgeAuthorization(
+            settings=bridge.BridgeSettings(
+                enabled=True,
+                token=TOKEN,
+                p2r_token=P2R_TOKEN,
+                literature_model_id=MODEL_ID,
+                hypothesis_model_id="",
+                p2r_enabled=False,
+                p2r_tools_enabled=False,
+            ),
+            phase=None,
+        ),
+        stable=stable,
+    )
+
+
+def direct_stream(
+    stable: FakeStable, stream: httpx.AsyncByteStream
+) -> tuple[httpx.AsyncClient, Any]:
+    client = httpx.AsyncClient(trust_env=False)
+    stable.transport.last_client = client
+    response = httpx.Response(200, stream=stream)
+    return client, bridge._stream_response(
+        stable=stable,
+        dispatch=FakeDispatch(),
+        response=response,
+        client=client,
+        requested_model=MODEL_ID,
+        started=0.0,
+        allow_tool_calls=False,
+    )
 
 
 def enable(monkeypatch) -> None:
@@ -106,8 +231,89 @@ def enable(monkeypatch) -> None:
     monkeypatch.setenv("AI_RESEARCH_LITERATURE_MODEL_ID", MODEL_ID)
 
 
+def enable_hypothesis(monkeypatch) -> None:
+    enable(monkeypatch)
+    monkeypatch.setenv("AI_RESEARCH_P2R_S2S_TOKEN", P2R_TOKEN)
+    monkeypatch.setenv("AI_RESEARCH_HYPOTHESIS_MODEL_ID", HYPOTHESIS_MODEL_ID)
+    monkeypatch.setenv("AI_RESEARCH_P2R_ENABLED", "true")
+    monkeypatch.setenv("AI_RESEARCH_P2R_TOOLS_ENABLED", "true")
+
+
+def bind_phase_prompt(monkeypatch, phase: str, prompt: str) -> None:
+    contracts = copy.deepcopy(bridge.P2R_PHASE_CONTRACTS)
+    contracts[phase]["promptSha256"] = hashlib.sha256(
+        prompt.encode("utf-8")
+    ).hexdigest()
+    monkeypatch.setattr(bridge, "P2R_PHASE_CONTRACTS", contracts)
+
+
+def enable_p2r(monkeypatch, prompt: str) -> None:
+    enable_hypothesis(monkeypatch)
+    bind_phase_prompt(monkeypatch, COHERENCE_PHASE, prompt)
+
+
 def headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {TOKEN}"}
+
+
+def p2r_headers(phase: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {P2R_TOKEN}",
+        "X-ModelMirror-P2R-Phase": phase,
+    }
+
+
+def canonical_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def artifact_messages(
+    *,
+    phase: str,
+    artifacts: list[tuple[str, str]],
+    qualification_run_id: str = QUALIFICATION_RUN_ID,
+    previous_receipt_sha256: str = PREVIOUS_RECEIPT_SHA256,
+    chunk_chars: int = bridge.P2R_MAX_ARTIFACT_CHUNK_CHARS,
+) -> list[dict[str, str]]:
+    messages: list[dict[str, str]] = []
+    for path, content in artifacts:
+        raw = content.encode("utf-8")
+        chunks = [
+            content[offset : offset + chunk_chars]
+            for offset in range(0, len(content), chunk_chars)
+        ] or [""]
+        for index, chunk in enumerate(chunks):
+            envelope = {
+                "protocol": bridge.P2R_PHASE_REQUEST_PROTOCOL,
+                "qualificationRunId": qualification_run_id,
+                "phase": phase,
+                "previousReceiptSha256": previous_receipt_sha256,
+                "artifact": {
+                    "path": path,
+                    "sha256": hashlib.sha256(raw).hexdigest(),
+                    "sizeBytes": len(raw),
+                    "chunkIndex": index,
+                    "chunkCount": len(chunks),
+                    "chunkSha256": hashlib.sha256(chunk.encode("utf-8")).hexdigest(),
+                    "content": chunk,
+                },
+            }
+            messages.append({"role": "user", "content": canonical_json(envelope)})
+    return messages
+
+
+def valid_payload(*, stream: bool = False) -> dict[str, Any]:
+    return {
+        "model": MODEL_ID,
+        "messages": [
+            {"role": "system", "content": "Write a literature synthesis."},
+            {"role": "user", "content": "What makes agent evaluation reproducible?"},
+        ],
+        "temperature": 0.2,
+        "max_tokens": 512,
+        "stream": stream,
+        **({"stream_options": {"include_usage": True}} if stream else {}),
+    }
 
 
 def test_main_app_registers_restricted_ai_research_routes(monkeypatch) -> None:
@@ -120,8 +326,12 @@ def test_main_app_registers_restricted_ai_research_routes(monkeypatch) -> None:
     ]
     assert len(registered) == 2
     assert registered == [
-        ("/api/ai-research/v1/models", ("GET",), models),
-        ("/api/ai-research/v1/chat/completions", ("POST",), chat_completions),
+        ("/api/ai-research/v1/models", ("GET",), bridge.models),
+        (
+            "/api/ai-research/v1/chat/completions",
+            ("POST",),
+            bridge.chat_completions,
+        ),
     ]
 
     client = TestClient(main_app)
@@ -147,18 +357,27 @@ def test_main_app_registers_restricted_ai_research_routes(monkeypatch) -> None:
     assert chat_response.status_code == 401
 
 
-def valid_payload(*, stream: bool = False) -> dict[str, Any]:
-    return {
-        "model": MODEL_ID,
-        "messages": [
-            {"role": "system", "content": "Write a literature synthesis."},
-            {"role": "user", "content": "What makes agent evaluation reproducible?"},
-        ],
-        "temperature": 0.2,
-        "max_tokens": 512,
-        "stream": stream,
-        **({"stream_options": {"include_usage": True}} if stream else {}),
+def test_p2r_phase_registry_is_closed() -> None:
+    assert set(bridge.P2R_PHASE_CONTRACTS) == {
+        "researchstudio.phase0.intent",
+        "researchstudio.phase0.partition",
+        "researchstudio.phase0.pattern_summary",
+        "researchstudio.phase0.coverage",
+        "researchstudio.phase1.bottleneck",
+        "researchstudio.phase2.select",
+        "researchstudio.phase2.generate",
+        "researchstudio.phase2.coherence",
     }
+    assert len(bridge.P2R_LOCKED_STATIC_ARTIFACT_SHA256) == 34
+    assert bridge.P2R_LOCKED_STATIC_ARTIFACT_SHA256[
+        "references/ideation-sub-patterns/C00.md"
+    ] == "0bc790076bc61bc5a902094b3b1326375b20a2210540b9665c97728f8a869d56"
+    assert bridge.P2R_LOCKED_STATIC_ARTIFACT_SHA256[
+        "references/ideation-sub-patterns/C30.md"
+    ] == "7e91d3605898cddc818268020289617ca76496905342b58adc4358eedc146497"
+    assert "references/ideation-sub-patterns/C31.md" not in (
+        bridge.P2R_LOCKED_STATIC_ARTIFACT_SHA256
+    )
 
 
 def tool_payload(*, stream: bool = False) -> dict[str, Any]:
@@ -179,6 +398,125 @@ def tool_payload(*, stream: bool = False) -> dict[str, Any]:
     ]
     payload["tool_choice"] = "auto"
     payload["parallel_tool_calls"] = False
+    return payload
+
+
+def p2r_text_payload(
+    prompt: str = LOCKED_TEXT_PHASE_PROMPT,
+    *,
+    phase: str = TEXT_PHASE,
+    artifacts: list[tuple[str, str]] | None = None,
+    response_shape: str = "object",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "model": HYPOTHESIS_MODEL_ID,
+        "messages": [
+            {"role": "system", "content": prompt},
+            *artifact_messages(
+                phase=phase,
+                artifacts=artifacts or [("phase0/user_query.txt", "Agent evaluation")],
+            ),
+        ],
+        "temperature": bridge.P2R_FIXED_TEMPERATURE,
+        "max_tokens": bridge.P2R_FIXED_MAX_TOKENS,
+        "stream": False,
+    }
+    if response_shape == "object":
+        payload["response_format"] = {"type": "json_object"}
+    return payload
+
+
+def ordinary_hypothesis_payload() -> dict[str, Any]:
+    return {
+        "model": HYPOTHESIS_MODEL_ID,
+        "messages": [
+            {
+                "role": "system",
+                "content": "Return a JSON object containing one bounded hypothesis.",
+            },
+            {
+                "role": "user",
+                "content": "Propose one testable agent-evaluation hypothesis.",
+            },
+        ],
+        "temperature": 0.2,
+        "max_tokens": 512,
+        "stream": False,
+        "response_format": {"type": "json_object"},
+    }
+
+
+def p2r_tool_payload(prompt: str) -> dict[str, Any]:
+    payload = p2r_text_payload(
+        prompt,
+        phase=COHERENCE_PHASE,
+        artifacts=[
+            ("phase2_select/phase2_select_output.json", '{"selected":"C01"}'),
+            ("phase2_generate/phase2_generate_output.json", '{"candidate":{}}'),
+        ],
+    )
+    payload["tools"] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "python",
+                "description": bridge.P2R_PYTHON_TOOL_DESCRIPTION,
+                "parameters": copy.deepcopy(bridge.P2R_PYTHON_PARAMETERS),
+                "strict": True,
+            },
+        }
+    ]
+    payload["tool_choice"] = "auto"
+    payload["parallel_tool_calls"] = False
+    return payload
+
+
+def p2r_python_receipt(code: str) -> dict[str, Any]:
+    stdout = "dry-run ok\n"
+    stderr = ""
+    return {
+        "protocol": bridge.P2R_PYTHON_RECEIPT_PROTOCOL,
+        "sandboxImage": bridge.P2R_PYTHON_SANDBOX_IMAGE,
+        "command": ["python3", "-"],
+        "scriptSha256": hashlib.sha256(code.encode("utf-8")).hexdigest(),
+        "scriptSizeBytes": len(code.encode("utf-8")),
+        "exitCode": 0,
+        "stdout": stdout,
+        "stdoutSha256": hashlib.sha256(stdout.encode("utf-8")).hexdigest(),
+        "stdoutSizeBytes": len(stdout.encode("utf-8")),
+        "stderr": stderr,
+        "stderrSha256": hashlib.sha256(stderr.encode("utf-8")).hexdigest(),
+        "stderrSizeBytes": len(stderr.encode("utf-8")),
+        "limits": copy.deepcopy(bridge.P2R_PYTHON_LIMITS),
+        "truncation": {"captureExceeded": False, "stderr": False, "stdout": False},
+    }
+
+
+def p2r_finalize_payload(prompt: str, *, code: str = "print('dry-run')") -> dict[str, Any]:
+    payload = p2r_tool_payload(prompt)
+    payload["messages"].extend(
+        [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_python",
+                        "type": "function",
+                        "function": {
+                            "name": "python",
+                            "arguments": canonical_json({"code": code}),
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_python",
+                "content": canonical_json(p2r_python_receipt(code)),
+            },
+        ]
+    )
     return payload
 
 
@@ -205,6 +543,795 @@ def test_disabled_wrong_token_and_models_fail_closed(monkeypatch) -> None:
     )
 
 
+def test_models_remains_generic_credential_surface_with_phase_header(
+    monkeypatch,
+) -> None:
+    enable_hypothesis(monkeypatch)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    with TestClient(app_for(stable)) as api:
+        p2r_credential = api.get(
+            "/api/ai-research/v1/models",
+            headers=p2r_headers(TEXT_PHASE),
+        )
+        assert p2r_credential.status_code == 401
+        assert stable.service_resolutions == 0
+        assert stable.readiness_calls == []
+
+        generic_credential = api.get(
+            "/api/ai-research/v1/models",
+            headers={
+                **headers(),
+                "X-ModelMirror-P2R-Phase": TEXT_PHASE,
+            },
+        )
+
+    assert generic_credential.status_code == 401
+    assert stable.service_resolutions == 0
+    assert stable.readiness_calls == []
+    assert stable.capabilities == []
+    assert stable.scoped_capabilities == []
+    assert stable.dispatched == 0
+
+
+def test_chat_credentials_cannot_cross_generic_and_p2r_surfaces(monkeypatch) -> None:
+    enable_hypothesis(monkeypatch)
+    bind_phase_prompt(monkeypatch, TEXT_PHASE, LOCKED_TEXT_PHASE_PROMPT)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    with TestClient(app_for(stable)) as api:
+        generic_on_phase = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=p2r_text_payload(),
+            headers={
+                **headers(),
+                "X-ModelMirror-P2R-Phase": TEXT_PHASE,
+            },
+        )
+        wrong_on_phase = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=p2r_text_payload(),
+            headers={
+                "Authorization": "Bearer wrong",
+                "X-ModelMirror-P2R-Phase": TEXT_PHASE,
+            },
+        )
+        p2r_without_phase = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=p2r_text_payload(),
+            headers={"Authorization": f"Bearer {P2R_TOKEN}"},
+        )
+
+    assert [
+        generic_on_phase.status_code,
+        wrong_on_phase.status_code,
+        p2r_without_phase.status_code,
+    ] == [401, 401, 401]
+    assert stable.service_resolutions == 0
+    assert stable.readiness_calls == []
+    assert stable.capabilities == []
+    assert stable.scoped_capabilities == []
+    assert stable.dispatched == 0
+
+
+@pytest.mark.parametrize("p2r_token", [None, TOKEN])
+def test_phase_requests_require_distinct_configured_p2r_credential(
+    monkeypatch,
+    p2r_token: str | None,
+) -> None:
+    enable_hypothesis(monkeypatch)
+    bind_phase_prompt(monkeypatch, TEXT_PHASE, LOCKED_TEXT_PHASE_PROMPT)
+    if p2r_token is None:
+        monkeypatch.delenv("AI_RESEARCH_P2R_S2S_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("AI_RESEARCH_P2R_S2S_TOKEN", p2r_token)
+    monkeypatch.setenv("AI_RESEARCH_P2R_ENABLED", "false")
+    monkeypatch.setenv("AI_RESEARCH_P2R_TOOLS_ENABLED", "false")
+
+    def upstream(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "model": HYPOTHESIS_MODEL_ID,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": '{"hypothesis":"bounded"}',
+                        },
+                    }
+                ],
+            },
+        )
+
+    stable = FakeStable(upstream)
+    stable.readiness_overrides[(HYPOTHESIS_MODEL_ID, "chat_tools")] = (
+        False,
+        "provider_chat_no_qualified_tools_route",
+    )
+    with TestClient(app_for(stable)) as api:
+        generic_models = api.get(
+            "/api/ai-research/v1/models",
+            headers=headers(),
+        )
+        assert generic_models.status_code == 200
+        assert stable.service_resolutions == 1
+        stable.readiness_calls.clear()
+
+        no_phase = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=ordinary_hypothesis_payload(),
+            headers=headers(),
+        )
+        phase_request = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=p2r_text_payload(),
+            headers={
+                **headers(),
+                "X-ModelMirror-P2R-Phase": TEXT_PHASE,
+            },
+        )
+
+    assert no_phase.status_code == 200
+    assert phase_request.status_code == 503
+    assert phase_request.json()["detail"] == (
+        "AI Research P2R service credential is not configured"
+    )
+    assert stable.readiness_calls == [(HYPOTHESIS_MODEL_ID, "chat_text")]
+    assert stable.service_resolutions == 2
+    assert stable.capabilities == []
+    assert stable.scoped_capabilities == ["chat_text"]
+    assert stable.scoped_requirements == [("chat_text",)]
+    assert stable.dispatched == 1
+
+
+def test_ordinary_hypothesis_requires_only_current_text_certification(
+    monkeypatch,
+) -> None:
+    enable_hypothesis(monkeypatch)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    stable.readiness_overrides[(HYPOTHESIS_MODEL_ID, "chat_text")] = (
+        False,
+        "provider_chat_no_qualified_text_route",
+    )
+
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=ordinary_hypothesis_payload(),
+            headers=headers(),
+        )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "provider_chat_no_qualified_text_route"
+    assert stable.readiness_calls == [(HYPOTHESIS_MODEL_ID, "chat_text")]
+    assert stable.scoped_capabilities == []
+    assert stable.dispatched == 0
+
+
+def test_ordinary_hypothesis_rejects_tools_before_readiness(monkeypatch) -> None:
+    enable_hypothesis(monkeypatch)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    stable.ready = False
+    stable.readiness_reason = "must not be observed"
+    payload = tool_payload()
+    payload["model"] = HYPOTHESIS_MODEL_ID
+
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=payload,
+            headers=headers(),
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == (
+        "tools are not enabled for ordinary hypothesis requests"
+    )
+    assert stable.readiness_calls == []
+    assert stable.capabilities == []
+    assert stable.scoped_capabilities == []
+    assert stable.dispatched == 0
+
+
+def test_hypothesis_model_requires_text_and_tool_certification(
+    monkeypatch,
+) -> None:
+    enable_hypothesis(monkeypatch)
+    bind_phase_prompt(monkeypatch, TEXT_PHASE, LOCKED_TEXT_PHASE_PROMPT)
+
+    def upstream(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["model"] == HYPOTHESIS_MODEL_ID
+        assert "tools" not in body
+        return httpx.Response(
+            200,
+            json={
+                "model": HYPOTHESIS_MODEL_ID,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": '{"state":"proceed"}'},
+                    }
+                ],
+            },
+        )
+
+    stable = FakeStable(upstream)
+    payload = p2r_text_payload()
+    tool_request = tool_payload()
+    tool_request["model"] = HYPOTHESIS_MODEL_ID
+
+    with TestClient(app_for(stable)) as api:
+        models_response = api.get(
+            "/api/ai-research/v1/models", headers=headers()
+        )
+        completion = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=payload,
+            headers=p2r_headers(TEXT_PHASE),
+        )
+        rejected_tool = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=tool_request,
+            headers=headers(),
+        )
+
+    assert models_response.status_code == 200
+    assert [item["id"] for item in models_response.json()["data"]] == [
+        MODEL_ID,
+        HYPOTHESIS_MODEL_ID,
+    ]
+    assert stable.readiness_calls == [
+        (MODEL_ID, "chat_tools"),
+        (HYPOTHESIS_MODEL_ID, "chat_text"),
+        (HYPOTHESIS_MODEL_ID, "chat_tools"),
+        (HYPOTHESIS_MODEL_ID, "chat_text"),
+        (HYPOTHESIS_MODEL_ID, "chat_tools"),
+    ]
+    assert completion.status_code == 200
+    assert rejected_tool.status_code == 422
+    assert stable.capabilities == []
+    assert stable.scoped_capabilities == ["chat_text"]
+    assert stable.scoped_requirements == [("chat_text", "chat_tools")]
+    assert stable.dispatched == 1
+
+
+def test_hypothesis_discovery_requires_both_flags_and_capabilities(
+    monkeypatch,
+) -> None:
+    enable_hypothesis(monkeypatch)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    monkeypatch.setenv("AI_RESEARCH_P2R_TOOLS_ENABLED", "false")
+    with TestClient(app_for(stable)) as api:
+        flags_off = api.get("/api/ai-research/v1/models", headers=headers())
+    assert [item["id"] for item in flags_off.json()["data"]] == [MODEL_ID]
+    assert stable.readiness_calls == [(MODEL_ID, "chat_tools")]
+
+    monkeypatch.setenv("AI_RESEARCH_P2R_TOOLS_ENABLED", "true")
+    stable.readiness_calls.clear()
+    stable.readiness_overrides[(HYPOTHESIS_MODEL_ID, "chat_tools")] = (
+        False,
+        "provider_chat_no_qualified_tools_route",
+    )
+    with TestClient(app_for(stable)) as api:
+        tools_unready = api.get("/api/ai-research/v1/models", headers=headers())
+    assert [item["id"] for item in tools_unready.json()["data"]] == [MODEL_ID]
+    assert stable.readiness_calls == [
+        (MODEL_ID, "chat_tools"),
+        (HYPOTHESIS_MODEL_ID, "chat_text"),
+        (HYPOTHESIS_MODEL_ID, "chat_tools"),
+    ]
+
+
+def test_direct_p2r_calls_require_both_scoped_certificates(monkeypatch) -> None:
+    enable_hypothesis(monkeypatch)
+    bind_phase_prompt(monkeypatch, TEXT_PHASE, LOCKED_TEXT_PHASE_PROMPT)
+    text_stable = FakeStable(lambda request: httpx.Response(500))
+    text_stable.readiness_overrides[(HYPOTHESIS_MODEL_ID, "chat_tools")] = (
+        False,
+        "provider_chat_no_qualified_tools_route",
+    )
+    with TestClient(app_for(text_stable)) as api:
+        text_response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=p2r_text_payload(),
+            headers=p2r_headers(TEXT_PHASE),
+        )
+    assert text_response.status_code == 503
+    assert text_response.json()["detail"] == "provider_chat_no_qualified_tools_route"
+    assert text_stable.readiness_calls == [
+        (HYPOTHESIS_MODEL_ID, "chat_text"),
+        (HYPOTHESIS_MODEL_ID, "chat_tools"),
+    ]
+    assert text_stable.scoped_capabilities == []
+    assert text_stable.dispatched == 0
+
+    coherence_prompt = "Locked ResearchStudio coherence JSON prompt."
+    enable_p2r(monkeypatch, coherence_prompt)
+    tools_stable = FakeStable(lambda request: httpx.Response(500))
+    tools_stable.readiness_overrides[(HYPOTHESIS_MODEL_ID, "chat_text")] = (
+        False,
+        "provider_chat_no_qualified_text_route",
+    )
+    with TestClient(app_for(tools_stable)) as api:
+        tools_response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=p2r_tool_payload(coherence_prompt),
+            headers=p2r_headers(COHERENCE_PHASE),
+        )
+    assert tools_response.status_code == 503
+    assert tools_response.json()["detail"] == "provider_chat_no_qualified_text_route"
+    assert tools_stable.readiness_calls == [
+        (HYPOTHESIS_MODEL_ID, "chat_text"),
+    ]
+    assert tools_stable.scoped_capabilities == []
+    assert tools_stable.dispatched == 0
+
+
+def test_p2r_coherence_tools_require_exact_prompt_schema_and_scoped_qualification(
+    monkeypatch,
+) -> None:
+    prompt = "Locked ResearchStudio coherence JSON prompt."
+    enable_p2r(monkeypatch, prompt)
+
+    def upstream(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["model"] == HYPOTHESIS_MODEL_ID
+        assert body["tools"] == p2r_tool_payload(prompt)["tools"]
+        return httpx.Response(
+            200,
+            json={
+                "model": HYPOTHESIS_MODEL_ID,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_python",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "python",
+                                        "arguments": '{"code":"print(1)"}',
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+            },
+        )
+
+    stable = FakeStable(upstream)
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=p2r_tool_payload(prompt),
+            headers=p2r_headers(COHERENCE_PHASE),
+        )
+
+    assert response.status_code == 200
+    assert stable.capabilities == []
+    assert stable.scoped_capabilities == ["chat_tools"]
+    assert stable.dispatched == 1
+
+
+def test_p2r_tool_contract_mutations_fail_before_provider_dispatch(monkeypatch) -> None:
+    prompt = "Locked ResearchStudio coherence JSON prompt."
+    enable_p2r(monkeypatch, prompt)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    mutations: list[dict[str, Any]] = []
+
+    wrong_prompt = p2r_tool_payload(prompt)
+    wrong_prompt["messages"][0]["content"] += " changed"
+    mutations.append(wrong_prompt)
+
+    wrong_name = p2r_tool_payload(prompt)
+    wrong_name["tools"][0]["function"]["name"] = "bash"
+    mutations.append(wrong_name)
+
+    wrong_schema = p2r_tool_payload(prompt)
+    wrong_schema["tools"][0]["function"]["parameters"]["properties"]["path"] = {
+        "type": "string"
+    }
+    mutations.append(wrong_schema)
+
+    not_strict = p2r_tool_payload(prompt)
+    not_strict["tools"][0]["function"]["strict"] = False
+    mutations.append(not_strict)
+
+    parallel = p2r_tool_payload(prompt)
+    parallel["parallel_tool_calls"] = True
+    mutations.append(parallel)
+
+    required = p2r_tool_payload(prompt)
+    required["tool_choice"] = "required"
+    mutations.append(required)
+
+    streamed = p2r_tool_payload(prompt)
+    streamed["stream"] = True
+    mutations.append(streamed)
+
+    with TestClient(app_for(stable)) as api:
+        for payload in mutations:
+            response = api.post(
+                "/api/ai-research/v1/chat/completions",
+                json=payload,
+                headers=p2r_headers(COHERENCE_PHASE),
+            )
+            assert response.status_code == 422
+
+    assert stable.dispatched == 0
+    assert stable.scoped_capabilities == []
+
+
+def test_p2r_coherence_content_only_response_is_a_hard_failure(monkeypatch) -> None:
+    prompt = "Locked ResearchStudio coherence JSON prompt."
+    enable_p2r(monkeypatch, prompt)
+    stable = FakeStable(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "model": HYPOTHESIS_MODEL_ID,
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": '{"execution":{"mode":"executed"}}',
+                        }
+                    }
+                ],
+            },
+        )
+    )
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=p2r_tool_payload(prompt),
+            headers=p2r_headers(COHERENCE_PHASE),
+        )
+    assert response.status_code == 502
+    assert stable.completed[0]["error_code"] == (
+        "ai_research_bridge_missing_p2r_tool_call"
+    )
+
+
+def test_p2r_completion_requires_explicit_fixed_model_identity(monkeypatch) -> None:
+    enable_hypothesis(monkeypatch)
+    bind_phase_prompt(monkeypatch, TEXT_PHASE, LOCKED_TEXT_PHASE_PROMPT)
+    stable = FakeStable(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": '{"state":"proceed"}',
+                        }
+                    }
+                ]
+            },
+        )
+    )
+
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=p2r_text_payload(),
+            headers=p2r_headers(TEXT_PHASE),
+        )
+
+    assert response.status_code == 502
+    assert stable.dispatched == 1
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["status"] == "failed"
+    assert stable.completed[0]["result_class"] == "hard_failure"
+    assert stable.completed[0]["error_code"] == (
+        "ai_research_bridge_model_identity_required"
+    )
+    assert stable.completed[0]["hard_failure"] is True
+    assert "actual_model" not in stable.completed[0]
+
+
+def test_p2r_coherence_finalize_binds_receipt_and_forbids_tampering(
+    monkeypatch,
+) -> None:
+    prompt = "Locked ResearchStudio coherence JSON prompt."
+    enable_p2r(monkeypatch, prompt)
+
+    def upstream(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["messages"][-1]["role"] == "tool"
+        return httpx.Response(
+            200,
+            json={
+                "model": HYPOTHESIS_MODEL_ID,
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": '{"state":"proceed"}',
+                        }
+                    }
+                ],
+            },
+        )
+
+    stable = FakeStable(upstream)
+    valid = p2r_finalize_payload(prompt)
+    tampered = p2r_finalize_payload(prompt)
+    receipt = json.loads(tampered["messages"][-1]["content"])
+    receipt["stdout"] += "tampered"
+    tampered["messages"][-1]["content"] = canonical_json(receipt)
+    with TestClient(app_for(stable)) as api:
+        accepted = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=valid,
+            headers=p2r_headers(COHERENCE_PHASE),
+        )
+        rejected = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=tampered,
+            headers=p2r_headers(COHERENCE_PHASE),
+        )
+    assert accepted.status_code == 200
+    assert rejected.status_code == 422
+    assert stable.dispatched == 1
+
+
+def test_p2r_artifact_binding_mutations_fail_before_dispatch(monkeypatch) -> None:
+    enable_hypothesis(monkeypatch)
+    bind_phase_prompt(monkeypatch, TEXT_PHASE, LOCKED_TEXT_PHASE_PROMPT)
+    stable = FakeStable(lambda request: httpx.Response(500))
+
+    tampered_hash = p2r_text_payload()
+    envelope = json.loads(tampered_hash["messages"][1]["content"])
+    envelope["artifact"]["sha256"] = "0" * 64
+    tampered_hash["messages"][1]["content"] = canonical_json(envelope)
+
+    wrong_phase = p2r_text_payload()
+    envelope = json.loads(wrong_phase["messages"][1]["content"])
+    envelope["phase"] = "researchstudio.phase0.partition"
+    wrong_phase["messages"][1]["content"] = canonical_json(envelope)
+
+    noncanonical = p2r_text_payload()
+    envelope = json.loads(noncanonical["messages"][1]["content"])
+    noncanonical["messages"][1]["content"] = json.dumps(envelope, ensure_ascii=False)
+
+    with TestClient(app_for(stable)) as api:
+        for payload in (tampered_hash, wrong_phase, noncanonical):
+            response = api.post(
+                "/api/ai-research/v1/chat/completions",
+                json=payload,
+                headers=p2r_headers(TEXT_PHASE),
+            )
+            assert response.status_code == 422
+    assert stable.dispatched == 0
+
+
+def test_p2r_locked_reference_tamper_and_unknown_card_fail_before_dispatch(
+    monkeypatch,
+) -> None:
+    select_phase = "researchstudio.phase2.select"
+    generate_phase = "researchstudio.phase2.generate"
+    select_prompt = "Locked select prompt."
+    generate_prompt = "Locked generate prompt."
+    enable_hypothesis(monkeypatch)
+    bind_phase_prompt(monkeypatch, select_phase, select_prompt)
+    bind_phase_prompt(monkeypatch, generate_phase, generate_prompt)
+    stable = FakeStable(lambda request: httpx.Response(500))
+
+    tampered_static = p2r_text_payload(
+        select_prompt,
+        phase=select_phase,
+        artifacts=[
+            ("phase0/user_query.txt", "Agent evaluation"),
+            ("phase1/phase1_output.json", "{}"),
+            ("references/ideation-patterns/overview.md", "tampered"),
+            ("references/ideation-patterns/companion-combos.md", "tampered"),
+            ("phase0/lit_table.md", "table"),
+            ("phase2_generate/closest_abstracts.json", "[]"),
+            ("references/ideation-sub-patterns/overview.md", "tampered"),
+        ],
+    )
+    unknown_card = p2r_text_payload(
+        generate_prompt,
+        phase=generate_phase,
+        artifacts=[
+            ("phase2_select/phase2_select_output.json", "{}"),
+            ("phase1/phase1_output.json", "{}"),
+            ("phase2_generate/closest_abstracts.json", "[]"),
+            ("phase0/fulltext_cache.json", "{}"),
+            ("references/ideation-sub-patterns/overview.md", "tampered"),
+            ("references/ideation-sub-patterns/C31.md", "invented"),
+        ],
+    )
+
+    with TestClient(app_for(stable)) as api:
+        for phase, payload in (
+            (select_phase, tampered_static),
+            (generate_phase, unknown_card),
+        ):
+            response = api.post(
+                "/api/ai-research/v1/chat/completions",
+                json=payload,
+                headers=p2r_headers(phase),
+            )
+            assert response.status_code == 422
+    assert stable.readiness_calls == []
+    assert stable.scoped_capabilities == []
+    assert stable.dispatched == 0
+
+
+def test_p2r_array_phase_uses_declared_top_level_shape(monkeypatch) -> None:
+    phase = "researchstudio.phase0.partition"
+    prompt = "Partition the papers and return a JSON array."
+    enable_hypothesis(monkeypatch)
+    bind_phase_prompt(monkeypatch, phase, prompt)
+    payload = p2r_text_payload(
+        prompt,
+        phase=phase,
+        response_shape="array",
+        artifacts=[
+            ("phase0/user_query.txt", "Agent evaluation"),
+            ("phase0/lit_results.json", "[]"),
+        ],
+    )
+    assert "response_format" not in payload
+
+    accepted_stable = FakeStable(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "model": HYPOTHESIS_MODEL_ID,
+                "choices": [{"message": {"role": "assistant", "content": "[]"}}],
+            },
+        )
+    )
+    with TestClient(app_for(accepted_stable)) as api:
+        accepted = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=payload,
+            headers=p2r_headers(phase),
+        )
+    assert accepted.status_code == 200
+
+    wrong_shape_stable = FakeStable(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "model": HYPOTHESIS_MODEL_ID,
+                "choices": [
+                    {"message": {"role": "assistant", "content": "{}"}}
+                ],
+            },
+        )
+    )
+    with TestClient(app_for(wrong_shape_stable)) as api:
+        rejected = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=payload,
+            headers=p2r_headers(phase),
+        )
+    assert rejected.status_code == 502
+    assert wrong_shape_stable.completed[0]["error_code"] == (
+        "ai_research_bridge_invalid_p2r_shape"
+    )
+
+
+def test_p2r_text_phase_requires_exact_locked_prompt_before_dispatch(monkeypatch) -> None:
+    enable_hypothesis(monkeypatch)
+    bind_phase_prompt(monkeypatch, TEXT_PHASE, LOCKED_TEXT_PHASE_PROMPT)
+    stable = FakeStable(lambda request: httpx.Response(500))
+
+    mutations: list[dict[str, Any]] = []
+    wrong_prompt = p2r_text_payload()
+    wrong_prompt["messages"][0]["content"] = LOCKED_TEXT_PHASE_PROMPT + " changed"
+    mutations.append(wrong_prompt)
+
+    extra_system = p2r_text_payload()
+    extra_system["messages"].insert(
+        1, {"role": "system", "content": LOCKED_TEXT_PHASE_PROMPT}
+    )
+    mutations.append(extra_system)
+
+    no_structured_output = p2r_text_payload()
+    no_structured_output.pop("response_format")
+    mutations.append(no_structured_output)
+
+    streamed = p2r_text_payload()
+    streamed["stream"] = True
+    mutations.append(streamed)
+
+    caller_sampling = p2r_text_payload()
+    caller_sampling["temperature"] = 0.7
+    mutations.append(caller_sampling)
+
+    arbitrary_text = p2r_text_payload()
+    arbitrary_text["messages"][1]["content"] = "Return an unrelated workload"
+    mutations.append(arbitrary_text)
+
+    with TestClient(app_for(stable)) as api:
+        for payload in mutations:
+            response = api.post(
+                "/api/ai-research/v1/chat/completions",
+                json=payload,
+                headers=p2r_headers(TEXT_PHASE),
+            )
+            assert response.status_code == 422
+
+        missing_header = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=p2r_text_payload(),
+            headers={"Authorization": f"Bearer {P2R_TOKEN}"},
+        )
+        assert missing_header.status_code == 401
+
+    assert stable.dispatched == 0
+    assert stable.scoped_capabilities == []
+
+
+def test_duplicate_hypothesis_model_configuration_fails_closed(monkeypatch) -> None:
+    enable(monkeypatch)
+    monkeypatch.setenv("AI_RESEARCH_HYPOTHESIS_MODEL_ID", MODEL_ID)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    with TestClient(app_for(stable)) as api:
+        assert api.get("/api/ai-research/v1/models", headers=headers()).status_code == 503
+        assert api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=valid_payload(),
+            headers=headers(),
+        ).status_code == 503
+    assert stable.readiness_calls == []
+    assert stable.dispatched == 0
+
+
+def test_unqualified_hypothesis_model_does_not_break_literature_discovery(
+    monkeypatch,
+) -> None:
+    enable_hypothesis(monkeypatch)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    stable.readiness_overrides[(HYPOTHESIS_MODEL_ID, "chat_text")] = (
+        False,
+        "provider_chat_no_qualified_route",
+    )
+    with TestClient(app_for(stable)) as api:
+        response = api.get("/api/ai-research/v1/models", headers=headers())
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["data"]] == [MODEL_ID]
+    assert stable.readiness_calls == [
+        (MODEL_ID, "chat_tools"),
+        (HYPOTHESIS_MODEL_ID, "chat_text"),
+        (HYPOTHESIS_MODEL_ID, "chat_tools"),
+    ]
+
+
+def test_unqualified_literature_model_does_not_break_hypothesis_discovery(
+    monkeypatch,
+) -> None:
+    enable_hypothesis(monkeypatch)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    stable.readiness_overrides[(MODEL_ID, "chat_tools")] = (
+        False,
+        "provider_chat_no_qualified_route",
+    )
+    with TestClient(app_for(stable)) as api:
+        response = api.get("/api/ai-research/v1/models", headers=headers())
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["data"]] == [
+        HYPOTHESIS_MODEL_ID
+    ]
+    assert stable.readiness_calls == [
+        (MODEL_ID, "chat_tools"),
+        (HYPOTHESIS_MODEL_ID, "chat_text"),
+        (HYPOTHESIS_MODEL_ID, "chat_tools"),
+    ]
+
+
 def test_rejects_wrong_model_multimodal_and_unknown_fields(monkeypatch) -> None:
     enable(monkeypatch)
     stable = FakeStable(lambda request: httpx.Response(500))
@@ -214,10 +1341,7 @@ def test_rejects_wrong_model_multimodal_and_unknown_fields(monkeypatch) -> None:
         assert api.post(
             "/api/ai-research/v1/chat/completions", json=wrong, headers=headers()
         ).status_code == 422
-        for field, value in (
-            ("response_format", {"type": "json_object"}),
-            ("user", "caller-selected-user"),
-        ):
+        for field, value in (("user", "caller-selected-user"),):
             invalid = valid_payload()
             invalid[field] = value
             assert api.post(
@@ -234,6 +1358,96 @@ def test_rejects_wrong_model_multimodal_and_unknown_fields(monkeypatch) -> None:
             json=multimodal,
             headers=headers(),
         ).status_code == 422
+    assert stable.dispatched == 0
+
+
+def test_json_object_response_format_is_bounded_and_preserved(monkeypatch) -> None:
+    enable_hypothesis(monkeypatch)
+
+    def upstream(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["model"] == HYPOTHESIS_MODEL_ID
+        assert body["response_format"] == {"type": "json_object"}
+        return httpx.Response(
+            200,
+            json={
+                "model": HYPOTHESIS_MODEL_ID,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": '{"ok":true}'},
+                    }
+                ],
+            },
+        )
+
+    stable = FakeStable(upstream)
+    accepted = ordinary_hypothesis_payload()
+    missing_instruction = ordinary_hypothesis_payload()
+    missing_instruction["messages"][0]["content"] = "No structured output instruction."
+    with TestClient(app_for(stable)) as api:
+        assert api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=accepted,
+            headers=headers(),
+        ).status_code == 200
+        for invalid_format in (
+            {"type": "json_schema"},
+            {"type": "json_object", "schema": {}},
+            {"type": "text"},
+        ):
+            invalid = ordinary_hypothesis_payload()
+            invalid["response_format"] = invalid_format
+            assert api.post(
+                "/api/ai-research/v1/chat/completions",
+                json=invalid,
+                headers=headers(),
+            ).status_code == 422
+        assert api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=missing_instruction,
+            headers=headers(),
+        ).status_code == 422
+    assert stable.dispatched == 1
+    assert stable.capabilities == []
+    assert stable.scoped_capabilities == ["chat_text"]
+    assert stable.scoped_requirements == [("chat_text",)]
+
+
+def test_literature_model_rejects_response_format_before_dispatch(monkeypatch) -> None:
+    enable_hypothesis(monkeypatch)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    payload = valid_payload()
+    payload["messages"][0]["content"] += " Return a JSON object."
+    payload["response_format"] = {"type": "json_object"}
+
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=payload,
+            headers=headers(),
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == (
+        "response_format is only enabled for the hypothesis model"
+    )
+    assert stable.dispatched == 0
+    assert stable.capabilities == []
+    assert stable.scoped_capabilities == []
+
+
+def test_literature_model_rejects_p2r_phase_header_before_dispatch(monkeypatch) -> None:
+    enable(monkeypatch)
+    monkeypatch.setenv("AI_RESEARCH_P2R_S2S_TOKEN", P2R_TOKEN)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=valid_payload(),
+            headers=p2r_headers(TEXT_PHASE),
+        )
+    assert response.status_code == 422
     assert stable.dispatched == 0
 
 
@@ -456,6 +1670,7 @@ def test_non_streaming_request_uses_fixed_control_and_records_usage(monkeypatch)
             "stop",
             "stream",
             "stream_options",
+            "response_format",
         }
         return httpx.Response(
             200,
@@ -487,6 +1702,139 @@ def test_non_streaming_request_uses_fixed_control_and_records_usage(monkeypatch)
     assert stable.dispatched == 1
     assert stable.completed[0]["status"] == "succeeded"
     assert stable.completed[0]["total_tokens"] == 13
+
+
+def test_non_streaming_send_cancellation_closes_and_terminalizes() -> None:
+    stable = FakeStable(lambda request: httpx.Response(500))
+
+    async def cancel_send(
+        client: httpx.AsyncClient, request: httpx.Request
+    ) -> httpx.Response:
+        stable.transport.last_client = client
+        raise asyncio.CancelledError
+
+    stable.transport.send_authorized_stream = cancel_send
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(call_direct(stable))
+
+    assert stable.dispatched == 1
+    assert stable.transport.last_client is not None
+    assert stable.transport.last_client.is_closed
+    assert stable.completed == [
+        {
+            "status": "cancelled",
+            "result_class": "client_cancelled",
+            "error_code": "provider_chat_client_cancelled",
+            "client_cancelled": True,
+            "e2e_ms": stable.completed[0]["e2e_ms"],
+        }
+    ]
+
+
+def test_non_streaming_2xx_read_cancellation_closes_and_terminalizes() -> None:
+    stream = CancelOnReadStream()
+    stable = FakeStable(lambda request: httpx.Response(200, stream=stream))
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(call_direct(stable))
+
+    assert stable.dispatched == 1
+    assert stream.close_calls >= 1
+    assert stable.transport.last_client is not None
+    assert stable.transport.last_client.is_closed
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["status"] == "cancelled"
+    assert stable.completed[0]["result_class"] == "client_cancelled"
+    assert stable.completed[0]["error_code"] == "provider_chat_client_cancelled"
+    assert stable.completed[0]["client_cancelled"] is True
+
+
+def test_non_streaming_401_drain_cancellation_preserves_hard_failure() -> None:
+    stream = CancelOnReadStream()
+    stable = HardFailureStable(lambda request: httpx.Response(401, stream=stream))
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(call_direct(stable))
+
+    assert stable.dispatched == 1
+    assert stream.close_calls >= 1
+    assert stable.transport.last_client is not None
+    assert stable.transport.last_client.is_closed
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["status"] == "failed"
+    assert stable.completed[0]["result_class"] == "hard_failure"
+    assert stable.completed[0]["error_code"] == "provider_chat_http_401"
+    assert stable.completed[0]["hard_failure"] is True
+    assert "client_cancelled" not in stable.completed[0]
+
+
+@pytest.mark.parametrize(
+    "stream",
+    [
+        UnexpectedReadStream(),
+        UnexpectedCloseStream(
+            json.dumps(
+                {
+                    "model": MODEL_ID,
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "Review",
+                            }
+                        }
+                    ],
+                }
+            ).encode("utf-8")
+        ),
+    ],
+)
+def test_non_streaming_unexpected_read_or_close_failure_terminalizes_once(
+    monkeypatch, stream: httpx.AsyncByteStream
+) -> None:
+    enable(monkeypatch)
+    stable = FakeStable(lambda request: httpx.Response(200, stream=stream))
+
+    with TestClient(app_for(stable), raise_server_exceptions=False) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=valid_payload(),
+            headers=headers(),
+        )
+
+    assert response.status_code == 503
+    assert stable.dispatched == 1
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["status"] == "failed"
+    assert stable.completed[0]["result_class"] == "transient_failure"
+    assert stable.completed[0]["error_code"] == (
+        "ai_research_bridge_response_read_failed"
+    )
+    assert stable.transport.last_client is not None
+    assert stable.transport.last_client.is_closed
+
+
+def test_non_streaming_http_hard_failure_wins_over_unexpected_close_failure(
+    monkeypatch,
+) -> None:
+    enable(monkeypatch)
+    stream = UnexpectedCloseStream(b'{"error":"denied"}')
+    stable = HardFailureStable(lambda request: httpx.Response(401, stream=stream))
+
+    with TestClient(app_for(stable), raise_server_exceptions=False) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=valid_payload(),
+            headers=headers(),
+        )
+
+    assert response.status_code == 502
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["status"] == "failed"
+    assert stable.completed[0]["result_class"] == "hard_failure"
+    assert stable.completed[0]["error_code"] == "provider_chat_http_401"
+    assert stable.completed[0]["hard_failure"] is True
 
 
 def test_non_streaming_response_with_other_model_fails_closed(monkeypatch) -> None:
@@ -566,6 +1914,105 @@ def test_rejects_total_text_over_bridge_limit_before_dispatch(monkeypatch) -> No
     assert stable.dispatched == 0
 
 
+def test_ordinary_hypothesis_accepts_total_text_over_literature_limit(
+    monkeypatch,
+) -> None:
+    enable_hypothesis(monkeypatch)
+    stable = FakeStable(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "model": HYPOTHESIS_MODEL_ID,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": '{"hypothesis":"bounded"}',
+                        },
+                    }
+                ],
+            },
+        )
+    )
+    payload = ordinary_hypothesis_payload()
+    payload["messages"] = [
+        {"role": "system", "content": "Return a JSON object."},
+        {"role": "user", "content": "a" * 70_000},
+        {"role": "user", "content": "b" * 70_000},
+    ]
+
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=payload,
+            headers=headers(),
+        )
+
+    assert response.status_code == 200
+    assert stable.readiness_calls == [(HYPOTHESIS_MODEL_ID, "chat_text")]
+    assert stable.scoped_capabilities == ["chat_text"]
+    assert stable.scoped_requirements == [("chat_text",)]
+    assert stable.dispatched == 1
+
+
+def test_hypothesis_model_accepts_bounded_canonical_chunked_artifact_context(
+    monkeypatch,
+) -> None:
+    enable_hypothesis(monkeypatch)
+    bind_phase_prompt(monkeypatch, TEXT_PHASE, LOCKED_TEXT_PHASE_PROMPT)
+    stable = FakeStable(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "model": HYPOTHESIS_MODEL_ID,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": '{"ok":true}'},
+                    }
+                ],
+            },
+        )
+    )
+    payload = p2r_text_payload(
+        artifacts=[("phase0/user_query.txt", "研究" + "x" * 220_000)]
+    )
+    assert len(payload["messages"]) == 4
+
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=payload,
+            headers=p2r_headers(TEXT_PHASE),
+        )
+
+    assert response.status_code == 200
+    assert stable.dispatched == 1
+    assert stable.scoped_capabilities == ["chat_text"]
+
+
+def test_hypothesis_model_rejects_context_over_scoped_limit(monkeypatch) -> None:
+    enable_hypothesis(monkeypatch)
+    stable = FakeStable(lambda request: httpx.Response(500))
+    payload = valid_payload()
+    payload["model"] = HYPOTHESIS_MODEL_ID
+    payload["messages"] = [
+        {"role": "user", "content": "x" * 110_000}
+        for _ in range(5)
+    ]
+
+    with TestClient(app_for(stable)) as api:
+        response = api.post(
+            "/api/ai-research/v1/chat/completions",
+            json=payload,
+            headers=headers(),
+        )
+
+    assert response.status_code == 422
+    assert stable.dispatched == 0
+
+
 def test_accepts_single_ldr_synthesis_message_over_legacy_limit(monkeypatch) -> None:
     enable(monkeypatch)
     stable = FakeStable(
@@ -619,6 +2066,344 @@ def test_streaming_request_preserves_sse_and_records_terminal(monkeypatch) -> No
     assert response.headers["x-modelmirror-route-run-id"] == "chatrun_test"
     assert stable.completed[0]["status"] == "succeeded"
     assert stable.completed[0]["total_tokens"] == 13
+
+
+def test_streaming_buffers_until_identity_then_allows_omitted_model() -> None:
+    stable = FakeStable(lambda request: httpx.Response(500))
+    before_identity = (
+        'data: {"choices":[{"delta":{"content":"held"},"finish_reason":null}]}\n\n'
+    )
+    identity = (
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{"content":"bound"}},"finish_reason":null}}]}}\n\n'
+    )
+    after_identity = (
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+    )
+    done = "data: [DONE]\n\n"
+    stream = ChunkedStream(
+        before_identity.encode("utf-8"),
+        identity.encode("utf-8"),
+        after_identity.encode("utf-8"),
+        done.encode("utf-8"),
+    )
+
+    async def exercise() -> list[str]:
+        _client, body = direct_stream(stable, stream)
+        return [chunk async for chunk in body]
+
+    yielded = asyncio.run(exercise())
+    assert yielded[0] == before_identity + identity
+    assert "".join(yielded) == before_identity + identity + after_identity + done
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["status"] == "succeeded"
+    assert stable.completed[0]["actual_model"] == MODEL_ID
+
+
+@pytest.mark.parametrize(
+    ("event", "expected_code"),
+    [
+        (
+            'data: {"model":"provider/unexpected-model","choices":[{"delta":{"content":"wrong"},"finish_reason":"stop"}]}\n\n',
+            "ai_research_bridge_model_mismatch",
+        ),
+        (
+            'data: {"choices":[{"delta":{"content":"unattributed"},"finish_reason":"stop"}]}\n\n',
+            "ai_research_bridge_model_identity_required",
+        ),
+    ],
+)
+def test_streaming_identity_failure_releases_no_payload(
+    event: str, expected_code: str
+) -> None:
+    stable = FakeStable(lambda request: httpx.Response(500))
+    stream = ChunkedStream(event.encode("utf-8"), b"data: [DONE]\n\n")
+    yielded: list[str] = []
+
+    async def exercise() -> httpx.AsyncClient:
+        client, body = direct_stream(stable, stream)
+        with pytest.raises(RuntimeError, match=expected_code):
+            async for chunk in body:
+                yielded.append(chunk)
+        return client
+
+    client = asyncio.run(exercise())
+    assert yielded == []
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["status"] == "failed"
+    assert stable.completed[0]["result_class"] == "hard_failure"
+    assert stable.completed[0]["error_code"] == expected_code
+    assert client.is_closed
+    assert stream.close_calls >= 1
+
+
+def test_streaming_late_model_mismatch_does_not_release_mismatched_event() -> None:
+    stable = FakeStable(lambda request: httpx.Response(500))
+    accepted = (
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{"content":"safe"}},"finish_reason":null}}]}}\n\n'
+    )
+    rejected = (
+        'data: {"model":"provider/unexpected-model","choices":[{"delta":{"content":"wrong"},"finish_reason":"stop"}]}\n\n'
+    )
+    stream = ChunkedStream(accepted.encode("utf-8"), rejected.encode("utf-8"))
+    yielded: list[str] = []
+
+    async def exercise() -> None:
+        _client, body = direct_stream(stable, stream)
+        with pytest.raises(RuntimeError, match="ai_research_bridge_model_mismatch"):
+            async for chunk in body:
+                yielded.append(chunk)
+
+    asyncio.run(exercise())
+    assert yielded == [accepted]
+    assert "wrong" not in "".join(yielded)
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["error_code"] == "ai_research_bridge_model_mismatch"
+
+
+@pytest.mark.parametrize(
+    "bad_event",
+    [
+        "data: provider-secret\n\n",
+        'data: {"error":{"message":"provider-secret","type":"upstream"}}\n\n',
+    ],
+)
+@pytest.mark.parametrize("identity_first", [False, True])
+def test_streaming_invalid_event_is_rejected_before_release(
+    bad_event: str, identity_first: bool
+) -> None:
+    stable = FakeStable(lambda request: httpx.Response(500))
+    accepted = (
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{"content":"safe"}},"finish_reason":null}}]}}\n\n'
+    )
+    chunks = (
+        (accepted.encode("utf-8"), bad_event.encode("utf-8"))
+        if identity_first
+        else (bad_event.encode("utf-8"), accepted.encode("utf-8"))
+    )
+    stream = ChunkedStream(*chunks)
+    yielded: list[str] = []
+
+    async def exercise() -> None:
+        _client, body = direct_stream(stable, stream)
+        with pytest.raises(RuntimeError, match="provider_chat_invalid_sse"):
+            async for chunk in body:
+                yielded.append(chunk)
+
+    asyncio.run(exercise())
+    assert yielded == ([accepted] if identity_first else [])
+    assert "provider-secret" not in "".join(yielded)
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["status"] == "failed"
+    assert stable.completed[0]["result_class"] == "hard_failure"
+    assert stable.completed[0]["error_code"] == "provider_chat_invalid_sse"
+
+
+@pytest.mark.parametrize("invalid_model", [None, 7, ""])
+def test_streaming_explicit_invalid_model_before_binding_releases_no_payload(
+    invalid_model: object,
+) -> None:
+    stable = FakeStable(lambda request: httpx.Response(500))
+    invalid = (
+        "data: "
+        + json.dumps(
+            {
+                "model": invalid_model,
+                "choices": [
+                    {"delta": {"content": "unattributed"}, "finish_reason": None}
+                ],
+            }
+        )
+        + "\n\n"
+    )
+    identity = (
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{"content":"bound"}},"finish_reason":"stop"}}]}}\n\n'
+    )
+    stream = ChunkedStream(invalid.encode("utf-8"), identity.encode("utf-8"))
+    yielded: list[str] = []
+
+    async def exercise() -> None:
+        _client, body = direct_stream(stable, stream)
+        with pytest.raises(
+            RuntimeError,
+            match="ai_research_bridge_model_identity_invalid",
+        ):
+            async for chunk in body:
+                yielded.append(chunk)
+
+    asyncio.run(exercise())
+    assert yielded == []
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["result_class"] == "hard_failure"
+    assert stable.completed[0]["error_code"] == (
+        "ai_research_bridge_model_identity_invalid"
+    )
+
+
+@pytest.mark.parametrize("invalid_model", [None, 7, ""])
+def test_streaming_explicit_invalid_model_after_binding_is_not_released(
+    invalid_model: object,
+) -> None:
+    stable = FakeStable(lambda request: httpx.Response(500))
+    accepted = (
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{"content":"safe"}},"finish_reason":null}}]}}\n\n'
+    )
+    invalid = (
+        "data: "
+        + json.dumps(
+            {
+                "model": invalid_model,
+                "choices": [
+                    {"delta": {"content": "unattributed"}, "finish_reason": "stop"}
+                ],
+            }
+        )
+        + "\n\n"
+    )
+    stream = ChunkedStream(accepted.encode("utf-8"), invalid.encode("utf-8"))
+    yielded: list[str] = []
+
+    async def exercise() -> None:
+        _client, body = direct_stream(stable, stream)
+        with pytest.raises(
+            RuntimeError,
+            match="ai_research_bridge_model_identity_invalid",
+        ):
+            async for chunk in body:
+                yielded.append(chunk)
+
+    asyncio.run(exercise())
+    assert yielded == [accepted]
+    assert "unattributed" not in "".join(yielded)
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["result_class"] == "hard_failure"
+    assert stable.completed[0]["error_code"] == (
+        "ai_research_bridge_model_identity_invalid"
+    )
+
+
+def test_streaming_identity_buffer_is_bounded_before_any_payload_release() -> None:
+    stable = FakeStable(lambda request: httpx.Response(500))
+    stream = ChunkedStream(
+        b"data: " + b"x" * (bridge.MAX_STREAM_IDENTITY_BUFFER_BYTES + 1)
+    )
+    yielded: list[str] = []
+
+    async def exercise() -> None:
+        _client, body = direct_stream(stable, stream)
+        with pytest.raises(
+            RuntimeError,
+            match="ai_research_bridge_stream_identity_buffer_exceeded",
+        ):
+            async for chunk in body:
+                yielded.append(chunk)
+
+    asyncio.run(exercise())
+    assert yielded == []
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["result_class"] == "hard_failure"
+
+
+def test_streaming_final_failed_pending_event_is_not_released() -> None:
+    stable = FakeStable(lambda request: httpx.Response(500))
+    accepted = (
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{"content":"safe"}},"finish_reason":null}}]}}\n\n'
+    )
+    invalid_pending = 'data: {"choices":['
+    stream = ChunkedStream(
+        accepted.encode("utf-8"), invalid_pending.encode("utf-8")
+    )
+    yielded: list[str] = []
+
+    async def exercise() -> None:
+        _client, body = direct_stream(stable, stream)
+        with pytest.raises(RuntimeError, match="provider_chat_invalid_sse"):
+            async for chunk in body:
+                yielded.append(chunk)
+
+    asyncio.run(exercise())
+    assert yielded == [accepted]
+    assert invalid_pending not in "".join(yielded)
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["status"] == "failed"
+    assert stable.completed[0]["error_code"] == "provider_chat_invalid_sse"
+
+
+def test_streaming_aclose_terminalizes_client_cancelled_exactly_once() -> None:
+    stable = FakeStable(lambda request: httpx.Response(500))
+    event = (
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{"content":"Review"}},"finish_reason":null}}]}}\n\n'
+    )
+    stream = ChunkedStream(event.encode("utf-8"), b"data: [DONE]\n\n")
+
+    async def exercise() -> httpx.AsyncClient:
+        client, body = direct_stream(stable, stream)
+        assert await anext(body) == event
+        await body.aclose()
+        await body.aclose()
+        return client
+
+    client = asyncio.run(exercise())
+    assert stable.completed == [
+        {
+            "status": "cancelled",
+            "result_class": "client_cancelled",
+            "error_code": "provider_chat_client_cancelled",
+            "client_cancelled": True,
+            "e2e_ms": stable.completed[0]["e2e_ms"],
+        }
+    ]
+    assert client.is_closed
+    assert stream.close_calls >= 1
+
+
+def test_streaming_aclose_close_failure_still_closes_client_once() -> None:
+    stable = FakeStable(lambda request: httpx.Response(500))
+    event = (
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{"content":"Review"}},"finish_reason":null}}]}}\n\n'
+    )
+    stream = UnexpectedCloseStream(event.encode("utf-8"), b"data: [DONE]\n\n")
+
+    async def exercise() -> httpx.AsyncClient:
+        client, body = direct_stream(stable, stream)
+        assert await anext(body) == event
+        with pytest.raises(RuntimeError, match="unexpected response close failure"):
+            await body.aclose()
+        return client
+
+    client = asyncio.run(exercise())
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["status"] == "cancelled"
+    assert stable.completed[0]["result_class"] == "client_cancelled"
+    assert client.is_closed
+    assert stream.close_calls >= 1
+
+
+def test_streaming_natural_close_failure_propagates_without_reterminalizing() -> None:
+    stable = FakeStable(lambda request: httpx.Response(500))
+    event = (
+        f'data: {{"model":"{MODEL_ID}","choices":[{{"delta":{{"content":"Review"}},"finish_reason":"stop"}}]}}\n\n'
+    )
+    done = "data: [DONE]\n\n"
+    stream = UnexpectedCloseStream(
+        event.encode("utf-8"), done.encode("utf-8")
+    )
+    yielded: list[str] = []
+
+    async def exercise() -> httpx.AsyncClient:
+        client, body = direct_stream(stable, stream)
+        with pytest.raises(RuntimeError, match="unexpected response close failure"):
+            async for chunk in body:
+                yielded.append(chunk)
+        return client
+
+    client = asyncio.run(exercise())
+    assert yielded == [event, done]
+    assert len(stable.completed) == 1
+    assert stable.completed[0]["status"] == "failed"
+    assert stable.completed[0]["result_class"] == "transient_failure"
+    assert stable.completed[0]["error_code"] == "ai_research_bridge_stream_failed"
+    assert client.is_closed
+    assert stream.close_calls >= 1
 
 
 def test_upstream_failure_is_sanitized_and_finalized(monkeypatch) -> None:

--- a/server/tests/test_provider_chat_stable_service.py
+++ b/server/tests/test_provider_chat_stable_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
+import threading
 from pathlib import Path
 
 import pytest
@@ -21,6 +22,7 @@ from server.model_router.service import ModelRouterService, RouterServiceError
 
 
 MODEL_ID = "provider/model"
+SCOPED_MODEL_ID = "provider/scoped-model"
 
 
 def _qualified_connection(
@@ -68,25 +70,34 @@ def _qualified_connection(
         catalog_fingerprint=f"catalog-{connection.id}",
         observed_at="2026-08-21T00:00:00+00:00",
     )
-    certification, created = repository.claim_chat_certification(
-        "local",
-        certification_id=f"cert-{connection.id}",
-        connection_id=connection.id,
-        connection_fingerprint=fingerprint,
-        contract_version="modelmirror-provider-chat-v1",
-        capability="chat_text",
-        requested_model=MODEL_ID,
-        idempotency_key_hash=hashlib.sha256(connection.id.encode()).hexdigest(),
-    )
-    assert created is True
-    repository.complete_chat_certification(
-        "local",
-        str(certification["id"]),
-        status="passed",
-        checks={"capability_verified": True},
-        warning_codes=[],
-        actual_model=MODEL_ID,
-    )
+    for capability in ("chat_text", "chat_tools"):
+        suffix = "" if capability == "chat_text" else f"-{capability}"
+        idempotency_seed = (
+            connection.id
+            if capability == "chat_text"
+            else f"{connection.id}:{capability}"
+        )
+        certification, created = repository.claim_chat_certification(
+            "local",
+            certification_id=f"cert-{connection.id}{suffix}",
+            connection_id=connection.id,
+            connection_fingerprint=fingerprint,
+            contract_version="modelmirror-provider-chat-v1",
+            capability=capability,
+            requested_model=MODEL_ID,
+            idempotency_key_hash=hashlib.sha256(
+                idempotency_seed.encode()
+            ).hexdigest(),
+        )
+        assert created is True
+        repository.complete_chat_certification(
+            "local",
+            str(certification["id"]),
+            status="passed",
+            checks={"capability_verified": True},
+            warning_codes=[],
+            actual_model=MODEL_ID,
+        )
     return connection.id
 
 
@@ -119,11 +130,75 @@ def _service(
                 ProviderChatControlRouteUpdate(
                     capability="chat_text",
                     connection_ids=[newapi_id, backup_id],
-                )
+                ),
+                ProviderChatControlRouteUpdate(
+                    capability="chat_tools",
+                    connection_ids=[newapi_id, backup_id],
+                ),
             ],
         )
     )
     return ProviderChatStableService(service), repository, newapi_id, backup_id
+
+
+def _qualify_scoped_model(
+    repository: SQLiteRouterRepository,
+    connection_id: str,
+    *,
+    revision: str = "",
+) -> None:
+    suffix = f"-{revision}" if revision else ""
+    fingerprint = repository.connection_config_fingerprint("local", connection_id)
+    refresh_id = f"refresh-scoped-{connection_id}{suffix}"
+    repository.claim_catalog_refresh(
+        "local",
+        refresh_id=refresh_id,
+        connection_id=connection_id,
+        connection_fingerprint=fingerprint,
+    )
+    repository.complete_catalog_refresh(
+        "local",
+        refresh_id,
+        connection_id=connection_id,
+        models=[
+            {
+                "model_id": model_id,
+                "normalized_model_id": model_id,
+                "capability_state": "declared",
+            }
+            for model_id in (MODEL_ID, SCOPED_MODEL_ID)
+        ],
+        offerings=[],
+        model_count=2,
+        truncated=False,
+        catalog_fingerprint=f"catalog-scoped-{connection_id}{suffix}",
+        observed_at="2026-08-21T00:01:00+00:00",
+    )
+    for capability in ("chat_text", "chat_tools"):
+        capability_suffix = "" if capability == "chat_text" else f"-{capability}"
+        certification, created = repository.claim_chat_certification(
+            "local",
+            certification_id=(
+                f"cert-scoped-{connection_id}{capability_suffix}{suffix}"
+            ),
+            connection_id=connection_id,
+            connection_fingerprint=fingerprint,
+            contract_version="modelmirror-provider-chat-v1",
+            capability=capability,
+            requested_model=SCOPED_MODEL_ID,
+            idempotency_key_hash=hashlib.sha256(
+                f"scoped-{connection_id}:{capability}:{revision}".encode()
+            ).hexdigest(),
+        )
+        assert created is True
+        repository.complete_chat_certification(
+            "local",
+            str(certification["id"]),
+            status="passed",
+            checks={"capability_verified": True},
+            warning_codes=[],
+            actual_model=SCOPED_MODEL_ID,
+        )
 
 
 def _activate_required_for_test(repository: SQLiteRouterRepository) -> None:
@@ -241,6 +316,16 @@ async def test_preferred_selects_backup_only_after_primary_preflight_failure(
         "provider_address_blocked",
         "provider_chat_preflight_backup_selected",
     )
+    assert [
+        (
+            binding.capability,
+            binding.connection_id,
+            binding.certification_id,
+        )
+        for binding in result.dispatch.required_certifications
+    ] == [
+        ("chat_text", backup_id, result.dispatch.certification_id),
+    ]
     receipts = repository.list_chat_control_receipts("local")
     assert len(receipts["runs"]) == 1
     attempts = receipts["attempts"]
@@ -249,6 +334,276 @@ async def test_preferred_selects_backup_only_after_primary_preflight_failure(
         (backup_id, 0),
     ]
     assert attempts[0]["error_code"] == "provider_address_blocked"
+
+
+@pytest.mark.asyncio
+async def test_scoped_certified_model_uses_current_certificate_without_stable_membership(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+
+    assert service.readiness(SCOPED_MODEL_ID, "chat_text") == (
+        False,
+        "provider_chat_no_qualified_route",
+    )
+    assert service.readiness_scoped_certified(SCOPED_MODEL_ID, "chat_text") == (
+        True,
+        None,
+    )
+
+    result = await service.begin_scoped_certified(SCOPED_MODEL_ID, "chat_text")
+
+    assert result.intercepted is True
+    assert result.dispatch is not None
+    assert result.dispatch.target.connection_id == backup_id
+    assert result.dispatch.certification_id == f"cert-scoped-{backup_id}"
+    receipts = repository.list_chat_control_receipts("local")
+    assert receipts["runs"][0]["gateway"] == "ai_research_scoped"
+
+
+@pytest.mark.asyncio
+async def test_scoped_certification_requires_exact_actual_model_at_readiness_and_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+
+    with sqlite3.connect(repository.database_path) as database:
+        database.execute(
+            """
+            UPDATE provider_chat_certifications
+            SET actual_model = NULL
+            WHERE tenant_id = 'local' AND requested_model = ?
+            """,
+            (SCOPED_MODEL_ID,),
+        )
+        database.commit()
+
+    assert service.readiness_scoped_certified(SCOPED_MODEL_ID, "chat_text") == (
+        False,
+        "provider_chat_certification_model_identity_required",
+    )
+
+    with sqlite3.connect(repository.database_path) as database:
+        database.execute(
+            """
+            UPDATE provider_chat_certifications
+            SET actual_model = ?
+            WHERE tenant_id = 'local' AND requested_model = ?
+            """,
+            (SCOPED_MODEL_ID, SCOPED_MODEL_ID),
+        )
+        database.commit()
+
+    result = await service.begin_scoped_certified(SCOPED_MODEL_ID, "chat_text")
+    assert result.dispatch is not None
+    with sqlite3.connect(repository.database_path) as database:
+        database.execute(
+            """
+            UPDATE provider_chat_certifications
+            SET actual_model = NULL
+            WHERE tenant_id = 'local' AND id = ?
+            """,
+            (result.dispatch.certification_id,),
+        )
+        database.commit()
+
+    monkeypatch.setattr(service, "ensure_dispatch_current", lambda _dispatch: None)
+    with pytest.raises(RouterServiceError) as exc_info:
+        service.mark_dispatched(result.dispatch)
+
+    assert exc_info.value.code == "provider_chat_policy_or_qualification_changed"
+    selected = next(
+        item
+        for item in repository.list_chat_control_receipts("local")["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )
+    assert selected["dispatched"] == 0
+    assert selected["status"] == "failed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "connection_update",
+    [
+        pytest.param(
+            {"base_url": "https://changed.example/v1"},
+            id="base-url",
+        ),
+        pytest.param({"api_key": "rotated-secret"}, id="credential"),
+        pytest.param({"scopes": ["embedding"]}, id="scopes"),
+    ],
+)
+async def test_scoped_dispatch_rechecks_connection_fingerprint_before_post(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    connection_update: dict[str, object],
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    result = await service.begin_scoped_certified(SCOPED_MODEL_ID, "chat_text")
+    assert result.dispatch is not None
+    repository.update_connection(
+        "local",
+        backup_id,
+        RouterConnectionUpdate(**connection_update),
+    )
+
+    with pytest.raises(RouterServiceError) as exc_info:
+        service.mark_dispatched(result.dispatch)
+
+    assert exc_info.value.code == "provider_chat_policy_or_qualification_changed"
+    selected = next(
+        item
+        for item in repository.list_chat_control_receipts("local")["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )
+    assert selected["dispatched"] == 0
+    assert selected["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_scoped_dispatch_binds_one_connection_snapshot_before_post(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    original_snapshot = repository.get_connection_credential_snapshot
+    rotated = False
+
+    def snapshot_with_interleaved_rotation(
+        tenant_id: str, connection_id: str
+    ) -> tuple[object, str, str]:
+        nonlocal rotated
+        snapshot = original_snapshot(tenant_id, connection_id)
+        if connection_id == backup_id and not rotated:
+            rotated = True
+            repository.update_connection(
+                tenant_id,
+                connection_id,
+                RouterConnectionUpdate(
+                    base_url="https://rotated.example/v1",
+                    api_key="rotated-secret",
+                ),
+            )
+            repository.save_test_result(
+                tenant_id,
+                connection_id,
+                health="online",
+                model_count=2,
+                checked_at="2026-08-21T00:02:00+00:00",
+            )
+            _qualify_scoped_model(
+                repository,
+                connection_id,
+                revision="rotated",
+            )
+        return snapshot
+
+    monkeypatch.setattr(
+        repository,
+        "get_connection_credential_snapshot",
+        snapshot_with_interleaved_rotation,
+    )
+    result = await service.begin_scoped_certified(SCOPED_MODEL_ID, "chat_text")
+
+    assert result.dispatch is not None
+    assert rotated is True
+    assert result.dispatch.target.endpoints.base_url == "https://openrouter.example/v1"
+    assert (
+        result.dispatch.connection_fingerprint
+        != repository.connection_config_fingerprint("local", backup_id)
+    )
+    with pytest.raises(RouterServiceError) as exc_info:
+        service.mark_dispatched(result.dispatch)
+
+    assert exc_info.value.code == "provider_chat_policy_or_qualification_changed"
+    selected = next(
+        item
+        for item in repository.list_chat_control_receipts("local")["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )
+    assert selected["dispatched"] == 0
+    assert selected["status"] == "failed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("actual_capability", "invalidated_capability"),
+    (("chat_text", "chat_tools"), ("chat_tools", "chat_text")),
+)
+async def test_scoped_dispatch_rechecks_every_required_certificate_before_post(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    actual_capability: str,
+    invalidated_capability: str,
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    result = await service.begin_scoped_certified(
+        SCOPED_MODEL_ID,
+        actual_capability,
+        required_capabilities=("chat_text", "chat_tools"),
+    )
+    assert result.dispatch is not None
+    bindings = {
+        binding.capability: binding
+        for binding in result.dispatch.required_certifications
+    }
+    assert set(bindings) == {"chat_text", "chat_tools"}
+    assert (
+        bindings[actual_capability].certification_id
+        == result.dispatch.certification_id
+    )
+
+    original_current_qualification = service.control.current_qualification
+    invalidated_after_valid_read = False
+
+    def current_qualification_with_concurrent_invalidation(**fields):
+        nonlocal invalidated_after_valid_read
+        qualification = original_current_qualification(**fields)
+        if (
+            fields["capability"] == invalidated_capability
+            and not invalidated_after_valid_read
+        ):
+            assert qualification[0] is not None
+            with sqlite3.connect(repository.database_path) as database:
+                database.execute(
+                    """
+                    UPDATE provider_chat_certifications
+                    SET status = 'failed'
+                    WHERE tenant_id = 'local' AND id = ?
+                    """,
+                    (bindings[invalidated_capability].certification_id,),
+                )
+                database.commit()
+            invalidated_after_valid_read = True
+        return qualification
+
+    monkeypatch.setattr(
+        service.control,
+        "current_qualification",
+        current_qualification_with_concurrent_invalidation,
+    )
+
+    with pytest.raises(RouterServiceError) as exc_info:
+        service.mark_dispatched(result.dispatch)
+
+    assert invalidated_after_valid_read is True
+    assert exc_info.value.code == "provider_chat_policy_or_qualification_changed"
+    selected = next(
+        item
+        for item in repository.list_chat_control_receipts("local")["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )
+    assert selected["dispatched"] == 0
+    assert selected["status"] == "failed"
 
 
 @pytest.mark.asyncio
@@ -300,6 +655,124 @@ async def test_dispatch_rechecks_feature_flag_before_post(
 
 
 @pytest.mark.asyncio
+async def test_duplicate_mark_does_not_rewrite_a_dispatched_attempt_as_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, _newapi_id, _backup_id = _service(tmp_path, monkeypatch)
+    result = await service.begin(MODEL_ID)
+    assert result.dispatch is not None
+    service.mark_dispatched(result.dispatch)
+
+    with pytest.raises(RouterServiceError) as exc_info:
+        service.mark_dispatched(result.dispatch)
+
+    assert exc_info.value.code == "provider_chat_policy_or_qualification_changed"
+    receipts = repository.list_chat_control_receipts("local")
+    selected = next(
+        item
+        for item in receipts["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )
+    run = next(
+        item for item in receipts["runs"] if item["id"] == result.dispatch.run_id
+    )
+    assert selected["dispatched"] == 1
+    assert selected["status"] == "running"
+    assert run["status"] == "running"
+
+    service.complete(
+        result.dispatch,
+        status="succeeded",
+        result_class="success",
+        actual_model=MODEL_ID,
+    )
+    completed = repository.list_chat_control_receipts("local")
+    assert completed["attempts"][-1]["status"] == "succeeded"
+    assert completed["runs"][-1]["status"] == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_atomic_dispatch_serializes_a_concurrent_certificate_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    result = await service.begin_scoped_certified(
+        SCOPED_MODEL_ID,
+        "chat_text",
+        required_capabilities=("chat_text", "chat_tools"),
+    )
+    assert result.dispatch is not None
+    transaction_open = threading.Event()
+    release_transaction = threading.Event()
+    dispatch_errors: list[BaseException] = []
+    original_envelope = repository._validate_chat_dispatch_envelope
+
+    def pause_inside_write_transaction(*args, **kwargs):
+        value = original_envelope(*args, **kwargs)
+        transaction_open.set()
+        if not release_transaction.wait(timeout=10):
+            raise AssertionError("dispatch transaction was not released")
+        return value
+
+    monkeypatch.setattr(
+        repository,
+        "_validate_chat_dispatch_envelope",
+        pause_inside_write_transaction,
+    )
+
+    def mark_dispatch() -> None:
+        try:
+            service.mark_dispatched(result.dispatch)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            dispatch_errors.append(exc)
+
+    dispatch_thread = threading.Thread(target=mark_dispatch, daemon=True)
+    dispatch_thread.start()
+    assert transaction_open.wait(timeout=10)
+    try:
+        with sqlite3.connect(repository.database_path, timeout=0) as database:
+            with pytest.raises(sqlite3.OperationalError, match="locked"):
+                database.execute(
+                    """
+                    UPDATE provider_chat_certifications
+                    SET status = 'failed'
+                    WHERE tenant_id = 'local' AND id = ?
+                    """,
+                    (
+                        result.dispatch.required_certifications[0]
+                        .certification_id,
+                    ),
+                )
+    finally:
+        release_transaction.set()
+        dispatch_thread.join(timeout=10)
+
+    assert dispatch_thread.is_alive() is False
+    assert dispatch_errors == []
+    selected = next(
+        item
+        for item in repository.list_chat_control_receipts("local")["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )
+    assert selected["dispatched"] == 1
+
+    with sqlite3.connect(repository.database_path, timeout=1) as database:
+        database.execute(
+            """
+            UPDATE provider_chat_certifications
+            SET status = 'failed'
+            WHERE tenant_id = 'local' AND id = ?
+            """,
+            (
+                result.dispatch.required_certifications[0].certification_id,
+            ),
+        )
+        database.commit()
+
+
+@pytest.mark.asyncio
 async def test_dispatch_completion_is_tenant_scoped_and_stores_no_content(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -325,6 +798,150 @@ async def test_dispatch_completion_is_tenant_scoped_and_stores_no_content(
         dump = "\n".join(database.iterdump())
     assert "private prompt" not in dump
     assert "model answer" not in dump
+
+
+@pytest.mark.asyncio
+async def test_dispatch_completion_rolls_back_attempt_when_run_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, _newapi_id, _backup_id = _service(
+        tmp_path,
+        monkeypatch,
+        newapi_ip="8.8.8.8",
+    )
+    result = await service.begin(MODEL_ID)
+    assert result.dispatch is not None
+    service.mark_dispatched(result.dispatch)
+
+    with sqlite3.connect(repository.database_path) as database:
+        database.execute(
+            f"""
+            CREATE TRIGGER abort_chat_run_completion
+            BEFORE UPDATE OF status ON provider_chat_runs
+            WHEN OLD.tenant_id = 'local'
+              AND OLD.id = '{result.dispatch.run_id}'
+              AND NEW.status != 'running'
+            BEGIN
+                SELECT RAISE(ABORT, 'simulated_run_write_failure');
+            END
+            """
+        )
+
+    with pytest.raises(sqlite3.IntegrityError, match="simulated_run_write_failure"):
+        service.complete(
+            result.dispatch,
+            status="failed",
+            result_class="hard_failure",
+            error_code="provider_chat_http_401",
+            hard_failure=True,
+        )
+
+    receipts = repository.list_chat_control_receipts("local")
+    attempt = next(
+        item
+        for item in receipts["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )
+    run = next(
+        item for item in receipts["runs"] if item["id"] == result.dispatch.run_id
+    )
+    assert attempt["status"] == "running"
+    assert attempt["result_class"] is None
+    assert run["status"] == "running"
+    assert run["hard_failure"] == 0
+
+    with sqlite3.connect(repository.database_path) as database:
+        database.execute("DROP TRIGGER abort_chat_run_completion")
+    service.complete(
+        result.dispatch,
+        status="failed",
+        result_class="hard_failure",
+        error_code="provider_chat_http_401",
+        hard_failure=True,
+    )
+    completed = repository.list_chat_control_receipts("local")
+    attempt = next(
+        item
+        for item in completed["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )
+    run = next(
+        item for item in completed["runs"] if item["id"] == result.dispatch.run_id
+    )
+    assert attempt["result_class"] == "hard_failure"
+    assert run["result_class"] == "hard_failure"
+    assert run["hard_failure"] == 1
+
+
+@pytest.mark.asyncio
+async def test_restart_rejects_orphaned_dispatched_hard_failure_attempt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, _backup_id = _service(
+        tmp_path,
+        monkeypatch,
+        newapi_ip="8.8.8.8",
+    )
+    _activate_required_for_test(repository)
+    failed = await service.begin(MODEL_ID)
+    pending = await service.begin(MODEL_ID)
+    assert failed.dispatch is not None
+    assert pending.dispatch is not None
+    service.mark_dispatched(failed.dispatch)
+
+    failure_time = "2099-08-31T00:00:00+00:00"
+    with sqlite3.connect(repository.database_path) as database:
+        database.execute(
+            """
+            UPDATE provider_chat_attempts
+            SET status = 'failed', result_class = 'hard_failure',
+                error_code = 'provider_chat_http_401',
+                updated_at = ?, completed_at = ?
+            WHERE tenant_id = 'local' AND id = ? AND dispatched = 1
+            """,
+            (failure_time, failure_time, failed.dispatch.attempt_id),
+        )
+    stale_receipts = repository.list_chat_control_receipts("local")
+    stale_run = next(
+        item
+        for item in stale_receipts["runs"]
+        if item["id"] == failed.dispatch.run_id
+    )
+    assert stale_run["status"] == "running"
+    assert stale_run["hard_failure"] == 0
+
+    monkeypatch.setattr(service, "ensure_dispatch_current", lambda _dispatch: None)
+    with pytest.raises(RouterServiceError) as exc_info:
+        service.mark_dispatched(pending.dispatch)
+    assert exc_info.value.code == "provider_chat_policy_or_qualification_changed"
+    rejected = repository.list_chat_control_receipts("local")
+    pending_attempt = next(
+        item
+        for item in rejected["attempts"]
+        if item["id"] == pending.dispatch.attempt_id
+    )
+    assert pending_attempt["dispatched"] == 0
+    assert pending_attempt["status"] == "failed"
+
+    restarted_repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    restarted = ProviderChatStableService(
+        ModelRouterService(
+            restarted_repository,
+            egress_policy=ProviderEgressPolicy(
+                resolver=lambda _host, _port: ["8.8.8.8"]
+            ),
+        )
+    )
+    qualification, reason = restarted.control.current_qualification(
+        connection_id=newapi_id,
+        model_id=MODEL_ID,
+        capability="chat_text",
+    )
+    assert qualification is None
+    assert reason == "provider_chat_hard_failure_recertification_required"
+    ready, readiness_reason = restarted.readiness(MODEL_ID, "chat_text")
+    assert ready is False
+    assert readiness_reason == "provider_chat_required_gate_degraded"
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_provider_chat_stable_service.py
+++ b/server/tests/test_provider_chat_stable_service.py
@@ -4,12 +4,16 @@ import hashlib
 import json
 import sqlite3
 import threading
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
 from server.model_router.chat_control import ProviderChatControlService
-from server.model_router.chat_stable import ProviderChatStableService
+from server.model_router.chat_stable import (
+    ProviderChatCertificationBinding,
+    ProviderChatStableService,
+)
 from server.model_router.egress import ProviderEgressPolicy
 from server.model_router.repository import (
     RouterCredentialUnavailable,
@@ -365,6 +369,117 @@ async def test_scoped_certified_model_uses_current_certificate_without_stable_me
     assert result.dispatch.certification_id == f"cert-scoped-{backup_id}"
     receipts = repository.list_chat_control_receipts("local")
     assert receipts["runs"][0]["gateway"] == "ai_research_scoped"
+
+
+@pytest.mark.asyncio
+async def test_scoped_multi_capability_requires_one_fully_qualified_connection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    with sqlite3.connect(repository.database_path) as database:
+        database.execute(
+            """
+            UPDATE provider_chat_certifications
+            SET status = 'failed'
+            WHERE tenant_id = 'local' AND requested_model = ?
+              AND ((connection_id = ? AND capability = 'chat_tools')
+                OR (connection_id = ? AND capability = 'chat_text'))
+            """,
+            (SCOPED_MODEL_ID, newapi_id, backup_id),
+        )
+        database.commit()
+
+    required = ("chat_text", "chat_tools")
+    ready, _reason = service.readiness_scoped_certified(
+        SCOPED_MODEL_ID,
+        "chat_tools",
+        required_capabilities=required,
+    )
+    rejected = await service.begin_scoped_certified(
+        SCOPED_MODEL_ID,
+        "chat_tools",
+        required_capabilities=required,
+    )
+
+    assert ready is False
+    assert rejected.intercepted is True
+    assert rejected.dispatch is None
+    assert all(
+        item["dispatched"] == 0
+        for item in repository.list_chat_control_receipts("local")["attempts"]
+    )
+
+    with sqlite3.connect(repository.database_path) as database:
+        database.execute(
+            """
+            UPDATE provider_chat_certifications
+            SET status = 'passed'
+            WHERE tenant_id = 'local' AND requested_model = ?
+              AND connection_id = ? AND capability = 'chat_text'
+            """,
+            (SCOPED_MODEL_ID, backup_id),
+        )
+        database.commit()
+
+    assert service.readiness_scoped_certified(
+        SCOPED_MODEL_ID,
+        "chat_tools",
+        required_capabilities=required,
+    ) == (True, None)
+    accepted = await service.begin_scoped_certified(
+        SCOPED_MODEL_ID,
+        "chat_tools",
+        required_capabilities=required,
+    )
+    assert accepted.dispatch is not None
+    assert accepted.dispatch.target.connection_id == backup_id
+    assert {
+        binding.connection_id
+        for binding in accepted.dispatch.required_certifications
+    } == {backup_id}
+
+
+@pytest.mark.asyncio
+async def test_atomic_dispatch_rejects_cross_connection_certificate_binding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    result = await service.begin_scoped_certified(
+        SCOPED_MODEL_ID,
+        "chat_tools",
+        required_capabilities=("chat_text", "chat_tools"),
+    )
+    assert result.dispatch is not None
+    assert result.dispatch.target.connection_id == backup_id
+    tampered = replace(
+        result.dispatch,
+        required_certifications=tuple(
+            ProviderChatCertificationBinding(
+                capability=binding.capability,
+                connection_id=newapi_id,
+                certification_id=f"cert-scoped-{newapi_id}",
+            )
+            if binding.capability == "chat_text"
+            else binding
+            for binding in result.dispatch.required_certifications
+        ),
+    )
+
+    with pytest.raises(RouterServiceError) as exc_info:
+        service.mark_dispatched(tampered)
+
+    assert exc_info.value.code == "provider_chat_policy_or_qualification_changed"
+    selected = next(
+        item
+        for item in repository.list_chat_control_receipts("local")["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )
+    assert selected["dispatched"] == 0
+    assert selected["status"] == "failed"
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_provider_chat_stable_service.py
+++ b/server/tests/test_provider_chat_stable_service.py
@@ -1418,6 +1418,47 @@ async def test_concurrent_reconcilers_do_not_report_a_completed_unlink_as_pendin
 
 
 @pytest.mark.asyncio
+async def test_reconcile_accepts_an_unlink_error_only_after_peer_removed_envelope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    result = await service.begin_scoped_certified(SCOPED_MODEL_ID)
+    assert result.dispatch is not None
+    service.mark_dispatched(result.dispatch)
+    repository.stage_chat_control_completion(
+        "local",
+        result.dispatch.attempt_id,
+        expected_run_id=result.dispatch.run_id,
+        status="succeeded",
+        result_class="success",
+        actual_model=SCOPED_MODEL_ID,
+        reason_codes=[],
+    )
+    outbox_path = next(repository.chat_completion_outbox_dir.glob("*.json"))
+    original_unlink = Path.unlink
+
+    def unlink_after_peer_removed(path: Path, *args, **kwargs) -> None:
+        if path == outbox_path:
+            original_unlink(path, *args, **kwargs)
+            raise PermissionError("simulated concurrent Windows unlink")
+        original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", unlink_after_peer_removed)
+
+    reconciled = repository.reconcile_chat_control_completions("local")
+
+    assert reconciled == {"applied": 1, "pending": 0}
+    assert outbox_path.exists() is False
+    completed = repository.list_chat_control_receipts("local")
+    assert next(
+        item for item in completed["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )["status"] == "succeeded"
+
+
+@pytest.mark.asyncio
 async def test_cleanup_refuses_pending_completion_before_deleting_receipts(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/server/tests/test_provider_chat_stable_service.py
+++ b/server/tests/test_provider_chat_stable_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
+import sys
 import threading
 from dataclasses import replace
 from pathlib import Path
@@ -10,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from server.model_router.chat_control import ProviderChatControlService
+from server.model_router.cleanup_chat_receipts import main as cleanup_receipts_main
 from server.model_router.chat_stable import (
     ProviderChatCertificationBinding,
     ProviderChatStableService,
@@ -1295,6 +1297,124 @@ async def test_completion_reconcile_is_idempotent_after_commit_before_unlink(
 
     assert reconciled == {"applied": 1, "pending": 0}
     assert list(repository.chat_completion_outbox_dir.glob("*.json")) == []
+
+
+@pytest.mark.asyncio
+async def test_maintenance_cleanup_does_not_recover_an_active_scoped_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    result = await service.begin_scoped_certified(SCOPED_MODEL_ID)
+    assert result.dispatch is not None
+    service.mark_dispatched(result.dispatch)
+
+    monkeypatch.setenv("MODEL_MIRROR_CREDENTIAL_MASTER_KEY", "x" * 32)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cleanup_chat_receipts",
+            "--storage-dir",
+            str(tmp_path),
+            "--older-than-days",
+            "1",
+        ],
+    )
+    assert cleanup_receipts_main() == 0
+    active = repository.list_chat_control_receipts("local")
+    assert next(
+        item for item in active["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )["status"] == "running"
+    assert next(
+        item for item in active["runs"]
+        if item["id"] == result.dispatch.run_id
+    )["status"] == "running"
+
+    assert service.complete(
+        result.dispatch,
+        status="succeeded",
+        result_class="success",
+        actual_model=SCOPED_MODEL_ID,
+    ) is True
+    assert list(repository.chat_completion_outbox_dir.glob("*.json")) == []
+    follow_up = await service.begin_scoped_certified(SCOPED_MODEL_ID)
+    assert follow_up.dispatch is not None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_reconcilers_do_not_report_a_completed_unlink_as_pending(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(tmp_path, monkeypatch)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    result = await service.begin_scoped_certified(SCOPED_MODEL_ID)
+    assert result.dispatch is not None
+    service.mark_dispatched(result.dispatch)
+    repository.stage_chat_control_completion(
+        "local",
+        result.dispatch.attempt_id,
+        expected_run_id=result.dispatch.run_id,
+        status="succeeded",
+        result_class="success",
+        actual_model=SCOPED_MODEL_ID,
+        reason_codes=[],
+    )
+    outbox_path = next(repository.chat_completion_outbox_dir.glob("*.json"))
+    first = SQLiteRouterRepository(
+        tmp_path,
+        master_key=b"x" * 32,
+        recover_chat_control_on_startup=False,
+    )
+    second = SQLiteRouterRepository(
+        tmp_path,
+        master_key=b"x" * 32,
+        recover_chat_control_on_startup=False,
+    )
+    unlink_barrier = threading.Barrier(2)
+    original_unlink = Path.unlink
+
+    def synchronized_unlink(path: Path, *args, **kwargs):
+        if path == outbox_path:
+            unlink_barrier.wait(timeout=10)
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", synchronized_unlink)
+    reconciled: list[dict[str, int]] = []
+    errors: list[BaseException] = []
+
+    def reconcile(candidate: SQLiteRouterRepository) -> None:
+        try:
+            reconciled.append(
+                candidate.reconcile_chat_control_completions("local")
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=reconcile, args=(candidate,), daemon=True)
+        for candidate in (first, second)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=15)
+
+    assert all(thread.is_alive() is False for thread in threads)
+    assert errors == []
+    assert reconciled == [
+        {"applied": 1, "pending": 0},
+        {"applied": 1, "pending": 0},
+    ]
+    assert list(repository.chat_completion_outbox_dir.glob("*.json")) == []
+    completed = repository.list_chat_control_receipts("local")
+    assert next(
+        item for item in completed["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )["status"] == "succeeded"
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_provider_chat_stable_service.py
+++ b/server/tests/test_provider_chat_stable_service.py
@@ -11,7 +11,10 @@ import pytest
 from server.model_router.chat_control import ProviderChatControlService
 from server.model_router.chat_stable import ProviderChatStableService
 from server.model_router.egress import ProviderEgressPolicy
-from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.repository import (
+    RouterRepositoryError,
+    SQLiteRouterRepository,
+)
 from server.model_router.schemas import (
     ProviderChatControlPolicyUpdate,
     ProviderChatControlRouteUpdate,
@@ -827,14 +830,13 @@ async def test_dispatch_completion_rolls_back_attempt_when_run_write_fails(
             """
         )
 
-    with pytest.raises(sqlite3.IntegrityError, match="simulated_run_write_failure"):
-        service.complete(
-            result.dispatch,
-            status="failed",
-            result_class="hard_failure",
-            error_code="provider_chat_http_401",
-            hard_failure=True,
-        )
+    assert service.complete(
+        result.dispatch,
+        status="failed",
+        result_class="hard_failure",
+        error_code="provider_chat_http_401",
+        hard_failure=True,
+    ) is False
 
     receipts = repository.list_chat_control_receipts("local")
     attempt = next(
@@ -849,16 +851,40 @@ async def test_dispatch_completion_rolls_back_attempt_when_run_write_fails(
     assert attempt["result_class"] is None
     assert run["status"] == "running"
     assert run["hard_failure"] == 0
+    pending = list(repository.chat_completion_outbox_dir.glob("*.json"))
+    assert len(pending) == 1
+    assert "private prompt" not in pending[0].read_text(encoding="utf-8")
+    with pytest.raises(RouterServiceError) as exc_info:
+        await service.begin(MODEL_ID)
+    assert exc_info.value.code == (
+        "provider_chat_completion_reconciliation_pending"
+    )
 
+    restarted_repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    retained = restarted_repository.list_chat_control_receipts("local")["runs"]
+    assert next(run for run in retained if run["id"] == result.dispatch.run_id)["status"] == "running"
+    restarted = ProviderChatStableService(
+        ModelRouterService(
+            restarted_repository,
+            egress_policy=ProviderEgressPolicy(
+                resolver=lambda _host, _port: ["8.8.8.8"]
+            ),
+        )
+    )
+    with pytest.raises(RouterServiceError) as exc_info:
+        await restarted.begin(MODEL_ID)
+    assert exc_info.value.code == (
+        "provider_chat_completion_reconciliation_pending"
+    )
+    pending_after_restart = restarted_repository.list_chat_control_receipts("local")
+    assert next(
+        item
+        for item in pending_after_restart["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )["status"] == "running"
     with sqlite3.connect(repository.database_path) as database:
         database.execute("DROP TRIGGER abort_chat_run_completion")
-    service.complete(
-        result.dispatch,
-        status="failed",
-        result_class="hard_failure",
-        error_code="provider_chat_http_401",
-        hard_failure=True,
-    )
+    await restarted.begin(MODEL_ID)
     completed = repository.list_chat_control_receipts("local")
     attempt = next(
         item
@@ -871,6 +897,244 @@ async def test_dispatch_completion_rolls_back_attempt_when_run_write_fails(
     assert attempt["result_class"] == "hard_failure"
     assert run["result_class"] == "hard_failure"
     assert run["hard_failure"] == 1
+    assert list(repository.chat_completion_outbox_dir.glob("*.json")) == []
+
+
+def test_cleanup_preserves_hard_failure_receipts_before_cutoff(
+    tmp_path: Path,
+) -> None:
+    repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    for run_id, hard_failure, attempt_hard_failure in (
+        ("ordinary-run", False, False),
+        ("hard-failure-run", True, True),
+        ("attempt-hard-failure-run", False, True),
+    ):
+        repository.claim_chat_control_run(
+            "local",
+            run_id=run_id,
+            policy_fingerprint="policy",
+            capability="chat_text",
+            requested_model="provider/model",
+            strategy="explicit_session",
+        )
+        repository.claim_chat_control_attempt(
+            "local",
+            attempt_id=f"{run_id}-attempt",
+            run_id=run_id,
+            capability="chat_text",
+            position=0,
+            connection_id="conn-1",
+            provider_kind="newapi",
+        )
+        repository.complete_chat_control_attempt(
+            "local",
+            f"{run_id}-attempt",
+            status="failed",
+            result_class="hard_failure" if attempt_hard_failure else "transient_failure",
+            error_code=(
+                "provider_chat_http_401"
+                if attempt_hard_failure
+                else "provider_chat_http_503"
+            ),
+        )
+        repository.complete_chat_control_run(
+            "local",
+            run_id,
+            status="failed",
+            result_class="hard_failure" if hard_failure else "transient_failure",
+            hard_failure=hard_failure,
+        )
+    with sqlite3.connect(repository.database_path) as connection:
+        connection.execute(
+            """
+            UPDATE provider_chat_runs
+            SET completed_at = ?, updated_at = ?
+            """,
+            ("2020-01-01T00:00:00+00:00", "2020-01-01T00:00:00+00:00"),
+        )
+        connection.execute(
+            """
+            UPDATE provider_chat_attempts
+            SET completed_at = ?, updated_at = ?
+            """,
+            ("2020-01-01T00:00:00+00:00", "2020-01-01T00:00:00+00:00"),
+        )
+
+    dry_run = repository.cleanup_chat_control_receipts(
+        "local", before="2021-01-01T00:00:00+00:00"
+    )
+    assert dry_run["runs"] == 1
+    assert dry_run["attempts"] == 1
+    result = repository.cleanup_chat_control_receipts(
+        "local",
+        before="2021-01-01T00:00:00+00:00",
+        apply=True,
+    )
+
+    assert result == {
+        "applied": True,
+        "before": "2021-01-01T00:00:00+00:00",
+        "runs": 1,
+        "attempts": 1,
+    }
+    retained = repository.list_chat_control_receipts("local")
+    assert {item["id"] for item in retained["runs"]} == {
+        "hard-failure-run", "attempt-hard-failure-run"
+    }
+    assert {item["id"] for item in retained["attempts"]} == {
+        "hard-failure-run-attempt", "attempt-hard-failure-run-attempt"
+    }
+
+
+@pytest.mark.asyncio
+async def test_active_dispatch_does_not_block_an_independent_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, _repository, _newapi_id, _backup_id = _service(
+        tmp_path, monkeypatch, newapi_ip="8.8.8.8"
+    )
+    first = await service.begin(MODEL_ID)
+    assert first.dispatch is not None
+    service.mark_dispatched(first.dispatch)
+
+    second = await service.begin(MODEL_ID)
+    assert second.dispatch is not None
+    assert second.dispatch.run_id != first.dispatch.run_id
+    service.mark_dispatched(second.dispatch)
+    for dispatch in (first.dispatch, second.dispatch):
+        assert service.complete(
+            dispatch, status="succeeded", result_class="success"
+        ) is True
+
+
+@pytest.mark.asyncio
+async def test_completion_reconcile_is_idempotent_after_commit_before_unlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, _newapi_id, _backup_id = _service(
+        tmp_path, monkeypatch
+    )
+    result = await service.begin(MODEL_ID)
+    assert result.dispatch is not None
+    service.mark_dispatched(result.dispatch)
+    fields = {
+        "expected_run_id": result.dispatch.run_id,
+        "status": "succeeded",
+        "result_class": "success",
+        "actual_model": MODEL_ID,
+        "reason_codes": [],
+    }
+    staged = repository.stage_chat_control_completion(
+        "local", result.dispatch.attempt_id, **fields
+    )
+    monkeypatch.setattr(
+        "server.model_router.repository.utc_now", lambda: "2099-01-01T00:00:00+00:00"
+    )
+    restaged = repository.stage_chat_control_completion(
+        "local", result.dispatch.attempt_id, **fields
+    )
+    assert restaged == staged
+    assert restaged["stagedAt"] != "2099-01-01T00:00:00+00:00"
+    repository.complete_chat_control_dispatch(
+        "local", result.dispatch.attempt_id, **fields
+    )
+    repeated = repository.complete_chat_control_dispatch(
+        "local", result.dispatch.attempt_id, **fields
+    )
+    assert repeated["attempt"]["status"] == "succeeded"
+    with pytest.raises(
+        RouterRepositoryError,
+        match="provider_chat_completion_conflict",
+    ):
+        repository.complete_chat_control_dispatch(
+            "local",
+            result.dispatch.attempt_id,
+            **{**fields, "status": "failed"},
+        )
+
+    reconciled = repository.reconcile_chat_control_completions("local")
+
+    assert reconciled == {"applied": 1, "pending": 0}
+    assert list(repository.chat_completion_outbox_dir.glob("*.json")) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tampered_field", ["status", "stagedAt", "broken_symlink"])
+async def test_unsafe_completion_outbox_fails_closed_after_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, tampered_field: str
+) -> None:
+    service, repository, _newapi_id, _backup_id = _service(
+        tmp_path,
+        monkeypatch,
+        newapi_ip="8.8.8.8",
+    )
+    result = await service.begin(MODEL_ID)
+    assert result.dispatch is not None
+    service.mark_dispatched(result.dispatch)
+    with sqlite3.connect(repository.database_path) as database:
+        database.execute(
+            f"""
+            CREATE TRIGGER abort_chat_run_completion
+            BEFORE UPDATE OF status ON provider_chat_runs
+            WHEN OLD.tenant_id = 'local'
+              AND OLD.id = '{result.dispatch.run_id}'
+              AND NEW.status != 'running'
+            BEGIN
+                SELECT RAISE(ABORT, 'simulated_run_write_failure');
+            END
+            """
+        )
+    assert service.complete(
+        result.dispatch,
+        status="failed",
+        result_class="hard_failure",
+        error_code="provider_chat_http_401",
+        hard_failure=True,
+    ) is False
+    outbox_path = next(repository.chat_completion_outbox_dir.glob("*.json"))
+    if tampered_field == "broken_symlink":
+        outbox_path.unlink()
+        try:
+            outbox_path.symlink_to(outbox_path.with_suffix(".missing"))
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation is unavailable")
+    else:
+        encoded = outbox_path.read_bytes()
+        marker = f'"{tampered_field}":"'.encode()
+        offset = encoded.index(marker) + len(marker)
+        altered = bytearray(encoded)
+        altered[offset] = ord("3") if tampered_field == "stagedAt" else ord("x")
+        assert sum(a != b for a, b in zip(encoded, altered)) == 1
+        outbox_path.write_bytes(altered)
+    with sqlite3.connect(repository.database_path) as database:
+        database.execute("DROP TRIGGER abort_chat_run_completion")
+
+    restarted_repository = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    restarted = ProviderChatStableService(
+        ModelRouterService(
+            restarted_repository,
+            egress_policy=ProviderEgressPolicy(
+                resolver=lambda _host, _port: ["8.8.8.8"]
+            ),
+        )
+    )
+    runs_before = len(
+        restarted_repository.list_chat_control_receipts("local")["runs"]
+    )
+    retained_run = next(
+        run for run in restarted_repository.list_chat_control_receipts("local")["runs"]
+        if run["id"] == result.dispatch.run_id
+    )
+    assert retained_run["status"] == "running"
+    with pytest.raises(RouterServiceError) as exc_info:
+        await restarted.begin(MODEL_ID)
+    assert exc_info.value.code == (
+        "provider_chat_completion_reconciliation_pending"
+    )
+    assert len(restarted_repository.list_chat_control_receipts("local")["runs"]) == (
+        runs_before
+    )
+    assert outbox_path.exists() or outbox_path.is_symlink()
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_provider_chat_stable_service.py
+++ b/server/tests/test_provider_chat_stable_service.py
@@ -1183,6 +1183,71 @@ async def test_completion_reconcile_is_idempotent_after_commit_before_unlink(
 
 
 @pytest.mark.asyncio
+async def test_cleanup_refuses_pending_completion_before_deleting_receipts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(
+        tmp_path, monkeypatch
+    )
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    result = await service.begin_scoped_certified(SCOPED_MODEL_ID)
+    assert result.dispatch is not None
+    service.mark_dispatched(result.dispatch)
+
+    original_unlink = Path.unlink
+
+    def fail_outbox_unlink(path: Path, *args, **kwargs) -> None:
+        if (
+            path.parent == repository.chat_completion_outbox_dir
+            and path.suffix == ".json"
+        ):
+            raise OSError("simulated completion outbox unlink failure")
+        original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_outbox_unlink)
+    assert service.complete(
+        result.dispatch,
+        status="succeeded",
+        result_class="success",
+        actual_model=SCOPED_MODEL_ID,
+    ) is False
+    outbox_path = next(repository.chat_completion_outbox_dir.glob("*.json"))
+    outbox_bytes = outbox_path.read_bytes()
+
+    with pytest.raises(
+        RouterRepositoryError,
+        match="provider_chat_completion_reconciliation_pending",
+    ):
+        repository.cleanup_chat_control_receipts(
+            "local",
+            before="2100-01-01T00:00:00+00:00",
+            apply=True,
+        )
+    retained = repository.list_chat_control_receipts("local")
+    assert any(item["id"] == result.dispatch.run_id for item in retained["runs"])
+    assert any(
+        item["id"] == result.dispatch.attempt_id for item in retained["attempts"]
+    )
+    retained_run_count = len(retained["runs"])
+    retained_attempt_count = len(retained["attempts"])
+    assert outbox_path.read_bytes() == outbox_bytes
+
+    monkeypatch.setattr(Path, "unlink", original_unlink)
+    cleaned = repository.cleanup_chat_control_receipts(
+        "local",
+        before="2100-01-01T00:00:00+00:00",
+        apply=True,
+    )
+    assert cleaned["runs"] == retained_run_count
+    assert cleaned["attempts"] == retained_attempt_count
+    assert list(repository.chat_completion_outbox_dir.glob("*.json")) == []
+    receipts = repository.list_chat_control_receipts("local")
+    assert receipts["runs"] == []
+    assert receipts["attempts"] == []
+
+
+@pytest.mark.asyncio
 async def test_mismatched_master_key_fails_before_startup_reconciliation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/server/tests/test_provider_chat_stable_service.py
+++ b/server/tests/test_provider_chat_stable_service.py
@@ -12,6 +12,7 @@ from server.model_router.chat_control import ProviderChatControlService
 from server.model_router.chat_stable import ProviderChatStableService
 from server.model_router.egress import ProviderEgressPolicy
 from server.model_router.repository import (
+    RouterCredentialUnavailable,
     RouterRepositoryError,
     SQLiteRouterRepository,
 )
@@ -804,15 +805,17 @@ async def test_dispatch_completion_is_tenant_scoped_and_stores_no_content(
 
 
 @pytest.mark.asyncio
-async def test_dispatch_completion_rolls_back_attempt_when_run_write_fails(
+async def test_scoped_dispatch_completion_rolls_back_attempt_when_run_write_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    service, repository, _newapi_id, _backup_id = _service(
+    service, repository, newapi_id, backup_id = _service(
         tmp_path,
         monkeypatch,
         newapi_ip="8.8.8.8",
     )
-    result = await service.begin(MODEL_ID)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    result = await service.begin_scoped_certified(SCOPED_MODEL_ID)
     assert result.dispatch is not None
     service.mark_dispatched(result.dispatch)
 
@@ -854,8 +857,16 @@ async def test_dispatch_completion_rolls_back_attempt_when_run_write_fails(
     pending = list(repository.chat_completion_outbox_dir.glob("*.json"))
     assert len(pending) == 1
     assert "private prompt" not in pending[0].read_text(encoding="utf-8")
+    default_result = await service.begin(MODEL_ID)
+    assert default_result.dispatch is not None
+    service.mark_dispatched(default_result.dispatch)
+    assert service.complete(
+        default_result.dispatch,
+        status="succeeded",
+        result_class="success",
+    ) is True
     with pytest.raises(RouterServiceError) as exc_info:
-        await service.begin(MODEL_ID)
+        await service.begin_scoped_certified(SCOPED_MODEL_ID)
     assert exc_info.value.code == (
         "provider_chat_completion_reconciliation_pending"
     )
@@ -872,7 +883,7 @@ async def test_dispatch_completion_rolls_back_attempt_when_run_write_fails(
         )
     )
     with pytest.raises(RouterServiceError) as exc_info:
-        await restarted.begin(MODEL_ID)
+        await restarted.begin_scoped_certified(SCOPED_MODEL_ID)
     assert exc_info.value.code == (
         "provider_chat_completion_reconciliation_pending"
     )
@@ -884,7 +895,7 @@ async def test_dispatch_completion_rolls_back_attempt_when_run_write_fails(
     )["status"] == "running"
     with sqlite3.connect(repository.database_path) as database:
         database.execute("DROP TRIGGER abort_chat_run_completion")
-    await restarted.begin(MODEL_ID)
+    await restarted.begin_scoped_certified(SCOPED_MODEL_ID)
     completed = repository.list_chat_control_receipts("local")
     attempt = next(
         item
@@ -898,6 +909,117 @@ async def test_dispatch_completion_rolls_back_attempt_when_run_write_fails(
     assert run["result_class"] == "hard_failure"
     assert run["hard_failure"] == 1
     assert list(repository.chat_completion_outbox_dir.glob("*.json")) == []
+
+
+@pytest.mark.asyncio
+async def test_default_dispatch_completion_does_not_use_scoped_outbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, _newapi_id, _backup_id = _service(
+        tmp_path,
+        monkeypatch,
+        newapi_ip="8.8.8.8",
+    )
+    result = await service.begin(MODEL_ID)
+    assert result.dispatch is not None
+    assert result.dispatch.gateway == "default"
+    service.mark_dispatched(result.dispatch)
+
+    with pytest.raises(
+        RouterRepositoryError,
+        match="provider_chat_completion_scope_invalid",
+    ):
+        repository.stage_chat_control_completion(
+            "local",
+            result.dispatch.attempt_id,
+            expected_run_id=result.dispatch.run_id,
+            status="failed",
+            result_class="hard_failure",
+        )
+    assert service.complete(
+        result.dispatch,
+        status="uncertain",
+        result_class="uncertain",
+        error_code="provider_chat_unexpected_error",
+    ) is True
+
+    receipts = repository.list_chat_control_receipts("local")
+    attempt = next(
+        item for item in receipts["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )
+    run = next(
+        item for item in receipts["runs"] if item["id"] == result.dispatch.run_id
+    )
+    assert attempt["status"] == "uncertain"
+    assert attempt["error_code"] == "provider_chat_unexpected_error"
+    assert run["status"] == "uncertain"
+    assert list(repository.chat_completion_outbox_dir.glob("*.json")) == []
+
+
+@pytest.mark.asyncio
+async def test_default_dispatched_run_remains_uncertain_after_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, _newapi_id, _backup_id = _service(
+        tmp_path,
+        monkeypatch,
+        newapi_ip="8.8.8.8",
+    )
+    result = await service.begin(MODEL_ID)
+    assert result.dispatch is not None
+    service.mark_dispatched(result.dispatch)
+
+    restarted = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    receipts = restarted.list_chat_control_receipts("local")
+    attempt = next(
+        item for item in receipts["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )
+    run = next(
+        item for item in receipts["runs"] if item["id"] == result.dispatch.run_id
+    )
+    assert attempt["status"] == "uncertain"
+    assert attempt["error_code"] == "server_restarted"
+    assert run["status"] == "uncertain"
+    assert run["reason_codes_json"] == '["server_restarted"]'
+
+
+@pytest.mark.asyncio
+async def test_scoped_undispatched_failure_cleans_up_without_outbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(
+        tmp_path,
+        monkeypatch,
+        newapi_ip="8.8.8.8",
+    )
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    result = await service.begin_scoped_certified(SCOPED_MODEL_ID)
+    assert result.dispatch is not None
+    assert result.dispatch.gateway == "ai_research_scoped"
+
+    assert service.fail_undispatched(
+        result.dispatch,
+        error_code="ai_research_bridge_transport_failed",
+    ) is True
+    receipts = repository.list_chat_control_receipts("local")
+    attempt = next(
+        item for item in receipts["attempts"]
+        if item["id"] == result.dispatch.attempt_id
+    )
+    run = next(
+        item for item in receipts["runs"] if item["id"] == result.dispatch.run_id
+    )
+    assert attempt["status"] == "failed"
+    assert attempt["result_class"] == "preflight_failure"
+    assert run["status"] == "failed"
+    assert run["result_class"] == "preflight_failure"
+    assert list(repository.chat_completion_outbox_dir.glob("*.json")) == []
+
+    retried = await service.begin_scoped_certified(SCOPED_MODEL_ID)
+    assert retried.dispatch is not None
 
 
 def test_cleanup_preserves_hard_failure_receipts_before_cutoff(
@@ -1011,17 +1133,19 @@ async def test_active_dispatch_does_not_block_an_independent_run(
 async def test_completion_reconcile_is_idempotent_after_commit_before_unlink(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    service, repository, _newapi_id, _backup_id = _service(
+    service, repository, newapi_id, backup_id = _service(
         tmp_path, monkeypatch
     )
-    result = await service.begin(MODEL_ID)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    result = await service.begin_scoped_certified(SCOPED_MODEL_ID)
     assert result.dispatch is not None
     service.mark_dispatched(result.dispatch)
     fields = {
         "expected_run_id": result.dispatch.run_id,
         "status": "succeeded",
         "result_class": "success",
-        "actual_model": MODEL_ID,
+        "actual_model": SCOPED_MODEL_ID,
         "reason_codes": [],
     }
     staged = repository.stage_chat_control_completion(
@@ -1059,16 +1183,74 @@ async def test_completion_reconcile_is_idempotent_after_commit_before_unlink(
 
 
 @pytest.mark.asyncio
+async def test_mismatched_master_key_fails_before_startup_reconciliation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service, repository, newapi_id, backup_id = _service(
+        tmp_path, monkeypatch
+    )
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    result = await service.begin_scoped_certified(SCOPED_MODEL_ID)
+    assert result.dispatch is not None
+    service.mark_dispatched(result.dispatch)
+    repository.stage_chat_control_completion(
+        "local",
+        result.dispatch.attempt_id,
+        expected_run_id=result.dispatch.run_id,
+        status="succeeded",
+        result_class="success",
+        actual_model=MODEL_ID,
+        reason_codes=[],
+    )
+    outbox_path = next(repository.chat_completion_outbox_dir.glob("*.json"))
+    outbox_bytes = outbox_path.read_bytes()
+
+    with pytest.raises(RouterCredentialUnavailable):
+        SQLiteRouterRepository(tmp_path, master_key=b"y" * 32)
+
+    with sqlite3.connect(repository.database_path) as database:
+        attempt_status = database.execute(
+            "SELECT status FROM provider_chat_attempts WHERE id = ?",
+            (result.dispatch.attempt_id,),
+        ).fetchone()[0]
+        run_status = database.execute(
+            "SELECT status FROM provider_chat_runs WHERE id = ?",
+            (result.dispatch.run_id,),
+        ).fetchone()[0]
+    assert attempt_status == "running"
+    assert run_status == "running"
+    assert outbox_path.is_file()
+    assert outbox_path.read_bytes() == outbox_bytes
+
+    recovered = SQLiteRouterRepository(tmp_path, master_key=b"x" * 32)
+    receipts = recovered.list_chat_control_receipts("local")
+    assert next(
+        attempt
+        for attempt in receipts["attempts"]
+        if attempt["id"] == result.dispatch.attempt_id
+    )["status"] == "succeeded"
+    assert next(
+        run
+        for run in receipts["runs"]
+        if run["id"] == result.dispatch.run_id
+    )["status"] == "succeeded"
+    assert list(recovered.chat_completion_outbox_dir.glob("*.json")) == []
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("tampered_field", ["status", "stagedAt", "broken_symlink"])
 async def test_unsafe_completion_outbox_fails_closed_after_restart(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, tampered_field: str
 ) -> None:
-    service, repository, _newapi_id, _backup_id = _service(
+    service, repository, newapi_id, backup_id = _service(
         tmp_path,
         monkeypatch,
         newapi_ip="8.8.8.8",
     )
-    result = await service.begin(MODEL_ID)
+    _qualify_scoped_model(repository, newapi_id)
+    _qualify_scoped_model(repository, backup_id)
+    result = await service.begin_scoped_certified(SCOPED_MODEL_ID)
     assert result.dispatch is not None
     service.mark_dispatched(result.dispatch)
     with sqlite3.connect(repository.database_path) as database:
@@ -1127,7 +1309,7 @@ async def test_unsafe_completion_outbox_fails_closed_after_restart(
     )
     assert retained_run["status"] == "running"
     with pytest.raises(RouterServiceError) as exc_info:
-        await restarted.begin(MODEL_ID)
+        await restarted.begin_scoped_certified(SCOPED_MODEL_ID)
     assert exc_info.value.code == (
         "provider_chat_completion_reconciliation_pending"
     )


### PR DESCRIPTION
# 变更摘要

本 PR 是已合并 trust 基线 #356 之后的 **PR-F 功能批**。它只修改冻结白名单中的 7 个父仓运行/测试文件，为 AI Research 的资格期 P2R 调用增加严格、可持久恢复的受限模型控制面。

它不激活 P2R、不增加产品入口、不执行真实模型调用，也不代表 V0.2 产品完成。P2R 继续保持 `disabled_no_go`、`productVisible=false`、`p2rQualification=not_run`。

## 变更内容

- 将普通文献/假设调用与 P2R 阶段调用的服务凭据、固定模型和能力资格隔离；P2R 只接受锁定阶段合同、提示词/制品哈希、采样参数和工具协议。
- 在 Provider Chat 控制面绑定模型、连接指纹、资格证书、策略快照和阶段上下文，并在实际出站前重新校验，发现漂移即失败关闭。
- 为已派发的 AI Research 调用增加原子终态持久化、durable completion outbox、启动恢复和幂等对账；保留取消、硬失败、原始模型身份及工程用量事实。
- 收紧流式与非流式响应的模型身份、大小、结束原因、关闭/取消和错误终态处理，避免未验证 payload 提前释放。
- 隔离维护清理流程，未完成或待同步的运行证据不会被删除。
- 修复 Windows 多进程同时删除同一 completion envelope 时的误报：仅当 `lstat()` 明确证明文件已由另一对账器删除才视为幂等成功；路径仍在或状态不可确认时继续 `pending`。

## 冻结范围

差异精确限定为：

- `server/model_router/ai_research_bridge.py`
- `server/model_router/chat_control.py`
- `server/model_router/chat_stable.py`
- `server/model_router/cleanup_chat_receipts.py`
- `server/model_router/repository.py`
- `server/tests/test_ai_research_bridge.py`
- `server/tests/test_provider_chat_stable_service.py`

未修改 `extensions/ai-research/**` 的 trust 文件、`client/`、`server/main.py`、根 Compose、Plugin schema、Studio 路由或默认依赖。没有主数据库迁移、用户可见页面或默认安装增量。

## Trust / candidate 绑定

- Trust 与 base：`06ef51ae8d58c4e33029f02ab7263e24066734b2`（#356 merge commit）
- Candidate：`9c8b2869b5759f7a54754c4b583b0e4d4a0488a1`
- Trust tree：`6dccefa76b14e5ce5860a1bd97d26044bdd6e3b7`
- Candidate tree：`31be807f33ea984a6e2b0fd3a1bd6c9329aa3f96`
- 40 个 trust 锁定文件的类型、大小与 SHA-256 均重新验证通过。

## 验证证据

状态只使用 `通过 / 未运行`：

| 检查 | 状态 | 结果 |
| --- | --- | --- |
| 并发缺陷复现 | 通过 | 修复前同一 Windows 用例 6 次失败 5 次；独立 3000 轮文件系统实验确认 `WinError 5` 后文件已消失 |
| 手术刀回归 | 通过 | 并发删除、peer 已删除但本方收到 OSError、真实删除失败保留 pending：`3 passed` |
| Windows 压力复测 | 通过 | 修复后同一并发用例 `50/50` 通过 |
| Provider Chat / Bridge 矩阵 | 通过 | `222 passed, 1 skipped`；skip 为既有条件性用例 |
| 精确宿主运行时 | 通过 | Python `3.12.13`，`-I -B`，锁定测试依赖 `pip check` 通过 |
| 可信 Full 主机测试 | 通过 | `157 passed, 2 skipped` |
| Control 容器测试 | 通过 | `122 passed, 7 skipped` |
| Worker 容器测试 | 通过 | `156 passed, 1 skipped` |
| Compose acceptance | 通过 | success/task-error/cancel、Inspect View、MLflow outbox、Worker fail-closed、两轮 Control/Tracking 重启恢复均通过 |
| 安全反证 | 通过 | 超大 worker 协议、Worker 网络隔离、Control 公网隔离、容器凭据扫描通过 |
| 零默认增量 | 通过 | base/head 默认客户端均为 42 文件、19,497,956 bytes、aggregate SHA-256 `0b8a52e8...`；默认 Compose 16 服务/22 卷一致 |
| 父仓全量 `server/tests/` | 未运行 | 已运行本 PR 影响面的完整 Provider Chat/Bridge 矩阵；其余由 CI 继续验证 |
| 真实模型/OpenAlex/Zotero | 未运行 | 本 PR 明确禁止模型与外部科研调用 |
| P2R 资格运行 | 未运行 | 保持 NO-GO 与产品不可见 |

可信 Full 最终退出码为 0：

- Full manifest 文件 SHA-256：`5a52b436192824ae9c1545bf106589fd0763c2c499504c926639f6c10e9b03e9`
- Full manifest canonical receipt：`e9a59760963a737f23bdc27d79cc3850df6469c05dbdabad84871625105b1189`
- Trusted bootstrap canonical receipt：`7fd4ae1e5e96e2817797a55149cf88fa875958f838f7cf4af12ed2583eda5e31`
- 独立复算均匹配；本机在 Full 结束后紧接执行的只读检查显示专用容器/网络为 0，证据卷按策略保留。

## 独立审阅

- 并发根因审阅排除了 SQLite 锁与脆弱断言，确认是 Windows 同路径删除竞态。
- 手术刀补丁独立只读审阅未发现 P0/P1/P2。
- 可信 Full 终审重新核对 Git ancestry、7 文件白名单、40 个锁定文件、回执/manifest/evidence 哈希、零默认增量及 P2R 不可见状态。

## 风险、停止点与回退

- 该变更触及共享 Provider Chat repository、派发和终态路径；因此 PR 合并前仍以 CI 和维护者审阅为硬门禁。
- 当前只证明资格控制面和工程证据闭环；没有证明真实模型、科研有效性或 V0.2 用户旅程。
- P2 证据边界：冻结回执未记录 Compose 项目名、端口/网段和宿主 Python 的精确版本；这些参数有本轮命令与本机检查证据，但不能把回执描述为可独立重建全部运行环境的执行签名。该增强只能另走 trust-only 批次，不能混入本 PR-F。
- 已知但不属于本修复的窄窗口：列出 outbox 后、读取前被另一进程删除仍可能由调用方观察到；本 PR 不扩展范围处理它。
- 回退方式为 revert 本 PR；不删除 AI Research 数据卷或历史证据，不需要主库迁移回滚。

## Help Center Impact

- 是否影响用户体验：`No`。
- 依据：没有前端、入口或可见能力变化；P2R 仍为 `productVisible=false`。
- 截图/预览器：不适用。
- 未验证边界：真实 Provider、OpenAlex、Zotero、文献旅程和 P2R 资格均未运行。

本 PR 先以 Draft 提交；不授权 Merge、Deploy、模型调用或产品激活。
