### PR TITLE
feature: 开放 Meta Planner 只读动态资源节点

### DIFF
--- a/client/src/components/meta/MetaPlannerV2.test.tsx
+++ b/client/src/components/meta/MetaPlannerV2.test.tsx
@@ -328,7 +328,7 @@ describe("Meta Planner managed compatibility", () => {
       apply_key: "apply-key",
       status: "pending",
       kind: "xpert_create",
-      title: "Meta Planner: Headless",
+      title: "元智能体规划：Headless",
       target_id: null,
       base_revision: null,
       payload: {

--- a/client/src/components/meta/MetaPlannerV2.tsx
+++ b/client/src/components/meta/MetaPlannerV2.tsx
@@ -10,15 +10,18 @@ import ProviderRouteReceiptSummary, {
 } from "./ProviderRouteReceiptSummary";
 import {
   authoringDiffSummary,
+  authoringOperationSummary,
   buildMetadataPatch,
   headlessStateMode,
   normalizeGraphPatchEnvelope,
   normalizeGraphPatchPreview,
   normalizeHeadlessProposalState,
+  normalizeSafeResourceSnapshots,
   normalizeAuthoringDiagnostics,
   type GraphPatchEnvelopeV1,
   type GraphPatchPreview,
   type HeadlessAuthoringProposalState,
+  type SafeResourceSnapshot,
 } from "./metaAuthoring";
 import WorkflowEditor from "../workflow/WorkflowEditor";
 
@@ -26,6 +29,7 @@ type ScopeKey =
   | "allowed_node_kinds"
   | "external_xpert_ids"
   | "knowledge_base_ids"
+  | "data_table_ids"
   | "toolset_ids"
   | "plugin_ids"
   | "prompt_profile_ids"
@@ -33,6 +37,7 @@ type ScopeKey =
 
 interface CapabilityItem {
   id?: string;
+  table_id?: string;
   kind?: string;
   title?: string;
   name?: string;
@@ -45,12 +50,27 @@ interface CapabilityItem {
   planner?: {
     task_binding?: "required" | "optional" | "forbidden";
   };
+  active_version_id?: string | null;
+  active_schema_version?: number | null;
+  schema_version?: number | null;
+  schema_checksum?: string;
+  metadata?: {
+    active_version_id?: string | null;
+  };
+  fields?: Array<{
+    name?: string;
+    label?: string;
+    data_type?: string;
+    type?: string;
+    required?: boolean;
+  }>;
 }
 
 interface MetaPlannerScope extends Record<ScopeKey, string[]> {
   allowed_node_kinds: string[];
   external_xpert_ids: string[];
   knowledge_base_ids: string[];
+  data_table_ids: string[];
   toolset_ids: string[];
   plugin_ids: string[];
   prompt_profile_ids: string[];
@@ -66,11 +86,12 @@ interface CapabilitySnapshot {
   nodes: CapabilityItem[];
   middleware: CapabilityItem[];
   external_xperts: CapabilityItem[];
-  knowledge_bases: CapabilityItem[];
+  knowledge_bases?: CapabilityItem[];
+  data_tables?: CapabilityItem[];
   toolsets: CapabilityItem[];
   plugins: CapabilityItem[];
   prompt_profiles: CapabilityItem[];
-  default_scope: MetaPlannerScope;
+  default_scope?: Partial<MetaPlannerScope>;
   authoring_protocol_version?: string | number;
   authoring_limits?: Record<string, unknown>;
 }
@@ -184,11 +205,60 @@ const emptyScope = (): MetaPlannerScope => ({
   allowed_node_kinds: [],
   external_xpert_ids: [],
   knowledge_base_ids: [],
+  data_table_ids: [],
   toolset_ids: [],
   plugin_ids: [],
   prompt_profile_ids: [],
   middleware_ids: [],
 });
+
+export function normalizeMetaPlannerScope(
+  value?: Partial<MetaPlannerScope> | null,
+): MetaPlannerScope {
+  const source = value ?? {};
+  const list = (key: ScopeKey) =>
+    Array.isArray(source[key])
+      ? source[key]!.filter((item): item is string => typeof item === "string")
+      : [];
+  return {
+    allowed_node_kinds: list("allowed_node_kinds"),
+    external_xpert_ids: list("external_xpert_ids"),
+    knowledge_base_ids: list("knowledge_base_ids"),
+    // Agent Table access always starts closed, even if an older or permissive
+    // capability payload accidentally supplies a default selection.
+    data_table_ids: [],
+    toolset_ids: list("toolset_ids"),
+    plugin_ids: list("plugin_ids"),
+    prompt_profile_ids: list("prompt_profile_ids"),
+    middleware_ids: list("middleware_ids"),
+  };
+}
+
+function capabilityItemId(item: CapabilityItem) {
+  return String(item.kind ?? item.id ?? item.table_id ?? "");
+}
+
+function capabilityItemDetail(item: CapabilityItem, group: ScopeKey) {
+  if (group === "knowledge_base_ids") {
+    const activeVersionId = item.active_version_id ?? item.metadata?.active_version_id;
+    return activeVersionId
+      ? `运行时跟随活动索引；当前观察版本 ${activeVersionId}`
+      : "当前没有活动索引，生成预检将阻断检索节点";
+  }
+  if (group === "data_table_ids") {
+    const schemaVersion = item.active_schema_version ?? item.schema_version;
+    const fields = item.fields ?? [];
+    const fieldSummary = fields
+      .slice(0, 6)
+      .map((field) => `${field.label || field.name || "field"}:${field.data_type || field.type || "unknown"}`)
+      .join(" · ");
+    return [
+      schemaVersion ? `生成时固定 Schema v${schemaVersion}` : "没有可固定的已发布 Schema",
+      fieldSummary || (fields.length ? `${fields.length} 个字段` : "字段摘要不可用"),
+    ].join("；");
+  }
+  return item.description ?? "";
+}
 
 function readError(payload: unknown, fallback: string) {
   if (typeof payload === "object" && payload !== null) {
@@ -357,6 +427,12 @@ const capabilityGroups: Array<{
     hint: "遵守运行时活动索引语义",
   },
   {
+    key: "data_table_ids",
+    source: "data_tables",
+    title: "Agent Table",
+    hint: "默认关闭；授权后固定已发布 Schema",
+  },
+  {
     key: "toolset_ids",
     source: "toolsets",
     title: "Toolset",
@@ -413,6 +489,8 @@ export default function MetaPlannerV2() {
   const [repairUsed, setRepairUsed] = useState(false);
   const [controlFlowReport, setControlFlowReport] =
     useState<ControlFlowReportSummary | null>(null);
+  const [resourceSnapshots, setResourceSnapshots] =
+    useState<SafeResourceSnapshot[]>([]);
   const [snapshotHash, setSnapshotHash] = useState("");
   const [routeReceipt, setRouteReceipt] = useState<ProviderRouteReceipt | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -446,7 +524,7 @@ export default function MetaPlannerV2() {
         };
         if (cancelled) return;
         setCapabilities(capabilityPayload);
-        setScope(capabilityPayload.default_scope);
+        setScope(normalizeMetaPlannerScope(capabilityPayload.default_scope));
         setEditableXperts(xpertResponse.items);
         const latest = proposalPayload.items?.[0];
         if (latest) {
@@ -491,6 +569,7 @@ export default function MetaPlannerV2() {
     setWarnings(Array.isArray(report.warnings) ? (report.warnings as string[]) : []);
     setRepairUsed(Boolean(report.repair_used));
     setControlFlowReport(controlFlowReportFrom(report));
+    setResourceSnapshots(normalizeSafeResourceSnapshots(report));
     const snapshot = report.capability_snapshot;
     setSnapshotHash(
       String(
@@ -663,7 +742,7 @@ export default function MetaPlannerV2() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           revision: proposal.revision,
-          title: `Meta Planner: ${nextCandidate.name}`,
+          title: `元智能体规划：${nextCandidate.name}`,
           payload: proposalPayload(nextCandidate),
           base_revision: proposal.base_revision,
         }),
@@ -1038,7 +1117,8 @@ export default function MetaPlannerV2() {
             <div className="mt-3 max-h-[520px] space-y-4 overflow-y-auto pr-1">
               {capabilities
                 ? capabilityGroups.map((group) => {
-                    const items = capabilities[group.source] as CapabilityItem[];
+                    const source = capabilities[group.source];
+                    const items = Array.isArray(source) ? source as CapabilityItem[] : [];
                     return (
                       <div key={group.key}>
                         <div className="flex items-end justify-between gap-2">
@@ -1047,14 +1127,16 @@ export default function MetaPlannerV2() {
                         </div>
                         <div className="mt-2 space-y-1.5">
                           {items.map((item) => {
-                            const value = String(item.kind ?? item.id ?? "");
+                            const value = capabilityItemId(item);
                             const checked = scope[group.key].includes(value);
+                            const detail = capabilityItemDetail(item, group.key);
                             return (
                               <label
                                 className="flex cursor-pointer items-start gap-2 rounded-md border border-white/5 bg-white/[0.025] px-2.5 py-2"
                                 key={`${group.key}-${value}`}
                               >
                                 <input
+                                  aria-label={`${group.title}：${item.title ?? item.name ?? value}`}
                                   checked={checked}
                                   className="mt-0.5 accent-cyan-300"
                                   onChange={() => toggleScope(group.key, value)}
@@ -1075,9 +1157,9 @@ export default function MetaPlannerV2() {
                                       </span>
                                     ) : null}
                                   </span>
-                                  {item.description ? (
+                                  {detail ? (
                                     <span className="mt-0.5 line-clamp-2 block text-[10px] leading-4 text-slate-500">
-                                      {item.description}
+                                      {detail}
                                     </span>
                                   ) : null}
                                 </span>
@@ -1256,6 +1338,33 @@ export default function MetaPlannerV2() {
                       </div>
                     </div>
                   ) : null}
+                  {resourceSnapshots.length ? (
+                    <div className="mt-3 rounded-md border border-emerald-300/15 bg-emerald-300/[0.05] p-2.5">
+                      <div className="flex flex-wrap items-center justify-between gap-2 text-[11px]">
+                        <span className="font-semibold text-emerald-100">只读资源快照</span>
+                        <span className="text-emerald-100/65">{resourceSnapshots.length} 个节点级引用</span>
+                      </div>
+                      <div className="mt-2 max-h-32 space-y-1.5 overflow-y-auto text-[10px] leading-4 text-slate-400">
+                        {resourceSnapshots.map((snapshot) => (
+                          <div key={`${snapshot.node_ref}-${snapshot.resource_id}`}>
+                            <p>
+                              <span className="font-mono text-slate-300">{snapshot.node_ref}</span>
+                              {` · ${snapshot.resource_kind || snapshot.node_kind || "resource"} ${snapshot.resource_id}`}
+                            </p>
+                            <p className="text-slate-500">
+                              {snapshot.schema_version != null
+                                ? `固定 Schema v${snapshot.schema_version}`
+                                : snapshot.observed_version_id
+                                  ? `动态活动索引；观察版本 ${snapshot.observed_version_id}`
+                                  : snapshot.resolved_version_id
+                                    ? `固定版本 ${snapshot.resolved_version_id}`
+                                    : snapshot.version_policy || "等待服务端解析"}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
                   {issues.length ? (
                     <div className="mt-3 max-h-32 space-y-1 overflow-y-auto text-[11px] text-rose-100">
                       {issues.map((item, index) => (
@@ -1346,6 +1455,10 @@ export default function MetaPlannerV2() {
                             authoringAvailability.state.allowed_middleware_ids,
                           allowedSourceAgentIds:
                             authoringAvailability.state.allowed_source_agent_ids,
+                          allowedKnowledgeBaseIds:
+                            authoringAvailability.state.allowed_knowledge_base_ids,
+                          allowedDataTableIds:
+                            authoringAvailability.state.allowed_data_table_ids,
                         }
                       : undefined
                   }
@@ -1427,7 +1540,7 @@ export default function MetaPlannerV2() {
                 <div className="mt-2 space-y-1 text-xs text-slate-400">
                   {pendingAuthoringPreview.patch.operations.map((operation, index) => (
                     <p key={`${operation.op}-${index}`}>
-                      {index + 1}. <span className="font-mono text-cyan-100">{operation.op}</span>
+                      {index + 1}. <span className="font-mono text-cyan-100">{authoringOperationSummary(operation)}</span>
                     </p>
                   ))}
                 </div>
@@ -1460,6 +1573,27 @@ export default function MetaPlannerV2() {
                 {pendingAuthoringPreview.preview.warnings.map((warning) => (
                   <p key={warning}>{warning}</p>
                 ))}
+              </div>
+            ) : null}
+
+            {pendingAuthoringPreview.preview.resource_snapshots.length ? (
+              <div className="mt-3 rounded-md border border-emerald-300/20 bg-emerald-300/[0.06] p-3">
+                <p className="text-xs font-semibold text-emerald-100">资源解析结果</p>
+                <div className="mt-2 space-y-1 text-xs text-slate-400">
+                  {pendingAuthoringPreview.preview.resource_snapshots.map((snapshot) => (
+                    <p key={`${snapshot.node_ref}-${snapshot.resource_id}`}>
+                      <span className="font-mono text-slate-300">{snapshot.node_ref}</span>
+                      {` · ${snapshot.resource_id}`}
+                      {snapshot.schema_version != null
+                        ? ` · Schema v${snapshot.schema_version}`
+                        : snapshot.observed_version_id
+                          ? ` · 活动索引 ${snapshot.observed_version_id}`
+                          : snapshot.resolved_version_id
+                            ? ` · 版本 ${snapshot.resolved_version_id}`
+                            : ""}
+                    </p>
+                  ))}
+                </div>
               </div>
             ) : null}
 

--- a/client/src/components/meta/metaAuthoring.test.ts
+++ b/client/src/components/meta/metaAuthoring.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import {
   authoringDiffSummary,
+  authoringOperationSummary,
   buildMetadataPatch,
   canUseTypedHeadlessAuthoring,
   headlessStateMode,
   normalizeGraphPatchEnvelope,
   normalizeGraphPatchPreview,
   normalizeHeadlessProposalState,
+  normalizeSafeResourceSnapshots,
 } from "./metaAuthoring";
 
 describe("Meta Planner headless authoring contracts", () => {
@@ -33,6 +35,8 @@ describe("Meta Planner headless authoring contracts", () => {
       compiler_managed_node_kinds: ["input", "output"],
       authorized_scope: {
         agent_ids: ["expert-reviewer"],
+        knowledge_base_ids: ["kb-allowed"],
+        data_table_ids: ["table-allowed"],
       },
       compatibility: { source_version: 3, lossy: false },
     });
@@ -52,6 +56,8 @@ describe("Meta Planner headless authoring contracts", () => {
         "dataset_compare",
       ],
       allowed_source_agent_ids: ["expert-reviewer"],
+      allowed_knowledge_base_ids: ["kb-allowed"],
+      allowed_data_table_ids: ["table-allowed"],
     });
     expect(state?.allowed_node_kinds).toContain("json_serialize");
     expect(state?.allowed_node_kinds).not.toContain("knowledge_retrieval");
@@ -161,6 +167,58 @@ describe("Meta Planner headless authoring contracts", () => {
     });
   });
 
+  it("projects node resource snapshots without leaking native config", () => {
+    const snapshots = normalizeSafeResourceSnapshots({
+      graph_ir: {
+        nodes: [
+          {
+            ref: "lookup",
+            kind: "data_table_query",
+            config: { api_key: "must-not-render", tableId: "native-injection" },
+            resource_ref: { resource_id: "table-orders" },
+            resource_snapshot: {
+              resource_id: "table-orders",
+              kind: "data_table",
+              version_policy: "pinned",
+              pinned_schema_version: 4,
+              schema_checksum: "a".repeat(64),
+              snapshot_checksum: "b".repeat(64),
+            },
+          },
+        ],
+      },
+    });
+
+    expect(snapshots).toEqual([
+      expect.objectContaining({
+        node_ref: "lookup",
+        node_kind: "data_table_query",
+        resource_id: "table-orders",
+        schema_version: 4,
+        schema_checksum: "aaaaaaaaaaaa",
+        resource_checksum: "bbbbbbbbbbbb",
+      }),
+    ]);
+    expect(JSON.stringify(snapshots)).not.toContain("must-not-render");
+    expect(JSON.stringify(snapshots)).not.toContain("native-injection");
+  });
+
+  it("summarizes resource and error-outcome patches from semantic fields only", () => {
+    expect(authoringOperationSummary({
+      op: "set_node_resource",
+      node_ref: "lookup",
+      resource_id: "table-orders",
+      config: { secret: "hidden" },
+    })).toBe("set_node_resource · lookup · resource table-orders");
+    expect(authoringOperationSummary({
+      op: "connect_control",
+      source_ref: "lookup",
+      outcome_ref: "error",
+      target_ref: "failure",
+      sourceHandle: "forged-native-handle",
+    })).toBe("connect_control · lookup:error -> failure");
+  });
+
   it("keeps failed preview diagnostics visible and non-applicable", () => {
     const preview = normalizeGraphPatchPreview({
       preview_checksum: "preview-1",
@@ -172,5 +230,6 @@ describe("Meta Planner headless authoring contracts", () => {
     expect(preview?.can_apply).toBe(false);
     expect(preview?.diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     expect(authoringDiffSummary(preview?.diff ?? {})).toContain("nodes_updated: 1");
+    expect(preview?.resource_snapshots).toEqual([]);
   });
 });

--- a/client/src/components/meta/metaAuthoring.ts
+++ b/client/src/components/meta/metaAuthoring.ts
@@ -38,6 +38,8 @@ export interface HeadlessAuthoringProposalState {
   allowed_node_kinds: WorkflowNodeKind[];
   allowed_middleware_ids: string[];
   allowed_source_agent_ids: string[];
+  allowed_knowledge_base_ids: string[];
+  allowed_data_table_ids: string[];
   compiler_managed_node_kinds: WorkflowNodeKind[];
   compatibility: HeadlessAuthoringCompatibility;
   diagnostics: AuthoringDiagnostic[];
@@ -51,6 +53,21 @@ export interface GraphPatchPreview {
   diff: Record<string, unknown>;
   graph_ir_checksum?: string;
   candidate_checksum?: string;
+  resource_snapshots: SafeResourceSnapshot[];
+}
+
+export interface SafeResourceSnapshot {
+  node_ref: string;
+  node_kind?: string;
+  resource_id: string;
+  resource_kind?: string;
+  version_policy?: string;
+  observed_version_id?: string;
+  resolved_version_id?: string;
+  schema_version?: number;
+  resource_checksum?: string;
+  schema_checksum?: string;
+  warnings: string[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -67,8 +84,84 @@ function numberValue(value: unknown, fallback = 0) {
 
 function stringArray(value: unknown) {
   return Array.isArray(value)
-    ? value.filter((item): item is string => typeof item === "string")
+    ? value
+        .filter((item): item is string => typeof item === "string")
+        .slice(0, 20)
     : [];
+}
+
+function optionalNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function abbreviatedChecksum(value: unknown) {
+  const checksum = stringValue(value);
+  return /^[a-f0-9]{16,}$/i.test(checksum) ? checksum.slice(0, 12) : undefined;
+}
+
+function normalizeSafeResourceSnapshot(
+  value: unknown,
+  node?: Record<string, unknown>,
+): SafeResourceSnapshot | null {
+  if (!isRecord(value)) return null;
+  const resourceRef = isRecord(node?.resource_ref) ? node?.resource_ref : {};
+  const resourceId = stringValue(
+    value.resource_id ?? value.id ?? resourceRef.resource_id,
+  );
+  const nodeRef = stringValue(
+    value.node_ref ?? value.ref ?? node?.ref,
+  );
+  if (!resourceId || !nodeRef) return null;
+  return {
+    node_ref: nodeRef.slice(0, 64),
+    node_kind: stringValue(value.node_kind ?? node?.kind).slice(0, 80) || undefined,
+    resource_id: resourceId.slice(0, 200),
+    resource_kind: stringValue(value.resource_kind ?? value.kind) || undefined,
+    version_policy:
+      stringValue(value.version_policy ?? value.resolution_policy) || undefined,
+    observed_version_id:
+      stringValue(value.observed_version_id ?? value.observed_version) || undefined,
+    resolved_version_id:
+      stringValue(value.resolved_version_id ?? value.version_id) || undefined,
+    schema_version: optionalNumber(
+      value.schema_version ?? value.pinned_schema_version,
+    ),
+    resource_checksum: abbreviatedChecksum(
+      value.resource_checksum ?? value.snapshot_checksum,
+    ),
+    schema_checksum: abbreviatedChecksum(value.schema_checksum),
+    warnings: stringArray(value.warnings),
+  };
+}
+
+export function normalizeSafeResourceSnapshots(value: unknown): SafeResourceSnapshot[] {
+  if (!isRecord(value)) return [];
+  const graph = isRecord(value.graph_ir) ? value.graph_ir : value;
+  const direct = Array.isArray(graph.resource_snapshots)
+    ? graph.resource_snapshots
+    : [];
+  const fromDirect = direct.flatMap((item) => {
+    const normalized = normalizeSafeResourceSnapshot(item);
+    return normalized ? [normalized] : [];
+  });
+  const fromNodes = Array.isArray(graph.nodes)
+    ? graph.nodes.flatMap((item) => {
+        if (!isRecord(item)) return [];
+        const snapshot = normalizeSafeResourceSnapshot(item.resource_snapshot, item);
+        if (snapshot) return [snapshot];
+        if (!isRecord(item.resource_ref)) return [];
+        const unresolved = normalizeSafeResourceSnapshot(
+          { ...item.resource_ref, node_ref: item.ref, node_kind: item.kind },
+          item,
+        );
+        return unresolved ? [unresolved] : [];
+      })
+    : [];
+  const unique = new Map<string, SafeResourceSnapshot>();
+  [...fromDirect, ...fromNodes].slice(0, 64).forEach((item) => {
+    unique.set(`${item.node_ref}:${item.resource_id}`, item);
+  });
+  return [...unique.values()];
 }
 
 export function normalizeAuthoringDiagnostics(value: unknown): AuthoringDiagnostic[] {
@@ -145,6 +238,8 @@ export function normalizeHeadlessProposalState(
     allowed_node_kinds: allowedKinds,
     allowed_middleware_ids: stringArray(authorizedScope.middleware_ids),
     allowed_source_agent_ids: stringArray(authorizedScope.agent_ids),
+    allowed_knowledge_base_ids: stringArray(authorizedScope.knowledge_base_ids),
+    allowed_data_table_ids: stringArray(authorizedScope.data_table_ids),
     compiler_managed_node_kinds: (
       stringArray(payload.compiler_managed_node_kinds).length
         ? stringArray(payload.compiler_managed_node_kinds)
@@ -250,6 +345,7 @@ export function normalizeGraphPatchPreview(payload: unknown): GraphPatchPreview 
           payload.compiled_workflow_checksum ??
           payload.compiled_candidate_checksum,
       ) || undefined,
+    resource_snapshots: normalizeSafeResourceSnapshots(payload),
   };
 }
 
@@ -284,6 +380,10 @@ export function authoringDiffSummary(diff: Record<string, unknown>): string[] {
     "edges_added",
     "edges_removed",
     "bindings_changed",
+    "node_resources_changed",
+    "resource_refs_changed",
+    "resource_snapshots_changed",
+    "error_outcomes_changed",
     "metadata_changed",
     "layout_changed",
   ];
@@ -294,13 +394,27 @@ export function authoringDiffSummary(diff: Record<string, unknown>): string[] {
     else if (typeof value === "number" && value > 0) lines.push(`${key}: ${value}`);
     else if (Array.isArray(value) && value.length > 0) lines.push(`${key}: ${value.length}`);
     else if (isRecord(value) && Object.keys(value).length > 0) {
-      lines.push(
-        `${key}: ${Object.entries(value)
-          .map(([name, count]) => `${name} ${String(count)}`)
-          .join(", ")}`,
-      );
+      lines.push(`${key}: ${Object.keys(value).length}`);
     }
     else if (value === true) lines.push(key);
   }
   return lines.length ? lines : ["服务端未返回可展示的结构差异摘要。"];
+}
+
+export function authoringOperationSummary(operation: GraphPatchOperationV1): string {
+  const op = stringValue(operation.op) || "unknown";
+  if (op === "set_node_resource" || op === "clear_node_resource") {
+    const nodeRef = stringValue(operation.node_ref ?? operation.ref);
+    const resourceId = stringValue(operation.resource_id);
+    return [op, nodeRef, resourceId ? `resource ${resourceId}` : ""]
+      .filter(Boolean)
+      .join(" · ");
+  }
+  if (op === "connect_control" || op === "disconnect_control") {
+    const source = stringValue(operation.source_ref);
+    const outcome = stringValue(operation.outcome_ref) || "success";
+    const target = stringValue(operation.target_ref);
+    return `${op} · ${source}:${outcome} -> ${target}`;
+  }
+  return op;
 }

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -3402,23 +3402,30 @@ function ResourceNodeConfig({
 
 function KnowledgeBaseSelector({
   allowLegacyEmpty = false,
+  allowedIds,
   onChange,
   onLoadStateChange,
   onSelectedOptionChange,
   value,
 }: {
   allowLegacyEmpty?: boolean;
+  allowedIds?: string[];
   onChange: (value: string) => void;
   onLoadStateChange?: (state: "loading" | "ready" | "error") => void;
   onSelectedOptionChange?: (option: WorkflowResourceOption | null) => void;
   value: string;
 }) {
   const { loadError, loading, options } = useWorkflowResourceOptions("knowledge_base");
+  const visibleOptions = useMemo(() => {
+    if (allowedIds === undefined) return options;
+    const allowed = new Set(allowedIds);
+    return options.filter((item) => allowed.has(item.id));
+  }, [allowedIds, options]);
   useEffect(() => {
     onSelectedOptionChange?.(
-      options.find((item) => item.id === value) ?? null,
+      visibleOptions.find((item) => item.id === value) ?? null,
     );
-  }, [onSelectedOptionChange, options, value]);
+  }, [onSelectedOptionChange, value, visibleOptions]);
   useEffect(() => {
     onLoadStateChange?.(loading ? "loading" : loadError ? "error" : "ready");
   }, [loadError, loading, onLoadStateChange]);
@@ -3432,7 +3439,7 @@ function KnowledgeBaseSelector({
         <option className="bg-slate-950" value="">
           {allowLegacyEmpty ? "未固定（仅单知识库旧图兼容）" : "选择知识库"}
         </option>
-        {options.map((item) => (
+        {visibleOptions.map((item) => (
           <option className="bg-slate-950" key={item.id} value={item.id}>
             {item.name} · {item.active_version_id ? "活动索引可用" : "暂无活动索引"}
           </option>
@@ -3455,6 +3462,7 @@ function KnowledgeRetrievalNodeConfig({
   update,
   onOpenVariableCenter,
   retryAvailability,
+  allowedKnowledgeBaseIds,
 }: {
   node: WorkflowNode;
   nodes: WorkflowNode[];
@@ -3465,6 +3473,7 @@ function KnowledgeRetrievalNodeConfig({
   update: (patch: Partial<WorkflowNodeData>) => void;
   onOpenVariableCenter: () => void;
   retryAvailability?: WorkflowRetryAvailability;
+  allowedKnowledgeBaseIds?: string[];
 }) {
   const isLegacy = Number(data.contractVersion ?? 1) !== 2;
   const [selectedKnowledgeBase, setSelectedKnowledgeBase] =
@@ -3499,6 +3508,7 @@ function KnowledgeRetrievalNodeConfig({
       <Field label="知识库">
         <KnowledgeBaseSelector
           allowLegacyEmpty={isLegacy}
+          allowedIds={allowedKnowledgeBaseIds}
           onChange={(value) => update({ knowledgeBaseId: value })}
           onLoadStateChange={setKnowledgeBaseLoadState}
           onSelectedOptionChange={setSelectedKnowledgeBase}
@@ -4459,6 +4469,7 @@ function NodeConfig({
         "data_table_delete",
       ].includes(data.kind) ? (
         <WorkflowTypedDataNodeConfig
+          allowedTableIds={authoringPolicy?.allowedDataTableIds}
           contract={variableContract}
           data={data}
           declarations={declarations}
@@ -5148,6 +5159,7 @@ function NodeConfig({
 
       {data.kind === "knowledge_retrieval" ? (
         <KnowledgeRetrievalNodeConfig
+          allowedKnowledgeBaseIds={authoringPolicy?.allowedKnowledgeBaseIds}
           data={data}
           declarations={declarations}
           edges={edges}
@@ -6740,6 +6752,8 @@ export interface WorkflowEditorAuthoringPolicy {
   compilerManagedNodeKinds?: WorkflowNodeKind[];
   allowedRuntimeMiddlewareIds?: string[];
   allowedSourceAgentIds?: string[];
+  allowedKnowledgeBaseIds?: string[];
+  allowedDataTableIds?: string[];
 }
 
 export const HEADLESS_WORKFLOW_AGENT_EDITABLE_FIELDS = [

--- a/client/src/components/workflow/WorkflowTypedDataNodeConfig.tsx
+++ b/client/src/components/workflow/WorkflowTypedDataNodeConfig.tsx
@@ -668,6 +668,7 @@ export default function WorkflowTypedDataNodeConfig({
   onChange,
   onOpenVariableCenter,
   retryAvailability,
+  allowedTableIds,
 }: {
   data: WorkflowNodeData;
   node: WorkflowNode;
@@ -678,6 +679,7 @@ export default function WorkflowTypedDataNodeConfig({
   onChange: (patch: Partial<WorkflowNodeData>) => void;
   onOpenVariableCenter?: () => void;
   retryAvailability?: WorkflowRetryAvailability;
+  allowedTableIds?: string[];
 }) {
   const isDataTable = dataTableKinds.has(data.kind);
   const [tables, setTables] = useState<AgentTableDefinition[]>([]);
@@ -692,6 +694,10 @@ export default function WorkflowTypedDataNodeConfig({
     expectedSchemaValue,
   );
   const [expectedSchemaError, setExpectedSchemaError] = useState("");
+  const allowedTableIdSet = useMemo(
+    () => allowedTableIds === undefined ? null : new Set(allowedTableIds),
+    [allowedTableIds],
+  );
 
   useEffect(() => {
     setExpectedSchemaDraft(expectedSchemaValue);
@@ -721,14 +727,18 @@ export default function WorkflowTypedDataNodeConfig({
       const payload = await requestAgentTableJson<{ items: AgentTableDefinition[] }>(
         "/api/data-tables?status=published&limit=500",
       );
-      setTables(payload.items ?? []);
+      setTables(
+        (payload.items ?? []).filter(
+          (table) => allowedTableIdSet === null || allowedTableIdSet.has(table.table_id),
+        ),
+      );
       setError("");
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : "数据表加载失败。" );
     } finally {
       setLoading(false);
     }
-  }, [isDataTable]);
+  }, [allowedTableIdSet, isDataTable]);
 
   useEffect(() => {
     void loadTables();
@@ -737,6 +747,11 @@ export default function WorkflowTypedDataNodeConfig({
   useEffect(() => {
     if (!isDataTable || !data.tableId) {
       setDetail(null);
+      return;
+    }
+    if (allowedTableIdSet !== null && !allowedTableIdSet.has(data.tableId)) {
+      setDetail(null);
+      setError("所选数据表不在当前 Proposal 的授权范围内。");
       return;
     }
     let cancelled = false;
@@ -756,7 +771,7 @@ export default function WorkflowTypedDataNodeConfig({
     return () => {
       cancelled = true;
     };
-  }, [data.tableId, isDataTable]);
+  }, [allowedTableIdSet, data.tableId, isDataTable]);
 
   const selectedSchema = useMemo(() => {
     if (!detail) return null;

--- a/client/src/components/workflow/workflowNodeRegistry.test.ts
+++ b/client/src/components/workflow/workflowNodeRegistry.test.ts
@@ -6,6 +6,49 @@ import {
 } from "./workflowNodeRegistry";
 
 describe("workflowNodeRegistry NodeContract V3 guard", () => {
+  const checksum = "a".repeat(64);
+  const validRegistry = {
+    version: "xpert-workflow-node-registry-v7",
+    contract_version: 3,
+    contract_checksum: checksum,
+    tabs: [{ id: "workflow" as const, label: "工作流" }],
+    sections: [{
+      id: "logic" as const,
+      label: "逻辑",
+      description: "逻辑节点",
+      items: [{
+        kind: "input" as const,
+        icon: "▶",
+        title: "触发器",
+        description: "工作流入口",
+        contract: {
+          kind: "input" as const,
+          contract_status: "complete" as const,
+          config_schema: {},
+          ports: [],
+          edge: {},
+          execution: {},
+          availability: {},
+          resources: [],
+          planner: {},
+          contract_version: 3,
+          checksum,
+          compiler_checksum: checksum,
+        },
+      }],
+    }],
+    knowledge_pipeline: { items: [], placeholders: [] },
+  };
+
+  it("accepts the current registry revision when its V3 contracts are valid", () => {
+    expect(hasNodeContractV3(validRegistry)).toBe(true);
+  });
+
+  it("rejects unrelated or pre-V3 registry revisions", () => {
+    expect(hasNodeContractV3({ ...validRegistry, version: "foreign-registry-v7" })).toBe(false);
+    expect(hasNodeContractV3({ ...validRegistry, version: "xpert-workflow-node-registry-v4" })).toBe(false);
+  });
+
   it("keeps fallback presentation-only and planner-neutral", () => {
     expect(hasNodeContractV3(workflowNodeRegistryFallback)).toBe(false);
 

--- a/client/src/components/workflow/workflowNodeRegistry.ts
+++ b/client/src/components/workflow/workflowNodeRegistry.ts
@@ -565,11 +565,16 @@ function isSha256(value: unknown): value is string {
   return typeof value === "string" && /^[a-f0-9]{64}$/i.test(value);
 }
 
+function hasCompatibleRegistryVersion(value: string): boolean {
+  const match = /^xpert-workflow-node-registry-v([1-9]\d*)$/.exec(value);
+  return match !== null && Number(match[1]) >= 5;
+}
+
 export function hasNodeContractV3(
   registry: WorkflowNodeRegistryResponse,
 ): boolean {
   if (
-    registry.version !== "xpert-workflow-node-registry-v5" ||
+    !hasCompatibleRegistryVersion(registry.version) ||
     registry.contract_version !== 3 ||
     !isSha256(registry.contract_checksum)
   ) {

--- a/client/src/pages/XpertEvaluationsPage.test.ts
+++ b/client/src/pages/XpertEvaluationsPage.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeResourceEvidence,
+  resourceEvidenceSummaryLabel,
+} from "./XpertEvaluationsPage";
+
+describe("Xpert evaluation resource evidence", () => {
+  it("uses the item-level resource_reads emitted by the backend", () => {
+    const evidence = normalizeResourceEvidence("verified", [
+      {
+        node_ref: "table_lookup",
+        kind: "data_table_query",
+        resource_id: "table_1",
+        schema_version: 3,
+        query_checksum: "a".repeat(64),
+        result_count: 1,
+        record_ids: ["record_1"],
+      },
+    ]);
+
+    expect(evidence).toMatchObject({
+      status: "verified",
+      reads: [
+        {
+          node_ref: "table_lookup",
+          schema_version: 3,
+          query_checksum: "aaaaaaaaaaaa",
+          result_count: 1,
+          record_ids: ["record_1"],
+        },
+      ],
+    });
+  });
+
+  it("renders aggregate counters without inventing an available status", () => {
+    expect(
+      resourceEvidenceSummaryLabel({
+        verified: 2,
+        failed: 1,
+        missing: 3,
+        not_applicable: 0,
+      }),
+    ).toBe("verified 2 · failed 1 · missing 3 · not_applicable 0");
+    expect(resourceEvidenceSummaryLabel({ supported: true })).toBeNull();
+  });
+});

--- a/client/src/pages/XpertEvaluationsPage.tsx
+++ b/client/src/pages/XpertEvaluationsPage.tsx
@@ -51,7 +51,40 @@ interface EvaluationCase {
     terminal: "success" | "error";
     error_code?: string | null;
   };
+  resource_reads?: EvaluationResourceReadExpectation[];
   weights?: Record<string, number>;
+}
+
+interface EvaluationResourceReadExpectation {
+  node_ref: string;
+  kind?: "knowledge_retrieval" | "data_table_query" | string;
+  resource_id?: string;
+  version_id?: string | null;
+  schema_version?: number | null;
+  query_checksum?: string;
+  expected_count?: number;
+  record_ids?: string[];
+  citation_ids?: string[];
+}
+
+export interface SafeResourceReadEvidence {
+  node_ref: string;
+  kind?: string;
+  resource_id?: string;
+  version_id?: string;
+  schema_version?: number;
+  query_checksum?: string;
+  result_count?: number;
+  record_ids: string[];
+  citation_ids: string[];
+  outcome?: "success" | "error" | string;
+}
+
+export interface SafeResourceEvidence {
+  status: string;
+  supported?: boolean;
+  reads: SafeResourceReadEvidence[];
+  warnings: string[];
 }
 
 interface DatasetSummary {
@@ -131,6 +164,8 @@ interface EvaluationItem {
     error_code?: string;
     warnings?: string[];
   };
+  resource_evidence?: unknown;
+  resource_reads?: unknown;
 }
 
 interface EvaluationRun {
@@ -174,6 +209,7 @@ interface EvaluationRun {
       model_calls: number;
       tool_calls: number;
       estimated_tokens: number;
+      resource_evidence?: unknown;
     }>;
     comparisons?: Array<{
       target_id: string;
@@ -242,6 +278,79 @@ function formatTime(value?: number | null) {
 function percent(value?: number) {
   if (value == null || Number.isNaN(value)) return "-";
   return `${(value * 100).toFixed(1)}%`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function safeString(value: unknown) {
+  return typeof value === "string" ? value : undefined;
+}
+
+function safeNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function safeStringList(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string").slice(0, 20)
+    : [];
+}
+
+export function normalizeResourceEvidence(
+  value: unknown,
+  directReads?: unknown,
+): SafeResourceEvidence | null {
+  const fallbackReads = Array.isArray(directReads) ? directReads : [];
+  if (typeof value === "string") {
+    return normalizeResourceEvidence({ status: value, reads: fallbackReads });
+  }
+  if (!isRecord(value)) return null;
+  const rawReads = Array.isArray(value.reads)
+    ? value.reads
+    : Array.isArray(value.items)
+      ? value.items
+      : fallbackReads;
+  const reads = rawReads.flatMap((item): SafeResourceReadEvidence[] => {
+    if (!isRecord(item) || typeof item.node_ref !== "string") return [];
+    const checksum = safeString(
+      item.query_contract_checksum ?? item.query_checksum,
+    );
+    return [{
+      node_ref: item.node_ref,
+      kind: safeString(item.kind ?? item.resource_kind),
+      resource_id: safeString(item.resource_id),
+      version_id: safeString(
+        item.version_id ?? item.resolved_version_id ?? item.observed_version_id,
+      ),
+      schema_version: safeNumber(item.schema_version),
+      query_checksum: checksum ? checksum.slice(0, 12) : undefined,
+      result_count: safeNumber(item.result_count ?? item.hit_count),
+      record_ids: safeStringList(item.record_ids),
+      citation_ids: safeStringList(item.citation_ids),
+      outcome: safeString(item.outcome),
+    }];
+  });
+  return {
+    status: safeString(value.status) || (value.supported === false ? "unsupported" : "available"),
+    supported: typeof value.supported === "boolean" ? value.supported : undefined,
+    reads,
+    warnings: safeStringList(value.warnings),
+  };
+}
+
+export function resourceEvidenceSummaryLabel(value: unknown): string | null {
+  if (!isRecord(value)) return typeof value === "string" ? value : null;
+  const fields = ["verified", "failed", "missing", "not_applicable"] as const;
+  if (!fields.some((field) => safeNumber(value[field]) != null)) return null;
+  return fields
+    .map((field) => `${field} ${safeNumber(value[field]) ?? 0}`)
+    .join(" · ");
+}
+
+export function evaluationMetricLabel(kind: string) {
+  return kind === "workflow_resource_match" ? "资源读取匹配" : kind;
 }
 
 function statusTone(status: string) {
@@ -838,6 +947,19 @@ export default function XpertEvaluationsPage() {
                   calibration job: {calibrationJobId}
                 </p>
               ) : null}
+              <details className="rounded-md border border-white/10 bg-white/[0.025] p-3 text-xs text-slate-400">
+                <summary className="cursor-pointer font-semibold text-slate-200">资源读取断言（可选）</summary>
+                <p className="mt-2 leading-5">
+                  在用例中添加 <code className="text-cyan-100">resource_reads</code>，可按 Planner 节点 ref
+                  断言知识库/数据表、固定版本、结果数量、记录 ID 或 Citation ID。不要填写记录正文或查询结果。
+                </p>
+                <pre className="mt-2 overflow-x-auto rounded bg-black/20 p-2 text-[10px] leading-5 text-slate-300">{`"resource_reads": [{
+  "node_ref": "lookup",
+  "kind": "data_table_query",
+  "resource_id": "table_id",
+  "expected_count": 1
+}]`}</pre>
+              </details>
               <textarea className="min-h-[380px] w-full resize-y rounded-md border border-white/10 bg-ink-950/70 p-4 font-mono text-xs leading-6 text-slate-200 outline-none focus:border-cyan-300/40" onChange={(event) => setCasesText(event.target.value)} spellCheck={false} value={casesText} />
               <div className="grid gap-3 sm:grid-cols-2">
                 <label className="text-xs font-semibold text-slate-300">
@@ -982,11 +1104,16 @@ export default function XpertEvaluationsPage() {
                 <div className="mt-3 space-y-1">
                   {Object.entries(target.metrics).map(([name, score]) => (
                     <div className="flex items-center justify-between text-[11px]" key={name}>
-                      <span className="text-slate-400">{name}</span>
+                      <span className="text-slate-400">{evaluationMetricLabel(name)}</span>
                       <span className="font-semibold text-slate-200">{percent(score)}</span>
                     </div>
                   ))}
                 </div>
+                {resourceEvidenceSummaryLabel(target.resource_evidence) ? (
+                  <p className="mt-3 border-t border-white/10 pt-2 text-[10px] text-slate-500">
+                    资源证据：{resourceEvidenceSummaryLabel(target.resource_evidence)}
+                  </p>
+                ) : null}
               </article>
             ))}
           </div>
@@ -1062,11 +1189,67 @@ export default function XpertEvaluationsPage() {
                       )}
                     </div>
                   ) : null}
+                  {(() => {
+                    const evidence = normalizeResourceEvidence(
+                      selectedItem.resource_evidence,
+                      selectedItem.resource_reads,
+                    );
+                    if (!evidence) return null;
+                    return (
+                      <div className="mt-4 rounded-md border border-emerald-300/15 bg-emerald-300/[0.05] p-3">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <span className="text-xs font-semibold text-emerald-100">只读资源证据</span>
+                          <span className="text-[11px] text-emerald-100/65">{evidence.status}</span>
+                        </div>
+                        {evidence.reads.length ? (
+                          <div className="mt-2 space-y-2 text-[11px] leading-5 text-slate-400">
+                            {evidence.reads.map((read, index) => (
+                              <div key={`${read.node_ref}-${index}`}>
+                                <p>
+                                  <span className="font-mono text-slate-300">{read.node_ref}</span>
+                                  {read.kind ? ` · ${read.kind}` : ""}
+                                  {read.resource_id ? ` · ${read.resource_id}` : ""}
+                                  {read.outcome ? ` · ${read.outcome}` : ""}
+                                </p>
+                                <p className="text-slate-500">
+                                  {read.schema_version != null
+                                    ? `Schema v${read.schema_version}`
+                                    : read.version_id
+                                      ? `版本 ${read.version_id}`
+                                      : "版本摘要不可用"}
+                                  {read.result_count != null ? ` · ${read.result_count} 条结果` : ""}
+                                  {read.query_checksum
+                                    ? ` · 查询 ${read.query_checksum}`
+                                    : ""}
+                                </p>
+                                {read.record_ids.length || read.citation_ids.length ? (
+                                  <p className="break-all text-slate-500">
+                                    {read.record_ids.length ? `记录 ${read.record_ids.join(", ")}` : ""}
+                                    {read.record_ids.length && read.citation_ids.length ? " · " : ""}
+                                    {read.citation_ids.length ? `引用 ${read.citation_ids.join(", ")}` : ""}
+                                  </p>
+                                ) : null}
+                              </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="mt-2 text-[11px] text-amber-100/80">
+                            当前报告未提供可验证的节点级资源读取记录。
+                          </p>
+                        )}
+                        {evidence.warnings.length ? (
+                          <p className="mt-2 text-[11px] leading-5 text-amber-100">
+                            {evidence.warnings.join("；")}
+                          </p>
+                        ) : null}
+                      </div>
+                    );
+                  })()}
                   <div className="mt-4 space-y-2">
                     {(selectedItem.metrics ?? []).map((metricItem) => (
                       <div className="rounded-md border border-white/10 bg-white/[0.025] p-3" key={metricItem.kind}>
                         <div className="flex items-center justify-between">
-                          <span className="text-xs font-semibold text-slate-200">{metricItem.kind}</span>
+                          <span className="text-xs font-semibold text-slate-200">{evaluationMetricLabel(metricItem.kind)}</span>
                           <span className={metricItem.passed ? "text-xs font-semibold text-emerald-200" : "text-xs font-semibold text-rose-200"}>{percent(metricItem.score)}</span>
                         </div>
                         <p className="mt-1 text-[11px] leading-5 text-slate-500">{metricItem.reason}</p>

--- a/docs/EVOAGENTX_EVALUATOR.md
+++ b/docs/EVOAGENTX_EVALUATOR.md
@@ -98,6 +98,7 @@ reasoning 正文。可恢复的空内容、契约缺失和截断解析错误复�
 - 1–5 个已发布 XpertVersion 或固定 revision 的 Authoring Proposal 候选。
 - 完整 workflow、资源固定版本、配置 checksum 和 Proposal revision。
 - 创建时的 Knowledge 活动索引版本。
+- Agent Table 查询固定 SchemaVersion、查询契约和同一只读事务内捕获的逐用例结果夹具。
 - Data X 已发布资源及外部 Xpert 固定版本。
 - seed、模型策略、Judge 模型和预算。
 
@@ -118,6 +119,13 @@ fail-closed 预检：
 - Toolset 只允许已发布版本中 `read_only=true` 且 `sensitive=false` 的工具。
 - External Xpert 必须固定版本，并递归通过同一预检。
 - Knowledge 查询固定到运行创建时的活动索引版本。
+- Agent Table Query 仅在谓词可由运行输入、常量或确定性纯节点推导时允许；结果必须
+  在运行创建时固化，重试和重启不得回退读取活表。
+- 夹具捕获与真实运行共用同一套会话裁剪和 Prompt Profile `{{args}}` 渲染；持久化记录
+  具有规范化内容 checksum，恢复时校验失败即关闭。私有夹具会从创建、取消、列表和
+  详情响应中统一剥离。
+- 使用 `error_output` 的资源节点仅在 `success` 路径产生 `result`；错误路径引用该输出
+  会在控制流分析阶段被拒绝。
 - Plugin 只有在展开后的 Toolset、middleware 和 Skill 均为只读安全能力时才允许。
 
 评测模式不会创建会话、写记忆、生成提案或进入人工审批队列。任何
@@ -154,11 +162,18 @@ checkpoint 仅记录 ID、状态、数量、耗时和安全错误摘要。
 - `citation_hit`
 - `rubric_judge`
 - `workflow_path_match`
+- `workflow_resource_match`
 
 `workflow_path_match` 只读取 classic runner 写入内部 checkpoint 的 Planner ref、
 语义 outcome、终点来源和受限错误码。它不新增 Workflow SSE 事件，也不从物理节点 ID
 或 native handle 猜测路径。缺少 Planner ref 的旧手工作业返回 unsupported warning。
 预期错误终点必须同时匹配路径和安全错误码，并且不得与文本答案指标混用。
+
+`workflow_resource_match` 只比较受限资源证据：Planner ref、资源 ID、固定知识版本或
+SchemaVersion、查询契约 checksum、命中数以及可选 record/citation ID。Agent Table
+夹具最多 1,000 个、单查询 200 行、合计 16 MiB，只保存在私有 Evaluation Store；API、
+报告和 checkpoint 均不返回记录正文。未声明 `resource_reads` 的旧 Dataset 可继续运行，
+但只读资源目标会标记 `resource_evidence=missing`，不能据此宣称资源能力已验证。
 
 LLM Judge 使用固定模型、温度 0 和严格 JSON，只保存 0–1 分数、通过状态与最多
 500 字符理由，不保存隐藏推理。
@@ -173,6 +188,7 @@ LLM Judge 使用固定模型、温度 0 和严格 JSON，只保存 0–1 分数�
 - 资源漂移与外部 Provider 不完全可复现 warning。
 - 逐样例截断输入、预期、最终输出和安全错误摘要。
 - 逐样例的语义 outcome、成功来源或预期错误终点证据。
+- 逐样例的固定资源快照、查询契约与受限资源读取匹配结果。
 
 ## 7. API
 

--- a/docs/META_AGENT.md
+++ b/docs/META_AGENT.md
@@ -134,9 +134,14 @@ EvoAgentX 的来源与已交付历史见
 2. 能力编译：从实时 Capability Snapshot 中选择真实节点、资源和中间件。
 3. 定向修复：本地确定性门禁失败时，最多调用模型修复一次。
 
+面向用户和画布展示的候选名称、任务标题、节点标题、说明、提示词及安全错误文案
+统一使用简体中文。资源 ID、Planner ref、字段名、错误码等机器标识保持原值，避免翻译
+破坏 Schema、资源绑定或确定性 checksum。编译器管理的输入、输出节点也遵守同一展示
+语言约束。
+
 ### NodeContract V3 能力门禁
 
-Meta Planner 的节点事实统一来自 `NodeContractRegistry`。Capability Snapshot V7
+Meta Planner 的节点事实统一来自 `NodeContractRegistry`。Capability Snapshot V8
 只暴露满足以下全部条件的节点：契约状态完整、Planner 显式启用、编译模式真实存在、
 Adapter 版本一致，并且契约与 Adapter 的 compiler checksum 匹配。UI Registry 中出现
 节点不等于 Planner 可以生成该节点。
@@ -144,8 +149,9 @@ Adapter 版本一致，并且契约与 Adapter 的 compiler checksum 匹配。UI
 当前开放范围为 `input`、`output`、`workflow_agent`、四类资源绑定，以及
 `json_serialize`、`json_deserialize`、`variable_aggregator`、`data_aggregate`、
 `dataset_compare` 五种无副作用类型化纯节点和 `condition`、`multi_route`、
-`data_merge`、`terminate_error` 四种受限控制流节点。NodeContract V3 与 Planner IR 独立演进。
-Capability Snapshot 当前为 V7，
+`data_merge`、`terminate_error` 四种受限控制流节点，以及 `knowledge_retrieval`、
+`data_table_query` 两种只读动态资源节点。NodeContract V3 与 Planner IR 独立演进。
+Capability Snapshot 当前为 V8，
 `ir_version=3` 且声明 `supported_ir_versions=[2,3]`。旧 V2 Snapshot 保持可读，详见
 [NODE_CONTRACT_V3.md](./NODE_CONTRACT_V3.md)。
 
@@ -156,8 +162,9 @@ Snapshot 和资源 Store 解析为 `ResolvedGraphIRV3`。模型不能指定资�
 执行效果或安全属性。Resolved IR 显式区分 `control/data/binding/metadata` 四类边；
 data 边只表达类型化变量来源，不进入 classic runner 的拓扑或调度。
 
-外部 Xpert、Toolset、Plugin 和 Prompt Profile 在解析时固定发布版本；知识库保持
-活动版本指针语义并记录观察版本。Graph checksum 排除布局和时间戳，编译产物另有
+外部 Xpert、Toolset、Plugin 和 Prompt Profile 在解析时固定发布版本；知识检索保持
+活动版本指针语义并记录观察版本，Agent Table 查询固定不可变 SchemaVersion 与
+checksum。Graph checksum 排除布局和时间戳，编译产物另有
 独立 checksum。新 Proposal 保存完整安全 IR 和两个 checksum；人工编辑候选后 IR
 标记为 `stale`，审批仍以实际 Workflow 为权威。
 
@@ -182,7 +189,7 @@ Apply。操作、接口、安全 receipt 和回退边界见
 类型化输入/输出变量、控制边、资源/中间件目标和唯一最终输出。任务和 Agent 不再
 强制一一对应：一个 Agent 可以覆盖多个任务，一个任务也可以由多个节点共同完成。
 
-Capability Snapshot V7 只暴露当前存在且与 NodeContract、Adapter checksum 校验一致的
+Capability Snapshot V8 只暴露当前存在且与 NodeContract、Adapter checksum 校验一致的
 编译能力。`workflow_agent` 的 `task_binding=required`，每个计划任务仍必须由 Agent
 覆盖；五种纯节点的 `task_binding=forbidden`，只能作为 Agent 之间的确定性辅助步骤，
 不能承担任务或成为最终输出。`input/output` 由编译器管理，外部 Xpert、知识库、
@@ -194,7 +201,7 @@ Meta Planner 只生成 JSON `contractVersion=2`：Deserialize 必须携带受限
 生成或自动升级。Variable Aggregator V2、Data Aggregate 和 Dataset Compare 复用
 现有 Runtime，并由 Adapter 从 Graph IR data 边派生原生变量绑定。
 
-控制流使用 `control_flow_contract_version=1`。模型只引用语义 outcome：普通节点为
+控制流使用 `control_flow_contract_version=2`。模型只引用语义 outcome：普通节点为
 `success`，Condition 为 `matched/unmatched`，Multi Route 为
 `case_1...case_8/default`；Native handle、路由 ID 和变量均由 Adapter 推导。确定性分析器
 限制最多 8 个路由节点和 256 个符号场景，阻止循环、死路、不可达、影子规则、路径上
@@ -211,7 +218,13 @@ witness 中；无法找到合法 witness 的 outcome（包括 default）继续�
 执行，不补造路径证据；显式存在但损坏的 outcome 映射仍会失败。Output V1 的旧
 运行不能被当作已经验证了 Output V2 路径合同。
 
-`variable_assign`、`list_operation`、`object_transform`、Agent Table、知识检索、视觉理解、
+只读资源节点通过节点自有 `resource_ref` 授权，不能与 Agent 的 `bind_resource` 混用。
+知识检索只允许 `top_k=1..10` 和 `context/result` 输出；Agent Table 查询只接受固定
+Schema 中的字段、受限条件树、排序与 `limit=1..200`。表默认不授权，必须由用户显式
+选择；模型不能提交原生资源字段、版本、Schema、Handle 或 checksum。两类节点均可走
+`success/error`，但不能承担计划任务或直接成为最终交付来源。
+
+`variable_assign`、`list_operation`、`object_transform`、Agent Table 写入、视觉理解、
 循环、等待、HITL、Handoff、Trigger 和 `question_classifier` 仍无 Planner Adapter，
 不会进入授权快照。
 

--- a/docs/META_PLANNER_HEADLESS_AUTHORING.md
+++ b/docs/META_PLANNER_HEADLESS_AUTHORING.md
@@ -26,8 +26,9 @@ Pydantic、Adapter 或 Proposal 服务前失败关闭。
 Patch 只接受 Planner ref、命名端口和 Adapter config。原生节点 ID、Handle、资源版本、
 NodeContract Schema、执行策略与 checksum 均由服务端推导，客户端或模型不能注入。
 
-支持 Xpert 元数据、Workflow Agent、五种纯数据 Adapter、控制/data 边、输出变量、
-四类资源、中间件、Prompt Profile、最终输出和布局。`input/output` 由编译器管理；
+支持 Xpert 元数据、Workflow Agent、五种纯数据 Adapter、四种控制流 Adapter、两种
+只读资源 Adapter、控制/data 边、输出变量、四类 Agent 资源、中间件、Prompt Profile、
+最终输出和布局。`input/output` 由编译器管理；
 布局不会改变 Graph checksum，但会改变 candidate checksum。纯节点配置、原生变量名、
 端口 Schema 和 binding ID 由 Adapter 推导，不能通过 Patch 注入。
 
@@ -43,6 +44,11 @@ Apply 必须携带 Preview checksum。服务端重新读取 Proposal、能力快
 - 更新目标的 draft revision 漂移。
 - 相关 NodeContract、Adapter、资源版本或动态 Schema 失效。
 - Patch 端口、类型、基数、控制图、授权或最终输出不合法。
+
+`set_node_resource` 只用于 `knowledge_retrieval` 与 `data_table_query` 的节点自有资源，
+不能替代 Agent 的 `bind_resource`。Preview/Apply 会重新解析知识库活动索引或固定的
+Agent Table SchemaVersion；知识活动指针变化给出 warning，表 Schema checksum、资源
+授权或固定版本失效则阻断。模型和客户端仍不能提交原生资源字段或版本。
 
 无关 Capability Snapshot 变化只产生 warning。Apply 成功只增加一次 Proposal revision，
 随后复用现有 Authoring validation。安全 receipt 最多保留 20 条，只记录操作类型、前后
@@ -76,9 +82,9 @@ POST /api/meta-agent/authoring/proposals/{proposal_id}/patch/preview
 POST /api/meta-agent/authoring/proposals/{proposal_id}/patch/apply
 ```
 
-Capability Snapshot V6 暴露 authoring protocol、操作 JSON Schema、Adapter authoring
-checksum、`task_binding` 和限制。Headless 编辑范围为原有七类加五种纯节点；纯节点
-不得承担任务、绑定资源/中间件或成为最终输出。
+Capability Snapshot V8 暴露 authoring protocol、操作 JSON Schema、Adapter authoring
+checksum、`task_binding` 和限制。Headless 编辑范围为十八种受支持能力；纯节点、
+控制流和只读资源节点不得承担任务，只读资源节点只能使用其 Adapter 声明的资源类型。
 
 ## 回退
 

--- a/docs/META_PLANNER_V3_V4_ROADMAP.md
+++ b/docs/META_PLANNER_V3_V4_ROADMAP.md
@@ -134,6 +134,13 @@ Iteration、等待、HITL、Handoff、Trigger、`question_classifier` 和表达�
 
 必须固定用户授权范围、知识版本或活动指针语义、Agent Table SchemaVersion、字段/操作白名单和漂移处理。Evaluator 必须固定资源快照。只有 chunk 或最终文本命中、却无法证明资源版本和查询契约正确的评测，不足以通过本轮。
 
+落地边界进一步固定为：知识检索保持运行时活动指针语义，但 Planner 记录观察版本，
+Evaluator 在运行创建时固定实际索引；Agent Table 查询在候选中固定不可变
+SchemaVersion，并在 Evaluator 中按目标、用例和节点生成私有事务夹具。两类节点通过
+节点自有资源引用授权，不能伪装成 Agent 资源绑定，也不能承担计划任务或直接作为最终
+交付来源。资源能力验收必须使用 `workflow_resource_match` 证明真实节点、资源版本和
+查询契约均匹配。
+
 ### Round 6：Vision
 
 开放 `vision_understanding`，要求：

--- a/docs/NODE_CONTRACT_V3.md
+++ b/docs/NODE_CONTRACT_V3.md
@@ -61,14 +61,15 @@ The first complete-contract group is:
 | Resource bindings | `external_xpert`, `knowledge_base`, `toolset_resource`, `plugin_resource` | binding only |
 | Pure-data adapters | `json_serialize`, `json_deserialize`, `variable_aggregator`, `data_aggregate`, `dataset_compare` | enabled, `task_binding=forbidden` |
 | Control-flow adapters | `condition`, `multi_route`, `data_merge`, `terminate_error` | enabled, `task_binding=forbidden` |
-| Read targets | `knowledge_retrieval`, `data_table_query`, `vision_understanding` | unsupported |
+| Read targets | `knowledge_retrieval`, `data_table_query` | enabled, `task_binding=forbidden`, node-owned resource |
+| Attachment target | `vision_understanding` | unsupported |
 | Write targets | `data_table_insert`, `data_table_update`, `data_table_delete` | unsupported |
 | Metadata and middleware | `annotation`, `runtime_middleware` | metadata or binding contract only |
 
 All other nodes have compatibility or explicitly unsupported contracts and
 remain executable through the existing classic validator and runner when their
-legacy validation permits it. Capability Snapshot V7 exposes the previous twelve
-kinds plus the four control-flow adapters. Graph IR V3 is the write format; Typed
+legacy validation permits it. Capability Snapshot V8 exposes the previous sixteen
+kinds plus the two read-resource adapters. Graph IR V3 is the write format; Typed
 IR V2 is read-only compatibility input.
 
 Unversioned JSON nodes retain their historical inline-error/null behavior.
@@ -76,12 +77,14 @@ Planner-generated JSON nodes use `contractVersion=2`, strict failure semantics,
 a 5 MiB boundary, and a trusted `WorkflowValueSchema` for Deserialize output.
 The other pure adapters keep their existing bounded Runtime contracts. Pure
 nodes cannot cover plan tasks or bind resources or middleware. Control-flow nodes
-also cannot cover plan tasks. Agent Table Query remains disabled in Evaluator. Vision remains
-disabled in Evaluator until evaluation datasets can carry explicit file assets.
+also cannot cover plan tasks. Agent Table Query is Evaluator-conditional: its
+SchemaVersion and query contract are fixed and its results are captured into a private,
+bounded read-transaction fixture before model execution. Vision remains disabled in
+Evaluator until evaluation datasets can carry explicit file assets.
 
-Control-flow contract version 1 gives `condition` the semantic outcomes
+Control-flow contract version 2 retains `condition` outcomes
 `matched/unmatched`, `multi_route` the outcomes `case_1...case_8/default`, and
-ordinary Planner nodes `success`. Native handles are compiler-owned. Output V2
+adds `success/error` for read-resource nodes. Native handles are compiler-owned. Output V2
 uses `exactly_one_arrived` across 1-8 trusted sources. `data_merge` is limited to
 two guaranteed fanout branches; it cannot merge optional values from mutually
 exclusive paths. `terminate_error` has no outgoing control edge. Loop, list,
@@ -97,8 +100,9 @@ domain checks continue to run in their existing services.
 
 The V3 migration preserves the current policy boundary:
 
-- Evaluator rejects Handoff, Human Intervention, every Agent Table node, and
-  Vision Understanding.
+- Evaluator rejects Handoff, Human Intervention, Agent Table writes, and Vision
+  Understanding. Agent Table Query is allowed only when its fixed read fixture can
+  be prepared without Agent-derived predicates or live-table fallback.
 - public App rejects External Xpert, Plugin, Human Intervention, every Agent
   Table node, and Vision Understanding.
 - Structure Evolution can currently add only adapter-backed
@@ -110,7 +114,7 @@ must still pass.
 ## API and frontend
 
 `GET /api/workflow/node-registry` returns registry version
-`xpert-workflow-node-registry-v6`, `contract_version=3`, the registry checksum,
+`xpert-workflow-node-registry-v7`, `contract_version=3`, the registry checksum,
 and a safe contract projection for each palette node.
 
 The frontend fallback contains presentation facts only. It has no contract or
@@ -118,10 +122,12 @@ Planner claims. If the server response is absent, incomplete, or has a checksum
 shape other than V3, contract-dependent operations stay disabled while the
 classic palette may continue to render.
 
-Meta Planner Capability Snapshot version is V7 with `ir_version=3`,
-`supported_ir_versions=[2,3]`, and `control_flow_contract_version=1`. V7 projects the typed Headless Authoring
+Meta Planner Capability Snapshot version is V8 with `ir_version=3`,
+`supported_ir_versions=[2,3]`, and `control_flow_contract_version=2`. V8 projects the typed Headless Authoring
 operation schema, `task_binding`, versioned execution semantics, and per-kind
-authoring checksum for the sixteen enabled kinds.
+authoring checksum for the eighteen enabled kinds. Its Agent Table catalog exposes
+only field names, types, required flags and Schema checksums; records and defaults
+remain private.
 Persisted V2 snapshots without contract metadata remain readable. Contract
 drift is a warning for an existing proposal; missing or invalid resources still
 block approval.

--- a/docs/audits/N8N_NODE_CAPABILITY_MATRIX.md
+++ b/docs/audits/N8N_NODE_CAPABILITY_MATRIX.md
@@ -22,7 +22,7 @@
 - R2.7 结果：新增完整合同 `rss_event_entry`，以仅公网 HTTPS、逐跳安全校验、首次无回放基线和持久条目去重提供 RSS 2.0/Atom 1.0 订阅入口；认证源、附件、WebSub、Xpert 与等待节点禁用
 - R2.8 结果：新增完整合同 `email_event_entry`，以只读 IMAPS 993、首次无回放 UID 基线和持久 UID 重读恢复提供固定 INBOX 邮件入口；OAuth2、IDLE、多文件夹、附件内容、原始 HTML、Xpert 与等待节点禁用
 - R2.9 PR2 结果：不新增节点类型；在 `http_request` V2、`data_table_query` 与 `knowledge_retrieval` V2 的结构化失败出口前增加默认关闭的持久受限重试。仅固定 GET 无正文、只读表查询及本地合格知识检索可对精确白名单瞬时故障尝试 2–3 次；恢复绑定 Scheduler V2、稳定等待 ID 和安全目标指纹。写操作、外部临时正文入口、公共 App、Evaluation、Evolution、Planner、凭据、权限、安全、配置、资源漂移、取消和未知异常不得重试
-- 当前 Registry 事实：55 Native、51 个已登记 Palette 项、默认 50 个可拖拽 Palette 项、52 个完整合同、3 个 compatibility 合同、16 个 Planner 节点
+- 当前 Registry 事实：55 Native、51 个已登记 Palette 项、默认 50 个可拖拽 Palette 项、52 个完整合同、3 个 compatibility 合同、18 个 Planner 节点
 - 默认运行功能门禁：3 个已登记项（`email_event_entry`、`knowledge_write_proposal`、`rss_event_entry`）允许编辑但执行面关闭；该口径与 Palette 是否登记、是否可拖拽相互独立
 - 参考清单：563 条节点名称/类型，其中 `.ee` 2 条仅保留名称审计
 
@@ -152,4 +152,4 @@ R1 为单实例、原子文件持久化版本，不宣称多 Worker、HA 或多�
 - 前端 `WorkflowNodeKind`、后端 `NativeNodeKind`、NodeContract Registry 必须完全一致。
 - Palette 必须是 NodeContract 合法子集；每个启用项必须有默认数据和配置入口。
 - compatibility 合同不得超过 #213 冻结白名单；新节点必须直接提供完整合同。
-- Planner 可生成类型仍固定为 16 类：只接受完整合同、匹配 checksum 且显式启用的 Adapter；由原七类、五种纯节点与四种受限控制流节点组成。R1–R2.9 中其他增量节点仍禁止 Planner 自动生成，不能用 Runtime 可执行性替代 Planner 授权。
+- Planner 可生成类型仍固定为 18 类：只接受完整合同、匹配 checksum 且显式启用的 Adapter；由原七类、五种纯节点、四种受限控制流节点与两种只读资源节点组成。R1–R2.9 中其他增量节点仍禁止 Planner 自动生成，不能用 Runtime 可执行性替代 Planner 授权。

--- a/scripts/generate_workflow_capability_audit.py
+++ b/scripts/generate_workflow_capability_audit.py
@@ -903,7 +903,7 @@ R1 为单实例、原子文件持久化版本，不宣称多 Worker、HA 或多�
 - 前端 `WorkflowNodeKind`、后端 `NativeNodeKind`、NodeContract Registry 必须完全一致。
 - Palette 必须是 NodeContract 合法子集；每个启用项必须有默认数据和配置入口。
 - compatibility 合同不得超过 #213 冻结白名单；新节点必须直接提供完整合同。
-- Planner 可生成类型仍固定为 {registry_facts.planner} 类：只接受完整合同、匹配 checksum 且显式启用的 Adapter；由原七类、五种纯节点与四种受限控制流节点组成。R1–R2.9 中其他增量节点仍禁止 Planner 自动生成，不能用 Runtime 可执行性替代 Planner 授权。
+- Planner 可生成类型仍固定为 {registry_facts.planner} 类：只接受完整合同、匹配 checksum 且显式启用的 Adapter；由原七类、五种纯节点、四种受限控制流节点与两种只读资源节点组成。R1–R2.9 中其他增量节点仍禁止 Planner 自动生成，不能用 Runtime 可执行性替代 Planner 授权。
 """
     (args.output_dir / "N8N_NODE_CAPABILITY_MATRIX.md").write_text(
         markdown,

--- a/server/data_tables/store.py
+++ b/server/data_tables/store.py
@@ -520,6 +520,81 @@ class SQLiteAgentTableBackend:
             for row in rows
         ]
 
+    def capture_evaluation_queries(
+        self,
+        queries: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Execute a bounded fixture batch in one SQLite read snapshot."""
+
+        if len(queries) > 1_000:
+            raise AgentTableValidationError(
+                "Evaluation fixture capture supports at most 1000 queries."
+            )
+        results: list[dict[str, Any]] = []
+        with self._lock, self._connection() as connection:
+            connection.execute("PRAGMA query_only = ON")
+            connection.execute("BEGIN")
+            for query in queries:
+                fixture_key = str(query.get("fixture_key") or "").strip()
+                table_id = str(query.get("table_id") or "").strip()
+                schema_version = int(query.get("schema_version") or 0)
+                bounded_limit = int(query.get("limit") or 0)
+                if not fixture_key or not 1 <= bounded_limit <= MAX_QUERY_LIMIT:
+                    raise AgentTableValidationError(
+                        "Evaluation fixture query is missing a key or has an invalid limit."
+                    )
+                table = self._load_table(connection, table_id)
+                schema = self._load_schema_version(
+                    connection,
+                    table_id,
+                    schema_version,
+                )
+                if str(query.get("schema_checksum") or "") != schema.checksum:
+                    raise AgentTableConflictError(
+                        "Evaluation fixture schema checksum no longer matches."
+                    )
+                raw_fields = query.get("fields")
+                fields = (
+                    [str(item) for item in raw_fields]
+                    if isinstance(raw_fields, list)
+                    else None
+                )
+                selected = self._validate_selected_fields(fields, schema.fields)
+                parameters: list[Any] = []
+                where = self._compile_filter(
+                    query.get("filter"),
+                    schema.fields,
+                    parameters,
+                    allow_empty=True,
+                )
+                raw_sort = query.get("sort")
+                order_by = self._compile_sort(
+                    raw_sort if isinstance(raw_sort, list) else [],
+                    schema.fields,
+                    parameters,
+                )
+                parameters.append(bounded_limit)
+                rows = connection.execute(
+                    "SELECT * FROM agent_table_records "
+                    "WHERE table_id = ? AND (" + where + ") "
+                    + order_by
+                    + " LIMIT ?",
+                    [table.table_id, *parameters],
+                ).fetchall()
+                results.append(
+                    {
+                        "fixture_key": fixture_key,
+                        "records": [
+                            self._flatten_record(
+                                self._record_from_row(row),
+                                selected,
+                            )
+                            for row in rows
+                        ],
+                    }
+                )
+        return results
+
     def create_record_for_schema(
         self,
         table_id: str,

--- a/server/evaluations/__init__.py
+++ b/server/evaluations/__init__.py
@@ -7,6 +7,7 @@ from .api import (
 )
 from .executor import XpertEvaluationExecutor
 from .metrics import aggregate_evaluation_report, evaluate_case_metrics
+from .resource_fixtures import render_evaluation_case_inputs
 from .service import XpertEvaluationService
 from .store import (
     EvaluationConflictError,
@@ -28,5 +29,6 @@ __all__ = [
     "get_xpert_evaluation_executor",
     "get_xpert_evaluation_service",
     "get_xpert_evaluation_store",
+    "render_evaluation_case_inputs",
     "router",
 ]

--- a/server/evaluations/api.py
+++ b/server/evaluations/api.py
@@ -46,6 +46,7 @@ def configure_xpert_evaluations(
     target_runner: TargetRunner,
     judge_runner: JudgeRunner | None,
     run_registry: Any,
+    agent_table_evaluation_backend: Any | None = None,
 ) -> XpertEvaluationExecutor:
     global _store, _service, _executor
     _store = XpertEvaluationStore(storage_dir)
@@ -58,6 +59,7 @@ def configure_xpert_evaluations(
         plugin_store=plugin_store,
         rag_service=rag_service,
         context_store=context_store,
+        agent_table_evaluation_backend=agent_table_evaluation_backend,
     )
     _executor = XpertEvaluationExecutor(
         _store,
@@ -105,6 +107,7 @@ async def get_capabilities() -> dict[str, Any]:
             "citation_hit",
             "tool_call_match",
             "workflow_path_match",
+            "workflow_resource_match",
             "rubric_judge",
         ],
         "dataset_limits": {"max_cases": 500, "max_cases_per_run": 100},
@@ -116,6 +119,11 @@ async def get_capabilities() -> dict[str, Any]:
             "max_tool_calls": 100,
         },
         "model_policies": ["snapshot", "override"],
+        "resource_fixture_limits": {
+            "max_rows_per_query": 200,
+            "max_fixtures_per_run": 1000,
+            "max_bytes_per_run": 16 * 1024 * 1024,
+        },
         "safe_mode": "read_only_fail_closed",
     }
 
@@ -388,6 +396,7 @@ def _parse_import(filename: str, content: bytes) -> list[dict[str, Any]]:
 
 def _sanitize_run_detail(run: dict[str, Any]) -> dict[str, Any]:
     payload = json.loads(json.dumps(run, ensure_ascii=False))
+    payload.pop("_resource_fixtures", None)
     dataset = dict(payload.get("dataset") or {})
     for case in dataset.get("cases") or []:
         case["message"] = str(case.get("message") or "")[:20_000]

--- a/server/evaluations/executor.py
+++ b/server/evaluations/executor.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from .metrics import aggregate_evaluation_report, evaluate_case_metrics
+from .resource_fixtures import sanitize_resource_reads
 from .store import XpertEvaluationStore
 
 
@@ -15,6 +16,15 @@ TargetRunner = Callable[
     Awaitable[dict[str, Any]],
 ]
 JudgeRunner = Callable[[str, str, str, str], Awaitable[dict[str, Any]]]
+
+
+def _target_requires_resource_evidence(target: dict[str, Any]) -> bool:
+    resources = dict(target.get("resources") or {})
+    return bool(resources.get("data_tables")) or any(
+        str(item.get("node_kind") or "") == "knowledge_retrieval"
+        for item in list(resources.get("knowledge_versions") or [])
+        if isinstance(item, dict)
+    )
 
 
 class XpertEvaluationExecutor:
@@ -136,6 +146,9 @@ class XpertEvaluationExecutor:
                     return
                 target = targets[item["target_id"]]
                 case = cases[item["case_id"]]
+                resource_evidence_required = _target_requires_resource_evidence(
+                    target
+                )
                 started = time.perf_counter()
                 try:
                     timeout = max(
@@ -148,12 +161,18 @@ class XpertEvaluationExecutor:
                             {
                                 **dict(run.get("config") or {}),
                                 "repetition": item["repetition"],
+                                "evaluation_run_id": run["run_id"],
+                                "evaluation_target_id": item["target_id"],
+                                "evaluation_case_id": item["case_id"],
                             },
                             registry_run.run_id if registry_run else None,
                         )
                     output = str(result.get("output") or "")[
                         : int(budget.get("max_output_chars") or 20_000)
                     ]
+                    resource_reads = sanitize_resource_reads(
+                        result.get("resource_reads")
+                    )
                     metrics = await evaluate_case_metrics(
                         case=case,
                         output=output,
@@ -164,6 +183,8 @@ class XpertEvaluationExecutor:
                             if str(item)
                         ],
                         control_flow=dict(result.get("control_flow") or {}),
+                        resource_reads=resource_reads,
+                        resource_evidence_required=resource_evidence_required,
                         judge=self.judge_runner,
                         judge_model_id=run.get("config", {}).get("judge_model_id"),
                     )
@@ -177,6 +198,7 @@ class XpertEvaluationExecutor:
                             if str(item)
                         ],
                         "control_flow": dict(result.get("control_flow") or {}),
+                        "resource_reads": resource_reads,
                         "usage": dict(result.get("usage") or {}),
                         "latency_ms": round(
                             (time.perf_counter() - started) * 1000, 3
@@ -186,11 +208,22 @@ class XpertEvaluationExecutor:
                         "error": None,
                     }
                 except Exception as exc:
+                    expects_resource_evidence = bool(case.get("resource_reads"))
                     payload = {
                         "status": "failed",
                         "output": "",
                         "citations": {},
                         "control_flow": {},
+                        "resource_reads": [],
+                        "resource_evidence": (
+                            "failed"
+                            if expects_resource_evidence
+                            else (
+                                "missing"
+                                if resource_evidence_required
+                                else "not_applicable"
+                            )
+                        ),
                         "usage": {},
                         "score": 0.0,
                         "metrics": [],

--- a/server/evaluations/metrics.py
+++ b/server/evaluations/metrics.py
@@ -18,12 +18,59 @@ async def evaluate_case_metrics(
     citations: dict[str, list[str]],
     tool_calls: list[str] | None = None,
     control_flow: dict[str, Any] | None = None,
+    resource_reads: list[dict[str, Any]] | None = None,
+    resource_evidence_required: bool = False,
     judge: JudgeCallback | None = None,
     judge_model_id: str | None = None,
 ) -> dict[str, Any]:
     expected = dict(case.get("expected") or {})
     weights = dict(case.get("weights") or {})
     metrics: list[dict[str, Any]] = []
+
+    expected_reads = [
+        dict(item)
+        for item in list(case.get("resource_reads") or [])
+        if isinstance(item, dict)
+    ]
+    resource_evidence = (
+        "missing"
+        if not expected_reads and resource_evidence_required
+        else "not_applicable"
+    )
+    if expected_reads:
+        actual_by_key = {
+            (
+                str(item.get("node_ref") or ""),
+                str(item.get("resource_kind") or item.get("kind") or ""),
+            ): item
+            for item in list(resource_reads or [])
+            if isinstance(item, dict)
+        }
+        matched = 0
+        failures: list[str] = []
+        for expected_read in expected_reads:
+            key = (
+                str(expected_read.get("node_ref") or ""),
+                str(expected_read.get("kind") or ""),
+            )
+            actual = actual_by_key.get(key)
+            checks = _resource_read_checks(expected_read, actual)
+            if checks:
+                failures.append(f"{key[0]}:{','.join(checks)}")
+            else:
+                matched += 1
+        metrics.append(
+            _metric(
+                "workflow_resource_match",
+                matched / len(expected_reads),
+                (
+                    f"Matched {matched} of {len(expected_reads)} resource reads."
+                    + (f" Failures: {'; '.join(failures[:8])}" if failures else "")
+                ),
+                weights,
+            )
+        )
+        resource_evidence = "verified" if matched == len(expected_reads) else "failed"
 
     path = case.get("path")
     if isinstance(path, dict):
@@ -201,6 +248,7 @@ async def evaluate_case_metrics(
         "score": round(total_score, 6),
         "metrics": metrics,
         "metric_count": len(metrics),
+        "resource_evidence": resource_evidence,
     }
 
 
@@ -250,6 +298,7 @@ def aggregate_evaluation_report(
                     int((item.get("usage") or {}).get("estimated_tokens") or 0)
                     for item in target_items
                 ),
+                "resource_evidence": _resource_evidence_summary(target_items),
             }
         )
     targets.sort(key=lambda item: (-float(item["score"]), item["target_id"]))
@@ -328,6 +377,40 @@ def _is_subsequence(expected: list[str], actual: list[str]) -> bool:
             if position == len(expected):
                 return True
     return False
+
+
+def _resource_read_checks(
+    expected: dict[str, Any], actual: dict[str, Any] | None
+) -> list[str]:
+    if actual is None:
+        return ["missing"]
+    failures: list[str] = []
+    if str(actual.get("resource_id") or "") != str(expected.get("resource_id") or ""):
+        failures.append("resource_id")
+    for field in ("version_id", "schema_version", "query_checksum"):
+        expected_value = expected.get(field)
+        if expected_value is not None and actual.get(field) != expected_value:
+            failures.append(field)
+    if expected.get("expected_count") is not None and int(
+        actual.get("result_count") or 0
+    ) != int(expected["expected_count"]):
+        failures.append("result_count")
+    for field in ("record_ids", "citation_ids"):
+        required = _string_set(expected.get(field))
+        observed = _string_set(actual.get(field))
+        if not required.issubset(observed):
+            failures.append(field)
+    return failures
+
+
+def _resource_evidence_summary(items: list[dict[str, Any]]) -> dict[str, int]:
+    result = {"verified": 0, "failed": 0, "missing": 0, "not_applicable": 0}
+    for item in items:
+        status = str(item.get("resource_evidence") or "not_applicable")
+        if status not in result:
+            status = "failed"
+        result[status] += 1
+    return result
 
 
 def _percentile(values: list[float], quantile: float) -> float:

--- a/server/evaluations/models.py
+++ b/server/evaluations/models.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 MetricKind = Literal[
@@ -12,6 +14,7 @@ MetricKind = Literal[
     "citation_hit",
     "tool_call_match",
     "workflow_path_match",
+    "workflow_resource_match",
     "rubric_judge",
 ]
 
@@ -42,7 +45,7 @@ class EvaluationPathExpectation(BaseModel):
 
     @model_validator(mode="after")
     def validate_path(self) -> "EvaluationPathExpectation":
-        outcome_pattern = r"^[a-z][a-z0-9_-]{0,63}:(?:success|matched|unmatched|case_[1-8]|default)$"
+        outcome_pattern = r"^[a-z][a-z0-9_-]{0,63}:(?:success|error|matched|unmatched|case_[1-8]|default)$"
         import re
 
         all_outcomes = [*self.required_outcomes, *self.forbidden_outcomes]
@@ -58,6 +61,107 @@ class EvaluationPathExpectation(BaseModel):
         elif self.error_code is not None:
             raise ValueError("Successful paths cannot declare an error_code.")
         return self
+
+
+class EvaluationResourceReadExpectation(BaseModel):
+    node_ref: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,63}$")
+    kind: Literal["knowledge_retrieval", "data_table_query"]
+    resource_id: str = Field(min_length=1, max_length=200)
+    version_id: str | None = Field(default=None, max_length=200)
+    schema_version: int | None = Field(default=None, ge=1)
+    query_checksum: str | None = Field(
+        default=None,
+        pattern=r"^[a-f0-9]{64}$",
+    )
+    expected_count: int | None = Field(default=None, ge=0, le=200)
+    record_ids: list[str] = Field(default_factory=list, max_length=200)
+    citation_ids: list[str] = Field(default_factory=list, max_length=200)
+
+    @model_validator(mode="after")
+    def validate_kind_fields(self) -> "EvaluationResourceReadExpectation":
+        if self.kind == "knowledge_retrieval":
+            if self.schema_version is not None or self.record_ids:
+                raise ValueError(
+                    "Knowledge resource assertions cannot declare table schema or record ids."
+                )
+        elif self.version_id is not None or self.citation_ids:
+            raise ValueError(
+                "Agent Table assertions cannot declare knowledge version or citation ids."
+            )
+        return self
+
+
+class AgentTableQueryFixture(BaseModel):
+    """Private evaluator input. API projections must never expose records."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    fixture_key: str = Field(pattern=r"^[a-f0-9]{64}$")
+    target_id: str = Field(min_length=1, max_length=240)
+    case_id: str = Field(min_length=1, max_length=120)
+    node_id: str = Field(min_length=1, max_length=200)
+    node_ref: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,63}$")
+    resource_kind: Literal["data_table_query"] = "data_table_query"
+    resource_id: str = Field(min_length=1, max_length=200)
+    table_id: str = Field(min_length=1, max_length=200)
+    schema_version: int = Field(ge=1)
+    schema_checksum: str = Field(pattern=r"^[a-f0-9]{64}$")
+    query_checksum: str = Field(pattern=r"^[a-f0-9]{64}$")
+    fields: list[str] | None = Field(default=None, max_length=50)
+    filter: dict[str, Any] | None = None
+    sort: list[dict[str, Any]] | None = Field(default=None, max_length=5)
+    limit: int = Field(ge=1, le=200)
+    return_mode: Literal["list", "first"] = "list"
+    records: list[dict[str, Any]] = Field(default_factory=list, max_length=200)
+    records_checksum: str = Field(pattern=r"^[a-f0-9]{64}$")
+    result_count: int = Field(ge=0, le=200)
+    record_ids: list[str] = Field(default_factory=list, max_length=200)
+
+    @model_validator(mode="after")
+    def validate_fixture_identity(self) -> "AgentTableQueryFixture":
+        if self.resource_id != self.table_id:
+            raise ValueError("Fixture resource_id must match table_id.")
+        if self.result_count != len(self.records):
+            raise ValueError("Fixture result_count must match the stored record count.")
+        if self.records_checksum != _evaluation_checksum(self.records):
+            raise ValueError("Fixture records checksum does not match its stored records.")
+        identity = {
+            "target_id": self.target_id,
+            "case_id": self.case_id,
+            "node_id": self.node_id,
+        }
+        if self.fixture_key != _evaluation_checksum(identity):
+            raise ValueError("Fixture key does not match its target, case, and node.")
+        query_contract = {
+            "table_id": self.table_id,
+            "schema_version": self.schema_version,
+            "fields": self.fields,
+            "filter": self.filter,
+            "sort": self.sort,
+            "limit": self.limit,
+            "return_mode": self.return_mode,
+        }
+        if self.query_checksum != _evaluation_checksum(query_contract):
+            raise ValueError("Fixture query checksum does not match its contract.")
+        expected_record_ids = [
+            str(record.get("record_id"))[:200]
+            for record in self.records
+            if str(record.get("record_id") or "")
+        ][:200]
+        if self.record_ids != expected_record_ids:
+            raise ValueError("Fixture record ids do not match its stored records.")
+        return self
+
+
+def _evaluation_checksum(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 class EvaluationProfessionalEvidence(BaseModel):
@@ -102,6 +206,10 @@ class EvaluationCaseInput(BaseModel):
     tags: list[str] = Field(default_factory=list, max_length=20)
     expected: EvaluationExpectation = Field(default_factory=EvaluationExpectation)
     path: EvaluationPathExpectation | None = None
+    resource_reads: list[EvaluationResourceReadExpectation] = Field(
+        default_factory=list,
+        max_length=32,
+    )
     weights: dict[MetricKind, float] = Field(default_factory=dict)
     targeting: EvaluationCaseTargeting | None = None
 
@@ -124,6 +232,9 @@ class EvaluationCaseInput(BaseModel):
                 raise ValueError(
                     "Expected error paths cannot include text-answer metrics."
                 )
+        resource_keys = [(item.node_ref, item.kind) for item in self.resource_reads]
+        if len(resource_keys) != len(set(resource_keys)):
+            raise ValueError("Resource read assertions must be unique by node_ref and kind.")
         return self
 
 

--- a/server/evaluations/resource_fixtures.py
+++ b/server/evaluations/resource_fixtures.py
@@ -1,0 +1,661 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from typing import Any, Protocol
+
+try:
+    from server.workflow_native.control_data import aggregate_rows, compare_datasets
+    from server.workflow_native.r20_nodes import execute_variable_aggregator_v2
+    from server.workflow_native.values import (
+        deserialize_workflow_value,
+        normalize_workflow_value,
+        serialize_workflow_value,
+    )
+except ModuleNotFoundError:  # pragma: no cover - container import layout
+    from workflow_native.control_data import aggregate_rows, compare_datasets
+    from workflow_native.r20_nodes import execute_variable_aggregator_v2
+    from workflow_native.values import (
+        deserialize_workflow_value,
+        normalize_workflow_value,
+        serialize_workflow_value,
+    )
+
+from .store import EvaluationStateError
+
+
+MAX_FIXTURE_ROWS = 200
+MAX_FIXTURES_PER_RUN = 1_000
+MAX_FIXTURE_BYTES_PER_RUN = 16 * 1024 * 1024
+_PURE_NODE_KINDS = {
+    "json_serialize",
+    "json_deserialize",
+    "variable_aggregator",
+    "data_aggregate",
+    "dataset_compare",
+}
+_AGENT_NODE_KINDS = {"agent", "workflow_agent", "agent_task"}
+
+
+def render_evaluation_case_inputs(
+    target: dict[str, Any],
+    case: dict[str, Any],
+) -> tuple[str, list[dict[str, str]], str]:
+    """Render the exact input shared by fixture capture and runtime execution."""
+
+    history = [
+        {
+            "role": str(item.get("role") or "user"),
+            "content": str(item.get("content") or "")[:20_000],
+        }
+        for item in list(case.get("messages") or [])[-20:]
+        if isinstance(item, dict) and str(item.get("content") or "").strip()
+    ]
+    history_json = json.dumps(history, ensure_ascii=False)
+    message = str(case.get("message") or "")[:20_000]
+    input_template = str(target.get("input_template") or "")
+    if input_template:
+        message = re.sub(r"{{\s*args\s*}}", message, input_template)[:20_000]
+    return message, history, history_json
+
+
+class AgentTableEvaluationBackend(Protocol):
+    """Trusted adapter supplied by the application integration layer.
+
+    ``capture_evaluation_queries`` must execute the whole request in one
+    read-only database snapshot. The Evaluator deliberately does not emulate
+    this with repeated ``query_records`` calls.
+    """
+
+    def resolve_schema_version(self, table_id: str, **kwargs: Any) -> Any: ...
+
+    def validate_workflow_node_contract(
+        self,
+        table_id: str,
+        **kwargs: Any,
+    ) -> None: ...
+
+    def capture_evaluation_queries(
+        self,
+        queries: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]: ...
+
+
+def prepare_agent_table_fixtures(
+    *,
+    targets: list[dict[str, Any]],
+    cases: list[dict[str, Any]],
+    backend: AgentTableEvaluationBackend | None,
+) -> list[dict[str, Any]]:
+    requests: list[dict[str, Any]] = []
+    for target in targets:
+        workflow = dict(target.get("workflow") or {})
+        table_nodes = [
+            node
+            for node in list(workflow.get("nodes") or [])
+            if _node_kind(node) == "data_table_query"
+        ]
+        if not table_nodes:
+            continue
+        if backend is None:
+            raise EvaluationStateError(
+                "Agent Table evaluation requires a transactional resource fixture provider."
+            )
+        _assert_query_dependencies_are_deterministic(target, workflow, table_nodes)
+        for case in cases:
+            required_variables: set[str] = set()
+            for node in table_nodes:
+                required_variables.update(
+                    _filter_variables(_node_data(node).get("filter"))
+                )
+            variables = _resolve_case_variables(
+                target,
+                case,
+                workflow,
+                required_variables=required_variables,
+            )
+            for node in table_nodes:
+                requests.append(
+                    _build_query_request(target, case, node, variables, backend)
+                )
+                if len(requests) > MAX_FIXTURES_PER_RUN:
+                    raise EvaluationStateError(
+                        "Evaluation run exceeds the 1000 Agent Table fixture limit."
+                    )
+    if not requests:
+        return []
+    assert backend is not None
+    raw = backend.capture_evaluation_queries(copy.deepcopy(requests))
+    if not isinstance(raw, list):
+        raise EvaluationStateError(
+            "Agent Table fixture provider returned an invalid response."
+        )
+    by_key: dict[str, dict[str, Any]] = {}
+    for item in raw:
+        if not isinstance(item, dict):
+            raise EvaluationStateError(
+                "Agent Table fixture provider returned a non-object fixture."
+            )
+        fixture_key = str(item.get("fixture_key") or "")
+        if not fixture_key or fixture_key in by_key:
+            raise EvaluationStateError(
+                "Agent Table fixture provider returned duplicate or missing fixture keys."
+            )
+        by_key[fixture_key] = item
+    expected_keys = {str(item["fixture_key"]) for item in requests}
+    if set(by_key) != expected_keys:
+        raise EvaluationStateError(
+            "Agent Table fixture provider did not return the exact requested fixture set."
+        )
+
+    fixtures: list[dict[str, Any]] = []
+    for request in requests:
+        response = by_key[str(request["fixture_key"])]
+        records = response.get("records")
+        if not isinstance(records, list):
+            raise EvaluationStateError("Agent Table fixture records must be an array.")
+        if len(records) > min(MAX_FIXTURE_ROWS, int(request["limit"])):
+            raise EvaluationStateError(
+                "Agent Table fixture exceeds the per-query row limit."
+            )
+        normalized = normalize_workflow_value(
+            records,
+            path=f"$.evaluation_fixtures.{request['fixture_key']}.records",
+        )
+        if not isinstance(normalized, list) or any(
+            not isinstance(record, dict) for record in normalized
+        ):
+            raise EvaluationStateError(
+                "Agent Table fixture records must contain JSON objects."
+            )
+        fixtures.append(
+            {
+                **copy.deepcopy(request),
+                "records": normalized,
+                "records_checksum": _checksum(normalized),
+                "result_count": len(normalized),
+                "record_ids": _record_ids(normalized),
+            }
+        )
+    encoded = _canonical_json(fixtures).encode("utf-8")
+    if len(encoded) > MAX_FIXTURE_BYTES_PER_RUN:
+        raise EvaluationStateError(
+            "Evaluation run exceeds the 16 MiB Agent Table fixture limit."
+        )
+    return fixtures
+
+
+def inspect_agent_table_node(
+    node: Any,
+    *,
+    backend: AgentTableEvaluationBackend | None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    data = _node_data(node)
+    if backend is None:
+        return None, {
+            "code": "evaluation_resource_fixture_unavailable",
+            "message": (
+                "Agent Table evaluation requires a transactional resource fixture provider."
+            ),
+            "node_id": _node_id(node),
+        }
+    try:
+        table_id = str(data.get("tableId") or "").strip()
+        policy = str(data.get("versionPolicy") or "latest").strip()
+        pinned = data.get("pinnedSchemaVersion")
+        schema = backend.resolve_schema_version(
+            table_id,
+            version_policy=policy,
+            pinned_version=int(pinned) if pinned not in {None, ""} else None,
+            write=False,
+        )
+        backend.validate_workflow_node_contract(
+            table_id,
+            schema_version=int(schema.version),
+            kind="data_table_query",
+            data=data,
+        )
+        limit = int(data.get("limit") or 20)
+        if not 1 <= limit <= MAX_FIXTURE_ROWS:
+            raise ValueError("Agent Table query limit must be between 1 and 200.")
+        data["evaluationPinnedSchemaVersion"] = int(schema.version)
+        data["evaluationPinnedSchemaChecksum"] = str(schema.checksum)
+        _set_node_data(node, data)
+        return {
+            "table_id": table_id,
+            "schema_version": int(schema.version),
+            "schema_checksum": str(schema.checksum),
+        }, None
+    except Exception as exc:
+        return None, {
+            "code": "evaluation_data_table_invalid",
+            "message": str(exc)[:500],
+            "node_id": _node_id(node),
+        }
+
+
+def assert_agent_table_dependencies(
+    workflow: Any,
+    table_nodes: list[Any],
+) -> list[dict[str, Any]]:
+    workflow_payload = (
+        workflow.model_dump(mode="json")
+        if hasattr(workflow, "model_dump")
+        else dict(workflow or {})
+    )
+    try:
+        _assert_query_dependencies_are_deterministic(
+            {}, workflow_payload, table_nodes
+        )
+    except EvaluationStateError as exc:
+        return [
+            {
+                "code": "evaluation_data_table_dynamic_dependency",
+                "message": str(exc)[:500],
+                "node_id": _node_id(table_nodes[0]) if table_nodes else None,
+            }
+        ]
+    return []
+
+
+def fixture_payload_for_item(
+    fixtures: list[dict[str, Any]],
+    *,
+    target_id: str,
+    case_id: str,
+) -> list[dict[str, Any]]:
+    return [
+        copy.deepcopy(item)
+        for item in fixtures
+        if str(item.get("target_id") or "") == target_id
+        and str(item.get("case_id") or "") == case_id
+    ]
+
+
+def sanitize_resource_reads(value: Any) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for item in list(value or [])[:100]:
+        if not isinstance(item, dict):
+            continue
+        kind = str(item.get("kind") or item.get("resource_kind") or "")
+        node_ref = str(item.get("node_ref") or "")[:64]
+        resource_id = str(item.get("resource_id") or "")[:200]
+        if kind not in {"knowledge_retrieval", "data_table_query"}:
+            continue
+        if not node_ref or not resource_id:
+            continue
+        clean: dict[str, Any] = {
+            "node_ref": node_ref,
+            "kind": kind,
+            "resource_id": resource_id,
+            "result_count": max(0, min(int(item.get("result_count") or 0), 10_000)),
+        }
+        if item.get("version_id") not in {None, ""}:
+            clean["version_id"] = str(item.get("version_id"))[:200]
+        if item.get("schema_version") not in {None, ""}:
+            clean["schema_version"] = max(1, int(item.get("schema_version")))
+        checksum = str(item.get("query_checksum") or "")
+        if len(checksum) == 64 and all(char in "0123456789abcdef" for char in checksum):
+            clean["query_checksum"] = checksum
+        clean["record_ids"] = _bounded_strings(item.get("record_ids"), 200, 200)
+        clean["citation_ids"] = _bounded_strings(item.get("citation_ids"), 50, 200)
+        result.append(clean)
+    return result
+
+
+def _build_query_request(
+    target: dict[str, Any],
+    case: dict[str, Any],
+    node: Any,
+    variables: dict[str, Any],
+    backend: AgentTableEvaluationBackend,
+) -> dict[str, Any]:
+    data = _node_data(node)
+    table_id = str(data.get("tableId") or "").strip()
+    schema_version = int(data.get("evaluationPinnedSchemaVersion") or 0)
+    if schema_version < 1:
+        policy = str(data.get("versionPolicy") or "latest")
+        pinned = data.get("pinnedSchemaVersion")
+        schema = backend.resolve_schema_version(
+            table_id,
+            version_policy=policy,
+            pinned_version=int(pinned) if pinned not in {None, ""} else None,
+            write=False,
+        )
+        schema_version = int(schema.version)
+        schema_checksum = str(schema.checksum)
+    else:
+        schema = backend.resolve_schema_version(
+            table_id,
+            version_policy="pinned",
+            pinned_version=schema_version,
+            write=False,
+        )
+        schema_checksum = str(schema.checksum)
+    resolved_filter = _resolve_filter(data.get("filter"), variables)
+    fields = data.get("selectFields")
+    selected_fields = [str(item) for item in fields] if isinstance(fields, list) else None
+    sort = data.get("sort")
+    normalized_sort = copy.deepcopy(sort) if isinstance(sort, list) else None
+    limit = max(1, min(int(data.get("limit") or 20), MAX_FIXTURE_ROWS))
+    return_mode = str(data.get("returnMode") or "list")
+    query_contract = {
+        "table_id": table_id,
+        "schema_version": schema_version,
+        "fields": selected_fields,
+        "filter": resolved_filter,
+        "sort": normalized_sort,
+        "limit": limit,
+        "return_mode": return_mode,
+    }
+    node_id = _node_id(node)
+    target_id = str(target.get("target_id") or "")
+    case_id = str(case.get("case_id") or "")
+    fixture_key = _checksum(
+        {"target_id": target_id, "case_id": case_id, "node_id": node_id}
+    )
+    return {
+        "fixture_key": fixture_key,
+        "target_id": target_id,
+        "case_id": case_id,
+        "node_id": node_id,
+        "node_ref": str(data.get("plannerRef") or node_id)[:64],
+        "resource_kind": "data_table_query",
+        "resource_id": table_id,
+        "table_id": table_id,
+        "schema_version": schema_version,
+        "schema_checksum": schema_checksum,
+        "query_checksum": _checksum(query_contract),
+        "fields": selected_fields,
+        "filter": resolved_filter,
+        "sort": normalized_sort,
+        "limit": limit,
+        "return_mode": return_mode,
+    }
+
+
+def _resolve_case_variables(
+    target: dict[str, Any],
+    case: dict[str, Any],
+    workflow: dict[str, Any],
+    *,
+    required_variables: set[str],
+) -> dict[str, Any]:
+    message, _history, history_json = render_evaluation_case_inputs(target, case)
+    variables: dict[str, Any] = {
+        str(target.get("input_variable") or "user_input"): message,
+        str(target.get("history_variable") or "conversation_history"): history_json,
+        "user_input": message,
+        "conversation_history": history_json,
+        "xpert_file_context": "",
+        "xpert_memory_context": "",
+    }
+    for declaration in list(workflow.get("variables") or []):
+        if not isinstance(declaration, dict):
+            continue
+        name = str(declaration.get("name") or "")
+        if not name or name in variables:
+            continue
+        if declaration.get("kind") == "constant" or "defaultValue" in declaration:
+            variables[name] = normalize_workflow_value(
+                declaration.get("defaultValue"), path=f"$.variables.{name}"
+            )
+    for node in list(workflow.get("nodes") or []):
+        if _node_kind(node) != "input":
+            continue
+        data = _node_data(node)
+        name = str(data.get("variableName") or "user_input")
+        variables.setdefault(name, variables.get("user_input", ""))
+
+    producers = {
+        str(_node_data(node).get("outputVariable") or ""): node
+        for node in list(workflow.get("nodes") or [])
+        if str(_node_data(node).get("outputVariable") or "")
+    }
+
+    def resolve(variable: str, stack: set[str]) -> None:
+        if variable in variables:
+            return
+        if variable in stack:
+            raise EvaluationStateError(
+                f"Agent Table fixture variable dependency is cyclic: {variable}."
+            )
+        producer = producers.get(variable)
+        if producer is None or _node_kind(producer) not in _PURE_NODE_KINDS:
+            raise EvaluationStateError(
+                f"Agent Table filter variable '{variable}' could not be frozen."
+            )
+        for source in _pure_inputs(producer):
+            resolve(source, {*stack, variable})
+        _execute_pure_node(producer, variables)
+
+    for required in sorted(required_variables):
+        resolve(required, set())
+    return variables
+
+
+def _execute_pure_node(node: Any, variables: dict[str, Any]) -> None:
+    data = _node_data(node)
+    kind = _node_kind(node)
+    output = str(data.get("outputVariable") or "")
+    if kind == "json_serialize":
+        variables[output] = serialize_workflow_value(
+            variables[str(data.get("inputVariable") or "")],
+            pretty=str(data.get("format") or "compact") == "pretty",
+            max_bytes=5 * 1024 * 1024,
+        )
+    elif kind == "json_deserialize":
+        variables[output] = deserialize_workflow_value(
+            variables[str(data.get("inputVariable") or "")],
+            expected_schema=data.get("expectedSchema"),
+            max_bytes=5 * 1024 * 1024,
+        )
+    elif kind == "variable_aggregator":
+        name, value = execute_variable_aggregator_v2(data, variables)
+        variables[name] = value
+    elif kind == "data_aggregate":
+        variables[output] = aggregate_rows(
+            variables[str(data.get("inputVariable") or "")],
+            group_by_fields=data.get("groupByFields"),
+            measures=data.get("measures"),
+        )
+    elif kind == "dataset_compare":
+        variables[output] = compare_datasets(
+            variables[str(data.get("leftVariable") or "")],
+            variables[str(data.get("rightVariable") or "")],
+            key_fields=data.get("keyFields"),
+            include_unchanged=bool(data.get("includeUnchanged", False)),
+        )
+
+
+def _assert_query_dependencies_are_deterministic(
+    target: dict[str, Any],
+    workflow: dict[str, Any],
+    table_nodes: list[Any],
+) -> None:
+    base = {
+        str(target.get("input_variable") or "user_input"),
+        str(target.get("history_variable") or "conversation_history"),
+        "user_input",
+        "conversation_history",
+        "xpert_file_context",
+        "xpert_memory_context",
+    }
+    producers: dict[str, Any] = {}
+    for declaration in list(workflow.get("variables") or []):
+        if (
+            isinstance(declaration, dict)
+            and declaration.get("kind") in {"input", "constant"}
+            and str(declaration.get("name") or "")
+        ):
+            base.add(str(declaration["name"]))
+    for node in list(workflow.get("nodes") or []):
+        data = _node_data(node)
+        if _node_kind(node) == "input":
+            base.add(str(data.get("variableName") or "user_input"))
+        output = str(data.get("outputVariable") or "")
+        if output:
+            producers[output] = node
+
+    def require_safe(variable: str, stack: set[str]) -> None:
+        if variable in base:
+            return
+        if variable in stack:
+            raise EvaluationStateError(
+                f"Agent Table filter variable dependency is cyclic: {variable}."
+            )
+        producer = producers.get(variable)
+        if producer is None:
+            raise EvaluationStateError(
+                f"Agent Table filter references unavailable variable '{variable}'."
+            )
+        kind = _node_kind(producer)
+        if kind in _AGENT_NODE_KINDS:
+            raise EvaluationStateError(
+                "Agent Table evaluation cannot freeze filters derived from a prior Agent output: "
+                + variable
+            )
+        if kind not in _PURE_NODE_KINDS:
+            raise EvaluationStateError(
+                f"Agent Table evaluation cannot freeze filter variable '{variable}' "
+                f"from node kind '{kind}'."
+            )
+        for source in _pure_inputs(producer):
+            require_safe(source, {*stack, variable})
+
+    for node in table_nodes:
+        for variable in _filter_variables(_node_data(node).get("filter")):
+            require_safe(variable, set())
+
+
+def _pure_inputs(node: Any) -> set[str]:
+    data = _node_data(node)
+    kind = _node_kind(node)
+    if kind in {"json_serialize", "json_deserialize", "data_aggregate"}:
+        return {str(data.get("inputVariable") or "")}
+    if kind == "dataset_compare":
+        return {
+            str(data.get("leftVariable") or ""),
+            str(data.get("rightVariable") or ""),
+        }
+    if kind == "variable_aggregator":
+        return {
+            str(item.get("sourceVariable") or "")
+            for item in list(data.get("bindings") or [])
+            if isinstance(item, dict)
+        }
+    return set()
+
+
+def _filter_variables(value: Any) -> set[str]:
+    if not isinstance(value, dict):
+        return set()
+    if isinstance(value.get("items"), list):
+        result: set[str] = set()
+        for item in value["items"]:
+            result.update(_filter_variables(item))
+        return result
+    binding = value.get("value")
+    if isinstance(binding, dict) and binding.get("source") == "variable":
+        name = str(binding.get("variable") or "")
+        return {name} if name else set()
+    return set()
+
+
+def _resolve_filter(value: Any, variables: dict[str, Any]) -> dict[str, Any] | None:
+    if value is None or value == () or value == {}:
+        return None
+    if not isinstance(value, dict):
+        raise EvaluationStateError("Agent Table filter must be an object.")
+    if "items" in value or "logic" in value:
+        items = value.get("items")
+        if not isinstance(items, list):
+            raise EvaluationStateError("Agent Table filter group items must be an array.")
+        return {
+            "logic": str(value.get("logic") or "").lower(),
+            "items": [_resolve_filter(item, variables) for item in items],
+        }
+    field = str(value.get("field") or "").strip()
+    operator = str(value.get("operator") or "").strip().lower()
+    result: dict[str, Any] = {"field": field, "operator": operator}
+    if operator != "is_null":
+        binding = value.get("value")
+        if not isinstance(binding, dict):
+            raise EvaluationStateError(
+                f"Agent Table filter '{field}' must use a typed value binding."
+            )
+        source = str(binding.get("source") or "")
+        if source == "literal" and "value" in binding:
+            result["value"] = normalize_workflow_value(
+                binding.get("value"), path=f"$.filter.{field}"
+            )
+        elif source == "variable":
+            variable = str(binding.get("variable") or "")
+            if variable not in variables:
+                raise EvaluationStateError(
+                    f"Agent Table filter variable '{variable}' could not be frozen."
+                )
+            result["value"] = normalize_workflow_value(
+                variables[variable], path=f"$.filter.{field}"
+            )
+        else:
+            raise EvaluationStateError(
+                f"Agent Table filter '{field}' has an invalid value binding."
+            )
+    return result
+
+
+def _node_data(node: Any) -> dict[str, Any]:
+    if isinstance(node, dict):
+        return dict(node.get("data") or {})
+    return dict(getattr(node, "data", {}) or {})
+
+
+def _set_node_data(node: Any, data: dict[str, Any]) -> None:
+    if isinstance(node, dict):
+        node["data"] = data
+    else:
+        node.data = data
+
+
+def _node_kind(node: Any) -> str:
+    data = _node_data(node)
+    if isinstance(node, dict):
+        return str(data.get("kind") or node.get("type") or "")
+    return str(data.get("kind") or getattr(node, "type", "") or "")
+
+
+def _node_id(node: Any) -> str:
+    return str(node.get("id") if isinstance(node, dict) else getattr(node, "id", ""))
+
+
+def _record_ids(records: list[dict[str, Any]]) -> list[str]:
+    return [
+        str(record.get("record_id"))[:200]
+        for record in records
+        if str(record.get("record_id") or "")
+    ][:MAX_FIXTURE_ROWS]
+
+
+def _bounded_strings(value: Any, limit: int, item_limit: int) -> list[str]:
+    return [
+        str(item).strip()[:item_limit]
+        for item in list(value or [])[:limit]
+        if str(item).strip()
+    ]
+
+
+def _checksum(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )

--- a/server/evaluations/service.py
+++ b/server/evaluations/service.py
@@ -30,6 +30,12 @@ from .store import (
     EvaluationStateError,
     XpertEvaluationStore,
 )
+from .resource_fixtures import (
+    AgentTableEvaluationBackend,
+    assert_agent_table_dependencies,
+    inspect_agent_table_node,
+    prepare_agent_table_fixtures,
+)
 
 
 UNSAFE_MIDDLEWARE_IDS = {
@@ -64,6 +70,7 @@ class XpertEvaluationService:
         plugin_store: Any,
         rag_service: Any,
         context_store: Any,
+        agent_table_evaluation_backend: AgentTableEvaluationBackend | None = None,
     ) -> None:
         self.store = store
         self.xpert_store = xpert_store
@@ -73,6 +80,7 @@ class XpertEvaluationService:
         self.plugin_store = plugin_store
         self.rag_service = rag_service
         self.context_store = context_store
+        self.agent_table_evaluation_backend = agent_table_evaluation_backend
 
     def snapshot_target(
         self,
@@ -387,13 +395,23 @@ class XpertEvaluationService:
         selected = [copy.deepcopy(item) for item in cases]
         if not selected:
             raise EvaluationStateError("No evaluation cases were selected.")
+        targets = ([baseline] if baseline else []) + list(candidates)
+        frozen_targets = [copy.deepcopy(item) for item in targets]
+        resource_fixtures = prepare_agent_table_fixtures(
+            targets=frozen_targets,
+            cases=selected,
+            backend=self.agent_table_evaluation_backend,
+        )
+        frozen_baseline = frozen_targets[0] if baseline else None
+        frozen_candidates = frozen_targets[1:] if baseline else frozen_targets
         return self.store.create_run(
             dataset_version=copy.deepcopy(dataset_version),
             cases=selected,
-            baseline=copy.deepcopy(baseline),
-            candidates=copy.deepcopy(candidates),
+            baseline=frozen_baseline,
+            candidates=frozen_candidates,
             config=copy.deepcopy(config),
             warnings=list(dict.fromkeys(warnings or [])),
+            resource_fixtures=resource_fixtures,
         )
 
     def create_run(self, payload: dict[str, Any]) -> dict[str, Any]:
@@ -433,11 +451,24 @@ class XpertEvaluationService:
             )
             candidate_snapshots.append(snapshot)
             warnings.extend(current)
+        targets = ([baseline_snapshot] if baseline_snapshot else []) + list(
+            candidate_snapshots
+        )
+        frozen_targets = [copy.deepcopy(item) for item in targets]
+        resource_fixtures = prepare_agent_table_fixtures(
+            targets=frozen_targets,
+            cases=cases,
+            backend=self.agent_table_evaluation_backend,
+        )
+        frozen_baseline = frozen_targets[0] if baseline_snapshot else None
+        frozen_candidates = (
+            frozen_targets[1:] if baseline_snapshot else frozen_targets
+        )
         return self.store.create_run(
             dataset_version=dataset,
             cases=cases,
-            baseline=baseline_snapshot,
-            candidates=candidate_snapshots,
+            baseline=frozen_baseline,
+            candidates=frozen_candidates,
             config={
                 "model_policy": model_policy,
                 "override_model_id": override_model_id,
@@ -446,6 +477,7 @@ class XpertEvaluationService:
                 "budget": copy.deepcopy(payload.get("budget") or {}),
             },
             warnings=list(dict.fromkeys(warnings)),
+            resource_fixtures=resource_fixtures,
         )
 
     def run_detail(self, run_id: str) -> dict[str, Any]:
@@ -562,9 +594,11 @@ class XpertEvaluationService:
         resources: dict[str, Any] = {
             "toolsets": [],
             "knowledge_versions": [],
+            "data_tables": [],
             "external_xperts": [],
             "plugins": [],
         }
+        table_nodes: list[Any] = []
         for node in workflow.nodes:
             data = node.data if isinstance(node.data, dict) else {}
             kind = str(data.get("kind") or node.type or "")
@@ -668,24 +702,41 @@ class XpertEvaluationService:
                             "node_id": node.id,
                         }
                     )
-            if kind == "knowledge_base":
+            if kind in {"knowledge_base", "knowledge_retrieval"}:
                 kb_id = str(data.get("knowledgeBaseId") or "").strip()
                 try:
                     active = self.rag_service.get_active_pipeline_version(kb_id)
+                    if not active and kind == "knowledge_retrieval":
+                        raise ValueError(
+                            f"Knowledge base {kb_id or '<missing>'} has no active pipeline version."
+                        )
                     if not active:
                         warnings.append(
                             f"Knowledge base {kb_id} has no active pipeline version."
                         )
-                    resources["knowledge_versions"].append(
-                        {
-                            "knowledge_base_id": kb_id,
-                            "version_id": (
-                                str(active.get("version_id") or "") if active else None
-                            ),
-                        }
-                    )
-                    data["evaluationPinnedVersionId"] = (
+                    observed_version = str(
+                        data.get("observedActiveVersionId") or ""
+                    ).strip()
+                    fixed_version = (
                         str(active.get("version_id") or "") if active else ""
+                    )
+                    if observed_version and fixed_version != observed_version:
+                        warnings.append(
+                            f"Knowledge base {kb_id} active version changed from "
+                            f"{observed_version} to {fixed_version}."
+                        )
+                    evidence = {
+                        "knowledge_base_id": kb_id,
+                        "version_id": fixed_version or None,
+                    }
+                    if kind == "knowledge_retrieval":
+                        evidence.update(
+                            {"node_id": node.id, "node_kind": kind}
+                        )
+                    if evidence not in resources["knowledge_versions"]:
+                        resources["knowledge_versions"].append(evidence)
+                    data["evaluationPinnedVersionId"] = (
+                        fixed_version
                     )
                     node.data = data
                 except Exception as exc:
@@ -694,6 +745,22 @@ class XpertEvaluationService:
                             "code": "evaluation_knowledge_invalid",
                             "message": str(exc),
                             "node_id": node.id,
+                        }
+                    )
+            if kind == "data_table_query":
+                table_nodes.append(node)
+                resource, issue = inspect_agent_table_node(
+                    node,
+                    backend=self.agent_table_evaluation_backend,
+                )
+                if issue is not None:
+                    issues.append(issue)
+                elif resource is not None:
+                    resources["data_tables"].append(
+                        {
+                            **resource,
+                            "node_id": node.id,
+                            "node_kind": kind,
                         }
                     )
             if kind == "external_xpert":
@@ -727,6 +794,8 @@ class XpertEvaluationService:
                     )
             if kind == "plugin_resource":
                 self._inspect_plugin(node, data, issues, resources)
+        if table_nodes:
+            issues.extend(assert_agent_table_dependencies(workflow, table_nodes))
         return issues, warnings, resources
 
     def _inspect_plugin(

--- a/server/evaluations/store.py
+++ b/server/evaluations/store.py
@@ -10,6 +10,8 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from .models import AgentTableQueryFixture
+
 
 class EvaluationError(RuntimeError):
     pass
@@ -32,6 +34,8 @@ class XpertEvaluationStore:
 
     MAX_DATASET_CASES = 500
     MAX_RUN_CASES = 100
+    MAX_RESOURCE_FIXTURES = 1_000
+    MAX_RESOURCE_FIXTURE_BYTES = 16 * 1024 * 1024
 
     def __init__(self, storage_dir: str | Path | None = None) -> None:
         root = Path(
@@ -371,6 +375,7 @@ class XpertEvaluationStore:
         candidates: list[dict[str, Any]],
         config: dict[str, Any],
         warnings: list[str],
+        resource_fixtures: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         if not 1 <= len(cases) <= self.MAX_RUN_CASES:
             raise EvaluationStateError("A run must contain between 1 and 100 cases.")
@@ -394,6 +399,11 @@ class XpertEvaluationStore:
                             "updated_at": now,
                         }
                     )
+        private_fixtures, fixture_bytes = self._validate_resource_fixtures(
+            copy.deepcopy(resource_fixtures or []),
+            targets=targets,
+            cases=cases,
+        )
         run = {
             "run_id": f"xeval_run_{uuid.uuid4().hex}",
             "status": "queued",
@@ -404,6 +414,11 @@ class XpertEvaluationStore:
             "config": copy.deepcopy(config),
             "warnings": [str(item)[:500] for item in warnings[:50]],
             "items": items,
+            "_resource_fixtures": private_fixtures,
+            "resource_fixture_summary": {
+                "fixture_count": len(private_fixtures),
+                "stored_bytes": fixture_bytes,
+            },
             "report": {},
             "cancel_requested": False,
             "run_registry_id": None,
@@ -415,7 +430,7 @@ class XpertEvaluationStore:
         with self._lock:
             self._data["runs"][run["run_id"]] = run
             self._save_unlocked()
-        return copy.deepcopy(run)
+        return self.run_payload(run, include_detail=True)
 
     def list_runs(self, *, status: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
         with self._lock:
@@ -534,7 +549,7 @@ class XpertEvaluationStore:
         with self._lock:
             run = self._run_unlocked(run_id)
             if run.get("status") in {"completed", "failed", "cancelled"}:
-                return copy.deepcopy(run)
+                return self.run_payload(run, include_detail=True)
             run["cancel_requested"] = True
             if run.get("status") == "queued":
                 run["status"] = "cancelled"
@@ -544,7 +559,34 @@ class XpertEvaluationStore:
                     item["status"] = "cancelled"
             run["updated_at"] = time.time()
             self._save_unlocked()
-            return copy.deepcopy(run)
+            return self.run_payload(run, include_detail=True)
+
+    def resource_fixtures_for_item(
+        self,
+        run_id: str,
+        *,
+        target_id: str,
+        case_id: str,
+    ) -> list[dict[str, Any]]:
+        with self._lock:
+            run = self._run_unlocked(run_id)
+            matches = [
+                item
+                for item in list(run.get("_resource_fixtures") or [])
+                if str(item.get("target_id") or "") == target_id
+                and str(item.get("case_id") or "") == case_id
+            ]
+            try:
+                return [
+                    AgentTableQueryFixture.model_validate(item).model_dump(
+                        mode="json"
+                    )
+                    for item in matches
+                ]
+            except Exception as exc:
+                raise EvaluationStateError(
+                    "Persisted evaluation resource fixture failed integrity validation."
+                ) from exc
 
     @staticmethod
     def dataset_payload(item: dict[str, Any], *, include_cases: bool) -> dict[str, Any]:
@@ -564,6 +606,7 @@ class XpertEvaluationStore:
     @staticmethod
     def run_payload(item: dict[str, Any], *, include_detail: bool) -> dict[str, Any]:
         payload = copy.deepcopy(item)
+        payload.pop("_resource_fixtures", None)
         payload["item_count"] = len(payload.get("items") or [])
         payload["completed_item_count"] = sum(
             1
@@ -615,6 +658,10 @@ class XpertEvaluationStore:
             "expected": copy.deepcopy(case.get("expected") or {}),
             "weights": copy.deepcopy(case.get("weights") or {}),
         }
+        if isinstance(case.get("path"), dict):
+            normalized["path"] = copy.deepcopy(case["path"])
+        if isinstance(case.get("resource_reads"), list):
+            normalized["resource_reads"] = copy.deepcopy(case["resource_reads"])
         if isinstance(case.get("targeting"), dict):
             normalized["targeting"] = copy.deepcopy(case["targeting"])
         return normalized
@@ -639,6 +686,58 @@ class XpertEvaluationStore:
             "datasets": datasets,
             "runs": dict(raw.get("runs") or {}),
         }
+
+    @classmethod
+    def _validate_resource_fixtures(
+        cls,
+        fixtures: list[dict[str, Any]],
+        *,
+        targets: list[dict[str, Any]],
+        cases: list[dict[str, Any]],
+    ) -> tuple[list[dict[str, Any]], int]:
+        if len(fixtures) > cls.MAX_RESOURCE_FIXTURES:
+            raise EvaluationStateError(
+                "Evaluation run exceeds the 1000 resource fixture limit."
+            )
+        target_ids = {str(item.get("target_id") or "") for item in targets}
+        case_ids = {str(item.get("case_id") or "") for item in cases}
+        normalized: list[dict[str, Any]] = []
+        keys: set[tuple[str, str, str]] = set()
+        for fixture in fixtures:
+            try:
+                item = AgentTableQueryFixture.model_validate(fixture).model_dump(mode="json")
+            except Exception as exc:
+                raise EvaluationStateError(
+                    "Evaluation resource fixture failed schema validation."
+                ) from exc
+            if item["target_id"] not in target_ids or item["case_id"] not in case_ids:
+                raise EvaluationStateError(
+                    "Evaluation resource fixture references a target or case outside this run."
+                )
+            key = (item["target_id"], item["case_id"], item["node_ref"])
+            if key in keys:
+                raise EvaluationStateError(
+                    "Evaluation resource fixtures must be unique per target, case, and node."
+                )
+            keys.add(key)
+            normalized.append(item)
+        try:
+            encoded = json.dumps(
+                normalized,
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        except (TypeError, ValueError) as exc:
+            raise EvaluationStateError(
+                "Evaluation resource fixtures must be JSON-safe."
+            ) from exc
+        if len(encoded) > cls.MAX_RESOURCE_FIXTURE_BYTES:
+            raise EvaluationStateError(
+                "Evaluation run exceeds the 16 MiB resource fixture limit."
+            )
+        return normalized, len(encoded)
 
     @staticmethod
     def _metadata_payload(item: dict[str, Any]) -> dict[str, Any]:

--- a/server/main.py
+++ b/server/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import ast
 import base64
+import copy
 import hashlib
 import json
 import logging
@@ -186,6 +187,7 @@ try:
         get_xpert_evaluation_executor,
         get_xpert_evaluation_service,
         get_xpert_evaluation_store,
+        render_evaluation_case_inputs,
         router as xpert_evaluations_router,
     )
 except ModuleNotFoundError:
@@ -194,6 +196,7 @@ except ModuleNotFoundError:
         get_xpert_evaluation_executor,
         get_xpert_evaluation_service,
         get_xpert_evaluation_store,
+        render_evaluation_case_inputs,
         router as xpert_evaluations_router,
     )
 
@@ -7473,11 +7476,40 @@ def build_meta_planner_capability_snapshot(
         item["active_version_id"] = active.get("version_id") if active else None
         knowledge_bases.append(item)
 
+    data_tables = []
+    for table in agent_table_store.list_tables(status="published", limit=200):
+        schema_versions = agent_table_store.list_schema_versions(table.table_id)
+        data_tables.append(
+            {
+                "table_id": table.table_id,
+                "name": table.name,
+                "description": table.description,
+                "status": table.status,
+                "active_schema_version": table.active_schema_version,
+                "schema_versions": [
+                    {
+                        "version": version.version,
+                        "checksum": version.checksum,
+                        "fields": [
+                            {
+                                "name": field.name,
+                                "data_type": field.data_type,
+                                "required": field.required,
+                            }
+                            for field in version.fields
+                        ],
+                    }
+                    for version in schema_versions
+                ],
+            }
+        )
+
     return build_capability_snapshot(
         workflow_registry=workflow_node_registry,
         middleware_registry=runtime_middleware_registry,
         external_xperts=published_xperts,
         knowledge_bases=knowledge_bases,
+        data_tables=data_tables,
         toolsets=toolset_store.list_toolsets(status="published", limit=500),
         plugins=get_plugin_store().list_plugins(status="published", limit=500),
         prompt_profiles=get_prompt_profile_store().list_profiles(
@@ -8974,7 +9006,7 @@ async def generate_meta_planner_xpert_candidate(
 
     run = await run_registry.create_run(
         "meta_planner",
-        f"Meta Planner: {payload.goal[:80]}",
+        f"元智能体规划：{payload.goal[:80]}",
         status="running",
         source_id=payload.target_xpert_id,
         metadata={
@@ -8987,7 +9019,7 @@ async def generate_meta_planner_xpert_candidate(
     await run_registry.record_checkpoint(
         run.run_id,
         event_type="meta_planner.started",
-        title="Meta Planner started",
+        title="元智能体规划已开始",
         metadata={"mode": payload.mode},
     )
 
@@ -10340,7 +10372,7 @@ async def _run_workflow_response(
         and all(
             isinstance(item, str)
             and re.fullmatch(
-                r"[a-z][a-z0-9_-]{0,63}:(?:success|matched|unmatched|case_[1-8]|default)",
+                r"[a-z][a-z0-9_-]{0,63}:(?:success|error|matched|unmatched|case_[1-8]|default)",
                 item,
             )
             for item in raw_retry_control_flow_trace
@@ -10577,6 +10609,7 @@ async def _run_workflow_response(
         "order_index": order_index,
         "final_output": str(safe_resume_state.get("final_output") or ""),
         "control_flow_trace": list(safe_resume_state.get("control_flow_trace") or []),
+        "evaluation_resource_reads": [],
         "control_flow_terminal": (
             dict(safe_resume_state.get("control_flow_terminal") or {})
             if isinstance(safe_resume_state.get("control_flow_terminal"), dict)
@@ -10771,6 +10804,11 @@ async def _run_workflow_response(
                     for index, route in enumerate(node.data.get("routes") or [], start=1)
                 }
                 expected_map["default"] = "default"
+            elif kind in {"knowledge_retrieval", "data_table_query"} and (
+                failure_action(node.data) == "error_output"
+            ):
+                expected_map = {"success": "", "error": "error"}
+                raw_map = node.data.get("plannerOutcomeMapV2")
             if (
                 not re.fullmatch(r"[a-z][a-z0-9_-]{0,63}", planner_ref)
                 or raw_map != expected_map
@@ -18010,6 +18048,48 @@ async def _run_workflow_response(
                     result_count = 0
                     affected_count = 0
                     if kind == "data_table_query":
+                        evaluation_fixture: dict[str, Any] | None = None
+                        if runtime_run_type == "xpert_evaluation":
+                            evaluation_context = dict(
+                                task_state.get("runtime_metadata") or {}
+                            )
+                            evaluation_run_id = str(
+                                evaluation_context.get("evaluation_run_id") or ""
+                            ).strip()
+                            evaluation_target_id = str(
+                                evaluation_context.get("evaluation_target_id") or ""
+                            ).strip()
+                            evaluation_case_id = str(
+                                evaluation_context.get("evaluation_case_id") or ""
+                            ).strip()
+                            if not all(
+                                (
+                                    evaluation_run_id,
+                                    evaluation_target_id,
+                                    evaluation_case_id,
+                                )
+                            ):
+                                raise WorkflowTerminationError(
+                                    "EVALUATION_RESOURCE_FIXTURE_MISSING",
+                                    "The fixed Agent Table evaluation fixture is unavailable.",
+                                    node_id=node.id,
+                                )
+                            fixture_matches = [
+                                item
+                                for item in get_xpert_evaluation_store().resource_fixtures_for_item(
+                                    evaluation_run_id,
+                                    target_id=evaluation_target_id,
+                                    case_id=evaluation_case_id,
+                                )
+                                if str(item.get("node_id") or "") == node.id
+                            ]
+                            if len(fixture_matches) != 1:
+                                raise WorkflowTerminationError(
+                                    "EVALUATION_RESOURCE_FIXTURE_MISSING",
+                                    "The fixed Agent Table evaluation fixture is unavailable.",
+                                    node_id=node.id,
+                                )
+                            evaluation_fixture = fixture_matches[0]
                         retry_attempt = require_retry_runtime(node)
                         active_retry_state = dict(retry_resume_state)
                         if retry_attempt > 1:
@@ -18047,21 +18127,90 @@ async def _run_workflow_response(
                         )
                         sort = node.data.get("sort")
                         try:
-                            if schema is None:
+                            if evaluation_fixture is not None:
+                                if (
+                                    str(evaluation_fixture.get("resource_kind") or "")
+                                    != "data_table_query"
+                                    or str(evaluation_fixture.get("table_id") or "")
+                                    != table_id
+                                ):
+                                    raise ValueError(
+                                        "Evaluation fixture resource identity does not match."
+                                    )
+                                fixture_schema_version = int(
+                                    evaluation_fixture.get("schema_version") or 0
+                                )
+                                pinned_schema_checksum = str(
+                                    node.data.get("pinnedSchemaChecksum")
+                                    or node.data.get(
+                                        "evaluationPinnedSchemaChecksum"
+                                    )
+                                    or ""
+                                ).strip()
                                 schema = agent_table_store.resolve_schema_version(
                                     table_id,
-                                    version_policy=version_policy,
-                                    pinned_version=pinned_version,
-                                    write=is_write,
+                                    version_policy="pinned",
+                                    pinned_version=fixture_schema_version,
+                                    write=False,
                                 )
-                            records = agent_table_store.query_records(
-                                table_id,
-                                schema_version=schema.version,
-                                fields=selected_fields,
-                                filter_tree=filter_tree,
-                                sort=sort if isinstance(sort, list) else None,
-                                limit=int(node.data.get("limit") or 20),
-                            )
+                                if (
+                                    str(evaluation_fixture.get("schema_checksum") or "")
+                                    != str(schema.checksum)
+                                    or (
+                                        pinned_schema_checksum
+                                        and pinned_schema_checksum
+                                        != str(schema.checksum)
+                                    )
+                                    or (
+                                        pinned_version is not None
+                                        and pinned_version != fixture_schema_version
+                                    )
+                                ):
+                                    raise ValueError(
+                                        "Evaluation fixture schema no longer matches the workflow snapshot."
+                                    )
+                                normalized_sort = (
+                                    copy.deepcopy(sort)
+                                    if isinstance(sort, list)
+                                    else None
+                                )
+                                query_contract_matches = (
+                                    evaluation_fixture.get("fields")
+                                    == selected_fields
+                                    and evaluation_fixture.get("filter")
+                                    == filter_tree
+                                    and evaluation_fixture.get("sort")
+                                    == normalized_sort
+                                    and int(evaluation_fixture.get("limit") or 0)
+                                    == int(node.data.get("limit") or 20)
+                                    and str(
+                                        evaluation_fixture.get("return_mode") or ""
+                                    )
+                                    == str(node.data.get("returnMode") or "list")
+                                )
+                                if not query_contract_matches:
+                                    raise ValueError(
+                                        "Evaluation fixture query contract no longer matches."
+                                    )
+                                records = copy.deepcopy(
+                                    list(evaluation_fixture.get("records") or [])
+                                )
+                            else:
+                                if schema is None:
+                                    schema = agent_table_store.resolve_schema_version(
+                                        table_id,
+                                        version_policy=version_policy,
+                                        pinned_version=pinned_version,
+                                        write=is_write,
+                                    )
+                                records = agent_table_store.query_records(
+                                    table_id,
+                                    schema_version=schema.version,
+                                    fields=selected_fields,
+                                    filter_tree=filter_tree,
+                                    sort=sort if isinstance(sort, list) else None,
+                                    limit=int(node.data.get("limit") or 20),
+                                )
                         except Exception as exc:
                             if cancellation_requested():
                                 yield sse_payload(cancellation_event())
@@ -18128,6 +18277,32 @@ async def _run_workflow_response(
                             else:
                                 stored_output = records
                             output = f"Agent Table query returned {result_count} record(s)."
+                            if evaluation_fixture is not None:
+                                task_state.setdefault(
+                                    "evaluation_resource_reads", []
+                                ).append(
+                                    {
+                                        "node_ref": str(
+                                            node.data.get("plannerRef") or node.id
+                                        )[:64],
+                                        "kind": "data_table_query",
+                                        "resource_id": table_id,
+                                        "schema_version": int(schema.version),
+                                        "query_checksum": str(
+                                            evaluation_fixture.get("query_checksum")
+                                            or ""
+                                        ),
+                                        "result_count": result_count,
+                                        "record_ids": [
+                                            str(item)[:200]
+                                            for item in list(
+                                                evaluation_fixture.get("record_ids")
+                                                or []
+                                            )[:200]
+                                            if str(item)
+                                        ],
+                                    }
+                                )
                         operation = "query"
                     elif kind == "data_table_insert":
                         values = resolve_data_table_values(
@@ -18636,6 +18811,16 @@ async def _run_workflow_response(
                         ).strip()
                         retry_target_fingerprint: str | None = None
                         retry_target_version_id: str | None = None
+                        if runtime_run_type == "xpert_evaluation":
+                            retry_target_version_id = str(
+                                node.data.get("evaluationPinnedVersionId") or ""
+                            ).strip()
+                            if not retry_target_version_id:
+                                raise WorkflowTerminationError(
+                                    "EVALUATION_KNOWLEDGE_VERSION_MISSING",
+                                    "The fixed knowledge evaluation version is unavailable.",
+                                    node_id=node.id,
+                                )
                         if retry_enabled(node.data):
                             try:
                                 (
@@ -18738,16 +18923,24 @@ async def _run_workflow_response(
                                 reason="resume_lease_lost",
                             )
                             raise
+                        retrieval_options: dict[str, Any] = {
+                            "configured_kb_id": configured_kb_id,
+                            "query": query_text,
+                            "top_k": top_k,
+                            "contract_version": contract_version,
+                            "return_mode": return_mode,
+                            "version_id": retry_target_version_id,
+                        }
+                        if runtime_run_type == "xpert_evaluation":
+                            retrieval_options["include_resource_evidence"] = True
                         output, retrieval_metadata = (
                             await execute_workflow_knowledge_retrieval(
                                 get_rag_service(),
-                                configured_kb_id=configured_kb_id,
-                                query=query_text,
-                                top_k=top_k,
-                                contract_version=contract_version,
-                                return_mode=return_mode,
-                                version_id=retry_target_version_id,
+                                **retrieval_options,
                             )
+                        )
+                        resource_evidence = dict(
+                            retrieval_metadata.pop("_resource_evidence", {}) or {}
                         )
                         if cancellation_requested():
                             await run_registry.cancel_run(
@@ -18765,6 +18958,33 @@ async def _run_workflow_response(
                             )
                             raise
                         variables[output_variable] = output
+                        if runtime_run_type == "xpert_evaluation":
+                            task_state.setdefault(
+                                "evaluation_resource_reads", []
+                            ).append(
+                                {
+                                    "node_ref": str(
+                                        node.data.get("plannerRef") or node.id
+                                    )[:64],
+                                    "kind": "knowledge_retrieval",
+                                    "resource_id": str(
+                                        retrieval_metadata.get("kb_id") or ""
+                                    )[:200],
+                                    "version_id": str(
+                                        retrieval_metadata.get("version_id") or ""
+                                    )[:200],
+                                    "result_count": int(
+                                        retrieval_metadata.get("hit_count") or 0
+                                    ),
+                                    "citation_ids": [
+                                        str(item)[:200]
+                                        for item in list(
+                                            resource_evidence.get("citation_ids") or []
+                                        )[:50]
+                                        if str(item)
+                                    ],
+                                }
+                            )
                         output_length = len(workflow_value_to_text(output))
                         await run_registry.update_run(
                             retrieval_run.run_id,
@@ -24808,6 +25028,13 @@ async def _run_workflow_response(
                             edge for edge in next_edges if not edge.sourceHandle
                         ][:1]
                     next_edges = matching_edges
+                elif kind in {"knowledge_retrieval", "data_table_query"} and (
+                    failure_action(node.data) == "error_output"
+                ):
+                    record_control_outcome(
+                        node,
+                        "error" if node_end_status == "handled_error" else "",
+                    )
                 elif kind != "terminate_error":
                     record_control_outcome(node, "")
 
@@ -30057,7 +30284,7 @@ async def evaluation_control_flow_summary(runtime_run_id: str) -> dict[str, Any]
         str(item)[:129]
         for item in list(metadata.get("outcomes") or [])[:256]
         if re.fullmatch(
-            r"[a-z][a-z0-9_-]{0,63}:(?:success|matched|unmatched|case_[1-8]|default)",
+            r"[a-z][a-z0-9_-]{0,63}:(?:success|error|matched|unmatched|case_[1-8]|default)",
             str(item),
         )
     ]
@@ -30085,19 +30312,7 @@ async def run_xpert_evaluation_target(
     parent_run_id: str | None,
 ) -> dict[str, Any]:
     workflow = WorkflowPayload.model_validate(target["workflow"])
-    history = [
-        {
-            "role": str(item.get("role") or "user"),
-            "content": str(item.get("content") or "")[:20_000],
-        }
-        for item in list(case.get("messages") or [])[-20:]
-        if isinstance(item, dict) and str(item.get("content") or "").strip()
-    ]
-    history_json = json.dumps(history, ensure_ascii=False)
-    message = str(case.get("message") or "")[:20_000]
-    input_template = str(target.get("input_template") or "")
-    if input_template:
-        message = re.sub(r"{{\s*args\s*}}", message, input_template)[:20_000]
+    message, history, history_json = render_evaluation_case_inputs(target, case)
     inputs = {
         str(target.get("input_variable") or "user_input"): message,
         str(target.get("history_variable") or "conversation_history"): history_json,
@@ -30136,6 +30351,8 @@ async def run_xpert_evaluation_target(
         "xpert_features": {},
         "evaluation_mode": "read_only",
         "evaluation_target_id": target.get("target_id"),
+        "evaluation_run_id": str(config.get("evaluation_run_id") or ""),
+        "evaluation_case_id": str(config.get("evaluation_case_id") or ""),
         "evaluation_resources": dict(target.get("resources") or {}),
         "evaluation_seed": int(config.get("seed") or 0),
         "memory_write_enabled": False,
@@ -30221,6 +30438,11 @@ async def run_xpert_evaluation_target(
         "citations": evaluation_citation_summary(citation_value),
         "tool_calls": await evaluation_tool_call_summary(runtime_run_id),
         "control_flow": control_flow,
+        "resource_reads": list(
+            task_state.get("evaluation_resource_reads") or []
+        )[:100]
+        if isinstance(task_state, dict)
+        else [],
         "usage": usage,
         "runtime_run_id": runtime_run_id or None,
     }
@@ -30600,6 +30822,7 @@ configure_xpert_evaluations(
     plugin_store=get_plugin_store(),
     rag_service=get_rag_service(),
     context_store=xpert_context_store,
+    agent_table_evaluation_backend=agent_table_store,
     target_runner=run_xpert_evaluation_target,
     judge_runner=run_xpert_evaluation_judge,
     run_registry=run_registry,

--- a/server/meta_agent/capabilities.py
+++ b/server/meta_agent/capabilities.py
@@ -107,6 +107,7 @@ def build_capability_snapshot(
     prompt_profiles: Iterable[Any],
     model_ids: Iterable[str],
     agents: Iterable[Any] = (),
+    data_tables: Iterable[dict[str, Any]] = (),
 ) -> MetaPlannerCapabilitySnapshot:
     node_payload = workflow_registry.to_payload()
     nodes: list[dict[str, Any]] = []
@@ -267,6 +268,85 @@ def build_capability_snapshot(
         for item in knowledge_bases
         if item.get("id") or item.get("kb_id")
     ]
+    tables: list[dict[str, Any]] = []
+    for raw_table in data_tables:
+        table = dict(raw_table)
+        table_id = str(table.get("table_id") or table.get("id") or "").strip()
+        schema_version = table.get("active_schema_version")
+        if not table_id or not schema_version:
+            continue
+        raw_versions = list(table.get("schema_versions") or [])
+        if not raw_versions and table.get("schema_checksum"):
+            raw_versions = [
+                {
+                    "version": schema_version,
+                    "checksum": table.get("schema_checksum"),
+                    "fields": table.get("fields"),
+                }
+            ]
+        safe_versions: list[dict[str, Any]] = []
+        for raw_version in raw_versions:
+            version = dict(raw_version)
+            checksum = str(version.get("checksum") or "").strip()
+            try:
+                version_number = int(version.get("version"))
+            except (TypeError, ValueError):
+                continue
+            fields = []
+            for raw_field in list(version.get("fields") or []):
+                field = dict(raw_field)
+                name = str(field.get("name") or "").strip()
+                data_type = str(
+                    field.get("data_type") or field.get("type") or ""
+                ).strip()
+                if not name or data_type not in {
+                    "string",
+                    "integer",
+                    "number",
+                    "boolean",
+                    "datetime",
+                    "json",
+                }:
+                    continue
+                fields.append(
+                    {
+                        "name": name,
+                        "type": data_type,
+                        "required": bool(field.get("required")),
+                    }
+                )
+            if checksum:
+                safe_versions.append(
+                    {
+                        "version": version_number,
+                        "checksum": checksum,
+                        "fields": sorted(fields, key=lambda item: item["name"]),
+                    }
+                )
+        safe_versions.sort(key=lambda item: item["version"])
+        active = next(
+            (
+                item
+                for item in safe_versions
+                if item["version"] == int(schema_version)
+            ),
+            None,
+        )
+        if active is None:
+            continue
+        tables.append(
+            {
+                "id": table_id,
+                "name": str(table.get("name") or table_id)[:160],
+                "description": str(table.get("description") or "")[:600],
+                "status": str(table.get("status") or "published")[:40],
+                "active_schema_version": int(schema_version),
+                "schema_checksum": active["checksum"],
+                "fields": active["fields"],
+                "schema_versions": safe_versions,
+            }
+        )
+    tables.sort(key=lambda item: item["id"])
     safe_toolsets = [
         _safe_resource(
             resource_id=item.id,
@@ -357,6 +437,7 @@ def build_capability_snapshot(
         allowed_node_kinds=sorted(core_node_kinds & available_node_kinds),
         external_xpert_ids=[item["id"] for item in xperts],
         knowledge_base_ids=[item["id"] for item in kbs],
+        data_table_ids=[],
         toolset_ids=[item["id"] for item in safe_toolsets],
         plugin_ids=[item["id"] for item in safe_plugins],
         prompt_profile_ids=[item["id"] for item in prompts],
@@ -364,10 +445,10 @@ def build_capability_snapshot(
         agent_ids=[item["id"] for item in expert_summaries],
     )
     payload = {
-        "version": "evoagentx-meta-planner-capabilities-v7",
+        "version": "evoagentx-meta-planner-capabilities-v8",
         "ir_version": 3,
         "supported_ir_versions": [2, 3],
-        "control_flow_contract_version": 1,
+        "control_flow_contract_version": 2,
         "contract_version": int(node_payload.get("contract_version") or 0),
         "contract_checksum": str(node_payload.get("contract_checksum") or ""),
         "node_registry_version": workflow_registry.version,
@@ -375,6 +456,7 @@ def build_capability_snapshot(
         "middleware": middleware,
         "external_xperts": xperts,
         "knowledge_bases": kbs,
+        "data_tables": tables,
         "toolsets": safe_toolsets,
         "plugins": safe_plugins,
         "prompt_profiles": prompts,
@@ -409,6 +491,7 @@ def assert_scope_is_authorized(
         "allowed_node_kinds": {item["kind"] for item in snapshot.nodes},
         "external_xpert_ids": {item["id"] for item in snapshot.external_xperts},
         "knowledge_base_ids": {item["id"] for item in snapshot.knowledge_bases},
+        "data_table_ids": {item["id"] for item in snapshot.data_tables},
         "toolset_ids": {item["id"] for item in snapshot.toolsets},
         "plugin_ids": {item["id"] for item in snapshot.plugins},
         "prompt_profile_ids": {item["id"] for item in snapshot.prompt_profiles},

--- a/server/meta_agent/control_flow.py
+++ b/server/meta_agent/control_flow.py
@@ -23,7 +23,7 @@ except ModuleNotFoundError:
 from .schemas import GraphIntentControlEdgeV3, GraphIntentNodeV3, GraphIntentV3
 
 
-CONTROL_FLOW_CONTRACT_VERSION = 1
+CONTROL_FLOW_CONTRACT_VERSION = 2
 MAX_ROUTER_NODES = 8
 MAX_SYMBOLIC_SCENARIOS = 256
 
@@ -43,6 +43,11 @@ def semantic_outcomes(node: GraphIntentNodeV3) -> tuple[str, ...]:
         return tuple([*(f"case_{index}" for index in range(1, count + 1)), "default"])
     if node.kind == "terminate_error":
         return ()
+    if (
+        node.kind in {"knowledge_retrieval", "data_table_query"}
+        and str(node.config.get("failure_action") or "stop") == "error_output"
+    ):
+        return ("success", "error")
     return ("success",)
 
 
@@ -59,6 +64,11 @@ def native_outcome_map(node: GraphIntentNodeV3) -> dict[str, str]:
         }
     if node.kind == "terminate_error":
         return {}
+    if (
+        node.kind in {"knowledge_retrieval", "data_table_query"}
+        and str(node.config.get("failure_action") or "stop") == "error_output"
+    ):
+        return {"success": "", "error": "error"}
     return {"success": ""}
 
 
@@ -285,9 +295,7 @@ def analyze_control_flow(intent: GraphIntentV3) -> dict[str, Any]:
     if len(order) != len(nodes):
         issues.append("Control flow must be acyclic.")
 
-    routers = [
-        node for node in intent.nodes if node.kind in {"condition", "multi_route"}
-    ]
+    routers = [node for node in intent.nodes if len(semantic_outcomes(node)) > 1]
     if len(routers) > MAX_ROUTER_NODES:
         issues.append(f"Control flow supports at most {MAX_ROUTER_NODES} route nodes.")
 
@@ -305,26 +313,30 @@ def analyze_control_flow(intent: GraphIntentV3) -> dict[str, Any]:
             issues.append(f"Node {node.ref} is a nonterminal dead end.")
         if actual and node.ref in final_refs:
             issues.append(f"Final source {node.ref} must not have outgoing edges.")
-        if node.kind in {"condition", "multi_route"}:
+        if len(expected) > 1:
             if actual_set != expected or len(actual) != len(expected):
                 issues.append(
                     f"Router {node.ref} must connect exactly once for outcomes: "
                     + ", ".join(sorted(expected))
                 )
-            witnesses = (
-                _condition_witnesses(node, nodes)
-                if node.kind == "condition"
-                else _route_witnesses(node, nodes)
-            )
-            missing_witnesses = sorted(expected - set(witnesses))
-            if missing_witnesses:
-                issues.append(
-                    f"Router {node.ref} has shadowed or unproven outcomes: "
-                    + ", ".join(missing_witnesses)
+            if node.kind in {"condition", "multi_route"}:
+                witnesses = (
+                    _condition_witnesses(node, nodes)
+                    if node.kind == "condition"
+                    else _route_witnesses(node, nodes)
                 )
+                missing_witnesses = sorted(expected - set(witnesses))
+                if missing_witnesses:
+                    issues.append(
+                        f"Router {node.ref} has shadowed or unproven outcomes: "
+                        + ", ".join(missing_witnesses)
+                    )
             route_domains.append((node.ref, tuple(sorted(expected))))
-        elif actual and actual_set != {"success"}:
-            issues.append(f"Node {node.ref} only permits the success outcome.")
+        elif actual and actual_set != expected:
+            issues.append(
+                f"Node {node.ref} only permits outcomes: "
+                + ", ".join(sorted(expected))
+            )
 
     scenario_count = 1
     for _ref, outcomes in route_domains:
@@ -455,10 +467,26 @@ def analyze_control_flow(intent: GraphIntentV3) -> dict[str, Any]:
             if binding.source_ref == "input":
                 continue
             source_scenarios = reached_by_ref.get(binding.source_ref, set())
+            source_node = nodes[binding.source_ref]
+            if (
+                source_node.kind in {"knowledge_retrieval", "data_table_query"}
+                and str(source_node.config.get("failure_action") or "stop")
+                == "error_output"
+                and binding.source_port == "result"
+            ):
+                source_scenarios = {
+                    scenario_index
+                    for scenario_index in source_scenarios
+                    if scenarios[scenario_index]["choices"].get(
+                        binding.source_ref
+                    )
+                    == "success"
+                }
             if not target_scenarios.issubset(source_scenarios):
                 issues.append(
                     f"Data source {binding.source_ref}.{binding.source_port} is not "
-                    f"guaranteed for {node.ref}.{binding.port}."
+                    f"available in every scenario and is not guaranteed for "
+                    f"{node.ref}.{binding.port}."
                 )
     if issues:
         raise ControlFlowAnalysisError(issues)

--- a/server/meta_agent/graph_ir_v3.py
+++ b/server/meta_agent/graph_ir_v3.py
@@ -45,6 +45,7 @@ from .schemas import (
     ResolvedGraphIRV3,
     ResolvedGraphNodeV3,
     ResolvedGraphPortV3,
+    ResolvedNodeResourceSnapshotV3,
     ResolvedPromptProfileV3,
 )
 
@@ -203,6 +204,19 @@ def graph_authoring_checksum(
     payload.pop("graph_checksum", None)
     payload.pop("capability_snapshot_version", None)
     payload.pop("capability_snapshot_hash", None)
+    for node in payload.get("nodes") or []:
+        resource = node.get("resource_snapshot")
+        if not isinstance(resource, dict) or resource.get("version_policy") != "active":
+            continue
+        resource["observed_version_id"] = None
+        resource["warnings"] = []
+        resource["snapshot_checksum"] = canonical_checksum(
+            {
+                "kind": resource.get("kind"),
+                "resource_id": resource.get("resource_id"),
+                "version_policy": "active",
+            }
+        )
     payload["tags"] = sorted(set(payload.get("tags") or []))
     payload["starters"] = sorted(set(payload.get("starters") or []))
     payload["nodes"] = sorted(
@@ -417,6 +431,7 @@ def v2_to_graph_intent(
                     )
                     for item in node.outputs
                 ],
+                resource_ref=node.resource_ref,
                 config=node.config,
             )
         )
@@ -522,6 +537,7 @@ def graph_intent_to_v2(intent: GraphIntentV3) -> MetaPlannerTypedBlueprintV2:
                     )
                     for item in node.outputs
                 ],
+                resource_ref=node.resource_ref,
                 config=node.config,
             )
             for node in intent.nodes
@@ -605,6 +621,7 @@ def _resolved_node(
     task_ids: list[str] | None = None,
     config: dict[str, Any] | None = None,
     execution_version: int | None = None,
+    resource_snapshot: ResolvedNodeResourceSnapshotV3 | None = None,
 ) -> ResolvedGraphNodeV3:
     contract = workflow_node_contract_registry.require(kind)
     execution_data = (
@@ -627,6 +644,7 @@ def _resolved_node(
         compiler_checksum=contract.compiler_checksum,
         execution=contract.effective_execution(execution_data).model_dump(mode="json"),
         resource_contracts=[item.model_dump(mode="json") for item in contract.resources],
+        resource_snapshot=resource_snapshot,
     )
 
 
@@ -663,6 +681,176 @@ def _resolve_immutable_resource_version(
             f"{label} drifted from pinned version {target} to {int(latest)}."
         )
     return target, canonical_checksum(resource)
+
+
+def _table_field_schema(field: dict[str, Any]) -> WorkflowValueSchema:
+    data_type = str(field.get("type") or "")
+    value_type = {
+        "string": "string",
+        "integer": "integer",
+        "number": "number",
+        "boolean": "boolean",
+        "datetime": "string",
+        "json": "any",
+    }.get(data_type)
+    if value_type is None:
+        raise ValueError(f"Agent Table field has unsupported type {data_type}.")
+    return WorkflowValueSchema(
+        type=value_type,
+        nullable=not bool(field.get("required")),
+    )
+
+
+def resolve_node_resource_snapshot(
+    node: GraphIntentNodeV3,
+    snapshot: MetaPlannerCapabilitySnapshot,
+    *,
+    pinned: dict[str, Any] | None = None,
+) -> ResolvedNodeResourceSnapshotV3 | None:
+    from .node_adapters import get_planner_node_adapter
+
+    adapter = get_planner_node_adapter(node.kind)
+    if adapter is None:
+        return None
+    if adapter.resource_kind is None:
+        if node.resource_ref is not None:
+            raise ValueError(
+                f"Node kind {node.kind} cannot carry a node resource reference."
+            )
+        return None
+    if node.resource_ref is None:
+        raise ValueError(f"Node kind {node.kind} requires a resource reference.")
+    resource_id = node.resource_ref.resource_id
+    if adapter.resource_kind == "knowledge_base":
+        resource = next(
+            (
+                item
+                for item in snapshot.knowledge_bases
+                if str(item.get("id") or "") == resource_id
+            ),
+            None,
+        )
+        if resource is None:
+            raise ValueError(f"Knowledge base {resource_id} is unavailable.")
+        observed = str(
+            (resource.get("metadata") or {}).get("active_version_id") or ""
+        ).strip()
+        if not observed:
+            raise ValueError(
+                f"Knowledge base {resource_id} has no active index version."
+            )
+        warnings: list[str] = []
+        previous = str((pinned or {}).get("observed_version_id") or "").strip()
+        if previous and previous != observed:
+            warnings.append(
+                f"Knowledge base {resource_id} active index changed from "
+                f"{previous} to {observed}."
+            )
+        checksum = canonical_checksum(
+            {
+                "kind": "knowledge_base",
+                "resource_id": resource_id,
+                "version_policy": "active",
+                "observed_version_id": observed,
+            }
+        )
+        return ResolvedNodeResourceSnapshotV3(
+            kind="knowledge_base",
+            resource_id=resource_id,
+            version_policy="active",
+            observed_version_id=observed,
+            snapshot_checksum=checksum,
+            warnings=warnings,
+        )
+    if adapter.resource_kind != "data_table":
+        raise ValueError(
+            f"Node kind {node.kind} has unsupported resource kind "
+            f"{adapter.resource_kind}."
+        )
+    resource = next(
+        (
+            item
+            for item in snapshot.data_tables
+            if str(item.get("id") or "") == resource_id
+        ),
+        None,
+    )
+    if resource is None:
+        raise ValueError(f"Agent Table {resource_id} is unavailable.")
+    expected_version = int(
+        (pinned or {}).get("pinned_schema_version")
+        or resource.get("active_schema_version")
+        or 0
+    )
+    versions = list(resource.get("schema_versions") or [])
+    version = next(
+        (
+            item
+            for item in versions
+            if isinstance(item, dict)
+            and int(item.get("version") or 0) == expected_version
+        ),
+        None,
+    )
+    if version is None and int(resource.get("active_schema_version") or 0) == expected_version:
+        version = {
+            "version": expected_version,
+            "checksum": resource.get("schema_checksum"),
+            "fields": resource.get("fields"),
+        }
+    if version is None:
+        raise ValueError(
+            f"Agent Table {resource_id} pinned SchemaVersion "
+            f"{expected_version} is unavailable."
+        )
+    schema_checksum = str(version.get("checksum") or "").strip()
+    expected_checksum = str((pinned or {}).get("schema_checksum") or "").strip()
+    if not schema_checksum or (
+        expected_checksum and expected_checksum != schema_checksum
+    ):
+        raise ValueError(
+            f"Agent Table {resource_id} SchemaVersion checksum does not match."
+        )
+    fields: dict[str, WorkflowValueSchema] = {
+        "record_id": WorkflowValueSchema(type="string"),
+        "created_at": WorkflowValueSchema(type="number"),
+        "updated_at": WorkflowValueSchema(type="number"),
+        "revision": WorkflowValueSchema(type="integer"),
+    }
+    required_fields = ["record_id", "created_at", "updated_at", "revision"]
+    for field in list(version.get("fields") or []):
+        if not isinstance(field, dict):
+            continue
+        name = str(field.get("name") or "").strip()
+        if not name or name in fields:
+            raise ValueError(
+                f"Agent Table {resource_id} has an invalid field schema."
+            )
+        fields[name] = _table_field_schema(field)
+        if bool(field.get("required")):
+            required_fields.append(name)
+    snapshot_payload = {
+        "kind": "data_table",
+        "resource_id": resource_id,
+        "version_policy": "pinned",
+        "pinned_schema_version": expected_version,
+        "schema_checksum": schema_checksum,
+        "fields": {
+            name: schema.model_dump(mode="json")
+            for name, schema in sorted(fields.items())
+        },
+    }
+    resolved = ResolvedNodeResourceSnapshotV3(
+        **snapshot_payload,
+        required_fields=tuple(required_fields),
+        snapshot_checksum=canonical_checksum(snapshot_payload),
+    )
+    expected_snapshot = str((pinned or {}).get("snapshot_checksum") or "").strip()
+    if expected_snapshot and expected_snapshot != resolved.snapshot_checksum:
+        raise ValueError(
+            f"Agent Table {resource_id} fixed resource snapshot has drifted."
+        )
+    return resolved
 
 
 def resolve_graph_intent(
@@ -744,7 +932,7 @@ def resolve_graph_intent(
             node_id="input",
             kind="input",
             role="input",
-            title="Conversation input",
+            title="对话输入",
             config={
                 "variableName": "user_input",
                 "historyVariable": "conversation_history",
@@ -781,6 +969,30 @@ def resolve_graph_intent(
         effective_node = node.model_copy(update={"config": resolved_config})
         parsed_config = adapter.validate_intent_node(effective_node)
         resolved_config = parsed_config.model_dump(mode="json")
+        resource_snapshot = resolve_node_resource_snapshot(
+            effective_node,
+            snapshot,
+            pinned=intent._pinned_node_resources.get(
+                (
+                    effective_node.ref,
+                    (
+                        effective_node.resource_ref.resource_id
+                        if effective_node.resource_ref is not None
+                        else ""
+                    ),
+                )
+            ),
+        )
+        resource_payload = (
+            resource_snapshot.model_dump(mode="json")
+            if resource_snapshot is not None
+            else None
+        )
+        adapter.validate_resolved_resource(
+            effective_node,
+            parsed_config,
+            resource_payload,
+        )
         contract = workflow_node_contract_registry.require(node.kind)
         if len(node.task_ids) != len(set(node.task_ids)):
             raise ValueError(f"Node {node.ref} task IDs must be unique.")
@@ -812,9 +1024,14 @@ def resolve_graph_intent(
             config=resolved_config,
             execution_version=(
                 2
-                if node.kind in {"json_serialize", "json_deserialize"}
+                if node.kind in {
+                    "json_serialize",
+                    "json_deserialize",
+                    "knowledge_retrieval",
+                }
                 else None
             ),
+            resource_snapshot=resource_snapshot,
         )
         contract_outputs = {
             port.name: port for port in resolved.ports if port.direction == "output"
@@ -828,10 +1045,12 @@ def resolve_graph_intent(
             authoritative_schema = adapter.authoritative_output_schema(
                 output.port,
                 parsed_config,
+                resource_payload,
             )
-            if canonical_checksum(
+            schema_matches = canonical_checksum(
                 output.value_schema.model_dump(mode="json")
-            ) != canonical_checksum(authoritative_schema.model_dump(mode="json")):
+            ) == canonical_checksum(authoritative_schema.model_dump(mode="json"))
+            if not schema_matches and adapter.resource_kind is None:
                 raise ValueError(
                     f"Node {node.ref} output {output.port} does not match its "
                     "authoritative Adapter type."
@@ -845,7 +1064,17 @@ def resolve_graph_intent(
                     f"Variable {output.variable} is produced by multiple nodes."
                 )
             producer_by_variable[output.variable] = node.ref
-            declared_outputs[key] = (output.variable, output.value_schema)
+            declared_outputs[key] = (output.variable, authoritative_schema)
+            resolved = resolved.model_copy(
+                update={
+                    "ports": [
+                        port.model_copy(update={"value_schema": authoritative_schema})
+                        if port.direction == "output" and port.name == output.port
+                        else port
+                        for port in resolved.ports
+                    ]
+                }
+            )
         nodes.append(resolved)
         resolved_by_ref[node.ref] = resolved
 
@@ -895,11 +1124,23 @@ def resolve_graph_intent(
         for binding in node.inputs:
             target_port = target_ports.get(binding.port)
             if target_port is None:
+                target_port = next(
+                    (
+                        port
+                        for name, port in target_ports.items()
+                        if binding.port.startswith(f"{name}_")
+                    ),
+                    None,
+                )
+            if target_port is None:
                 raise ValueError(
                     f"Node {node.ref} declares unknown input port {binding.port}."
                 )
-            counts[binding.port] += 1
-            if counts[binding.port] > 1 and target_port.cardinality != "many":
+            counts[target_port.name] += 1
+            if (
+                counts[target_port.name] > 1
+                and target_port.cardinality != "many"
+            ):
                 raise ValueError(
                     f"Node {node.ref} input port {binding.port} exceeds cardinality."
                 )
@@ -1128,7 +1369,7 @@ def resolve_graph_intent(
         node_id="output",
         kind="output",
         role="output",
-        title="Final answer",
+        title="最终回答",
         config={
             "contractVersion": 2,
             "selectionPolicy": "exactly_one_arrived",
@@ -1237,11 +1478,24 @@ def annotate_candidate_with_graph_ir(
         data["plannerCompilerChecksum"] = resolved.compiler_checksum
         source = intent_by_ref.get(resolved.ref)
         if source is not None:
+            resolved_outputs = {
+                port.name: port.value_schema
+                for port in resolved.ports
+                if port.direction == "output"
+            }
             data["plannerInputsV3"] = [
                 item.model_dump(mode="json") for item in source.inputs
             ]
             data["plannerOutputsV3"] = [
-                item.model_dump(mode="json") for item in source.outputs
+                item.model_copy(
+                    update={
+                        "value_schema": resolved_outputs.get(
+                            item.port,
+                            item.value_schema,
+                        )
+                    }
+                ).model_dump(mode="json")
+                for item in source.outputs
             ]
             if source.kind == "data_merge":
                 data["plannerControlInputMapV1"] = {
@@ -1329,6 +1583,7 @@ def decompile_candidate_to_graph_intent_compat(
     ref_by_id: dict[str, str] = {}
     business_nodes: list[GraphIntentNodeV3] = []
     legacy_nodes: list[MetaPlannerIRNode] = []
+    pinned_node_resources: dict[tuple[str, str], dict[str, Any]] = {}
     for raw_node in planner_nodes:
         native_node = NativeWorkflowNode.model_validate(raw_node)
         restored = (
@@ -1338,6 +1593,61 @@ def decompile_candidate_to_graph_intent_compat(
         )
         node_id = str(raw_node.get("id") or "")
         ref_by_id[node_id] = restored.ref
+        raw_data = raw_node.get("data") or {}
+        if restored.kind == "knowledge_retrieval":
+            resource_id = str(raw_data.get("knowledgeBaseId") or "").strip()
+            observed_version_id = str(
+                raw_data.get("observedActiveVersionId") or ""
+            ).strip()
+            snapshot_checksum = str(
+                raw_data.get("plannerResourceSnapshotChecksum") or ""
+            ).strip()
+            if not resource_id or not observed_version_id or not snapshot_checksum:
+                raise ValueError(
+                    "Compiled knowledge retrieval resource metadata is incomplete."
+                )
+            expected_snapshot_checksum = canonical_checksum(
+                {
+                    "kind": "knowledge_base",
+                    "resource_id": resource_id,
+                    "version_policy": "active",
+                    "observed_version_id": observed_version_id,
+                }
+            )
+            if snapshot_checksum != expected_snapshot_checksum:
+                raise ValueError(
+                    "Compiled knowledge retrieval resource metadata has drifted."
+                )
+            pinned_node_resources[(restored.ref, resource_id)] = {
+                "observed_version_id": observed_version_id,
+                "snapshot_checksum": snapshot_checksum,
+            }
+        elif restored.kind == "data_table_query":
+            resource_id = str(raw_data.get("tableId") or "").strip()
+            schema_checksum = str(
+                raw_data.get("pinnedSchemaChecksum") or ""
+            ).strip()
+            snapshot_checksum = str(
+                raw_data.get("plannerResourceSnapshotChecksum") or ""
+            ).strip()
+            try:
+                schema_version = int(raw_data.get("pinnedSchemaVersion"))
+            except (TypeError, ValueError):
+                schema_version = 0
+            if (
+                not resource_id
+                or schema_version < 1
+                or not schema_checksum
+                or not snapshot_checksum
+            ):
+                raise ValueError(
+                    "Compiled Agent Table resource metadata is incomplete."
+                )
+            pinned_node_resources[(restored.ref, resource_id)] = {
+                "pinned_schema_version": schema_version,
+                "schema_checksum": schema_checksum,
+                "snapshot_checksum": snapshot_checksum,
+            }
         if use_v3:
             business_nodes.append(restored)
         else:
@@ -1389,8 +1699,11 @@ def decompile_candidate_to_graph_intent_compat(
 
                 source_intent = business_by_ref[source_ref]
                 expected_outcomes = native_outcome_map(source_intent)
-                raw_outcomes = (node_by_id[source_id].get("data") or {}).get(
-                    "plannerOutcomeMapV1"
+                source_data = node_by_id[source_id].get("data") or {}
+                raw_outcomes = (
+                    source_data.get("plannerOutcomeMapV2")
+                    if "plannerOutcomeMapV2" in source_data
+                    else source_data.get("plannerOutcomeMapV1")
                 )
                 if raw_outcomes != expected_outcomes:
                     raise ValueError(
@@ -1702,6 +2015,7 @@ def decompile_candidate_to_graph_intent_compat(
             return None, compatibility
     intent._pinned_resource_versions = pinned_resource_versions
     intent._pinned_prompt_profile_versions = pinned_prompt_versions
+    intent._pinned_node_resources = pinned_node_resources
     return intent, compatibility
 
 

--- a/server/meta_agent/graph_patch.py
+++ b/server/meta_agent/graph_patch.py
@@ -26,6 +26,7 @@ from .schemas import (
     GraphIntentFinalOutputSourceV3,
     GraphIntentInputBindingV3,
     GraphIntentNodeV3,
+    GraphIntentNodeResourceRefV3,
     GraphIntentOutputBindingV3,
     GraphIntentV3,
     MetaPlannerIRMiddlewareBinding,
@@ -117,7 +118,7 @@ class ConnectControlOperation(GraphPatchModel):
     source_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
     outcome_ref: str = Field(
         default="success",
-        pattern=r"^(?:success|matched|unmatched|case_[1-8]|default)$",
+        pattern=r"^(?:success|error|matched|unmatched|case_[1-8]|default)$",
     )
     target_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
 
@@ -127,7 +128,7 @@ class DisconnectControlOperation(GraphPatchModel):
     source_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
     outcome_ref: str = Field(
         default="success",
-        pattern=r"^(?:success|matched|unmatched|case_[1-8]|default)$",
+        pattern=r"^(?:success|error|matched|unmatched|case_[1-8]|default)$",
     )
     target_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
 
@@ -180,6 +181,12 @@ class UnbindResourceOperation(GraphPatchModel):
         "toolset_resource",
         "plugin_resource",
     ]
+    resource_id: str = Field(min_length=1, max_length=200)
+
+
+class SetNodeResourceOperation(GraphPatchModel):
+    op: Literal["set_node_resource"] = "set_node_resource"
+    node_ref: str = Field(pattern=GRAPH_PATCH_REF_PATTERN)
     resource_id: str = Field(min_length=1, max_length=200)
 
 
@@ -244,6 +251,7 @@ GraphPatchOperation = Annotated[
         SetOutputVariableOperation,
         BindResourceOperation,
         UnbindResourceOperation,
+        SetNodeResourceOperation,
         BindMiddlewareOperation,
         UnbindMiddlewareOperation,
         BindPromptProfileOperation,
@@ -293,9 +301,20 @@ def graph_patch_checksum(patch: GraphPatchEnvelopeV1) -> str:
 
 
 def _port_schema(kind: str, port_name: str, direction: str) -> WorkflowValueSchema:
-    contract = workflow_node_contract_registry.require(kind)
-    for port in contract.ports:
-        if port.name == port_name and port.direction == direction:
+    adapter = get_planner_node_adapter(kind)
+    ports = (
+        adapter.intent_port_contracts(direction)
+        if adapter is not None
+        else tuple(
+            port
+            for port in workflow_node_contract_registry.require(kind).ports
+            if port.direction == direction
+        )
+    )
+    for port in ports:
+        if (
+            port.name == port_name or port_name.startswith(f"{port.name}_")
+        ):
             return port.value_schema
     raise ValueError(f"Node kind {kind} has no {direction} port {port_name}.")
 
@@ -391,6 +410,7 @@ def apply_graph_patch(
     result._pinned_prompt_profile_versions = dict(
         intent._pinned_prompt_profile_versions
     )
+    result._pinned_node_resources = dict(intent._pinned_node_resources)
     original_resource_pins = dict(intent._pinned_resource_versions)
     next_layout = deepcopy(layout or {})
     pending_removals: set[str] = set()
@@ -418,11 +438,9 @@ def apply_graph_patch(
             _validate_task_ids(operation.kind, operation.task_ids, plan_task_ids)
             parsed_config = adapter.validate_authoring_config(operation.config)
             parsed_model = adapter.config_model.model_validate(parsed_config)
-            contract = workflow_node_contract_registry.require(operation.kind)
             output_ports = {
                 port.name: port
-                for port in contract.ports
-                if port.direction == "output"
+                for port in adapter.intent_port_contracts("output")
             }
             unknown_ports = sorted(set(operation.output_variables) - set(output_ports))
             if unknown_ports:
@@ -661,6 +679,35 @@ def apply_graph_patch(
             )
             continue
 
+        if isinstance(operation, SetNodeResourceOperation):
+            target = _node(result, operation.node_ref)
+            adapter = get_planner_node_adapter(target.kind)
+            if adapter is None or adapter.resource_kind is None:
+                raise ValueError(
+                    f"Node kind {target.kind} does not own a dynamic resource."
+                )
+            previous_id = (
+                target.resource_ref.resource_id
+                if target.resource_ref is not None
+                else ""
+            )
+            _replace_node(
+                result,
+                target.model_copy(
+                    update={
+                        "resource_ref": GraphIntentNodeResourceRefV3(
+                            resource_id=operation.resource_id
+                        )
+                    }
+                ),
+            )
+            if previous_id != operation.resource_id:
+                result._pinned_node_resources.pop(
+                    (target.ref, previous_id),
+                    None,
+                )
+            continue
+
         if isinstance(operation, BindMiddlewareOperation):
             _node(result, operation.target_ref)
             candidate = MetaPlannerIRMiddlewareBinding(
@@ -822,6 +869,7 @@ def apply_graph_patch(
     validated._pinned_prompt_profile_versions = dict(
         result._pinned_prompt_profile_versions
     )
+    validated._pinned_node_resources = dict(result._pinned_node_resources)
     return GraphPatchResult(
         intent=validated,
         layout=next_layout,
@@ -919,6 +967,13 @@ def diff_graph_intents(
                 output_variables={item.port: item.variable for item in node.outputs},
             )
         )
+        if node.resource_ref is not None:
+            operations.append(
+                SetNodeResourceOperation(
+                    node_ref=node.ref,
+                    resource_id=node.resource_ref.resource_id,
+                )
+            )
 
     for ref in sorted(set(source_nodes) & set(target_nodes)):
         before = source_nodes[ref]
@@ -933,6 +988,17 @@ def diff_graph_intents(
                 updates[field_name] = getattr(after, field_name)
         if len(updates) > 1:
             operations.append(UpdateNodeOperation(**updates))
+        if before.resource_ref != after.resource_ref:
+            if after.resource_ref is None:
+                raise ValueError(
+                    f"Editor change for {ref} removes a required node resource."
+                )
+            operations.append(
+                SetNodeResourceOperation(
+                    node_ref=ref,
+                    resource_id=after.resource_ref.resource_id,
+                )
+            )
         before_outputs = {item.port: item for item in before.outputs}
         after_outputs = {item.port: item for item in after.outputs}
         if set(before_outputs) != set(after_outputs):

--- a/server/meta_agent/headless_authoring.py
+++ b/server/meta_agent/headless_authoring.py
@@ -48,6 +48,7 @@ from .graph_ir_v3 import (
     decompile_candidate_to_graph_intent_compat,
     graph_authoring_checksum,
     resolve_graph_intent,
+    resolve_node_resource_snapshot,
     workflow_authoring_checksum,
     workflow_semantic_checksum,
 )
@@ -66,6 +67,7 @@ from .node_adapters import META_PLANNER_ADAPTER_KINDS, get_planner_node_adapter
 from .schemas import (
     GraphIntentInputBindingV3,
     GraphIntentNodeV3,
+    GraphIntentNodeResourceRefV3,
     GraphIntentOutputBindingV3,
     GraphIntentV3,
     MetaPlannerCapabilitySnapshot,
@@ -190,6 +192,38 @@ _AUTHORABLE_PURE_NODE_DATA_FIELDS: dict[str, frozenset[str]] = {
             "description",
             "errorCode",
             "message",
+        }
+    ),
+    "knowledge_retrieval": frozenset(
+        {
+            "kind",
+            "title",
+            "description",
+            "knowledgeBaseId",
+            "queryVariable",
+            "top_k",
+            "returnMode",
+            "outputVariable",
+            "failureAction",
+            "retryMode",
+            "maxAttempts",
+        }
+    ),
+    "data_table_query": frozenset(
+        {
+            "kind",
+            "title",
+            "description",
+            "tableId",
+            "selectFields",
+            "filter",
+            "sort",
+            "limit",
+            "returnMode",
+            "outputVariable",
+            "failureAction",
+            "retryMode",
+            "maxAttempts",
         }
     ),
 }
@@ -339,9 +373,18 @@ def _round_trip_candidate_projection(
     """Normalize only fields introduced by the lossless V2-to-V3 upgrade."""
 
     projected = deepcopy(candidate)
+    workflow = (projected.get("draft") or {}).get("workflow") or {}
+    for node in workflow.get("nodes") or []:
+        data = node.get("data") if isinstance(node, dict) else None
+        if not isinstance(data, dict) or str(data.get("kind") or "") != "knowledge_retrieval":
+            continue
+        # The active knowledge pointer is dynamic by contract. These fields are
+        # provenance markers, not execution settings, so pointer drift must not
+        # be reported as a lossy editor round trip.
+        data.pop("observedActiveVersionId", None)
+        data.pop("plannerResourceSnapshotChecksum", None)
     if source_version != 2:
         return projected
-    workflow = (projected.get("draft") or {}).get("workflow") or {}
     # V2 and V3 compiler provenance use different workflow version labels.
     # The label is not an execution setting, so exclude it from the behavioral
     # losslessness proof while retaining every runtime-owned node field.
@@ -437,6 +480,7 @@ def _intersect_scope(
         "allowed_node_kinds": {str(item.get("kind") or "") for item in snapshot.nodes},
         "external_xpert_ids": {str(item.get("id") or "") for item in snapshot.external_xperts},
         "knowledge_base_ids": {str(item.get("id") or "") for item in snapshot.knowledge_bases},
+        "data_table_ids": {str(item.get("id") or "") for item in snapshot.data_tables},
         "toolset_ids": {str(item.get("id") or "") for item in snapshot.toolsets},
         "plugin_ids": {str(item.get("id") or "") for item in snapshot.plugins},
         "prompt_profile_ids": {str(item.get("id") or "") for item in snapshot.prompt_profiles},
@@ -478,6 +522,10 @@ def _validate_intent_authorization(
         "toolset_resource": set(scope.toolset_ids),
         "plugin_resource": set(scope.plugin_ids),
     }
+    allowed_node_resources = {
+        "knowledge_retrieval": set(scope.knowledge_base_ids),
+        "data_table_query": set(scope.data_table_ids),
+    }
     violations: list[str] = []
     for node in intent.nodes:
         if node.kind not in set(scope.allowed_node_kinds):
@@ -485,6 +533,16 @@ def _validate_intent_authorization(
         source_agent_id = str(node.config.get("source_agent_id") or "").strip()
         if source_agent_id and source_agent_id not in set(scope.agent_ids):
             violations.append(f"source_agent:{source_agent_id}")
+        expected = allowed_node_resources.get(node.kind)
+        if expected is None:
+            if node.resource_ref is not None:
+                violations.append(f"node_resource:{node.ref}:unexpected")
+        elif node.resource_ref is None:
+            violations.append(f"node_resource:{node.ref}:missing")
+        elif node.resource_ref.resource_id not in expected:
+            violations.append(
+                f"node_resource:{node.kind}:{node.resource_ref.resource_id}"
+            )
     for binding in intent.resources:
         if binding.resource_id not in allowed_resources[binding.kind]:
             violations.append(f"resource:{binding.kind}:{binding.resource_id}")
@@ -1389,6 +1447,13 @@ class HeadlessAuthoringService:
                     }
                 elif source_kind == "terminate_error":
                     allowed_source_handles = set()
+                elif source_kind in {"knowledge_retrieval", "data_table_query"}:
+                    allowed_source_handles = (
+                        {"", "error"}
+                        if str((source.data or {}).get("failureAction") or "stop")
+                        == "error_output"
+                        else {""}
+                    )
                 else:
                     allowed_source_handles = {""}
                 source_handle = str(edge.sourceHandle or "")
@@ -1488,6 +1553,8 @@ class HeadlessAuthoringService:
                 ancestors[ref].update(ancestors[parent])
 
         parsed_by_ref: dict[str, Any] = {}
+        resource_refs_by_ref: dict[str, GraphIntentNodeResourceRefV3] = {}
+        resource_snapshots_by_ref: dict[str, dict[str, Any]] = {}
         output_bindings_by_ref: dict[str, list[GraphIntentOutputBindingV3]] = {}
         output_by_variable: dict[
             str, list[tuple[str, str, WorkflowValueSchema]]
@@ -1506,12 +1573,58 @@ class HeadlessAuthoringService:
                     data["rolePrompt"] = role_prompt or defaults["role_prompt"]
                     data["taskInput"] = task_input or defaults["task_input"]
             parsed = adapter.authoring_config_from_native(data)
+            resource_payload: dict[str, Any] | None = None
+            if adapter.resource_kind is not None:
+                resource_field = {
+                    "knowledge_base": "knowledgeBaseId",
+                    "data_table": "tableId",
+                }[adapter.resource_kind]
+                resource_id = str(data.get(resource_field) or "").strip()
+                allowed_resource_ids = (
+                    set(state.scope.knowledge_base_ids)
+                    if adapter.resource_kind == "knowledge_base"
+                    else set(state.scope.data_table_ids)
+                )
+                if resource_id not in allowed_resource_ids:
+                    raise ValueError(
+                        f"Editor node {ref} references an unauthorized "
+                        f"{adapter.resource_kind} resource."
+                    )
+                resource_ref = GraphIntentNodeResourceRefV3(
+                    resource_id=resource_id
+                )
+                resource_node = GraphIntentNodeV3(
+                    ref=ref,
+                    kind=kind,
+                    title=str(data.get("title") or ref),
+                    config=parsed.model_dump(mode="json"),
+                    resource_ref=resource_ref,
+                )
+                resolved_resource = resolve_node_resource_snapshot(
+                    resource_node,
+                    state.snapshot,
+                    pinned=state.intent._pinned_node_resources.get(
+                        (ref, resource_id)
+                    ),
+                )
+                resource_payload = resolved_resource.model_dump(mode="json")
+                adapter.validate_resolved_resource(
+                    resource_node,
+                    parsed,
+                    resource_payload,
+                )
+                resource_refs_by_ref[ref] = resource_ref
+                resource_snapshots_by_ref[ref] = resource_payload
             output_variables = adapter.editor_output_variables(data, parsed)
             outputs = [
                 GraphIntentOutputBindingV3(
                     port=port,
                     variable=variable,
-                    value_schema=adapter.authoritative_output_schema(port, parsed),
+                    value_schema=adapter.authoritative_output_schema(
+                        port,
+                        parsed,
+                        resource_payload,
+                    ),
                 )
                 for port, variable in output_variables.items()
             ]
@@ -1609,8 +1722,10 @@ class HeadlessAuthoringService:
                 task_ids=task_ids,
                 inputs=inputs,
                 outputs=outputs,
+                resource_ref=resource_refs_by_ref.get(ref),
                 config=parsed.model_dump(mode="json"),
             )
+            outcome_map = native_outcome_map(intent_node)
             data.update(
                 {
                     "plannerIRVersion": 3,
@@ -1631,9 +1746,33 @@ class HeadlessAuthoringService:
                         }
                         for item in outputs
                     ],
-                    "plannerOutcomeMapV1": native_outcome_map(intent_node),
+                    "plannerOutcomeMapV1": {"success": ""},
+                    "plannerAdapterConfigV1": parsed.model_dump(mode="json"),
                 }
             )
+            if len(outcome_map) > 1:
+                data["plannerOutcomeMapV2"] = outcome_map
+            else:
+                data.pop("plannerOutcomeMapV2", None)
+            resource_payload = resource_snapshots_by_ref.get(ref)
+            if resource_payload is not None:
+                data["plannerResourceSnapshotChecksum"] = resource_payload[
+                    "snapshot_checksum"
+                ]
+                if kind == "knowledge_retrieval":
+                    data["knowledgeBaseId"] = resource_payload["resource_id"]
+                    data["observedActiveVersionId"] = resource_payload.get(
+                        "observed_version_id"
+                    )
+                elif kind == "data_table_query":
+                    data["tableId"] = resource_payload["resource_id"]
+                    data["versionPolicy"] = "pinned"
+                    data["pinnedSchemaVersion"] = resource_payload[
+                        "pinned_schema_version"
+                    ]
+                    data["pinnedSchemaChecksum"] = resource_payload[
+                        "schema_checksum"
+                    ]
             if kind == "data_merge":
                 data["plannerControlInputMapV1"] = {
                     item.port: item.source_ref for item in inputs

--- a/server/meta_agent/meta_planner_v2.py
+++ b/server/meta_agent/meta_planner_v2.py
@@ -8,7 +8,7 @@ from collections import Counter, defaultdict, deque
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 try:
     from server.prompts.models import PromptProfileBinding
@@ -56,11 +56,22 @@ from .graph_ir_v3 import (
     graph_intent_to_v2,
     resolve_middleware_config,
     resolve_graph_intent,
+    resolve_node_resource_snapshot,
     v2_to_graph_intent,
     workflow_authoring_checksum,
     workflow_semantic_checksum,
 )
-from .graph_patch import GraphPatchEnvelopeV1, apply_graph_patch
+from .graph_patch import (
+    GRAPH_PATCH_MAX_OPERATIONS,
+    AddNodeOperation,
+    ConnectDataOperation,
+    DisconnectDataOperation,
+    GraphPatchEnvelopeV1,
+    GraphPatchOperation,
+    RemoveNodeOperation,
+    SetOutputVariableOperation,
+    apply_graph_patch,
+)
 from .node_adapters import (
     META_PLANNER_BINDING_KINDS,
     META_PLANNER_COMPILER_MANAGED_KINDS,
@@ -100,10 +111,26 @@ PreflightCallback = Callable[[XpertDefinition], Any]
 TASK_PLAN_SYSTEM_PROMPT = """\
 You are the task-planning stage of ModelMirror Meta Planner Graph IR V3.
 Return one strict JSON object only. Do not include markdown or hidden reasoning.
+The object must contain exactly the task-plan fields summary, assumptions, and tasks;
+never return a workflow, GraphIntent, status, error, or explanatory wrapper.
+Write every human-visible summary, assumption, title, objective, contract, and
+acceptance field in Simplified Chinese. Keep machine identifiers in their exact
+contract form and do not translate registered resource or schema field names.
 Create a bounded task DAG. Every task must have a stable lowercase task_id,
 explicit dependencies, an input contract, and one output contract.
 Tasks represent model-driven responsibilities. Deterministic helper-node operations
 must not become tasks; obey the supplied task_planning_contract.
+"""
+
+
+TASK_PLAN_REPAIR_SYSTEM_PROMPT = """\
+You repair one invalid ModelMirror Meta Planner task plan. Return one strict JSON
+object only with exactly summary, assumptions, and tasks. Do not include markdown,
+hidden reasoning, a workflow, GraphIntent, status, error, or an explanatory wrapper.
+Write every human-visible field in Simplified Chinese while preserving machine
+identifiers and registered resource or schema field names exactly.
+Make the smallest changes required by the structured validation issues and obey the
+supplied task-planning contract. This consumes the generation's only repair pass.
 """
 
 
@@ -117,10 +144,17 @@ Compile the task DAG into explicit typed IR nodes, control edges, resource bindi
 middleware bindings, and one explicit final output. A node may cover multiple tasks
 and every task must be covered by a workflow_agent. Auxiliary pure nodes must have an
 empty task_ids list. Bindings must target a workflow_agent node ref.
+Write all human-visible Xpert metadata, node titles/descriptions, prompts, starters,
+and user-facing error messages in Simplified Chinese. Keep refs, IDs, field names,
+variables, operators, model IDs, and fixed error codes in contract form.
 Every node input must identify its source node and source port. Use the workflow_agent
 task port for each task input; that port accepts multiple typed variables.
 Respect the supplied typed_ir_constraints, including its workflow-agent node limit.
 Never invent credentials, tools, resource IDs, node kinds, versions, or private content.
+Agent Table reads belong to data_table_query.resource_ref and knowledge reads belong
+to knowledge_retrieval.resource_ref. Never represent either as a toolset_resource or
+an Agent-bound resource. Only a read node configured with failure_action=error_output
+may emit the error outcome; workflow_agent emits success only.
 """
 
 
@@ -131,19 +165,67 @@ executable nodes; input/output and resource nodes are compiler-managed.
 Make the smallest changes required by the structured validation issues. Do not add
 capabilities outside the supplied authorized snapshot. This is the only repair pass.
 Return the complete blueprint and obey every supplied typed_ir_constraint.
+All repaired human-visible metadata, titles, descriptions, prompts, starters, and
+user-facing messages must be in Simplified Chinese; machine identifiers stay exact.
+For node-owned reads, keep the resource ID in resource_ref, never resources or config.
+Only the read node may own its error outcome; workflow_agent emits success only.
 """
 
 
 PATCH_REPAIR_SYSTEM_PROMPT = """\
-You repair one parsed ModelMirror GraphIntentV3 using GraphPatchEnvelopeV1.
+You repair one parsed ModelMirror GraphIntentV3 using typed Graph Patch operations.
 Return one strict JSON object only. Never return a complete workflow or GraphIntent.
 Use only the listed semantic refs, named ports, Adapter config, and authorized IDs.
-Do not emit native node IDs, Handles, resource versions, schemas, policies, checksums
-other than the exact expected checksums supplied in the envelope. Make the smallest
-ordered patch that addresses the validation issues. This is the only repair pass.
+Return exactly one operations array. The server owns the Patch envelope, proposal
+revision, graph checksum, and candidate checksum; never emit those fields. Do not
+emit native node IDs, Handles, resource versions, schemas, policies, status, error,
+or explanation fields. Make the smallest ordered patch that addresses the validation
+issues. If no safe operation is possible, return {"operations": []}. This is the
+only repair pass.
+Any human-visible string changed by the patch must be in Simplified Chinese; machine
+identifiers, registered resource names, and schema field names stay exact.
 The virtual refs input and output may be referenced where allowed but can never be
 added, updated, removed, or moved as nodes.
 """
+
+
+class PlannerGraphPatchRepairPayloadV1(BaseModel):
+    """Model-authored operations; trusted envelope fields stay server-owned."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    operations: list[GraphPatchOperation] = Field(
+        default_factory=list,
+        max_length=GRAPH_PATCH_MAX_OPERATIONS,
+    )
+
+
+DISPLAY_LANGUAGE_CONTRACT = {
+    "locale": "zh-CN",
+    "human_visible_fields": [
+        "name",
+        "description",
+        "tags",
+        "starters",
+        "task_plan.summary",
+        "task_plan.assumptions",
+        "tasks[].title",
+        "tasks[].objective",
+        "tasks[].input_contract",
+        "tasks[].output_contract",
+        "tasks[].acceptance",
+        "nodes[].title",
+        "nodes[].description",
+        "workflow_agent.config.role_prompt",
+        "workflow_agent.config.task_input",
+        "terminate_error.config.message",
+    ],
+    "rules": [
+        "Write every human-visible field in Simplified Chinese.",
+        "Keep refs, task_ids, variables, node kinds, resource IDs, model IDs, field names, operators, and error_code values in their exact machine-readable form.",
+        "Do not translate registered resource names or schema field names when referring to them inside Chinese text.",
+    ],
+}
 
 
 def _json_payload(raw_text: str) -> dict[str, Any]:
@@ -249,6 +331,8 @@ def _task_planning_contract(
             or planner.get("task_binding") != "forbidden"
         ):
             continue
+        adapter = get_planner_node_adapter(kind)
+        assert adapter is not None
         contracts = dict(item.get("contracts") or {})
 
         def port_summary(port: Any) -> dict[str, Any]:
@@ -273,6 +357,8 @@ def _task_planning_contract(
                 "outputs": [
                     port_summary(port)
                     for port in list(contracts.get("outputs") or [])
+                    if str((port or {}).get("name") or "")
+                    not in adapter.control_only_output_ports
                 ],
             }
         )
@@ -297,6 +383,8 @@ def _task_planning_contract(
             "Pack named variables into one object.",
             "Group rows and calculate deterministic measures.",
             "Compare two datasets by stable keys.",
+            "Read authorized Agent Table rows with data_table_query.",
+            "Retrieve authorized knowledge evidence with knowledge_retrieval.",
         ],
         "expert_task_examples": [
             "Extract audit controls from unstructured evidence.",
@@ -306,11 +394,296 @@ def _task_planning_contract(
             "Plan tasks describe model-driven judgment, responsibility, or synthesis that a workflow_agent must perform.",
             "Deterministic operations represented by auxiliary_node_kinds must not become plan tasks; they are compiled later as task-free helper nodes.",
             "Do not create one expert task per requested JSON conversion, packing, aggregation, or dataset comparison step.",
+            "Do not create an expert task merely to perform an authorized Agent Table query or knowledge retrieval.",
             "Apply expert_task_test to every proposed task and omit the task unless the required answer is yes.",
             "Use auxiliary_node_contracts purpose and ports to recognize deterministic steps before emitting tasks.",
             "Keep distinct expert responsibilities separate, but do not split a single responsibility merely to name its deterministic data transforms.",
         ],
     }
+
+
+_REPAIR_REQUIRED_OUTPUT_PORTS: dict[str, tuple[str, ...]] = {
+    "knowledge_retrieval": ("result",),
+    "data_table_query": ("result",),
+}
+
+
+def _repair_output_variable(
+    node_ref: str,
+    port: str,
+    *,
+    used_variables: set[str],
+) -> str:
+    base = _safe_identifier(f"{node_ref}_{port}", "node_output")
+    if base not in used_variables and base not in {
+        "user_input",
+        "conversation_history",
+    }:
+        used_variables.add(base)
+        return base
+    suffix = canonical_checksum({"node_ref": node_ref, "port": port})[:8]
+    candidate = f"{base[:111]}_{suffix}"
+    used_variables.add(candidate)
+    return candidate
+
+
+def _normalize_repair_patch_required_outputs(
+    blueprint: GraphIntentV3,
+    patch: GraphPatchEnvelopeV1,
+) -> tuple[GraphPatchEnvelopeV1, list[str]]:
+    """Restore deterministic primary outputs before applying a model repair."""
+
+    operations = list(patch.operations)
+    removed_refs = {
+        operation.ref
+        for operation in operations
+        if isinstance(operation, RemoveNodeOperation)
+    }
+    explicit_variables = {
+        (operation.node_ref, operation.port): operation.variable
+        for operation in operations
+        if isinstance(operation, SetOutputVariableOperation)
+    }
+    used_variables = {
+        output.variable
+        for node in blueprint.nodes
+        for output in node.outputs
+    }
+    for operation in operations:
+        if isinstance(operation, AddNodeOperation):
+            used_variables.update(operation.output_variables.values())
+    used_variables.update(explicit_variables.values())
+
+    downstream_variables: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for node in blueprint.nodes:
+        for binding in node.inputs:
+            downstream_variables[(binding.source_ref, binding.source_port)].add(
+                binding.variable
+            )
+
+    prepended: list[SetOutputVariableOperation] = []
+    absorbed_explicit: set[tuple[str, str]] = set()
+    normalized_refs: list[str] = []
+    for node in blueprint.nodes:
+        required_ports = _REPAIR_REQUIRED_OUTPUT_PORTS.get(node.kind, ())
+        if not required_ports or node.ref in removed_refs:
+            continue
+        existing_ports = {output.port for output in node.outputs}
+        for port in required_ports:
+            if port in existing_ports:
+                continue
+            key = (node.ref, port)
+            candidates = downstream_variables.get(key, set())
+            if len(candidates) > 1:
+                continue
+            variable = explicit_variables.get(key)
+            if variable is None and len(candidates) == 1:
+                variable = next(iter(candidates))
+                used_variables.add(variable)
+            if variable is None:
+                variable = _repair_output_variable(
+                    node.ref,
+                    port,
+                    used_variables=used_variables,
+                )
+            prepended.append(
+                SetOutputVariableOperation(
+                    node_ref=node.ref,
+                    port=port,
+                    variable=variable,
+                )
+            )
+            if key in explicit_variables:
+                absorbed_explicit.add(key)
+            normalized_refs.append(f"{node.ref}.{port}")
+
+    normalized_operations = []
+    for operation in operations:
+        if isinstance(operation, AddNodeOperation):
+            required_ports = _REPAIR_REQUIRED_OUTPUT_PORTS.get(operation.kind, ())
+            if required_ports:
+                output_variables = dict(operation.output_variables)
+                for port in required_ports:
+                    if port in output_variables:
+                        continue
+                    key = (operation.ref, port)
+                    variable = explicit_variables.get(key)
+                    if variable is None:
+                        variable = _repair_output_variable(
+                            operation.ref,
+                            port,
+                            used_variables=used_variables,
+                        )
+                    output_variables[port] = variable
+                    if key in explicit_variables:
+                        absorbed_explicit.add(key)
+                    normalized_refs.append(f"{operation.ref}.{port}")
+                operation = operation.model_copy(
+                    update={"output_variables": output_variables}
+                )
+        if (
+            isinstance(operation, SetOutputVariableOperation)
+            and (operation.node_ref, operation.port) in absorbed_explicit
+        ):
+            continue
+        normalized_operations.append(operation)
+
+    if not normalized_refs:
+        return patch, []
+    normalized = GraphPatchEnvelopeV1.model_validate(
+        {
+            **patch.model_dump(mode="json", exclude={"operations"}),
+            "operations": [
+                operation.model_dump(mode="json")
+                for operation in [*prepended, *normalized_operations]
+            ],
+        }
+    )
+    return normalized, sorted(set(normalized_refs))
+
+
+def _normalize_repair_control_only_outputs(
+    blueprint: GraphIntentV3,
+    patch: GraphPatchEnvelopeV1,
+) -> tuple[GraphIntentV3, GraphPatchEnvelopeV1, list[str]]:
+    """Keep semantic error outcomes out of GraphIntent data bindings."""
+
+    normalized_blueprint = blueprint.model_copy(deep=True)
+    normalized_refs: list[str] = []
+    for node in normalized_blueprint.nodes:
+        adapter = get_planner_node_adapter(node.kind)
+        if adapter is None or not adapter.control_only_output_ports:
+            continue
+        forbidden = set(adapter.control_only_output_ports)
+        declared = [output for output in node.outputs if output.port in forbidden]
+        if not declared:
+            continue
+        consumed = {
+            binding.source_port
+            for target in normalized_blueprint.nodes
+            for binding in target.inputs
+            if binding.source_ref == node.ref and binding.source_port in forbidden
+        }
+        if consumed:
+            continue
+        node.outputs = [
+            output for output in node.outputs if output.port not in forbidden
+        ]
+        normalized_refs.extend(f"{node.ref}.{output.port}" for output in declared)
+
+    kinds_by_ref = {node.ref: node.kind for node in normalized_blueprint.nodes}
+    for operation in patch.operations:
+        if isinstance(operation, AddNodeOperation):
+            kinds_by_ref[operation.ref] = operation.kind
+    data_reads = {
+        (operation.source_ref, operation.source_port)
+        for operation in patch.operations
+        if getattr(operation, "op", "") == "connect_data"
+    }
+    normalized_operations = []
+    for operation in patch.operations:
+        if isinstance(operation, AddNodeOperation):
+            adapter = get_planner_node_adapter(operation.kind)
+            forbidden = set(
+                adapter.control_only_output_ports if adapter is not None else ()
+            )
+            removed = sorted(set(operation.output_variables) & forbidden)
+            if removed and not any(
+                (operation.ref, port) in data_reads for port in removed
+            ):
+                operation = operation.model_copy(
+                    update={
+                        "output_variables": {
+                            port: variable
+                            for port, variable in operation.output_variables.items()
+                            if port not in forbidden
+                        }
+                    }
+                )
+                normalized_refs.extend(
+                    f"{operation.ref}.{port}" for port in removed
+                )
+        elif isinstance(operation, SetOutputVariableOperation):
+            adapter = get_planner_node_adapter(kinds_by_ref.get(operation.node_ref, ""))
+            if (
+                adapter is not None
+                and operation.port in adapter.control_only_output_ports
+                and (operation.node_ref, operation.port) not in data_reads
+            ):
+                normalized_refs.append(f"{operation.node_ref}.{operation.port}")
+                continue
+        normalized_operations.append(operation)
+
+    if normalized_operations != list(patch.operations):
+        patch = GraphPatchEnvelopeV1.model_validate(
+            {
+                **patch.model_dump(mode="json", exclude={"operations"}),
+                "operations": [
+                    operation.model_dump(mode="json")
+                    for operation in normalized_operations
+                ],
+            }
+        )
+    return normalized_blueprint, patch, sorted(set(normalized_refs))
+
+
+def _normalize_repair_duplicate_data_edges(
+    blueprint: GraphIntentV3,
+    patch: GraphPatchEnvelopeV1,
+) -> tuple[GraphPatchEnvelopeV1, list[str]]:
+    """Drop exact connect-data no-ops only for the bounded model repair."""
+
+    known_edges = {
+        (
+            binding.source_ref,
+            binding.source_port,
+            node.ref,
+            binding.port,
+        )
+        for node in blueprint.nodes
+        for binding in node.inputs
+    }
+    normalized_operations = []
+    removed: list[str] = []
+    for operation in patch.operations:
+        if isinstance(operation, DisconnectDataOperation):
+            known_edges.discard(
+                (
+                    operation.source_ref,
+                    operation.source_port,
+                    operation.target_ref,
+                    operation.target_port,
+                )
+            )
+            normalized_operations.append(operation)
+            continue
+        if isinstance(operation, ConnectDataOperation):
+            key = (
+                operation.source_ref,
+                operation.source_port,
+                operation.target_ref,
+                operation.target_port,
+            )
+            if key in known_edges:
+                removed.append(
+                    f"{operation.source_ref}.{operation.source_port}->"
+                    f"{operation.target_ref}.{operation.target_port}"
+                )
+                continue
+            known_edges.add(key)
+        normalized_operations.append(operation)
+    if not removed:
+        return patch, []
+    normalized = GraphPatchEnvelopeV1.model_validate(
+        {
+            **patch.model_dump(mode="json", exclude={"operations"}),
+            "operations": [
+                operation.model_dump(mode="json")
+                for operation in normalized_operations
+            ],
+        }
+    )
+    return normalized, sorted(set(removed))
 
 
 def _graph_patch_repair_contract(
@@ -331,6 +704,9 @@ def _graph_patch_repair_contract(
                     }
                 ),
                 "output_ports": sorted(output.port for output in node.outputs),
+                "required_output_ports": list(
+                    _REPAIR_REQUIRED_OUTPUT_PORTS.get(node.kind, ())
+                ),
             }
             for node in blueprint.nodes
         ),
@@ -339,6 +715,7 @@ def _graph_patch_repair_contract(
     workflow_agent_count = sum(
         node.kind == "workflow_agent" for node in blueprint.nodes
     )
+    nodes_by_ref = {node.ref: node for node in blueprint.nodes}
     agent_overflow = workflow_agent_count > request.max_agents
     issue_playbook: list[str] = []
     if agent_overflow or any("exceeds max_agents" in issue for issue in issues):
@@ -348,10 +725,120 @@ def _graph_patch_repair_contract(
             "control and data edges, set a retained workflow_agent as final output, "
             "then remove surplus agents; do not add workflow_agent nodes."
         )
+    for issue in issues:
+        missing_read = re.search(
+            r"Required node-owned resource read "
+            r"([a-z][a-z0-9_]*):([^ ]+) is missing",
+            issue,
+        )
+        unconsumed_read = re.search(
+            r"Required node-owned resource read "
+            r"([a-z][a-z0-9_]*):([^ ]+) is not consumed",
+            issue,
+        )
+        if missing_read is not None:
+            node_kind, resource_id = missing_read.groups()
+            issue_playbook.append(
+                f"For required read {node_kind}:{resource_id}, add one task-free "
+                f"{node_kind} node, attach exactly {resource_id} with "
+                "set_node_resource, declare its result output, route its success "
+                "control path through the required typed bridge to a retained "
+                "workflow_agent, and update that Agent task_input to consume the "
+                "bridge output. Do not bind the resource to the Agent or replace "
+                "the read with prompt text."
+            )
+        elif unconsumed_read is not None:
+            node_kind, resource_id = unconsumed_read.groups()
+            issue_playbook.append(
+                f"For unconsumed read {node_kind}:{resource_id}, connect its result "
+                "through a type-compatible deterministic bridge to a retained "
+                "workflow_agent task input and route the success control path "
+                "through the same nodes."
+            )
+    for issue in issues:
+        match = re.search(
+            r"Node ([a-z][a-z0-9_-]{0,63}) requires exactly one "
+            r"([A-Za-z_][A-Za-z0-9_-]{0,63}) output",
+            issue,
+        )
+        if match is None:
+            continue
+        node_ref, port = match.groups()
+        issue_playbook.append(
+            f"For the missing {node_ref}.{port} output, use "
+            "set_output_variable before any connect_data that reads it. "
+            f"Use a stable variable such as {node_ref}_{port}."
+        )
+    for issue in issues:
+        rejected = re.search(
+            r"Node ([a-z][a-z0-9_-]{0,63}) input port "
+            r"([A-Za-z_][A-Za-z0-9_-]{0,63}) rejects its value type",
+            issue,
+        )
+        incompatible = re.search(
+            r"Node ([a-z][a-z0-9_-]{0,63}) input "
+            r"([A-Za-z_][A-Za-z0-9_]{0,127}) has an incompatible type",
+            issue,
+        )
+        if rejected is not None:
+            target_ref, target_port = rejected.groups()
+            target = nodes_by_ref.get(target_ref)
+            bindings = [
+                binding
+                for binding in (target.inputs if target is not None else [])
+                if binding.port == target_port
+            ]
+        elif incompatible is not None:
+            target_ref, variable = incompatible.groups()
+            target = nodes_by_ref.get(target_ref)
+            bindings = [
+                binding
+                for binding in (target.inputs if target is not None else [])
+                if binding.variable == variable
+            ]
+            target_port = bindings[0].port if len(bindings) == 1 else ""
+        else:
+            continue
+        if (
+            target is None
+            or target.kind != "workflow_agent"
+            or target_port != "task"
+            or len(bindings) != 1
+        ):
+            continue
+        binding = bindings[0]
+        edge = (
+            f"{binding.source_ref}.{binding.source_port}->"
+            f"{target_ref}.{binding.port}"
+        )
+        if "json_serialize" in request.scope.allowed_node_kinds:
+            issue_playbook.append(
+                f"For typed data edge {edge}, keep workflow_agent.task as a "
+                "string boundary: disconnect that data edge, add one "
+                "json_serialize node with empty task_ids and format=compact, "
+                "connect the typed source to its value port and its json port "
+                "to the Agent task port, update the Agent task_input/role_prompt "
+                "templates to reference the serializer output variable instead "
+                "of the removed typed variable, and route the success control "
+                "path through the serializer. Preserve any separate error outcome."
+            )
+        else:
+            issue_playbook.append(
+                f"Typed data edge {edge} cannot target workflow_agent.task and "
+                "json_serialize is not authorized; do not fake the source or "
+                "binding Schema. Leave the candidate invalid if no authorized "
+                "string-producing path exists."
+            )
     return {
         "compiler_managed_refs": ["input", "output"],
         "existing_node_refs": [item["ref"] for item in existing_nodes],
         "existing_nodes": existing_nodes,
+        "existing_data_edges": sorted(
+            f"{binding.source_ref}.{binding.source_port}->"
+            f"{node.ref}.{binding.port}"
+            for node in blueprint.nodes
+            for binding in node.inputs
+        ),
         "max_workflow_agent_nodes": request.max_agents,
         "current_workflow_agent_nodes": workflow_agent_count,
         "allow_add_workflow_agent": workflow_agent_count < request.max_agents,
@@ -368,6 +855,10 @@ def _graph_patch_repair_contract(
             "update_node, remove_node, and move_node may target only existing_node_refs.",
             "Pure nodes use empty task_ids; workflow_agent nodes cover all fixed plan tasks.",
             "Do not add a workflow_agent when allow_add_workflow_agent is false.",
+            "Every added node must declare all required_output_ports in "
+            "add_node.output_variables before connect_data reads them.",
+            "Do not emit connect_data for an edge already listed in "
+            "existing_data_edges unless the patch disconnects that exact edge first.",
             "Adapter-derived output Schemas are recomputed by the server after this repair; never inject or patch output Schemas directly.",
         ],
     }
@@ -375,6 +866,7 @@ def _graph_patch_repair_contract(
 
 def _normalize_adapter_outputs_for_repair(
     intent: GraphIntentV3,
+    snapshot: MetaPlannerCapabilitySnapshot,
 ) -> tuple[GraphIntentV3, list[str]]:
     """Refresh Adapter-owned outputs and their derived data-edge schemas."""
 
@@ -389,9 +881,29 @@ def _normalize_adapter_outputs_for_repair(
             output_normalized_nodes.append(node)
             continue
         parsed = adapter.validate_intent_node(node)
+        resource_snapshot = resolve_node_resource_snapshot(
+            node,
+            snapshot,
+            pinned=intent._pinned_node_resources.get(
+                (
+                    node.ref,
+                    node.resource_ref.resource_id if node.resource_ref else "",
+                )
+            ),
+        )
+        resource_payload = (
+            resource_snapshot.model_dump(mode="json")
+            if resource_snapshot is not None
+            else None
+        )
+        adapter.validate_resolved_resource(node, parsed, resource_payload)
         outputs = []
         for output in node.outputs:
-            authoritative = adapter.authoritative_output_schema(output.port, parsed)
+            authoritative = adapter.authoritative_output_schema(
+                output.port,
+                parsed,
+                resource_payload,
+            )
             authoritative_outputs[(node.ref, output.port)] = (
                 output.variable,
                 authoritative,
@@ -449,17 +961,33 @@ def _graph_intent_prompt_contract(
         for item in snapshot.nodes
         if isinstance(item, dict)
     }
-    node_contracts = {
-        str(item.get("kind") or ""): {
+    node_contracts: dict[str, dict[str, Any]] = {}
+    for item in snapshot.nodes:
+        kind = str(item.get("kind") or "")
+        if kind not in executable_kinds:
+            continue
+        adapter = get_planner_node_adapter(kind)
+        assert adapter is not None
+        node_contracts[kind] = {
             "task_binding": dict(item.get("planner") or {}).get("task_binding"),
             "config_schema": dict(
                 (item.get("contract") or {}).get("planner") or {}
             ).get("ir_config_schema", {}),
-            "ports": list((item.get("contract") or {}).get("ports") or []),
+            "ports": [
+                port
+                for port in list((item.get("contract") or {}).get("ports") or [])
+                if not (
+                    str((port or {}).get("direction") or "") == "output"
+                    and str((port or {}).get("name") or "")
+                    in adapter.control_only_output_ports
+                )
+            ],
+            "control_outcomes": (
+                ["success", "error"]
+                if adapter.control_only_output_ports
+                else ["success"]
+            ),
         }
-        for item in snapshot.nodes
-        if str(item.get("kind") or "") in executable_kinds
-    }
 
     return {
         "required_ir_version": GRAPH_IR_VERSION,
@@ -490,6 +1018,7 @@ def _graph_intent_prompt_contract(
             "prompt_profile_ids": list(request.scope.prompt_profile_ids),
             "external_xpert_ids": list(request.scope.external_xpert_ids),
             "knowledge_base_ids": list(request.scope.knowledge_base_ids),
+            "data_table_ids": list(request.scope.data_table_ids),
             "toolset_ids": list(request.scope.toolset_ids),
             "plugin_ids": list(request.scope.plugin_ids),
         },
@@ -497,17 +1026,22 @@ def _graph_intent_prompt_contract(
             "Set ir_version to 3; never return a V2 blueprint.",
             "nodes may contain only executable_node_kinds.",
             "Never put compiler_managed_node_kinds or resource_binding_kinds in nodes.",
-            "Represent resources only in resources and target a workflow_agent ref.",
+            "Represent Agent-bound resources only in resources and target a workflow_agent ref; node-owned read resources use resource_ref only.",
             "Use snake_case workflow_agent config fields exactly as config_field_names; never emit outputVariable, taskInput, rolePrompt, or agent_id in config.",
             "Every workflow_agent declares exactly one string output on port result with a unique variable.",
             "Every workflow_agent has one or more task_ids; nodes whose task_binding is forbidden have an empty task_ids list.",
             "Pure nodes are deterministic auxiliary transforms only; do not use redundant serialize-deserialize round trips or duplicate aggregates.",
             "Pure node config, named ports, and output Schema must exactly match executable_node_contracts.",
+            "workflow_agent task inputs are string boundaries. Route object, array, number, boolean, or null values through an authorized string-producing node; use one compact json_serialize for JSON-safe typed resource results.",
+            "Never relabel a dynamic Adapter output as string to bypass type checking; the server restores its authoritative Schema.",
             "Every root workflow_agent binds user_input from source_ref input and source_port user_input to input port task.",
             "Every dependency input binds the exact ancestor result variable from source_port result to input port task.",
             "Every {{variable}} used in role_prompt or task_input has a matching explicit input binding.",
             "Control edges use source_ref, semantic outcome_ref, and target_ref; never emit native Handles or route IDs.",
             "Ordinary nodes use success; condition uses matched/unmatched; multi_route uses case_1 through case_8 plus default.",
+            "knowledge_retrieval and data_table_query use resource_ref.resource_id; never place native resource IDs, versions, Schemas, Handles, or checksums in config.",
+            "When a read node uses failure_action=error_output, connect both success and error outcomes exactly once; otherwise it only uses success.",
+            "The error outcome is control flow only; never declare it in node outputs or connect it as data.",
             "Every declared router outcome must have exactly one edge, and control edges must form an acyclic graph.",
             "A route scenario must reach exactly one final workflow_agent source or one terminate_error node.",
             "final_output uses sources and selection_policy exactly_one_arrived; never emit variable names in final_output.",
@@ -540,6 +1074,9 @@ def _planner_prompt_snapshot(
             "knowledge_bases": authorized(
                 snapshot.knowledge_bases, request.scope.knowledge_base_ids
             ),
+            "data_tables": authorized(
+                snapshot.data_tables, request.scope.data_table_ids
+            ),
             "toolsets": authorized(snapshot.toolsets, request.scope.toolset_ids),
             "plugins": authorized(snapshot.plugins, request.scope.plugin_ids),
             "prompt_profiles": authorized(
@@ -556,6 +1093,215 @@ def _planner_prompt_snapshot(
     }
 
 
+def _resource_text_matches(text: str, value: object) -> bool:
+    needle = str(value or "").strip().casefold()
+    if len(needle) < 3:
+        return False
+    haystack = text.casefold()
+    if any(character.isalnum() and not character.isascii() for character in needle):
+        return needle in haystack
+    return re.search(rf"(?<![a-z0-9_]){re.escape(needle)}(?![a-z0-9_])", haystack) is not None
+
+
+def _required_node_resource_reads(
+    request: MetaPlannerGenerateRequest,
+    snapshot: MetaPlannerCapabilitySnapshot,
+    plan: MetaPlannerTaskPlan | None = None,
+) -> list[dict[str, str]]:
+    """Derive explicit node-owned reads without treating authorization as intent."""
+
+    goal_text = request.goal
+    plan_text = (
+        json.dumps(plan.model_dump(mode="json"), ensure_ascii=False)
+        if plan is not None
+        else ""
+    )
+    requirements: list[dict[str, str]] = []
+    catalogs = (
+        (
+            "data_table_query",
+            "data_table",
+            request.scope.data_table_ids,
+            snapshot.data_tables,
+        ),
+        (
+            "knowledge_retrieval",
+            "knowledge_base",
+            request.scope.knowledge_base_ids,
+            snapshot.knowledge_bases,
+        ),
+    )
+    for node_kind, resource_kind, scoped_ids, catalog in catalogs:
+        selected = set(scoped_ids)
+        available = [
+            item for item in catalog if str(item.get("id") or "") in selected
+        ]
+        explicit_adapter_choice = node_kind.casefold() in plan_text.casefold()
+        for item in available:
+            resource_id = str(item.get("id") or "")
+            resource_name = str(item.get("name") or "")
+            goal_names_resource = any(
+                _resource_text_matches(goal_text, value)
+                for value in (resource_id, resource_name)
+            )
+            plan_names_resource = any(
+                _resource_text_matches(plan_text, value)
+                for value in (resource_id, resource_name)
+            )
+            adapter_selects_only_resource = (
+                explicit_adapter_choice and len(available) == 1
+            )
+            if not (
+                goal_names_resource
+                or plan_names_resource
+                or adapter_selects_only_resource
+            ):
+                continue
+            reasons: list[str] = []
+            if goal_names_resource:
+                reasons.append("goal_names_resource")
+            if plan_names_resource:
+                reasons.append("plan_names_resource")
+            if adapter_selects_only_resource:
+                reasons.append("plan_selects_adapter")
+            requirements.append(
+                {
+                    "node_kind": node_kind,
+                    "resource_kind": resource_kind,
+                    "resource_id": resource_id,
+                    "reason": "+".join(reasons),
+                }
+            )
+    return sorted(
+        requirements,
+        key=lambda item: (item["node_kind"], item["resource_id"]),
+    )
+
+
+def _read_resource_authoring_guide(
+    request: MetaPlannerGenerateRequest,
+    snapshot: MetaPlannerCapabilitySnapshot,
+    plan: MetaPlannerTaskPlan | None = None,
+) -> dict[str, Any]:
+    allowed_kinds = set(request.scope.allowed_node_kinds)
+    entries: list[dict[str, Any]] = []
+    if "data_table_query" in allowed_kinds and request.scope.data_table_ids:
+        available = {
+            str(item.get("id") or "")
+            for item in snapshot.data_tables
+            if item.get("id")
+        }
+        entries.append(
+            {
+                "resource_kind": "data_table",
+                "node_kind": "data_table_query",
+                "authorized_resource_ids": [
+                    resource_id
+                    for resource_id in request.scope.data_table_ids
+                    if resource_id in available
+                ],
+                "resource_location": "nodes[].resource_ref.resource_id",
+                "task_ids": [],
+                "typed_result_bridge": (
+                    "Connect data_table_query.result to json_serialize.value before "
+                    "feeding the resulting string to workflow_agent.task."
+                ),
+            }
+        )
+    if "knowledge_retrieval" in allowed_kinds and request.scope.knowledge_base_ids:
+        available = {
+            str(item.get("id") or "")
+            for item in snapshot.knowledge_bases
+            if item.get("id")
+        }
+        entries.append(
+            {
+                "resource_kind": "knowledge_base",
+                "node_kind": "knowledge_retrieval",
+                "authorized_resource_ids": [
+                    resource_id
+                    for resource_id in request.scope.knowledge_base_ids
+                    if resource_id in available
+                ],
+                "resource_location": "nodes[].resource_ref.resource_id",
+                "task_ids": [],
+                "typed_result_bridge": (
+                    "Use return_mode=context for a direct string Agent input, or "
+                    "serialize return_mode=result before workflow_agent.task."
+                ),
+            }
+        )
+    return {
+        "node_owned_resources": entries,
+        "required_reads": _required_node_resource_reads(request, snapshot, plan),
+        "rules": [
+            "Agent Table data is read only by data_table_query; never substitute workflow_agent, toolset_resource, or resources[].",
+            "Knowledge evidence is read only by knowledge_retrieval; knowledge_base in resources[] is only an Agent binding.",
+            "Put the exact authorized resource ID only in resource_ref.resource_id; never emit tableId, knowledgeBaseId, versions, schemas, Handles, or checksums.",
+            "When failure_action is error_output, success and error control edges both originate from that read node. workflow_agent has only success.",
+            "Read nodes are task-free helpers and cannot be final_output sources.",
+            "Every required_reads entry must be represented by the exact node kind and resource ID, and its result must reach a workflow_agent through typed data bindings.",
+        ],
+    }
+
+
+def _validate_required_node_resource_reads(
+    request: MetaPlannerGenerateRequest,
+    plan: MetaPlannerTaskPlan,
+    blueprint: GraphIntentV3,
+    snapshot: MetaPlannerCapabilitySnapshot,
+) -> list[str]:
+    requirements = _required_node_resource_reads(request, snapshot, plan)
+    if not requirements:
+        return []
+
+    nodes_by_ref = {node.ref: node for node in blueprint.nodes}
+    data_children: dict[str, set[str]] = defaultdict(set)
+    for target in blueprint.nodes:
+        for binding in target.inputs:
+            data_children[binding.source_ref].add(target.ref)
+
+    def reaches_agent(source_ref: str) -> bool:
+        queue = deque(sorted(data_children.get(source_ref, set())))
+        visited: set[str] = set()
+        while queue:
+            current = queue.popleft()
+            if current in visited:
+                continue
+            visited.add(current)
+            node = nodes_by_ref.get(current)
+            if node is not None and node.kind == "workflow_agent":
+                return True
+            queue.extend(sorted(data_children.get(current, set()) - visited))
+        return False
+
+    issues: list[str] = []
+    for requirement in requirements:
+        node_kind = requirement["node_kind"]
+        resource_id = requirement["resource_id"]
+        matching = [
+            node
+            for node in blueprint.nodes
+            if node.kind == node_kind
+            and node.resource_ref is not None
+            and node.resource_ref.resource_id == resource_id
+        ]
+        label = f"{node_kind}:{resource_id}"
+        if not matching:
+            issues.append(
+                f"Required node-owned resource read {label} is missing; a "
+                "workflow_agent cannot claim this read in its prompt or perform it "
+                "without the dedicated read node."
+            )
+            continue
+        if not any(reaches_agent(node.ref) for node in matching):
+            issues.append(
+                f"Required node-owned resource read {label} is not consumed by a "
+                "workflow_agent through typed data bindings."
+            )
+    return issues
+
+
 def _canonical_graph_intent_example(
     request: MetaPlannerGenerateRequest,
     plan: MetaPlannerTaskPlan,
@@ -565,16 +1311,16 @@ def _canonical_graph_intent_example(
     task_ids = [task.task_id for task in plan.tasks]
     return {
         "ir_version": GRAPH_IR_VERSION,
-        "name": "Replace with the candidate Xpert name",
-        "description": "Replace with a concise candidate description",
+        "name": "候选智能体名称",
+        "description": "候选智能体的简洁说明",
         "tags": [],
         "starters": [],
         "nodes": [
             {
                 "ref": "xpert_agent",
                 "kind": "workflow_agent",
-                "title": "Replace with the workflow agent title",
-                "description": "Replace with the workflow agent responsibility",
+                "title": "工作流智能体",
+                "description": "说明该智能体承担的职责",
                 "task_ids": task_ids,
                 "inputs": [
                     {
@@ -593,7 +1339,7 @@ def _canonical_graph_intent_example(
                     }
                 ],
                 "config": {
-                    "role_prompt": "Replace with instructions covering task_ids.",
+                    "role_prompt": "使用中文说明如何完成 task_ids 对应职责。",
                     "task_input": "{{user_input}}",
                     "model_id": request.default_agent_model_id,
                     "source_agent_id": None,
@@ -936,6 +1682,7 @@ def _typed_blueprint(
                         )
                         for item in node.outputs
                     ],
+                    resource_ref=node.resource_ref,
                     config=node.config,
                 )
                 for node in blueprint.nodes
@@ -1043,6 +1790,27 @@ def validate_blueprint_authorization(
         if isinstance(blueprint, GraphIntentV3)
         else {}
     )
+    if isinstance(blueprint, GraphIntentV3):
+        issues.extend(
+            _validate_required_node_resource_reads(
+                request,
+                plan,
+                blueprint,
+                snapshot,
+            )
+        )
+    node_resource_scope = {
+        "knowledge_base": set(request.scope.knowledge_base_ids),
+        "data_table": set(request.scope.data_table_ids),
+    }
+    node_resource_available = {
+        "knowledge_base": {
+            str(item.get("id") or "") for item in snapshot.knowledge_bases
+        },
+        "data_table": {
+            str(item.get("id") or "") for item in snapshot.data_tables
+        },
+    }
     for node in typed.nodes:
         if node.kind not in request.scope.allowed_node_kinds:
             issues.append(f"Node kind {node.kind} is not authorized.")
@@ -1064,6 +1832,47 @@ def validate_blueprint_authorization(
             )
             continue
         contract = workflow_node_contract_registry.require(node.kind)
+        expected_resource_kind = adapter.resource_kind
+        node_resource = node.resource_ref
+        if expected_resource_kind is None and node_resource is not None:
+            issues.append(f"Node {node.ref} cannot carry a node resource reference.")
+        elif expected_resource_kind is not None:
+            if node_resource is None:
+                issues.append(
+                    f"Node {node.ref} requires a {expected_resource_kind} resource."
+                )
+            else:
+                resource_id = node_resource.resource_id
+                if resource_id not in node_resource_scope[expected_resource_kind]:
+                    issues.append(
+                        f"Node resource {resource_id} is not authorized for "
+                        f"{expected_resource_kind}."
+                    )
+                if resource_id not in node_resource_available[expected_resource_kind]:
+                    issues.append(f"Node resource {resource_id} is no longer available.")
+                if isinstance(blueprint, GraphIntentV3):
+                    try:
+                        resource_snapshot = resolve_node_resource_snapshot(
+                            graph_nodes_by_ref[node.ref],
+                            snapshot,
+                            pinned=blueprint._pinned_node_resources.get(
+                                (node.ref, resource_id)
+                            ),
+                        )
+                        adapter.validate_resolved_resource(
+                            graph_nodes_by_ref[node.ref],
+                            parsed,
+                            (
+                                resource_snapshot.model_dump(mode="json")
+                                if resource_snapshot is not None
+                                else None
+                            ),
+                        )
+                    except ValueError as exc:
+                        issues.append(
+                            f"Node {node.ref} resource is invalid: "
+                            f"{_safe_exception_message(exc)}"
+                        )
         task_binding = contract.planner.task_binding
         if task_binding == "required" and not node.task_ids:
             issues.append(f"Node {node.ref} must cover at least one plan task.")
@@ -1742,7 +2551,7 @@ def compile_xpert_candidate(
             position=WorkflowPosition(x=40, y=160),
             data={
                 "kind": "input",
-                "title": "Conversation input",
+                "title": "对话输入",
                 "variableName": "user_input",
                 "historyVariable": "conversation_history",
             },
@@ -1818,6 +2627,13 @@ def compile_xpert_candidate(
                     acceptance_criteria=acceptance,
                     has_runtime_resources=bool(resources_by_ref[ref]),
                     requires_runtime_mode=requires_runtime_mode,
+                    resource_snapshot=(
+                        resolved_nodes_by_ref[ref].resource_snapshot.model_dump(
+                            mode="json"
+                        )
+                        if resolved_nodes_by_ref[ref].resource_snapshot is not None
+                        else None
+                    ),
                 ),
             )
         )
@@ -2030,7 +2846,7 @@ def compile_xpert_candidate(
             position=WorkflowPosition(x=output_x, y=output_y),
             data={
                 "kind": "output",
-                "title": "Final answer",
+                "title": "最终回答",
                 "contractVersion": 2,
                 "selectionPolicy": "exactly_one_arrived",
                 "outputSources": [
@@ -2248,6 +3064,10 @@ class MetaPlannerV2Service:
                     + ". Use create mode or wait for a dedicated compiler adapter."
                 )
 
+        repair_used = False
+        repair_protocol = "none"
+        warnings: list[str] = []
+
         plan_prompt = self._plan_prompt(request, snapshot)
         raw_plan = await self.completion(
             request.planner_model_id,
@@ -2256,17 +3076,51 @@ class MetaPlannerV2Service:
             request.temperature,
             4_096,
         )
+        plan: MetaPlannerTaskPlan | None = None
         try:
             plan = MetaPlannerTaskPlan.model_validate(_json_payload(raw_plan))
+            plan_issues = validate_task_plan(
+                plan,
+                max_agents=request.max_agents,
+                authorized_agent_ids=set(request.scope.agent_ids),
+            )
         except Exception as exc:
-            raise ValueError(_safe_exception_message(exc)) from exc
-        plan_issues = validate_task_plan(
-            plan,
-            max_agents=request.max_agents,
-            authorized_agent_ids=set(request.scope.agent_ids),
-        )
+            plan_issues = [_safe_exception_message(exc)]
         if plan_issues:
-            raise ValueError("; ".join(plan_issues))
+            repair_used = True
+            repair_protocol = "task_plan_v1"
+            repaired_raw_plan = await self.completion(
+                request.planner_model_id,
+                TASK_PLAN_REPAIR_SYSTEM_PROMPT,
+                self._plan_repair_prompt(
+                    request,
+                    snapshot,
+                    raw_plan,
+                    plan_issues,
+                ),
+                0,
+                4_096,
+            )
+            try:
+                plan = MetaPlannerTaskPlan.model_validate(
+                    _json_payload(repaired_raw_plan)
+                )
+                repaired_plan_issues = validate_task_plan(
+                    plan,
+                    max_agents=request.max_agents,
+                    authorized_agent_ids=set(request.scope.agent_ids),
+                )
+            except Exception as exc:
+                repaired_plan_issues = [_safe_exception_message(exc)]
+            if repaired_plan_issues:
+                raise ValueError(
+                    "Task-plan repair failed: " + "; ".join(repaired_plan_issues)
+                )
+            warnings.append(
+                "The single repair pass repaired the task plan before capability "
+                "compilation."
+            )
+        assert plan is not None
 
         raw_blueprint = await self.completion(
             request.planner_model_id,
@@ -2275,8 +3129,6 @@ class MetaPlannerV2Service:
             request.temperature,
             8_192,
         )
-        repair_used = False
-        warnings: list[str] = []
         (
             blueprint,
             candidate,
@@ -2291,8 +3143,7 @@ class MetaPlannerV2Service:
             snapshot=snapshot,
             target=target,
         )
-        repair_protocol = "none"
-        if issues:
+        if issues and not repair_used:
             repair_used = True
             if blueprint is not None:
                 repair_protocol = "graph_patch_v1"
@@ -2309,37 +3160,70 @@ class MetaPlannerV2Service:
                         snapshot,
                         blueprint,
                         issues,
-                        expected_graph_checksum=base_graph_checksum,
-                        expected_candidate_checksum=base_candidate_checksum,
                     ),
                     0,
                     8_192,
                 )
                 try:
-                    repair_patch = GraphPatchEnvelopeV1.model_validate(
+                    repair_payload = PlannerGraphPatchRepairPayloadV1.model_validate(
                         _json_payload(repaired_raw)
                     )
-                    if repair_patch.proposal_revision != 1:
-                        raise ValueError(
-                            "Planner repair patch must use synthetic revision 1."
+                    repair_patch = GraphPatchEnvelopeV1(
+                        proposal_revision=1,
+                        expected_graph_checksum=base_graph_checksum,
+                        expected_candidate_checksum=base_candidate_checksum,
+                        operations=repair_payload.operations,
+                    )
+                    repair_blueprint, repair_patch, removed_control_outputs = (
+                        _normalize_repair_control_only_outputs(
+                            blueprint,
+                            repair_patch,
                         )
-                    if (
-                        repair_patch.expected_graph_checksum
-                        != base_graph_checksum
-                        or repair_patch.expected_candidate_checksum
-                        != base_candidate_checksum
-                    ):
-                        raise ValueError(
-                            "Planner repair patch changed its base checksums."
+                    )
+                    if removed_control_outputs:
+                        warnings.append(
+                            "The single Graph Patch repair removed control-only "
+                            "outcomes from data outputs: "
+                            + ", ".join(removed_control_outputs)
+                            + "."
+                        )
+                    repair_patch, restored_outputs = (
+                        _normalize_repair_patch_required_outputs(
+                            repair_blueprint,
+                            repair_patch,
+                        )
+                    )
+                    if restored_outputs:
+                        warnings.append(
+                            "The single Graph Patch repair restored required "
+                            "output bindings for: "
+                            + ", ".join(restored_outputs)
+                            + "."
+                        )
+                    repair_patch, duplicate_data_edges = (
+                        _normalize_repair_duplicate_data_edges(
+                            repair_blueprint,
+                            repair_patch,
+                        )
+                    )
+                    if duplicate_data_edges:
+                        warnings.append(
+                            "The single Graph Patch repair removed exact "
+                            "duplicate data-edge no-ops: "
+                            + ", ".join(duplicate_data_edges)
+                            + "."
                         )
                     patched = apply_graph_patch(
-                        blueprint,
+                        repair_blueprint,
                         repair_patch,
                         plan_task_ids={task.task_id for task in plan.tasks},
                         allowed_node_kinds=set(request.scope.allowed_node_kinds),
                     )
                     normalized_intent, normalized_refs = (
-                        _normalize_adapter_outputs_for_repair(patched.intent)
+                        _normalize_adapter_outputs_for_repair(
+                            patched.intent,
+                            snapshot,
+                        )
                     )
                     if normalized_refs:
                         warnings.append(
@@ -2402,44 +3286,49 @@ class MetaPlannerV2Service:
                     snapshot=snapshot,
                     target=target,
                 )
-            if issues:
+        if issues:
+            if repair_protocol == "task_plan_v1":
                 warnings.append(
-                    "The single repair pass did not produce an approvable candidate."
+                    "The single repair pass was consumed by task-plan repair; "
+                    "the invalid capability compilation was not retried."
                 )
-                if not candidate:
-                    candidate, graph_ir, compatibility = self._fallback_candidate(
-                        request=request,
-                        plan=plan,
-                        snapshot=snapshot,
-                        target=target,
-                    )
-                    validation = _validation_report(
-                        candidate,
-                        target=target,
-                        preflight=self.preflight,
-                    )
-                repair_stage = {
-                    "id": "planner_repair",
-                    "valid": False,
-                    "issues": [
-                        {
-                            "code": "meta_planner_repair_failed",
-                            "message": issue[:500],
-                            "severity": "error",
-                        }
-                        for issue in issues[:20]
-                    ],
-                }
-                validation = dict(validation)
-                validation["valid"] = False
-                validation["stages"] = [
-                    repair_stage,
-                    *list(validation.get("stages") or []),
-                ]
-                validation["issues"] = [
-                    *repair_stage["issues"],
-                    *list(validation.get("issues") or []),
-                ]
+            warnings.append(
+                "The single repair pass did not produce an approvable candidate."
+            )
+            if not candidate:
+                candidate, graph_ir, compatibility = self._fallback_candidate(
+                    request=request,
+                    plan=plan,
+                    snapshot=snapshot,
+                    target=target,
+                )
+                validation = _validation_report(
+                    candidate,
+                    target=target,
+                    preflight=self.preflight,
+                )
+            repair_stage = {
+                "id": "planner_repair",
+                "valid": False,
+                "issues": [
+                    {
+                        "code": "meta_planner_repair_failed",
+                        "message": issue[:500],
+                        "severity": "error",
+                    }
+                    for issue in issues[:20]
+                ],
+            }
+            validation = dict(validation)
+            validation["valid"] = False
+            validation["stages"] = [
+                repair_stage,
+                *list(validation.get("stages") or []),
+            ]
+            validation["issues"] = [
+                *repair_stage["issues"],
+                *list(validation.get("issues") or []),
+            ]
 
         report = {
             "planner_version": "evoagentx-meta-planner-graph-ir-v3",
@@ -2482,7 +3371,7 @@ class MetaPlannerV2Service:
             payload = {**candidate, "meta_planner_report": report}
             proposal = self.authoring_service.proposal_store.create(
                 kind="xpert_create",
-                title=f"Meta Planner: {candidate['name']}",
+                title=f"元智能体规划：{candidate['name']}",
                 payload=payload,
                 source_type="meta_planner",
                 source_id=f"meta_planner:{uuid.uuid4().hex}",
@@ -2497,7 +3386,7 @@ class MetaPlannerV2Service:
             }
             proposal = self.authoring_service.proposal_store.create(
                 kind="xpert_update",
-                title=f"Meta Planner update: {candidate['name']}",
+                title=f"元智能体更新：{candidate['name']}",
                 payload=payload,
                 source_type="meta_planner",
                 source_id=f"meta_planner:{uuid.uuid4().hex}",
@@ -2601,13 +3490,13 @@ class MetaPlannerV2Service:
         target: XpertDefinition | None,
     ) -> tuple[dict[str, Any], ResolvedGraphIRV3, MetaPlannerIRCompatibility]:
         blueprint = MetaPlannerBlueprint(
-            name=(target.name if target is not None else "Unresolved Xpert candidate"),
-            description="Meta Planner repair failed. Review validation issues.",
+            name=(target.name if target is not None else "待修复的智能体候选"),
+            description="元智能体修复失败，请检查校验问题。",
             agents=[
                 MetaPlannerAgentBlueprint(
                     task_id=task.task_id,
                     name=task.title,
-                    role_prompt="Candidate requires human repair before approval.",
+                    role_prompt="该候选需要人工修复后才能批准。",
                     task_input="{{user_input}}",
                     output_variable=_safe_identifier(
                         f"{task.task_id}_output", "agent_output"
@@ -2743,6 +3632,7 @@ class MetaPlannerV2Service:
             if isinstance(required_schema.get("$defs"), dict)
             else {}
         )
+
         properties = task_schema.get("properties")
         if isinstance(properties, dict):
             for field_name in ("task_type", "interaction_prompt", "output_variable"):
@@ -2758,6 +3648,7 @@ class MetaPlannerV2Service:
         return json.dumps(
             {
                 "goal": request.goal,
+                "display_language_contract": DISPLAY_LANGUAGE_CONTRACT,
                 "mode": request.mode,
                 "max_tasks": 8,
                 "max_workflow_agents": request.max_agents,
@@ -2771,6 +3662,37 @@ class MetaPlannerV2Service:
                     "When authorized_agent_ids is empty, omit agent_id or set it to null for every task.",
                     "Never invent descriptive role names as agent_id values.",
                     "Use no more than max_workflow_agents distinct non-null agent_id values.",
+                ],
+            },
+            ensure_ascii=False,
+        )
+
+    @staticmethod
+    def _plan_repair_prompt(
+        request: MetaPlannerGenerateRequest,
+        snapshot: MetaPlannerCapabilitySnapshot,
+        raw_plan: str,
+        issues: list[str],
+    ) -> str:
+        return json.dumps(
+            {
+                "goal": request.goal,
+                "display_language_contract": DISPLAY_LANGUAGE_CONTRACT,
+                "invalid_task_plan": raw_plan[:30_000],
+                "validation_issues": issues[:20],
+                "max_tasks": 8,
+                "max_workflow_agents": request.max_agents,
+                "authorized_agent_ids": list(request.scope.agent_ids),
+                "task_planning_contract": _task_planning_contract(
+                    request, snapshot
+                ),
+                "required_schema": MetaPlannerTaskPlan.model_json_schema(),
+                "rules": [
+                    "Return the task plan object directly; do not wrap it in plan or result.",
+                    "Use exactly the top-level fields summary, assumptions, and tasks.",
+                    "Do not add deterministic helper operations as tasks.",
+                    "Do not invent agents, resources, node kinds, or private content.",
+                    "This is the only repair pass.",
                 ],
             },
             ensure_ascii=False,
@@ -2796,6 +3718,7 @@ class MetaPlannerV2Service:
         return json.dumps(
             {
                 "goal": request.goal,
+                "display_language_contract": DISPLAY_LANGUAGE_CONTRACT,
                 "task_plan": plan.model_dump(mode="json"),
                 "default_agent_model_id": request.default_agent_model_id,
                 "authorized_scope": request.scope.model_dump(mode="json"),
@@ -2803,6 +3726,9 @@ class MetaPlannerV2Service:
                 "graph_intent_contract": prompt_snapshot[
                     "graph_intent_contract"
                 ],
+                "read_resource_authoring_guide": _read_resource_authoring_guide(
+                    request, snapshot, plan
+                ),
                 "target_xpert": target_summary,
                 "required_schema": GraphIntentV3.model_json_schema(),
                 "canonical_minimal_example": _canonical_graph_intent_example(
@@ -2820,7 +3746,7 @@ class MetaPlannerV2Service:
                     "Resource and middleware bindings target workflow_agent node refs.",
                     "Reference dependency outputs in task_input using {{variable}}.",
                     "Do not include credentials, hidden reasoning, or raw private data.",
-                    "When uncertain, preserve the exact shape of canonical_minimal_example and adapt its content; never change it to V2.",
+                    "canonical_minimal_example applies only when required_reads is empty; otherwise add every required read node and its typed bridge before adapting the Agent. Never change the result to V2.",
                 ],
             },
             ensure_ascii=False,
@@ -2839,6 +3765,7 @@ class MetaPlannerV2Service:
         return json.dumps(
             {
                 "goal": request.goal,
+                "display_language_contract": DISPLAY_LANGUAGE_CONTRACT,
                 "task_plan": plan.model_dump(mode="json"),
                 "default_agent_model_id": request.default_agent_model_id,
                 "authorized_scope": request.scope.model_dump(mode="json"),
@@ -2847,6 +3774,9 @@ class MetaPlannerV2Service:
                 "graph_intent_contract": prompt_snapshot[
                     "graph_intent_contract"
                 ],
+                "read_resource_authoring_guide": _read_resource_authoring_guide(
+                    request, snapshot, plan
+                ),
                 "available_resources": {
                     **resources,
                     "middleware": prompt_snapshot["middleware"],
@@ -2869,39 +3799,43 @@ class MetaPlannerV2Service:
         snapshot: MetaPlannerCapabilitySnapshot,
         blueprint: GraphIntentV3,
         issues: list[str],
-        *,
-        expected_graph_checksum: str,
-        expected_candidate_checksum: str,
     ) -> str:
         prompt_snapshot = _planner_prompt_snapshot(request, snapshot)
         return json.dumps(
             {
                 "goal": request.goal,
+                "display_language_contract": DISPLAY_LANGUAGE_CONTRACT,
                 "task_plan": plan.model_dump(mode="json"),
                 "authorized_scope": request.scope.model_dump(mode="json"),
                 "capability_snapshot_hash": snapshot.snapshot_hash,
                 "capability_snapshot": prompt_snapshot,
+                "read_resource_authoring_guide": _read_resource_authoring_guide(
+                    request, snapshot, plan
+                ),
                 "base_graph_intent": blueprint.model_dump(mode="json"),
                 "validation_issues": issues[:30],
-                "required_schema": GraphPatchEnvelopeV1.model_json_schema(),
+                "required_schema": (
+                    PlannerGraphPatchRepairPayloadV1.model_json_schema()
+                ),
                 "typed_ir_constraints": _typed_ir_prompt_constraints(
                     request, plan
                 ),
                 "repair_contract": _graph_patch_repair_contract(
                     request, blueprint, issues
                 ),
-                "required_envelope": {
-                    "protocol_version": 1,
-                    "proposal_revision": 1,
-                    "expected_graph_checksum": expected_graph_checksum,
-                    "expected_candidate_checksum": expected_candidate_checksum,
-                },
+                "server_owned_fields": [
+                    "protocol_version",
+                    "proposal_revision",
+                    "expected_graph_checksum",
+                    "expected_candidate_checksum",
+                ],
                 "rules": [
-                    "Return GraphPatchEnvelopeV1, never a complete GraphIntent or Native Workflow.",
-                    "Copy every required_envelope value exactly.",
+                    "Return exactly one object with an operations array; never return a complete GraphIntent or Native Workflow.",
+                    "Do not emit any server_owned_fields; the server constructs and validates the trusted envelope.",
                     "Use Adapter config only; do not emit resource versions, Handles, schemas, policies, or native node IDs.",
                     "Obey repair_contract ref scopes and issue_playbook exactly.",
                     "Do not change the fixed task plan or add unauthorized capabilities.",
+                    "If no safe patch is possible, return an empty operations array instead of an error or explanation field.",
                     "This is the only repair pass.",
                 ],
             },

--- a/server/meta_agent/node_adapters.py
+++ b/server/meta_agent/node_adapters.py
@@ -17,9 +17,13 @@ try:
         ConditionPlannerConfig,
         DataAggregatePlannerConfig,
         DataMergePlannerConfig,
+        DataTableQueryFilterPlannerConfig,
+        DataTableQueryPlannerConfig,
+        DataTableQueryPredicatePlannerConfig,
         DatasetComparePlannerConfig,
         JsonDeserializePlannerConfig,
         JsonSerializePlannerConfig,
+        KnowledgeRetrievalPlannerConfig,
         MultiRoutePlannerConfig,
         NODE_CONTRACT_VERSION,
         TerminateErrorPlannerConfig,
@@ -34,9 +38,13 @@ except ModuleNotFoundError:
         ConditionPlannerConfig,
         DataAggregatePlannerConfig,
         DataMergePlannerConfig,
+        DataTableQueryFilterPlannerConfig,
+        DataTableQueryPlannerConfig,
+        DataTableQueryPredicatePlannerConfig,
         DatasetComparePlannerConfig,
         JsonDeserializePlannerConfig,
         JsonSerializePlannerConfig,
+        KnowledgeRetrievalPlannerConfig,
         MultiRoutePlannerConfig,
         NODE_CONTRACT_VERSION,
         TerminateErrorPlannerConfig,
@@ -70,6 +78,7 @@ class PlannerNodeCompileContext:
     acceptance_criteria: str
     has_runtime_resources: bool
     requires_runtime_mode: bool
+    resource_snapshot: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -83,18 +92,38 @@ class PlannerNodeAdapter:
     decompile_node: Callable[[NativeWorkflowNode], MetaPlannerIRNode]
     decompile_node_v3: Callable[[NativeWorkflowNode], GraphIntentNodeV3]
     referenced_variables: Callable[[BaseModel], set[str]] | None = None
-    output_schema: Callable[[str, BaseModel], WorkflowValueSchema] | None = None
+    output_schema: Callable[
+        [str, BaseModel, dict[str, Any] | None], WorkflowValueSchema
+    ] | None = None
     validate_node_shape: Callable[
         [MetaPlannerIRNode | GraphIntentNodeV3, BaseModel], None
     ] | None = None
     native_config: Callable[[dict[str, Any]], dict[str, Any]] | None = None
+    editor_config_projector: Callable[[dict[str, Any]], dict[str, Any]] | None = None
     native_inputs: Callable[
         [dict[str, Any], BaseModel], list[tuple[str, str]]
     ] | None = None
     native_outputs: Callable[
         [dict[str, Any], BaseModel], dict[str, str]
     ] | None = None
+    resource_kind: str | None = None
+    validate_resource: Callable[
+        [GraphIntentNodeV3, BaseModel, dict[str, Any]], None
+    ] | None = None
+    control_only_output_ports: tuple[str, ...] = ()
     contract_version: int = NODE_CONTRACT_VERSION
+
+    def intent_port_contracts(self, direction: str) -> tuple[Any, ...]:
+        contract = workflow_node_contract_registry.require(self.kind)
+        return tuple(
+            port
+            for port in contract.ports
+            if port.direction == direction
+            and not (
+                direction == "output"
+                and port.name in self.control_only_output_ports
+            )
+        )
 
     def validate_config(self, node: MetaPlannerIRNode) -> BaseModel:
         parsed = self.config_model.model_validate(node.config)
@@ -117,9 +146,10 @@ class PlannerNodeAdapter:
         self,
         port: str,
         parsed: BaseModel,
+        resource_snapshot: dict[str, Any] | None = None,
     ) -> WorkflowValueSchema:
         if self.output_schema is not None:
-            return self.output_schema(port, parsed)
+            return self.output_schema(port, parsed, resource_snapshot)
         contract = workflow_node_contract_registry.require(self.kind)
         match = next(
             (
@@ -133,12 +163,34 @@ class PlannerNodeAdapter:
             raise ValueError(f"Node kind {self.kind} has no output port {port}.")
         return match.value_schema
 
+    def validate_resolved_resource(
+        self,
+        node: GraphIntentNodeV3,
+        parsed: BaseModel,
+        resource_snapshot: dict[str, Any] | None,
+    ) -> None:
+        if self.resource_kind is None:
+            if node.resource_ref is not None or resource_snapshot is not None:
+                raise ValueError(
+                    f"Node kind {self.kind} cannot carry a node resource reference."
+                )
+            return
+        if node.resource_ref is None or resource_snapshot is None:
+            raise ValueError(f"Node kind {self.kind} requires a resource reference.")
+        if resource_snapshot.get("kind") != self.resource_kind:
+            raise ValueError(
+                f"Node kind {self.kind} requires resource kind {self.resource_kind}."
+            )
+        if self.validate_resource is not None:
+            self.validate_resource(node, parsed, resource_snapshot)
+
     def authoring_config_from_native(self, data: dict[str, Any]) -> BaseModel:
-        if self.native_config is None:
+        projector = self.editor_config_projector or self.native_config
+        if projector is None:
             raise ValueError(
                 f"Node kind {self.kind} cannot be projected from editor data."
             )
-        return self.config_model.model_validate(self.native_config(data))
+        return self.config_model.model_validate(projector(data))
 
     def editor_input_variables(
         self,
@@ -340,6 +392,219 @@ def _validate_data_merge_shape(
     _require_single_output(node, "result")
 
 
+def _validate_knowledge_retrieval_shape(
+    node: MetaPlannerIRNode | GraphIntentNodeV3,
+    _parsed: BaseModel,
+) -> None:
+    _require_single_input(node, "query")
+    if len(node.inputs) != 1:
+        raise ValueError(f"Node {node.ref} accepts only one query input.")
+    _require_single_output(node, "result")
+
+
+def _table_predicates(
+    item: DataTableQueryFilterPlannerConfig
+    | DataTableQueryPredicatePlannerConfig
+    | None,
+) -> list[DataTableQueryPredicatePlannerConfig]:
+    if item is None:
+        return []
+    if isinstance(item, DataTableQueryPredicatePlannerConfig):
+        return [item]
+    return [
+        predicate
+        for child in item.items
+        for predicate in _table_predicates(child)
+    ]
+
+
+def _validate_data_table_query_shape(
+    node: MetaPlannerIRNode | GraphIntentNodeV3,
+    parsed: BaseModel,
+) -> None:
+    config = DataTableQueryPlannerConfig.model_validate(parsed)
+    expected = {
+        f"predicate_{item.ref}"
+        for item in _table_predicates(config.filter)
+        if item.value_source == "input"
+    }
+    actual = [item.port for item in node.inputs]
+    if set(actual) != expected or len(actual) != len(expected):
+        raise ValueError(
+            f"Node {node.ref} dynamic predicate inputs must exactly match "
+            "the configured predicate refs."
+        )
+    _require_single_output(node, "result")
+
+
+def _field_value_schema(data_type: str, *, required: bool = True) -> WorkflowValueSchema:
+    value_type = {
+        "string": "string",
+        "integer": "integer",
+        "number": "number",
+        "boolean": "boolean",
+        "datetime": "string",
+        "json": "any",
+    }.get(data_type)
+    if value_type is None:
+        raise ValueError(f"Unsupported Agent Table field type {data_type}.")
+    return WorkflowValueSchema(type=value_type, nullable=not required)
+
+
+def _table_snapshot_fields(
+    resource_snapshot: dict[str, Any],
+) -> dict[str, WorkflowValueSchema]:
+    fields = resource_snapshot.get("fields")
+    if not isinstance(fields, dict):
+        raise ValueError("Agent Table resource snapshot has no trusted field schema.")
+    return {
+        str(name): WorkflowValueSchema.model_validate(schema)
+        for name, schema in fields.items()
+    }
+
+
+def _validate_data_table_resource(
+    node: GraphIntentNodeV3,
+    parsed: BaseModel,
+    resource_snapshot: dict[str, Any],
+) -> None:
+    config = DataTableQueryPlannerConfig.model_validate(parsed)
+    fields = _table_snapshot_fields(resource_snapshot)
+    business_fields = {
+        name for name in fields if name not in {
+            "record_id", "created_at", "updated_at", "revision"
+        }
+    }
+    unknown_selected = sorted(set(config.select_fields) - business_fields)
+    unknown_sort = sorted({item.field for item in config.sort} - set(fields))
+    if unknown_selected:
+        raise ValueError(
+            "Agent Table query selects unknown fields: "
+            + ", ".join(unknown_selected)
+        )
+    if unknown_sort:
+        raise ValueError(
+            "Agent Table query sorts unknown fields: " + ", ".join(unknown_sort)
+        )
+    inputs = {item.port: item for item in node.inputs}
+    for predicate in _table_predicates(config.filter):
+        field_schema = fields.get(predicate.field)
+        if field_schema is None:
+            raise ValueError(
+                f"Agent Table predicate {predicate.ref} uses unknown field "
+                f"{predicate.field}."
+            )
+        if predicate.operator == "contains" and field_schema.type != "string":
+            raise ValueError(
+                f"Agent Table predicate {predicate.ref} contains requires a string field."
+            )
+        expected_schema = (
+            WorkflowValueSchema(type="array", items=field_schema.model_copy(
+                update={"nullable": False}
+            ))
+            if predicate.operator == "in"
+            else field_schema.model_copy(update={"nullable": False})
+        )
+        if predicate.value_source == "input":
+            binding = inputs[f"predicate_{predicate.ref}"]
+            if canonical_checksum(
+                binding.value_schema.model_dump(mode="json")
+            ) != canonical_checksum(expected_schema.model_dump(mode="json")):
+                raise ValueError(
+                    f"Agent Table predicate {predicate.ref} input type does not "
+                    "match its fixed SchemaVersion."
+                )
+        elif predicate.value_source == "literal":
+            expected_schema.assert_value(
+                predicate.value,
+                path=f"$.filter.{predicate.ref}.value",
+            )
+
+
+def _knowledge_output_schema(
+    port: str,
+    parsed: BaseModel,
+    _resource_snapshot: dict[str, Any] | None,
+) -> WorkflowValueSchema:
+    if port != "result":
+        raise ValueError(f"Knowledge retrieval has no output port {port}.")
+    config = KnowledgeRetrievalPlannerConfig.model_validate(parsed)
+    if config.return_mode == "context":
+        return WorkflowValueSchema(type="string")
+    return WorkflowValueSchema(
+        type="object",
+        properties={
+            "knowledge_base_id": WorkflowValueSchema(type="string"),
+            "version_id": WorkflowValueSchema(type="string"),
+            "context": WorkflowValueSchema(type="string"),
+            "context_truncated": WorkflowValueSchema(type="boolean"),
+            "sources": WorkflowValueSchema(
+                type="array", items=WorkflowValueSchema(type="object")
+            ),
+            "citations": WorkflowValueSchema(
+                type="array", items=WorkflowValueSchema(type="object")
+            ),
+            "citation_count": WorkflowValueSchema(type="integer"),
+            "retrieval": WorkflowValueSchema(type="object"),
+            "warnings": WorkflowValueSchema(
+                type="array", items=WorkflowValueSchema(type="string")
+            ),
+        },
+        required=(
+            "knowledge_base_id",
+            "version_id",
+            "context",
+            "sources",
+            "citations",
+            "citation_count",
+            "retrieval",
+            "warnings",
+        ),
+    )
+
+
+def _data_table_output_schema(
+    port: str,
+    parsed: BaseModel,
+    resource_snapshot: dict[str, Any] | None,
+) -> WorkflowValueSchema:
+    if port != "result":
+        raise ValueError(f"Agent Table query has no output port {port}.")
+    if resource_snapshot is None:
+        contract = workflow_node_contract_registry.require("data_table_query")
+        return next(
+            item.value_schema
+            for item in contract.ports
+            if item.direction == "output" and item.name == port
+        )
+    config = DataTableQueryPlannerConfig.model_validate(parsed)
+    fields = _table_snapshot_fields(resource_snapshot)
+    selected = config.select_fields or [
+        name
+        for name in fields
+        if name not in {"record_id", "created_at", "updated_at", "revision"}
+    ]
+    selected_set = {
+        "record_id", "created_at", "updated_at", "revision", *selected
+    }
+    properties = {
+        name: schema for name, schema in fields.items() if name in selected_set
+    }
+    required = tuple(
+        name
+        for name in ("record_id", "created_at", "updated_at", "revision", *selected)
+        if name in properties and not properties[name].nullable
+    )
+    item_schema = WorkflowValueSchema(
+        type="object",
+        properties=properties,
+        required=required,
+    )
+    if config.return_mode == "first":
+        return item_schema.model_copy(update={"nullable": True})
+    return WorkflowValueSchema(type="array", items=item_schema)
+
+
 def _workflow_agent_references(parsed: BaseModel) -> set[str]:
     config = MetaPlannerWorkflowAgentConfig.model_validate(parsed)
     referenced: set[str] = set()
@@ -417,6 +682,80 @@ def _dataset_compare_native_inputs(
     ]
 
 
+def _data_table_filter_inputs_from_native(
+    configured: DataTableQueryFilterPlannerConfig
+    | DataTableQueryPredicatePlannerConfig
+    | None,
+    native: Any,
+) -> list[tuple[str, str]]:
+    if configured is None:
+        if native not in (None, {}):
+            raise ValueError("Planner Agent Table filter has drifted.")
+        return []
+    if not isinstance(native, dict):
+        raise ValueError("Planner Agent Table filter is missing.")
+    if isinstance(configured, DataTableQueryFilterPlannerConfig):
+        if set(native) != {"logic", "items"}:
+            raise ValueError("Planner Agent Table filter group has drifted.")
+        items = native.get("items")
+        if native.get("logic") != configured.logic or not isinstance(items, list):
+            raise ValueError("Planner Agent Table filter group has drifted.")
+        if len(items) != len(configured.items):
+            raise ValueError("Planner Agent Table filter item count has drifted.")
+        return [
+            binding
+            for child, native_child in zip(configured.items, items, strict=True)
+            for binding in _data_table_filter_inputs_from_native(
+                child, native_child
+            )
+        ]
+    expected_keys = {"field", "operator"}
+    if configured.operator != "is_null":
+        expected_keys.add("value")
+    if set(native) != expected_keys:
+        raise ValueError(
+            f"Planner Agent Table predicate {configured.ref} has drifted."
+        )
+    if (
+        native.get("field") != configured.field
+        or native.get("operator") != configured.operator
+    ):
+        raise ValueError(
+            f"Planner Agent Table predicate {configured.ref} has drifted."
+        )
+    if configured.operator == "is_null":
+        return []
+    binding = native.get("value")
+    if not isinstance(binding, dict):
+        raise ValueError(
+            f"Planner Agent Table predicate {configured.ref} has no value binding."
+        )
+    if configured.value_source == "literal":
+        expected = {"source": "literal", "value": configured.value}
+        if canonical_checksum(binding) != canonical_checksum(expected):
+            raise ValueError(
+                f"Planner Agent Table predicate {configured.ref} literal has drifted."
+            )
+        return []
+    variable = str(binding.get("variable") or "").strip()
+    if set(binding) != {"source", "variable"} or binding.get("source") != "variable":
+        raise ValueError(
+            f"Planner Agent Table predicate {configured.ref} binding has drifted."
+        )
+    if not variable:
+        raise ValueError(
+            f"Planner Agent Table predicate {configured.ref} variable is missing."
+        )
+    return [(f"predicate_{configured.ref}", variable)]
+
+
+def _data_table_query_native_inputs(
+    data: dict[str, Any], parsed: BaseModel
+) -> list[tuple[str, str]]:
+    config = DataTableQueryPlannerConfig.model_validate(parsed)
+    return _data_table_filter_inputs_from_native(config.filter, data.get("filter"))
+
+
 def _no_native_inputs(
     _data: dict[str, Any], _parsed: BaseModel
 ) -> list[tuple[str, str]]:
@@ -441,6 +780,7 @@ def _data_merge_native_inputs(
 def _json_deserialize_output_schema(
     port: str,
     parsed: BaseModel,
+    _resource_snapshot: dict[str, Any] | None,
 ) -> WorkflowValueSchema:
     if port != "value":
         raise ValueError(f"JSON deserialize has no output port {port}.")
@@ -689,6 +1029,153 @@ def _compile_data_merge(
     )
 
 
+def _resource_compile_snapshot(
+    context: PlannerNodeCompileContext,
+    *,
+    kind: str,
+) -> dict[str, Any]:
+    snapshot = context.resource_snapshot
+    if not isinstance(snapshot, dict) or snapshot.get("kind") != kind:
+        raise ValueError(f"Planner compiler requires a trusted {kind} snapshot.")
+    return snapshot
+
+
+def _planner_error_variable(node: MetaPlannerIRNode) -> str:
+    return f"planner_error_{canonical_checksum({'ref': node.ref})[:16]}"
+
+
+def _compile_knowledge_retrieval(
+    node: MetaPlannerIRNode,
+    parsed: BaseModel,
+    context: PlannerNodeCompileContext,
+) -> NativeWorkflowNode:
+    config = KnowledgeRetrievalPlannerConfig.model_validate(parsed)
+    source = _require_single_input(node, "query")
+    output = _require_single_output(node, "result")
+    resource = _resource_compile_snapshot(context, kind="knowledge_base")
+    outcome_map = (
+        {"success": "", "error": "error"}
+        if config.failure_action == "error_output"
+        else {"success": ""}
+    )
+    return NativeWorkflowNode(
+        id=context.node_id,
+        type="knowledge_retrieval",
+        position=context.position,
+        data={
+            **_base_pure_node_data(node),
+            "plannerOutcomeMapV1": {"success": ""},
+            **(
+                {"plannerOutcomeMapV2": outcome_map}
+                if len(outcome_map) > 1
+                else {}
+            ),
+            "plannerAdapterConfigV1": config.model_dump(mode="json"),
+            "plannerResourceSnapshotChecksum": resource["snapshot_checksum"],
+            "contractVersion": 2,
+            "knowledgeBaseId": resource["resource_id"],
+            "observedActiveVersionId": resource.get("observed_version_id"),
+            "queryVariable": source.variable,
+            "top_k": config.top_k,
+            "returnMode": config.return_mode,
+            "outputVariable": output.variable,
+            "failureAction": config.failure_action,
+            **(
+                {"errorVariable": _planner_error_variable(node)}
+                if config.failure_action == "error_output"
+                else {}
+            ),
+            "retryMode": config.retry_mode,
+            "maxAttempts": config.max_attempts,
+        },
+    )
+
+
+def _compile_data_table_filter(
+    item: DataTableQueryFilterPlannerConfig | DataTableQueryPredicatePlannerConfig,
+    node: MetaPlannerIRNode,
+) -> dict[str, Any]:
+    if isinstance(item, DataTableQueryFilterPlannerConfig):
+        return {
+            "logic": item.logic,
+            "items": [
+                _compile_data_table_filter(child, node) for child in item.items
+            ],
+        }
+    payload: dict[str, Any] = {
+        "field": item.field,
+        "operator": item.operator,
+    }
+    if item.operator == "is_null":
+        return payload
+    if item.value_source == "literal":
+        payload["value"] = {"source": "literal", "value": item.value}
+        return payload
+    binding = _require_single_input(node, f"predicate_{item.ref}")
+    payload["value"] = {
+        "source": "variable",
+        "variable": binding.variable,
+    }
+    return payload
+
+
+def _compile_data_table_query(
+    node: MetaPlannerIRNode,
+    parsed: BaseModel,
+    context: PlannerNodeCompileContext,
+) -> NativeWorkflowNode:
+    config = DataTableQueryPlannerConfig.model_validate(parsed)
+    output = _require_single_output(node, "result")
+    resource = _resource_compile_snapshot(context, kind="data_table")
+    filter_tree = (
+        _compile_data_table_filter(config.filter, node)
+        if config.filter is not None
+        else None
+    )
+    outcome_map = (
+        {"success": "", "error": "error"}
+        if config.failure_action == "error_output"
+        else {"success": ""}
+    )
+    return NativeWorkflowNode(
+        id=context.node_id,
+        type="data_table_query",
+        position=context.position,
+        data={
+            **_base_pure_node_data(node),
+            "plannerOutcomeMapV1": {"success": ""},
+            **(
+                {"plannerOutcomeMapV2": outcome_map}
+                if len(outcome_map) > 1
+                else {}
+            ),
+            "plannerAdapterConfigV1": config.model_dump(mode="json"),
+            "plannerResourceSnapshotChecksum": resource["snapshot_checksum"],
+            "tableId": resource["resource_id"],
+            "versionPolicy": "pinned",
+            "pinnedSchemaVersion": resource["pinned_schema_version"],
+            "pinnedSchemaChecksum": resource["schema_checksum"],
+            "selectFields": list(config.select_fields),
+            "filter": filter_tree,
+            "sort": [
+                {"field": item.field, "direction": item.direction}
+                for item in config.sort
+            ],
+            "limit": config.limit,
+            "returnMode": config.return_mode,
+            "outputVariable": output.variable,
+            "failureAction": config.failure_action,
+            **(
+                {"errorVariable": _planner_error_variable(node)}
+                if config.failure_action == "error_output"
+                else {}
+            ),
+            "retryMode": config.retry_mode,
+            "maxAttempts": config.max_attempts,
+        },
+    )
+
+
 def _compile_terminate_error(
     node: MetaPlannerIRNode,
     parsed: BaseModel,
@@ -826,7 +1313,112 @@ def _decompile_workflow_agent_v3(node: NativeWorkflowNode) -> GraphIntentNodeV3:
     )
 
 
+def _knowledge_editor_config_from_native(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "top_k": int(data.get("top_k") or 0),
+        "return_mode": str(data.get("returnMode") or ""),
+        "failure_action": str(data.get("failureAction") or "stop"),
+        "retry_mode": str(data.get("retryMode") or "none"),
+        "max_attempts": int(data.get("maxAttempts") or 2),
+    }
+
+
+def _table_editor_filter_from_native(
+    raw: Any,
+    *,
+    path: tuple[int, ...] = (),
+) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError("Planner Agent Table filter must be an object.")
+    if "items" in raw:
+        items = raw.get("items")
+        if not isinstance(items, list):
+            raise ValueError("Planner Agent Table filter group must contain items.")
+        return {
+            "kind": "group",
+            "logic": str(raw.get("logic") or "and"),
+            "items": [
+                _table_editor_filter_from_native(item, path=(*path, index))
+                for index, item in enumerate(items)
+            ],
+        }
+    field = str(raw.get("field") or "")
+    operator = str(raw.get("operator") or "")
+    ref = "p_" + canonical_checksum(
+        {"path": path, "field": field, "operator": operator}
+    )[:12]
+    result: dict[str, Any] = {
+        "kind": "predicate",
+        "ref": ref,
+        "field": field,
+        "operator": operator,
+    }
+    if operator == "is_null":
+        result["value_source"] = "none"
+        return result
+    value = raw.get("value")
+    if not isinstance(value, dict):
+        raise ValueError("Planner Agent Table predicate value is invalid.")
+    source = str(value.get("source") or "")
+    if source == "literal":
+        result.update({"value_source": "literal", "value": value.get("value")})
+        return result
+    if source == "variable" and str(value.get("variable") or "").strip():
+        result.update({"value_source": "input", "value": None})
+        return result
+    raise ValueError("Planner Agent Table predicate source is invalid.")
+
+
+def _data_table_editor_config_from_native(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "select_fields": list(data.get("selectFields") or []),
+        "filter": _table_editor_filter_from_native(data.get("filter")),
+        "sort": list(data.get("sort") or []),
+        "limit": int(data.get("limit") or 0),
+        "return_mode": str(data.get("returnMode") or ""),
+        "failure_action": str(data.get("failureAction") or "stop"),
+        "retry_mode": str(data.get("retryMode") or "none"),
+        "max_attempts": int(data.get("maxAttempts") or 2),
+    }
+
+
 def _pure_config_from_native(kind: str, data: dict[str, Any]) -> dict[str, Any]:
+    if kind == "knowledge_retrieval":
+        payload = data.get("plannerAdapterConfigV1")
+        if not isinstance(payload, dict):
+            raise ValueError("Planner knowledge retrieval is missing Adapter config.")
+        config = KnowledgeRetrievalPlannerConfig.model_validate(payload)
+        expected = {
+            "top_k": int(data.get("top_k") or 0),
+            "return_mode": str(data.get("returnMode") or ""),
+            "failure_action": str(data.get("failureAction") or "stop"),
+            "retry_mode": str(data.get("retryMode") or "none"),
+            "max_attempts": int(data.get("maxAttempts") or 2),
+        }
+        if config.model_dump(mode="json") != expected:
+            raise ValueError("Planner knowledge retrieval native config has drifted.")
+        return config.model_dump(mode="json")
+    if kind == "data_table_query":
+        payload = data.get("plannerAdapterConfigV1")
+        if not isinstance(payload, dict):
+            raise ValueError("Planner Agent Table query is missing Adapter config.")
+        config = DataTableQueryPlannerConfig.model_validate(payload)
+        expected_scalars = {
+            "select_fields": list(data.get("selectFields") or []),
+            "sort": list(data.get("sort") or []),
+            "limit": int(data.get("limit") or 0),
+            "return_mode": str(data.get("returnMode") or ""),
+            "failure_action": str(data.get("failureAction") or "stop"),
+            "retry_mode": str(data.get("retryMode") or "none"),
+            "max_attempts": int(data.get("maxAttempts") or 2),
+        }
+        actual = config.model_dump(mode="json")
+        if any(actual[key] != value for key, value in expected_scalars.items()):
+            raise ValueError("Planner Agent Table native config has drifted.")
+        _data_table_filter_inputs_from_native(config.filter, data.get("filter"))
+        return actual
     if kind == "condition":
         if int(data.get("contractVersion") or 0) != 2:
             raise ValueError("Planner condition nodes require contractVersion 2.")
@@ -916,6 +1508,21 @@ def _pure_config_from_native(kind: str, data: dict[str, Any]) -> dict[str, Any]:
     raise ValueError(f"Node kind {kind} is not a pure Planner node.")
 
 
+def _resource_ref_from_native(kind: str, data: dict[str, Any]) -> dict[str, str]:
+    field = {
+        "knowledge_retrieval": "knowledgeBaseId",
+        "data_table_query": "tableId",
+    }.get(kind)
+    if field is None:
+        raise ValueError(f"Node kind {kind} has no node-owned resource.")
+    resource_id = str(data.get(field) or "").strip()
+    if not resource_id:
+        raise ValueError(f"Planner {kind} is missing its resource ID.")
+    if not str(data.get("plannerResourceSnapshotChecksum") or "").strip():
+        raise ValueError(f"Planner {kind} is missing its resource snapshot marker.")
+    return {"resource_id": resource_id}
+
+
 def _decompile_pure_node(
     node: NativeWorkflowNode,
     *,
@@ -948,6 +1555,8 @@ def _decompile_pure_node(
         "outputs": outputs,
         "config": _pure_config_from_native(kind, data),
     }
+    if kind in {"knowledge_retrieval", "data_table_query"}:
+        payload["resource_ref"] = _resource_ref_from_native(kind, data)
     model: type[MetaPlannerIRNode] | type[GraphIntentNodeV3] = (
         GraphIntentNodeV3 if graph_ir_v3 else MetaPlannerIRNode
     )
@@ -996,6 +1605,12 @@ _decompile_data_merge, _decompile_data_merge_v3 = _pure_decompilers("data_merge"
 _decompile_terminate_error, _decompile_terminate_error_v3 = _pure_decompilers(
     "terminate_error"
 )
+_decompile_knowledge_retrieval, _decompile_knowledge_retrieval_v3 = (
+    _pure_decompilers("knowledge_retrieval")
+)
+_decompile_data_table_query, _decompile_data_table_query_v3 = _pure_decompilers(
+    "data_table_query"
+)
 
 
 PLANNER_NODE_ADAPTERS: dict[str, PlannerNodeAdapter] = {
@@ -1009,6 +1624,41 @@ PLANNER_NODE_ADAPTERS: dict[str, PlannerNodeAdapter] = {
         native_config=_workflow_agent_config_from_native,
         native_inputs=_workflow_agent_native_inputs,
         native_outputs=_single_native_output("outputVariable", "result"),
+    ),
+    "knowledge_retrieval": PlannerNodeAdapter(
+        kind="knowledge_retrieval",
+        config_model=KnowledgeRetrievalPlannerConfig,
+        compile_node=_compile_knowledge_retrieval,
+        decompile_node=_decompile_knowledge_retrieval,
+        decompile_node_v3=_decompile_knowledge_retrieval_v3,
+        output_schema=_knowledge_output_schema,
+        validate_node_shape=_validate_knowledge_retrieval_shape,
+        native_config=lambda data: _pure_config_from_native(
+            "knowledge_retrieval", data
+        ),
+        editor_config_projector=_knowledge_editor_config_from_native,
+        native_inputs=_single_native_input("queryVariable", "query"),
+        native_outputs=_single_native_output("outputVariable", "result"),
+        resource_kind="knowledge_base",
+        control_only_output_ports=("error",),
+    ),
+    "data_table_query": PlannerNodeAdapter(
+        kind="data_table_query",
+        config_model=DataTableQueryPlannerConfig,
+        compile_node=_compile_data_table_query,
+        decompile_node=_decompile_data_table_query,
+        decompile_node_v3=_decompile_data_table_query_v3,
+        output_schema=_data_table_output_schema,
+        validate_node_shape=_validate_data_table_query_shape,
+        native_config=lambda data: _pure_config_from_native(
+            "data_table_query", data
+        ),
+        editor_config_projector=_data_table_editor_config_from_native,
+        native_inputs=_data_table_query_native_inputs,
+        native_outputs=_single_native_output("outputVariable", "result"),
+        resource_kind="data_table",
+        validate_resource=_validate_data_table_resource,
+        control_only_output_ports=("error",),
     ),
     "json_serialize": PlannerNodeAdapter(
         kind="json_serialize",

--- a/server/meta_agent/schemas.py
+++ b/server/meta_agent/schemas.py
@@ -97,6 +97,7 @@ class MetaPlannerScope(BaseModel):
     allowed_node_kinds: list[str] = Field(default_factory=list, max_length=40)
     external_xpert_ids: list[str] = Field(default_factory=list, max_length=20)
     knowledge_base_ids: list[str] = Field(default_factory=list, max_length=20)
+    data_table_ids: list[str] = Field(default_factory=list, max_length=20)
     toolset_ids: list[str] = Field(default_factory=list, max_length=20)
     plugin_ids: list[str] = Field(default_factory=list, max_length=20)
     prompt_profile_ids: list[str] = Field(default_factory=list, max_length=20)
@@ -223,6 +224,12 @@ MetaPlannerValueType = Literal[
 ]
 
 
+class GraphIntentNodeResourceRefV3(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    resource_id: str = Field(min_length=1, max_length=200)
+
+
 class MetaPlannerIRInputBinding(BaseModel):
     port: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_-]{0,63}$")
     variable: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
@@ -245,6 +252,7 @@ class MetaPlannerIRNode(BaseModel):
     outputs: list[MetaPlannerIROutputBinding] = Field(
         default_factory=list, max_length=16
     )
+    resource_ref: GraphIntentNodeResourceRefV3 | None = None
     config: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -339,6 +347,7 @@ class GraphIntentNodeV3(BaseModel):
     outputs: list[GraphIntentOutputBindingV3] = Field(
         default_factory=list, max_length=16
     )
+    resource_ref: GraphIntentNodeResourceRefV3 | None = None
     config: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -348,7 +357,7 @@ class GraphIntentControlEdgeV3(BaseModel):
     source_ref: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,63}$")
     outcome_ref: str = Field(
         default="success",
-        pattern=r"^(?:success|matched|unmatched|case_[1-8]|default)$",
+        pattern=r"^(?:success|error|matched|unmatched|case_[1-8]|default)$",
     )
     target_ref: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,63}$")
 
@@ -410,6 +419,9 @@ class GraphIntentV3(BaseModel):
     _pinned_prompt_profile_versions: dict[str, int] = PrivateAttr(
         default_factory=dict
     )
+    _pinned_node_resources: dict[tuple[str, str], dict[str, Any]] = PrivateAttr(
+        default_factory=dict
+    )
 
     ir_version: Literal[3] = 3
     name: str = Field(min_length=1, max_length=120)
@@ -439,6 +451,19 @@ class ResolvedGraphPortV3(BaseModel):
     binding: Literal["variable", "literal", "resource", "none"] = "variable"
 
 
+class ResolvedNodeResourceSnapshotV3(BaseModel):
+    kind: Literal["knowledge_base", "data_table"]
+    resource_id: str
+    version_policy: Literal["active", "pinned"]
+    observed_version_id: str | None = None
+    pinned_schema_version: int | None = None
+    schema_checksum: str = ""
+    fields: dict[str, WorkflowValueSchema] = Field(default_factory=dict)
+    required_fields: tuple[str, ...] = ()
+    snapshot_checksum: str
+    warnings: list[str] = Field(default_factory=list)
+
+
 class ResolvedGraphNodeV3(BaseModel):
     ref: str
     node_id: str
@@ -454,6 +479,7 @@ class ResolvedGraphNodeV3(BaseModel):
     compiler_checksum: str
     execution: dict[str, Any] = Field(default_factory=dict)
     resource_contracts: list[dict[str, Any]] = Field(default_factory=list)
+    resource_snapshot: ResolvedNodeResourceSnapshotV3 | None = None
 
 
 class ResolvedGraphEndpointV3(BaseModel):
@@ -490,7 +516,7 @@ class ResolvedGraphIRV3(BaseModel):
     edges: list[ResolvedGraphEdgeV3]
     prompt_profiles: list[ResolvedPromptProfileV3] = Field(default_factory=list)
     final_output: GraphIntentFinalOutputV3
-    control_flow_contract_version: Literal[1] = 1
+    control_flow_contract_version: Literal[1, 2] = 2
     control_flow_report: dict[str, Any] = Field(default_factory=dict)
     default_outcome: Literal["success"] = "success"
     join_policy: Literal["all"] = "all"
@@ -527,6 +553,7 @@ class MetaPlannerCapabilitySnapshot(BaseModel):
     middleware: list[dict[str, Any]]
     external_xperts: list[dict[str, Any]]
     knowledge_bases: list[dict[str, Any]]
+    data_tables: list[dict[str, Any]] = Field(default_factory=list)
     toolsets: list[dict[str, Any]]
     plugins: list[dict[str, Any]]
     prompt_profiles: list[dict[str, Any]]

--- a/server/tests/test_meta_planner_headless_authoring.py
+++ b/server/tests/test_meta_planner_headless_authoring.py
@@ -349,8 +349,8 @@ def _headless_fixture(
 def test_capability_snapshot_exposes_patch_protocol_and_pure_node_pack():
     snapshot = _snapshot()
 
-    assert snapshot.version == "evoagentx-meta-planner-capabilities-v7"
-    assert snapshot.control_flow_contract_version == 1
+    assert snapshot.version == "evoagentx-meta-planner-capabilities-v8"
+    assert snapshot.control_flow_contract_version == 2
     assert snapshot.authoring_protocol_version == 1
     assert snapshot.authoring_limits["max_operations"] == 64
     assert snapshot.authoring_limits["max_receipts"] == 20
@@ -362,6 +362,7 @@ def test_capability_snapshot_exposes_patch_protocol_and_pure_node_pack():
     assert {item["kind"] for item in snapshot.nodes} == {
         "data_aggregate",
         "data_merge",
+        "data_table_query",
         "dataset_compare",
         "condition",
         "input",
@@ -371,6 +372,7 @@ def test_capability_snapshot_exposes_patch_protocol_and_pure_node_pack():
         "workflow_agent",
         "external_xpert",
         "knowledge_base",
+        "knowledge_retrieval",
         "toolset_resource",
         "variable_aggregator",
         "plugin_resource",

--- a/server/tests/test_meta_planner_pure_nodes.py
+++ b/server/tests/test_meta_planner_pure_nodes.py
@@ -124,8 +124,6 @@ def test_patch_repair_prompt_has_issue_scoped_ref_and_agent_limits() -> None:
             _snapshot(),
             intent,
             ["Typed IR exceeds max_agents=1."],
-            expected_graph_checksum="a" * 64,
-            expected_candidate_checksum="b" * 64,
         )
     )
     contract = prompt["repair_contract"]
@@ -147,6 +145,8 @@ def test_patch_repair_prompt_has_issue_scoped_ref_and_agent_limits() -> None:
     assert any(
         "recomputed by the server" in rule for rule in contract["rules"]
     )
+    assert set(prompt["required_schema"]["properties"]) == {"operations"}
+    assert "required_envelope" not in prompt
 
 
 def test_repair_normalizes_only_adapter_derived_output_schema() -> None:
@@ -154,7 +154,7 @@ def test_repair_normalizes_only_adapter_derived_output_schema() -> None:
     decode = next(node for node in intent.nodes if node.ref == "decode_rows")
     decode.outputs[0].value_schema = OBJECT
 
-    normalized, refs = _normalize_adapter_outputs_for_repair(intent)
+    normalized, refs = _normalize_adapter_outputs_for_repair(intent, _snapshot())
 
     normalized_decode = next(
         node for node in normalized.nodes if node.ref == "decode_rows"
@@ -169,7 +169,7 @@ def test_repair_normalizes_only_adapter_derived_output_schema() -> None:
     )
     forged_decode.outputs[0].port = "forged"
     with pytest.raises(ValueError, match="requires exactly one value output"):
-        _normalize_adapter_outputs_for_repair(forged)
+        _normalize_adapter_outputs_for_repair(forged, _snapshot())
 
 
 @pytest.mark.asyncio
@@ -200,8 +200,7 @@ async def test_single_patch_repair_refreshes_dynamic_deserialize_schema(
             return _plan().model_dump_json()
         if len(calls) == 2:
             return invalid.model_dump_json()
-        prompt = json.loads(user_prompt)
-        return json.dumps({**prompt["required_envelope"], "operations": []})
+        return json.dumps({"operations": []})
 
     response = await MetaPlannerV2Service(
         authoring_service=authoring,
@@ -255,8 +254,7 @@ async def test_semantic_adapter_failure_preserves_intent_for_patch_repair(
             return _plan().model_dump_json()
         if len(calls) == 2:
             return invalid.model_dump_json()
-        prompt = json.loads(user_prompt)
-        return json.dumps({**prompt["required_envelope"], "operations": []})
+        return json.dumps({"operations": []})
 
     response = await MetaPlannerV2Service(
         authoring_service=authoring,

--- a/server/tests/test_meta_planner_read_resources.py
+++ b/server/tests/test_meta_planner_read_resources.py
@@ -1,0 +1,1241 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from server.meta_agent.capabilities import build_capability_snapshot
+from server.meta_agent.graph_ir_v3 import (
+    decompile_candidate_to_graph_intent,
+    resolve_graph_intent,
+)
+from server.meta_agent.graph_patch import (
+    BindResourceOperation,
+    ConnectDataOperation,
+    GraphPatchEnvelopeV1,
+    SetNodeResourceOperation,
+    SetOutputVariableOperation,
+    apply_graph_patch,
+)
+from server.meta_agent.meta_planner_v2 import (
+    MetaPlannerV2Service,
+    compile_xpert_candidate,
+    validate_blueprint_authorization,
+)
+from server.meta_agent.schemas import (
+    GraphIntentControlEdgeV3,
+    GraphIntentFinalOutputSourceV3,
+    GraphIntentFinalOutputV3,
+    GraphIntentInputBindingV3,
+    GraphIntentNodeResourceRefV3,
+    GraphIntentNodeV3,
+    GraphIntentOutputBindingV3,
+    GraphIntentV3,
+    MetaPlannerGenerateRequest,
+    MetaPlannerIRResourceBinding,
+    MetaPlannerScope,
+    MetaPlannerTask,
+    MetaPlannerTaskPlan,
+)
+from server.workflow_native.node_contracts import WorkflowValueSchema
+from server.skills.draft_store import WorkspaceSkillDraftStore
+from server.xpert_runtime.authoring_service import AuthoringService
+from server.xpert_runtime.authoring_store import AuthoringProposalStore
+from server.xpert_runtime.middleware_registry import runtime_middleware_registry
+from server.xpert_runtime.workflow_node_registry import workflow_node_registry
+from server.xperts.store import XpertStore
+from server.xperts.validation import validate_xpert_definition
+
+
+STRING = WorkflowValueSchema(type="string")
+ANY = WorkflowValueSchema()
+
+
+def _table_catalog(*, active_version: int = 1, include_v1: bool = True):
+    versions = []
+    if include_v1:
+        versions.append(
+            {
+                "version": 1,
+                "checksum": "schema-v1",
+                "fields": [
+                    {
+                        "name": "sku",
+                        "data_type": "string",
+                        "required": True,
+                        "default_value": "secret-default",
+                    },
+                    {
+                        "name": "score",
+                        "data_type": "number",
+                        "required": False,
+                    },
+                ],
+            }
+        )
+    if active_version == 2:
+        versions.append(
+            {
+                "version": 2,
+                "checksum": "schema-v2",
+                "fields": [
+                    {"name": "sku", "data_type": "string", "required": True},
+                    {"name": "score", "data_type": "number", "required": False},
+                    {"name": "region", "data_type": "string", "required": False},
+                ],
+            }
+        )
+    return [
+        {
+            "table_id": "table-orders",
+            "name": "Orders",
+            "description": "Synthetic order records",
+            "status": "published",
+            "active_schema_version": active_version,
+            "schema_versions": versions,
+            "records": [{"sku": "must-not-leak"}],
+        }
+    ]
+
+
+def _snapshot(
+    *,
+    knowledge_version: str | None = "kb-v1",
+    table_active_version: int = 1,
+    include_table_v1: bool = True,
+):
+    return build_capability_snapshot(
+        workflow_registry=workflow_node_registry,
+        middleware_registry=runtime_middleware_registry,
+        external_xperts=[],
+        knowledge_bases=[
+            {
+                "id": "kb-docs",
+                "name": "Docs",
+                "active_version_id": knowledge_version,
+            }
+        ],
+        data_tables=_table_catalog(
+            active_version=table_active_version,
+            include_v1=include_table_v1,
+        ),
+        toolsets=[],
+        plugins=[],
+        prompt_profiles=[],
+        model_ids=["model/planner", "model/agent"],
+    )
+
+
+def _request(snapshot) -> MetaPlannerGenerateRequest:
+    return MetaPlannerGenerateRequest(
+        goal="Use one authorized read resource and answer.",
+        planner_model_id="model/planner",
+        default_agent_model_id="model/agent",
+        max_agents=2,
+        scope=MetaPlannerScope(
+            allowed_node_kinds=[item["kind"] for item in snapshot.nodes],
+            knowledge_base_ids=["kb-docs"],
+            data_table_ids=["table-orders"],
+        ),
+    )
+
+
+def _plan() -> MetaPlannerTaskPlan:
+    return MetaPlannerTaskPlan(
+        summary="Answer from a deterministic read.",
+        tasks=[
+            MetaPlannerTask(
+                task_id="answer",
+                title="Answer",
+                objective="Interpret the retrieved value.",
+                output_contract="A concise answer.",
+            )
+        ],
+    )
+
+
+def _input(
+    port: str,
+    variable: str,
+    source_ref: str,
+    source_port: str,
+    schema: WorkflowValueSchema,
+) -> GraphIntentInputBindingV3:
+    return GraphIntentInputBindingV3(
+        port=port,
+        variable=variable,
+        source_ref=source_ref,
+        source_port=source_port,
+        value_schema=schema,
+    )
+
+
+def _answer_node(
+    *, source_ref: str, source_port: str, variable: str, schema: WorkflowValueSchema
+) -> GraphIntentNodeV3:
+    return GraphIntentNodeV3(
+        ref="answer",
+        kind="workflow_agent",
+        title="Answer",
+        task_ids=["answer"],
+        inputs=[_input("task", variable, source_ref, source_port, schema)],
+        outputs=[
+            GraphIntentOutputBindingV3(
+                port="result", variable="agent_output", value_schema=STRING
+            )
+        ],
+        config={
+            "role_prompt": "Use only the supplied resource result.",
+            "task_input": "{{" + variable + "}}",
+            "model_id": "model/agent",
+        },
+    )
+
+
+def _serialize_node(
+    *, source_ref: str, variable: str, schema: WorkflowValueSchema
+) -> GraphIntentNodeV3:
+    return GraphIntentNodeV3(
+        ref="encode",
+        kind="json_serialize",
+        title="Encode resource result",
+        inputs=[_input("value", variable, source_ref, "result", schema)],
+        outputs=[
+            GraphIntentOutputBindingV3(
+                port="json", variable="encoded_resource", value_schema=STRING
+            )
+        ],
+        config={"format": "compact"},
+    )
+
+
+def _knowledge_intent() -> GraphIntentV3:
+    result_schema = WorkflowValueSchema(type="object")
+    return GraphIntentV3(
+        name="Knowledge read",
+        nodes=[
+            GraphIntentNodeV3(
+                ref="retrieve",
+                kind="knowledge_retrieval",
+                title="Retrieve docs",
+                inputs=[_input("query", "user_input", "input", "user_input", STRING)],
+                outputs=[
+                    GraphIntentOutputBindingV3(
+                        port="result",
+                        variable="knowledge_result",
+                        value_schema=result_schema,
+                    )
+                ],
+                resource_ref=GraphIntentNodeResourceRefV3(resource_id="kb-docs"),
+                config={"top_k": 5, "return_mode": "result"},
+            ),
+            _serialize_node(
+                source_ref="retrieve",
+                variable="knowledge_result",
+                schema=result_schema,
+            ),
+            _answer_node(
+                source_ref="encode",
+                source_port="json",
+                variable="encoded_resource",
+                schema=STRING,
+            ),
+        ],
+        control_edges=[
+            GraphIntentControlEdgeV3(source_ref="retrieve", target_ref="encode"),
+            GraphIntentControlEdgeV3(source_ref="encode", target_ref="answer"),
+        ],
+        final_output=GraphIntentFinalOutputV3(
+            sources=[GraphIntentFinalOutputSourceV3(node_ref="answer")]
+        ),
+    )
+
+
+def _table_intent(*, input_schema: WorkflowValueSchema = STRING) -> GraphIntentV3:
+    result_schema = WorkflowValueSchema(type="array", items=WorkflowValueSchema(type="object"))
+    return GraphIntentV3(
+        name="Table read",
+        nodes=[
+            GraphIntentNodeV3(
+                ref="lookup",
+                kind="data_table_query",
+                title="Lookup order",
+                inputs=[
+                    _input(
+                        "predicate_sku",
+                        "user_input",
+                        "input",
+                        "user_input",
+                        input_schema,
+                    )
+                ],
+                outputs=[
+                    GraphIntentOutputBindingV3(
+                        port="result", variable="rows", value_schema=ANY
+                    )
+                ],
+                resource_ref=GraphIntentNodeResourceRefV3(
+                    resource_id="table-orders"
+                ),
+                config={
+                    "select_fields": ["sku", "score"],
+                    "filter": {
+                        "kind": "predicate",
+                        "ref": "sku",
+                        "field": "sku",
+                        "operator": "eq",
+                        "value_source": "input",
+                    },
+                    "sort": [{"field": "score", "direction": "desc"}],
+                    "limit": 20,
+                    "return_mode": "list",
+                },
+            ),
+            _serialize_node(
+                source_ref="lookup", variable="rows", schema=result_schema
+            ),
+            _answer_node(
+                source_ref="encode",
+                source_port="json",
+                variable="encoded_resource",
+                schema=STRING,
+            ),
+        ],
+        control_edges=[
+            GraphIntentControlEdgeV3(source_ref="lookup", target_ref="encode"),
+            GraphIntentControlEdgeV3(source_ref="encode", target_ref="answer"),
+        ],
+        final_output=GraphIntentFinalOutputV3(
+            sources=[GraphIntentFinalOutputSourceV3(node_ref="answer")]
+        ),
+    )
+
+
+def test_capability_snapshot_opens_exactly_two_reads_and_hides_table_data() -> None:
+    snapshot = _snapshot()
+    kinds = {item["kind"] for item in snapshot.nodes}
+
+    assert len(kinds) == 18
+    assert {"knowledge_retrieval", "data_table_query"} <= kinds
+    assert snapshot.default_scope.data_table_ids == []
+    assert snapshot.default_scope.knowledge_base_ids == ["kb-docs"]
+    serialized = snapshot.model_dump_json()
+    assert "secret-default" not in serialized
+    assert "must-not-leak" not in serialized
+    assert snapshot.data_tables[0]["fields"] == [
+        {"name": "score", "type": "number", "required": False},
+        {"name": "sku", "type": "string", "required": True},
+    ]
+
+
+def test_planner_prompt_exposes_read_error_as_control_outcome_only() -> None:
+    snapshot = _snapshot()
+    request = _request(snapshot)
+    prompt = json.loads(
+        MetaPlannerV2Service._blueprint_prompt(
+            request,
+            _plan(),
+            snapshot,
+            None,
+        )
+    )
+    contract = prompt["graph_intent_contract"]["node_roles"][
+        "executable_node_contracts"
+    ]["data_table_query"]
+
+    assert contract["control_outcomes"] == ["success", "error"]
+    assert [
+        port["name"]
+        for port in contract["ports"]
+        if port["direction"] == "output"
+    ] == ["result"]
+    assert any(
+        "workflow_agent task inputs are string boundaries" in rule
+        for rule in prompt["graph_intent_contract"]["rules"]
+    )
+    guide = prompt["read_resource_authoring_guide"]
+    table_guide = next(
+        item
+        for item in guide["node_owned_resources"]
+        if item["node_kind"] == "data_table_query"
+    )
+    assert table_guide == {
+        "resource_kind": "data_table",
+        "node_kind": "data_table_query",
+        "authorized_resource_ids": ["table-orders"],
+        "resource_location": "nodes[].resource_ref.resource_id",
+        "task_ids": [],
+        "typed_result_bridge": (
+            "Connect data_table_query.result to json_serialize.value before "
+            "feeding the resulting string to workflow_agent.task."
+        ),
+    }
+    assert any(
+        "workflow_agent has only success" in rule for rule in guide["rules"]
+    )
+    plan_prompt = json.loads(MetaPlannerV2Service._plan_prompt(request, snapshot))
+    assert "Read authorized Agent Table rows with data_table_query." in (
+        plan_prompt["task_planning_contract"]["non_task_examples"]
+    )
+
+    repair_prompt = json.loads(
+        MetaPlannerV2Service._repair_prompt(
+            request,
+            _plan(),
+            snapshot,
+            '{"invalid": true}',
+            ["Node answer only permits outcomes: success"],
+        )
+    )
+    assert repair_prompt["read_resource_authoring_guide"] == guide
+    assert "must-not-leak" not in json.dumps(repair_prompt)
+
+
+def test_named_table_read_cannot_be_replaced_by_agent_prompt_claim() -> None:
+    snapshot = _snapshot()
+    request = _request(snapshot).model_copy(
+        update={"goal": "看看 Orders 表里的订单，再给我一个简短结论。"}
+    )
+    plan = _plan()
+    agent_only = GraphIntentV3(
+        name="订单助手",
+        nodes=[
+            _answer_node(
+                source_ref="input",
+                source_port="user_input",
+                variable="user_input",
+                schema=STRING,
+            )
+        ],
+        final_output=GraphIntentFinalOutputV3(
+            sources=[GraphIntentFinalOutputSourceV3(node_ref="answer")]
+        ),
+    )
+    agent_only.nodes[0].config["role_prompt"] = (
+        "直接查询 Orders 数据表并回答，但不要使用任何读取节点。"
+    )
+
+    issues = validate_blueprint_authorization(
+        request,
+        plan,
+        agent_only,
+        snapshot,
+    )
+
+    assert any(
+        "Required node-owned resource read data_table_query:table-orders is missing"
+        in issue
+        for issue in issues
+    )
+
+    prompt = json.loads(
+        MetaPlannerV2Service._blueprint_prompt(request, plan, snapshot, None)
+    )
+    assert prompt["read_resource_authoring_guide"]["required_reads"] == [
+        {
+            "node_kind": "data_table_query",
+            "resource_kind": "data_table",
+            "resource_id": "table-orders",
+            "reason": "goal_names_resource",
+        }
+    ]
+
+
+def test_required_table_read_must_feed_an_agent_by_typed_data_edges() -> None:
+    snapshot = _snapshot()
+    request = _request(snapshot).model_copy(
+        update={"goal": "读取 Orders 表并解释查询结果。"}
+    )
+    intent = _table_intent()
+    answer = next(node for node in intent.nodes if node.ref == "answer")
+    answer.inputs = [
+        _input("task", "user_input", "input", "user_input", STRING)
+    ]
+    answer.config["task_input"] = "{{user_input}}"
+    intent.nodes = [node for node in intent.nodes if node.ref != "encode"]
+    intent.control_edges = []
+
+    issues = validate_blueprint_authorization(request, _plan(), intent, snapshot)
+
+    assert any(
+        "Required node-owned resource read data_table_query:table-orders is not "
+        "consumed by a workflow_agent through typed data bindings"
+        in issue
+        for issue in issues
+    )
+
+
+def test_resource_ref_and_adapter_config_reject_runtime_owned_injection() -> None:
+    with pytest.raises(ValidationError):
+        GraphIntentNodeResourceRefV3.model_validate(
+            {"resource_id": "table-orders", "pinned_schema_version": 999}
+        )
+
+    intent = _table_intent()
+    intent.nodes[0].config["tableId"] = "attacker-table"
+    issues = validate_blueprint_authorization(
+        _request(_snapshot()), _plan(), intent, _snapshot()
+    )
+    assert any("tableId: Extra inputs are not permitted" in issue for issue in issues)
+
+
+def test_knowledge_pointer_drift_warns_but_missing_active_index_blocks() -> None:
+    initial = _snapshot(knowledge_version="kb-v1")
+    intent = _knowledge_intent()
+    candidate = compile_xpert_candidate(
+        request=_request(initial),
+        plan=_plan(),
+        blueprint=intent,
+        snapshot=initial,
+        target=None,
+    )
+    restored = decompile_candidate_to_graph_intent(candidate)
+
+    moved = _snapshot(knowledge_version="kb-v2")
+    resolved = resolve_graph_intent(
+        restored, moved, default_agent_model_id="model/agent"
+    )
+    retrieval = next(node for node in resolved.nodes if node.ref == "retrieve")
+    assert retrieval.resource_snapshot is not None
+    assert retrieval.resource_snapshot.observed_version_id == "kb-v2"
+    assert retrieval.resource_snapshot.warnings == [
+        "Knowledge base kb-docs active index changed from kb-v1 to kb-v2."
+    ]
+
+    with pytest.raises(ValueError, match="no active index version"):
+        resolve_graph_intent(
+            restored,
+            _snapshot(knowledge_version=None),
+            default_agent_model_id="model/agent",
+        )
+
+
+def test_knowledge_decompile_rejects_forged_dynamic_provenance() -> None:
+    initial = _snapshot(knowledge_version="kb-v1")
+    candidate = compile_xpert_candidate(
+        request=_request(initial),
+        plan=_plan(),
+        blueprint=_knowledge_intent(),
+        snapshot=initial,
+        target=None,
+    )
+    tampered = deepcopy(candidate)
+    native = next(
+        node
+        for node in tampered["draft"]["workflow"]["nodes"]
+        if node["data"].get("plannerRef") == "retrieve"
+    )
+    native["data"]["observedActiveVersionId"] = "forged-version"
+
+    with pytest.raises(ValueError, match="resource metadata has drifted"):
+        decompile_candidate_to_graph_intent(tampered)
+
+
+def test_table_schema_is_pinned_and_authoritative_output_survives_round_trip() -> None:
+    initial = _snapshot(table_active_version=1)
+    intent = _table_intent()
+    candidate = compile_xpert_candidate(
+        request=_request(initial),
+        plan=_plan(),
+        blueprint=intent,
+        snapshot=initial,
+        target=None,
+    )
+    native = next(
+        node
+        for node in candidate["draft"]["workflow"]["nodes"]
+        if node["data"].get("plannerRef") == "lookup"
+    )
+    assert native["data"]["pinnedSchemaVersion"] == 1
+    planner_output = native["data"]["plannerOutputsV3"][0]["value_schema"]
+    assert planner_output["type"] == "array"
+    assert set(planner_output["items"]["properties"]) == {
+        "record_id",
+        "created_at",
+        "updated_at",
+        "revision",
+        "sku",
+        "score",
+    }
+
+    restored = decompile_candidate_to_graph_intent(candidate)
+    advanced = _snapshot(table_active_version=2)
+    resolved = resolve_graph_intent(
+        restored, advanced, default_agent_model_id="model/agent"
+    )
+    table_node = next(node for node in resolved.nodes if node.ref == "lookup")
+    assert table_node.resource_snapshot is not None
+    assert table_node.resource_snapshot.pinned_schema_version == 1
+    rebuilt = compile_xpert_candidate(
+        request=_request(advanced),
+        plan=_plan(),
+        blueprint=restored,
+        snapshot=advanced,
+        target=None,
+    )
+    rebuilt_native = next(
+        node
+        for node in rebuilt["draft"]["workflow"]["nodes"]
+        if node["data"].get("plannerRef") == "lookup"
+    )
+    assert rebuilt_native["data"]["pinnedSchemaVersion"] == 1
+    assert rebuilt_native["data"]["pinnedSchemaChecksum"] == "schema-v1"
+    assert rebuilt_native["data"]["selectFields"] == ["sku", "score"]
+
+    with pytest.raises(ValueError, match="pinned SchemaVersion 1 is unavailable"):
+        resolve_graph_intent(
+            restored,
+            _snapshot(table_active_version=2, include_table_v1=False),
+            default_agent_model_id="model/agent",
+        )
+
+
+def test_table_dynamic_predicate_type_is_checked_against_fixed_schema() -> None:
+    intent = _table_intent(input_schema=WorkflowValueSchema(type="number"))
+    issues = validate_blueprint_authorization(
+        _request(_snapshot()), _plan(), intent, _snapshot()
+    )
+    assert any("input type does not match its fixed SchemaVersion" in issue for issue in issues)
+
+
+def test_set_node_resource_is_distinct_from_agent_resource_binding() -> None:
+    intent = _table_intent()
+    checksums = "a" * 64
+    result = apply_graph_patch(
+        intent,
+        GraphPatchEnvelopeV1(
+            proposal_revision=1,
+            expected_graph_checksum=checksums,
+            expected_candidate_checksum=checksums,
+            operations=[
+                SetNodeResourceOperation(
+                    node_ref="lookup", resource_id="table-orders-next"
+                )
+            ],
+        ),
+        plan_task_ids={"answer"},
+        allowed_node_kinds={"workflow_agent", "data_table_query"},
+    )
+    assert result.intent.nodes[0].resource_ref.resource_id == "table-orders-next"
+
+    mixed = deepcopy(intent)
+    mixed.resources.append(
+        MetaPlannerIRResourceBinding(
+            target_ref="lookup",
+            kind="knowledge_base",
+            resource_id="kb-docs",
+        )
+    )
+    issues = validate_blueprint_authorization(
+        _request(_snapshot()), _plan(), mixed, _snapshot()
+    )
+    assert "Resource kb-docs must target a workflow_agent ref." in issues
+
+    with pytest.raises(ValueError, match="does not own a dynamic resource"):
+        apply_graph_patch(
+            intent,
+            GraphPatchEnvelopeV1(
+                proposal_revision=1,
+                expected_graph_checksum=checksums,
+                expected_candidate_checksum=checksums,
+                operations=[
+                    SetNodeResourceOperation(
+                        node_ref="answer", resource_id="table-orders"
+                    )
+                ],
+            ),
+            plan_task_ids={"answer"},
+            allowed_node_kinds={"workflow_agent", "data_table_query"},
+        )
+
+    with pytest.raises(ValueError, match="no output port error"):
+        apply_graph_patch(
+            intent,
+            GraphPatchEnvelopeV1(
+                proposal_revision=1,
+                expected_graph_checksum=checksums,
+                expected_candidate_checksum=checksums,
+                operations=[
+                    SetOutputVariableOperation(
+                        node_ref="lookup",
+                        port="error",
+                        variable="forged_error_data",
+                    )
+                ],
+            ),
+            plan_task_ids={"answer"},
+            allowed_node_kinds={"workflow_agent", "data_table_query"},
+        )
+
+    with pytest.raises(ValueError, match="Data edge already exists"):
+        apply_graph_patch(
+            intent,
+            GraphPatchEnvelopeV1(
+                proposal_revision=1,
+                expected_graph_checksum=checksums,
+                expected_candidate_checksum=checksums,
+                operations=[
+                    ConnectDataOperation(
+                        source_ref="lookup",
+                        source_port="result",
+                        target_ref="encode",
+                        target_port="value",
+                    )
+                ],
+            ),
+            plan_task_ids={"answer"},
+            allowed_node_kinds={
+                "workflow_agent",
+                "data_table_query",
+                "json_serialize",
+            },
+        )
+
+
+def test_bind_resource_operation_cannot_smuggle_node_owned_resource() -> None:
+    intent = _table_intent()
+    checksums = "a" * 64
+    result = apply_graph_patch(
+        intent,
+        GraphPatchEnvelopeV1(
+            proposal_revision=1,
+            expected_graph_checksum=checksums,
+            expected_candidate_checksum=checksums,
+            operations=[
+                BindResourceOperation(
+                    target_ref="lookup",
+                    kind="knowledge_base",
+                    resource_id="kb-docs",
+                )
+            ],
+        ),
+        plan_task_ids={"answer"},
+        allowed_node_kinds={"workflow_agent", "data_table_query"},
+    )
+    issues = validate_blueprint_authorization(
+        _request(_snapshot()), _plan(), result.intent, _snapshot()
+    )
+    assert "Resource kb-docs must target a workflow_agent ref." in issues
+
+
+def test_error_branch_cannot_consume_success_only_resource_result() -> None:
+    intent = _table_intent()
+    result_schema = WorkflowValueSchema(
+        type="array", items=WorkflowValueSchema(type="object")
+    )
+    intent.nodes[0].config["failure_action"] = "error_output"
+    intent.nodes.append(
+        GraphIntentNodeV3(
+            ref="error_encode",
+            kind="json_serialize",
+            title="Encode unavailable result",
+            inputs=[
+                _input("value", "rows", "lookup", "result", result_schema)
+            ],
+            outputs=[
+                GraphIntentOutputBindingV3(
+                    port="json",
+                    variable="error_rows_json",
+                    value_schema=STRING,
+                )
+            ],
+            config={"format": "compact"},
+        )
+    )
+    intent.nodes.append(
+        GraphIntentNodeV3(
+            ref="fallback",
+            kind="workflow_agent",
+            title="Fallback",
+            task_ids=["answer"],
+            inputs=[
+                _input(
+                    "task",
+                    "error_rows_json",
+                    "error_encode",
+                    "json",
+                    STRING,
+                )
+            ],
+            outputs=[
+                GraphIntentOutputBindingV3(
+                    port="result",
+                    variable="fallback_output",
+                    value_schema=STRING,
+                )
+            ],
+            config={
+                "role_prompt": "Explain that the lookup failed.",
+                "task_input": "{{error_rows_json}}",
+                "model_id": "model/agent",
+            },
+        )
+    )
+    intent.control_edges.append(
+        GraphIntentControlEdgeV3(
+            source_ref="lookup",
+            outcome_ref="error",
+            target_ref="error_encode",
+        )
+    )
+    intent.control_edges.append(
+        GraphIntentControlEdgeV3(
+            source_ref="error_encode",
+            outcome_ref="success",
+            target_ref="fallback",
+        )
+    )
+    intent.final_output.sources.append(
+        GraphIntentFinalOutputSourceV3(node_ref="fallback")
+    )
+
+    with pytest.raises(ValueError, match="lookup.result is not available"):
+        resolve_graph_intent(
+            intent,
+            _snapshot(),
+            default_agent_model_id="model/agent",
+        )
+
+
+@pytest.mark.asyncio
+async def test_patch_repair_restores_missing_table_result_output(
+    tmp_path: Path,
+) -> None:
+    proposal_store = AuthoringProposalStore(tmp_path / "runtime")
+    authoring = AuthoringService(
+        proposal_store,
+        XpertStore(tmp_path / "xperts"),
+        WorkspaceSkillDraftStore(tmp_path / "skills"),
+        xpert_preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+    )
+    invalid = _table_intent()
+    lookup = next(node for node in invalid.nodes if node.ref == "lookup")
+    lookup.outputs = []
+    calls: list[dict[str, object]] = []
+
+    async def complete(model_id, system_prompt, user_prompt, temperature, max_tokens):
+        calls.append({"system_prompt": system_prompt, "user_prompt": user_prompt})
+        if len(calls) == 1:
+            return _plan().model_dump_json()
+        if len(calls) == 2:
+            return invalid.model_dump_json()
+        prompt = json.loads(user_prompt)
+        assert any(
+            "lookup.result" in item
+            for item in prompt["repair_contract"]["issue_playbook"]
+        )
+        return json.dumps({"operations": []})
+
+    response = await MetaPlannerV2Service(
+        authoring_service=authoring,
+        preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+        completion=complete,
+    ).generate(_request(_snapshot()), _snapshot())
+
+    assert len(calls) == 3
+    assert response.repair_used is True
+    assert response.validation["valid"] is True
+    assert any(
+        "lookup.result" in warning and "restored required output" in warning
+        for warning in response.warnings
+    )
+    proposal = proposal_store.require(response.proposal_id)
+    native_lookup = next(
+        node
+        for node in proposal.payload["draft"]["workflow"]["nodes"]
+        if node["data"].get("plannerRef") == "lookup"
+    )
+    assert native_lookup["data"]["outputVariable"] == "rows"
+
+
+@pytest.mark.asyncio
+async def test_patch_repair_removes_control_only_table_error_output(
+    tmp_path: Path,
+) -> None:
+    proposal_store = AuthoringProposalStore(tmp_path / "runtime")
+    authoring = AuthoringService(
+        proposal_store,
+        XpertStore(tmp_path / "xperts"),
+        WorkspaceSkillDraftStore(tmp_path / "skills"),
+        xpert_preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+    )
+    invalid = _table_intent()
+    lookup = next(node for node in invalid.nodes if node.ref == "lookup")
+    lookup.config["failure_action"] = "error_output"
+    lookup.outputs.append(
+        GraphIntentOutputBindingV3(
+            port="error",
+            variable="lookup_error",
+            value_schema=WorkflowValueSchema(type="object"),
+        )
+    )
+    invalid.nodes.append(
+        GraphIntentNodeV3(
+            ref="query_failed",
+            kind="terminate_error",
+            title="Stop after query failure",
+            config={
+                "error_code": "TABLE_QUERY_FAILED",
+                "message": "The incident table query failed.",
+            },
+        )
+    )
+    invalid.control_edges.append(
+        GraphIntentControlEdgeV3(
+            source_ref="lookup",
+            outcome_ref="error",
+            target_ref="query_failed",
+        )
+    )
+    calls: list[dict[str, object]] = []
+
+    async def complete(model_id, system_prompt, user_prompt, temperature, max_tokens):
+        calls.append({"system_prompt": system_prompt, "user_prompt": user_prompt})
+        if len(calls) == 1:
+            return _plan().model_dump_json()
+        if len(calls) == 2:
+            return invalid.model_dump_json()
+        prompt = json.loads(user_prompt)
+        return json.dumps(
+            {
+                "operations": [
+                    {
+                        "op": "connect_data",
+                        "source_ref": "lookup",
+                        "source_port": "result",
+                        "target_ref": "encode",
+                        "target_port": "value",
+                    }
+                ],
+            }
+        )
+
+    response = await MetaPlannerV2Service(
+        authoring_service=authoring,
+        preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+        completion=complete,
+    ).generate(_request(_snapshot()), _snapshot())
+
+    assert len(calls) == 3
+    assert response.repair_used is True
+    assert response.validation["valid"] is True
+    assert any(
+        "lookup.error" in warning and "control-only" in warning
+        for warning in response.warnings
+    )
+    assert any(
+        "lookup.result->encode.value" in warning
+        and "duplicate data-edge" in warning
+        for warning in response.warnings
+    )
+    proposal = proposal_store.require(response.proposal_id)
+    native_lookup = next(
+        node
+        for node in proposal.payload["draft"]["workflow"]["nodes"]
+        if node["data"].get("plannerRef") == "lookup"
+    )
+    assert native_lookup["data"]["failureAction"] == "error_output"
+    assert len(native_lookup["data"]["plannerOutputsV3"]) == 1
+    assert native_lookup["data"]["plannerOutputsV3"][0]["port"] == "result"
+
+
+@pytest.mark.asyncio
+async def test_patch_repair_routes_typed_table_result_through_json(
+    tmp_path: Path,
+) -> None:
+    proposal_store = AuthoringProposalStore(tmp_path / "runtime")
+    authoring = AuthoringService(
+        proposal_store,
+        XpertStore(tmp_path / "xperts"),
+        WorkspaceSkillDraftStore(tmp_path / "skills"),
+        xpert_preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+    )
+    invalid = _table_intent()
+    lookup = next(node for node in invalid.nodes if node.ref == "lookup")
+    answer = next(node for node in invalid.nodes if node.ref == "answer")
+    result_schema = WorkflowValueSchema(
+        type="array",
+        items=WorkflowValueSchema(type="object"),
+    )
+    answer.inputs = [
+        _input("task", "rows", "lookup", "result", result_schema)
+    ]
+    answer.config["task_input"] = "{{rows}}"
+    invalid.nodes = [lookup, answer]
+    invalid.control_edges = [
+        GraphIntentControlEdgeV3(source_ref="lookup", target_ref="answer")
+    ]
+    calls: list[dict[str, object]] = []
+
+    async def complete(model_id, system_prompt, user_prompt, temperature, max_tokens):
+        calls.append({"system_prompt": system_prompt, "user_prompt": user_prompt})
+        if len(calls) == 1:
+            return _plan().model_dump_json()
+        if len(calls) == 2:
+            return invalid.model_dump_json()
+        prompt = json.loads(user_prompt)
+        assert any(
+            "lookup.result->answer.task" in item and "json_serialize" in item
+            for item in prompt["repair_contract"]["issue_playbook"]
+        )
+        return json.dumps(
+            {
+                "operations": [
+                    {
+                        "op": "disconnect_data",
+                        "source_ref": "lookup",
+                        "source_port": "result",
+                        "target_ref": "answer",
+                        "target_port": "task",
+                    },
+                    {
+                        "op": "disconnect_control",
+                        "source_ref": "lookup",
+                        "outcome_ref": "success",
+                        "target_ref": "answer",
+                    },
+                    {
+                        "op": "add_node",
+                        "ref": "encode_rows",
+                        "kind": "json_serialize",
+                        "title": "Encode table rows",
+                        "description": "Render the typed rows for the Agent prompt.",
+                        "task_ids": [],
+                        "config": {"format": "compact"},
+                        "output_variables": {"json": "rows_json"},
+                    },
+                    {
+                        "op": "update_node",
+                        "ref": "answer",
+                        "config": {
+                            "role_prompt": "Use only the supplied resource result.",
+                            "task_input": "{{rows_json}}",
+                            "model_id": "model/agent",
+                            "source_agent_id": None,
+                            "method_skill_ids": [],
+                        },
+                    },
+                    {
+                        "op": "connect_data",
+                        "source_ref": "lookup",
+                        "source_port": "result",
+                        "target_ref": "encode_rows",
+                        "target_port": "value",
+                    },
+                    {
+                        "op": "connect_data",
+                        "source_ref": "encode_rows",
+                        "source_port": "json",
+                        "target_ref": "answer",
+                        "target_port": "task",
+                    },
+                    {
+                        "op": "connect_control",
+                        "source_ref": "lookup",
+                        "outcome_ref": "success",
+                        "target_ref": "encode_rows",
+                    },
+                    {
+                        "op": "connect_control",
+                        "source_ref": "encode_rows",
+                        "outcome_ref": "success",
+                        "target_ref": "answer",
+                    },
+                ],
+            }
+        )
+
+    snapshot = _snapshot()
+    response = await MetaPlannerV2Service(
+        authoring_service=authoring,
+        preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+        completion=complete,
+    ).generate(_request(snapshot), snapshot)
+
+    assert len(calls) == 3
+    assert response.repair_used is True
+    assert response.validation["valid"] is True, json.dumps(
+        response.validation,
+        ensure_ascii=False,
+        indent=2,
+    )
+    proposal = proposal_store.require(response.proposal_id)
+    nodes = proposal.payload["draft"]["workflow"]["nodes"]
+    assert any(node["type"] == "json_serialize" for node in nodes)
+
+
+@pytest.mark.asyncio
+async def test_patch_repair_realizes_named_table_read_instead_of_prompt_claim(
+    tmp_path: Path,
+) -> None:
+    proposal_store = AuthoringProposalStore(tmp_path / "runtime")
+    authoring = AuthoringService(
+        proposal_store,
+        XpertStore(tmp_path / "xperts"),
+        WorkspaceSkillDraftStore(tmp_path / "skills"),
+        xpert_preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+    )
+    snapshot = _snapshot()
+    request = _request(snapshot).model_copy(
+        update={"goal": "读取 Orders 表并用中文解释结果。"}
+    )
+    plan = _plan()
+    agent_only = GraphIntentV3(
+        name="订单助手",
+        nodes=[
+            _answer_node(
+                source_ref="input",
+                source_port="user_input",
+                variable="user_input",
+                schema=STRING,
+            )
+        ],
+        final_output=GraphIntentFinalOutputV3(
+            sources=[GraphIntentFinalOutputSourceV3(node_ref="answer")]
+        ),
+    )
+    calls: list[dict[str, object]] = []
+
+    async def complete(model_id, system_prompt, user_prompt, temperature, max_tokens):
+        calls.append({"system_prompt": system_prompt, "user_prompt": user_prompt})
+        if len(calls) == 1:
+            return plan.model_dump_json()
+        if len(calls) == 2:
+            return agent_only.model_dump_json()
+        prompt = json.loads(user_prompt)
+        assert any(
+            "required read data_table_query:table-orders" in item
+            and "set_node_resource" in item
+            for item in prompt["repair_contract"]["issue_playbook"]
+        )
+        return json.dumps(
+            {
+                "operations": [
+                    {
+                        "op": "add_node",
+                        "ref": "lookup",
+                        "kind": "data_table_query",
+                        "title": "查询订单",
+                        "description": "从固定表结构中读取允许字段。",
+                        "task_ids": [],
+                        "config": {
+                            "select_fields": ["sku", "score"],
+                            "filter": None,
+                            "sort": [{"field": "score", "direction": "desc"}],
+                            "limit": 20,
+                            "return_mode": "list",
+                            "failure_action": "stop",
+                            "retry_mode": "none",
+                            "max_attempts": 2,
+                        },
+                        "output_variables": {"result": "rows"},
+                    },
+                    {
+                        "op": "set_node_resource",
+                        "node_ref": "lookup",
+                        "resource_id": "table-orders",
+                    },
+                    {
+                        "op": "add_node",
+                        "ref": "encode_rows",
+                        "kind": "json_serialize",
+                        "title": "序列化查询结果",
+                        "description": "将类型化记录转换为智能体可读的 JSON。",
+                        "task_ids": [],
+                        "config": {"format": "compact"},
+                        "output_variables": {"json": "rows_json"},
+                    },
+                    {
+                        "op": "update_node",
+                        "ref": "answer",
+                        "config": {
+                            "role_prompt": "仅依据已提供的订单记录，用中文回答。",
+                            "task_input": "用户请求：{{user_input}}\n订单记录：{{rows_json}}",
+                            "model_id": "model/agent",
+                            "source_agent_id": None,
+                            "method_skill_ids": [],
+                        },
+                    },
+                    {
+                        "op": "connect_data",
+                        "source_ref": "lookup",
+                        "source_port": "result",
+                        "target_ref": "encode_rows",
+                        "target_port": "value",
+                    },
+                    {
+                        "op": "connect_data",
+                        "source_ref": "encode_rows",
+                        "source_port": "json",
+                        "target_ref": "answer",
+                        "target_port": "task",
+                    },
+                    {
+                        "op": "connect_control",
+                        "source_ref": "lookup",
+                        "outcome_ref": "success",
+                        "target_ref": "encode_rows",
+                    },
+                    {
+                        "op": "connect_control",
+                        "source_ref": "encode_rows",
+                        "outcome_ref": "success",
+                        "target_ref": "answer",
+                    },
+                ]
+            }
+        )
+
+    response = await MetaPlannerV2Service(
+        authoring_service=authoring,
+        preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+        completion=complete,
+    ).generate(request, snapshot)
+
+    assert len(calls) == 3
+    assert response.repair_used is True
+    assert response.validation["valid"] is True, json.dumps(
+        response.validation,
+        ensure_ascii=False,
+        indent=2,
+    )
+    nodes = response.candidate["draft"]["workflow"]["nodes"]
+    lookup = next(node for node in nodes if node["type"] == "data_table_query")
+    assert lookup["data"]["tableId"] == "table-orders"
+    assert lookup["data"]["pinnedSchemaVersion"] == 1
+    assert any(node["type"] == "json_serialize" for node in nodes)

--- a/server/tests/test_meta_planner_v2.py
+++ b/server/tests/test_meta_planner_v2.py
@@ -131,6 +131,11 @@ def test_blueprint_and_repair_prompts_expose_typed_ir_agent_constraints():
     )
 
     for prompt in (blueprint_prompt, repair_prompt):
+        assert prompt["display_language_contract"]["locale"] == "zh-CN"
+        assert any(
+            "Simplified Chinese" in rule
+            for rule in prompt["display_language_contract"]["rules"]
+        )
         constraints = prompt["typed_ir_constraints"]
         graph_contract = prompt["graph_intent_contract"]
         assert constraints["max_workflow_agent_nodes"] == request.max_agents
@@ -211,6 +216,7 @@ def test_blueprint_and_repair_prompts_expose_typed_ir_agent_constraints():
         "Typed IR exceeds max_agents=3."
     ]
     assert plan_prompt["authorized_agent_ids"] == request.scope.agent_ids
+    assert plan_prompt["display_language_contract"]["locale"] == "zh-CN"
     assert any(
         "omit agent_id or set it to null" in rule
         for rule in plan_prompt["rules"]
@@ -490,8 +496,8 @@ def test_capability_api_returns_stable_safe_contract():
     response = client.get("/api/meta-agent/capabilities")
     assert response.status_code == 200
     payload = response.json()
-    assert payload["version"] == "evoagentx-meta-planner-capabilities-v7"
-    assert payload["control_flow_contract_version"] == 1
+    assert payload["version"] == "evoagentx-meta-planner-capabilities-v8"
+    assert payload["control_flow_contract_version"] == 2
     assert payload["authoring_protocol_version"] == 1
     assert payload["authoring_limits"]["max_operations"] == 64
     assert payload["ir_version"] == 3
@@ -512,6 +518,7 @@ def test_capability_snapshot_only_exposes_compilable_node_kinds():
         "condition",
         "data_aggregate",
         "data_merge",
+        "data_table_query",
         "dataset_compare",
         "input",
         "json_deserialize",
@@ -523,6 +530,7 @@ def test_capability_snapshot_only_exposes_compilable_node_kinds():
         "workflow_agent",
         "external_xpert",
         "knowledge_base",
+        "knowledge_retrieval",
         "toolset_resource",
         "plugin_resource",
     }
@@ -553,6 +561,12 @@ def test_compiler_creates_control_and_five_binding_edge_shapes():
         target=None,
     )
     workflow = candidate["draft"]["workflow"]
+    compiler_titles = {
+        node["type"]: node["data"]["title"]
+        for node in workflow["nodes"]
+        if node["type"] in {"input", "output"}
+    }
+    assert compiler_titles == {"input": "对话输入", "output": "最终回答"}
     handles = {
         edge.get("targetHandle")
         for edge in workflow["edges"]
@@ -825,6 +839,108 @@ async def test_generation_persists_proposal_and_uses_at_most_one_repair(
 
 
 @pytest.mark.asyncio
+async def test_invalid_task_plan_uses_the_single_shared_repair_pass(
+    tmp_path: Path,
+):
+    proposal_store = AuthoringProposalStore(tmp_path / "runtime")
+    authoring = AuthoringService(
+        proposal_store,
+        XpertStore(tmp_path / "xperts"),
+        WorkspaceSkillDraftStore(tmp_path / "skills"),
+        xpert_preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+    )
+    graph_intent, _ = v2_to_graph_intent(_typed_blueprint())
+    assert graph_intent is not None
+    outputs = [
+        json.dumps({"result": "Please clarify the request."}),
+        _plan().model_dump_json(),
+        graph_intent.model_dump_json(),
+    ]
+    calls: list[dict[str, object]] = []
+
+    async def complete(model_id, system_prompt, user_prompt, temperature, max_tokens):
+        calls.append(
+            {
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "temperature": temperature,
+            }
+        )
+        return outputs.pop(0)
+
+    response = await MetaPlannerV2Service(
+        authoring_service=authoring,
+        preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+        completion=complete,
+    ).generate(_request(), _snapshot())
+
+    assert len(calls) == 3
+    assert calls[1]["temperature"] == 0
+    assert "task plan" in str(calls[1]["system_prompt"])
+    assert response.repair_used is True
+    assert response.validation["valid"] is True
+    proposal = proposal_store.require(response.proposal_id)
+    report = proposal.payload["meta_planner_report"]
+    assert report["repair_protocol"] == "task_plan_v1"
+    assert any("repaired the task plan" in item for item in response.warnings)
+
+
+@pytest.mark.asyncio
+async def test_task_plan_repair_never_allows_a_fourth_blueprint_call(
+    tmp_path: Path,
+):
+    proposal_store = AuthoringProposalStore(tmp_path / "runtime")
+    authoring = AuthoringService(
+        proposal_store,
+        XpertStore(tmp_path / "xperts"),
+        WorkspaceSkillDraftStore(tmp_path / "skills"),
+        xpert_preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+    )
+    outputs = [
+        json.dumps({"result": "Please clarify the request."}),
+        _plan().model_dump_json(),
+        json.dumps({"name": "invalid blueprint"}),
+    ]
+    calls: list[dict[str, object]] = []
+
+    async def complete(model_id, system_prompt, user_prompt, temperature, max_tokens):
+        calls.append({"system_prompt": system_prompt, "temperature": temperature})
+        return outputs.pop(0)
+
+    response = await MetaPlannerV2Service(
+        authoring_service=authoring,
+        preflight=lambda candidate: (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow,
+            [],
+        ),
+        completion=complete,
+    ).generate(_request(), _snapshot())
+
+    assert len(calls) == 3
+    assert response.repair_used is True
+    assert response.validation["valid"] is False
+    proposal = proposal_store.require(response.proposal_id)
+    assert proposal.status == "pending"
+    assert proposal.validation["valid"] is False
+    report = proposal.payload["meta_planner_report"]
+    assert report["repair_protocol"] == "task_plan_v1"
+    assert any("was consumed by task-plan repair" in item for item in response.warnings)
+
+
+@pytest.mark.asyncio
 async def test_parseable_v3_repair_uses_one_typed_graph_patch(tmp_path: Path):
     proposal_store = AuthoringProposalStore(tmp_path / "runtime")
     xpert_store = XpertStore(tmp_path / "xperts")
@@ -856,9 +972,16 @@ async def test_parseable_v3_repair_uses_one_typed_graph_patch(tmp_path: Path):
         if len(calls) == 2:
             return invalid.model_dump_json()
         prompt = json.loads(user_prompt)
+        assert "required_envelope" not in prompt
+        assert prompt["server_owned_fields"] == [
+            "protocol_version",
+            "proposal_revision",
+            "expected_graph_checksum",
+            "expected_candidate_checksum",
+        ]
+        assert set(prompt["required_schema"]["properties"]) == {"operations"}
         return json.dumps(
             {
-                **prompt["required_envelope"],
                 "operations": [
                     {
                         "op": "set_final_output",
@@ -881,7 +1004,7 @@ async def test_parseable_v3_repair_uses_one_typed_graph_patch(tmp_path: Path):
     response = await service.generate(_request(), _snapshot())
 
     assert len(calls) == 3
-    assert "GraphPatchEnvelopeV1" in str(calls[-1]["system_prompt"])
+    assert "typed Graph Patch operations" in str(calls[-1]["system_prompt"])
     assert calls[-1]["temperature"] == 0
     assert response.repair_used is True
     assert response.validation["valid"] is True

--- a/server/tests/test_workflow_capability_audit.py
+++ b/server/tests/test_workflow_capability_audit.py
@@ -319,7 +319,7 @@ def test_capability_audit_tracks_baseline_and_r1_nodes() -> None:
     assert facts.palette_draggable == 50
     assert facts.complete == 52
     assert facts.compatibility == 3
-    assert facts.planner == 16
+    assert facts.planner == 18
     planner_kinds = {
         contract.kind
         for contract in workflow_node_contract_registry.list()
@@ -329,12 +329,14 @@ def test_capability_audit_tracks_baseline_and_r1_nodes() -> None:
         "condition",
         "data_aggregate",
         "data_merge",
+        "data_table_query",
         "dataset_compare",
         "external_xpert",
         "input",
         "json_deserialize",
         "json_serialize",
         "knowledge_base",
+        "knowledge_retrieval",
         "multi_route",
         "output",
         "plugin_resource",
@@ -433,5 +435,5 @@ def test_capability_audit_tracks_baseline_and_r1_nodes() -> None:
     assert current_registry_line == (
         "当前 Registry 事实：55 Native、51 个已登记 Palette 项、"
         "默认 50 个可拖拽 Palette 项、52 个完整合同、"
-        "3 个 compatibility 合同、16 个 Planner 节点"
+        "3 个 compatibility 合同、18 个 Planner 节点"
     )

--- a/server/tests/test_workflow_data_table_nodes.py
+++ b/server/tests/test_workflow_data_table_nodes.py
@@ -229,7 +229,7 @@ def test_data_table_node_validation_contract_and_variable_reachability() -> None
     assert "missing_data_table_filter" in {issue.code for issue in result.issues}
 
 
-def test_data_table_nodes_are_runtime_enabled_but_planner_deferred() -> None:
+def test_only_data_table_query_is_planner_enabled() -> None:
     registry = WorkflowNodeRegistry()
     register_builtin_workflow_nodes(registry)
     items = {
@@ -246,7 +246,15 @@ def test_data_table_nodes_are_runtime_enabled_but_planner_deferred() -> None:
         "data_table_delete",
     }
     assert all(item.enabled is True for item in items.values())
-    assert all(item.to_payload()["planner"]["enabled"] is False for item in items.values())
+    assert items["data_table_query"].to_payload()["planner"]["enabled"] is True
+    assert all(
+        items[kind].to_payload()["planner"]["enabled"] is False
+        for kind in {
+            "data_table_insert",
+            "data_table_update",
+            "data_table_delete",
+        }
+    )
     assert all(
         item.to_payload()["contract"]["contract_status"] == "complete"
         for item in items.values()

--- a/server/tests/test_workflow_node_contracts.py
+++ b/server/tests/test_workflow_node_contracts.py
@@ -33,6 +33,7 @@ EXPECTED_PLANNER_KINDS = {
     "condition",
     "data_aggregate",
     "data_merge",
+    "data_table_query",
     "dataset_compare",
     "input",
     "json_deserialize",
@@ -44,6 +45,7 @@ EXPECTED_PLANNER_KINDS = {
     "workflow_agent",
     "external_xpert",
     "knowledge_base",
+    "knowledge_retrieval",
     "toolset_resource",
     "plugin_resource",
 }
@@ -655,7 +657,6 @@ def test_policy_service_preserves_current_entrypoint_boundaries() -> None:
         "human_intervention",
         "mcp_tool",
         "vision_understanding",
-        "data_table_query",
         "data_table_insert",
         "data_table_update",
         "data_table_delete",
@@ -752,7 +753,7 @@ def test_old_capability_snapshot_remains_readable() -> None:
     assert snapshot.contract_checksum == ""
 
 
-def test_registry_ui_projection_is_v6_and_contains_no_runtime_payloads() -> None:
+def test_registry_ui_projection_is_v7_and_contains_no_runtime_payloads() -> None:
     payload = workflow_node_registry.to_payload()
     serialized = str(payload).lower()
     items = [
@@ -762,7 +763,7 @@ def test_registry_ui_projection_is_v6_and_contains_no_runtime_payloads() -> None
     ] + list(payload["knowledge_pipeline"]["items"])
 
     assert len({item["kind"] for item in items}) == 51
-    assert payload["version"] == "xpert-workflow-node-registry-v6"
+    assert payload["version"] == "xpert-workflow-node-registry-v7"
     assert payload["contract_version"] == 3
     assert payload["contract_checksum"] == workflow_node_contract_registry.checksum
     assert all(item["contract"]["kind"] == item["kind"] for item in items)

--- a/server/tests/test_workflow_retry_policy.py
+++ b/server/tests/test_workflow_retry_policy.py
@@ -201,13 +201,17 @@ def test_retry_contract_metadata_is_limited_to_three_nodes() -> None:
     }
 
     assert supported == RETRYABLE_NODE_KINDS
+    assert {
+        kind
+        for kind in RETRYABLE_NODE_KINDS
+        if workflow_node_contract_registry.require(kind).planner.enabled
+    } == {"data_table_query", "knowledge_retrieval"}
     assert len(workflow_node_contract_registry.list()) == 55
     for kind in RETRYABLE_NODE_KINDS:
         contract = workflow_node_contract_registry.require(kind)
         assert contract.retry.modes == ("none", "transient")
         assert contract.retry.max_attempts == (2, 3)
         assert contract.retry.backoff_seconds == (5, 30)
-        assert contract.planner.enabled is False
         assert effective_can_wait({}, contract) is False
         assert effective_can_wait({"retryMode": "transient"}, contract) is True
 

--- a/server/tests/test_xpert_evaluation_resource_fixtures.py
+++ b/server/tests/test_xpert_evaluation_resource_fixtures.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import server.main as main_module
+from server.data_tables.store import AgentTableStore
+from server.evaluations.metrics import evaluate_case_metrics
+from server.evaluations.api import _sanitize_run_detail
+from server.evaluations.resource_fixtures import prepare_agent_table_fixtures
+from server.evaluations.service import XpertEvaluationService
+from server.evaluations.store import EvaluationStateError, XpertEvaluationStore
+from server.workflow_native.schemas import NativeWorkflowDefinition
+from server.xperts import XpertStore
+
+
+class _EmptyStore:
+    def get_version(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise KeyError("resource not found")
+
+
+class _RagStub:
+    def get_active_pipeline_version(self, kb_id: str) -> dict[str, Any] | None:
+        if kb_id == "kb-ready":
+            return {"version_id": "pipeline-fixed"}
+        return None
+
+
+def _published_table(tmp_path: Path):
+    store = AgentTableStore(tmp_path / "tables")
+    table = store.create_table(
+        name="Tasks",
+        fields=[
+            {"name": "name", "data_type": "string", "required": True},
+            {"name": "priority", "data_type": "integer", "required": True},
+        ],
+    )
+    schema = store.publish_table(table.table_id, revision=table.draft_revision)
+    first = store.create_record_for_schema(
+        table.table_id,
+        schema_version=schema.version,
+        data={"name": "Review", "priority": 5},
+        operation_id="seed-review",
+    )
+    return store, table, schema, first
+
+
+def _table_target(table_id: str, schema_version: int) -> dict[str, Any]:
+    return {
+        "target_id": "candidate",
+        "label": "Candidate",
+        "input_variable": "user_input",
+        "history_variable": "conversation_history",
+        "workflow": {
+            "id": "fixture-workflow",
+            "title": "Fixture workflow",
+            "nodes": [
+                {
+                    "id": "query-native",
+                    "type": "data_table_query",
+                    "data": {
+                        "kind": "data_table_query",
+                        "plannerRef": "task_lookup",
+                        "tableId": table_id,
+                        "versionPolicy": "pinned",
+                        "pinnedSchemaVersion": schema_version,
+                        "selectFields": ["name", "priority"],
+                        "filter": {
+                            "field": "name",
+                            "operator": "contains",
+                            "value": {
+                                "source": "variable",
+                                "variable": "user_input",
+                            },
+                        },
+                        "sort": [{"field": "priority", "direction": "desc"}],
+                        "limit": 20,
+                        "returnMode": "list",
+                        "outputVariable": "records",
+                    },
+                }
+            ],
+            "edges": [],
+        },
+    }
+
+
+def _case() -> dict[str, Any]:
+    return {"case_id": "case-review", "message": "Review", "expected": {}}
+
+
+def test_table_fixtures_survive_reload_and_do_not_follow_live_rows(
+    tmp_path: Path,
+) -> None:
+    table_store, table, schema, original = _published_table(tmp_path)
+    target = _table_target(table.table_id, schema.version)
+    case = _case()
+    fixtures = prepare_agent_table_fixtures(
+        targets=[target],
+        cases=[case],
+        backend=table_store,
+    )
+    assert fixtures[0]["record_ids"] == [original["record_id"]]
+
+    evaluation_store = XpertEvaluationStore(tmp_path / "evaluations")
+    run = evaluation_store.create_run(
+        dataset_version={
+            "dataset_id": "dataset",
+            "version": 1,
+            "cases": [case],
+        },
+        cases=[case],
+        baseline=None,
+        candidates=[target],
+        config={"budget": {"repetitions": 1}},
+        warnings=[],
+        resource_fixtures=fixtures,
+    )
+    assert "_resource_fixtures" not in run
+    table_store.create_record_for_schema(
+        table.table_id,
+        schema_version=schema.version,
+        data={"name": "Review later", "priority": 9},
+        operation_id="seed-later",
+    )
+
+    restored = XpertEvaluationStore(tmp_path / "evaluations")
+    frozen = restored.resource_fixtures_for_item(
+        run["run_id"],
+        target_id="candidate",
+        case_id="case-review",
+    )
+    assert len(frozen) == 1
+    assert frozen[0]["record_ids"] == [original["record_id"]]
+    assert len(frozen[0]["records"]) == 1
+    assert "_resource_fixtures" not in restored.run_payload(
+        restored.require_run(run["run_id"]),
+        include_detail=True,
+    )
+
+
+def test_persisted_table_fixture_tampering_fails_closed(tmp_path: Path) -> None:
+    table_store, table, schema, _record = _published_table(tmp_path)
+    target = _table_target(table.table_id, schema.version)
+    case = _case()
+    fixtures = prepare_agent_table_fixtures(
+        targets=[target], cases=[case], backend=table_store
+    )
+    evaluation_store = XpertEvaluationStore(tmp_path / "evaluations")
+    run = evaluation_store.create_run(
+        dataset_version={"dataset_id": "dataset", "version": 1, "cases": [case]},
+        cases=[case],
+        baseline=None,
+        candidates=[target],
+        config={"budget": {"repetitions": 1}},
+        warnings=[],
+        resource_fixtures=fixtures,
+    )
+
+    raw = json.loads(evaluation_store.path.read_text(encoding="utf-8"))
+    raw["runs"][run["run_id"]]["_resource_fixtures"][0]["records"][0][
+        "priority"
+    ] = 999
+    evaluation_store.path.write_text(
+        json.dumps(raw, ensure_ascii=False), encoding="utf-8"
+    )
+
+    restored = XpertEvaluationStore(tmp_path / "evaluations")
+    with pytest.raises(EvaluationStateError, match="integrity"):
+        restored.resource_fixtures_for_item(
+            run["run_id"], target_id="candidate", case_id="case-review"
+        )
+
+
+def test_run_create_cancel_and_api_projection_never_expose_private_fixtures(
+    tmp_path: Path,
+) -> None:
+    table_store, table, schema, _record = _published_table(tmp_path)
+    target = _table_target(table.table_id, schema.version)
+    case = _case()
+    fixtures = prepare_agent_table_fixtures(
+        targets=[target], cases=[case], backend=table_store
+    )
+    store = XpertEvaluationStore(tmp_path / "evaluations")
+    run = store.create_run(
+        dataset_version={"dataset_id": "dataset", "version": 1, "cases": [case]},
+        cases=[case],
+        baseline=None,
+        candidates=[target],
+        config={"budget": {"repetitions": 1}},
+        warnings=[],
+        resource_fixtures=fixtures,
+    )
+
+    assert "_resource_fixtures" not in run
+    assert "_resource_fixtures" not in store.cancel_run(run["run_id"])
+    raw = store.require_run(run["run_id"])
+    assert "_resource_fixtures" in raw
+    assert "_resource_fixtures" not in _sanitize_run_detail(raw)
+
+
+def test_fixture_capture_uses_the_same_prompt_profile_input_as_runtime(
+    tmp_path: Path,
+) -> None:
+    table_store, table, schema, _record = _published_table(tmp_path)
+    rendered = table_store.create_record_for_schema(
+        table.table_id,
+        schema_version=schema.version,
+        data={"name": "Ticket Review", "priority": 8},
+        operation_id="seed-rendered",
+    )
+    target = _table_target(table.table_id, schema.version)
+    target["input_template"] = "Ticket {{args}}"
+
+    fixtures = prepare_agent_table_fixtures(
+        targets=[target], cases=[_case()], backend=table_store
+    )
+
+    assert fixtures[0]["filter"]["value"] == "Ticket Review"
+    assert fixtures[0]["record_ids"] == [rendered["record_id"]]
+
+
+def test_agent_derived_table_filter_is_rejected_before_fixture_capture(
+    tmp_path: Path,
+) -> None:
+    table_store, table, schema, _record = _published_table(tmp_path)
+    target = _table_target(table.table_id, schema.version)
+    target["workflow"]["nodes"].insert(
+        0,
+        {
+            "id": "agent-native",
+            "type": "workflow_agent",
+            "data": {
+                "kind": "workflow_agent",
+                "plannerRef": "agent_decision",
+                "outputVariable": "agent_filter",
+            },
+        },
+    )
+    target["workflow"]["nodes"][1]["data"]["filter"]["value"][
+        "variable"
+    ] = "agent_filter"
+
+    with pytest.raises(EvaluationStateError, match="prior Agent output"):
+        prepare_agent_table_fixtures(
+            targets=[target], cases=[_case()], backend=table_store
+        )
+
+
+def test_knowledge_retrieval_preflight_fixes_the_actual_index_version(
+    tmp_path: Path,
+) -> None:
+    service = XpertEvaluationService(
+        XpertEvaluationStore(tmp_path / "evaluations"),
+        xpert_store=XpertStore(tmp_path / "xperts"),
+        proposal_store=_EmptyStore(),
+        prompt_preflight=lambda _xpert: None,
+        toolset_store=_EmptyStore(),
+        plugin_store=_EmptyStore(),
+        rag_service=_RagStub(),
+        context_store=_EmptyStore(),
+    )
+    workflow = NativeWorkflowDefinition.model_validate(
+        {
+            "id": "knowledge-evaluation",
+            "title": "Knowledge evaluation",
+            "nodes": [
+                {
+                    "id": "lookup",
+                    "type": "knowledge_retrieval",
+                    "data": {
+                        "kind": "knowledge_retrieval",
+                        "plannerRef": "kb_lookup",
+                        "knowledgeBaseId": "kb-ready",
+                        "observedActiveVersionId": "pipeline-old",
+                        "queryVariable": "user_input",
+                        "outputVariable": "knowledge",
+                    },
+                }
+            ],
+            "edges": [],
+        }
+    )
+
+    issues, warnings, resources = service._safe_preflight(
+        workflow, recursion_path=("root",)
+    )
+    assert not issues
+    assert any("changed" in warning for warning in warnings)
+    assert workflow.nodes[0].data["evaluationPinnedVersionId"] == "pipeline-fixed"
+    assert resources["knowledge_versions"] == [
+        {
+            "knowledge_base_id": "kb-ready",
+            "version_id": "pipeline-fixed",
+            "node_id": "lookup",
+            "node_kind": "knowledge_retrieval",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resource_metric_distinguishes_verified_missing_and_failed() -> None:
+    case = {
+        "message": "lookup",
+        "expected": {},
+        "resource_reads": [
+            {
+                "node_ref": "task_lookup",
+                "kind": "data_table_query",
+                "resource_id": "table-1",
+                "schema_version": 2,
+                "query_checksum": "a" * 64,
+                "expected_count": 1,
+                "record_ids": ["record-1"],
+            }
+        ],
+        "weights": {"workflow_resource_match": 1},
+    }
+    verified = await evaluate_case_metrics(
+        case=case,
+        output="done",
+        citations={},
+        resource_reads=[
+            {
+                "node_ref": "task_lookup",
+                "kind": "data_table_query",
+                "resource_id": "table-1",
+                "schema_version": 2,
+                "query_checksum": "a" * 64,
+                "result_count": 1,
+                "record_ids": ["record-1"],
+            }
+        ],
+    )
+    missing = await evaluate_case_metrics(
+        case={"message": "lookup", "expected": {}},
+        output="done",
+        citations={},
+        resource_reads=[],
+        resource_evidence_required=True,
+    )
+    failed = await evaluate_case_metrics(
+        case=case,
+        output="done",
+        citations={},
+        resource_reads=[],
+    )
+
+    assert verified["resource_evidence"] == "verified"
+    assert verified["metrics"][0]["kind"] == "workflow_resource_match"
+    assert verified["metrics"][0]["passed"] is True
+    assert missing["resource_evidence"] == "missing"
+    assert failed["resource_evidence"] == "failed"
+
+
+def test_resource_fixture_size_limit_is_checked_before_run_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    table_store, table, schema, _record = _published_table(tmp_path)
+    target = _table_target(table.table_id, schema.version)
+    case = _case()
+    fixtures = prepare_agent_table_fixtures(
+        targets=[target], cases=[case], backend=table_store
+    )
+    store = XpertEvaluationStore(tmp_path / "evaluations")
+    monkeypatch.setattr(XpertEvaluationStore, "MAX_RESOURCE_FIXTURE_BYTES", 1)
+
+    with pytest.raises(EvaluationStateError, match="16 MiB"):
+        store.create_run(
+            dataset_version={"dataset_id": "dataset", "version": 1, "cases": [case]},
+            cases=[case],
+            baseline=None,
+            candidates=[target],
+            config={"budget": {"repetitions": 1}},
+            warnings=[],
+            resource_fixtures=fixtures,
+        )
+    assert store.list_runs() == []
+
+
+@pytest.mark.asyncio
+async def test_real_evaluation_runner_returns_fixed_table_resource_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    table_store, table, schema, _original = _published_table(tmp_path)
+    rendered = table_store.create_record_for_schema(
+        table.table_id,
+        schema_version=schema.version,
+        data={"name": "Ticket Review", "priority": 8},
+        operation_id="seed-runner-rendered",
+    )
+    target = _table_target(table.table_id, schema.version)
+    target.update(
+        {
+            "source": {"kind": "xpert_version", "version": 1},
+            "xpert": {"id": "xpert-test", "slug": "test", "name": "Test"},
+            "output_variable": "records",
+            "agent_config": {},
+            "checksum": "fixture-target",
+            "input_template": "Ticket {{args}}",
+        }
+    )
+    target["workflow"]["nodes"].append(
+        {
+            "id": "output-native",
+            "type": "output",
+            "data": {"kind": "output", "outputVariable": "records"},
+        }
+    )
+    target["workflow"]["edges"] = [
+        {"id": "query-output", "source": "query-native", "target": "output-native"}
+    ]
+    case = _case()
+    fixtures = prepare_agent_table_fixtures(
+        targets=[target], cases=[case], backend=table_store
+    )
+    evaluation_store = XpertEvaluationStore(tmp_path / "evaluations")
+    run = evaluation_store.create_run(
+        dataset_version={"dataset_id": "dataset", "version": 1, "cases": [case]},
+        cases=[case],
+        baseline=None,
+        candidates=[target],
+        config={"budget": {"repetitions": 1}},
+        warnings=[],
+        resource_fixtures=fixtures,
+    )
+    monkeypatch.setattr(main_module, "agent_table_store", table_store)
+    monkeypatch.setattr(
+        main_module, "get_xpert_evaluation_store", lambda: evaluation_store
+    )
+    previous_task_ids = set(main_module.workflow_task_store)
+    try:
+        result = await main_module.run_xpert_evaluation_target(
+            target,
+            case,
+            {
+                "evaluation_run_id": run["run_id"],
+                "evaluation_target_id": target["target_id"],
+                "evaluation_case_id": case["case_id"],
+                "budget": {},
+            },
+            None,
+        )
+    finally:
+        for task_id in set(main_module.workflow_task_store) - previous_task_ids:
+            main_module.workflow_task_store.pop(task_id, None)
+
+    assert result["resource_reads"] == [
+        {
+            "node_ref": "task_lookup",
+            "kind": "data_table_query",
+            "resource_id": table.table_id,
+            "schema_version": schema.version,
+            "query_checksum": fixtures[0]["query_checksum"],
+            "result_count": 1,
+            "record_ids": [rendered["record_id"]],
+        }
+    ]
+    assert rendered["record_id"] in result["output"]

--- a/server/tests/test_xpert_runtime_workflow_node_registry.py
+++ b/server/tests/test_xpert_runtime_workflow_node_registry.py
@@ -31,7 +31,7 @@ def _registry() -> WorkflowNodeRegistry:
 def test_workflow_node_registry_returns_workflow_and_knowledge_tabs() -> None:
     payload = _registry().to_payload()
 
-    assert payload["version"] == "xpert-workflow-node-registry-v6"
+    assert payload["version"] == "xpert-workflow-node-registry-v7"
     assert payload["contract_version"] == 3
     assert len(payload["contract_checksum"]) == 64
     assert {tab["id"] for tab in payload["tabs"]} == {"workflow", "knowledge"}
@@ -48,8 +48,9 @@ def test_workflow_node_registry_returns_workflow_and_knowledge_tabs() -> None:
     knowledge_base, retrieval, proposal, vision = knowledge_items
     assert knowledge_base["planner"]["support"] == "binding_only"
     assert knowledge_base["contracts"]["resources"][0]["kind"] == "knowledge_base"
-    assert retrieval["planner"]["enabled"] is False
-    assert retrieval["planner"]["support"] == "unsupported"
+    assert retrieval["planner"]["enabled"] is True
+    assert retrieval["planner"]["support"] == "full"
+    assert retrieval["planner"]["task_binding"] == "forbidden"
     assert retrieval["contracts"]["outputs"][0]["name"] == "result"
     assert retrieval["contracts"]["outputs"][0]["value_schema"]["type"] == "any"
     assert len(retrieval["contracts"]["outputs"][0]["value_schema"]["any_of"]) == 2
@@ -132,7 +133,7 @@ async def test_workflow_node_registry_api_returns_stable_shape(
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["version"] == "xpert-workflow-node-registry-v6"
+    assert payload["version"] == "xpert-workflow-node-registry-v7"
     assert payload["contract_version"] == 3
     assert len(payload["contract_checksum"]) == 64
     assert isinstance(payload["tabs"], list)

--- a/server/workflow_native/node_contracts.py
+++ b/server/workflow_native/node_contracts.py
@@ -445,6 +445,120 @@ class DatasetComparePlannerConfig(BaseModel):
         return self
 
 
+class KnowledgeRetrievalPlannerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    top_k: int = Field(default=5, ge=1, le=10)
+    return_mode: Literal["context", "result"] = "result"
+    failure_action: Literal["stop", "error_output"] = "stop"
+    retry_mode: Literal["none", "transient"] = "none"
+    max_attempts: Literal[2, 3] = 2
+
+    @model_validator(mode="after")
+    def validate_retry(self) -> "KnowledgeRetrievalPlannerConfig":
+        if self.retry_mode == "none" and self.max_attempts != 2:
+            raise ValueError("max_attempts must remain 2 when retry_mode is none")
+        return self
+
+
+DataTableQueryOperator = Literal[
+    "eq",
+    "ne",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "in",
+    "contains",
+    "is_null",
+]
+
+
+class DataTableQueryPredicatePlannerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["predicate"] = "predicate"
+    ref: str = Field(pattern=r"^[a-z][a-z0-9_-]{0,39}$")
+    field: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+    operator: DataTableQueryOperator
+    value_source: Literal["literal", "input", "none"] = "literal"
+    value: Any = None
+
+    @model_validator(mode="after")
+    def validate_value_source(self) -> "DataTableQueryPredicatePlannerConfig":
+        if self.operator == "is_null":
+            if self.value_source != "none" or self.value is not None:
+                raise ValueError("is_null predicates require value_source=none")
+            return self
+        if self.value_source == "none":
+            raise ValueError("non-is_null predicates require a value source")
+        if self.value_source == "input" and self.value is not None:
+            raise ValueError("input predicates cannot include a literal value")
+        if self.value_source == "literal" and self.value is None:
+            raise ValueError("literal predicates require a non-null value")
+        return self
+
+
+class DataTableQueryFilterPlannerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["group"] = "group"
+    logic: Literal["and", "or"] = "and"
+    items: list[
+        "DataTableQueryFilterPlannerConfig | DataTableQueryPredicatePlannerConfig"
+    ] = Field(min_length=1, max_length=20)
+
+
+class DataTableQuerySortPlannerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+    direction: Literal["asc", "desc"] = "asc"
+
+
+class DataTableQueryPlannerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    select_fields: list[str] = Field(default_factory=list, max_length=50)
+    filter: DataTableQueryFilterPlannerConfig | DataTableQueryPredicatePlannerConfig | None = None
+    sort: list[DataTableQuerySortPlannerConfig] = Field(default_factory=list, max_length=5)
+    limit: int = Field(default=20, ge=1, le=200)
+    return_mode: Literal["list", "first"] = "list"
+    failure_action: Literal["stop", "error_output"] = "stop"
+    retry_mode: Literal["none", "transient"] = "none"
+    max_attempts: Literal[2, 3] = 2
+
+    @model_validator(mode="after")
+    def validate_query(self) -> "DataTableQueryPlannerConfig":
+        field_pattern = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+        if any(not field_pattern.fullmatch(item) for item in self.select_fields):
+            raise ValueError("select_fields contains an invalid field name")
+        if len(self.select_fields) != len(set(self.select_fields)):
+            raise ValueError("select_fields must be unique")
+        if self.retry_mode == "none" and self.max_attempts != 2:
+            raise ValueError("max_attempts must remain 2 when retry_mode is none")
+        predicate_refs: list[str] = []
+
+        def visit(
+            item: DataTableQueryFilterPlannerConfig | DataTableQueryPredicatePlannerConfig,
+            depth: int,
+        ) -> None:
+            if depth > 3:
+                raise ValueError("filter depth cannot exceed 3")
+            if isinstance(item, DataTableQueryPredicatePlannerConfig):
+                predicate_refs.append(item.ref)
+                return
+            for child in item.items:
+                visit(child, depth + 1)
+
+        if self.filter is not None:
+            visit(self.filter, 1)
+        if len(predicate_refs) > 20:
+            raise ValueError("filter cannot contain more than 20 predicates")
+        if len(predicate_refs) != len(set(predicate_refs)):
+            raise ValueError("predicate refs must be unique")
+        return self
+
 class ConditionPlannerConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -3576,18 +3690,24 @@ def _complete_contracts() -> dict[str, NodeContract]:
             ),
         ),
         planner=_planner(
+            enabled=True,
+            support="full",
+            compilation_mode="adapter",
+            adapter_version=planner_adapter_version,
+            task_binding="forbidden",
             default_data={
-                "contractVersion": 2,
-                "knowledgeBaseId": "",
-                "queryVariable": "user_input",
-                "top_k": "5",
-                "returnMode": "result",
-                "outputVariable": "knowledge_result",
+                "top_k": 5,
+                "return_mode": "result",
+                "failure_action": "stop",
+                "retry_mode": "none",
+                "max_attempts": 2,
             },
             constraints={
-                "required": ["knowledgeBaseId", "queryVariable", "outputVariable"],
+                "resource_ref": "knowledge_base",
+                "required_input": "query",
                 "return_mode": ["context", "result"],
             },
+            ir_config_schema=KnowledgeRetrievalPlannerConfig.model_json_schema(),
         ),
     )
 
@@ -3705,7 +3825,12 @@ def _complete_contracts() -> dict[str, NodeContract]:
     table_specs = {
         "data_table_query": (
             "read",
-            array_object_value,
+            WorkflowValueSchema(
+                any_of=(
+                    array_object_value,
+                    WorkflowValueSchema(type="object", nullable=True),
+                )
+            ),
             {
                 "versionPolicy": "latest",
                 "selectFields": [],
@@ -3799,6 +3924,19 @@ def _complete_contracts() -> dict[str, NodeContract]:
                 required=["tableId", "outputVariable"],
             ),
             ports=(
+                *(
+                    (
+                        NodePortContract(
+                            name="predicate",
+                            direction="input",
+                            value_schema=any_value,
+                            required=False,
+                            cardinality="many",
+                        ),
+                    )
+                    if kind == "data_table_query"
+                    else ()
+                ),
                 NodePortContract(
                     name="result", direction="output", value_schema=output_schema
                 ),
@@ -3839,10 +3977,21 @@ def _complete_contracts() -> dict[str, NodeContract]:
             ),
             availability=_availability(
                 app=app_table_denied,
-                evaluation=_rule(
-                    "deny",
-                    code="evaluation_unsafe_node",
-                    message=f"Evaluation does not allow node kind: {kind}.",
+                evaluation=(
+                    _rule(
+                        "conditional",
+                        code="evaluation_data_table_fixture_required",
+                        message=(
+                            "Evaluation requires a fixed per-case Agent Table "
+                            "query fixture."
+                        ),
+                    )
+                    if kind == "data_table_query"
+                    else _rule(
+                        "deny",
+                        code="evaluation_unsafe_node",
+                        message=f"Evaluation does not allow node kind: {kind}.",
+                    )
                 ),
             ),
             resources=(
@@ -3854,7 +4003,34 @@ def _complete_contracts() -> dict[str, NodeContract]:
                     dynamic_schema=True,
                 ),
             ),
-            planner=_planner(default_data=defaults),
+            planner=(
+                _planner(
+                    enabled=True,
+                    support="full",
+                    compilation_mode="adapter",
+                    adapter_version=planner_adapter_version,
+                    task_binding="forbidden",
+                    default_data={
+                        "select_fields": [],
+                        "filter": None,
+                        "sort": [],
+                        "limit": 20,
+                        "return_mode": "list",
+                        "failure_action": "stop",
+                        "retry_mode": "none",
+                        "max_attempts": 2,
+                    },
+                    constraints={
+                        "resource_ref": "data_table",
+                        "filter_max_depth": 3,
+                        "filter_max_predicates": 20,
+                        "limit_max": 200,
+                    },
+                    ir_config_schema=DataTableQueryPlannerConfig.model_json_schema(),
+                )
+                if kind == "data_table_query"
+                else _planner(default_data=defaults)
+            ),
         )
 
     contracts["vision_understanding"] = NodeContract(

--- a/server/xpert_runtime/workflow_knowledge.py
+++ b/server/xpert_runtime/workflow_knowledge.py
@@ -125,6 +125,7 @@ async def execute_workflow_knowledge_retrieval(
     contract_version: int,
     return_mode: str,
     version_id: str | None = None,
+    include_resource_evidence: bool = False,
 ) -> tuple[str | dict[str, Any], dict[str, Any]]:
     is_v2 = contract_version >= 2
     knowledge_base_id, compatibility_warnings = resolve_workflow_knowledge_base(
@@ -169,6 +170,17 @@ async def execute_workflow_knowledge_retrieval(
         "contract_version": contract_version,
         "return_mode": return_mode,
     }
+    if include_resource_evidence:
+        # The workflow runner removes this private field before emitting events
+        # or checkpoints. Evaluation uses it to prove which fixed resource was
+        # actually read without issuing a second retrieval.
+        metadata["_resource_evidence"] = {
+            "citation_ids": [
+                str(item.get("citation_id") or "")
+                for item in citations
+                if str(item.get("citation_id") or "")
+            ][:50],
+        }
     if not is_v2 or return_mode == "context":
         return context, metadata
     return {

--- a/server/xpert_runtime/workflow_node_registry.py
+++ b/server/xpert_runtime/workflow_node_registry.py
@@ -154,7 +154,7 @@ class WorkflowNodeRegistry:
     """Xpert-style metadata registry for classic workflow palette nodes."""
 
     def __init__(self) -> None:
-        self.version = "xpert-workflow-node-registry-v6"
+        self.version = "xpert-workflow-node-registry-v7"
         self.contract_registry = workflow_node_contract_registry
         self._tabs: list[WorkflowPaletteTab] = []
         self._sections: list[WorkflowPaletteSection] = []
@@ -194,7 +194,7 @@ class WorkflowNodeRegistry:
         return {
             "version": self.version,
             "contract_version": NODE_CONTRACT_VERSION,
-            "control_flow_contract_version": 1,
+            "control_flow_contract_version": 2,
             "contract_checksum": self.contract_registry.checksum,
             "tabs": [tab.to_payload() for tab in self._tabs],
             "sections": [section.to_payload() for section in self._sections],


### PR DESCRIPTION
## 摘要
- 向 Meta Planner 开放 knowledge_retrieval 与 data_table_query，补齐资源授权、版本快照、Schema 固定和 success/error 控制流。
- 为 Evaluator 增加知识索引固定与 Agent Table 查询夹具，以及 workflow_resource_match 确定性证据。
- 收口 Headless Authoring、Graph Patch、前端资源配置和中文候选展示契约。
- 修复前端 Node Registry 目录修订号漂移，并增加 fail-closed 回归测试。

## 验证
- 后端 Meta Planner 重点套件：77 passed。
- 前端定向测试：11 passed。
- npm.cmd run build：通过，仅有既有 chunk size warning。
- 后端 py_compile、git diff --check、敏感信息与运行实例扫描：通过。
- 独立预览器使用 DeepSeek V4 Flash 0731 完成口语化数据表查询候选生成；Proposal 保持 pending，未批准或发布。

## 边界
- 未开放写节点、视觉、循环、等待、公共 App 新权限或 Structure Evolution。
- 本次未重跑全量 server/tests，交由 PR CI 继续验证。